### PR TITLE
feat(multiplayer): pregame seat management with host controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,6 +1422,7 @@ dependencies = [
  "http",
  "phase-ai",
  "rusqlite",
+ "seat-reducer",
  "serde",
  "serde_json",
  "server-core",

--- a/client/src/adapter/__tests__/contract-fixtures.test.ts
+++ b/client/src/adapter/__tests__/contract-fixtures.test.ts
@@ -39,7 +39,7 @@ const SERVER_HELLO = JSON.stringify({
   data: {
     server_version: "0.0.0-test",
     build_commit: "testhash",
-    protocol_version: 2,
+    protocol_version: 3,
     mode: "Full",
   },
 });

--- a/client/src/adapter/__tests__/p2p-adapter-broker.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-broker.test.ts
@@ -126,6 +126,7 @@ function makeHost(
     undefined,
     5_000,
     broker,
+    true,
     brokerGameCode,
   );
   return { adapter, emitConnection };
@@ -163,6 +164,7 @@ describe("P2PHostAdapter — broker integration", () => {
           undefined,
           5_000,
           broker,
+          true,
         ),
     ).toThrow("brokerGameCode is required");
   });

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -43,7 +43,7 @@ const SERVER_HELLO = JSON.stringify({
   data: {
     server_version: "0.0.0-test",
     build_commit: "testhash",
-    protocol_version: 2,
+    protocol_version: 3,
     mode: "Full",
   },
 });

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -198,6 +198,14 @@ export class EngineWorkerClient {
     await this.request<null>({ type: "setMultiplayerMode", enabled });
   }
 
+  async applySeatMutation(stateJson: string, mutationJson: string): Promise<unknown> {
+    return this.request<unknown>({
+      type: "applySeatMutation",
+      stateJson,
+      mutationJson,
+    });
+  }
+
   async ping(): Promise<string> {
     return this.request<string>({ type: "ping" });
   }

--- a/client/src/adapter/engine-worker.ts
+++ b/client/src/adapter/engine-worker.ts
@@ -18,6 +18,7 @@ import init, {
   restore_game_state,
   resume_multiplayer_host_state,
   load_card_database,
+  apply_seat_mutation,
   export_game_state_json,
   clear_game_state,
   set_multiplayer_mode,
@@ -65,7 +66,8 @@ type EngineRequest =
   | { type: "loadCardDbFromUrl"; id: number }
   | { type: "resetGame"; id: number }
   | { type: "setMultiplayerMode"; id: number; enabled: boolean }
-  | { type: "ping"; id: number };
+  | { type: "ping"; id: number }
+  | { type: "applySeatMutation"; id: number; stateJson: string; mutationJson: string };
 
 type EngineResponse =
   | { type: "ready" }
@@ -248,6 +250,12 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
 
       case "ping": {
         result(msg.id, ping());
+        break;
+      }
+
+      case "applySeatMutation": {
+        const delta = apply_seat_mutation(msg.stateJson, msg.mutationJson);
+        result(msg.id, delta ?? null);
         break;
       }
     }

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -17,6 +17,14 @@ import { AdapterError } from "./types";
 import { WasmAdapter } from "./wasm-adapter";
 import { createPeerSession, type PeerSession } from "../network/peer";
 import type { P2PMessage } from "../network/protocol";
