### PR TITLE
chore: update coverage stats and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img alt="Card Coverage" src="https://img.shields.io/badge/card_coverage-81%25-green">
   <img alt="Keywords" src="https://img.shields.io/badge/keywords-168%2F168-brightgreen">
-  <img alt="Cards" src="https://img.shields.io/badge/cards-27959%2F34502-green">
+  <img alt="Cards" src="https://img.shields.io/badge/cards-27948%2F34502-green">
   <br/>
   <img alt="Pauper" src="https://img.shields.io/badge/Pauper-93%25-brightgreen">
   <img alt="Pioneer" src="https://img.shields.io/badge/Pioneer-88%25-green">
@@ -25,6 +25,7 @@
   <img alt="Commander" src="https://img.shields.io/badge/Commander-84%25-green">
 </p>
 <!-- coverage-badges:end -->
+
 
 
 

--- a/data/coverage-stats.json
+++ b/data/coverage-stats.json
@@ -3,56 +3,56 @@
   "formats": {
     "brawl": {
       "pct": 85,
-      "supported": 12960,
+      "supported": 12948,
       "total": 15211
     },
     "commander": {
       "pct": 84,
-      "supported": 26481,
-      "total": 31376
+      "supported": 26474,
+      "total": 31378
     },
     "historic": {
       "pct": 85,
-      "supported": 12922,
+      "supported": 12910,
       "total": 15167
     },
     "legacy": {
       "pct": 85,
-      "supported": 26438,
-      "total": 31222
+      "supported": 26431,
+      "total": 31224
     },
     "modern": {
       "pct": 87,
-      "supported": 19548,
-      "total": 22394
+      "supported": 19540,
+      "total": 22395
     },
     "pauper": {
       "pct": 93,
-      "supported": 9886,
+      "supported": 9879,
       "total": 10608
     },
     "pioneer": {
       "pct": 88,
-      "supported": 12866,
+      "supported": 12855,
       "total": 14668
     },
     "standard": {
       "pct": 87,
-      "supported": 3771,
+      "supported": 3768,
       "total": 4348
     },
     "standardbrawl": {
       "pct": 87,
-      "supported": 3782,
+      "supported": 3779,
       "total": 4360
     },
     "vintage": {
       "pct": 85,
-      "supported": 26449,
-      "total": 31238
+      "supported": 26442,
+      "total": 31240
     }
   },
   "keyword_count": 168,
-  "supported_cards": 27959,
+  "supported_cards": 27948,
   "total_cards": 34502
 }


### PR DESCRIPTION
Automated update of README coverage badges from latest card data.