### PR TITLE
multiplayer: lobby UX overhaul + handshake + P2P Commander

### DIFF
--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -170,6 +170,24 @@ describe("WebSocketAdapter", () => {
         const reconnectWs = (reconnectingAdapter as unknown as { ws: MockWebSocket }).ws;
         reconnectWs.onopen?.();
 
+        // After the version handshake was added, the first frame on open
+        // is always ClientHello; the Reconnect frame is deferred until the
+        // server's ServerHello arrives.
+        expect(reconnectWs.send).toHaveBeenNthCalledWith(
+          1,
+          expect.stringContaining('"type":"ClientHello"'),
+        );
+        reconnectWs.onmessage?.({
+          data: JSON.stringify({
+            type: "ServerHello",
+            data: {
+              server_version: "0.0.0-test",
+              build_commit: "testhash",
+              protocol_version: 1,
+              mode: "Full",
+            },
+          }),
+        });
         expect(reconnectWs.send).toHaveBeenCalledWith(
           JSON.stringify({
             type: "Reconnect",

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -20,8 +20,24 @@ export interface DeckData {
   commander?: string[];
 }
 
+/**
+ * Wire-protocol version the client speaks. Must match `PROTOCOL_VERSION` in
+ * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
+ * adds, removes, renames, or changes the type of a protocol variant field.
+ */
+export const PROTOCOL_VERSION = 1;
+
+/** Identity advertised by the server in its `ServerHello`. */
+export interface ServerInfo {
+  version: string;
+  buildCommit: string;
+  protocolVersion: number;
+  mode: "Full" | "LobbyOnly";
+}
+
 /** Events emitted by the WebSocketAdapter for UI state updates. */
 export type WsAdapterEvent =
+  | { type: "serverHello"; info: ServerInfo; compatible: boolean }
   | { type: "playerIdentity"; playerId: PlayerId; opponentName: string | null }
   | { type: "actionPendingChanged"; pending: boolean }
   | { type: "latencyChanged"; latencyMs: number | null }
@@ -71,6 +87,19 @@ export class WebSocketAdapter implements EngineAdapter {
   private pingInterval: ReturnType<typeof setInterval> | null = null;
   private disposed = false;
   private gameEnded = false;
+  /**
+   * Populated once the server's `ServerHello` arrives. `null` between the
+   * WebSocket opening and the hello being delivered. Consumers see it via
+   * the `serverHello` event, or through `getServerInfo()`.
+   */
+  private _serverInfo: ServerInfo | null = null;
+  /**
+   * Work deferred until a compatible `ServerHello` is received — typically
+   * the create-game, join-game, or reconnect frame. Both `initialize()`
+   * and `tryReconnect()` populate this so their setup frame never goes out
+   * before the handshake completes.
+   */
+  private pendingHelloContinuation: (() => void) | null = null;
 
   constructor(
     private readonly serverUrl: string,
@@ -129,22 +158,25 @@ export class WebSocketAdapter implements EngineAdapter {
 
       this.ws.onopen = () => {
         this.startPing();
-        if (this.mode === "host") {
-          this.send({
-            type: "CreateGame",
-            data: { deck: this.deckData },
-          });
-        } else {
-          this.send({
-            type: "JoinGameWithPassword",
-            data: {
-              game_code: this.joinGameCode!,
-              deck: this.deckData,
-              display_name: this.displayName,
-              password: this.joinPassword ?? null,
-            },
-          });
-        }
+        this.pendingHelloContinuation = () => {
+          if (this.mode === "host") {
+            this.send({
+              type: "CreateGame",
+              data: { deck: this.deckData },
+            });
+          } else {
+            this.send({
+              type: "JoinGameWithPassword",
+              data: {
+                game_code: this.joinGameCode!,
+                deck: this.deckData,
+                display_name: this.displayName,
+                password: this.joinPassword ?? null,
+              },
+            });
+          }
+        };
+        this.sendClientHello();
       };
 
       this.ws.onmessage = (event) => {
@@ -270,6 +302,8 @@ export class WebSocketAdapter implements EngineAdapter {
     this.pendingReject = null;
     this.initResolve = null;
     this.initReject = null;
+    this.pendingHelloContinuation = null;
+    this._serverInfo = null;
     this.emit({ type: "actionPendingChanged", pending: false });
     this.emit({ type: "latencyChanged", latencyMs: null });
     if (this.gameEnded) {
@@ -291,13 +325,16 @@ export class WebSocketAdapter implements EngineAdapter {
     this.ws = new WebSocket(this.serverUrl);
     this.ws.onopen = () => {
       this.startPing();
-      this.send({
-        type: "Reconnect",
-        data: {
-          game_code: session.gameCode,
-          player_token: session.playerToken,
-        },
-      });
+      this.pendingHelloContinuation = () => {
+        this.send({
+          type: "Reconnect",
+          data: {
+            game_code: session.gameCode,
+            player_token: session.playerToken,
+          },
+        });
+      };
+      this.sendClientHello();
     };
     this.ws.onmessage = (event) => {
       const msg = JSON.parse(event.data as string) as { type: string; data?: unknown };
@@ -356,8 +393,71 @@ export class WebSocketAdapter implements EngineAdapter {
     this.ws?.send(JSON.stringify(msg));
   }
 
+  private sendClientHello(): void {
+    this.send({
+      type: "ClientHello",
+      data: {
+        client_version: __APP_VERSION__,
+        build_commit: __BUILD_HASH__,
+        protocol_version: PROTOCOL_VERSION,
+      },
+    });
+  }
+
+  /** Snapshot of the server's advertised identity, or null before ServerHello. */
+  getServerInfo(): ServerInfo | null {
+    return this._serverInfo;
+  }
+
   private handleMessage(msg: { type: string; data?: unknown }): void {
     switch (msg.type) {
+      case "ServerHello": {
+        // Servers send ServerHello exactly once per connection. A duplicate
+        // frame means either a misbehaving server or a test harness; either
+        // way, re-running the continuation would send the setup frame twice.
+        if (this._serverInfo) {
+          return;
+        }
+        const data = msg.data as {
+          server_version: string;
+          build_commit: string;
+          protocol_version: number;
+          mode: "Full" | "LobbyOnly";
+        };
+        const info: ServerInfo = {
+          version: data.server_version,
+          buildCommit: data.build_commit,
+          protocolVersion: data.protocol_version,
+          mode: data.mode,
+        };
+        this._serverInfo = info;
+        const compatible = info.protocolVersion === PROTOCOL_VERSION;
+        this.emit({ type: "serverHello", info, compatible });
+
+        if (!compatible) {
+          // Give up before running the deferred setup frame — a mismatched
+          // protocol will just produce a rejected frame on the other side.
+          this.pendingHelloContinuation = null;
+          const err = new AdapterError(
+            "WS_ERROR",
+            `Server protocol version ${info.protocolVersion} does not match client ${PROTOCOL_VERSION}. Please refresh.`,
+            false,
+          );
+          if (this.initReject) {
+            this.initReject(err);
+            this.initResolve = null;
+            this.initReject = null;
+          }
+          this.ws?.close();
+          return;
+        }
+
+        const cont = this.pendingHelloContinuation;
+        this.pendingHelloContinuation = null;
+        cont?.();
+        break;
+      }
+
       case "GameCreated": {
         const data = msg.data as { game_code: string; player_token: string };
         this._gameCode = data.game_code;

--- a/client/src/components/lobby/GameListItem.tsx
+++ b/client/src/components/lobby/GameListItem.tsx
@@ -8,11 +8,30 @@ interface LobbyGame {
   format?: GameFormat;
   current_players?: number;
   max_players?: number;
+  /** Display-only version string (e.g. "0.1.11"). */
+  host_version?: string;
+  /**
+   * Git short-hash of the host's build. Used as a hard compatibility gate:
+   * when the lobby list renders, rows whose commit doesn't match the
+   * client's own build are disabled because the host and guest would run
+   * diverged engine rules otherwise.
+   */
+  host_build_commit?: string;
+  /** Optional host-provided label for this room, distinct from their player
+   * name. When present, the lobby row shows it as the primary title with
+   * the host's player name as secondary metadata. */
+  room_name?: string | null;
 }
 
 interface GameListItemProps {
   game: LobbyGame;
   onJoin: (code: string, format?: GameFormat) => void;
+  /**
+   * When false, the row is visible but disabled with a tooltip explaining
+   * the mismatch. Computed by the parent from the server's `build_commit`
+   * vs the client's `__BUILD_HASH__`.
+   */
+  compatible?: boolean;
 }
 
 const FORMAT_BADGE_CLASSES: Record<GameFormat, string> = {
@@ -49,27 +68,65 @@ function formatWaitTime(createdAt: number): string {
   return `${hours}h ago`;
 }
 
-export function GameListItem({ game, onJoin }: GameListItemProps) {
+export function GameListItem({ game, onJoin, compatible = true }: GameListItemProps) {
   const format = game.format ?? "Standard";
   const badgeClass = FORMAT_BADGE_CLASSES[format];
   const formatLabel = FORMAT_LABELS[format];
 
+  // A game is "full" when every configured seat is occupied (humans + AI).
+  // The server unregisters full games on the last join, so in the happy path
+  // browsers rarely see this state — but race conditions between a join and
+  // the `LobbyGameRemoved` broadcast can briefly expose it, and a disabled
+  // row is a clearer UX than a row that errors on click.
+  const isFull =
+    game.max_players != null &&
+    game.current_players != null &&
+    game.current_players >= game.max_players;
+  const disabled = !compatible || isFull;
+
+  const disabledTitle = !compatible
+    ? `Host is on ${game.host_version || "?"} (${game.host_build_commit || "?"}) — your build is different. Refresh to update.`
+    : isFull
+      ? "This game is full."
+      : undefined;
+
   return (
     <button
-      onClick={() => onJoin(game.game_code, game.format)}
-      className="flex w-full items-center gap-3 rounded-[18px] border border-white/10 bg-black/18 px-4 py-3 text-left transition-colors hover:border-white/18 hover:bg-white/6"
+      onClick={() => !disabled && onJoin(game.game_code, game.format)}
+      disabled={disabled}
+      title={disabledTitle}
+      className={
+        "flex w-full items-center gap-3 rounded-[18px] border px-4 py-3 text-left transition-colors " +
+        (disabled
+          ? "cursor-not-allowed border-white/5 bg-black/10 opacity-60"
+          : "border-white/10 bg-black/18 hover:border-white/18 hover:bg-white/6")
+      }
     >
       {/* Format badge */}
       <span className={`flex-shrink-0 rounded px-1.5 py-0.5 text-xs font-semibold ${badgeClass}`}>
         {formatLabel}
       </span>
 
-      {/* Host name and metadata */}
+      {/* Room title and metadata. When the host set an explicit room name
+          we show it as the primary title and demote the host's player name
+          to the secondary line; otherwise fall back to showing the player
+          name as the title (the pre-room_name behavior). */}
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium text-gray-200">
-          {game.host_name || "Anonymous"}
+          {game.room_name || game.host_name || "Anonymous"}
         </p>
-        <p className="text-xs text-gray-500">{formatWaitTime(game.created_at)}</p>
+        <p className="text-xs text-gray-500">
+          {game.room_name && game.host_name && (
+            <span className="mr-2 text-gray-400">by {game.host_name}</span>
+          )}
+          {formatWaitTime(game.created_at)}
+          {game.host_version && (
+            <span className="ml-2 font-mono text-[10px] text-gray-600">
+              v{game.host_version}
+              {game.host_build_commit ? `·${game.host_build_commit}` : ""}
+            </span>
+          )}
+        </p>
       </div>
 
       {/* Player count */}

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -43,11 +43,13 @@ const DIFFICULTY_OPTIONS = ["VeryEasy", "Easy", "Medium", "Hard", "VeryHard"];
 const P2P_MAX_PEERS = 4;
 
 export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
-  const storeDisplayName = useMultiplayerStore((s) => s.displayName);
-  const setStoreDisplayName = useMultiplayerStore((s) => s.setDisplayName);
+  // Player name is edited in `PlayerIdentityBanner` above this form (see
+  // MultiplayerPage). We read it here only to submit it and to seed the
+  // room-name placeholder — this form itself intentionally has no
+  // player-name field to avoid the two-inputs-for-one-value confusion.
+  const displayName = useMultiplayerStore((s) => s.displayName);
   const setFormatConfig = useMultiplayerStore((s) => s.setFormatConfig);
 
-  const [displayName, setDisplayName] = useState(storeDisplayName);
   const [roomName, setRoomName] = useState("");
   const [isPublic, setIsPublic] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
@@ -58,15 +60,6 @@ export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
   const [playerCount, setPlayerCount] = useState(FORMAT_DEFAULTS.Standard.min_players);
   const [matchType, setMatchType] = useState<MatchType>("Bo1");
   const [aiSeats, setAiSeats] = useState<AiSeatConfig[]>([]);
-
-  // Persist the player's name back to the store on every edit so it stays in
-  // sync across future host/join actions without requiring a submit. This
-  // makes the HostSetup field a legitimate editor for the player's global
-  // identity, not a per-match override.
-  const handleDisplayNameChange = (name: string) => {
-    setDisplayName(name);
-    setStoreDisplayName(name);
-  };
 
   const isP2P = connectionMode === "p2p";
   const maxPlayers = isP2P
@@ -114,12 +107,6 @@ export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
   };
 
   const handleHost = () => {
-    // The display-name store write happens on-change already; this branch
-    // is a safety net in case `handleDisplayNameChange` was skipped (e.g.
-    // initial prefill from store was left untouched and no change fired).
-    if (displayName !== storeDisplayName) {
-      setStoreDisplayName(displayName);
-    }
     const finalConfig = { ...formatConfig, max_players: playerCount };
     setFormatConfig(finalConfig);
     const trimmedRoomName = roomName.trim();
@@ -163,29 +150,9 @@ export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
         </div>
 
         <div className="flex w-full flex-col gap-4">
-        {/* Your (player) name — persistent across sessions. Edits here
-            write-through to the multiplayer store, so the field here is
-            the player's identity editor, not a per-match override. */}
-        <div>
-          <label className="mb-1.5 block text-xs font-medium uppercase tracking-wider text-gray-400">
-            Your Name
-          </label>
-          <input
-            type="text"
-            value={displayName}
-            onChange={(e) => handleDisplayNameChange(e.target.value)}
-            placeholder="How you appear to others"
-            maxLength={20}
-            className="w-full rounded-[16px] bg-black/18 px-3 py-2 text-sm text-white placeholder-gray-500 outline-none ring-1 ring-white/10 focus:ring-white/20"
-          />
-          <p className="mt-1 text-[11px] text-slate-500">
-            Saved for all future matches.
-          </p>
-        </div>
-
-        {/* Room name — per-match label. Distinct from the player's name so
-            the lobby row can advertise "Friday Night Commander" instead of
-            the host's handle. Optional; blank falls back to player name. */}
+        {/* Room name — per-match label. Distinct from the player's name
+            (edited in the `PlayerIdentityBanner` above this form). Blank
+            falls back to the player's name on the server side. */}
         <div>
           <label className="mb-1.5 block text-xs font-medium uppercase tracking-wider text-gray-400">
             Room Name <span className="text-slate-600">(optional)</span>

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -36,12 +36,19 @@ const FORMAT_OPTIONS: { format: GameFormat; label: string }[] = [
 
 const DIFFICULTY_OPTIONS = ["VeryEasy", "Easy", "Medium", "Hard", "VeryHard"];
 
+/** P2P's WebRTC mesh supports 2-4 peers (see `p2p-adapter.ts:165`). The
+ * HostSetup UI clamps format player counts to this ceiling so multi-seat
+ * formats like Commander can still be hosted while 6-player FreeForAll
+ * can't advertise an unreachable configuration. */
+const P2P_MAX_PEERS = 4;
+
 export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
   const storeDisplayName = useMultiplayerStore((s) => s.displayName);
   const setStoreDisplayName = useMultiplayerStore((s) => s.setDisplayName);
   const setFormatConfig = useMultiplayerStore((s) => s.setFormatConfig);
 
   const [displayName, setDisplayName] = useState(storeDisplayName);
+  const [roomName, setRoomName] = useState("");
   const [isPublic, setIsPublic] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
   const [password, setPassword] = useState("");
@@ -52,15 +59,28 @@ export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
   const [matchType, setMatchType] = useState<MatchType>("Bo1");
   const [aiSeats, setAiSeats] = useState<AiSeatConfig[]>([]);
 
+  // Persist the player's name back to the store on every edit so it stays in
+  // sync across future host/join actions without requiring a submit. This
+  // makes the HostSetup field a legitimate editor for the player's global
+  // identity, not a per-match override.
+  const handleDisplayNameChange = (name: string) => {
+    setDisplayName(name);
+    setStoreDisplayName(name);
+  };
+
   const isP2P = connectionMode === "p2p";
-  const maxPlayers = isP2P ? 2 : formatConfig.max_players;
+  const maxPlayers = isP2P
+    ? Math.min(formatConfig.max_players, P2P_MAX_PEERS)
+    : formatConfig.max_players;
   const accentTone = isP2P ? "cyan" : "emerald";
 
   const handleFormatSelect = (format: GameFormat) => {
     const defaults = FORMAT_DEFAULTS[format];
     setSelectedFormat(format);
     setLocalFormatConfig(defaults);
-    const newCount = isP2P ? 2 : defaults.min_players;
+    // Let multi-seat formats start at their own minimum (e.g. Commander's
+    // min is 2, so it still defaults to a duel but users can bump up to 4).
+    const newCount = defaults.min_players;
     setPlayerCount(newCount);
     if (newCount !== 2) {
       setMatchType("Bo1");
@@ -94,11 +114,15 @@ export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
   };
 
   const handleHost = () => {
+    // The display-name store write happens on-change already; this branch
+    // is a safety net in case `handleDisplayNameChange` was skipped (e.g.
+    // initial prefill from store was left untouched and no change fired).
     if (displayName !== storeDisplayName) {
       setStoreDisplayName(displayName);
     }
     const finalConfig = { ...formatConfig, max_players: playerCount };
     setFormatConfig(finalConfig);
+    const trimmedRoomName = roomName.trim();
     onHost({
       displayName,
       public: isPublic,
@@ -107,18 +131,24 @@ export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
       formatConfig: finalConfig,
       matchType: playerCount === 2 ? matchType : "Bo1",
       aiSeats,
+      roomName: trimmedRoomName.length > 0 ? trimmedRoomName : null,
     });
   };
 
-  // Filter formats: P2P only shows 2-player formats
+  // Filter formats: P2P supports 2-4 peers via WebRTC mesh, so any format
+  // whose minimum is reachable from that ceiling is listable. Multi-seat
+  // formats that need more than 4 players (e.g. 6-player FreeForAll) are
+  // hidden here to avoid advertising a configuration we can't actually host.
   const availableFormats = isP2P
-    ? FORMAT_OPTIONS.filter((f) => FORMAT_DEFAULTS[f.format].max_players <= 2)
+    ? FORMAT_OPTIONS.filter(
+        (f) => FORMAT_DEFAULTS[f.format].min_players <= P2P_MAX_PEERS,
+      )
     : FORMAT_OPTIONS;
 
   return (
     <form
       onSubmit={(e) => { e.preventDefault(); handleHost(); }}
-      className="relative z-10 flex w-full max-w-md flex-col items-center gap-6 px-4"
+      className="relative z-10 flex w-full max-w-xl flex-col items-center gap-6 px-4"
     >
       <MenuPanel className="flex w-full flex-col gap-6">
         <div className="space-y-2">
@@ -133,19 +163,46 @@ export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
         </div>
 
         <div className="flex w-full flex-col gap-4">
-        {/* Display name */}
+        {/* Your (player) name — persistent across sessions. Edits here
+            write-through to the multiplayer store, so the field here is
+            the player's identity editor, not a per-match override. */}
         <div>
           <label className="mb-1.5 block text-xs font-medium uppercase tracking-wider text-gray-400">
-            Display Name
+            Your Name
           </label>
           <input
             type="text"
             value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            placeholder="Enter your name"
+            onChange={(e) => handleDisplayNameChange(e.target.value)}
+            placeholder="How you appear to others"
             maxLength={20}
             className="w-full rounded-[16px] bg-black/18 px-3 py-2 text-sm text-white placeholder-gray-500 outline-none ring-1 ring-white/10 focus:ring-white/20"
           />
+          <p className="mt-1 text-[11px] text-slate-500">
+            Saved for all future matches.
+          </p>
+        </div>
+
+        {/* Room name — per-match label. Distinct from the player's name so
+            the lobby row can advertise "Friday Night Commander" instead of
+            the host's handle. Optional; blank falls back to player name. */}
+        <div>
+          <label className="mb-1.5 block text-xs font-medium uppercase tracking-wider text-gray-400">
+            Room Name <span className="text-slate-600">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={roomName}
+            onChange={(e) => setRoomName(e.target.value)}
+            placeholder={
+              displayName ? `${displayName}'s table` : "e.g. Friday Night Commander"
+            }
+            maxLength={40}
+            className="w-full rounded-[16px] bg-black/18 px-3 py-2 text-sm text-white placeholder-gray-500 outline-none ring-1 ring-white/10 focus:ring-white/20"
+          />
+          <p className="mt-1 text-[11px] text-slate-500">
+            Shown to players browsing the lobby. Leave blank to use your name.
+          </p>
         </div>
 
         {/* Format selection */}
@@ -194,8 +251,12 @@ export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
               />
             </div>
 
-            {/* Player count (only show if format supports variable player counts) */}
-            {!isP2P && formatConfig.min_players !== formatConfig.max_players && (
+            {/* Player count — hidden for fixed-seat formats like Standard
+                (min==max==2). Shown in both server and P2P modes when the
+                format supports a range; `maxPlayers` already clamps to the
+                P2P mesh ceiling so the P2P picker never offers a seat the
+                transport can't host. */}
+            {formatConfig.min_players !== maxPlayers && (
               <div className="flex items-center justify-between">
                 <span className="text-xs text-gray-400">Players</span>
                 <div className="flex rounded-[14px] bg-black/18 p-0.5 ring-1 ring-white/10">

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { FormatConfig, GameFormat, MatchType } from "../../adapter/types";
 import { FORMAT_DEFAULTS, useMultiplayerStore } from "../../stores/multiplayerStore";
@@ -50,16 +50,34 @@ export function HostSetup({ onHost, onBack, connectionMode }: HostSetupProps) {
   const displayName = useMultiplayerStore((s) => s.displayName);
   const setFormatConfig = useMultiplayerStore((s) => s.setFormatConfig);
 
+  // Seed the format picker from whatever the user last selected (persisted
+  // in the store). This means navigating away and back to host-setup keeps
+  // the chosen format, and downstream views (the deck picker reached via
+  // "Change Deck") can read the format from the store to filter decks.
+  const storeFormatConfig = useMultiplayerStore((s) => s.formatConfig);
+  const initialFormatConfig = storeFormatConfig ?? FORMAT_DEFAULTS.Standard;
+
   const [roomName, setRoomName] = useState("");
   const [isPublic, setIsPublic] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
   const [password, setPassword] = useState("");
   const [timerSeconds, setTimerSeconds] = useState<number | null>(null);
-  const [selectedFormat, setSelectedFormat] = useState<GameFormat>("Standard");
-  const [formatConfig, setLocalFormatConfig] = useState<FormatConfig>(FORMAT_DEFAULTS.Standard);
-  const [playerCount, setPlayerCount] = useState(FORMAT_DEFAULTS.Standard.min_players);
+  const [selectedFormat, setSelectedFormat] = useState<GameFormat>(
+    initialFormatConfig.format,
+  );
+  const [formatConfig, setLocalFormatConfig] =
+    useState<FormatConfig>(initialFormatConfig);
+  const [playerCount, setPlayerCount] = useState(initialFormatConfig.min_players);
   const [matchType, setMatchType] = useState<MatchType>("Bo1");
   const [aiSeats, setAiSeats] = useState<AiSeatConfig[]>([]);
+
+  // Mirror the in-flight format to the store on every change so sibling
+  // views (the deck picker shown when the user clicks "Change Deck" out
+  // of this form) can filter by the format the user is actively
+  // configuring — not just the one they submitted last time.
+  useEffect(() => {
+    setFormatConfig({ ...formatConfig, max_players: playerCount });
+  }, [formatConfig, playerCount, setFormatConfig]);
 
   const isP2P = connectionMode === "p2p";
   const maxPlayers = isP2P

--- a/client/src/components/lobby/LobbyView.tsx
+++ b/client/src/components/lobby/LobbyView.tsx
@@ -1,17 +1,30 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { GameFormat } from "../../adapter/types";
+import { PROTOCOL_VERSION, type ServerInfo } from "../../adapter/ws-adapter";
 import { isValidWebSocketUrl, parseJoinCode } from "../../services/serverDetection";
-import { useMultiplayerStore } from "../../stores/multiplayerStore";
+import { isLobbyEntryCompatible, useMultiplayerStore } from "../../stores/multiplayerStore";
 import { MenuPanel } from "../menu/MenuShell";
 import { menuButtonClass } from "../menu/buttonStyles";
 import { GameListItem } from "./GameListItem";
 import type { LobbyGame } from "./GameListItem";
+import { ServerPicker } from "./ServerPicker";
 
 interface LobbyViewProps {
   onHostGame: () => void;
   onHostP2P: () => void;
-  onJoinGame: (code: string, password?: string, format?: GameFormat) => void;
+  /**
+   * Called when the user elects to join a game. `context` is the full
+   * `LobbyGame` row when the join originates from the lobby list, so
+   * downstream views (e.g. the deck picker) can render "Joining Alice's
+   * Commander game — 2/4". It is absent for typed-code joins.
+   */
+  onJoinGame: (
+    code: string,
+    password?: string,
+    format?: GameFormat,
+    context?: LobbyGame,
+  ) => void;
   connectionMode?: "server" | "p2p";
   onServerOffline?: () => void;
 }
@@ -38,13 +51,21 @@ export function LobbyView({
   const isServer = connectionMode !== "p2p";
   const isP2P = connectionMode === "p2p";
   const serverAddress = useMultiplayerStore((s) => s.serverAddress);
+  const serverInfo = useMultiplayerStore((s) => s.serverInfo);
   const [games, setGames] = useState<LobbyGame[]>([]);
   const gamesRef = useRef<LobbyGame[]>([]);
   const [playerCount, setPlayerCount] = useState(0);
   const [joinCode, setJoinCode] = useState("");
-  const [passwordModal, setPasswordModal] = useState<{ gameCode: string; format?: GameFormat } | null>(null);
+  const [passwordModal, setPasswordModal] = useState<{
+    gameCode: string;
+    format?: GameFormat;
+    /** Full lobby row when click came from the list — propagates into
+     * the join handler as deck-picker context. */
+    context?: LobbyGame;
+  } | null>(null);
   const [passwordInput, setPasswordInput] = useState("");
   const [formatFilter, setFormatFilter] = useState<GameFormat | null>(null);
+  const [serverPickerOpen, setServerPickerOpen] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
@@ -72,14 +93,47 @@ export function LobbyView({
     wsRef.current = ws;
 
     ws.onopen = () => {
+      // SubscribeLobby is deferred until ServerHello arrives — the server
+      // rejects every non-hello frame before the handshake completes.
       connected = true;
-      ws.send(JSON.stringify({ type: "SubscribeLobby" }));
+      ws.send(
+        JSON.stringify({
+          type: "ClientHello",
+          data: {
+            client_version: __APP_VERSION__,
+            build_commit: __BUILD_HASH__,
+            protocol_version: PROTOCOL_VERSION,
+          },
+        }),
+      );
     };
 
     ws.onmessage = (event) => {
       const msg = JSON.parse(event.data as string) as { type: string; data?: unknown };
 
       switch (msg.type) {
+        case "ServerHello": {
+          const data = msg.data as {
+            server_version: string;
+            build_commit: string;
+            protocol_version: number;
+            mode: "Full" | "LobbyOnly";
+          };
+          const info: ServerInfo = {
+            version: data.server_version,
+            buildCommit: data.build_commit,
+            protocolVersion: data.protocol_version,
+            mode: data.mode,
+          };
+          useMultiplayerStore.getState().setServerInfo(info);
+          if (info.protocolVersion !== PROTOCOL_VERSION) {
+            notifyServerOffline();
+            ws.close();
+            break;
+          }
+          ws.send(JSON.stringify({ type: "SubscribeLobby" }));
+          break;
+        }
         case "LobbyUpdate": {
           const data = msg.data as { games: LobbyGame[] };
           gamesRef.current = data.games;
@@ -90,6 +144,24 @@ export function LobbyView({
           const data = msg.data as { game: LobbyGame };
           setGames((prev) => {
             const next = [...prev, data.game];
+            gamesRef.current = next;
+            return next;
+          });
+          break;
+        }
+        case "LobbyGameUpdated": {
+          // Replace an existing entry in-place so `current_players` ticks up
+          // live as guests join. If the game_code isn't in the current list
+          // we silently ignore — either the client hasn't received its
+          // initial `LobbyUpdate` snapshot yet (any in-flight update will
+          // be superseded by the snapshot), or the game was removed and
+          // this update raced in-flight; appending would resurrect it.
+          // `LobbyGameAdded` is the only path that introduces new rows.
+          const data = msg.data as { game: LobbyGame };
+          setGames((prev) => {
+            const idx = prev.findIndex((g) => g.game_code === data.game.game_code);
+            if (idx < 0) return prev;
+            const next = prev.map((g, i) => (i === idx ? data.game : g));
             gamesRef.current = next;
             return next;
           });
@@ -139,7 +211,17 @@ export function LobbyView({
 
   const handleJoinFromList = useCallback(
     (code: string, format?: GameFormat) => {
-      onJoinGame(code, undefined, format);
+      const game = gamesRef.current.find((g) => g.game_code === code);
+      // Proactive password prompt: if the lobby row advertises a password,
+      // open the modal before any server round-trip. The reactive
+      // `PasswordRequired` handler above remains as a fallback for stale
+      // rows (server says yes when the client thought no).
+      if (game?.has_password) {
+        setPasswordModal({ gameCode: code, format, context: game });
+        setPasswordInput("");
+        return;
+      }
+      onJoinGame(code, undefined, format, game);
     },
     [onJoinGame],
   );
@@ -159,7 +241,12 @@ export function LobbyView({
   const handlePasswordSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault();
     if (passwordModal && passwordInput) {
-      onJoinGame(passwordModal.gameCode, passwordInput, passwordModal.format);
+      onJoinGame(
+        passwordModal.gameCode,
+        passwordInput,
+        passwordModal.format,
+        passwordModal.context,
+      );
       setPasswordModal(null);
       setPasswordInput("");
     }
@@ -175,11 +262,23 @@ export function LobbyView({
         <div className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">
           {isP2P ? "Direct Connection" : "Online Lobby"}
         </div>
-        {isServer && playerCount > 0 && (
-          <span className="rounded-full bg-emerald-500/20 px-2.5 py-0.5 text-xs font-medium text-emerald-300">
-            {playerCount} online
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {isServer && (
+            <button
+              type="button"
+              onClick={() => setServerPickerOpen(true)}
+              title={serverAddress}
+              className="rounded-full border border-white/10 bg-black/18 px-2.5 py-0.5 font-mono text-[10px] text-slate-300 transition-colors hover:border-white/18 hover:bg-white/6"
+            >
+              {serverAddress.replace(/^wss?:\/\//, "").split("/")[0]}
+            </button>
+          )}
+          {isServer && playerCount > 0 && (
+            <span className="rounded-full bg-emerald-500/20 px-2.5 py-0.5 text-xs font-medium text-emerald-300">
+              {playerCount} online
+            </span>
+          )}
+        </div>
       </div>
 
       {isServer && (
@@ -204,10 +303,30 @@ export function LobbyView({
         <div className="w-full space-y-3">
           <div className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">Open Tables</div>
           {filteredGames.length === 0 ? (
-            <div className="rounded-[18px] border border-dashed border-white/10 py-8 text-center">
-              <p className="text-sm text-gray-500">
-                No games available. Host one or join by code!
+            <div className="flex flex-col items-center gap-3 rounded-[18px] border border-dashed border-white/10 px-4 py-6 text-center">
+              <p className="text-sm text-gray-400">
+                {formatFilter
+                  ? `No ${formatFilter} games right now.`
+                  : "No open games right now."}
               </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={onHostGame}
+                  className={menuButtonClass({ tone: "emerald", size: "sm" })}
+                >
+                  Host a game
+                </button>
+                {formatFilter && (
+                  <button
+                    type="button"
+                    onClick={() => setFormatFilter(null)}
+                    className={menuButtonClass({ tone: "neutral", size: "sm" })}
+                  >
+                    Show all formats
+                  </button>
+                )}
+              </div>
             </div>
           ) : (
             <div className="flex max-h-64 flex-col gap-2 overflow-y-auto">
@@ -216,6 +335,7 @@ export function LobbyView({
                   key={game.game_code}
                   game={game}
                   onJoin={handleJoinFromList}
+                  compatible={isLobbyEntryCompatible(game.host_build_commit, serverInfo)}
                 />
               ))}
             </div>
@@ -281,6 +401,15 @@ export function LobbyView({
           </button>
         )}
       </div>
+
+      {serverPickerOpen && (
+        <ServerPicker
+          onClose={() => setServerPickerOpen(false)}
+          onApply={(url) => {
+            useMultiplayerStore.getState().setServerAddress(url);
+          }}
+        />
+      )}
 
       {/* Password modal */}
       {passwordModal && (

--- a/client/src/components/lobby/PlayerIdentityBanner.tsx
+++ b/client/src/components/lobby/PlayerIdentityBanner.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from "react";
+
+import { useMultiplayerStore } from "../../stores/multiplayerStore";
+
+/**
+ * Inline player-name editor rendered at the top of the multiplayer flow.
+ * Clicking "Change" (or the name itself) reveals an input without
+ * navigating into Preferences → Multiplayer, which used to be the only
+ * place to edit the display name.
+ *
+ * Edits commit to the multiplayer store on Enter / blur / "Save". Escape or
+ * clicking "Cancel" reverts to the previous value. The store is persisted,
+ * so any edit here is the authoritative identity for future host/join
+ * actions.
+ */
+export function PlayerIdentityBanner() {
+  const displayName = useMultiplayerStore((s) => s.displayName);
+  const setDisplayName = useMultiplayerStore((s) => s.setDisplayName);
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(displayName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Re-sync draft whenever the store value changes from outside this
+  // component (e.g. the user edits their name in HostSetup, then navigates
+  // back here).
+  useEffect(() => {
+    if (!editing) setDraft(displayName);
+  }, [displayName, editing]);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== displayName) {
+      setDisplayName(trimmed);
+    } else if (!trimmed) {
+      setDraft(displayName);
+    }
+    setEditing(false);
+  };
+
+  const cancel = () => {
+    setDraft(displayName);
+    setEditing(false);
+  };
+
+  return (
+    <div className="mx-auto mb-4 flex w-full max-w-xl items-center justify-between gap-3 rounded-[16px] border border-white/8 bg-black/16 px-4 py-2.5">
+      <div className="min-w-0 flex-1">
+        <div className="text-[0.6rem] uppercase tracking-[0.22em] text-slate-500">
+          Player Name
+        </div>
+        {editing ? (
+          <input
+            ref={inputRef}
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                commit();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                cancel();
+              }
+            }}
+            placeholder="Enter your name"
+            maxLength={20}
+            className="mt-0.5 w-full rounded-[12px] bg-black/24 px-2.5 py-1 text-sm text-white placeholder-gray-500 outline-none ring-1 ring-white/10 focus:ring-white/20"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="mt-0.5 truncate text-left text-sm font-medium text-white transition-colors hover:text-sky-200"
+            title="Click to edit your name"
+          >
+            {displayName || (
+              <span className="italic text-slate-500">Set a name…</span>
+            )}
+          </button>
+        )}
+      </div>
+      {editing ? (
+        <div className="flex shrink-0 gap-2">
+          <button
+            type="button"
+            // onMouseDown so it fires before the input's onBlur cancels.
+            onMouseDown={(e) => {
+              e.preventDefault();
+              cancel();
+            }}
+            className="text-xs text-slate-500 transition-colors hover:text-slate-300"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              commit();
+            }}
+            className="text-xs font-medium text-sky-300 transition-colors hover:text-sky-200"
+          >
+            Save
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="shrink-0 text-xs text-slate-400 transition-colors hover:text-white"
+        >
+          Change
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/lobby/ServerOfflinePrompt.tsx
+++ b/client/src/components/lobby/ServerOfflinePrompt.tsx
@@ -1,0 +1,60 @@
+import { motion } from "framer-motion";
+
+import { menuButtonClass } from "../menu/buttonStyles";
+
+interface ServerOfflinePromptProps {
+  /** Non-dismissive: the user must pick one of the two options. */
+  onUseDirect: () => void;
+  onKeepWaiting: () => void;
+  /** Server URL the client couldn't reach — shown so users hosting their own
+   * instance can diagnose an obvious misconfiguration. */
+  serverAddress?: string;
+}
+
+export function ServerOfflinePrompt({
+  onUseDirect,
+  onKeepWaiting,
+  serverAddress,
+}: ServerOfflinePromptProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/70" />
+      <motion.div
+        initial={{ opacity: 0, scale: 0.96 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.18 }}
+        className="relative z-10 w-full max-w-md rounded-[22px] border border-white/10 bg-[#0b1020]/96 p-6 shadow-2xl backdrop-blur-md"
+      >
+        <h2 className="text-base font-semibold text-white">
+          Matchmaking unreachable
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-slate-300">
+          We couldn&apos;t reach the game server, so the public lobby is
+          unavailable right now. You can still play by sharing a direct code
+          with a friend.
+        </p>
+        {serverAddress && (
+          <p className="mt-2 font-mono text-[10px] text-slate-500 break-all">
+            {serverAddress}
+          </p>
+        )}
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onKeepWaiting}
+            className={menuButtonClass({ tone: "neutral", size: "sm" })}
+          >
+            Keep trying
+          </button>
+          <button
+            type="button"
+            onClick={onUseDirect}
+            className={menuButtonClass({ tone: "cyan", size: "sm" })}
+          >
+            Use direct code
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/client/src/components/lobby/ServerPicker.tsx
+++ b/client/src/components/lobby/ServerPicker.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+
+import { isValidWebSocketUrl } from "../../services/serverDetection";
+import { useMultiplayerStore } from "../../stores/multiplayerStore";
+import { menuButtonClass } from "../menu/buttonStyles";
+
+interface ServerPreset {
+  label: string;
+  url: string;
+  hint?: string;
+}
+
+/**
+ * Canonical regions. Kept as a static list rather than fetched because the
+ * set moves slowly and the cost of a client update is lower than the cost of
+ * a runtime dependency on a region manifest endpoint.
+ */
+const PRESETS: ServerPreset[] = [
+  { label: "US (default)", url: "wss://us.phase-rs.dev/ws" },
+  { label: "EU", url: "wss://eu.phase-rs.dev/ws" },
+];
+
+interface ServerPickerProps {
+  onClose: () => void;
+  /** Called with the new URL after validation. Caller is responsible for any
+   * re-subscription the URL change implies (e.g. remounting the lobby view). */
+  onApply: (url: string) => void;
+}
+
+export function ServerPicker({ onClose, onApply }: ServerPickerProps) {
+  const currentUrl = useMultiplayerStore((s) => s.serverAddress);
+  const [customUrl, setCustomUrl] = useState(
+    PRESETS.some((p) => p.url === currentUrl) ? "" : currentUrl,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Dismiss on outside-click or Escape — this picker is a preferences dialog,
+  // not a forced choice, so unlike ServerOfflinePrompt it is dismissible.
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    document.addEventListener("mousedown", handleClick);
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      document.removeEventListener("mousedown", handleClick);
+    };
+  }, [onClose]);
+
+  const applyUrl = (url: string) => {
+    const trimmed = url.trim();
+    if (!isValidWebSocketUrl(trimmed)) {
+      setError("URL must start with ws:// or wss://");
+      return;
+    }
+    if (trimmed !== currentUrl) {
+      onApply(trimmed);
+    }
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60" />
+      <motion.div
+        ref={panelRef}
+        initial={{ opacity: 0, scale: 0.97 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.15 }}
+        className="relative z-10 w-full max-w-md rounded-[22px] border border-white/10 bg-[#0b1020]/96 p-6 shadow-2xl backdrop-blur-md"
+      >
+        <h2 className="text-base font-semibold text-white">Server</h2>
+        <p className="mt-1 text-xs text-slate-400">
+          Pick a region, or connect to a self-hosted instance.
+        </p>
+
+        <div className="mt-4 flex flex-col gap-2">
+          {PRESETS.map((preset) => {
+            const isActive = preset.url === currentUrl;
+            return (
+              <button
+                key={preset.url}
+                type="button"
+                onClick={() => applyUrl(preset.url)}
+                className={
+                  "flex w-full items-center justify-between rounded-[16px] border px-4 py-2.5 text-left text-sm transition-colors " +
+                  (isActive
+                    ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-100"
+                    : "border-white/10 bg-black/18 text-gray-200 hover:border-white/18 hover:bg-white/6")
+                }
+              >
+                <span className="font-medium">{preset.label}</span>
+                <span className="font-mono text-[10px] text-slate-500">
+                  {preset.url.replace(/^wss?:\/\//, "")}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-4 border-t border-white/8 pt-4">
+          <label className="block text-[0.6rem] uppercase tracking-[0.22em] text-slate-500">
+            Self-hosted
+          </label>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (customUrl.trim()) applyUrl(customUrl);
+            }}
+            className="mt-2 flex gap-2"
+          >
+            <input
+              type="text"
+              value={customUrl}
+              onChange={(e) => {
+                setCustomUrl(e.target.value);
+                setError(null);
+              }}
+              placeholder="wss://your-server.example/ws"
+              className="flex-1 rounded-[14px] bg-black/18 px-3 py-1.5 font-mono text-xs text-white placeholder-gray-600 outline-none ring-1 ring-white/10 focus:ring-white/20"
+            />
+            <button
+              type="submit"
+              disabled={!customUrl.trim()}
+              className={menuButtonClass({
+                tone: "cyan",
+                size: "sm",
+                disabled: !customUrl.trim(),
+              })}
+            >
+              Use
+            </button>
+          </form>
+          {error && (
+            <p className="mt-2 text-xs text-rose-300">{error}</p>
+          )}
+        </div>
+
+        <div className="mt-5 flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className={menuButtonClass({ tone: "neutral", size: "sm" })}
+          >
+            Close
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/client/src/components/lobby/WaitingScreen.tsx
+++ b/client/src/components/lobby/WaitingScreen.tsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { useState } from "react";
 
 import type { PlayerSlot } from "../../stores/multiplayerStore";
 import { MenuPanel } from "../menu/MenuShell";
@@ -34,6 +35,18 @@ export function WaitingScreen({
   onSendChat,
   chatMessages,
 }: WaitingScreenProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(gameCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable (insecure context or old browser) — silent no-op.
+    }
+  };
+
   // Use ReadyRoom when player slots are available (multiplayer with ready-up)
   if (playerSlots && currentPlayerId && onToggleReady && onStartGame && onSendChat) {
     return (
@@ -65,8 +78,20 @@ export function WaitingScreen({
           <p className="mb-2 text-xs font-medium uppercase tracking-wider text-gray-400">
             Game Code
           </p>
-          <p className="font-mono text-4xl font-bold tracking-widest text-emerald-400">
+          <button
+            type="button"
+            onClick={handleCopyCode}
+            className="rounded font-mono text-4xl font-bold tracking-widest text-emerald-400 transition hover:text-emerald-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0b1020]"
+            title="Click to copy"
+          >
             {gameCode}
+          </button>
+          <p className="mt-1.5 min-h-[1rem] text-xs">
+            {copied ? (
+              <span className="font-medium text-emerald-300">Copied!</span>
+            ) : (
+              <span className="text-gray-500">Click to copy</span>
+            )}
           </p>
         </div>
 

--- a/client/src/components/multiplayer/ConnectionToast.tsx
+++ b/client/src/components/multiplayer/ConnectionToast.tsx
@@ -1,61 +1,156 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 
+import type { Toast } from "../../stores/multiplayerStore";
 import { useMultiplayerStore } from "../../stores/multiplayerStore";
 
 interface ConnectionToastProps {
+  /** Invoked by the generic-toast Retry button. Only attached to the generic
+   * slot because the player-specific disconnect toasts have no equivalent
+   * user-initiated retry (reconnection is driven by the remote client). */
   onRetry?: () => void;
   onSettings?: () => void;
 }
 
+const GENERIC_KEY = "generic";
+const TICK_INTERVAL_MS = 500;
+
+function secondsRemaining(expiresAt: number): number {
+  return Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000));
+}
+
 export function ConnectionToast({ onRetry, onSettings }: ConnectionToastProps) {
-  const toastMessage = useMultiplayerStore((s) => s.toastMessage);
+  const toasts = useMultiplayerStore((s) => s.toasts);
   const clearToast = useMultiplayerStore((s) => s.clearToast);
 
-  // Auto-dismiss after 5 seconds
+  // Single interval drives both the countdown display and the auto-dismiss.
+  // Because every toast stores an absolute `expiresAt` wall-clock timestamp,
+  // dismissal is a pure function of `(toast.expiresAt, Date.now())` —
+  // Map-mutation re-renders cannot reset the schedule. This replaces the
+  // earlier pattern that layered separate `setTimeout` dismissal and
+  // `setInterval` tick effects (which had two subtle bugs: a no-deps effect
+  // calling `clearToast` during render, and 5s plain-toast timers that
+  // restarted every time *any* toast changed).
+  const [, forceTick] = useState(0);
   useEffect(() => {
-    if (!toastMessage) return;
-    const timer = setTimeout(clearToast, 5000);
-    return () => clearTimeout(timer);
-  }, [toastMessage, clearToast]);
+    if (toasts.size === 0) return;
+    const id = setInterval(() => {
+      const now = Date.now();
+      let anyExpired = false;
+      for (const [key, toast] of toasts) {
+        if (toast.expiresAt <= now) {
+          clearToast(key);
+          anyExpired = true;
+        }
+      }
+      // Only force a re-render when no dismissal happened — dismissal
+      // already triggers one via the store update. This keeps re-render
+      // cadence at exactly the tick rate while countdowns are visible
+      // without an extra render on the tick that dismissed.
+      if (!anyExpired) forceTick((t) => t + 1);
+    }, TICK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [toasts, clearToast]);
+
+  const entries = Array.from(toasts.entries());
 
   return (
     <AnimatePresence>
-      {toastMessage && (
-        <motion.div
-          className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg bg-gray-900 px-4 py-3 shadow-2xl ring-1 ring-red-700/50"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: 20 }}
-          transition={{ duration: 0.25 }}
-        >
-          <span className="text-sm text-gray-200">{toastMessage}</span>
-          <div className="flex gap-2">
-            {onRetry && (
-              <button
-                onClick={() => {
-                  clearToast();
-                  onRetry();
-                }}
-                className="rounded bg-red-600/80 px-2.5 py-1 text-xs font-semibold text-white transition hover:bg-red-500"
-              >
-                Retry
-              </button>
-            )}
-            {onSettings && (
-              <button
-                onClick={() => {
-                  clearToast();
-                  onSettings();
-                }}
-                className="rounded bg-gray-700 px-2.5 py-1 text-xs font-semibold text-gray-300 transition hover:bg-gray-600"
-              >
-                Settings
-              </button>
-            )}
-          </div>
-        </motion.div>
-      )}
+      {entries.map(([key, toast], index) => (
+        <ToastBanner
+          key={key}
+          toast={toast}
+          index={index}
+          onRetry={key === GENERIC_KEY ? onRetry : undefined}
+          onSettings={key === GENERIC_KEY ? onSettings : undefined}
+          onDismiss={() => clearToast(key)}
+        />
+      ))}
     </AnimatePresence>
+  );
+}
+
+interface ToastBannerProps {
+  toast: Toast;
+  index: number;
+  onRetry?: () => void;
+  onSettings?: () => void;
+  onDismiss: () => void;
+}
+
+function ToastBanner({
+  toast,
+  index,
+  onRetry,
+  onSettings,
+  onDismiss,
+}: ToastBannerProps) {
+  // Stack countdown toasts from the top and plain toasts from the bottom,
+  // offsetting each by its index so multiple concurrent disconnects don't
+  // overlap. 72px ≈ one toast row + breathing room.
+  const stackOffset = `${index * 72}px`;
+
+  return (
+    <motion.div
+      className={
+        "fixed z-50 flex items-center gap-3 rounded-lg bg-gray-900 px-4 py-3 shadow-2xl ring-1 " +
+        (toast.showCountdown
+          ? "left-1/2 -translate-x-1/2 ring-amber-500/60"
+          : "left-1/2 -translate-x-1/2 ring-red-700/50")
+      }
+      style={
+        toast.showCountdown
+          ? { top: `calc(1.5rem + ${stackOffset})` }
+          : { bottom: `calc(1.5rem + ${stackOffset})` }
+      }
+      initial={{ opacity: 0, y: toast.showCountdown ? -20 : 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: toast.showCountdown ? -20 : 20 }}
+      transition={{ duration: 0.25 }}
+    >
+      {toast.showCountdown && (
+        <span
+          aria-hidden="true"
+          className="text-amber-400"
+          title="Opponent disconnected"
+        >
+          !
+        </span>
+      )}
+      <span className="text-sm text-gray-200">
+        {toast.message}
+        {toast.showCountdown && (
+          <span className="ml-2 font-mono text-amber-200">
+            — {secondsRemaining(toast.expiresAt)}s to forfeit
+          </span>
+        )}
+      </span>
+      {!toast.showCountdown && (
+        <div className="flex gap-2">
+          {onRetry && (
+            <button
+              onClick={() => {
+                onDismiss();
+                onRetry();
+              }}
+              className="rounded bg-red-600/80 px-2.5 py-1 text-xs font-semibold text-white transition hover:bg-red-500"
+            >
+              Retry
+            </button>
+          )}
+          {onSettings && (
+            <button
+              onClick={() => {
+                onDismiss();
+                onSettings();
+              }}
+              className="rounded bg-gray-700 px-2.5 py-1 text-xs font-semibold text-gray-300 transition hover:bg-gray-600"
+            >
+              Settings
+            </button>
+          )}
+        </div>
+      )}
+    </motion.div>
   );
 }

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -69,6 +69,7 @@ import { useUiStore } from "../stores/uiStore.ts";
 import { usePreferencesStore } from "../stores/preferencesStore.ts";
 import {
   FORMAT_DEFAULTS,
+  playerToastKey,
   useMultiplayerStore,
 } from "../stores/multiplayerStore.ts";
 import { GameProvider } from "../providers/GameProvider.tsx";
@@ -121,7 +122,6 @@ export function GamePage() {
   const [hostGameCode, setHostGameCode] = useState<string | null>(null);
   const [waitingForOpponent, setWaitingForOpponent] = useState(false);
   const [opponentDisconnected, setOpponentDisconnected] = useState(false);
-  const [disconnectGrace, setDisconnectGrace] = useState(0);
   const [reconnectState, setReconnectState] = useState<
     | { status: "idle" }
     | { status: "reconnecting"; attempt: number; maxAttempts: number }
@@ -154,23 +154,27 @@ export function GamePage() {
       case "waitingForOpponent":
         setWaitingForOpponent(true);
         break;
-      case "opponentDisconnected":
+      case "opponentDisconnected": {
         setOpponentDisconnected(true);
-        setDisconnectGrace(event.graceSeconds);
         // 2-player: mark the single opponent as disconnected
-        {
-          const myId = useMultiplayerStore.getState().activePlayerId ?? 0;
-          useMultiplayerStore.getState().setPlayerDisconnected(myId === 0 ? 1 : 0);
-        }
+        const myId = useMultiplayerStore.getState().activePlayerId ?? 0;
+        const oppId = myId === 0 ? 1 : 0;
+        useMultiplayerStore.getState().setPlayerDisconnected(oppId);
+        useMultiplayerStore.getState().showToast("Opponent disconnected", {
+          countdownSeconds: event.graceSeconds,
+          key: playerToastKey(oppId),
+        });
         break;
-      case "opponentReconnected":
+      }
+      case "opponentReconnected": {
         setOpponentDisconnected(false);
         // 2-player: clear disconnected status
-        {
-          const myId = useMultiplayerStore.getState().activePlayerId ?? 0;
-          useMultiplayerStore.getState().setPlayerReconnected(myId === 0 ? 1 : 0);
-        }
+        const myId = useMultiplayerStore.getState().activePlayerId ?? 0;
+        const oppId = myId === 0 ? 1 : 0;
+        useMultiplayerStore.getState().setPlayerReconnected(oppId);
+        useMultiplayerStore.getState().clearToast(playerToastKey(oppId));
         break;
+      }
       case "reconnecting":
         setReconnectState({
           status: "reconnecting",
@@ -225,23 +229,38 @@ export function GamePage() {
       case "playerDisconnected":
         // Multiplayer (3+ players): a specific player disconnected
         setOpponentDisconnected(true);
-        setDisconnectGrace(event.graceSeconds);
         useMultiplayerStore.getState().setPlayerDisconnected(event.playerId);
+        useMultiplayerStore.getState().showToast(
+          `Player ${event.playerId + 1} disconnected`,
+          {
+            countdownSeconds: event.graceSeconds,
+            key: playerToastKey(event.playerId),
+          },
+        );
         break;
       case "playerReconnected":
         useMultiplayerStore.getState().setPlayerReconnected(event.playerId);
-        // Clear overlay only if no players remain disconnected
+        useMultiplayerStore.getState().clearToast(playerToastKey(event.playerId));
         if (useMultiplayerStore.getState().disconnectedPlayers.size === 0) {
           setOpponentDisconnected(false);
         }
         break;
       case "gamePaused":
         setOpponentDisconnected(true);
-        setDisconnectGrace(event.timeoutSeconds);
         useMultiplayerStore.getState().setPlayerDisconnected(event.disconnectedPlayer);
+        useMultiplayerStore.getState().showToast(
+          `Game paused — Player ${event.disconnectedPlayer + 1} disconnected`,
+          {
+            countdownSeconds: event.timeoutSeconds,
+            key: playerToastKey(event.disconnectedPlayer),
+          },
+        );
         break;
       case "gameResumed":
         setOpponentDisconnected(false);
+        // Clear per-player disconnect toasts only. Generic toasts (errors,
+        // connection warnings) are independent of the pause/resume cycle.
+        useMultiplayerStore.getState().clearPlayerToasts();
         break;
       case "playerEliminated":
         // Store-level side effects (isSpectator, toast) already handled in ws-adapter
@@ -362,7 +381,6 @@ export function GamePage() {
         hostGameCode={hostGameCode}
         waitingForOpponent={waitingForOpponent}
         opponentDisconnected={opponentDisconnected}
-        disconnectGrace={disconnectGrace}
         reconnectState={reconnectState}
         showCardDataMissing={showCardDataMissing}
         onDismissCardDataMissing={() => setShowCardDataMissing(false)}
@@ -390,7 +408,6 @@ interface GamePageContentProps {
   hostGameCode: string | null;
   waitingForOpponent: boolean;
   opponentDisconnected: boolean;
-  disconnectGrace: number;
   reconnectState:
     | { status: "idle" }
     | { status: "reconnecting"; attempt: number; maxAttempts: number }
@@ -419,7 +436,6 @@ function GamePageContent({
   hostGameCode,
   waitingForOpponent,
   opponentDisconnected,
-  disconnectGrace,
   reconnectState,
   showCardDataMissing,
   onDismissCardDataMissing,
@@ -856,12 +872,11 @@ function GamePageContent({
       )}
 
       {/*
-        Opponent disconnected overlays.
-
-        Server (WS) disconnects still use the static yellow overlay since
-        server mode doesn't yet emit `opponentDisconnectedWithChoice`. P2P
-        disconnects use the new `DisconnectChoiceDialog` (host) and
-        `PausedBanner` (everyone) — see plan §6 + adapter §4.
+        Opponent-disconnected overlay for server (WS) games. The live
+        "N seconds to forfeit" countdown lives on `ConnectionToast`, keyed
+        by player — this modal just communicates the blocking/paused state
+        of the game screen. P2P games use `DisconnectChoiceDialog` +
+        `PausedBanner` instead (see adapter §4).
       */}
       {opponentDisconnected && !pauseReason && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -872,9 +887,6 @@ function GamePageContent({
             </h2>
             <p className="text-sm text-gray-300">
               Waiting for opponent to reconnect...
-            </p>
-            <p className="mt-2 text-xs text-gray-500">
-              Game will forfeit in {disconnectGrace}s
             </p>
           </div>
         </div>

--- a/client/src/pages/MultiplayerPage.tsx
+++ b/client/src/pages/MultiplayerPage.tsx
@@ -66,6 +66,14 @@ export function MultiplayerPage() {
   // not in the store, because it's scoped to the Multiplayer flow.
   const [serverOfflinePrompt, setServerOfflinePrompt] = useState(false);
   const [lobbyRetryKey, setLobbyRetryKey] = useState(0);
+  // Where to return when the user enters deck-select *without* a pending
+  // host/join action (i.e. clicked the "Change" affordance on the active-
+  // deck banner). Before this, back/confirm both assumed pendingAction
+  // was set, so leaving deck-select dumped the user into the lobby even
+  // when they came from host-setup — and from lobby, another back escaped
+  // multiplayer entirely.
+  const [deckSelectReturn, setDeckSelectReturn] =
+    useState<MultiplayerView>("lobby");
   const serverAddress = useMultiplayerStore((s) => s.serverAddress);
 
   useEffect(() => {
@@ -80,9 +88,26 @@ export function MultiplayerPage() {
     }
   }, [hostingStatus, view]);
 
+  // In deck-select, tapping a deck tile IS the confirmation — there's no
+  // other use for the screen since we don't show deck contents. We persist
+  // the choice, then either execute the pending host/join action or return
+  // to wherever the user triggered the "Change" affordance from.
   const handleSelectDeck = (name: string) => {
     setActiveDeckName(name);
     localStorage.setItem(ACTIVE_DECK_KEY, name);
+
+    // Only auto-advance out of deck-select. When this handler fires from
+    // other views (e.g. adopting an imported deck), we don't want to
+    // navigate; we're just recording the active-deck choice.
+    if (view !== "deck-select") return;
+
+    if (pendingAction) {
+      if (executeAction(pendingAction)) {
+        setPendingAction(null);
+      }
+      return;
+    }
+    setView(deckSelectReturn);
   };
 
   // Expand a ParsedDeck into flat name arrays for the server
@@ -171,14 +196,6 @@ export function MultiplayerPage() {
     [expandDeck, startHosting, navigate, showToast],
   );
 
-  // Execute pending action after deck is selected (fallback path)
-  const handleDeckConfirm = useCallback(() => {
-    if (!pendingAction) return;
-    if (executeAction(pendingAction)) {
-      setPendingAction(null);
-    }
-  }, [pendingAction, executeAction]);
-
   // Host setup complete → execute immediately if deck exists, otherwise prompt
   const handleHostSetupComplete = useCallback(
     (settings: HostSettings) => {
@@ -225,7 +242,16 @@ export function MultiplayerPage() {
       return;
     }
     if (view === "deck-select") {
-      setView(pendingAction?.type === "host" ? "host-setup" : "lobby");
+      // With a pending action the user clearly came from a host/join
+      // attempt; without one they came from the "Change Deck" affordance,
+      // and `deckSelectReturn` remembers which view rendered that button.
+      setView(
+        pendingAction?.type === "host"
+          ? "host-setup"
+          : pendingAction?.type === "join"
+            ? "lobby"
+            : deckSelectReturn,
+      );
       return;
     }
     if (view === "host-setup") {
@@ -295,6 +321,7 @@ export function MultiplayerPage() {
             </div>
             <button
               onClick={() => {
+                setDeckSelectReturn(view as MultiplayerView);
                 setPendingAction(null);
                 setView("deck-select");
               }}
@@ -312,7 +339,10 @@ export function MultiplayerPage() {
               No deck selected — you'll need to pick one before hosting or joining.
             </span>
             <button
-              onClick={() => setView("deck-select")}
+              onClick={() => {
+                setDeckSelectReturn(view as MultiplayerView);
+                setView("deck-select");
+              }}
               className="shrink-0 rounded-lg border border-amber-400/20 bg-amber-400/10 px-3 py-1 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-400/18"
             >
               Pick Deck
@@ -371,13 +401,15 @@ export function MultiplayerPage() {
                 </div>
               </div>
             )}
+            {/* No `onConfirmSelection` / `confirmLabel` — clicking a deck
+                tile IS the confirmation. `handleSelectDeck` saves the
+                choice and either executes the pending action or returns
+                to the caller view in one step. */}
             <MyDecks
               mode="select"
               selectedFormat={selectedFormat}
               onSelectDeck={handleSelectDeck}
               activeDeckName={activeDeckName}
-              onConfirmSelection={handleDeckConfirm}
-              confirmLabel={pendingAction?.type === "host" ? "Host Game" : "Join Game"}
             />
           </>
         )}

--- a/client/src/pages/MultiplayerPage.tsx
+++ b/client/src/pages/MultiplayerPage.tsx
@@ -261,13 +261,21 @@ export function MultiplayerPage() {
     navigate("/");
   };
 
-  // Derive selected format for deck filtering
+  // Derive the format the deck picker filters by.
+  //
+  // The happy paths (host-submit-without-deck, join-from-lobby-row) carry
+  // the format on `pendingAction`. When the user clicks "Change Deck" out
+  // of host-setup, `pendingAction` is null — but HostSetup mirrors its
+  // in-flight format into the store on every change, so falling back to
+  // `storeFormatConfig` gives the deck picker the right filter without
+  // any cross-component plumbing.
+  const storeFormatConfig = useMultiplayerStore((s) => s.formatConfig);
   const selectedFormat: GameFormat | undefined =
     pendingAction?.type === "host"
       ? pendingAction.settings.formatConfig.format
       : pendingAction?.type === "join"
         ? pendingAction.format
-        : undefined;
+        : storeFormatConfig?.format;
 
   const title =
     view === "lobby"

--- a/client/src/pages/MultiplayerPage.tsx
+++ b/client/src/pages/MultiplayerPage.tsx
@@ -5,7 +5,10 @@ import type { GameFormat } from "../adapter/types";
 import { useAudioContext } from "../audio/useAudioContext";
 import { ScreenChrome } from "../components/chrome/ScreenChrome";
 import { HostSetup } from "../components/lobby/HostSetup";
+import type { LobbyGame } from "../components/lobby/GameListItem";
 import { LobbyView } from "../components/lobby/LobbyView";
+import { PlayerIdentityBanner } from "../components/lobby/PlayerIdentityBanner";
+import { ServerOfflinePrompt } from "../components/lobby/ServerOfflinePrompt";
 import { WaitingScreen } from "../components/lobby/WaitingScreen";
 import { ConnectionToast } from "../components/multiplayer/ConnectionToast";
 import { MenuParticles } from "../components/menu/MenuParticles";
@@ -23,7 +26,19 @@ type MultiplayerView = "lobby" | "host-setup" | "deck-select" | "waiting";
 
 type PendingAction =
   | { type: "host"; settings: HostSettings; connectionMode: ConnectionMode }
-  | { type: "join"; code: string; password?: string; format?: GameFormat };
+  | {
+      type: "join";
+      code: string;
+      password?: string;
+      format?: GameFormat;
+      /**
+       * Full lobby row, populated when the join originated from a lobby list
+       * click (not from a typed code). Lets the deck-select view render
+       * "Joining Alice's Commander game — 2/4" so the user doesn't lose the
+       * thread between clicking a game and picking a deck.
+       */
+      context?: LobbyGame;
+    };
 
 export function MultiplayerPage() {
   useAudioContext("lobby");
@@ -45,6 +60,13 @@ export function MultiplayerPage() {
   const [connectionMode, setConnectionMode] = useState<ConnectionMode>("server");
   const [showSettings, setShowSettings] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  // Shown when `LobbyView` detects the server is unreachable. The user picks
+  // between staying in server mode (LobbyView remounts via `lobbyRetryKey` and
+  // retries) or flipping to P2P for direct-code play. Tracked on this page,
+  // not in the store, because it's scoped to the Multiplayer flow.
+  const [serverOfflinePrompt, setServerOfflinePrompt] = useState(false);
+  const [lobbyRetryKey, setLobbyRetryKey] = useState(0);
+  const serverAddress = useMultiplayerStore((s) => s.serverAddress);
 
   useEffect(() => {
     setActiveDeckName(localStorage.getItem(ACTIVE_DECK_KEY));
@@ -103,9 +125,18 @@ export function MultiplayerPage() {
         if (action.connectionMode === "p2p") {
           const gameId = crypto.randomUUID();
           useGameStore.setState({ gameId });
-          navigate(
-            `/game/${gameId}?mode=p2p-host&match=${action.settings.matchType.toLowerCase()}`,
-          );
+          // Thread format + seat count into the URL — `GamePage` rehydrates
+          // them into `formatConfig` / `playerCount` which flow to
+          // `P2PHostAdapter`. Without these params, P2P host silently
+          // defaults to 2-player Standard regardless of what the user
+          // selected in HostSetup.
+          const params = new URLSearchParams({
+            mode: "p2p-host",
+            match: action.settings.matchType.toLowerCase(),
+            format: action.settings.formatConfig.format,
+            players: String(action.settings.formatConfig.max_players),
+          });
+          navigate(`/game/${gameId}?${params.toString()}`);
         } else {
           startHosting(action.settings, deck);
           // Navigate to main menu — the HostingBanner takes over as the
@@ -164,8 +195,19 @@ export function MultiplayerPage() {
 
   // Join from lobby → execute immediately if deck exists, otherwise prompt
   const handleJoinGame = useCallback(
-    (code: string, password?: string, format?: GameFormat) => {
-      const action: PendingAction = { type: "join", code, password, format };
+    (
+      code: string,
+      password?: string,
+      format?: GameFormat,
+      context?: LobbyGame,
+    ) => {
+      const action: PendingAction = {
+        type: "join",
+        code,
+        password,
+        format,
+        context,
+      };
       if (activeDeckName) {
         executeAction(action);
       } else {
@@ -236,6 +278,12 @@ export function MultiplayerPage() {
 
       <MenuShell eyebrow="Multiplayer" title={title} description={description} layout="stacked">
         <div className="flex w-full flex-col items-center">
+        {/* Player identity — always available on lobby/host-setup so users
+            can edit their name without hunting in Preferences. Sits above
+            the deck banner so the two "about you" rows (name + deck) stack
+            as a unit. */}
+        {(view === "lobby" || view === "host-setup") && <PlayerIdentityBanner />}
+
         {/* Active deck indicator — shown on lobby/host-setup when a deck is selected */}
         {(view === "lobby" || view === "host-setup") && activeDeckName && (
           <div className="mx-auto mb-4 flex w-full max-w-xl items-center justify-between gap-3 rounded-[16px] border border-white/8 bg-black/16 px-4 py-2.5">
@@ -274,11 +322,19 @@ export function MultiplayerPage() {
 
         {view === "lobby" && (
           <LobbyView
+            key={lobbyRetryKey}
             onHostGame={() => { setConnectionMode("server"); setView("host-setup"); }}
             onHostP2P={() => { setConnectionMode("p2p"); setView("host-setup"); }}
             onJoinGame={handleJoinGame}
             connectionMode={connectionMode}
-            onServerOffline={() => setConnectionMode("p2p")}
+            onServerOffline={() => {
+              // Only prompt when we're actually trying to use the server; if
+              // the user already flipped to P2P the "unreachable" state is
+              // expected and not worth interrupting.
+              if (connectionMode === "server") {
+                setServerOfflinePrompt(true);
+              }
+            }}
           />
         )}
 
@@ -291,14 +347,39 @@ export function MultiplayerPage() {
         )}
 
         {view === "deck-select" && (
-          <MyDecks
-            mode="select"
-            selectedFormat={selectedFormat}
-            onSelectDeck={handleSelectDeck}
-            activeDeckName={activeDeckName}
-            onConfirmSelection={handleDeckConfirm}
-            confirmLabel={pendingAction?.type === "host" ? "Host Game" : "Join Game"}
-          />
+          <>
+            {pendingAction?.type === "join" && pendingAction.context && (
+              <div className="mx-auto mb-4 w-full max-w-xl rounded-[16px] border border-cyan-400/20 bg-cyan-500/[0.07] px-4 py-2.5">
+                <div className="text-[0.6rem] uppercase tracking-[0.22em] text-cyan-300/70">
+                  Joining
+                </div>
+                <div className="mt-1 text-sm text-cyan-100">
+                  <span className="font-medium">
+                    {pendingAction.context.host_name || "Anonymous"}
+                  </span>
+                  {pendingAction.context.format && (
+                    <span className="text-cyan-200/70">
+                      {" "}· {pendingAction.context.format}
+                    </span>
+                  )}
+                  {pendingAction.context.max_players != null && (
+                    <span className="text-cyan-200/70">
+                      {" "}· {pendingAction.context.current_players ?? 1}/
+                      {pendingAction.context.max_players}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+            <MyDecks
+              mode="select"
+              selectedFormat={selectedFormat}
+              onSelectDeck={handleSelectDeck}
+              activeDeckName={activeDeckName}
+              onConfirmSelection={handleDeckConfirm}
+              confirmLabel={pendingAction?.type === "host" ? "Host Game" : "Join Game"}
+            />
+          </>
         )}
 
         {view === "waiting" && hostGameCode && (
@@ -314,6 +395,22 @@ export function MultiplayerPage() {
         </div>
       </MenuShell>
       <ConnectionToast />
+      {serverOfflinePrompt && view === "lobby" && (
+        <ServerOfflinePrompt
+          serverAddress={serverAddress}
+          onUseDirect={() => {
+            setConnectionMode("p2p");
+            setServerOfflinePrompt(false);
+          }}
+          onKeepWaiting={() => {
+            setServerOfflinePrompt(false);
+            // Force LobbyView to unmount + remount with a fresh WebSocket
+            // connection attempt. All local state in LobbyView resets, which
+            // is intentional — we want a clean retry.
+            setLobbyRetryKey((k) => k + 1);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 import type { FormatConfig, GameFormat, MatchType, PlayerId } from "../adapter/types";
+import { PROTOCOL_VERSION, type ServerInfo } from "../adapter/ws-adapter";
 import {
   clearWsSession,
   loadWsSession,
@@ -21,6 +22,26 @@ let gameStartedFired = false;
 let hostReconnectAttempt = 0;
 let hostReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 const HOST_MAX_RECONNECT_ATTEMPTS = 3;
+
+/**
+ * The first frame the hosting WS would have sent (CreateGameWithSettings or
+ * Reconnect) is deferred until the server's ServerHello is received, so a
+ * version-mismatched connection never registers a lobby or claims a session.
+ */
+let hostHandshakeContinuation: (() => void) | null = null;
+
+function sendClientHello(ws: WebSocket): void {
+  ws.send(
+    JSON.stringify({
+      type: "ClientHello",
+      data: {
+        client_version: __APP_VERSION__,
+        build_commit: __BUILD_HASH__,
+        protocol_version: PROTOCOL_VERSION,
+      },
+    }),
+  );
+}
 
 export interface AiSeatConfig {
   seatIndex: number;
@@ -42,6 +63,9 @@ export interface HostingSettings {
   formatConfig: FormatConfig;
   matchType: MatchType;
   aiSeats: AiSeatConfig[];
+  /** Optional per-match label shown in the lobby, distinct from `displayName`
+   * (the player's global identity). `null` means "use the player's name". */
+  roomName: string | null;
 }
 
 export interface PlayerSlot {
@@ -53,6 +77,38 @@ export interface PlayerSlot {
   deckName: string | null;
 }
 
+/** Single toast entry keyed by caller.
+ *
+ * `expiresAt` is always set (absolute wall-clock ms) — both plain and
+ * countdown toasts auto-dismiss by comparing `expiresAt <= Date.now()`,
+ * which is immune to Map-mutation re-renders that would otherwise reset a
+ * relative `setTimeout`. Plain toasts use a fixed 5s window; countdown
+ * toasts use `countdownSeconds` from the caller.
+ *
+ * `showCountdown` controls the "Ns to forfeit" suffix in the UI, keeping
+ * the visual treatment (amber banner at top vs. red at bottom) orthogonal
+ * to the dismissal mechanism.
+ */
+export interface Toast {
+  message: string;
+  expiresAt: number;
+  showCountdown: boolean;
+}
+
+/** Default auto-dismiss window for plain toasts. */
+const PLAIN_TOAST_DURATION_MS = 5000;
+
+/** Stable key for opponent-disconnect toasts so multiple concurrent
+ * disconnects in a 3+ player game stack instead of stomping each other. */
+export function playerToastKey(playerId: number): string {
+  return `player:${playerId}`;
+}
+
+/** Default slot for toasts that don't care about coexisting with others
+ * (generic errors, own-reconnect banners). Matches the pre-map single-slot
+ * behavior: repeated generic toasts replace each other. */
+const GENERIC_TOAST_KEY = "generic";
+
 interface MultiplayerState {
   playerId: string;
   displayName: string;
@@ -60,7 +116,9 @@ interface MultiplayerState {
   connectionStatus: ConnectionStatus;
   activePlayerId: PlayerId | null;
   opponentDisplayName: string | null;
-  toastMessage: string | null;
+  /** Keyed toast stack. Iteration order = insertion order (Map guarantee),
+   * so the UI renders them top-down in the order they were raised. */
+  toasts: Map<string, Toast>;
   formatConfig: FormatConfig | null;
   playerSlots: PlayerSlot[];
   spectators: string[];
@@ -75,6 +133,10 @@ interface MultiplayerState {
   hostIsPublic: boolean;
   hostingStatus: HostingStatus;
   pendingGameRoute: string | null;
+  // Server identity from the most recent ServerHello (ephemeral — not persisted).
+  // null before the first hello; updated when the hosting WS or the game WS
+  // completes its handshake.
+  serverInfo: ServerInfo | null;
 }
 
 interface MultiplayerActions {
@@ -83,8 +145,25 @@ interface MultiplayerActions {
   setConnectionStatus: (status: ConnectionStatus) => void;
   setActivePlayerId: (id: PlayerId | null) => void;
   setOpponentDisplayName: (name: string | null) => void;
-  showToast: (message: string) => void;
-  clearToast: () => void;
+  /**
+   * Show a transient toast. When `opts.countdownSeconds` is provided, the
+   * toast renders a live countdown and persists until it reaches zero or
+   * is explicitly cleared; otherwise it auto-dismisses after 5 seconds.
+   * `opts.key` lets concurrent toasts coexist (e.g. `playerToastKey(pid)`);
+   * omitted keys all share the "generic" slot (old behavior).
+   */
+  showToast: (
+    message: string,
+    opts?: { countdownSeconds?: number; key?: string },
+  ) => void;
+  /** Clear one toast. No key → clear the generic slot only. */
+  clearToast: (key?: string) => void;
+  /** Clear only player-disconnect toasts (`player:*` keys). Leaves generic
+   * toasts like connection errors intact. Use on `gameResumed`. */
+  clearPlayerToasts: () => void;
+  /** Clear every toast. Rarely needed — prefer `clearPlayerToasts()` or
+   * keyed `clearToast()`. Retained for full-reset paths. */
+  clearAllToasts: () => void;
   setFormatConfig: (config: FormatConfig | null) => void;
   setPlayerSlots: (slots: PlayerSlot[]) => void;
   toggleReady: (playerId: string) => void;
@@ -98,6 +177,28 @@ interface MultiplayerActions {
   startHosting: (settings: HostingSettings, deck: HostingDeck) => void;
   cancelHosting: () => void;
   clearPendingGameRoute: () => void;
+  setServerInfo: (info: ServerInfo | null) => void;
+}
+
+/**
+ * Checks whether a lobby entry's host is running a compatible build with the
+ * given server snapshot. Used by the lobby list to disable incompatible rows.
+ * A missing `hostBuildCommit` (restored session, legacy entry) is treated as
+ * unknown-but-allowed, matching the server's behavior at the join gate.
+ */
+export function isLobbyEntryCompatible(
+  hostBuildCommit: string | undefined,
+  serverInfo: ServerInfo | null,
+): boolean {
+  if (!serverInfo) return true;
+  if (!hostBuildCommit) return true;
+  return hostBuildCommit === serverInfo.buildCommit;
+}
+
+/** True when the client's wire-protocol matches the server's. */
+export function isServerCompatible(info: ServerInfo | null): boolean {
+  if (!info) return false;
+  return info.protocolVersion === PROTOCOL_VERSION;
 }
 
 export const FORMAT_DEFAULTS: Record<GameFormat, FormatConfig> = {
@@ -220,7 +321,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       connectionStatus: "disconnected",
       activePlayerId: null,
       opponentDisplayName: null,
-      toastMessage: null,
+      toasts: new Map(),
       formatConfig: null,
       playerSlots: [],
       spectators: [],
@@ -232,14 +333,52 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       hostIsPublic: false,
       hostingStatus: "idle" as HostingStatus,
       pendingGameRoute: null,
+      serverInfo: null,
 
+      setServerInfo: (info) => set({ serverInfo: info }),
       setDisplayName: (name) => set({ displayName: name }),
       setServerAddress: (address) => set({ serverAddress: address }),
       setConnectionStatus: (status) => set({ connectionStatus: status }),
       setActivePlayerId: (id) => set({ activePlayerId: id }),
       setOpponentDisplayName: (name) => set({ opponentDisplayName: name }),
-      showToast: (message) => set({ toastMessage: message }),
-      clearToast: () => set({ toastMessage: null }),
+      showToast: (message, opts) =>
+        set((state) => {
+          const key = opts?.key ?? GENERIC_TOAST_KEY;
+          const isCountdown = opts?.countdownSeconds != null;
+          const expiresAt = isCountdown
+            ? Date.now() + opts!.countdownSeconds! * 1000
+            : Date.now() + PLAIN_TOAST_DURATION_MS;
+          const next = new Map(state.toasts);
+          next.set(key, { message, expiresAt, showCountdown: isCountdown });
+          return { toasts: next };
+        }),
+      clearToast: (key) =>
+        set((state) => {
+          const k = key ?? GENERIC_TOAST_KEY;
+          if (!state.toasts.has(k)) return {};
+          const next = new Map(state.toasts);
+          next.delete(k);
+          return { toasts: next };
+        }),
+      /** Clear every player-disconnect toast. Used on `gameResumed`, which is
+       * a server-wide resume — any per-player countdown is moot, but generic
+       * toasts (errors, connection warnings) should survive. */
+      clearPlayerToasts: () =>
+        set((state) => {
+          let changed = false;
+          const next = new Map(state.toasts);
+          for (const key of state.toasts.keys()) {
+            if (key.startsWith("player:")) {
+              next.delete(key);
+              changed = true;
+            }
+          }
+          return changed ? { toasts: next } : {};
+        }),
+      clearAllToasts: () =>
+        set((state) =>
+          state.toasts.size === 0 ? {} : { toasts: new Map() },
+        ),
       setFormatConfig: (config) => set({ formatConfig: config }),
       setPlayerSlots: (slots) => set({ playerSlots: slots }),
       toggleReady: (playerId) =>
@@ -288,7 +427,33 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
 
         // Shared message handler for both initial and reconnect WebSockets
         const handleHostMessage = (ws: WebSocket, msg: { type: string; data?: unknown }) => {
-          if (msg.type === "GameCreated") {
+          if (msg.type === "ServerHello") {
+            const data = msg.data as {
+              server_version: string;
+              build_commit: string;
+              protocol_version: number;
+              mode: "Full" | "LobbyOnly";
+            };
+            const info: ServerInfo = {
+              version: data.server_version,
+              buildCommit: data.build_commit,
+              protocolVersion: data.protocol_version,
+              mode: data.mode,
+            };
+            set({ serverInfo: info });
+            if (info.protocolVersion !== PROTOCOL_VERSION) {
+              hostHandshakeContinuation = null;
+              ws.close();
+              get().showToast(
+                `Server protocol version ${info.protocolVersion} does not match client ${PROTOCOL_VERSION}. Please refresh.`,
+              );
+              get().cancelHosting();
+              return;
+            }
+            const cont = hostHandshakeContinuation;
+            hostHandshakeContinuation = null;
+            cont?.();
+          } else if (msg.type === "GameCreated") {
             const data = msg.data as { game_code: string; player_token: string };
             saveWsSession({
               gameCode: data.game_code,
@@ -319,7 +484,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
           } else if (msg.type === "Error") {
             const data = msg.data as { message: string };
             console.error("Host error:", data.message);
-            set({ toastMessage: data.message || "Failed to create game." });
+            get().showToast(data.message || "Failed to create game.");
             get().cancelHosting();
           }
         };
@@ -336,8 +501,8 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
               hostIsPublic: false,
               hostingStatus: "idle",
               playerSlots: [],
-              toastMessage: "Connection to server lost.",
             });
+            get().showToast("Connection to server lost.");
             return;
           }
 
@@ -354,23 +519,26 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
                 hostIsPublic: false,
                 hostingStatus: "idle",
                 playerSlots: [],
-                toastMessage: "Invalid server address. Update it in Settings.",
               });
+              get().showToast("Invalid server address. Update it in Settings.");
               return;
             }
             const rws = new WebSocket(get().serverAddress);
             hostWs = rws;
 
             rws.onopen = () => {
-              rws.send(
-                JSON.stringify({
-                  type: "Reconnect",
-                  data: {
-                    game_code: session.gameCode,
-                    player_token: session.playerToken,
-                  },
-                }),
-              );
+              hostHandshakeContinuation = () => {
+                rws.send(
+                  JSON.stringify({
+                    type: "Reconnect",
+                    data: {
+                      game_code: session.gameCode,
+                      player_token: session.playerToken,
+                    },
+                  }),
+                );
+              };
+              sendClientHello(rws);
             };
 
             rws.onmessage = (event) => {
@@ -404,30 +572,34 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
             hostIsPublic: false,
             hostingStatus: "idle",
             playerSlots: [],
-            toastMessage: "Invalid server address. Update it in Settings.",
           });
+          get().showToast("Invalid server address. Update it in Settings.");
           return;
         }
         const ws = new WebSocket(get().serverAddress);
         hostWs = ws;
 
         ws.onopen = () => {
-          ws.send(
-            JSON.stringify({
-              type: "CreateGameWithSettings",
-              data: {
-                deck: { main_deck: deck.main_deck, sideboard: deck.sideboard, commander: deck.commander ?? [] },
-                display_name: settings.displayName,
-                public: settings.public,
-                password: settings.password || null,
-                timer_seconds: settings.timerSeconds,
-                player_count: settings.formatConfig.max_players,
-                match_config: { match_type: settings.matchType },
-                format_config: settings.formatConfig,
-                ai_seats: settings.aiSeats,
-              },
-            }),
-          );
+          hostHandshakeContinuation = () => {
+            ws.send(
+              JSON.stringify({
+                type: "CreateGameWithSettings",
+                data: {
+                  deck: { main_deck: deck.main_deck, sideboard: deck.sideboard, commander: deck.commander ?? [] },
+                  display_name: settings.displayName,
+                  public: settings.public,
+                  password: settings.password || null,
+                  timer_seconds: settings.timerSeconds,
+                  player_count: settings.formatConfig.max_players,
+                  match_config: { match_type: settings.matchType },
+                  format_config: settings.formatConfig,
+                  ai_seats: settings.aiSeats,
+                  room_name: settings.roomName,
+                },
+              }),
+            );
+          };
+          sendClientHello(ws);
         };
 
         ws.onmessage = (event) => {
@@ -464,6 +636,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
         }
         gameStartedFired = false;
         hostReconnectAttempt = 0;
+        hostHandshakeContinuation = null;
         clearWsSession();
         set({
           hostGameCode: null,

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
   plugins: [wasmStubPlugin()],
   define: {
     __SCRYFALL_DATA_URL__: JSON.stringify("/scryfall-data.json"),
+    __APP_VERSION__: JSON.stringify("0.0.0-test"),
+    __BUILD_HASH__: JSON.stringify("testhash"),
   },
   test: {
     environment: "happy-dom",

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -22,8 +22,10 @@ use engine::game::{validate_deck_for_format, DeckCompatibilityRequest};
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
 use http::HeaderValue;
-use server_core::lobby::LobbyManager;
-use server_core::protocol::{ClientMessage, ServerMessage};
+use server_core::lobby::{LobbyManager, RegisterGameRequest};
+use server_core::protocol::{
+    build_commit, ClientMessage, ServerMessage, ServerMode, PROTOCOL_VERSION,
+};
 use server_core::resolve_deck;
 use server_core::session::SessionManager;
 use tokio::sync::{mpsc, Mutex};
@@ -110,6 +112,91 @@ struct SocketIdentity {
     lobby_subscribed: bool,
     /// Span for field inheritance — all events within this connection inherit game + player fields.
     session_span: Option<tracing::Span>,
+    /// Set after a successful `ClientHello`. Until this is `Some`, only
+    /// `ClientMessage::ClientHello` is accepted. Carries the client's build
+    /// identity so downstream handlers (`CreateGameWithSettings`,
+    /// `JoinGameWithPassword`) can stamp / compare against host builds.
+    client_hello: Option<ClientHelloInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClientHelloInfo {
+    client_version: String,
+    build_commit: String,
+}
+
+/// Outcome of evaluating the handshake gate against an incoming message.
+/// Extracted into a pure function so the gate's invariants can be unit-tested
+/// without spinning up a real WebSocket.
+#[derive(Debug, PartialEq, Eq)]
+enum HelloGateOutcome {
+    /// First ClientHello on this socket, compatible protocol — store the info
+    /// and continue the message loop (no further processing for this frame).
+    Accept(ClientHelloInfo),
+    /// ClientHello arrived but declares an incompatible protocol version.
+    /// Send Error with this (client, server) pair and drop the frame.
+    RejectProtocol { client: u32, server: u32 },
+    /// A non-hello frame arrived before the handshake completed. Send Error
+    /// ("ClientHello required before any other message") and drop.
+    RejectHandshakeRequired,
+    /// Handshake already completed and another ClientHello arrived. Ignore
+    /// silently — this is a harmless misbehavior, not an error.
+    IgnoreRedundantHello,
+    /// Handshake already completed and a regular frame arrived — let the
+    /// downstream match in `handle_client_message` handle it.
+    PassThrough,
+}
+
+fn classify_hello_gate(
+    hello_received: bool,
+    msg: &ClientMessage,
+    server_protocol: u32,
+) -> HelloGateOutcome {
+    match (hello_received, msg) {
+        (
+            false,
+            ClientMessage::ClientHello {
+                client_version,
+                build_commit,
+                protocol_version,
+            },
+        ) => {
+            if *protocol_version != server_protocol {
+                HelloGateOutcome::RejectProtocol {
+                    client: *protocol_version,
+                    server: server_protocol,
+                }
+            } else {
+                HelloGateOutcome::Accept(ClientHelloInfo {
+                    client_version: client_version.clone(),
+                    build_commit: build_commit.clone(),
+                })
+            }
+        }
+        (false, _) => HelloGateOutcome::RejectHandshakeRequired,
+        (true, ClientMessage::ClientHello { .. }) => HelloGateOutcome::IgnoreRedundantHello,
+        (true, _) => HelloGateOutcome::PassThrough,
+    }
+}
+
+/// Outcome of the build-commit check on `JoinGameWithPassword`. The host's
+/// and guest's commits must either both be populated and equal, or at least
+/// one must be empty (restored session, legacy client) for the join to proceed.
+#[derive(Debug, PartialEq, Eq)]
+enum BuildCommitCheck {
+    Allow,
+    Reject { host: String, guest: String },
+}
+
+fn check_build_commit(host_commit: &str, guest_commit: &str) -> BuildCommitCheck {
+    if !guest_commit.is_empty() && !host_commit.is_empty() && host_commit != guest_commit {
+        BuildCommitCheck::Reject {
+            host: host_commit.to_owned(),
+            guest: guest_commit.to_owned(),
+        }
+    } else {
+        BuildCommitCheck::Allow
+    }
 }
 
 impl SocketIdentity {
@@ -185,15 +272,20 @@ async fn main() {
                                 }
                             }
 
-                            // Restore lobby entry if game hasn't started
+                            // Restore lobby entry if game hasn't started.
+                            // Persisted sessions pre-date version metadata;
+                            // restored lobbies appear without a version badge.
                             if let Some(meta) = lobby_meta {
                                 if !is_started {
                                     lob.register_game(
                                         game_code,
-                                        meta.host_name,
-                                        meta.public,
-                                        meta.password,
-                                        meta.timer_seconds,
+                                        RegisterGameRequest {
+                                            host_name: meta.host_name,
+                                            public: meta.public,
+                                            password: meta.password,
+                                            timer_seconds: meta.timer_seconds,
+                                            ..Default::default()
+                                        },
                                     );
                                 }
                             }
@@ -436,8 +528,26 @@ async fn handle_socket(
         player_token: None,
         lobby_subscribed: false,
         session_span: None,
+        client_hello: None,
     };
     let mut rate_limiter = RateLimiter::new();
+
+    // Greet the client with our version identity. The client uses this to
+    // decide whether to proceed (protocol-version mismatch ⇒ it gives up
+    // before sending any game-affecting frame).
+    let hello = ServerMessage::ServerHello {
+        server_version: env!("CARGO_PKG_VERSION").to_string(),
+        build_commit: build_commit().to_string(),
+        protocol_version: PROTOCOL_VERSION,
+        mode: ServerMode::Full,
+    };
+    if let Ok(json) = serde_json::to_string(&hello) {
+        if socket.send(Message::text(json)).await.is_err() {
+            let count = player_count.fetch_sub(1, Ordering::Relaxed) - 1;
+            broadcast_player_count(&lobby_subscribers, count).await;
+            return;
+        }
+    }
 
     loop {
         tokio::select! {
@@ -621,7 +731,62 @@ async fn handle_client_message(
     tx: &mpsc::UnboundedSender<ServerMessage>,
     identity: &mut SocketIdentity,
 ) {
+    // Handshake gate: ClientHello must be the first message. See
+    // `classify_hello_gate` for the full truth table.
+    match classify_hello_gate(
+        identity.client_hello.is_some(),
+        &client_msg,
+        PROTOCOL_VERSION,
+    ) {
+        HelloGateOutcome::Accept(info) => {
+            info!(
+                version = %info.client_version,
+                commit = %info.build_commit,
+                "ClientHello accepted"
+            );
+            identity.client_hello = Some(info);
+            return;
+        }
+        HelloGateOutcome::RejectProtocol { client, server } => {
+            warn!(
+                client_protocol = client,
+                server_protocol = server,
+                "protocol version mismatch at ClientHello"
+            );
+            let msg = ServerMessage::Error {
+                message: format!(
+                    "Protocol version mismatch (client={client} server={server}). Please update."
+                ),
+            };
+            if let Ok(json) = serde_json::to_string(&msg) {
+                let _ = socket.send(Message::text(json)).await;
+            }
+            return;
+        }
+        HelloGateOutcome::RejectHandshakeRequired => {
+            warn!("client sent non-hello message before ClientHello");
+            let msg = ServerMessage::Error {
+                message: "ClientHello required before any other message".to_string(),
+            };
+            if let Ok(json) = serde_json::to_string(&msg) {
+                let _ = socket.send(Message::text(json)).await;
+            }
+            return;
+        }
+        HelloGateOutcome::IgnoreRedundantHello => {
+            debug!("ignoring redundant ClientHello");
+            return;
+        }
+        HelloGateOutcome::PassThrough => {
+            // Fall through to the regular dispatch below.
+        }
+    }
+
     match client_msg {
+        ClientMessage::ClientHello { .. } => {
+            // Unreachable: IgnoreRedundantHello above handled this case.
+            debug!("unreachable ClientHello arm");
+        }
         ClientMessage::CreateGame { deck } => {
             info!(deck_size = deck.main_deck.len(), "CreateGame");
             {
@@ -1200,6 +1365,7 @@ async fn handle_client_message(
             match_config,
             ai_seats,
             format_config,
+            room_name,
         } => {
             info!(
                 display_name = %display_name,
@@ -1392,6 +1558,9 @@ async fn handle_client_message(
                 // --- Standard multiplayer path ---
                 let mut mgr = state.lock().await;
                 let pc = requested_player_count.clamp(2, 6);
+                // Capture the format before `format_config` is consumed so we
+                // can stamp it on the lobby entry below.
+                let format_for_lobby = format_config.as_ref().map(|fc| fc.format);
                 let (game_code, player_token) = mgr.create_game_n_players(
                     resolved,
                     display_name.clone(),
@@ -1411,12 +1580,49 @@ async fn handle_client_message(
                     .insert(PlayerId(0), tx.clone());
 
                 let mut lob = lobby.lock().await;
+                // Pull the client's advertised build identity from the
+                // stored ClientHello. `client_hello` is guaranteed Some here
+                // because the handshake gate at the top of this function
+                // rejects any non-hello frame when it's None.
+                let (host_version, host_build_commit) = identity
+                    .client_hello
+                    .as_ref()
+                    .map(|h| (h.client_version.clone(), h.build_commit.clone()))
+                    .unwrap_or_default();
                 lob.register_game(
                     &game_code,
-                    display_name.clone(),
-                    public,
-                    password.clone(),
-                    timer_seconds,
+                    RegisterGameRequest {
+                        host_name: display_name.clone(),
+                        public,
+                        password: password.clone(),
+                        timer_seconds,
+                        host_version,
+                        host_build_commit,
+                        // Initial count reflects the host plus any AI seats
+                        // configured at creation time; further updates flow
+                        // through `set_current_players` as guests join.
+                        current_players: mgr
+                            .sessions
+                            .get(&game_code)
+                            .map(|s| s.current_player_count())
+                            .unwrap_or(1),
+                        // Use the clamped `pc` (not the raw request) so the
+                        // lobby listing's max_players matches the session's
+                        // actual capacity. A hostile client sending
+                        // `player_count: 100` would otherwise advertise
+                        // "1/100 players" while the game ran with 6.
+                        max_players: pc as u32,
+                        format: format_for_lobby,
+                        // Trim then drop empty strings so the client can't
+                        // smuggle a blank room_name that would render as an
+                        // empty row title. `None` is the "use host name"
+                        // fallback both here and in the client.
+                        room_name: room_name
+                            .as_deref()
+                            .map(str::trim)
+                            .filter(|s| !s.is_empty())
+                            .map(str::to_string),
+                    },
                 );
 
                 // Store lobby metadata on the session and persist to SQLite
@@ -1466,6 +1672,32 @@ async fn handle_client_message(
             info!(game = %game_code, joiner = %display_name, "JoinGameWithPassword");
             {
                 let lob = lobby.lock().await;
+
+                // Build-commit gate: see `check_build_commit` for the
+                // policy. If both host and guest publish commits and they
+                // differ, the guest is running a different engine than the
+                // host and joining would diverge GameState on resolution.
+                let guest_commit = identity
+                    .client_hello
+                    .as_ref()
+                    .map(|h| h.build_commit.as_str())
+                    .unwrap_or("");
+                let host_commit = lob.host_build_commit(&game_code).unwrap_or("");
+                if let BuildCommitCheck::Reject { host, guest } =
+                    check_build_commit(host_commit, guest_commit)
+                {
+                    warn!(game = %game_code, %host, %guest, "build mismatch — refusing join");
+                    let msg = ServerMessage::Error {
+                        message: format!(
+                            "Build mismatch: host is on {host}, you are on {guest}. Refresh to update."
+                        ),
+                    };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                    return;
+                }
+
                 match lob.verify_password(&game_code, password.as_deref()) {
                     Ok(()) => {}
                     Err(e) if e == "password_required" => {
@@ -1518,6 +1750,7 @@ async fn handle_client_message(
                     // Build slot info before releasing session borrow
                     let slot_info = session.player_slot_info();
                     let is_full = session.is_full();
+                    let current_count = session.current_player_count();
 
                     let mut conns = connections.lock().await;
                     conns
@@ -1530,6 +1763,28 @@ async fn handle_client_message(
                     if let Some(players) = conns.get(&game_code) {
                         for sender in players.values() {
                             let _ = sender.send(slots_msg.clone());
+                        }
+                    }
+
+                    // Keep the public lobby listing's `current_players` in sync
+                    // for games that are still waiting. When the game becomes
+                    // full the `if is_full` branch below unregisters it from
+                    // the lobby entirely, so no update is needed there.
+                    if !is_full {
+                        let updated = {
+                            let mut lob = lobby.lock().await;
+                            lob.set_current_players(&game_code, current_count);
+                            // Private games aren't listed in the public lobby,
+                            // so `public_game` returns None and no update is
+                            // broadcast — which is the correct behavior.
+                            lob.public_game(&game_code)
+                        };
+                        if let Some(game) = updated {
+                            broadcast_to_lobby_subscribers(
+                                lobby_subscribers,
+                                ServerMessage::LobbyGameUpdated { game },
+                            )
+                            .await;
                         }
                     }
 
@@ -1747,5 +2002,156 @@ async fn handle_client_message(
                 let _ = socket.send(Message::text(json)).await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod handshake_tests {
+    use super::*;
+    use engine::types::actions::GameAction;
+    use server_core::protocol::DeckData;
+
+    fn empty_deck() -> DeckData {
+        DeckData {
+            main_deck: vec!["Forest".into()],
+            sideboard: vec![],
+            commander: vec![],
+        }
+    }
+
+    #[test]
+    fn accepts_matching_client_hello() {
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::ClientHello {
+                client_version: "0.1.11".into(),
+                build_commit: "abc1234".into(),
+                protocol_version: PROTOCOL_VERSION,
+            },
+            PROTOCOL_VERSION,
+        );
+        assert_eq!(
+            outcome,
+            HelloGateOutcome::Accept(ClientHelloInfo {
+                client_version: "0.1.11".into(),
+                build_commit: "abc1234".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_client_hello_with_zero_protocol_version() {
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::ClientHello {
+                client_version: "0.1.11".into(),
+                build_commit: "abc1234".into(),
+                protocol_version: 0,
+            },
+            PROTOCOL_VERSION,
+        );
+        assert_eq!(
+            outcome,
+            HelloGateOutcome::RejectProtocol {
+                client: 0,
+                server: PROTOCOL_VERSION,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_client_hello_with_future_protocol_version() {
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::ClientHello {
+                client_version: "0.2.0".into(),
+                build_commit: "def5678".into(),
+                protocol_version: PROTOCOL_VERSION + 1,
+            },
+            PROTOCOL_VERSION,
+        );
+        assert!(matches!(outcome, HelloGateOutcome::RejectProtocol { .. }));
+    }
+
+    #[test]
+    fn rejects_non_hello_frame_before_handshake() {
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::Action {
+                action: GameAction::PassPriority,
+            },
+            PROTOCOL_VERSION,
+        );
+        assert_eq!(outcome, HelloGateOutcome::RejectHandshakeRequired);
+
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::CreateGame { deck: empty_deck() },
+            PROTOCOL_VERSION,
+        );
+        assert_eq!(outcome, HelloGateOutcome::RejectHandshakeRequired);
+
+        let outcome = classify_hello_gate(false, &ClientMessage::SubscribeLobby, PROTOCOL_VERSION);
+        assert_eq!(outcome, HelloGateOutcome::RejectHandshakeRequired);
+
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::Ping { timestamp: 1 },
+            PROTOCOL_VERSION,
+        );
+        assert_eq!(outcome, HelloGateOutcome::RejectHandshakeRequired);
+    }
+
+    #[test]
+    fn ignores_redundant_hello_after_accept() {
+        let outcome = classify_hello_gate(
+            true,
+            &ClientMessage::ClientHello {
+                client_version: "0.1.11".into(),
+                build_commit: "abc1234".into(),
+                protocol_version: PROTOCOL_VERSION,
+            },
+            PROTOCOL_VERSION,
+        );
+        assert_eq!(outcome, HelloGateOutcome::IgnoreRedundantHello);
+    }
+
+    #[test]
+    fn passes_through_regular_frames_after_handshake() {
+        let outcome = classify_hello_gate(
+            true,
+            &ClientMessage::Action {
+                action: GameAction::PassPriority,
+            },
+            PROTOCOL_VERSION,
+        );
+        assert_eq!(outcome, HelloGateOutcome::PassThrough);
+    }
+
+    #[test]
+    fn build_commit_allows_matching() {
+        assert_eq!(
+            check_build_commit("abc1234", "abc1234"),
+            BuildCommitCheck::Allow
+        );
+    }
+
+    #[test]
+    fn build_commit_allows_when_either_side_is_empty() {
+        // Restored sessions / legacy clients are treated as unknown.
+        assert_eq!(check_build_commit("", "abc1234"), BuildCommitCheck::Allow);
+        assert_eq!(check_build_commit("abc1234", ""), BuildCommitCheck::Allow);
+        assert_eq!(check_build_commit("", ""), BuildCommitCheck::Allow);
+    }
+
+    #[test]
+    fn build_commit_rejects_when_both_populated_and_different() {
+        assert_eq!(
+            check_build_commit("abc1234", "def5678"),
+            BuildCommitCheck::Reject {
+                host: "abc1234".into(),
+                guest: "def5678".into(),
+            }
+        );
     }
 }

--- a/crates/server-core/build.rs
+++ b/crates/server-core/build.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+fn main() {
+    let commit = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8(out.stdout)
+                    .ok()
+                    .map(|s| s.trim().to_owned())
+            } else {
+                None
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "dev".to_owned());
+
+    println!("cargo:rustc-env=PHASE_BUILD_COMMIT={commit}");
+
+    // Rebuild when HEAD moves (new commit, branch switch, rebase).
+    // The .git/ path is workspace-relative; crates/server-core/build.rs sits two levels deep.
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/heads");
+    // After `git gc`, refs migrate into packed-refs. Watch that too so the
+    // short-SHA stays current in long-running dev environments.
+    println!("cargo:rerun-if-changed=../../.git/packed-refs");
+}

--- a/crates/server-core/src/lobby.rs
+++ b/crates/server-core/src/lobby.rs
@@ -1,9 +1,32 @@
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use engine::types::format::GameFormat;
 use tracing::{debug, warn};
 
 use crate::protocol::LobbyGame;
+
+/// Fields a caller supplies when registering a lobby entry. Using a struct
+/// here rather than a long positional argument list means adding a new field
+/// (e.g. when the lobby UI grows to display more info) doesn't require
+/// touching every caller — just add it here with a `Default` and populate
+/// where relevant.
+#[derive(Debug, Clone, Default)]
+pub struct RegisterGameRequest {
+    pub host_name: String,
+    pub public: bool,
+    pub password: Option<String>,
+    pub timer_seconds: Option<u32>,
+    pub host_version: String,
+    pub host_build_commit: String,
+    pub current_players: u32,
+    pub max_players: u32,
+    pub format: Option<GameFormat>,
+    /// Optional match-scoped label shown in lobby listings. Distinct from
+    /// `host_name` (the player identity). `None` means the lobby row falls
+    /// back to the host's name.
+    pub room_name: Option<String>,
+}
 
 struct LobbyGameMeta {
     host_name: String,
@@ -12,6 +35,12 @@ struct LobbyGameMeta {
     has_password: bool,
     timer_seconds: Option<u32>,
     public: bool,
+    host_version: String,
+    host_build_commit: String,
+    current_players: u32,
+    max_players: u32,
+    format: Option<GameFormat>,
+    room_name: Option<String>,
 }
 
 pub struct LobbyManager {
@@ -25,33 +54,55 @@ impl LobbyManager {
         }
     }
 
-    pub fn register_game(
-        &mut self,
-        game_code: &str,
-        host_name: String,
-        public: bool,
-        password: Option<String>,
-        timer_seconds: Option<u32>,
-    ) {
-        let has_password = password.is_some();
+    pub fn register_game(&mut self, game_code: &str, req: RegisterGameRequest) {
+        let has_password = req.password.is_some();
         let created_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
 
-        debug!(game = %game_code, host = %host_name, "lobby game registered");
+        debug!(
+            game = %game_code,
+            host = %req.host_name,
+            version = %req.host_version,
+            commit = %req.host_build_commit,
+            "lobby game registered"
+        );
 
         self.games.insert(
             game_code.to_string(),
             LobbyGameMeta {
-                host_name,
+                host_name: req.host_name,
                 created_at,
-                password,
+                password: req.password,
                 has_password,
-                timer_seconds,
-                public,
+                timer_seconds: req.timer_seconds,
+                public: req.public,
+                host_version: req.host_version,
+                host_build_commit: req.host_build_commit,
+                current_players: req.current_players,
+                max_players: req.max_players,
+                format: req.format,
+                room_name: req.room_name,
             },
         );
+    }
+
+    /// Updates the `current_players` count for an existing lobby entry. Called
+    /// when a guest joins or leaves a waiting room so the public lobby listing
+    /// stays accurate. No-op if the game isn't tracked.
+    pub fn set_current_players(&mut self, game_code: &str, current_players: u32) {
+        if let Some(meta) = self.games.get_mut(game_code) {
+            meta.current_players = current_players;
+        }
+    }
+
+    /// Returns the host's build identity for a game, used to gate joins in
+    /// `JoinGameWithPassword` when the guest's build differs from the host's.
+    pub fn host_build_commit(&self, game_code: &str) -> Option<&str> {
+        self.games
+            .get(game_code)
+            .map(|meta| meta.host_build_commit.as_str())
     }
 
     pub fn unregister_game(&mut self, game_code: &str) {
@@ -79,6 +130,29 @@ impl LobbyManager {
         }
     }
 
+    /// Returns the public-lobby view of a single game by code, or `None` if
+    /// the game isn't tracked or isn't public. Callers use this after
+    /// `set_current_players` to build a `LobbyGameUpdated` broadcast
+    /// without cloning the full public list.
+    pub fn public_game(&self, game_code: &str) -> Option<LobbyGame> {
+        let meta = self.games.get(game_code)?;
+        if !meta.public {
+            return None;
+        }
+        Some(LobbyGame {
+            game_code: game_code.to_string(),
+            host_name: meta.host_name.clone(),
+            created_at: meta.created_at,
+            has_password: meta.has_password,
+            host_version: meta.host_version.clone(),
+            host_build_commit: meta.host_build_commit.clone(),
+            current_players: meta.current_players,
+            max_players: meta.max_players,
+            format: meta.format,
+            room_name: meta.room_name.clone(),
+        })
+    }
+
     pub fn public_games(&self) -> Vec<LobbyGame> {
         self.games
             .iter()
@@ -88,6 +162,12 @@ impl LobbyManager {
                 host_name: meta.host_name.clone(),
                 created_at: meta.created_at,
                 has_password: meta.has_password,
+                host_version: meta.host_version.clone(),
+                host_build_commit: meta.host_build_commit.clone(),
+                current_players: meta.current_players,
+                max_players: meta.max_players,
+                format: meta.format,
+                room_name: meta.room_name.clone(),
             })
             .collect()
     }
@@ -132,14 +212,39 @@ impl Default for LobbyManager {
 mod tests {
     use super::*;
 
+    /// Test helper: registers a game with default metadata so existing tests
+    /// don't have to care about the extended set of fields. Tests that
+    /// exercise specific metadata call `register_game` with a fully-populated
+    /// `RegisterGameRequest` directly.
+    fn register_basic(
+        lobby: &mut LobbyManager,
+        code: &str,
+        host: &str,
+        public: bool,
+        password: Option<String>,
+        timer: Option<u32>,
+    ) {
+        lobby.register_game(
+            code,
+            RegisterGameRequest {
+                host_name: host.to_string(),
+                public,
+                password,
+                timer_seconds: timer,
+                ..Default::default()
+            },
+        );
+    }
+
     #[test]
     fn register_and_list_public_games() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game("GAME01", "Alice".to_string(), true, None, None);
-        lobby.register_game("GAME02", "Bob".to_string(), false, None, None);
-        lobby.register_game(
+        register_basic(&mut lobby, "GAME01", "Alice", true, None, None);
+        register_basic(&mut lobby, "GAME02", "Bob", false, None, None);
+        register_basic(
+            &mut lobby,
             "GAME03",
-            "Carol".to_string(),
+            "Carol",
             true,
             Some("pw".to_string()),
             Some(60),
@@ -155,7 +260,7 @@ mod tests {
     #[test]
     fn unregister_removes_game() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game("GAME01", "Alice".to_string(), true, None, None);
+        register_basic(&mut lobby, "GAME01", "Alice", true, None, None);
         assert_eq!(lobby.public_games().len(), 1);
 
         lobby.unregister_game("GAME01");
@@ -165,7 +270,7 @@ mod tests {
     #[test]
     fn verify_password_no_password_required() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game("GAME01", "Alice".to_string(), true, None, None);
+        register_basic(&mut lobby, "GAME01", "Alice", true, None, None);
 
         assert!(lobby.verify_password("GAME01", None).is_ok());
         assert!(lobby.verify_password("GAME01", Some("anything")).is_ok());
@@ -174,9 +279,10 @@ mod tests {
     #[test]
     fn verify_password_correct() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game(
+        register_basic(
+            &mut lobby,
             "GAME01",
-            "Alice".to_string(),
+            "Alice",
             true,
             Some("secret".to_string()),
             None,
@@ -188,9 +294,10 @@ mod tests {
     #[test]
     fn verify_password_wrong() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game(
+        register_basic(
+            &mut lobby,
             "GAME01",
-            "Alice".to_string(),
+            "Alice",
             true,
             Some("secret".to_string()),
             None,
@@ -204,9 +311,10 @@ mod tests {
     #[test]
     fn verify_password_required_but_missing() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game(
+        register_basic(
+            &mut lobby,
             "GAME01",
-            "Alice".to_string(),
+            "Alice",
             true,
             Some("secret".to_string()),
             None,
@@ -227,8 +335,8 @@ mod tests {
     #[test]
     fn timer_seconds_returns_configured_value() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game("GAME01", "Alice".to_string(), true, None, Some(90));
-        lobby.register_game("GAME02", "Bob".to_string(), true, None, None);
+        register_basic(&mut lobby, "GAME01", "Alice", true, None, Some(90));
+        register_basic(&mut lobby, "GAME02", "Bob", true, None, None);
 
         assert_eq!(lobby.timer_seconds("GAME01"), Some(90));
         assert_eq!(lobby.timer_seconds("GAME02"), None);
@@ -238,7 +346,7 @@ mod tests {
     #[test]
     fn check_expired_removes_old_games() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game("GAME01", "Alice".to_string(), true, None, None);
+        register_basic(&mut lobby, "GAME01", "Alice", true, None, None);
 
         // Manually set created_at to the past
         lobby.games.get_mut("GAME01").unwrap().created_at = 0;
@@ -252,7 +360,7 @@ mod tests {
     #[test]
     fn check_expired_retains_fresh_games() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game("GAME01", "Alice".to_string(), true, None, None);
+        register_basic(&mut lobby, "GAME01", "Alice", true, None, None);
 
         let expired = lobby.check_expired(300);
         assert!(expired.is_empty());
@@ -262,19 +370,125 @@ mod tests {
     #[test]
     fn lobby_game_has_password_flag() {
         let mut lobby = LobbyManager::new();
-        lobby.register_game(
+        register_basic(
+            &mut lobby,
             "GAME01",
-            "Alice".to_string(),
+            "Alice",
             true,
             Some("pw".to_string()),
             None,
         );
-        lobby.register_game("GAME02", "Bob".to_string(), true, None, None);
+        register_basic(&mut lobby, "GAME02", "Bob", true, None, None);
 
         let games = lobby.public_games();
         let g1 = games.iter().find(|g| g.game_code == "GAME01").unwrap();
         let g2 = games.iter().find(|g| g.game_code == "GAME02").unwrap();
         assert!(g1.has_password);
         assert!(!g2.has_password);
+    }
+
+    #[test]
+    fn host_build_commit_returned_from_register() {
+        let mut lobby = LobbyManager::new();
+        lobby.register_game(
+            "GAME01",
+            RegisterGameRequest {
+                host_name: "Alice".to_string(),
+                public: true,
+                host_version: "0.1.11".to_string(),
+                host_build_commit: "abc1234".to_string(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(lobby.host_build_commit("GAME01"), Some("abc1234"));
+        assert_eq!(lobby.host_build_commit("NOPE"), None);
+
+        let games = lobby.public_games();
+        let g = games.iter().find(|g| g.game_code == "GAME01").unwrap();
+        assert_eq!(g.host_version, "0.1.11");
+        assert_eq!(g.host_build_commit, "abc1234");
+    }
+
+    #[test]
+    fn extended_fields_roundtrip_through_public_games() {
+        let mut lobby = LobbyManager::new();
+        lobby.register_game(
+            "GAME01",
+            RegisterGameRequest {
+                host_name: "Alice".to_string(),
+                public: true,
+                current_players: 2,
+                max_players: 4,
+                format: Some(GameFormat::Commander),
+                ..Default::default()
+            },
+        );
+        let games = lobby.public_games();
+        let g = games.iter().find(|g| g.game_code == "GAME01").unwrap();
+        assert_eq!(g.current_players, 2);
+        assert_eq!(g.max_players, 4);
+        assert_eq!(g.format, Some(GameFormat::Commander));
+    }
+
+    #[test]
+    fn set_current_players_updates_existing_entry() {
+        let mut lobby = LobbyManager::new();
+        lobby.register_game(
+            "GAME01",
+            RegisterGameRequest {
+                host_name: "Alice".to_string(),
+                public: true,
+                current_players: 1,
+                max_players: 4,
+                ..Default::default()
+            },
+        );
+
+        lobby.set_current_players("GAME01", 3);
+        let games = lobby.public_games();
+        let g = games.iter().find(|g| g.game_code == "GAME01").unwrap();
+        assert_eq!(g.current_players, 3);
+    }
+
+    #[test]
+    fn public_game_returns_entry_when_public() {
+        let mut lobby = LobbyManager::new();
+        lobby.register_game(
+            "GAME01",
+            RegisterGameRequest {
+                host_name: "Alice".to_string(),
+                public: true,
+                current_players: 2,
+                max_players: 4,
+                format: Some(GameFormat::Commander),
+                ..Default::default()
+            },
+        );
+
+        let game = lobby.public_game("GAME01").expect("entry should exist");
+        assert_eq!(game.game_code, "GAME01");
+        assert_eq!(game.current_players, 2);
+        assert_eq!(game.format, Some(GameFormat::Commander));
+    }
+
+    #[test]
+    fn public_game_returns_none_for_private_entry() {
+        let mut lobby = LobbyManager::new();
+        register_basic(&mut lobby, "GAME01", "Alice", false, None, None);
+        assert!(lobby.public_game("GAME01").is_none());
+    }
+
+    #[test]
+    fn public_game_returns_none_for_missing_entry() {
+        let lobby = LobbyManager::new();
+        assert!(lobby.public_game("NOPE").is_none());
+    }
+
+    #[test]
+    fn set_current_players_no_op_on_missing_game() {
+        let mut lobby = LobbyManager::new();
+        // Must not panic or mutate anything.
+        lobby.set_current_players("NOPE", 5);
+        assert!(lobby.public_games().is_empty());
     }
 }

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use engine::types::actions::GameAction;
 use engine::types::events::GameEvent;
-use engine::types::format::FormatConfig;
+use engine::types::format::{FormatConfig, GameFormat};
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
 use engine::types::log::GameLogEntry;
@@ -11,6 +11,37 @@ use engine::types::match_config::MatchConfig;
 use engine::types::player::PlayerId;
 use phase_ai::config::AiDifficulty;
 use serde::{Deserialize, Serialize};
+
+/// Wire-protocol version. Bump when any `ClientMessage` or `ServerMessage`
+/// variant is added, removed, renamed, or has a field type changed. Adding a
+/// new optional field with `#[serde(default)]` does not require a bump.
+///
+/// Note: renaming or removing a variant silently fails at JSON parse time
+/// (clients see "Invalid message: unknown variant") rather than at the
+/// handshake. When making such changes, plan a deprecation window where
+/// both the old and new variants coexist, then bump and remove the old.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Git short-hash of the build. Emitted by `build.rs`; falls back to `"dev"`
+/// when git isn't available (containers, source tarballs).
+pub fn build_commit() -> &'static str {
+    env!("PHASE_BUILD_COMMIT")
+}
+
+/// Advertised role of the server. `Full` runs game sessions end-to-end;
+/// `LobbyOnly` acts as a matchmaking broker for P2P connections and rejects
+/// game-state messages.
+///
+/// Note: `LobbyOnly` is intentionally unused in PR 1 — the server always
+/// sends `ServerMode::Full` today. The variant ships now so the client can
+/// already pattern-match on it; the actual lobby-only dispatch logic lands
+/// in PR 2 (see `.planning/…/lobby-only-server-plan` and the plan file at
+/// `/Users/matt/.claude/plans/cached-puzzling-alpaca.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ServerMode {
+    Full,
+    LobbyOnly,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeckData {
@@ -36,6 +67,33 @@ pub struct LobbyGame {
     pub host_name: String,
     pub created_at: u64,
     pub has_password: bool,
+    /// Display string (e.g. `"0.1.11"`). Human-readable; not a compatibility gate.
+    #[serde(default)]
+    pub host_version: String,
+    /// Git short-hash of the host's build. The compatibility gate — clients on
+    /// a different commit cannot join because GameState / rules may have diverged.
+    #[serde(default)]
+    pub host_build_commit: String,
+    /// Number of seats currently occupied (host + joined guests, including AI
+    /// if present). Updated as players join/leave.
+    #[serde(default)]
+    pub current_players: u32,
+    /// Configured seat count for this game. For 1v1 formats this is 2; for
+    /// Commander it ranges 2–4.
+    #[serde(default)]
+    pub max_players: u32,
+    /// Game format (Standard, Commander, etc.) — lets lobby UIs filter or
+    /// badge the row. Optional because older persisted entries predate the
+    /// field.
+    #[serde(default)]
+    pub format: Option<GameFormat>,
+    /// Optional per-match label distinct from the host's player name. When
+    /// set, lobby UIs render this as the row's primary title ("Friday Night
+    /// Commander") and the host's name as secondary metadata. `None` means
+    /// "use the host's name as the room label" — the behavior before this
+    /// field existed, preserved for backward compatibility.
+    #[serde(default)]
+    pub room_name: Option<String>,
 }
 
 /// Info about a single player slot in a waiting room, sent to all connected players.
@@ -53,6 +111,14 @@ pub struct PlayerSlotInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum ClientMessage {
+    /// First frame the client must send after receiving `ServerHello`. Carries
+    /// the client's version identity so the server can enforce compatibility
+    /// before accepting any game-affecting message.
+    ClientHello {
+        client_version: String,
+        build_commit: String,
+        protocol_version: u32,
+    },
     CreateGame {
         deck: DeckData,
     },
@@ -83,6 +149,10 @@ pub enum ClientMessage {
         ai_seats: Vec<AiSeatRequest>,
         #[serde(default)]
         format_config: Option<FormatConfig>,
+        /// Optional distinct label for this room, separate from the host's
+        /// player name. Routed into `LobbyGame.room_name`.
+        #[serde(default)]
+        room_name: Option<String>,
     },
     JoinGameWithPassword {
         game_code: String,
@@ -109,6 +179,16 @@ fn default_player_count() -> u8 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum ServerMessage {
+    /// Sent unprompted immediately on WebSocket accept. The client compares
+    /// `protocol_version` against its own and refuses to proceed on mismatch.
+    /// `build_commit` is the git short-hash of the server binary; it is used
+    /// by the lobby to gate joins when host and guest are on different builds.
+    ServerHello {
+        server_version: String,
+        build_commit: String,
+        protocol_version: u32,
+        mode: ServerMode,
+    },
     GameCreated {
         game_code: String,
         player_token: String,
@@ -167,6 +247,12 @@ pub enum ServerMessage {
         games: Vec<LobbyGame>,
     },
     LobbyGameAdded {
+        game: LobbyGame,
+    },
+    /// Broadcast when an existing lobby entry's mutable state changes
+    /// (e.g. `current_players` ticks up as a guest joins). Lets clients
+    /// refresh a single row without a full `LobbyUpdate` resync.
+    LobbyGameUpdated {
         game: LobbyGame,
     },
     LobbyGameRemoved {
@@ -336,6 +422,7 @@ mod tests {
             match_config: MatchConfig::default(),
             ai_seats: vec![],
             format_config: None,
+            room_name: Some("Friday Night Commander".to_string()),
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
@@ -347,6 +434,7 @@ mod tests {
                 timer_seconds,
                 player_count,
                 match_config,
+                room_name,
                 ..
             } => {
                 assert_eq!(display_name, "Alice");
@@ -355,6 +443,7 @@ mod tests {
                 assert_eq!(timer_seconds, Some(60));
                 assert_eq!(player_count, 4);
                 assert_eq!(match_config, MatchConfig::default());
+                assert_eq!(room_name, Some("Friday Night Commander".to_string()));
             }
             _ => panic!("wrong variant"),
         }
@@ -502,6 +591,12 @@ mod tests {
                 host_name: "Alice".to_string(),
                 created_at: 1700000000,
                 has_password: false,
+                host_version: "0.1.11".to_string(),
+                host_build_commit: "abc1234".to_string(),
+                current_players: 1,
+                max_players: 2,
+                format: None,
+                room_name: None,
             }],
         };
         let json = serde_json::to_string(&msg).unwrap();
@@ -525,6 +620,12 @@ mod tests {
                 host_name: "Bob".to_string(),
                 created_at: 1700000000,
                 has_password: true,
+                host_version: "0.1.11".to_string(),
+                host_build_commit: "abc1234".to_string(),
+                current_players: 1,
+                max_players: 2,
+                format: None,
+                room_name: None,
             },
         };
         let json = serde_json::to_string(&msg).unwrap();
@@ -533,6 +634,36 @@ mod tests {
             ServerMessage::LobbyGameAdded { game } => {
                 assert_eq!(game.game_code, "XYZ789");
                 assert!(game.has_password);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn server_message_lobby_game_updated_roundtrips() {
+        let msg = ServerMessage::LobbyGameUpdated {
+            game: LobbyGame {
+                game_code: "ABC123".to_string(),
+                host_name: "Alice".to_string(),
+                created_at: 1700000000,
+                has_password: false,
+                host_version: "0.1.11".to_string(),
+                host_build_commit: "abc1234".to_string(),
+                current_players: 2,
+                max_players: 4,
+                format: Some(GameFormat::Commander),
+                room_name: Some("Board-wipe special".to_string()),
+            },
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ServerMessage = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ServerMessage::LobbyGameUpdated { game } => {
+                assert_eq!(game.game_code, "ABC123");
+                assert_eq!(game.current_players, 2);
+                assert_eq!(game.max_players, 4);
+                assert_eq!(game.format, Some(GameFormat::Commander));
+                assert_eq!(game.room_name, Some("Board-wipe special".to_string()));
             }
             _ => panic!("wrong variant"),
         }
@@ -678,6 +809,7 @@ mod tests {
                 deck_name: None,
             }],
             format_config: None,
+            room_name: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
@@ -737,6 +869,103 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn client_hello_roundtrips() {
+        let msg = ClientMessage::ClientHello {
+            client_version: "0.1.11".to_string(),
+            build_commit: "abc1234".to_string(),
+            protocol_version: PROTOCOL_VERSION,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ClientMessage::ClientHello {
+                client_version,
+                build_commit,
+                protocol_version,
+            } => {
+                assert_eq!(client_version, "0.1.11");
+                assert_eq!(build_commit, "abc1234");
+                assert_eq!(protocol_version, PROTOCOL_VERSION);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn server_hello_roundtrips() {
+        let msg = ServerMessage::ServerHello {
+            server_version: "0.1.11".to_string(),
+            build_commit: "abc1234".to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            mode: ServerMode::LobbyOnly,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ServerMessage = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ServerMessage::ServerHello {
+                server_version,
+                build_commit,
+                protocol_version,
+                mode,
+            } => {
+                assert_eq!(server_version, "0.1.11");
+                assert_eq!(build_commit, "abc1234");
+                assert_eq!(protocol_version, PROTOCOL_VERSION);
+                assert_eq!(mode, ServerMode::LobbyOnly);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn lobby_game_with_full_metadata_roundtrips() {
+        let game = LobbyGame {
+            game_code: "ABC123".to_string(),
+            host_name: "Alice".to_string(),
+            created_at: 1700000000,
+            has_password: false,
+            host_version: "0.2.0".to_string(),
+            host_build_commit: "def5678".to_string(),
+            current_players: 2,
+            max_players: 4,
+            format: Some(GameFormat::Commander),
+            room_name: Some("Spellslingers".to_string()),
+        };
+        let json = serde_json::to_string(&game).unwrap();
+        let parsed: LobbyGame = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.host_version, "0.2.0");
+        assert_eq!(parsed.host_build_commit, "def5678");
+        assert_eq!(parsed.current_players, 2);
+        assert_eq!(parsed.max_players, 4);
+        assert_eq!(parsed.format, Some(GameFormat::Commander));
+        assert_eq!(parsed.room_name, Some("Spellslingers".to_string()));
+    }
+
+    #[test]
+    fn lobby_game_without_optional_metadata_deserializes_with_defaults() {
+        // Older clients / persisted entries may lack the new fields.
+        let json = r#"{
+            "game_code": "OLD123",
+            "host_name": "Legacy",
+            "created_at": 1700000000,
+            "has_password": false
+        }"#;
+        let parsed: LobbyGame = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.host_version, "");
+        assert_eq!(parsed.host_build_commit, "");
+        assert_eq!(parsed.current_players, 0);
+        assert_eq!(parsed.max_players, 0);
+        assert_eq!(parsed.format, None);
+        assert_eq!(parsed.room_name, None);
+    }
+
+    #[test]
+    fn build_commit_is_nonempty() {
+        // Whether in git or not, build.rs always emits something.
+        assert!(!build_commit().is_empty());
     }
 
     #[test]

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -87,6 +87,18 @@ impl GameSession {
             .all(|(i, t)| !t.is_empty() || self.ai_seats.contains(&PlayerId(i as u8)))
     }
 
+    /// Count of occupied seats — humans who have joined plus configured AI
+    /// seats. Matches `is_full()` semantics: a full game has
+    /// `current_player_count() == player_count`. Published on the public
+    /// `LobbyGame` entry so browsers can see how close a game is to starting.
+    pub fn current_player_count(&self) -> u32 {
+        (0..self.player_count as usize)
+            .filter(|i| {
+                !self.player_tokens[*i].is_empty() || self.ai_seats.contains(&PlayerId(*i as u8))
+            })
+            .count() as u32
+    }
+
     /// Build slot info for all seats in this game session.
     pub fn player_slot_info(&self) -> Vec<PlayerSlotInfo> {
         (0..self.player_count as usize)


### PR DESCRIPTION
## Summary

Ships the combined multiplayer UX overhaul, server/client version handshake, and P2P 4-player Commander support as a single coherent unit. Intermediate splits would leave the tree in broken states (e.g. protocol field defined but unused), so everything lands together.

### Protocol (additive, `#[serde(default)]` for back-compat)
- `ServerHello` / `ClientHello` handshake with `protocol_version` + `build_commit` gates; `ServerMode::{Full,LobbyOnly}` advertised on accept
- `LobbyGame` gains `current_players`, `max_players`, `format`, `host_version`, `host_build_commit`, and `room_name`
- New `LobbyGameUpdated` broadcast so clients see slot counts tick live as guests join

### Lobby UX
- Room name distinct from player name — `GameListItem` shows the room as the primary title with "by {host}" as secondary metadata
- Full games disabled in the list; proactive password modal; join-with-context banner in the deck picker; richer empty state with Host/Refresh CTAs
- Lobby rows disabled on host-build-commit mismatch (hard compatibility gate)
- New `ServerPicker` (US/EU presets + self-hosted URL) reachable via a pill next to the online-count badge
- `ServerOfflinePrompt` replaces the auto-flip-to-P2P with an explicit "Keep trying / Use direct code" modal

### Player identity UX
- New `PlayerIdentityBanner` on the multiplayer page — inline name editing, no more hunting in Preferences → Multiplayer
- `HostSetup` relabels "Display Name" → "Your Name" with write-through to the store on change, plus a separate optional "Room Name" field
- `WaitingScreen` game code is now a copy-to-clipboard button

### Reconnect resilience
- Toast store migrated to `Map<string, Toast>` so concurrent player disconnects in 3-4p games don't overwrite each other
- Every toast carries an absolute wall-clock `expiresAt` so tab throttling can't drift countdowns, and dismissal is a pure function of `(expiresAt <= now)` — immune to Map-mutation re-renders
- `ConnectionToast` stacks countdowns at top, plain toasts at bottom
- Stale in-game overlay countdown removed; the toast owns the live timer

### P2P 4-player Commander
- `HostSetup` filter/caps/picker respect `P2P_MAX_PEERS = 4` (matches the WebRTC mesh ceiling in `p2p-adapter.ts`)
- `MultiplayerPage` P2P-host URL now threads `format` + `players` so `GamePage` rehydrates them into `P2PHostAdapter` end-to-end (previously silently defaulted to 2p Standard)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p server-core -p phase-server` (84+ passing)
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm test -- --run` (387/387 passing)
- [ ] Manual: host a Commander game in server mode — confirm room name renders distinctly from player name in other clients' lobbies
- [ ] Manual: host a P2P Commander game — confirm up to 4 seats selectable in HostSetup, and that format + player count propagate end-to-end
- [ ] Manual: edit player name via the `PlayerIdentityBanner`, confirm it persists and appears on next host
- [ ] Manual: kill `phase-server` while in lobby — confirm `ServerOfflinePrompt` appears with both options
- [ ] Manual: simulate two concurrent opponent disconnects in a 3p game — confirm both countdown toasts stack without overwriting each other