+import type {
+  PlayerSlot,
+  SeatKind,
+  SeatMutation,
+  SeatState,
+  SeatMutationResult,
+  SeatView,
+} from "../multiplayer/seatTypes";
 import type { BrokerClient } from "../services/brokerClient";
 import {
   clearP2PHostSession,
@@ -66,15 +74,16 @@ export type P2PAdapterEvent =
   | { type: "gamePaused"; reason: string }
   | { type: "gameResumed" }
   | { type: "lobbyProgress"; joined: number; total: number }
+  | { type: "playerSlotsUpdated"; slots: PlayerSlot[] }
   | { type: "reconnecting"; attempt: number }
   | { type: "reconnectFailed"; reason: string };
 
 type P2PAdapterEventListener = (event: P2PAdapterEvent) => void;
 
 interface DeckListPayload {
-  player: { main_deck: string[]; sideboard: string[] };
-  opponent: { main_deck: string[]; sideboard: string[] };
-  ai_decks: Array<{ main_deck: string[]; sideboard: string[] }>;
+  player: { main_deck: string[]; sideboard: string[]; commander: string[] };
+  opponent: { main_deck: string[]; sideboard: string[]; commander: string[] };
+  ai_decks: Array<{ main_deck: string[]; sideboard: string[]; commander: string[] }>;
 }
 
 /**
@@ -114,37 +123,59 @@ const RESUME_GRACE_PERIOD_MS = 5 * 60_000;
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000, 60_000];
 const RECONNECT_STEADY_STATE_MS = 60_000;
 
-function traceAdapter(side: "Host" | "Guest", event: string, data?: Record<string, unknown>): void {
-  console.debug(`[P2P ${side} Adapter]`, performance.now().toFixed(1), event, data ?? {});
+function defaultSeatState(playerCount: number, formatConfig?: FormatConfig): SeatState {
+  return {
+    seats: [
+      { type: "HostHuman" },
+      ...Array.from({ length: playerCount - 1 }, () => ({ type: "WaitingHuman" as const })),
+    ],
+    tokens: Array.from({ length: playerCount }, (_, idx) => (idx === 0 ? "host" : "")),
+    format: formatConfig ?? {
+      format: "Standard",
+      starting_life: 20,
+      min_players: 2,
+      max_players: 2,
+      deck_size: 60,
+      singleton: false,
+      command_zone: false,
+      commander_damage_threshold: null,
+      range_of_influence: null,
+      team_based: false,
+    },
+    gameStarted: false,
+  };
 }
 
-/**
- * Build the engine deck payload from per-seat decks.
- *
- * The WASM `initialize_game` accepts `{ player, opponent, ai_decks }` where
- * `ai_decks[i]` becomes seat `PlayerId(i + 2)`. For 3-4p P2P we use the same
- * shape: host is `player`, guest 1 is `opponent`, guests 2..N go into
- * `ai_decks` in seat order.
- */
-function buildDeckPayload(
-  hostDeck: DeckListPayload["player"],
-  guestDecks: Map<PlayerId, DeckListPayload["player"]>,
-): DeckListPayload {
-  const sortedSeats = [...guestDecks.keys()].sort((a, b) => a - b);
-  if (sortedSeats.length === 0) {
-    throw new AdapterError(
-      "P2P_NO_GUESTS",
-      "Cannot start P2P game with zero guests",
-      false,
-    );
-  }
-  const opponent = guestDecks.get(sortedSeats[0])!;
-  const aiDecks = sortedSeats.slice(1).map((seat) => guestDecks.get(seat)!);
+function seatStateToView(state: SeatState): SeatView {
   return {
-    player: hostDeck,
-    opponent,
-    ai_decks: aiDecks,
+    seats: state.seats,
+    format: state.format,
+    isFull: state.seats.every((seat) => seat.type !== "WaitingHuman"),
+    gameStarted: state.gameStarted,
   };
+}
+
+function occupiedSeatCount(state: SeatState): number {
+  return state.seats.filter((seat) => seat.type !== "WaitingHuman").length;
+}
+
+function playerSlotsFromSeatView(view: SeatView): PlayerSlot[] {
+  return view.seats.map((kind, playerId) => ({
+    playerId,
+    kind,
+    name:
+      playerId === 0
+        ? "Host"
+        : kind.type === "Ai"
+          ? `AI (${kind.data.difficulty})`
+          : kind.type === "WaitingHuman"
+            ? ""
+            : `Player ${playerId + 1}`,
+  }));
+}
+
+function traceAdapter(side: "Host" | "Guest", event: string, data?: Record<string, unknown>): void {
+  console.debug(`[P2P ${side} Adapter]`, performance.now().toFixed(1), event, data ?? {});
 }
 
 /**
@@ -165,7 +196,8 @@ export class P2PHostAdapter implements EngineAdapter {
   private listeners: P2PAdapterEventListener[] = [];
 
   private guestSessions = new Map<PlayerId, PeerSession>();
-  private guestDecks = new Map<PlayerId, unknown>();
+  private guestDecks = new Map<PlayerId, DeckListPayload["player"]>();
+  private aiDecks = new Map<PlayerId, DeckListPayload["player"]>();
   private playerTokens = new Map<PlayerId, string>();
   /**
    * Mid-game disconnect tracker. `timer` is nullable: it is set when the grace
@@ -187,12 +219,14 @@ export class P2PHostAdapter implements EngineAdapter {
   private eliminatedSeats = new Set<PlayerId>();
   private gameRunState: GameRunState = "running";
 
-  private nextSeat: PlayerId = 1;
   private gameStarted = false;
   private guestDeckResolvers: Array<() => void> = [];
   private hostConnectionUnsub: (() => void) | null = null;
   private guestNames = new Map<PlayerId, string>();
   private hostDisplayName: string | null = null;
+  private pregameSeatState: SeatState;
+  private pregameOpQueue: Promise<void> = Promise.resolve();
+  private allowPartialStart = false;
 
   /**
    * Identifier used as the key when this adapter writes its resume
@@ -239,6 +273,7 @@ export class P2PHostAdapter implements EngineAdapter {
      * where no server-side listing exists.
      */
     private readonly broker?: BrokerClient,
+    private readonly ownsBroker: boolean = true,
     /**
      * Server-assigned game code for the lobby entry the broker holds.
      * Required when `broker` is set; unused otherwise. Distinct from the
@@ -276,6 +311,7 @@ export class P2PHostAdapter implements EngineAdapter {
         false,
       );
     }
+    this.pregameSeatState = defaultSeatState(playerCount, formatConfig);
     this.gameId = persistence?.gameId ?? null;
     this.roomCode = persistence?.roomCode ?? null;
     this.hostDisplayName = persistence?.hostDisplayName ?? null;
@@ -298,21 +334,22 @@ export class P2PHostAdapter implements EngineAdapter {
    * only handles adapter-owned transport + security state.
    */
   private rehydrateFromPersistedSession(session: PersistedP2PHostSession): void {
+    if (session.seatState) {
+      this.pregameSeatState = session.seatState;
+    }
     for (const [pidStr, token] of Object.entries(session.playerTokens)) {
       this.playerTokens.set(Number(pidStr), token);
     }
     for (const [pidStr, deck] of Object.entries(session.guestDecks)) {
-      this.guestDecks.set(Number(pidStr), deck);
+      this.guestDecks.set(Number(pidStr), deck as DeckListPayload["player"]);
+    }
+    for (const [pidStr, deck] of Object.entries(session.aiDecks ?? {})) {
+      this.aiDecks.set(Number(pidStr), deck as DeckListPayload["player"]);
     }
     for (const token of session.kickedTokens) this.kickedTokens.add(token);
     for (const pid of session.eliminatedSeats) {
       this.eliminatedSeats.add(pid);
     }
-    // `nextSeat` is the smallest seat index not yet assigned. For a
-    // 3-player resumed game with seats 0/1/2 filled, it must be 3 so
-    // no new joiner clobbers an existing seat.
-    const seatIds = Object.keys(session.playerTokens).map(Number);
-    this.nextSeat = seatIds.length > 0 ? Math.max(...seatIds) + 1 : 1;
     this.gameStarted = session.gameStarted;
 
     // Every persisted guest is "disconnected" from the resumed host's
@@ -371,6 +408,10 @@ export class P2PHostAdapter implements EngineAdapter {
     for (const [pid, deck] of this.guestDecks.entries()) {
       guestDecks[pid] = deck;
     }
+    const aiDecks: Record<number, unknown> = {};
+    for (const [pid, deck] of this.aiDecks.entries()) {
+      aiDecks[pid] = deck;
+    }
     return {
       gameId: this.gameId,
       roomCode: this.roomCode,
@@ -378,6 +419,7 @@ export class P2PHostAdapter implements EngineAdapter {
       useBroker: this.broker !== undefined,
       playerTokens,
       guestDecks,
+      aiDecks,
       kickedTokens: [...this.kickedTokens],
       eliminatedSeats: [...this.eliminatedSeats],
       playerCount: this.playerCount,
@@ -385,7 +427,26 @@ export class P2PHostAdapter implements EngineAdapter {
       matchConfig: this.matchConfig,
       hostDeckData: this.hostDeckData,
       gameStarted: this.gameStarted,
+      seatState: this.pregameSeatState,
     };
+  }
+
+  getPlayerSlots(): PlayerSlot[] {
+    return this.pregameSeatState.seats.map((kind, playerId) => ({
+      playerId,
+      kind,
+      name: this.displayNameForSeat(playerId, kind),
+    }));
+  }
+
+  private displayNameForSeat(playerId: number, kind: SeatKind): string {
+    if (playerId === 0) {
+      return this.hostDisplayName ?? "Host";
+    }
+    if (kind.type === "Ai") {
+      return `AI (${kind.data.difficulty})`;
+    }
+    return this.guestNames.get(playerId) ?? "";
   }
 
   /**
@@ -413,8 +474,157 @@ export class P2PHostAdapter implements EngineAdapter {
    * broker-side lifecycle (per CLAUDE.md's "single authority" rule).
    */
   startNow(): void {
+    this.allowPartialStart = true;
     const resolvers = this.guestDeckResolvers.splice(0);
     for (const r of resolvers) r();
+  }
+
+  private enqueuePregameOp<T>(work: () => Promise<T>): Promise<T> {
+    const next = this.pregameOpQueue.then(work, work);
+    this.pregameOpQueue = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  private firstWaitingSeat(): PlayerId | null {
+    for (let seat = 1; seat < this.pregameSeatState.seats.length; seat++) {
+      if (this.pregameSeatState.seats[seat]?.type === "WaitingHuman") {
+        return seat;
+      }
+    }
+    return null;
+  }
+
+  private remapSeatMap<T>(source: Map<PlayerId, T>, remapping: Array<[number, number]>): Map<PlayerId, T> {
+    const remapped = new Map<PlayerId, T>();
+    for (const [pid, value] of source.entries()) {
+      const mapped = remapping.find(([oldPid]) => oldPid === pid)?.[1] ?? pid;
+      remapped.set(mapped, value);
+    }
+    return remapped;
+  }
+
+  private remapSeatSet(source: Set<PlayerId>, remapping: Array<[number, number]>): Set<PlayerId> {
+    const remapped = new Set<PlayerId>();
+    for (const pid of source.values()) {
+      remapped.add(remapping.find(([oldPid]) => oldPid === pid)?.[1] ?? pid);
+    }
+    return remapped;
+  }
+
+  private broadcastSeatSnapshot(): void {
+    const view = seatStateToView(this.pregameSeatState);
+    for (const session of this.guestSessions.values()) {
+      session.send({ type: "seat_snapshot", view });
+    }
+    this.emit({ type: "playerSlotsUpdated", slots: this.getPlayerSlots() });
+  }
+
+  private syncLobbyMetadata(): void {
+    const currentPlayers = occupiedSeatCount(this.pregameSeatState);
+    const maxPlayers = this.pregameSeatState.seats.length;
+    this.emit({ type: "lobbyProgress", joined: currentPlayers, total: maxPlayers });
+    if (this.broker && this.brokerGameCode) {
+      this.broker.updateMetadata(this.brokerGameCode, currentPlayers, maxPlayers);
+    }
+  }
+
+  async applySeatMutation(mutation: SeatMutation): Promise<void> {
+    await this.enqueuePregameOp(async () => {
+      if (this.gameStarted) {
+        throw new AdapterError("P2P_ERROR", "Pregame seats can no longer be edited", false);
+      }
+      if (mutation.type === "Start") {
+        throw new AdapterError("P2P_ERROR", "Use startPregameGame() for Start mutations", false);
+      return;
+      }
+
+      const result = await this.wasm.applySeatMutation(
+        JSON.stringify(this.pregameSeatState),
+        JSON.stringify(mutation),
+      ) as SeatMutationResult;
+
+      for (const token of result.delta.invalidatedTokens) {
+        for (const [pid, seatToken] of this.playerTokens.entries()) {
+          if (seatToken !== token) continue;
+          const session = this.guestSessions.get(pid);
+          if (session) {
+            session.send({ type: "kick", reason: "Removed from the room by the host" });
+            try {
+              session.close("Removed by host");
+            } catch {
+              /* best-effort */
+            }
+          }
+          this.guestSessions.delete(pid);
+          this.playerTokens.delete(pid);
+          this.guestDecks.delete(pid);
+          this.guestNames.delete(pid);
+          break;
+        }
+      }
+
+      for (const seatIndex of result.delta.removedAi) {
+        this.aiDecks.delete(seatIndex);
+      }
+      for (const [seatIndex, _difficulty, deck] of result.delta.newAi) {
+        this.aiDecks.set(seatIndex, deck as DeckListPayload["player"]);
+      }
+
+      if (result.delta.renumbering) {
+        const { remapping } = result.delta.renumbering;
+        this.guestSessions = this.remapSeatMap(this.guestSessions, remapping);
+        this.guestDecks = this.remapSeatMap(this.guestDecks, remapping);
+        this.aiDecks = this.remapSeatMap(this.aiDecks, remapping);
+        this.playerTokens = this.remapSeatMap(this.playerTokens, remapping);
+        this.guestNames = this.remapSeatMap(this.guestNames, remapping);
+        this.disconnectedSeats = this.remapSeatMap(this.disconnectedSeats, remapping);
+        this.eliminatedSeats = this.remapSeatSet(this.eliminatedSeats, remapping);
+      }
+
+      this.pregameSeatState = result.state;
+      this.saveSession();
+      for (const session of this.guestSessions.values()) {
+        session.send({ type: "seat_mutate", mutation });
+      }
+      this.broadcastSeatSnapshot();
+      this.syncLobbyMetadata();
+    });
+  }
+
+  private async runAiLoop(): Promise<void> {
+    if (!this.gameStarted) return;
+
+    for (;;) {
+      const state = await this.wasm.getState();
+      if (!state || typeof state !== "object" || !("waiting_for" in state)) {
+        return;
+      }
+      const waitingFor = state.waiting_for;
+      if (!waitingFor || typeof waitingFor !== "object") {
+        return;
+      }
+      if (!("data" in waitingFor) || !waitingFor.data || !("player" in waitingFor.data)) {
+        return;
+      }
+      const aiSeat = this.pregameSeatState.seats[waitingFor.data.player];
+      if (!aiSeat || aiSeat.type !== "Ai") {
+        return;
+      }
+      const action = await this.wasm.getAiAction(aiSeat.data.difficulty, waitingFor.data.player);
+      if (!action) {
+        return;
+      }
+      const result = await this.wasm.submitAction(action, waitingFor.data.player);
+      await this.broadcastStateUpdate(result.events);
+      const nextState = await this.wasm.getState();
+      const legalResult = await this.wasm.getLegalActions();
+      this.emit({
+        type: "stateChanged",
+        state: nextState,
+        events: result.events,
+        legalResult,
+      });
+    }
   }
 
   onEvent(listener: P2PAdapterEventListener): () => void {
@@ -458,6 +668,10 @@ export class P2PHostAdapter implements EngineAdapter {
       });
     } else {
       await this.wasm.setMultiplayerMode(true);
+    }
+    if (!this.gameStarted) {
+      this.broadcastSeatSnapshot();
+      this.syncLobbyMetadata();
     }
     traceAdapter("Host", "initialize-complete", {});
   }
@@ -511,119 +725,122 @@ export class P2PHostAdapter implements EngineAdapter {
       session.close("Game in progress");
       return;
     }
-    if (this.guestSessions.size >= this.playerCount - 1) {
+    const pid = this.firstWaitingSeat();
+    if (pid === null) {
       session.send({ type: "kick", reason: "Lobby full" });
       session.close("Lobby full");
       return;
     }
-
-    const pid = this.nextSeat;
-    this.nextSeat++;
 
     // Issue a token immediately on join. The guest needs it for reconnect
     // even during the deck-collection window.
     const token = crypto.randomUUID();
     this.playerTokens.set(pid, token);
     this.guestSessions.set(pid, session);
-    this.guestDecks.set(pid, deckData);
+    this.guestDecks.set(pid, (deckData as DeckListPayload).player);
     if (displayName) this.guestNames.set(pid, displayName);
+    this.pregameSeatState.seats[pid] = { type: "JoinedHuman" };
+    this.pregameSeatState.tokens[pid] = token;
     this.saveSession();
 
     // Route subsequent messages from this guest.
     session.onMessage((msg) => this.handleGuestMessage(pid, msg));
 
-    this.broadcastLobbyProgress();
-
-    // If all guest decks are in, resolve the deck-collection promise.
-    if (this.guestDecks.size === this.playerCount - 1) {
-      const resolvers = this.guestDeckResolvers.splice(0);
-      for (const r of resolvers) r();
-    }
+    this.broadcastSeatSnapshot();
+    this.syncLobbyMetadata();
   }
 
-  private broadcastLobbyProgress(): void {
-    const joined = this.guestSessions.size + 1;
-    const total = this.playerCount;
-    for (const [, session] of this.guestSessions) {
-      session.send({ type: "lobby_progress", joined, total });
-    }
-    this.emit({ type: "lobbyProgress", joined, total });
-    if (this.broker && this.brokerGameCode) {
-      this.broker.updateMetadata(this.brokerGameCode, joined, total);
-    }
+  async initializeGame(): Promise<SubmitResult> {
+    return this.startPregameGame();
   }
 
-  async initializeGame(
-    _deckData?: unknown,
-    _formatConfig?: FormatConfig,
-    _playerCount?: number,
-    _matchConfig?: MatchConfig,
-    _firstPlayer?: number,
-  ): Promise<SubmitResult> {
-    // Wait until all guest decks are in.
-    if (this.guestDecks.size < this.playerCount - 1) {
-      await new Promise<void>((resolve) => {
-        this.guestDeckResolvers.push(resolve);
-      });
-    }
+  async startPregameGame(): Promise<SubmitResult> {
+    return this.enqueuePregameOp(() => this.startPregameGameInner());
+  }
 
-    const hostDeck = this.hostDeckData as DeckListPayload;
-    const guestDeckMap = new Map<PlayerId, DeckListPayload["player"]>();
-    for (const [pid, raw] of this.guestDecks) {
-      guestDeckMap.set(pid, (raw as DeckListPayload).player);
-    }
-    const deckPayload = buildDeckPayload(hostDeck.player, guestDeckMap);
+  private async startPregameGameInner(): Promise<SubmitResult> {
+      if (this.gameStarted) {
+        return { events: [] };
+      }
+      const allowPartialStart = this.allowPartialStart;
+      this.allowPartialStart = false;
+      const hasWaitingSeats = this.pregameSeatState.seats.some((seat) => seat.type === "WaitingHuman");
+      if (hasWaitingSeats && !allowPartialStart) {
+        throw new AdapterError("P2P_ERROR", "Fill or remove all open seats before starting", false);
+      }
 
-    const result = await this.wasm.initializeGame(
-      deckPayload,
-      this.formatConfig,
-      this.playerCount,
-      this.matchConfig,
-      undefined,
-    );
-    this.gameStarted = true;
-    // Mark the session as started-and-playable. From this point forward
-    // a reload can resume mid-game; before this, reload goes back to
-    // the lobby and guests must rejoin fresh.
-    this.saveSession();
-    const allNames: Record<number, string> = {};
-    if (this.hostDisplayName) allNames[0] = this.hostDisplayName;
-    for (const [pid, name] of this.guestNames) allNames[pid] = name;
-    this.emit({ type: "playerIdentity", playerId: 0, playerNames: allNames });
+      const hostDeck = this.hostDeckData as DeckListPayload;
+      const orderedOpponents: DeckListPayload["player"][] = [];
+      for (let seat = 1; seat < this.pregameSeatState.seats.length; seat++) {
+        const kind = this.pregameSeatState.seats[seat];
+        if (kind.type === "JoinedHuman") {
+          const deck = this.guestDecks.get(seat);
+          if (!deck) {
+            throw new AdapterError("P2P_ERROR", `Seat ${seat} has no submitted deck`, false);
+          }
+          orderedOpponents.push(deck);
+          continue;
+        }
+        if (kind.type === "Ai") {
+          const deck = this.aiDecks.get(seat);
+          if (!deck) {
+            throw new AdapterError("P2P_ERROR", `AI seat ${seat} is missing a resolved deck`, false);
+          }
+          orderedOpponents.push(deck);
+        }
+      }
+      if (orderedOpponents.length === 0) {
+        throw new AdapterError("P2P_ERROR", "Cannot start P2P game with zero opponents", false);
+      }
 
-    // Tear down the public lobby entry only *after* the engine is live.
-    // If the earlier `initializeGame` had thrown (deck resolution, WASM
-    // panic, etc.), firing unregister first would leave the lobby gone
-    // with a dead game — a "room listed but un-joinable" stuck state.
-    // Best-effort: a failure here falls back on the server's 5-minute
-    // `check_expired` backstop; the local game proceeds regardless.
-    if (this.broker && this.brokerGameCode) {
-      void this.broker
-        .unregister(this.brokerGameCode)
-        .catch(() => {
-          /* best-effort — see comment above */
+      const deckPayload: DeckListPayload = {
+        player: hostDeck.player,
+        opponent: orderedOpponents[0],
+        ai_decks: orderedOpponents.slice(1),
+      };
+      const playerCount = allowPartialStart
+        ? orderedOpponents.length + 1
+        : this.pregameSeatState.seats.length;
+      const result = await this.wasm.initializeGame(
+        deckPayload,
+        this.formatConfig,
+        playerCount,
+        this.matchConfig,
+        undefined,
+      );
+      this.gameStarted = true;
+      this.pregameSeatState.gameStarted = true;
+      this.saveSession();
+
+      const allNames: Record<number, string> = {};
+      if (this.hostDisplayName) allNames[0] = this.hostDisplayName;
+      for (const [pid, name] of this.guestNames) allNames[pid] = name;
+      this.emit({ type: "playerIdentity", playerId: 0, playerNames: allNames });
+
+      if (this.broker && this.brokerGameCode) {
+        void this.broker.unregister(this.brokerGameCode).catch(() => {
+          /* best-effort */
         });
-    }
+      }
 
-    // Per-guest game_setup: each guest receives their unique
-    // assignedPlayerId, playerToken, and filtered state.
-    const legal = await this.wasm.getLegalActions();
-    for (const [pid, session] of this.guestSessions) {
-      const token = this.playerTokens.get(pid)!;
-      const filteredState = await this.wasm.getFilteredState(pid);
-      session.send({
-        type: "game_setup",
-        assignedPlayerId: pid,
-        playerToken: token,
-        state: filteredState,
-        events: result.events,
-        legalActions: legal.actions,
-        autoPassRecommended: legal.autoPassRecommended,
-        playerNames: allNames,
-      });
-    }
+      const legal = await this.wasm.getLegalActions();
+      for (const [pid, session] of this.guestSessions) {
+        const token = this.playerTokens.get(pid)!;
+        const filteredState = await this.wasm.getFilteredState(pid);
+        session.send({
+          type: "game_setup",
+          assignedPlayerId: pid,
+          playerToken: token,
+          state: filteredState,
+          events: result.events,
+          legalActions: legal.actions,
+          autoPassRecommended: legal.autoPassRecommended,
+          playerNames: allNames,
+        });
+      }
 
-    return result;
+      await this.runAiLoop();
+      return result;
   }
 
   async submitAction(action: GameAction, actor: PlayerId): Promise<SubmitResult> {
@@ -640,6 +857,7 @@ export class P2PHostAdapter implements EngineAdapter {
     }
     const result = await this.wasm.submitAction(action, actor);
     await this.broadcastStateUpdate(result.events);
+    await this.runAiLoop();
     return result;
   }
 
@@ -700,17 +918,19 @@ export class P2PHostAdapter implements EngineAdapter {
     this.kickedTokens.clear();
     this.playerTokens.clear();
     this.guestDecks.clear();
+    this.aiDecks.clear();
     try {
       this.hostPeer.destroy();
     } catch {
       /* best-effort */
     }
     this.wasm.dispose();
-    // The broker (when set) wraps a PhaseSocket that the adapter adopted
-    // at construction. Ownership transferred here, so dispose is the last
-    // authority that can close it. `close()` is idempotent via the internal
-    // `closed` flag, so a prior error-path close in GameProvider is safe.
-    this.broker?.close();
+    // Close the broker only when the adapter owns it. When the multiplayer
+    // store owns the broker (externally managed), it survives adapter disposal
+    // so the lobby entry stays alive across page navigations.
+    if (this.ownsBroker) {
+      this.broker?.close();
+    }
     this.listeners = [];
   }
 
@@ -845,12 +1065,12 @@ export class P2PHostAdapter implements EngineAdapter {
       // `nextSeat` rewind so the next joiner takes the same slot.
       this.playerTokens.delete(pid);
       this.guestDecks.delete(pid);
-      // Rewind nextSeat if this was the most recent join.
-      if (pid === this.nextSeat - 1) {
-        this.nextSeat = pid;
-      }
+      this.guestNames.delete(pid);
+      this.pregameSeatState.seats[pid] = { type: "WaitingHuman" };
+      this.pregameSeatState.tokens[pid] = "";
       this.saveSession();
-      this.broadcastLobbyProgress();
+      this.broadcastSeatSnapshot();
+      this.syncLobbyMetadata();
       return;
     }
 
@@ -1001,6 +1221,7 @@ export class P2PHostAdapter implements EngineAdapter {
       // on behalf of (e.g. grace-expiry or kick).
       const result = await this.wasm.submitAction(concedeAction, pid);
       await this.broadcastStateUpdate(result.events);
+      await this.runAiLoop();
       const state = await this.wasm.getState();
       const legalResult = await this.wasm.getLegalActions();
       this.emit({
@@ -1422,6 +1643,16 @@ export class P2PGuestAdapter implements EngineAdapter {
           joined: msg.joined,
           total: msg.total,
         });
+        break;
+      }
+      case "seat_snapshot": {
+        this.emit({
+          type: "playerSlotsUpdated",
+          slots: playerSlotsFromSeatView(msg.view),
+        });
+        break;
+      }
+      case "seat_mutate": {
         break;
       }
       default:

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -227,6 +227,15 @@ export class WasmAdapter implements EngineAdapter {
     }
   }
 
+  async applySeatMutation(stateJson: string, mutationJson: string): Promise<unknown> {
+    this.assertInitialized();
+    await this.ensureCardDb();
+    if (this.engine) {
+      return this.engine.applySeatMutation(stateJson, mutationJson);
+    }
+    return this.fallback!.applySeatMutation(stateJson, mutationJson);
+  }
+
   /**
    * Resume a P2P host session from a persisted `GameState`. Stamps a fresh
    * RNG seed (so continued play diverges from the pre-save sequence) and
@@ -352,6 +361,7 @@ interface MainThreadFallback {
   restoreState(stateJson: string): void;
   resumeMultiplayerHostState(stateJson: string): void;
   setMultiplayerMode(enabled: boolean): void;
+  applySeatMutation(stateJson: string, mutationJson: string): Promise<unknown>;
   ping(): string;
   initializeGame(
     deckData: unknown | null,
@@ -424,6 +434,9 @@ async function createMainThreadFallback(): Promise<MainThreadFallback> {
     setMultiplayerMode: (enabled: boolean) => {
       enqueue(() => wasm.set_multiplayer_mode(enabled));
     },
+
+    applySeatMutation: (stateJson: string, mutationJson: string) =>
+      enqueue(() => wasm.apply_seat_mutation(stateJson, mutationJson)),
 
     ping: () => wasm.ping(),
 

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -30,7 +30,7 @@ export interface DeckData {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  */
-export const PROTOCOL_VERSION = 2;
+export const PROTOCOL_VERSION = 3;
 
 /** Identity advertised by the server in its `ServerHello`. */
 export interface ServerInfo {

--- a/client/src/components/chrome/HostControlTile.tsx
+++ b/client/src/components/chrome/HostControlTile.tsx
@@ -1,10 +1,38 @@
+import { listSavedDeckNames } from "../../constants/storage";
 import { useNavigate, useLocation } from "react-router";
+import { loadDeck } from "../menu/deckHelpers";
 
 import {
   useMultiplayerStore,
+  type DeckChoice,
   type PlayerSlot,
+  type SeatMutation,
   type SeatKind,
 } from "../../stores/multiplayerStore";
+
+const AI_DIFFICULTIES = ["Easy", "Medium", "Hard", "VeryHard"] as const;
+const RANDOM_DECK: DeckChoice = { type: "Random" };
+
+function compatibleDeckChoices(
+  minDeckSize: number,
+  commandZone: boolean,
+): Array<{ label: string; choice: DeckChoice }> {
+  const choices: Array<{ label: string; choice: DeckChoice }> = [
+    { label: "Random", choice: RANDOM_DECK },
+  ];
+
+  for (const deckName of listSavedDeckNames()) {
+    const deck = loadDeck(deckName);
+    if (!deck) continue;
+    const mainCount = deck.main.reduce((sum, entry) => sum + entry.count, 0);
+    const hasCommander = (deck.commander?.length ?? 0) > 0;
+    if (mainCount < minDeckSize) continue;
+    if (hasCommander !== commandZone) continue;
+    choices.push({ label: deckName, choice: { type: "Named", data: deckName } });
+  }
+
+  return choices;
+}
 
 function seatLabel(kind: SeatKind): string {
   switch (kind.type) {
@@ -32,16 +60,187 @@ function seatColor(kind: SeatKind): string {
   }
 }
 
-function SeatRow({ slot }: { slot: PlayerSlot }) {
+function SeatRow({
+  slot,
+  minPlayers,
+  seatCount,
+  canEdit,
+  deckChoices,
+  mutate,
+}: {
+  slot: PlayerSlot;
+  minPlayers: number;
+  seatCount: number;
+  canEdit: boolean;
+  deckChoices: Array<{ label: string; choice: DeckChoice }>;
+  mutate: (mutation: SeatMutation) => void;
+}) {
   const isOpen = slot.kind.type === "WaitingHuman";
+  const kickLabel = slot.name || `Player ${slot.playerId + 1}`;
+  const aiSeat = slot.kind.type === "Ai" ? slot.kind : null;
   return (
-    <div className="flex items-center justify-between gap-2 py-0.5">
-      <span className={`text-xs ${isOpen ? "italic text-slate-500" : "text-slate-300"}`}>
-        {isOpen ? "Waiting…" : slot.name || `Seat ${slot.playerId}`}
-      </span>
-      <span className={`text-[10px] font-medium ${seatColor(slot.kind)}`}>
-        {seatLabel(slot.kind)}
-      </span>
+    <div className="py-1">
+      <div className="flex items-center justify-between gap-2">
+        <span className={`text-xs ${isOpen ? "italic text-slate-500" : "text-slate-300"}`}>
+          {isOpen ? "Waiting…" : slot.name || `Seat ${slot.playerId}`}
+        </span>
+        <span className={`text-[10px] font-medium ${seatColor(slot.kind)}`}>
+          {seatLabel(slot.kind)}
+        </span>
+      </div>
+      {canEdit && slot.playerId !== 0 && (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {slot.kind.type === "WaitingHuman" && (
+            <>
+              <button
+                type="button"
+                onClick={() =>
+                  mutate({
+                    type: "SetKind",
+                    data: {
+                      seatIndex: slot.playerId,
+                      kind: {
+                        type: "Ai",
+                        data: { difficulty: "Medium", deck: RANDOM_DECK },
+                      },
+                    },
+                  })
+                }
+                className="rounded border border-cyan-500/20 px-2 py-0.5 text-[10px] text-cyan-300"
+              >
+                Add AI
+              </button>
+              {seatCount > minPlayers && (
+                <button
+                  type="button"
+                  onClick={() => mutate({ type: "Remove", data: { seatIndex: slot.playerId } })}
+                  className="rounded border border-white/10 px-2 py-0.5 text-[10px] text-slate-400"
+                >
+                  Remove
+                </button>
+              )}
+            </>
+          )}
+          {slot.kind.type === "Ai" && (
+            <>
+              <select
+                value={slot.kind.data.difficulty}
+                onChange={(e) =>
+                  mutate({
+                    type: "SetKind",
+                    data: {
+                      seatIndex: slot.playerId,
+                      kind: {
+                        type: "Ai",
+                        data: {
+                          difficulty: e.target.value,
+                          deck: slot.kind.type === "Ai" ? slot.kind.data.deck : RANDOM_DECK,
+                        },
+                      },
+                    },
+                  })
+                }
+                className="rounded border border-white/10 bg-slate-950 px-1 py-0.5 text-[10px] text-slate-200"
+              >
+                {AI_DIFFICULTIES.map((difficulty) => (
+                  <option key={difficulty} value={difficulty}>
+                    {difficulty}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={aiSeat?.data.deck.type === "Named" ? aiSeat.data.deck.data : ""}
+                onChange={(e) =>
+                  mutate({
+                    type: "SetKind",
+                    data: {
+                      seatIndex: slot.playerId,
+                      kind: {
+                        type: "Ai",
+                        data: {
+                          difficulty: aiSeat?.data.difficulty ?? "Medium",
+                          deck: e.target.value
+                            ? { type: "Named", data: e.target.value }
+                            : RANDOM_DECK,
+                        },
+                      },
+                    },
+                  })
+                }
+                className="rounded border border-white/10 bg-slate-950 px-1 py-0.5 text-[10px] text-slate-200"
+              >
+                {deckChoices.map(({ label, choice }) => (
+                  <option
+                    key={choice.type === "Named" ? choice.data : "Random"}
+                    value={choice.type === "Named" ? choice.data : ""}
+                  >
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() =>
+                  mutate({
+                    type: "SetKind",
+                    data: { seatIndex: slot.playerId, kind: { type: "WaitingHuman" } },
+                  })
+                }
+                className="rounded border border-white/10 px-2 py-0.5 text-[10px] text-slate-300"
+              >
+                Human
+              </button>
+              {seatCount > minPlayers && (
+                <button
+                  type="button"
+                  onClick={() => mutate({ type: "Remove", data: { seatIndex: slot.playerId } })}
+                  className="rounded border border-white/10 px-2 py-0.5 text-[10px] text-slate-400"
+                >
+                  Remove
+                </button>
+              )}
+            </>
+          )}
+          {slot.kind.type === "JoinedHuman" && (
+            <>
+              <button
+                type="button"
+                onClick={() => {
+                  if (!window.confirm(`Kick ${kickLabel} from the room?`)) return;
+                  mutate({
+                    type: "SetKind",
+                    data: { seatIndex: slot.playerId, kind: { type: "WaitingHuman" } },
+                  });
+                }}
+                className="rounded border border-amber-500/20 px-2 py-0.5 text-[10px] text-amber-300"
+              >
+                Kick
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  if (!window.confirm(`Replace ${kickLabel} with AI? This removes them from the room.`)) {
+                    return;
+                  }
+                  mutate({
+                    type: "SetKind",
+                    data: {
+                      seatIndex: slot.playerId,
+                      kind: {
+                        type: "Ai",
+                        data: { difficulty: "Medium", deck: RANDOM_DECK },
+                      },
+                    },
+                  });
+                }}
+                className="rounded border border-cyan-500/20 px-2 py-0.5 text-[10px] text-cyan-300"
+              >
+                Replace AI
+              </button>
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -52,14 +251,43 @@ export function HostControlTile() {
   const cancelHosting = useMultiplayerStore((s) => s.cancelHosting);
   const playerSlots = useMultiplayerStore((s) => s.playerSlots);
   const hostSession = useMultiplayerStore((s) => s.hostSession);
+  const seatMutate = useMultiplayerStore((s) => s.seatMutate);
   const navigate = useNavigate();
   const location = useLocation();
 
-  if (hostingStatus === "idle" || location.pathname.startsWith("/game/")) {
+  if (hostingStatus === "idle") {
     return null;
   }
 
   const isConnecting = hostingStatus === "connecting";
+  const minPlayers = hostSession?.formatConfig.min_players ?? 2;
+  const deckChoices = compatibleDeckChoices(
+    hostSession?.formatConfig.deck_size ?? 60,
+    hostSession?.formatConfig.command_zone ?? false,
+  );
+  const waitingSeats = playerSlots.filter((slot) => slot.kind.type === "WaitingHuman");
+  const occupiedSeats = playerSlots.length - waitingSeats.length;
+  const canEditSeats = hostingStatus === "waiting";
+
+  const startWithCurrentPlayers = () => {
+    for (const slot of [...waitingSeats].sort((a, b) => b.playerId - a.playerId)) {
+      seatMutate({ type: "Remove", data: { seatIndex: slot.playerId } });
+    }
+    seatMutate({ type: "Start" });
+  };
+
+  const fillWithAiAndStart = () => {
+    for (const slot of waitingSeats) {
+      seatMutate({
+        type: "SetKind",
+        data: {
+          seatIndex: slot.playerId,
+          kind: { type: "Ai", data: { difficulty: "Medium", deck: RANDOM_DECK } },
+        },
+      });
+    }
+    seatMutate({ type: "Start" });
+  };
 
   return (
     <div
@@ -71,7 +299,13 @@ export function HostControlTile() {
         <div className="flex items-center justify-between border-b border-white/5 px-3 py-2">
           <button
             type="button"
-            onClick={() => navigate("/multiplayer")}
+            onClick={() => {
+              if (location.pathname.startsWith("/game/") && hostGameCode) {
+                void navigator.clipboard?.writeText(hostGameCode);
+              } else {
+                navigate("/multiplayer");
+              }
+            }}
             className="flex items-center gap-2 text-xs text-slate-300 transition-colors hover:text-white"
           >
             <span className="relative flex h-2 w-2">
@@ -98,6 +332,9 @@ export function HostControlTile() {
             onClick={(e) => {
               e.stopPropagation();
               cancelHosting();
+              if (location.pathname.startsWith("/game/")) {
+                navigate("/multiplayer");
+              }
             }}
             className="text-slate-500 transition-colors hover:text-rose-400"
             aria-label="Cancel hosting"
@@ -110,8 +347,53 @@ export function HostControlTile() {
         {playerSlots.length > 0 && (
           <div className="px-3 py-2">
             {playerSlots.map((slot) => (
-              <SeatRow key={slot.playerId} slot={slot} />
+              <SeatRow
+                key={slot.playerId}
+                slot={slot}
+                minPlayers={minPlayers}
+                seatCount={playerSlots.length}
+                canEdit={canEditSeats}
+                deckChoices={deckChoices}
+                mutate={seatMutate}
+              />
             ))}
+          </div>
+        )}
+        {canEditSeats && hostSession && (
+          <div className="border-t border-white/5 px-3 py-2">
+            <div className="mb-2 text-[10px] uppercase tracking-wide text-slate-500">
+              {occupiedSeats}/{playerSlots.length} seats occupied
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {waitingSeats.length === 0 ? (
+                <button
+                  type="button"
+                  onClick={() => seatMutate({ type: "Start" })}
+                  className="rounded border border-emerald-500/20 px-2 py-1 text-[11px] font-medium text-emerald-300"
+                >
+                  Start Game
+                </button>
+              ) : (
+                <>
+                  {occupiedSeats >= minPlayers && (
+                    <button
+                      type="button"
+                      onClick={startWithCurrentPlayers}
+                      className="rounded border border-emerald-500/20 px-2 py-1 text-[11px] font-medium text-emerald-300"
+                    >
+                      Start Now
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={fillWithAiAndStart}
+                    className="rounded border border-cyan-500/20 px-2 py-1 text-[11px] font-medium text-cyan-300"
+                  >
+                    Fill With AI
+                  </button>
+                </>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/client/src/multiplayer/seatTypes.ts
+++ b/client/src/multiplayer/seatTypes.ts
@@ -1,0 +1,50 @@
+import type { FormatConfig } from "../adapter/types";
+
+export type DeckChoice =
+  | { type: "Random" }
+  | { type: "Named"; data: string };
+
+export type SeatKind =
+  | { type: "HostHuman" }
+  | { type: "JoinedHuman" }
+  | { type: "WaitingHuman" }
+  | { type: "Ai"; data: { difficulty: string; deck: DeckChoice } };
+
+export interface PlayerSlot {
+  playerId: number;
+  name: string;
+  kind: SeatKind;
+}
+
+export type SeatMutation =
+  | { type: "SetKind"; data: { seatIndex: number; kind: SeatKind } }
+  | { type: "Remove"; data: { seatIndex: number } }
+  | { type: "Start" };
+
+export interface SeatState {
+  seats: SeatKind[];
+  tokens: string[];
+  format: FormatConfig;
+  gameStarted: boolean;
+}
+
+export interface SeatView {
+  seats: SeatKind[];
+  format: FormatConfig;
+  isFull: boolean;
+  gameStarted: boolean;
+}
+
+export interface SeatDelta {
+  mutatedSeats: number[];
+  invalidatedTokens: string[];
+  removedAi: number[];
+  newAi: Array<[number, string, unknown]>;
+  renumbering: { removedIndex: number; remapping: Array<[number, number]> } | null;
+  nowStarted: boolean;
+}
+
+export interface SeatMutationResult {
+  state: SeatState;
+  delta: SeatDelta;
+}

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -1,4 +1,5 @@
 import type { GameAction, GameEvent, GameState } from "../adapter/types";
+import type { SeatMutation, SeatView } from "../multiplayer/seatTypes";
 
 export type P2PMessage =
   | { type: "guest_deck"; deckData: unknown; displayName?: string }
@@ -60,7 +61,9 @@ export type P2PMessage =
   | { type: "game_paused"; reason: string }
   | { type: "game_resumed" }
   // Pre-game lobby progress (host → all peers in the lobby).
-  | { type: "lobby_progress"; joined: number; total: number };
+  | { type: "lobby_progress"; joined: number; total: number }
+  | { type: "seat_mutate"; mutation: SeatMutation }
+  | { type: "seat_snapshot"; view: SeatView };
 
 const VALID_TYPES = new Set([
   "guest_deck",
@@ -85,6 +88,8 @@ const VALID_TYPES = new Set([
   "game_paused",
   "game_resumed",
   "lobby_progress",
+  "seat_mutate",
+  "seat_snapshot",
 ]);
 
 /** Validate an already-parsed object as a P2PMessage. Throws on malformed data. */

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -78,6 +78,7 @@ import {
   getPlayerDisplayName,
   playerToastKey,
   useMultiplayerStore,
+  type PlayerSlot,
 } from "../stores/multiplayerStore.ts";
 import { GameProvider } from "../providers/GameProvider.tsx";
 import { useCanActForWaitingState, usePerspectivePlayerId, usePlayerId } from "../hooks/usePlayerId.ts";
@@ -128,6 +129,7 @@ export function GamePage() {
   const playersParam = searchParams.get("players");
   const matchParam = searchParams.get("match");
   const firstParam = searchParams.get("first");
+  const roomNameParam = searchParams.get("roomName");
   const playerCount = playersParam ? Number(playersParam) : undefined;
   // Memoize so the `GameProvider` `useEffect` dep array doesn't
   // tear-down/rebuild the P2P session on every parent re-render. Without
@@ -321,9 +323,35 @@ export function GamePage() {
 
   const handleP2PEvent = useCallback((event: P2PAdapterEvent) => {
     switch (event.type) {
-      case "roomCreated":
+      case "roomCreated": {
         setHostGameCode(event.roomCode);
+        const effectivePlayerCount = playerCount ?? formatConfig?.max_players ?? 2;
+        const slots: PlayerSlot[] = [
+          {
+            playerId: 0,
+            name: useMultiplayerStore.getState().displayName || "Host",
+            kind: { type: "HostHuman" },
+          },
+          ...Array.from({ length: effectivePlayerCount - 1 }, (_, i) => ({
+            playerId: i + 1,
+            name: "",
+            kind: { type: "WaitingHuman" as const },
+          })),
+        ];
+        useMultiplayerStore.setState({
+          hostGameCode: event.roomCode,
+          hostingStatus: "waiting",
+          hostSession: formatConfig
+            ? {
+                formatConfig,
+                timerSeconds: null,
+                matchType: matchConfig?.match_type === "Bo3" ? "Bo3" : "Bo1",
+              }
+            : null,
+          playerSlots: slots,
+        });
         break;
+      }
       case "waitingForGuest":
         setWaitingForOpponent(true);
         break;
@@ -364,6 +392,10 @@ export function GamePage() {
         if (event.joined >= event.total) {
           setLobbyProgress(null);
           setWaitingForOpponent(false);
+          useMultiplayerStore.setState({
+            hostGameCode: null,
+            hostingStatus: "idle",
+          });
         }
         break;
       }
@@ -393,7 +425,7 @@ export function GamePage() {
         break;
       }
     }
-  }, [navigate]);
+  }, [navigate, formatConfig, matchConfig, playerCount]);
 
   const handleReady = useCallback(() => {
     setWaitingForOpponent(false);
@@ -425,6 +457,7 @@ export function GamePage() {
       matchConfig={matchConfig}
       firstPlayer={firstPlayer}
       useBroker={useBroker}
+      roomName={roomNameParam ?? undefined}
       onWsEvent={mode === "online" ? handleWsEvent : undefined}
       onP2PEvent={
         mode === "p2p-host" || mode === "p2p-join" ? handleP2PEvent : undefined
@@ -498,7 +531,7 @@ function GamePageContent({
   mode,
   isOnlineMode,
   hostGameCode,
-  waitingForOpponent,
+  waitingForOpponent: _waitingForOpponent,
   opponentDisconnected,
   reconnectState,
   showCardDataMissing,
@@ -918,64 +951,6 @@ function GamePageContent({
         />
       )}
 
-      {/* Host game: show game code while waiting */}
-      {waitingForOpponent && hostGameCode && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div className="absolute inset-0 bg-black/70" />
-          <div className="relative z-10 w-full max-w-md rounded-[24px] border border-white/10 bg-[#0b1020]/96 p-8 text-center shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-md">
-            <h2 className="mb-2 text-xl font-bold text-white">
-              Waiting for Opponent
-            </h2>
-            <p className="mb-4 text-sm text-gray-400">
-              Share this code with your opponent:
-            </p>
-            <div className="mb-4 flex items-center justify-center gap-3">
-              {/* `select-all` + `cursor-text` + explicit `user-select: text`
-                  so the entire code highlights on a single click even if a
-                  parent has set `user-select: none` for the game surface. */}
-              <span
-                className="select-all font-mono text-4xl font-bold tracking-widest text-emerald-400"
-                style={{ userSelect: "text" }}
-              >
-                {hostGameCode}
-              </span>
-              <button
-                type="button"
-                onClick={() => {
-                  void navigator.clipboard?.writeText(hostGameCode);
-                }}
-                title="Copy code"
-                aria-label="Copy code to clipboard"
-                className="rounded-lg border border-white/10 bg-white/5 p-2 text-slate-300 transition-colors hover:border-white/18 hover:bg-white/10 hover:text-white"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  className="h-4 w-4"
-                  aria-hidden="true"
-                >
-                  <path d="M7 3a2 2 0 0 0-2 2v1H4a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2v-1h1a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2H7Zm0 2h8v8h-1V8a2 2 0 0 0-2-2H7V5Zm-3 3h8v8H4V8Z" />
-                </svg>
-              </button>
-            </div>
-            <p className="text-xs text-gray-500">
-              The game will start when your opponent joins.
-            </p>
-          </div>
-        </div>
-      )}
-
-      {/* Join game: waiting overlay */}
-      {waitingForOpponent && !hostGameCode && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div className="absolute inset-0 bg-black/70" />
-          <div className="relative z-10 w-full max-w-sm rounded-[24px] border border-white/10 bg-[#0b1020]/96 p-6 text-center shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-md">
-            <h2 className="text-lg font-bold text-white">Joining Game...</h2>
-            <p className="mt-2 text-sm text-gray-400">Connecting to game</p>
-          </div>
-        </div>
-      )}
 
       {/*
         Opponent-disconnected overlay for server (WS) games. The live

--- a/client/src/pages/MultiplayerPage.tsx
+++ b/client/src/pages/MultiplayerPage.tsx
@@ -49,6 +49,7 @@ export function MultiplayerPage() {
   const navigate = useNavigate();
 
   const startHosting = useMultiplayerStore((s) => s.startHosting);
+  const startP2PHostingSession = useMultiplayerStore((s) => s.startP2PHostingSession);
   const showToast = useMultiplayerStore((s) => s.showToast);
 
   const [view, setView] = useState<MultiplayerView>("lobby");
@@ -182,32 +183,6 @@ export function MultiplayerPage() {
     }
     setView(deckSelectReturn);
   };
-
-  // Expand a ParsedDeck into flat name arrays for the server
-  // Extract the per-game URL params + navigate for the P2P host path.
-  // Same shape is used by the happy path (broker reachable) and the
-  // "continue without lobby" fallback, so factoring out keeps them in
-  // lockstep.
-  const navigateToP2PHost = useCallback(
-    (action: Extract<PendingAction, { type: "host" }>, useBroker: boolean) => {
-      const gameId = crypto.randomUUID();
-      useGameStore.setState({ gameId });
-      const params = new URLSearchParams({
-        mode: "p2p-host",
-        match: action.settings.matchType.toLowerCase(),
-        format: action.settings.formatConfig.format,
-        players: String(action.settings.formatConfig.max_players),
-      });
-      // `useBroker` travels via React Router location state — we
-      // intentionally avoid a URL param so a hard refresh re-evaluates
-      // broker reachability from scratch instead of pinning the user to
-      // "no listing" silently.
-      navigate(`/game/${gameId}?${params.toString()}`, {
-        state: { useBroker },
-      });
-    },
-    [navigate],
-  );
 
   const expandDeck = useCallback(() => {
     const deck = loadActiveDeck();
@@ -373,7 +348,14 @@ export function MultiplayerPage() {
             setBrokerOfflinePrompt({ action });
             return false;
           }
-          navigateToP2PHost(action, /* useBroker */ mode === "LobbyOnly");
+          const ok = await startP2PHostingSession(action.settings, deck, {
+            useBroker: mode === "LobbyOnly",
+            roomName: action.settings.roomName,
+          });
+          if (!ok) {
+            return false;
+          }
+          navigate("/");
         } else {
           // Server-mode host: if the server is unreachable, surface the
           // offline prompt and offer a P2P fallback rather than handing
@@ -414,7 +396,7 @@ export function MultiplayerPage() {
 
       return true;
     },
-    [expandDeck, startHosting, navigate, navigateToP2PHost, showToast],
+    [expandDeck, startHosting, startP2PHostingSession, navigate, showToast],
   );
 
   // Host setup complete → execute immediately if deck exists, otherwise prompt
@@ -683,7 +665,17 @@ export function MultiplayerPage() {
             const { action } = brokerOfflinePrompt;
             setBrokerOfflinePrompt(null);
             if (action.type === "host") {
-              navigateToP2PHost(action, /* useBroker */ false);
+              const deck = expandDeck();
+              if (!deck) {
+                showToast("Could not load deck. Try re-importing it.");
+                return;
+              }
+              void startP2PHostingSession(action.settings, deck, {
+                useBroker: false,
+                roomName: action.settings.roomName,
+              }).then((ok) => {
+                if (ok) navigate("/");
+              });
             }
           }}
         />

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -13,10 +13,7 @@ import type { FeedDeck } from "../types/feed";
 import { createGameLoopController } from "../game/controllers/gameLoopController";
 import { dispatchAction, processRemoteUpdate } from "../game/dispatch";
 import { hostRoom, joinRoom } from "../network/connection";
-import {
-  openBrokerClient,
-  type BrokerClient,
-} from "../services/brokerClient";
+import type { BrokerClient } from "../services/brokerClient";
 import { loadP2PSession } from "../services/p2pSession";
 import type { ParsedDeck } from "../services/deckParser";
 import { consumeRecentAutoUpdateMarker } from "../pwa/updateMarker";
@@ -187,6 +184,7 @@ export interface GameProviderProps {
    * the P2P host flow.
    */
   useBroker?: boolean;
+  roomName?: string;
   onWsEvent?: (event: WsAdapterEvent) => void;
   onP2PEvent?: (event: P2PAdapterEvent) => void;
   onReady?: () => void;
@@ -207,6 +205,7 @@ export function GameProvider({
   matchConfig,
   firstPlayer,
   useBroker = false,
+  roomName,
   onWsEvent,
   onP2PEvent,
   onReady,
@@ -311,6 +310,14 @@ export function GameProvider({
 
         try {
           if (mode === "p2p-host") {
+            const activeHost = useMultiplayerStore.getState().getActiveP2PHost();
+            if (activeHost?.gameId === gameId) {
+              const adapter = activeHost.adapter;
+              p2pAdapter = adapter;
+              wireP2PEvents(adapter);
+              await resumeP2PHost(gameId, adapter);
+              signal.throwIfAborted();
+            } else {
             // Resume detection: if both the engine state and the P2P
             // host session were persisted for this gameId, the host
             // crashed/reloaded mid-game and should dial back in on the
@@ -343,12 +350,6 @@ export function GameProvider({
             // the broker's 5-min TTL. Returning guests dial the host
             // directly via their cached peer-id + token; they never go
             // through the lobby list for reconnect.
-            if (useBroker && !isResume) {
-              const serverAddress = useMultiplayerStore.getState().serverAddress;
-              broker = await openBrokerClient(serverAddress, { signal });
-              signal.throwIfAborted();
-            }
-
             const host = await hostRoom(signal, {
               preferredRoomCode: isResume ? savedSession.roomCode : undefined,
             });
@@ -358,11 +359,12 @@ export function GameProvider({
             hostPeerHandle = host;
             signal.throwIfAborted();
 
-            if (broker) {
-              const registered = await broker.registerHost({
+            if (useBroker && !isResume) {
+              const store = useMultiplayerStore.getState();
+              const result = await store.openBroker({
                 hostPeerId: host.peer.id,
                 deck: deckList.player,
-                displayName: useMultiplayerStore.getState().displayName || "Host",
+                displayName: store.displayName || "Host",
                 public: true,
                 password: null,
                 timerSeconds: null,
@@ -370,10 +372,13 @@ export function GameProvider({
                 matchConfig: matchConfig ?? { match_type: "Bo1" },
                 formatConfig: formatConfig ?? null,
                 aiSeats: [],
-                roomName: null,
+                roomName: roomName ?? null,
               });
-              serverGameCode = registered.gameCode;
               signal.throwIfAborted();
+              if (result) {
+                broker = result.broker;
+                serverGameCode = result.gameCode;
+              }
             }
 
             // Always display the peer `roomCode` to the host — it's the
@@ -405,6 +410,7 @@ export function GameProvider({
               matchConfig,
               undefined,
               broker ?? undefined,
+              false,
               serverGameCode ?? undefined,
               {
                 gameId,
@@ -436,6 +442,7 @@ export function GameProvider({
               saveActiveGame({ id: gameId, mode: "p2p-host", difficulty: "" });
             }
             signal.throwIfAborted();
+            }
           } else {
             // p2p-join
             const code = joinCode!;
@@ -485,7 +492,6 @@ export function GameProvider({
               /* best-effort */
             });
           }
-          broker?.close();
           hostPeerHandle?.destroy();
           if (signal.aborted) return;
           const message = err instanceof Error ? err.message : String(err);
@@ -764,7 +770,7 @@ export function GameProvider({
         scheduleStoreReset(reset);
       }
     };
-  }, [gameId, mode, difficulty, joinCode, formatConfig, playerCount, matchConfig, firstPlayer, useBroker]);
+  }, [gameId, mode, difficulty, joinCode, formatConfig, playerCount, matchConfig, firstPlayer, useBroker, roomName]);
 
   return (
     <GameDispatchContext.Provider value={dispatchAction}>

--- a/client/src/services/__tests__/openPhaseSocket.test.ts
+++ b/client/src/services/__tests__/openPhaseSocket.test.ts
@@ -44,7 +44,7 @@ function helloFrame(
     data: {
       server_version: "0.0.0-test",
       build_commit: "testhash",
-      protocol_version: 2,
+      protocol_version: 3,
       mode: "Full",
       ...overrides,
     },
@@ -64,7 +64,7 @@ describe("openPhaseSocket", () => {
 
     const socket = await promise;
     expect(socket.serverInfo.mode).toBe("Full");
-    expect(socket.serverInfo.protocolVersion).toBe(2);
+    expect(socket.serverInfo.protocolVersion).toBe(3);
     expect(ws.send).toHaveBeenCalledWith(
       expect.stringContaining('"type":"ClientHello"'),
     );

--- a/client/src/services/gamePersistence.ts
+++ b/client/src/services/gamePersistence.ts
@@ -1,6 +1,7 @@
 import { createStore, del, get, set } from "idb-keyval";
 
 import type { FormatConfig, GameState, MatchConfig } from "../adapter/types";
+import type { SeatState } from "../multiplayer/seatTypes";
 import { ACTIVE_GAME_KEY, GAME_CHECKPOINTS_PREFIX, GAME_KEY_PREFIX } from "../constants/storage";
 
 export interface ActiveGameMeta {
@@ -41,6 +42,8 @@ export interface PersistedP2PHostSession {
   playerTokens: Record<number, string>;
   /** PlayerId.0 → deck submitted by that guest (pre-game data). */
   guestDecks: Record<number, unknown>;
+  /** PlayerId.0 → resolved AI deck for AI-controlled seats. */
+  aiDecks?: Record<number, unknown>;
   /** Tokens that were kicked — refused on reconnect on resume. */
   kickedTokens: string[];
   /** PlayerId.0 values that conceded. */
@@ -51,6 +54,7 @@ export interface PersistedP2PHostSession {
   hostDeckData: unknown;
   /** True once `initializeGame` has run; false while still in lobby. */
   gameStarted: boolean;
+  seatState?: SeatState;
 }
 
 const P2P_HOST_KEY_PREFIX = "phase-p2p-host:";

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -9,8 +9,11 @@ import {
   saveWsSession,
 } from "../services/multiplayerSession";
 import {
+  openBrokerClient,
   resolveGuestOver,
   subscribeLobbyOver,
+  type BrokerClient,
+  type RegisterHostRequest,
   type ResolveResult,
 } from "../services/brokerClient";
 import {
@@ -22,12 +25,32 @@ import {
 } from "../services/openPhaseSocket";
 import { isValidWebSocketUrl } from "../services/serverDetection";
 import { saveActiveGame, useGameStore } from "./gameStore";
+import type { P2PHostAdapter } from "../adapter/p2p-adapter";
+import type {
+  PlayerSlot,
+  SeatMutation,
+} from "../multiplayer/seatTypes";
+export type { DeckChoice, PlayerSlot, SeatKind, SeatMutation } from "../multiplayer/seatTypes";
 
 type ConnectionStatus = "disconnected" | "connecting" | "connected";
 type HostingStatus = "idle" | "connecting" | "waiting";
 
 // Module-level WebSocket ref (non-serializable, lives outside store)
 let hostWs: WebSocket | null = null;
+// Module-level broker client for P2P LobbyOnly hosting. Survives page
+// navigations so the lobby entry stays alive while the tile is showing.
+let activeBroker: BrokerClient | null = null;
+let activeBrokerGameCode: string | null = null;
+let activeP2PHostAdapter: P2PHostAdapter | null = null;
+let activeP2PHostGameId: string | null = null;
+
+function asDeckPayload(deck: HostingDeck): { main_deck: string[]; sideboard: string[]; commander: string[] } {
+  return {
+    main_deck: deck.main_deck,
+    sideboard: deck.sideboard,
+    commander: deck.commander ?? [],
+  };
+}
 // Prevents onclose from clearing session token after GameStarted
 let gameStartedFired = false;
 // Reconnection state for the hosting WebSocket
@@ -96,23 +119,6 @@ export interface HostingSettings {
   /** Optional per-match label shown in the lobby, distinct from `displayName`
    * (the player's global identity). `null` means "use the player's name". */
   roomName: string | null;
-}
-
-/** Discriminated union mirroring `seat_reducer::types::SeatKind`. */
-export type SeatKind =
-  | { type: "HostHuman" }
-  | { type: "JoinedHuman" }
-  | { type: "WaitingHuman" }
-  | { type: "Ai"; data: { difficulty: string; deck: DeckChoice } };
-
-export type DeckChoice =
-  | { type: "Random" }
-  | { type: "Named"; data: string };
-
-export interface PlayerSlot {
-  playerId: number;
-  name: string;
-  kind: SeatKind;
 }
 
 /** Snapshot of the host's session config, captured at startHosting time.
@@ -226,6 +232,16 @@ interface MultiplayerActions {
   cancelHosting: () => void;
   clearPendingGameRoute: () => void;
   setServerInfo: (info: ServerInfo | null) => void;
+  openBroker: (req: RegisterHostRequest) => Promise<{ broker: BrokerClient; gameCode: string } | null>;
+  closeBroker: () => void;
+  getBroker: () => { broker: BrokerClient; gameCode: string } | null;
+  startP2PHostingSession: (
+    settings: HostingSettings,
+    deck: HostingDeck,
+    opts: { useBroker: boolean; roomName?: string | null },
+  ) => Promise<boolean>;
+  getActiveP2PHost: () => { adapter: P2PHostAdapter; gameId: string } | null;
+  seatMutate: (mutation: SeatMutation) => void;
   /**
    * Lazily open the long-lived subscription socket and return the
    * `PhaseSocket`. Idempotent: a second call while an open is in flight
@@ -689,6 +705,19 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
           hostWs.close();
           hostWs = null;
         }
+        if (activeP2PHostAdapter) {
+          activeP2PHostAdapter.dispose();
+          activeP2PHostAdapter = null;
+          activeP2PHostGameId = null;
+        }
+        if (activeBroker) {
+          if (activeBrokerGameCode) {
+            void activeBroker.unregister(activeBrokerGameCode).catch(() => {});
+          }
+          activeBroker.close();
+          activeBroker = null;
+          activeBrokerGameCode = null;
+        }
         gameStartedFired = false;
         hostReconnectAttempt = 0;
         clearWsSession();
@@ -703,6 +732,166 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       },
 
       clearPendingGameRoute: () => set({ pendingGameRoute: null }),
+
+      openBroker: async (req) => {
+        if (activeBroker) {
+          activeBroker.close();
+          activeBroker = null;
+          activeBrokerGameCode = null;
+        }
+        try {
+          const broker = await openBrokerClient(get().serverAddress);
+          const registered = await broker.registerHost(req);
+          activeBroker = broker;
+          activeBrokerGameCode = registered.gameCode;
+          return { broker, gameCode: registered.gameCode };
+        } catch (err) {
+          console.error("[openBroker] failed:", err);
+          return null;
+        }
+      },
+
+      closeBroker: () => {
+        activeBroker?.close();
+        activeBroker = null;
+        activeBrokerGameCode = null;
+      },
+
+      getBroker: () => {
+        if (activeBroker && activeBrokerGameCode) {
+          return { broker: activeBroker, gameCode: activeBrokerGameCode };
+        }
+        return null;
+      },
+
+      startP2PHostingSession: async (settings, deck, opts) => {
+        const [{ hostRoom }, { P2PHostAdapter }] = await Promise.all([
+          import("../network/connection"),
+          import("../adapter/p2p-adapter"),
+        ]);
+
+        if (activeP2PHostAdapter) {
+          activeP2PHostAdapter.dispose();
+          activeP2PHostAdapter = null;
+          activeP2PHostGameId = null;
+        }
+
+        let broker: BrokerClient | null = null;
+        let brokerGameCode: string | null = null;
+        const host = await hostRoom(undefined, {});
+        if (opts.useBroker) {
+          try {
+            broker = await openBrokerClient(get().serverAddress);
+            const registered = await broker.registerHost({
+              hostPeerId: host.peer.id,
+              deck: asDeckPayload(deck),
+              displayName: get().displayName || "Host",
+              public: true,
+              password: null,
+              timerSeconds: null,
+              playerCount: settings.formatConfig.max_players,
+              matchConfig: { match_type: settings.matchType },
+              formatConfig: settings.formatConfig,
+              aiSeats: [],
+              roomName: opts.roomName ?? null,
+            });
+            brokerGameCode = registered.gameCode;
+            activeBroker = broker;
+            activeBrokerGameCode = registered.gameCode;
+          } catch (err) {
+            host.destroy();
+            console.error("[startP2PHostingSession] broker registration failed:", err);
+            return false;
+          }
+        }
+
+        const gameId = crypto.randomUUID();
+        const adapter = new P2PHostAdapter(
+          {
+            player: asDeckPayload(deck),
+            opponent: { main_deck: [], sideboard: [], commander: [] },
+            ai_decks: [],
+          },
+          host.peer,
+          host.onGuestConnected,
+          settings.formatConfig.max_players,
+          settings.formatConfig,
+          { match_type: settings.matchType },
+          undefined,
+          broker ?? undefined,
+          false,
+          brokerGameCode ?? undefined,
+          {
+            gameId,
+            roomCode: host.roomCode,
+            hostDisplayName: get().displayName || undefined,
+          },
+        );
+
+        adapter.onEvent((event) => {
+          if (event.type === "playerSlotsUpdated" || event.type === "lobbyProgress") {
+            set({ playerSlots: adapter.getPlayerSlots() });
+          } else if (event.type === "error") {
+            get().showToast(event.message);
+          }
+        });
+
+        await adapter.initialize();
+        activeP2PHostAdapter = adapter;
+        activeP2PHostGameId = gameId;
+
+        set({
+          hostIsPublic: opts.useBroker,
+          hostingStatus: "waiting",
+          hostGameCode: host.roomCode,
+          hostSession: {
+            formatConfig: settings.formatConfig,
+            timerSeconds: settings.timerSeconds,
+            matchType: settings.matchType,
+          },
+          playerSlots: adapter.getPlayerSlots(),
+        });
+        return true;
+      },
+
+      getActiveP2PHost: () => {
+        if (activeP2PHostAdapter && activeP2PHostGameId) {
+          return { adapter: activeP2PHostAdapter, gameId: activeP2PHostGameId };
+        }
+        return null;
+      },
+
+      seatMutate: (mutation) => {
+        if (activeP2PHostAdapter) {
+          void (async () => {
+            if (mutation.type === "Start") {
+              await activeP2PHostAdapter.startPregameGame();
+              const gameId = activeP2PHostGameId ?? crypto.randomUUID();
+              saveActiveGame({ id: gameId, mode: "p2p-host", difficulty: "" });
+              useGameStore.setState({ gameId });
+              set({
+                pendingGameRoute: `/game/${gameId}?mode=p2p-host`,
+                hostGameCode: null,
+                hostingStatus: "idle",
+              });
+            } else {
+              await activeP2PHostAdapter.applySeatMutation(mutation);
+              set({ playerSlots: activeP2PHostAdapter.getPlayerSlots() });
+            }
+          })().catch((err) => {
+            get().showToast(err instanceof Error ? err.message : String(err));
+          });
+          return;
+        }
+        if (!hostWs || hostWs.readyState !== WebSocket.OPEN) {
+          get().showToast("Host connection is not active.");
+          return;
+        }
+        hostWs.send(JSON.stringify({
+          type: "SeatMutate",
+          data: { mutation },
+        }));
+      },
 
       ensureSubscriptionSocket: async () => {
         // Fast path: handle is live and currently has a connected socket.

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -3,8 +3,8 @@
 
 /**
  * Apply a seat mutation to a seat state, using the TLS card database for deck
- * resolution. Both arguments are JSON strings; returns the `SeatDelta` as a JS
- * object on success, or a JS error string on failure.
+ * resolution. Both arguments are JSON strings; returns `{ state, delta }` as
+ * a JS object on success, or a JS error string on failure.
  */
 export function apply_seat_mutation(state_json: string, mutation_json: string): any;
 

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -566,8 +566,8 @@ pub fn select_action_from_scores(
 }
 
 /// Apply a seat mutation to a seat state, using the TLS card database for deck
-/// resolution. Both arguments are JSON strings; returns the `SeatDelta` as a JS
-/// object on success, or a JS error string on failure.
+/// resolution. Both arguments are JSON strings; returns `{ state, delta }` as
+/// a JS object on success, or a JS error string on failure.
 #[wasm_bindgen]
 pub fn apply_seat_mutation(state_json: &str, mutation_json: &str) -> Result<JsValue, JsValue> {
     struct WasmDeckResolver;
@@ -603,8 +603,15 @@ pub fn apply_seat_mutation(state_json: &str, mutation_json: &str) -> Result<JsVa
         deck_resolver: &WasmDeckResolver,
     };
 
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct SeatMutationResult {
+        state: SeatState,
+        delta: seat_reducer::types::SeatDelta,
+    }
+
     match seat_reducer::apply(&mut state, mutation, &ctx) {
-        Ok(delta) => Ok(to_js(&delta)),
+        Ok(delta) => Ok(to_js(&SeatMutationResult { state, delta })),
         Err(e) => Err(JsValue::from_str(&format!("{e:?}"))),
     }
 }

--- a/crates/phase-server/Cargo.toml
+++ b/crates/phase-server/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 server-core = { path = "../server-core" }
 engine = { path = "../engine" }
 phase-ai = { path = "../phase-ai" }
+seat-reducer = { path = "../seat-reducer" }
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4", features = ["derive", "env"] }
 http = "1"

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -22,6 +22,7 @@ use engine::game::{validate_deck_for_format, DeckCompatibilityRequest};
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
 use http::HeaderValue;
+use seat_reducer::types::{DeckChoice, DeckResolver, ReducerCtx};
 use server_core::lobby::{LobbyManager, RegisterGameRequest};
 use server_core::protocol::{
     build_commit, ClientMessage, ServerMessage, ServerMode, PROTOCOL_VERSION,
@@ -251,6 +252,7 @@ fn reject_if_disabled(msg: &ClientMessage, mode: ServerMode) -> Option<&'static 
         | ClientMessage::JoinGame { .. }
         | ClientMessage::Action { .. }
         | ClientMessage::Reconnect { .. }
+        | ClientMessage::SeatMutate { .. }
         | ClientMessage::Concede
         | ClientMessage::Emote { .. }
         | ClientMessage::SpectatorJoin { .. } => match mode {
@@ -833,6 +835,153 @@ fn delete_session_async(game_db: &SharedGameDb, game_code: &str) {
             error!(game = %code, error = %e, "failed to delete persisted session");
         }
     });
+}
+
+struct ServerDeckResolver<'a> {
+    db: &'a CardDatabase,
+}
+
+impl DeckResolver for ServerDeckResolver<'_> {
+    fn resolve(
+        &self,
+        choice: &DeckChoice,
+    ) -> Result<engine::game::deck_loading::PlayerDeckPayload, String> {
+        let deck = match choice {
+            DeckChoice::Random => server_core::starter_decks::random_starter_deck(),
+            DeckChoice::Named(name) => server_core::starter_decks::find_starter_deck(name)
+                .ok_or_else(|| format!("Starter deck not found: {name}"))?,
+        };
+        server_core::resolve_deck(self.db, &deck)
+    }
+}
+
+async fn broadcast_game_started(
+    state: &SharedState,
+    connections: &SharedConnections,
+    game_db: &SharedGameDb,
+    game_code: &str,
+) {
+    let (player_messages, ai_results, player_count) = {
+        let mut mgr = state.lock().await;
+        let Some(session) = mgr.sessions.get_mut(game_code) else {
+            return;
+        };
+
+        let (legal_actions, spell_costs_all) = engine_legal_actions_with_costs(&session.state);
+        let auto_pass = engine_auto_pass(&session.state, &legal_actions);
+        let actor = server_core::acting_player(&session.state);
+        let player_names = session.display_names.clone();
+
+        let player_messages = (0..session.player_count)
+            .filter(|pid| !session.ai_seats.contains(&PlayerId(*pid)))
+            .map(|pid| {
+                let player = PlayerId(pid);
+                let filtered = server_core::filter_state_for_player(&session.state, player);
+                let opponent_name = engine::game::players::opponents(&session.state, player)
+                    .first()
+                    .and_then(|opp| {
+                        let name = &session.display_names[opp.0 as usize];
+                        if name.is_empty() {
+                            None
+                        } else {
+                            Some(name.clone())
+                        }
+                    });
+                let is_actor = actor == Some(player);
+                (
+                    player,
+                    ServerMessage::GameStarted {
+                        state: filtered,
+                        your_player: player,
+                        opponent_name,
+                        player_names: player_names.clone(),
+                        legal_actions: if is_actor {
+                            legal_actions.clone()
+                        } else {
+                            Vec::new()
+                        },
+                        auto_pass_recommended: if is_actor { auto_pass } else { false },
+                        spell_costs: if is_actor {
+                            spell_costs_all.clone()
+                        } else {
+                            HashMap::new()
+                        },
+                        player_token: None,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let ai_results = session.run_ai();
+        let player_count = session.player_count;
+        persist_session_async(game_db, game_code, session);
+        (player_messages, ai_results, player_count)
+    };
+
+    {
+        let conns = connections.lock().await;
+        if let Some(players) = conns.get(game_code) {
+            for (pid, msg) in &player_messages {
+                if let Some(sender) = players.get(pid) {
+                    let _ = sender.send(msg.clone());
+                }
+            }
+        }
+    }
+
+    for result in ai_results {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let (raw_state, events, legal_actions, log_entries, auto_pass, spell_costs) = result;
+        let actor = {
+            let mgr = state.lock().await;
+            mgr.sessions
+                .get(game_code)
+                .and_then(|session| server_core::acting_player(&session.state))
+        };
+        let filtered_states: Vec<(PlayerId, GameState)> = (0..player_count)
+            .map(PlayerId)
+            .map(|pid| (pid, server_core::filter_state_for_player(&raw_state, pid)))
+            .collect();
+
+        let conns = connections.lock().await;
+        if let Some(players) = conns.get(game_code) {
+            for (pid, pstate) in &filtered_states {
+                if let Some(sender) = players.get(pid) {
+                    let is_actor = actor == Some(*pid);
+                    let _ = sender.send(ServerMessage::StateUpdate {
+                        state: pstate.clone(),
+                        events: events.clone(),
+                        legal_actions: if is_actor {
+                            legal_actions.clone()
+                        } else {
+                            Vec::new()
+                        },
+                        auto_pass_recommended: if is_actor { auto_pass } else { false },
+                        eliminated_players: Vec::new(),
+                        log_entries: log_entries.clone(),
+                        spell_costs: if is_actor {
+                            spell_costs.clone()
+                        } else {
+                            HashMap::new()
+                        },
+                    });
+                }
+            }
+        }
+    }
+}
+
+async fn require_host(identity: &SocketIdentity, socket: &mut WebSocket) -> Result<(), ()> {
+    if identity.player_id != Some(PlayerId(0)) {
+        let msg = ServerMessage::Error {
+            message: "Only the host can modify seats.".to_string(),
+        };
+        if let Ok(json) = serde_json::to_string(&msg) {
+            let _ = socket.send(Message::text(json)).await;
+        }
+        return Err(());
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2139,11 +2288,8 @@ async fn handle_client_message(
                     persist_session_async(game_db, &game_code, session);
                     identity.set_session(game_code.clone(), joiner, player_token.clone());
 
-                    let player_names = session.display_names.clone();
-
                     // Build slot info before releasing session borrow
                     let slot_info = session.player_slot_info();
-                    let is_full = session.is_full();
                     let current_count = session.current_player_count();
 
                     let mut conns = connections.lock().await;
@@ -2160,122 +2306,31 @@ async fn handle_client_message(
                         }
                     }
 
-                    // Keep the public lobby listing's `current_players` in sync
-                    // for games that are still waiting. When the game becomes
-                    // full the `if is_full` branch below unregisters it from
-                    // the lobby entirely, so no update is needed there.
-                    if !is_full {
-                        let updated = {
-                            let mut lob = lobby.lock().await;
-                            lob.set_current_players(&game_code, current_count);
-                            // Private games aren't listed in the public lobby,
-                            // so `public_game` returns None and no update is
-                            // broadcast — which is the correct behavior.
-                            lob.public_game(&game_code)
-                        };
-                        if let Some(game) = updated {
-                            broadcast_to_lobby_subscribers(
-                                lobby_subscribers,
-                                ServerMessage::LobbyGameUpdated { game },
-                            )
-                            .await;
-                        }
+                    let updated = {
+                        let mut lob = lobby.lock().await;
+                        lob.set_current_players(&game_code, current_count);
+                        lob.public_game(&game_code)
+                    };
+                    if let Some(game) = updated {
+                        broadcast_to_lobby_subscribers(
+                            lobby_subscribers,
+                            ServerMessage::LobbyGameUpdated { game },
+                        )
+                        .await;
                     }
 
-                    // Only send GameStarted when the game is full
-                    if is_full {
-                        let (legal_actions, spell_costs_all) =
-                            engine_legal_actions_with_costs(&session.state);
-                        let auto_pass = engine_auto_pass(&session.state, &legal_actions);
-                        let actor = server_core::acting_player(&session.state);
-
-                        // Find first opponent name for backward compat
-                        let joiner_opp_name =
-                            engine::game::players::opponents(&session.state, joiner)
-                                .first()
-                                .and_then(|&opp| {
-                                    let name = &session.display_names[opp.0 as usize];
-                                    if name.is_empty() {
-                                        None
-                                    } else {
-                                        Some(name.clone())
-                                    }
-                                });
-
-                        let is_joiner_actor = actor == Some(joiner);
-                        let joiner_legals = if is_joiner_actor {
-                            legal_actions.clone()
-                        } else {
-                            vec![]
-                        };
-                        let msg = ServerMessage::GameStarted {
-                            state: filtered_state,
-                            your_player: joiner,
-                            opponent_name: joiner_opp_name,
-                            player_names: player_names.clone(),
-                            legal_actions: joiner_legals,
-                            auto_pass_recommended: if is_joiner_actor { auto_pass } else { false },
-                            spell_costs: if is_joiner_actor {
-                                spell_costs_all.clone()
-                            } else {
-                                HashMap::new()
-                            },
-                            player_token: Some(player_token.clone()),
-                        };
-                        if let Ok(json) = serde_json::to_string(&msg) {
-                            let _ = socket.send(Message::text(json)).await;
-                        }
-
-                        // Send GameStarted to all other connected players
-                        for (&pid, sender) in conns.get(&game_code).unwrap().iter() {
-                            if pid != joiner {
-                                let p_state =
-                                    server_core::filter_state_for_player(&session.state, pid);
-                                let opp_name =
-                                    engine::game::players::opponents(&session.state, pid)
-                                        .first()
-                                        .and_then(|&opp| {
-                                            let name = &session.display_names[opp.0 as usize];
-                                            if name.is_empty() {
-                                                None
-                                            } else {
-                                                Some(name.clone())
-                                            }
-                                        });
-                                let is_actor = actor == Some(pid);
-                                let p_legals = if is_actor {
-                                    legal_actions.clone()
-                                } else {
-                                    vec![]
-                                };
-                                let _ = sender.send(ServerMessage::GameStarted {
-                                    state: p_state,
-                                    your_player: pid,
-                                    opponent_name: opp_name,
-                                    player_names: player_names.clone(),
-                                    legal_actions: p_legals,
-                                    auto_pass_recommended: if is_actor { auto_pass } else { false },
-                                    spell_costs: if is_actor {
-                                        spell_costs_all.clone()
-                                    } else {
-                                        HashMap::new()
-                                    },
-                                    player_token: None,
-                                });
-                            }
-                        }
+                    let msg = ServerMessage::StateUpdate {
+                        state: filtered_state,
+                        events: vec![],
+                        legal_actions: vec![],
+                        auto_pass_recommended: false,
+                        eliminated_players: vec![],
+                        log_entries: vec![],
+                        spell_costs: HashMap::new(),
+                    };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
                     }
-
-                    let mut lob = lobby.lock().await;
-                    lob.unregister_game(&game_code);
-
-                    broadcast_to_lobby_subscribers(
-                        lobby_subscribers,
-                        ServerMessage::LobbyGameRemoved {
-                            game_code: game_code.clone(),
-                        },
-                    )
-                    .await;
 
                     let count = player_count.load(Ordering::Relaxed);
                     broadcast_player_count(lobby_subscribers, count).await;
@@ -2394,6 +2449,142 @@ async fn handle_client_message(
             let msg = ServerMessage::Pong { timestamp };
             if let Ok(json) = serde_json::to_string(&msg) {
                 let _ = socket.send(Message::text(json)).await;
+            }
+        }
+
+        ClientMessage::SeatMutate { mutation } => {
+            if matches!(mode, ServerMode::LobbyOnly) {
+                let msg = ServerMessage::Error {
+                    message: "Seat mutations are not available on lobby-only servers.".to_string(),
+                };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
+            if require_host(identity, socket).await.is_err() {
+                return;
+            }
+
+            let Some(game_code) = identity.game_code.clone() else {
+                return;
+            };
+
+            let (slot_info, kicked_players, started, current_players, max_players, public_before) = {
+                let mut mgr = state.lock().await;
+                let Some(session) = mgr.sessions.get_mut(&game_code) else {
+                    let msg = ServerMessage::Error {
+                        message: format!("Game not found: {game_code}"),
+                    };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                    return;
+                };
+
+                let public_before = session.lobby_meta.as_ref().is_some_and(|meta| meta.public);
+                let mut seat_state = session.seat_state();
+                let delta_result = {
+                    let resolver = ServerDeckResolver { db: db.as_ref() };
+                    let ctx = ReducerCtx {
+                        platform: phase_ai::config::Platform::Native,
+                        deck_resolver: &resolver,
+                    };
+                    seat_reducer::apply(&mut seat_state, mutation, &ctx)
+                };
+                let delta = match delta_result {
+                    Ok(delta) => delta,
+                    Err(err) => {
+                        let msg = ServerMessage::Error {
+                            message: format!("Seat mutation failed: {err:?}"),
+                        };
+                        if let Ok(json) = serde_json::to_string(&msg) {
+                            let _ = socket.send(Message::text(json)).await;
+                        }
+                        return;
+                    }
+                };
+
+                let kicked_players = delta
+                    .invalidated_tokens
+                    .iter()
+                    .filter_map(|token| {
+                        session
+                            .player_for_token(token)
+                            .map(|pid| (pid, token.clone()))
+                    })
+                    .collect::<Vec<_>>();
+
+                session.apply_seat_delta(seat_state, &delta);
+                if delta.now_started {
+                    session.start_game();
+                }
+                let slot_info = session.player_slot_info();
+                let current_players = session.current_player_count();
+                let max_players = session.player_count;
+                let started = delta.now_started;
+                persist_session_async(game_db, &game_code, session);
+                (
+                    slot_info,
+                    kicked_players,
+                    started,
+                    current_players,
+                    max_players,
+                    public_before,
+                )
+            };
+
+            {
+                let mut conns = connections.lock().await;
+                if let Some(players) = conns.get_mut(&game_code) {
+                    for (pid, _) in &kicked_players {
+                        if let Some(sender) = players.remove(pid) {
+                            let _ = sender.send(ServerMessage::Error {
+                                message: "You were removed from the room by the host.".to_string(),
+                            });
+                        }
+                    }
+
+                    let msg = ServerMessage::PlayerSlotsUpdate {
+                        slots: slot_info.clone(),
+                    };
+                    for sender in players.values() {
+                        let _ = sender.send(msg.clone());
+                    }
+                }
+            }
+
+            if started {
+                let removed = {
+                    let mut lob = lobby.lock().await;
+                    let existed = lob.has_game(&game_code);
+                    lob.unregister_game(&game_code);
+                    existed
+                };
+                if removed && public_before {
+                    broadcast_to_lobby_subscribers(
+                        lobby_subscribers,
+                        ServerMessage::LobbyGameRemoved {
+                            game_code: game_code.clone(),
+                        },
+                    )
+                    .await;
+                }
+                broadcast_game_started(state, connections, game_db, &game_code).await;
+            } else {
+                let updated = {
+                    let mut lob = lobby.lock().await;
+                    lob.set_current_players(&game_code, current_players);
+                    lob.set_max_players(&game_code, max_players);
+                    lob.public_game(&game_code)
+                };
+                if let Some(game) = updated {
+                    broadcast_to_lobby_subscribers(
+                        lobby_subscribers,
+                        ServerMessage::LobbyGameUpdated { game },
+                    )
+                    .await;
+                }
             }
         }
 

--- a/crates/seat-reducer/src/lib.rs
+++ b/crates/seat-reducer/src/lib.rs
@@ -35,18 +35,112 @@ fn apply_start(state: &mut SeatState, _ctx: &ReducerCtx) -> Result<SeatDelta, Se
 }
 
 fn apply_set_kind(
-    _state: &mut SeatState,
-    _seat_index: u8,
-    _kind: SeatKind,
-    _ctx: &ReducerCtx,
+    state: &mut SeatState,
+    seat_index: u8,
+    kind: SeatKind,
+    ctx: &ReducerCtx,
 ) -> Result<SeatDelta, SeatError> {
-    // Phase 2: full transition matrix
-    Err(SeatError::InvalidTransition)
+    let seat = seat_index as usize;
+    if seat == 0 || seat >= state.seats.len() {
+        return Err(SeatError::SeatImmutable);
+    }
+
+    let current = state.seats[seat].clone();
+    if current == kind {
+        return Ok(SeatDelta::empty());
+    }
+
+    let mut delta = SeatDelta::empty();
+    delta.mutated_seats.push(seat_index);
+
+    match (current, kind.clone()) {
+        (SeatKind::HostHuman, _) => Err(SeatError::SeatImmutable),
+        (SeatKind::WaitingHuman, SeatKind::JoinedHuman)
+        | (SeatKind::Ai { .. }, SeatKind::JoinedHuman)
+        | (SeatKind::JoinedHuman, SeatKind::HostHuman)
+        | (SeatKind::WaitingHuman, SeatKind::HostHuman)
+        | (SeatKind::Ai { .. }, SeatKind::HostHuman) => Err(SeatError::InvalidTransition),
+        (SeatKind::WaitingHuman, SeatKind::WaitingHuman)
+        | (SeatKind::JoinedHuman, SeatKind::JoinedHuman) => Ok(delta),
+        (SeatKind::WaitingHuman, SeatKind::Ai { difficulty, deck }) => {
+            let resolved = ctx
+                .deck_resolver
+                .resolve(&deck)
+                .map_err(SeatError::DeckResolutionFailed)?;
+            state.seats[seat] = kind;
+            state.tokens[seat].clear();
+            delta.new_ai.push((seat_index, difficulty, resolved));
+            Ok(delta)
+        }
+        (SeatKind::Ai { .. }, SeatKind::WaitingHuman) => {
+            state.seats[seat] = SeatKind::WaitingHuman;
+            state.tokens[seat].clear();
+            delta.removed_ai.push(seat_index);
+            Ok(delta)
+        }
+        (SeatKind::Ai { .. }, SeatKind::Ai { difficulty, deck }) => {
+            let resolved = ctx
+                .deck_resolver
+                .resolve(&deck)
+                .map_err(SeatError::DeckResolutionFailed)?;
+            state.seats[seat] = kind;
+            state.tokens[seat].clear();
+            delta.removed_ai.push(seat_index);
+            delta.new_ai.push((seat_index, difficulty, resolved));
+            Ok(delta)
+        }
+        (SeatKind::JoinedHuman, SeatKind::WaitingHuman) => {
+            delta.invalidated_tokens.push(state.tokens[seat].clone());
+            state.tokens[seat].clear();
+            state.seats[seat] = SeatKind::WaitingHuman;
+            Ok(delta)
+        }
+        (SeatKind::JoinedHuman, SeatKind::Ai { difficulty, deck }) => {
+            let resolved = ctx
+                .deck_resolver
+                .resolve(&deck)
+                .map_err(SeatError::DeckResolutionFailed)?;
+            delta.invalidated_tokens.push(state.tokens[seat].clone());
+            state.tokens[seat].clear();
+            state.seats[seat] = kind;
+            delta.new_ai.push((seat_index, difficulty, resolved));
+            Ok(delta)
+        }
+    }
 }
 
-fn apply_remove(_state: &mut SeatState, _seat_index: u8) -> Result<SeatDelta, SeatError> {
-    // Phase 2: removal with renumbering
-    Err(SeatError::InvalidTransition)
+fn apply_remove(state: &mut SeatState, seat_index: u8) -> Result<SeatDelta, SeatError> {
+    let seat = seat_index as usize;
+    if seat == 0 || seat >= state.seats.len() {
+        return Err(SeatError::SeatImmutable);
+    }
+    if state.seats.len() <= state.format.min_players as usize {
+        return Err(SeatError::BelowFormatMin);
+    }
+
+    match &state.seats[seat] {
+        SeatKind::JoinedHuman => return Err(SeatError::SeatClaimed),
+        SeatKind::HostHuman => return Err(SeatError::SeatImmutable),
+        SeatKind::Ai { .. } | SeatKind::WaitingHuman => {}
+    }
+
+    let removed_kind = state.seats.remove(seat);
+    state.tokens.remove(seat);
+
+    let mut delta = SeatDelta::empty();
+    delta.mutated_seats = (seat_index..state.seats.len() as u8).collect();
+    if matches!(removed_kind, SeatKind::Ai { .. }) {
+        delta.removed_ai.push(seat_index);
+    }
+
+    delta.renumbering = Some(types::Renumbering {
+        removed_index: seat_index,
+        remapping: (seat_index + 1..=state.seats.len() as u8)
+            .map(|old| (old, old - 1))
+            .collect(),
+    });
+
+    Ok(delta)
 }
 
 #[cfg(test)]

--- a/crates/seat-reducer/src/tests.rs
+++ b/crates/seat-reducer/src/tests.rs
@@ -7,7 +7,10 @@ use crate::types::*;
 struct NoOpResolver;
 impl DeckResolver for NoOpResolver {
     fn resolve(&self, _choice: &DeckChoice) -> Result<PlayerDeckPayload, String> {
-        Err("no-op".to_string())
+        Ok(PlayerDeckPayload {
+            main_deck: vec![],
+            sideboard: vec![],
+        })
     }
 }
 
@@ -106,9 +109,9 @@ fn is_pregame_reflects_game_started() {
 }
 
 #[test]
-fn set_kind_returns_placeholder_error() {
+fn waiting_seat_can_become_ai() {
     let mut state = two_player_waiting();
-    let err = crate::apply(
+    let delta = crate::apply(
         &mut state,
         SeatMutation::SetKind {
             seat_index: 1,
@@ -119,13 +122,40 @@ fn set_kind_returns_placeholder_error() {
         },
         &ctx(),
     )
-    .unwrap_err();
-    assert_eq!(err, SeatError::InvalidTransition);
+    .unwrap();
+    assert_eq!(delta.new_ai.len(), 1);
+    assert!(matches!(state.seats[1], SeatKind::Ai { .. }));
 }
 
 #[test]
-fn remove_returns_placeholder_error() {
-    let mut state = two_player_waiting();
+fn remove_waiting_seat_respects_min_players() {
+    let mut state = SeatState {
+        seats: vec![
+            SeatKind::HostHuman,
+            SeatKind::WaitingHuman,
+            SeatKind::WaitingHuman,
+        ],
+        tokens: vec!["host".to_string(), String::new(), String::new()],
+        format: FormatConfig::commander(),
+        game_started: false,
+    };
+    let delta = crate::apply(&mut state, SeatMutation::Remove { seat_index: 2 }, &ctx()).unwrap();
+    assert_eq!(state.seats.len(), 2);
+    assert!(delta.renumbering.is_some());
+}
+
+#[test]
+fn remove_rejects_claimed_human_seat() {
+    let mut state = SeatState {
+        seats: vec![
+            SeatKind::HostHuman,
+            SeatKind::JoinedHuman,
+            SeatKind::WaitingHuman,
+        ],
+        tokens: vec!["host".to_string(), "guest".to_string(), String::new()],
+        format: FormatConfig::commander(),
+        game_started: false,
+    };
     let err = crate::apply(&mut state, SeatMutation::Remove { seat_index: 1 }, &ctx()).unwrap_err();
-    assert_eq!(err, SeatError::InvalidTransition);
+    assert_eq!(err, SeatError::SeatClaimed);
 }

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 /// (clients see "Invalid message: unknown variant") rather than at the
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Git short-hash of the build. Emitted by `build.rs`; falls back to `"dev"`
 /// when git isn't available (containers, source tarballs).
@@ -176,6 +176,9 @@ pub enum ClientMessage {
         game_code: String,
         current_players: u8,
         max_players: u8,
+    },
+    SeatMutate {
+        mutation: SeatMutation,
     },
     /// Sent by a P2P host on a `LobbyOnly` server once their game is live
     /// (guest(s) have dialed in and the P2P session is established) so the

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -18,7 +18,7 @@ use engine::types::match_config::MatchConfig;
 use engine::types::player::PlayerId;
 use phase_ai::config::{AiConfig, AiDifficulty, Platform};
 use rand::{Rng, SeedableRng};
-use seat_reducer::types::{DeckChoice, SeatKind};
+use seat_reducer::types::{DeckChoice, SeatDelta, SeatKind, SeatState};
 use tracing::{debug, info, warn};
 
 use crate::filter::filter_state_for_player;
@@ -147,6 +147,171 @@ impl GameSession {
                 }
             })
             .collect()
+    }
+
+    pub fn seat_state(&self) -> SeatState {
+        SeatState {
+            seats: (0..self.player_count as usize)
+                .map(|i| {
+                    let pid = PlayerId(i as u8);
+                    if i == 0 {
+                        SeatKind::HostHuman
+                    } else if self.ai_seats.contains(&pid) {
+                        let difficulty = self
+                            .ai_configs
+                            .get(&pid)
+                            .map(|c| c.difficulty)
+                            .unwrap_or(AiDifficulty::Medium);
+                        SeatKind::Ai {
+                            difficulty,
+                            deck: DeckChoice::Random,
+                        }
+                    } else if !self.player_tokens[i].is_empty() {
+                        SeatKind::JoinedHuman
+                    } else {
+                        SeatKind::WaitingHuman
+                    }
+                })
+                .collect(),
+            tokens: self.player_tokens.clone(),
+            format: self.state.format_config.clone(),
+            game_started: self.game_started,
+        }
+    }
+
+    fn rebuild_pregame_state(&mut self, player_count: u8) {
+        let format_config = self.state.format_config.clone();
+        let match_config = self.state.match_config;
+        self.state = GameState::new(format_config, player_count, rand::rng().random());
+        self.state.match_config = if player_count == 2 {
+            match_config
+        } else {
+            MatchConfig::default()
+        };
+    }
+
+    pub fn apply_seat_delta(&mut self, new_state: SeatState, delta: &SeatDelta) {
+        let old_player_count = self.player_count;
+        let new_player_count = new_state.seats.len() as u8;
+
+        let mut old_to_new: Vec<Option<usize>> = (0..old_player_count as usize).map(Some).collect();
+        if let Some(renumbering) = &delta.renumbering {
+            old_to_new[renumbering.removed_index as usize] = None;
+            for &(old_idx, new_idx) in &renumbering.remapping {
+                old_to_new[old_idx as usize] = Some(new_idx as usize);
+            }
+        }
+
+        let mut next_tokens = vec![String::new(); new_player_count as usize];
+        let mut next_connected = vec![false; new_player_count as usize];
+        let mut next_decks = vec![None; new_player_count as usize];
+        let mut next_names = vec![String::new(); new_player_count as usize];
+
+        for (old_idx, maybe_new_idx) in old_to_new
+            .iter()
+            .enumerate()
+            .take(old_player_count as usize)
+        {
+            let Some(new_idx) = *maybe_new_idx else {
+                continue;
+            };
+            next_tokens[new_idx] = self.player_tokens[old_idx].clone();
+            next_connected[new_idx] = self.connected[old_idx];
+            next_decks[new_idx] = self.decks[old_idx].clone();
+            next_names[new_idx] = self.display_names[old_idx].clone();
+        }
+
+        self.player_count = new_player_count;
+        self.player_tokens = next_tokens;
+        self.connected = next_connected;
+        self.decks = next_decks;
+        self.display_names = next_names;
+        self.ai_seats.clear();
+
+        let mut next_ai_configs = HashMap::new();
+        for (seat_idx, kind) in new_state.seats.iter().enumerate() {
+            match kind {
+                SeatKind::HostHuman | SeatKind::JoinedHuman => {}
+                SeatKind::WaitingHuman => {
+                    self.player_tokens[seat_idx].clear();
+                    self.connected[seat_idx] = false;
+                    self.decks[seat_idx] = None;
+                    if seat_idx != 0 {
+                        self.display_names[seat_idx].clear();
+                    }
+                }
+                SeatKind::Ai { difficulty, .. } => {
+                    let pid = PlayerId(seat_idx as u8);
+                    self.ai_seats.insert(pid);
+                    self.player_tokens[seat_idx].clear();
+                    self.connected[seat_idx] = true;
+                    self.display_names[seat_idx] = format!("AI ({difficulty:?})");
+                    let config = phase_ai::config::create_config_for_players(
+                        *difficulty,
+                        Platform::Native,
+                        new_player_count,
+                    );
+                    next_ai_configs.insert(pid, config);
+                }
+            }
+        }
+
+        for &(seat_idx, _, ref deck) in &delta.new_ai {
+            self.decks[seat_idx as usize] = Some(deck.clone());
+        }
+        for &seat_idx in &delta.removed_ai {
+            if seat_idx as usize >= self.decks.len() {
+                continue;
+            }
+            if !delta
+                .new_ai
+                .iter()
+                .any(|(new_idx, _, _)| *new_idx == seat_idx)
+            {
+                self.decks[seat_idx as usize] = None;
+            }
+        }
+
+        self.ai_configs = next_ai_configs;
+        self.game_started = new_state.game_started;
+
+        if old_player_count != new_player_count {
+            self.rebuild_pregame_state(new_player_count);
+        }
+    }
+
+    pub fn start_game(&mut self) {
+        let player_deck = self.decks[0].clone().unwrap_or(PlayerDeckPayload {
+            main_deck: Vec::new(),
+            sideboard: Vec::new(),
+        });
+        let opponent_deck = self.decks[1].clone().unwrap_or(PlayerDeckPayload {
+            main_deck: Vec::new(),
+            sideboard: Vec::new(),
+        });
+        let ai_decks: Vec<PlayerDeckPayload> = self.decks[2..]
+            .iter()
+            .map(|deck| {
+                deck.clone().unwrap_or(PlayerDeckPayload {
+                    main_deck: Vec::new(),
+                    sideboard: Vec::new(),
+                })
+            })
+            .collect();
+
+        self.rebuild_pregame_state(self.player_count);
+        load_deck_into_state(
+            &mut self.state,
+            &DeckPayload {
+                player: player_deck,
+                opponent: opponent_deck,
+                ai_decks,
+            },
+        );
+        self.state.log_player_names = self.display_names.clone();
+        let _ = start_game(&mut self.state);
+        self.game_started = true;
+        self.lobby_meta = None;
     }
 
     /// Run AI actions and return per-action broadcast data.
@@ -396,35 +561,6 @@ impl SessionManager {
 
         info!(game = %game_code, player = ?player_id, seat, "player joined session");
 
-        // Start the game when the last human seat is filled
-        if session.is_full() {
-            // Game is no longer in lobby
-            session.lobby_meta = None;
-
-            // Load deck data into game state before starting
-            let player_deck = session.decks[0].clone().unwrap_or(PlayerDeckPayload {
-                main_deck: Vec::new(),
-                sideboard: Vec::new(),
-            });
-            let opponent_deck = session.decks[1].clone().unwrap_or(PlayerDeckPayload {
-                main_deck: Vec::new(),
-                sideboard: Vec::new(),
-            });
-            let payload = DeckPayload {
-                player: player_deck,
-                opponent: opponent_deck,
-                ai_decks: vec![],
-            };
-            load_deck_into_state(&mut session.state, &payload);
-
-            // Set player names for log resolution
-            session.state.log_player_names = session.display_names.clone();
-
-            // Initialize the game via engine
-            let _result = start_game(&mut session.state);
-            session.game_started = true;
-        }
-
         let filtered = filter_state_for_player(&session.state, player_id);
         Ok((player_token, filtered))
     }
@@ -477,34 +613,8 @@ impl SessionManager {
             session.ai_configs.insert(pid, config);
         }
 
-        // Build DeckPayload: seat 0 → player, seat 1 → opponent, seats 2+ → ai_decks
-        let player_deck = session.decks[0].clone().unwrap_or(PlayerDeckPayload {
-            main_deck: Vec::new(),
-            sideboard: Vec::new(),
-        });
-        let opponent_deck = session.decks[1].clone().unwrap_or(PlayerDeckPayload {
-            main_deck: Vec::new(),
-            sideboard: Vec::new(),
-        });
-        let ai_decks: Vec<PlayerDeckPayload> = session.decks[2..]
-            .iter()
-            .map(|d| {
-                d.clone().unwrap_or(PlayerDeckPayload {
-                    main_deck: Vec::new(),
-                    sideboard: Vec::new(),
-                })
-            })
-            .collect();
-        let payload = DeckPayload {
-            player: player_deck,
-            opponent: opponent_deck,
-            ai_decks,
-        };
-        load_deck_into_state(&mut session.state, &payload);
         session.state.all_card_names = card_names.into();
-        session.state.log_player_names = session.display_names.clone();
-        let _result = start_game(&mut session.state);
-        session.game_started = true;
+        session.start_game();
 
         (game_code, player_token)
     }


### PR DESCRIPTION
## Summary

- Implement full pregame seat management: hosts can add/remove AI opponents, kick joined players, replace humans with AI, and start games with partial lobbies
- Complete the `seat-reducer` crate's `SetKind` transition matrix and `Remove` with seat renumbering (previously stub errors)
- Add `SeatMutate` protocol message (v2→v3) wiring through P2P adapter, WebSocket server, and server-core session management
- Refactor game start to be decoupled from lobby fill — host explicitly triggers start via seat mutation or UI controls
- HostControlTile gains full seat editing UI: AI difficulty/deck pickers, kick/replace controls, "Start Now" / "Fill With AI" buttons
- Move P2P hosting session creation into `multiplayerStore` so lobby tile persists across page navigations

## Test plan

- [ ] Verify `cargo test -p seat-reducer` passes with new SetKind and Remove tests
- [ ] Host a P2P game, add AI to empty seats, change AI difficulty/deck, then start
- [ ] Host a P2P game, wait for a human to join, kick them, verify seat reopens
- [ ] Host a P2P game with 3+ players, remove a seat, verify renumbering works
- [ ] Host via server (WebSocket), use SeatMutate to add AI and start
- [ ] Verify "Start Now" with partial lobby (removes empty seats) works
- [ ] Verify "Fill With AI" fills remaining seats and auto-starts
- [ ] Verify HostControlTile appears on menu page and persists navigating to game
- [ ] Verify protocol version 3 handshake succeeds between client and server