### PR TITLE
Add Tivit, Seller of Secrets

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -648,6 +648,16 @@ export type WaitingFor =
   | { type: "ManifestDreadChoice"; data: { player: PlayerId; cards: ObjectId[] } }
   | { type: "LearnChoice"; data: { player: PlayerId; hand_cards: ObjectId[] } }
   | { type: "ClashCardPlacement"; data: { player: PlayerId; card: ObjectId; remaining: [PlayerId, ObjectId][] } }
+  | { type: "VoteChoice"; data: {
+      player: PlayerId;
+      remaining_votes: number;
+      options: string[];
+      option_labels: string[];
+      remaining_voters: [PlayerId, number][];
+      tallies: number[];
+      controller: PlayerId;
+      source_id: ObjectId;
+    } }
   | { type: "ChooseDungeon"; data: { player: PlayerId; options: DungeonId[] } }
   | { type: "ChooseDungeonRoom"; data: { player: PlayerId; dungeon: DungeonId; options: number[]; option_names: string[] } }
   | { type: "CategoryChoice"; data: {

--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -10,6 +10,7 @@ import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { ChoiceOverlay, ConfirmButton, ScrollableCardStrip } from "./ChoiceOverlay.tsx";
 import { ManaSymbol } from "../mana/ManaSymbol.tsx";
 import { NamedChoiceModal } from "./NamedChoiceModal.tsx";
+import { VoteChoiceModal } from "./VoteChoiceModal.tsx";
 import { DungeonChoiceModal, RoomChoiceModal } from "./DungeonChoiceModal.tsx";
 import { DamageAssignmentModal } from "../combat/DamageAssignmentModal.tsx";
 import { DistributeAmongModal } from "./DistributeAmongModal.tsx";
@@ -115,6 +116,9 @@ export function CardChoiceModal() {
     case "NamedChoice":
       if (!canActForWaitingState) return null;
       return <NamedChoiceModal data={waitingFor.data} />;
+    case "VoteChoice":
+      if (!canActForWaitingState) return null;
+      return <VoteChoiceModal data={waitingFor.data} />;
     case "DiscardToHandSize":
       if (!canActForWaitingState) return null;
       return <DiscardModal data={waitingFor.data} />;

--- a/client/src/components/modal/VoteChoiceModal.tsx
+++ b/client/src/components/modal/VoteChoiceModal.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useState } from "react";
+import { motion } from "framer-motion";
+
+import { ChoiceOverlay, ConfirmButton } from "./ChoiceOverlay.tsx";
+import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
+import type { WaitingFor } from "../../adapter/types.ts";
+
+type VoteChoice = Extract<WaitingFor, { type: "VoteChoice" }>;
+
+/**
+ * CR 701.38a: Council's-dilemma vote prompt. The engine collects one
+ * `ChooseOption { choice }` action per vote; this modal renders the canonical
+ * choice list (lowercase, from `data.options`) using the original-case
+ * `data.option_labels` for display.
+ *
+ * Display layer only — `remaining_votes`, the running tally, and the queued
+ * voter list all come straight from the engine's `WaitingFor::VoteChoice`.
+ */
+export function VoteChoiceModal({ data }: { data: VoteChoice["data"] }) {
+  const dispatch = useGameDispatch();
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const handleConfirm = useCallback(() => {
+    if (selected !== null) {
+      dispatch({ type: "ChooseOption", data: { choice: selected } });
+      setSelected(null);
+    }
+  }, [dispatch, selected]);
+
+  const subtitle =
+    data.remaining_votes > 1
+      ? `Cast a vote (${data.remaining_votes} remaining)`
+      : "Cast your vote";
+
+  return (
+    <ChoiceOverlay
+      title="Vote"
+      subtitle={subtitle}
+      widthClassName="w-fit max-w-full"
+      maxWidthClassName="max-w-3xl"
+      footer={<ConfirmButton onClick={handleConfirm} disabled={selected === null} />}
+    >
+      <div className="mx-auto mb-4 flex w-fit max-w-3xl flex-wrap items-center justify-center gap-3 sm:mb-6">
+        {data.options.map((option, index) => {
+          const label = data.option_labels[index] ?? option;
+          const tally = data.tallies[index] ?? 0;
+          const isSelected = selected === option;
+          return (
+            <motion.button
+              key={option}
+              className={`min-h-11 rounded-lg border-2 px-4 py-3 text-sm font-semibold transition sm:px-5 sm:text-base ${
+                isSelected
+                  ? "border-emerald-400 bg-emerald-500/30 text-white"
+                  : "border-gray-600 bg-gray-800/80 text-gray-300 hover:border-gray-400 hover:text-white"
+              }`}
+              initial={{ opacity: 0, y: 20, scale: 0.95 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              transition={{ delay: 0.05 + index * 0.03, duration: 0.25 }}
+              whileHover={{ scale: 1.05 }}
+              onClick={() => setSelected(isSelected ? null : option)}
+            >
+              {label}
+              {tally > 0 ? (
+                <span className="ml-2 rounded bg-black/30 px-2 py-0.5 text-xs">
+                  {tally}
+                </span>
+              ) : null}
+            </motion.button>
+          );
+        })}
+      </div>
+    </ChoiceOverlay>
+  );
+}

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -634,6 +634,25 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             choice_type,
             ..
         } => named_choice_actions(state, *player, options, choice_type),
+        // CR 701.38: Vote — every option is a legal candidate; the AI picks via
+        // the standard ChooseOption action. Each remaining vote produces an
+        // identical action set (CR 701.38d allows repeats), so emitting one
+        // candidate per option is correct: the engine re-enters VoteChoice for
+        // each subsequent vote.
+        WaitingFor::VoteChoice {
+            player, options, ..
+        } => options
+            .iter()
+            .map(|opt| {
+                candidate(
+                    GameAction::ChooseOption {
+                        choice: opt.clone(),
+                    },
+                    TacticalClass::Selection,
+                    Some(*player),
+                )
+            })
+            .collect(),
         WaitingFor::ModeChoice {
             player,
             modal,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1565,6 +1565,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::VentureInto { .. }
         | Effect::TakeTheInitiative
         | Effect::Clash
+        | Effect::Vote { .. }
         | Effect::Incubate { .. }
         | Effect::TimeTravel
         | Effect::Conjure { .. }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -114,6 +114,7 @@ pub mod token_copy;
 pub mod transform_effect;
 pub mod tribute;
 pub mod venture;
+pub mod vote;
 pub mod win_lose;
 
 fn matches_player_scope(
@@ -308,6 +309,8 @@ pub fn resolve_effect(
         Effect::Proliferate => proliferate::resolve(state, ability, events),
         Effect::Populate => populate::resolve(state, ability, events),
         Effect::Clash => clash::resolve(state, ability, events),
+        // CR 701.38: Council's-dilemma voting — see effects/vote.rs.
+        Effect::Vote { .. } => vote::resolve(state, ability, events),
         Effect::SwitchPT { .. } => switch_pt::resolve(state, ability, events),
         Effect::CopySpell { .. } => copy_spell::resolve(state, ability, events),
         Effect::CopyTokenOf { .. } => token_copy::resolve(state, ability, events),

--- a/crates/engine/src/game/effects/vote.rs
+++ b/crates/engine/src/game/effects/vote.rs
@@ -1,0 +1,369 @@
+//! CR 701.38: Vote — Council's dilemma family.
+//!
+//! Each player, starting with a specified player and proceeding in turn order
+//! (CR 101.4), chooses one of the listed options. After every player has cast
+//! their votes, the per-choice sub-effects resolve once for each vote tallied
+//! against that choice.
+//!
+//! CR 701.38d: A player who has multiple votes (granted by a static ability
+//! such as Tivit's "While voting, you may vote an additional time") makes
+//! those choices at the same time they would otherwise have voted.
+//!
+//! The resolver entry point sets `WaitingFor::VoteChoice` for the starting
+//! voter, embeds `per_choice_effect` directly on the `WaitingFor` (so the
+//! tally flows through state filtering and live multiplayer echoes without
+//! reaching back into the source ability), and stashes only the parent's
+//! post-Vote sub_ability on a pending continuation. The
+//! `engine_resolution_choices.rs` handler tallies each vote, advances voters
+//! in APNAP order, and finally calls `resolve_tally` to fan out the per-choice
+//! sub-effects.
+
+use crate::types::ability::{
+    AbilityDefinition, ControllerRef, Effect, EffectError, EffectKind, QuantityExpr,
+    ResolvedAbility,
+};
+use crate::types::events::GameEvent;
+use crate::types::game_state::{GameState, PendingContinuation, WaitingFor};
+use crate::types::player::PlayerId;
+
+use super::resolve_ability_chain;
+
+/// CR 701.38a + CR 101.4: Initiate a vote. Builds the APNAP voter queue
+/// starting from `starting_with` (resolved against the ability controller),
+/// computes each voter's total votes (1 + extra-vote grants from
+/// `Player::extra_votes_per_session`), and parks on `WaitingFor::VoteChoice`
+/// for the first voter.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let Effect::Vote {
+        choices,
+        per_choice_effect,
+        starting_with,
+    } = &ability.effect
+    else {
+        return Err(EffectError::InvalidParam(
+            "vote::resolve called with non-Vote effect".into(),
+        ));
+    };
+
+    // Parser invariant: one sub-effect per choice. Surfaced as a hard error so
+    // misparses fail fast rather than silently dropping ballots.
+    if choices.len() != per_choice_effect.len() {
+        return Err(EffectError::InvalidParam(format!(
+            "Effect::Vote choices/per_choice_effect length mismatch: {} vs {}",
+            choices.len(),
+            per_choice_effect.len()
+        )));
+    }
+    if choices.is_empty() {
+        return Err(EffectError::InvalidParam(
+            "Effect::Vote requires at least one choice".into(),
+        ));
+    }
+
+    let controller = ability.controller;
+    let starting_player = resolve_starting_voter(state, controller, starting_with.clone());
+
+    // CR 101.4 + CR 701.38a: Build APNAP voter order from the starting player.
+    let voters_in_order = apnap_order_from(state, starting_player);
+    if voters_in_order.is_empty() {
+        // No eligible voters (e.g., everyone eliminated). Emit EffectResolved
+        // and let the chain continue — nothing to tally.
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::Vote,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
+    let voter_queue: Vec<(PlayerId, u32)> = voters_in_order
+        .into_iter()
+        .map(|pid| (pid, votes_per_session_for(state, pid)))
+        .collect();
+
+    let (first_player, first_votes) = voter_queue[0];
+    let remaining_voters = voter_queue[1..].to_vec();
+
+    // Display labels: title-case each choice for the modal. Engine compares
+    // votes against the lowercase canonical `choices` field.
+    let option_labels: Vec<String> = choices.iter().map(|c| title_case_word(c)).collect();
+    let tallies = vec![0u32; choices.len()];
+
+    state.waiting_for = WaitingFor::VoteChoice {
+        player: first_player,
+        remaining_votes: first_votes,
+        options: choices.clone(),
+        option_labels,
+        remaining_voters,
+        tallies,
+        per_choice_effect: per_choice_effect.clone(),
+        controller,
+        source_id: ability.source_id,
+    };
+
+    // Stash the parent's sub_ability tail so it resumes after the tally fans
+    // out. The Vote effect itself does NOT belong on the continuation — the
+    // tally handler in engine_resolution_choices.rs explicitly calls
+    // `resolve_tally`, then drains this continuation to run any post-Vote
+    // chained effects. Mirrors clash::stash_sub.
+    if let Some(sub) = ability.sub_ability.as_ref() {
+        state.pending_continuation = Some(PendingContinuation::new(sub.clone()));
+    }
+
+    Ok(())
+}
+
+/// CR 701.38: After every voter has cast all their votes, fan out the per-choice
+/// sub-effects. For each `i`, `per_choice_effect[i]` is resolved once per vote
+/// tallied for `choices[i]`. Sub-effect resolutions inherit the source object
+/// and controller of the originating Vote ability.
+///
+/// Called from `engine_resolution_choices.rs` once the voter queue empties.
+pub fn resolve_tally(
+    state: &mut GameState,
+    source_id: crate::types::identifiers::ObjectId,
+    controller: PlayerId,
+    options: &[String],
+    per_choice_effect: &[Box<AbilityDefinition>],
+    tallies: &[u32],
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    debug_assert_eq!(options.len(), per_choice_effect.len());
+    debug_assert_eq!(options.len(), tallies.len());
+
+    for (idx, votes) in tallies.iter().enumerate() {
+        if *votes == 0 {
+            continue;
+        }
+        // Resolve `per_choice_effect[idx]` once per vote via repeat_for.
+        // CR 609.3: repeat_for runs the same effect N times within the same
+        // ability resolution, exactly mirroring "for each [X] vote, [effect]".
+        let chain = ResolvedAbility {
+            effect: (*per_choice_effect[idx].effect).clone(),
+            targets: Vec::new(),
+            source_id,
+            controller,
+            kind: per_choice_effect[idx].kind,
+            sub_ability: per_choice_effect[idx]
+                .sub_ability
+                .as_ref()
+                .map(|sub| Box::new(resolved_from_def(sub, source_id, controller))),
+            else_ability: None,
+            duration: per_choice_effect[idx].duration.clone(),
+            condition: per_choice_effect[idx].condition.clone(),
+            context: Default::default(),
+            optional_targeting: per_choice_effect[idx].optional_targeting,
+            optional: per_choice_effect[idx].optional,
+            optional_for: None,
+            multi_target: None,
+            description: per_choice_effect[idx].description.clone(),
+            repeat_for: Some(QuantityExpr::Fixed {
+                value: *votes as i32,
+            }),
+            forward_result: per_choice_effect[idx].forward_result,
+            unless_pay: None,
+            distribution: None,
+            player_scope: None,
+            chosen_x: None,
+        };
+        resolve_ability_chain(state, &chain, events, 0)?;
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::Vote,
+        source_id,
+    });
+    Ok(())
+}
+
+/// Convert a stored `AbilityDefinition` (typically a sub-effect) into a
+/// `ResolvedAbility` carrying the same source/controller as the parent Vote.
+fn resolved_from_def(
+    def: &AbilityDefinition,
+    source_id: crate::types::identifiers::ObjectId,
+    controller: PlayerId,
+) -> ResolvedAbility {
+    ResolvedAbility {
+        effect: (*def.effect).clone(),
+        targets: Vec::new(),
+        source_id,
+        controller,
+        kind: def.kind,
+        sub_ability: def
+            .sub_ability
+            .as_ref()
+            .map(|sub| Box::new(resolved_from_def(sub, source_id, controller))),
+        else_ability: None,
+        duration: def.duration.clone(),
+        condition: def.condition.clone(),
+        context: Default::default(),
+        optional_targeting: def.optional_targeting,
+        optional: def.optional,
+        optional_for: None,
+        multi_target: None,
+        description: def.description.clone(),
+        repeat_for: None,
+        forward_result: def.forward_result,
+        unless_pay: None,
+        distribution: None,
+        player_scope: None,
+        chosen_x: None,
+    }
+}
+
+/// CR 701.38a: Resolve `ControllerRef::You` (and friends) to the concrete
+/// starting voter PlayerId. Falls back to `controller` if the ref doesn't
+/// resolve to a non-eliminated player.
+fn resolve_starting_voter(
+    _state: &GameState,
+    controller: PlayerId,
+    starting_with: ControllerRef,
+) -> PlayerId {
+    match starting_with {
+        ControllerRef::You => controller,
+        // Other refs (TargetPlayer, etc.) are not currently produced by the
+        // Council's dilemma parser. Default to controller — extending this is
+        // a one-line change when "starting with the affected player" / similar
+        // phrasings appear.
+        _ => controller,
+    }
+}
+
+/// CR 101.4: Build a turn-order voter sequence beginning with `start`, walking
+/// forward through PlayerId order and skipping eliminated players. Supports
+/// arbitrary player counts (multiplayer).
+fn apnap_order_from(state: &GameState, start: PlayerId) -> Vec<PlayerId> {
+    let n = state.players.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    let start_idx = state
+        .players
+        .iter()
+        .position(|p| p.id == start)
+        .unwrap_or(0);
+    (0..n)
+        .map(|offset| (start_idx + offset) % n)
+        .filter_map(|i| {
+            let p = &state.players[i];
+            (!p.is_eliminated).then_some(p.id)
+        })
+        .collect()
+}
+
+/// CR 701.38d: A player's total votes for one Council's dilemma session is
+/// 1 plus the count of `StaticMode::GrantsExtraVote` permanents the player
+/// currently controls (Tivit, Seller of Secrets — "While voting, you may vote
+/// an additional time").
+///
+/// Snapshotted once at vote-session start (CR 701.38d: extra votes happen at
+/// the same time the player would otherwise have voted), so granting
+/// permanents that enter or leave mid-session do not retroactively change
+/// vote counts.
+fn votes_per_session_for(state: &GameState, player: PlayerId) -> u32 {
+    use crate::game::functioning_abilities::active_static_definitions;
+    use crate::types::statics::StaticMode;
+
+    let mut extras: u32 = 0;
+    for &src_id in state.battlefield.iter() {
+        let Some(obj) = state.objects.get(&src_id) else {
+            continue;
+        };
+        if obj.controller != player {
+            continue;
+        }
+        for s in active_static_definitions(state, obj) {
+            if matches!(s.mode, StaticMode::GrantsExtraVote) {
+                extras = extras.saturating_add(1);
+            }
+        }
+    }
+    1 + extras
+}
+
+/// Title-case the first character of a single word for display labels. The
+/// engine never compares against this value — only `options` (lowercase).
+fn title_case_word(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().chain(chars).collect(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ability::AbilityKind;
+    use crate::types::identifiers::ObjectId;
+
+    /// CR 701.38a + CR 101.4: Initiating a Vote sets `WaitingFor::VoteChoice`
+    /// for the controller, queuing the opponent next, with no extra-vote
+    /// granters present (so each player gets exactly 1 vote).
+    #[test]
+    fn vote_initiates_with_controller_first() {
+        let mut state = GameState::new_two_player(42);
+        let controller = state.players[0].id;
+
+        let inv_def = AbilityDefinition::new(AbilityKind::Spell, Effect::Investigate);
+        let token_def = AbilityDefinition::new(AbilityKind::Spell, Effect::Investigate); // simple stand-in
+
+        let ability = ResolvedAbility {
+            effect: Effect::Vote {
+                choices: vec!["evidence".to_string(), "bribery".to_string()],
+                per_choice_effect: vec![Box::new(inv_def), Box::new(token_def)],
+                starting_with: ControllerRef::You,
+            },
+            targets: vec![],
+            source_id: ObjectId(1),
+            controller,
+            kind: AbilityKind::Spell,
+            sub_ability: None,
+            else_ability: None,
+            duration: None,
+            condition: None,
+            context: Default::default(),
+            optional_targeting: false,
+            optional: false,
+            optional_for: None,
+            multi_target: None,
+            description: None,
+            repeat_for: None,
+            forward_result: false,
+            unless_pay: None,
+            distribution: None,
+            player_scope: None,
+            chosen_x: None,
+        };
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).expect("vote resolves");
+
+        match state.waiting_for {
+            WaitingFor::VoteChoice {
+                player,
+                remaining_votes,
+                ref options,
+                ref tallies,
+                ref remaining_voters,
+                ..
+            } => {
+                assert_eq!(player, controller);
+                assert_eq!(remaining_votes, 1);
+                assert_eq!(
+                    options,
+                    &vec!["evidence".to_string(), "bribery".to_string()]
+                );
+                assert_eq!(tallies, &vec![0u32, 0]);
+                // Opponent queued next with their 1 vote.
+                assert_eq!(remaining_voters.len(), 1);
+                assert_ne!(remaining_voters[0].0, controller);
+                assert_eq!(remaining_voters[0].1, 1);
+            }
+            other => panic!("expected VoteChoice, got {:?}", other),
+        }
+    }
+}

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -30,6 +30,7 @@ pub(super) fn handles(waiting_for: &WaitingFor) -> bool {
             | WaitingFor::TopOrBottomChoice { .. }
             | WaitingFor::PopulateChoice { .. }
             | WaitingFor::ClashCardPlacement { .. }
+            | WaitingFor::VoteChoice { .. }
             | WaitingFor::DigChoice { .. }
             | WaitingFor::SurveilChoice { .. }
             | WaitingFor::RevealChoice { .. }
@@ -335,6 +336,95 @@ pub(super) fn handle_resolution_choice(
                 ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
             } else {
                 ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            }
+        }
+        // CR 701.38: Tally a vote, then either advance to the same voter's
+        // next vote (CR 701.38d), the next voter (CR 101.4), or — if every
+        // voter has voted — fan out the per-choice sub-effects via
+        // `vote::resolve_tally` and drain the post-vote continuation.
+        (
+            WaitingFor::VoteChoice {
+                player,
+                remaining_votes,
+                options,
+                option_labels,
+                remaining_voters,
+                tallies,
+                per_choice_effect,
+                controller,
+                source_id,
+            },
+            GameAction::ChooseOption { choice },
+        ) => {
+            // CR 701.38a: Validate the cast vote. Compare lowercase against
+            // the canonical options list; reject anything else.
+            let lower = choice.to_lowercase();
+            let Some(idx) = options.iter().position(|o| o == &lower) else {
+                return Err(EngineError::InvalidAction(format!(
+                    "Invalid vote '{}'; valid choices are {:?}",
+                    choice, options
+                )));
+            };
+            let mut new_tallies = tallies.clone();
+            new_tallies[idx] += 1;
+            events.push(GameEvent::VoteCast {
+                voter: player,
+                choice: lower,
+                source_id,
+            });
+
+            if remaining_votes > 1 {
+                // CR 701.38d: Same player still has votes to cast.
+                state.waiting_for = WaitingFor::VoteChoice {
+                    player,
+                    remaining_votes: remaining_votes - 1,
+                    options,
+                    option_labels,
+                    remaining_voters,
+                    tallies: new_tallies,
+                    per_choice_effect,
+                    controller,
+                    source_id,
+                };
+                ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
+            } else if let Some(((next_player, next_votes), rest)) = remaining_voters.split_first() {
+                // CR 101.4: Advance to the next voter in turn order.
+                state.waiting_for = WaitingFor::VoteChoice {
+                    player: *next_player,
+                    remaining_votes: *next_votes,
+                    options,
+                    option_labels,
+                    remaining_voters: rest.to_vec(),
+                    tallies: new_tallies,
+                    per_choice_effect,
+                    controller,
+                    source_id,
+                };
+                ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
+            } else {
+                // CR 701.38: All votes cast — resolve per-choice sub-effects,
+                // emit the final tally event, then drain any post-Vote
+                // continuation (e.g., a chained effect).
+                events.push(GameEvent::VoteResolved {
+                    source_id,
+                    tallies: options
+                        .iter()
+                        .cloned()
+                        .zip(new_tallies.iter().copied())
+                        .collect(),
+                });
+                let _ = effects::vote::resolve_tally(
+                    state,
+                    source_id,
+                    controller,
+                    &options,
+                    &per_choice_effect,
+                    &new_tallies,
+                    events,
+                );
+                ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(
+                    state, controller, events,
+                ))
             }
         }
         (

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -185,6 +185,8 @@ fn categorize(event: &GameEvent) -> LogCategory {
         | GameEvent::DungeonCompleted { .. }
         | GameEvent::InitiativeTaken { .. }
         | GameEvent::Clash { .. }
+        | GameEvent::VoteCast { .. }
+        | GameEvent::VoteResolved { .. }
         | GameEvent::XValueChosen { .. } => LogCategory::Special,
         GameEvent::CombatTaxPaid { .. } | GameEvent::CombatTaxDeclined { .. } => {
             LogCategory::Combat
@@ -837,6 +839,21 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
         GameEvent::DungeonCompleted { .. } => vec![text("Dungeon completed")],
         GameEvent::InitiativeTaken { .. } => vec![text("Initiative taken")],
         GameEvent::Clash { .. } => vec![text("Clash")],
+        GameEvent::VoteCast { voter, choice, .. } => {
+            vec![player_seg(state, *voter), text(" voted "), text(choice)]
+        }
+        GameEvent::VoteResolved { tallies, .. } => {
+            let mut segs = vec![text("Vote resolved: ")];
+            for (i, (label, count)) in tallies.iter().enumerate() {
+                if i > 0 {
+                    segs.push(text(", "));
+                }
+                segs.push(text(label));
+                segs.push(text(": "));
+                segs.push(text(&count.to_string()));
+            }
+            segs
+        }
         GameEvent::XValueChosen { value, .. } => {
             vec![text("Chose X = "), text(&value.to_string())]
         }

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1107,6 +1107,7 @@ impl GameRunner {
             WaitingFor::ChooseDungeonRoom { .. } => "ChooseDungeonRoom",
             WaitingFor::PopulateChoice { .. } => "PopulateChoice",
             WaitingFor::ClashCardPlacement { .. } => "ClashCardPlacement",
+            WaitingFor::VoteChoice { .. } => "VoteChoice",
             WaitingFor::CategoryChoice { .. } => "CategoryChoice",
             WaitingFor::ChooseXValue { .. } => "ChooseXValue",
             WaitingFor::CombatTaxPayment { .. } => "CombatTaxPayment",

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -183,6 +183,11 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     // additional_land_drops(). Coverage support is via is_data_carrying_static().
     // CR 114.3: EmblemStatic — fallback for unparseable emblem static text.
     registry.insert(StaticMode::EmblemStatic, handle_rule_mod);
+    // CR 701.38d: GrantsExtraVote — "While voting, you may vote an additional time."
+    // Runtime enforcement is in game/effects/vote.rs::votes_per_session_for(), which
+    // scans active_static_definitions at vote-session start. No continuous-effect
+    // plumbing needed; registered here so coverage marks the card as supported.
+    registry.insert(StaticMode::GrantsExtraVote, handle_rule_mod);
 
     // No generic `StaticMode::Other(...)` stubs are currently needed.
     //

--- a/crates/engine/src/parser/mod.rs
+++ b/crates/engine/src/parser/mod.rs
@@ -20,6 +20,7 @@ pub mod oracle_target;
 pub(crate) mod oracle_target_scope;
 pub mod oracle_trigger;
 pub mod oracle_util;
+pub(crate) mod oracle_vote;
 pub mod oracle_warnings;
 
 pub use oracle::parse_oracle_text;

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -418,6 +418,33 @@ fn parse_static_line_inner(text: &str, inverted: InvertedAsLongAs) -> Option<Sta
         );
     }
 
+    // CR 701.38d: "While voting, you may vote an additional time." (Tivit,
+    // Seller of Secrets and the Council's-dilemma extra-vote family.) Built
+    // for the class — covers any phrasing where the controller gets one
+    // additional vote per session. Dispatched via nom so future variants
+    // ("two additional times", "while voting on a Council's dilemma you cast")
+    // can be added as new combinator arms rather than as additional
+    // string-equality checks.
+    {
+        let lower_trim = tp.lower.trim_end_matches('.').trim();
+        let res: nom::IResult<&str, (), nom_language::error::VerboseError<&str>> =
+            nom::combinator::value(
+                (),
+                nom::branch::alt((
+                    nom::bytes::complete::tag("while voting, you may vote an additional time"),
+                    nom::bytes::complete::tag("while voting you may vote an additional time"),
+                )),
+            )
+            .parse(lower_trim);
+        if res.is_ok() {
+            return Some(
+                StaticDefinition::new(StaticMode::GrantsExtraVote)
+                    .affected(TargetFilter::Player)
+                    .description(text.to_string()),
+            );
+        }
+    }
+
     // CR 604.3 + CR 601.2a: "Once during each of your turns, you may cast [filter] from your graveyard."
     if let Some(result) = try_parse_graveyard_cast_permission(&text, &lower) {
         return Some(result);

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -482,8 +482,20 @@ pub(crate) fn parse_trigger_line_with_index(
     // Parse the effect
     let has_up_to = scan_contains(&effect_for_parse, "up to one");
     let execute = if !effect_for_parse.is_empty() {
-        let mut ability =
-            parse_effect_chain_with_context(&effect_for_parse, AbilityKind::Spell, &effect_ctx);
+        // CR 701.38 + CR 207.2c: Council's-dilemma / Will-of-the-Council vote
+        // blocks have a fixed three-sentence shape ("starting with you, each
+        // player votes for X or Y. For each X vote, A. For each Y vote, B.")
+        // that can't be cleanly split by `parse_effect_chain` because the per-
+        // choice tally clauses are semantically welded to the vote prompt.
+        // Try the dedicated detector first; fall back to the chain parser if
+        // the input isn't a vote block.
+        let mut ability = if let Some(vote_def) =
+            crate::parser::oracle_vote::parse_vote_block(&effect_for_parse, AbilityKind::Spell)
+        {
+            vote_def
+        } else {
+            parse_effect_chain_with_context(&effect_for_parse, AbilityKind::Spell, &effect_ctx)
+        };
         if has_up_to {
             ability.optional_targeting = true;
         }

--- a/crates/engine/src/parser/oracle_vote.rs
+++ b/crates/engine/src/parser/oracle_vote.rs
@@ -1,0 +1,253 @@
+//! CR 701.38 + CR 207.2c: Council's-dilemma / Will-of-the-Council voting parser.
+//!
+//! This module owns recognition of the full vote effect block:
+//!
+//! ```text
+//! starting with you, each player votes for <choice-a> or <choice-b>.
+//! For each <choice-a> vote, <effect-a>.
+//! For each <choice-b> vote, <effect-b>.
+//! ```
+//!
+//! Output: a synthesized `Effect::Vote` whose `per_choice_effect` slots carry
+//! the parsed sub-effects in `choices` declaration order.
+//!
+//! Architectural rules:
+//! * Nom combinators for ALL dispatch — never `find` / `contains` / `split_once`.
+//! * Builds for the *class* of cards (every Will-of-the-Council / Council's-
+//!   dilemma vote with two-or-more named choices), not just Tivit.
+//! * The detector is pure: given vote text, it returns the synthesized
+//!   `AbilityDefinition`. Failure to match returns `None`, leaving the caller
+//!   free to fall back to the standard chain parser.
+
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::combinator::value;
+use nom::Parser;
+use nom_language::error::VerboseError;
+
+use crate::types::ability::{AbilityDefinition, AbilityKind, ControllerRef, Effect};
+
+use super::oracle_effect::{parse_effect_chain_with_context, ParseContext};
+
+/// Detect and parse the entire Council's-dilemma vote block. Returns a single
+/// `AbilityDefinition` whose `effect` is `Effect::Vote` populated with the
+/// per-choice sub-effects, or `None` if the input doesn't match the pattern.
+///
+/// The input is the trigger/effect *body* text — i.e., what comes after
+/// "Whenever ~ enters or deals combat damage to a player, ". The "starting
+/// with you, " prefix is consumed here (kept inside this module so chain-level
+/// stripping in `parse_effect_chain_impl` doesn't interfere).
+pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityDefinition> {
+    let lower = text.to_lowercase();
+    // Phase 1: optional "starting with you," prefix.
+    let (i, starting_with) =
+        parse_starting_with(&lower).unwrap_or((lower.as_str(), ControllerRef::You));
+    // Phase 2: "each player votes for <a> or <b>." (allowing "each player may vote").
+    let (i, choices) = parse_each_player_votes_clause(i)?;
+    if choices.len() < 2 {
+        return None;
+    }
+    // Phase 3: "For each <choice> vote, <effect>." Once per choice. Walk the
+    // text exactly once and key the parsed sub-effects by their canonical
+    // `choices` index so the output array always matches declaration order.
+    let mut slots: Vec<Option<Box<AbilityDefinition>>> = (0..choices.len()).map(|_| None).collect();
+    let mut walk = i.trim_start();
+    while !walk.is_empty() {
+        let (rest, (choice, effect_text)) = parse_for_each_vote_clause(walk, &choices)?;
+        let idx = choices.iter().position(|c| c == &choice)?;
+        if slots[idx].is_some() {
+            // Same choice referenced twice — shape we don't yet model.
+            return None;
+        }
+        let parsed = parse_effect_chain_with_context(effect_text, kind, &ParseContext::default());
+        slots[idx] = Some(Box::new(parsed));
+        walk = rest.trim_start();
+    }
+    let per_choice_effect: Vec<Box<AbilityDefinition>> =
+        slots.into_iter().collect::<Option<Vec<_>>>()?;
+
+    Some(AbilityDefinition::new(
+        kind,
+        Effect::Vote {
+            choices,
+            per_choice_effect,
+            starting_with,
+        },
+    ))
+}
+
+/// Parse the optional "starting with you, " prefix. Returns the unconsumed
+/// remainder plus the resolved `ControllerRef`. Other phrasings ("starting
+/// with the player to your left") map to `ControllerRef::You` until we model
+/// player-position refs.
+fn parse_starting_with(input: &str) -> Option<(&str, ControllerRef)> {
+    let res: nom::IResult<&str, (), VerboseError<&str>> = value(
+        (),
+        alt((tag("starting with you, "), tag("starting with you "))),
+    )
+    .parse(input);
+    match res {
+        Ok((rest, ())) => Some((rest, ControllerRef::You)),
+        Err(_) => None,
+    }
+}
+
+/// Parse "each player votes for <a> or <b>." or its "may vote" cousin.
+/// Returns the unconsumed remainder plus the lowercase choice list.
+///
+/// Generalized to N>=2 choices via repeated " or " / ", " separators —
+/// covers cards like Capital Punishment that vote on three options.
+fn parse_each_player_votes_clause(input: &str) -> Option<(&str, Vec<String>)> {
+    let res: nom::IResult<&str, (), VerboseError<&str>> = value(
+        (),
+        alt((
+            tag("each player votes for "),
+            tag("each player may vote for "),
+        )),
+    )
+    .parse(input);
+    let (rest, ()) = res.ok()?;
+
+    // Read the choice list: "<a>[, <b>][, <c>] or <last>." — allow "or"
+    // separator for the last item, comma between earlier items.
+    let (after, choice_list_text) = read_until_period(rest)?;
+    let choices = split_choices(choice_list_text)?;
+    Some((after, choices))
+}
+
+/// Parse "For each <choice> vote, <effect>." Returns the choice (lowercase)
+/// and the inner effect text. Whitespace handling:
+/// * Accepts both upper- and lowercase "For"/"for".
+/// * Consumes a trailing period if present.
+fn parse_for_each_vote_clause<'a>(
+    input: &'a str,
+    choices: &[String],
+) -> Option<(&'a str, (String, &'a str))> {
+    let lower = input.to_lowercase();
+    let res: nom::IResult<&str, (), VerboseError<&str>> =
+        value((), alt((tag("for each "),))).parse(lower.as_str());
+    let (lower_rest, ()) = res.ok()?;
+    // Slice the original input at the same offset.
+    let consumed = input.len() - lower_rest.len();
+    let original_rest = &input[consumed..];
+
+    // Read the choice token (case-insensitive); choices are whitespace-free
+    // single words in canonical Council's-dilemma cards.
+    let (choice, after_choice) = read_word(original_rest)?;
+    let choice_lower = choice.to_lowercase();
+    if !choices.iter().any(|c| c == &choice_lower) {
+        return None;
+    }
+    // Consume " vote, " (singular) — plural "votes" would imply the resolver
+    // re-tally pattern that Council's dilemma never uses; reject to keep the
+    // detector tight.
+    let after_vote = after_choice.strip_prefix(" vote, ")?;
+    // Read up to terminator: either next "For each " OR end-of-string,
+    // stripping trailing period.
+    let (effect_text, rest) = read_effect_until_next_clause(after_vote);
+    Some((rest, (choice_lower, effect_text)))
+}
+
+/// Read a maximal prefix up to (but not including) the next "For each "
+/// clause or end of input. Strips a trailing period from the consumed slice.
+fn read_effect_until_next_clause(input: &str) -> (&str, &str) {
+    let lower = input.to_lowercase();
+    // Find the next "for each " case-insensitively. structural: not dispatch
+    // — this is a local sentence-boundary scanner, not a parser dispatch
+    // decision. We use lowercase for the search but slice the original input
+    // so casing is preserved in the returned effect text.
+    let cut = lower
+        .match_indices("for each ")
+        .find(|(idx, _)| {
+            *idx == 0
+                || matches!(
+                    lower.as_bytes().get(*idx - 1),
+                    Some(b' ') | Some(b'.') | Some(b',')
+                )
+        })
+        .map(|(idx, _)| idx)
+        .unwrap_or(input.len());
+    let head = &input[..cut];
+    let tail = &input[cut..];
+    let head_trimmed = head.trim_end();
+    let head_no_period = head_trimmed.strip_suffix('.').unwrap_or(head_trimmed);
+    (head_no_period.trim(), tail.trim_start())
+}
+
+/// Read a word (alphanumeric + apostrophes). Returns (word, remainder).
+fn read_word(input: &str) -> Option<(&str, &str)> {
+    let end = input
+        .char_indices()
+        .find(|(_, c)| !c.is_alphanumeric() && *c != '\'' && *c != '-')
+        .map(|(i, _)| i)
+        .unwrap_or(input.len());
+    if end == 0 {
+        return None;
+    }
+    Some((&input[..end], &input[end..]))
+}
+
+/// Read characters up to and including a period; return the substring before
+/// the period and the remainder after it.
+fn read_until_period(input: &str) -> Option<(&str, &str)> {
+    let idx = input.find('.')?;
+    Some((&input[idx + 1..], &input[..idx]))
+}
+
+/// Split a list like "evidence or bribery" or "guards, hounds, or dragons"
+/// into individual lowercase choices. Returns `None` if fewer than two
+/// choices were found.
+fn split_choices(input: &str) -> Option<Vec<String>> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Split on " or " for the final pair, then on ", " for the prefix.
+    // structural: not dispatch — splitting a known-finished list, not parsing.
+    let (head, tail) = trimmed.rsplit_once(" or ")?;
+    let mut choices: Vec<String> = head
+        .split(", ")
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect();
+    choices.push(tail.trim().to_lowercase());
+    if choices.len() < 2 {
+        return None;
+    }
+    Some(choices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_tivit_vote_block() {
+        let text = "starting with you, each player votes for evidence or bribery. For each evidence vote, investigate. For each bribery vote, create a Treasure token.";
+        let def = parse_vote_block(text, AbilityKind::Spell).expect("vote block parses");
+        match *def.effect {
+            Effect::Vote {
+                ref choices,
+                ref per_choice_effect,
+                starting_with,
+            } => {
+                assert_eq!(
+                    choices,
+                    &vec!["evidence".to_string(), "bribery".to_string()]
+                );
+                assert_eq!(per_choice_effect.len(), 2);
+                assert_eq!(starting_with, ControllerRef::You);
+                // First per-choice = Investigate
+                assert!(matches!(*per_choice_effect[0].effect, Effect::Investigate));
+                // Second per-choice = Token (Treasure)
+                assert!(matches!(*per_choice_effect[1].effect, Effect::Token { .. }));
+            }
+            other => panic!("expected Vote, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rejects_non_vote_text() {
+        assert!(parse_vote_block("Draw a card.", AbilityKind::Spell).is_none());
+    }
+}

--- a/crates/engine/src/parser/oracle_vote.rs
+++ b/crates/engine/src/parser/oracle_vote.rs
@@ -141,7 +141,9 @@ fn parse_for_each_vote_clause<'a>(
     // Consume " vote, " (singular) — plural "votes" would imply the resolver
     // re-tally pattern that Council's dilemma never uses; reject to keep the
     // detector tight.
-    let after_vote = after_choice.strip_prefix(" vote, ")?;
+    let (after_vote, _): (&str, &str) = tag::<_, _, VerboseError<&str>>(" vote, ")
+        .parse(after_choice)
+        .ok()?;
     // Read up to terminator: either next "For each " OR end-of-string,
     // stripping trailing period.
     let (effect_text, rest) = read_effect_until_next_clause(after_vote);
@@ -170,6 +172,7 @@ fn read_effect_until_next_clause(input: &str) -> (&str, &str) {
     let head = &input[..cut];
     let tail = &input[cut..];
     let head_trimmed = head.trim_end();
+    // allow-noncombinator: structural period strip on pre-extracted sentence clause
     let head_no_period = head_trimmed.strip_suffix('.').unwrap_or(head_trimmed);
     (head_no_period.trim(), tail.trim_start())
 }
@@ -197,20 +200,33 @@ fn read_until_period(input: &str) -> Option<(&str, &str)> {
 /// Split a list like "evidence or bribery" or "guards, hounds, or dragons"
 /// into individual lowercase choices. Returns `None` if fewer than two
 /// choices were found.
+///
+/// Uses nom to consume word tokens separated by `", or "`, `" or "`, or `", "` —
+/// handling the standard MTG list formats without string-splitting on raw bytes.
 fn split_choices(input: &str) -> Option<Vec<String>> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
+    let lower = input.trim().to_lowercase();
+    if lower.is_empty() {
         return None;
     }
-    // Split on " or " for the final pair, then on ", " for the prefix.
-    // structural: not dispatch — splitting a known-finished list, not parsing.
-    let (head, tail) = trimmed.rsplit_once(" or ")?;
-    let mut choices: Vec<String> = head
-        .split(", ")
-        .map(|s| s.trim().to_lowercase())
-        .filter(|s| !s.is_empty())
-        .collect();
-    choices.push(tail.trim().to_lowercase());
+    let word_chars = |c: char| c.is_alphanumeric() || c == '\'' || c == '-';
+    let mut choices: Vec<String> = Vec::new();
+    let mut rest: &str = lower.as_str();
+    loop {
+        let (after_word, word) =
+            nom::bytes::complete::take_while1::<_, &str, VerboseError<&str>>(word_chars)
+                .parse(rest)
+                .ok()?;
+        choices.push(word.to_string());
+        rest = after_word;
+        if rest.is_empty() {
+            break;
+        }
+        // Consume separator; try longest match first to avoid partial matches.
+        let sep_res: nom::IResult<&str, (), VerboseError<&str>> =
+            value((), alt((tag(", or "), tag(" or "), tag(", ")))).parse(rest);
+        let (after_sep, ()) = sep_res.ok()?;
+        rest = after_sep;
+    }
     if choices.len() < 2 {
         return None;
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3193,6 +3193,36 @@ pub enum Effect {
     Populate,
     /// CR 701.30: Clash with an opponent — reveal top cards, compare mana values.
     Clash,
+    /// CR 701.38: Vote — each player chooses one of the listed options, starting
+    /// with a specified player and proceeding in turn order. After all votes are
+    /// collected, the resolver runs `per_choice_effect[i]` once for each vote
+    /// cast for `choices[i]`. CR 701.38d: A player with multiple votes (granted
+    /// by static "you may vote an additional time") makes those choices at the
+    /// same time they would otherwise have voted.
+    ///
+    /// The starting player defaults to the ability's controller (the canonical
+    /// "Council's dilemma — starting with you" pattern). `per_choice_effect[i]`
+    /// resolves once per vote tallied for `choices[i]` (Tivit's "for each
+    /// evidence vote, investigate" / "for each bribery vote, create a Treasure
+    /// token"). Each per-vote sub-resolution inherits the source ability's
+    /// controller and source object, identical to how `ForEach`-style replicate
+    /// effects fan out.
+    Vote {
+        /// Lowercase choice identifiers ("evidence", "bribery", a creature
+        /// type, etc.). Display capitalization is restored from the original
+        /// Oracle text by the parser before serialization.
+        choices: Vec<String>,
+        /// One sub-effect per choice. `per_choice_effect[i]` resolves once for
+        /// every vote cast for `choices[i]`. Length must equal `choices.len()`
+        /// — the parser is the single authority and the resolver asserts this
+        /// invariant.
+        per_choice_effect: Vec<Box<AbilityDefinition>>,
+        /// CR 101.4 + CR 701.38a: The first voter. `ControllerRef::You` covers
+        /// "starting with you"; other refs cover "starting with the player to
+        /// your left" / "the affected player" if those phrasings ever land.
+        #[serde(default = "default_controller_ref_you")]
+        starting_with: ControllerRef,
+    },
     /// CR 613.4d: Switch a creature's power and toughness. Applied in layer 7d.
     SwitchPT {
         #[serde(default = "default_target_filter_any")]
@@ -4090,6 +4120,13 @@ fn default_target_filter_self_ref() -> TargetFilter {
     TargetFilter::SelfRef
 }
 
+/// CR 701.38a + CR 101.4: Default starting voter for `Effect::Vote` is the
+/// ability controller ("starting with you"). Defining this as a free function
+/// (not an enum default) keeps the serde shape stable across schema upgrades.
+fn default_controller_ref_you() -> ControllerRef {
+    ControllerRef::You
+}
+
 impl TargetFilter {
     /// CR 115.1: Returns true for filters that are NOT player-chosen targets —
     /// context references (triggering event participants per CR 603.7c),
@@ -4303,6 +4340,7 @@ impl Effect {
             | Effect::Proliferate
             | Effect::Populate
             | Effect::Clash
+            | Effect::Vote { .. }
             | Effect::Cleanup { .. }
             | Effect::Mana { .. }
             | Effect::RevealTop { .. }
@@ -4415,6 +4453,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::Proliferate => "Proliferate",
         Effect::Populate => "Populate",
         Effect::Clash => "Clash",
+        Effect::Vote { .. } => "Vote",
         Effect::SwitchPT { .. } => "SwitchPT",
         Effect::CopySpell { .. } => "CopySpell",
         Effect::CopyTokenOf { .. } => "CopyTokenOf",
@@ -4573,6 +4612,8 @@ pub enum EffectKind {
     Proliferate,
     Populate,
     Clash,
+    /// CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.
+    Vote,
     SwitchPT,
     CopySpell,
     CopyTokenOf,
@@ -4732,6 +4773,7 @@ impl From<&Effect> for EffectKind {
             Effect::Proliferate => EffectKind::Proliferate,
             Effect::Populate => EffectKind::Populate,
             Effect::Clash => EffectKind::Clash,
+            Effect::Vote { .. } => EffectKind::Vote,
             Effect::SwitchPT { .. } => EffectKind::SwitchPT,
             Effect::CopySpell { .. } => EffectKind::CopySpell,
             Effect::CopyTokenOf { .. } => EffectKind::CopyTokenOf,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5916,6 +5916,7 @@ impl TriggerDefinition {
 /// Static ability definition with typed fields. Zero params HashMap.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StaticDefinition {
+    #[serde(deserialize_with = "crate::types::statics::deserialize_static_mode_fwd")]
     pub mode: StaticMode,
     #[serde(default)]
     pub affected: Option<TargetFilter>,

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -444,6 +444,22 @@ pub enum GameEvent {
         opponent_mana_value: Option<u32>,
         result: ClashResult,
     },
+    /// CR 701.38a: A player cast a single vote in a Council's-dilemma
+    /// resolution. One event per vote (so a player with multiple votes
+    /// produces multiple events). `choice` is the lowercase canonical
+    /// option name from `Effect::Vote.choices`.
+    VoteCast {
+        voter: PlayerId,
+        choice: String,
+        source_id: ObjectId,
+    },
+    /// CR 701.38: All voters have voted. Emitted before the per-choice tally
+    /// sub-effects fire. `tallies` is `(choice, count)` pairs in `options`
+    /// declaration order.
+    VoteResolved {
+        source_id: ObjectId,
+        tallies: Vec<(String, u32)>,
+    },
     /// Emitted when layer re-evaluation changes a creature's effective power/toughness.
     /// Generic event — not tied to any specific card or effect.
     PowerToughnessChanged {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1401,6 +1401,48 @@ pub enum WaitingFor {
         card: ObjectId,
         remaining: Vec<(PlayerId, ObjectId)>,
     },
+    /// CR 701.38: A player is voting on the listed choices. After this player
+    /// has cast all of their votes (1 + extras from "you may vote an additional
+    /// time" static abilities), the engine advances to the next player in
+    /// APNAP order until every non-eliminated player has voted, then resolves
+    /// the per-choice tally sub-effects. Lives in the engine — frontend just
+    /// renders the modal.
+    VoteChoice {
+        /// The voter currently making a choice.
+        player: PlayerId,
+        /// CR 701.38d: Remaining votes this player must cast before passing
+        /// the turn to the next voter. Always >= 1 when this state is entered.
+        remaining_votes: u32,
+        /// Lowercase choice identifiers as defined in `Effect::Vote.choices`.
+        /// Persisted on `WaitingFor` (not just on the ability) so multiplayer
+        /// state filtering and the frontend modal can render the prompt
+        /// without re-walking the stack.
+        options: Vec<String>,
+        /// Display labels (original-case from Oracle text) — frontend renders
+        /// these; the engine compares votes against `options`.
+        option_labels: Vec<String>,
+        /// Players still awaiting their first vote, in APNAP order from the
+        /// starting voter. Each entry is `(player_id, total_votes)` where
+        /// `total_votes` is computed at vote-session start (CR 701.38d: extra
+        /// votes resolve at the same time the player would otherwise vote).
+        remaining_voters: Vec<(PlayerId, u32)>,
+        /// Vote tallies indexed parallel to `options`. `tallies[i]` is the
+        /// number of votes cast for `options[i]` so far.
+        tallies: Vec<u32>,
+        /// CR 701.38: Per-choice sub-effects. `per_choice_effect[i]` resolves
+        /// once for each vote tallied against `options[i]`. Carried on the
+        /// WaitingFor so the resolver chain doesn't need to re-find the source
+        /// ability — voting can outlive permanents (LKI) and the WaitingFor is
+        /// always the canonical state.
+        per_choice_effect: Vec<Box<super::ability::AbilityDefinition>>,
+        /// Ability controller — the player who owns the Vote effect. Used by
+        /// the tally resolver to scope sub-effects to the correct controller.
+        controller: PlayerId,
+        /// Source ability's object ID — used by logging and for state-filter
+        /// echoes; mirrors the `source_id` carried on other interactive
+        /// `WaitingFor` variants (e.g., NamedChoice).
+        source_id: ObjectId,
+    },
     /// CR 702.139a: Before the game begins, reveal companion from outside the game.
     CompanionReveal {
         player: PlayerId,
@@ -1674,6 +1716,7 @@ impl WaitingFor {
             | WaitingFor::ParadigmCastOffer { player, .. }
             | WaitingFor::PopulateChoice { player, .. }
             | WaitingFor::ClashCardPlacement { player, .. }
+            | WaitingFor::VoteChoice { player, .. }
             | WaitingFor::CompanionReveal { player, .. }
             | WaitingFor::ChooseLegend { player, .. }
             | WaitingFor::BattleProtectorChoice { player, .. }

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1062,11 +1062,18 @@ impl FromStr for StaticMode {
 /// Usage: `#[serde(deserialize_with = "crate::types::statics::deserialize_static_mode_fwd")]`
 ///
 /// # How it avoids infinite recursion
-/// - String values go through `FromStr`, which has an `Other(s)` fallback for
-///   unknown variants and never calls `<StaticMode as Deserialize>::deserialize`.
-/// - Non-string (object) values are fed to `serde_json::from_value::<StaticMode>`,
-///   which invokes the *derived* `StaticMode::Deserialize` impl directly (not this
-///   helper). No cycle is possible.
+/// For both string and object values, the function delegates to
+/// `serde_json::from_value::<StaticMode>`, which invokes the **derived**
+/// `StaticMode::Deserialize` impl — not this field-level helper. For unknown
+/// unit variants (string values that the derived impl rejects), the fallback
+/// wraps the raw string in `Other(s)`. No cycle is possible.
+///
+/// # Why not `FromStr`?
+/// `FromStr` for `StaticMode` does not enumerate every unit variant by its
+/// exact Rust identifier (it's a separate parser for human-facing strings).
+/// Using `FromStr` would map known variants like `"SpendManaAsAnyColor"` to
+/// `Other("SpendManaAsAnyColor")` whenever they aren't explicitly listed,
+/// breaking coverage and registry lookups for those cards.
 pub fn deserialize_static_mode_fwd<'de, D>(d: D) -> Result<StaticMode, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -1075,9 +1082,15 @@ where
     let raw: serde_json::Value = serde_json::Value::deserialize(d)?;
     match raw {
         serde_json::Value::String(ref s) => {
-            // Unit variant path. `FromStr` maps unknown strings to `Other(s)`
-            // so old binaries can load card data produced by newer code.
-            s.parse::<StaticMode>().map_err(serde::de::Error::custom)
+            // Unit variant path. Try the derived deserializer first so all
+            // known unit variants (e.g. "SpendManaAsAnyColor", "Flying", …)
+            // round-trip correctly. If the derived impl rejects the string
+            // (unknown variant from a newer engine build), fall back to
+            // Other(s) so the card still loads without a hard error.
+            match serde_json::from_value::<StaticMode>(serde_json::Value::String(s.clone())) {
+                Ok(mode) => Ok(mode),
+                Err(_) => Ok(StaticMode::Other(s.clone())),
+            }
         }
         other => {
             // Data-carrying variant path. Delegate to the derived Deserialize

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -332,6 +332,18 @@ pub enum StaticMode {
         cause: ProhibitionScope,
     },
     CastWithFlash,
+    /// CR 701.38d: While voting, the controller of this permanent may vote an
+    /// additional time. Each active source grants +1 to the controller's
+    /// `Player::extra_votes_per_session` snapshot taken at vote-session start
+    /// (Tivit, Seller of Secrets — "While voting, you may vote an additional
+    /// time.").
+    ///
+    /// The vote-effect resolver scans the battlefield for permanents with this
+    /// static at session start (CR 701.38d: extra votes happen at the same
+    /// time the player would otherwise have voted). It does *not* feed into
+    /// layer 7 — there is no continuous P/T or keyword grant; the static is a
+    /// pure "session-start +1 votes" signal.
+    GrantsExtraVote,
     /// CR 702.51a: Grants a keyword to spells during casting.
     /// Generalized version of CastWithFlash — the `spell_filter` on the StaticDefinition
     /// determines which spells are affected (e.g., "Creature spells you cast have convoke").
@@ -648,6 +660,7 @@ impl fmt::Display for StaticMode {
                 write!(f, "SuppressTriggers({})", parts.join("+"))
             }
             StaticMode::CastWithFlash => write!(f, "CastWithFlash"),
+            StaticMode::GrantsExtraVote => write!(f, "GrantsExtraVote"),
             StaticMode::CastWithKeyword { keyword } => {
                 write!(f, "CastWithKeyword({keyword:?})")
             }

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -914,6 +914,8 @@ impl FromStr for StaticMode {
             "UntapsDuringEachOtherPlayersUntapStep" => {
                 StaticMode::UntapsDuringEachOtherPlayersUntapStep
             }
+            // CR 701.38d: "While voting, you may vote an additional time."
+            "GrantsExtraVote" => StaticMode::GrantsExtraVote,
             // Parameterized
             other => {
                 if let Some(inner) = other
@@ -1048,6 +1050,40 @@ impl FromStr for StaticMode {
             }
         };
         Ok(mode)
+    }
+}
+
+/// Forward-compatible deserializer for `StaticMode` fields in persisted JSON
+/// (card-data.json). Handles the common case where a new unit-variant is added
+/// to the engine but an older WASM binary tries to load card data that contains
+/// that variant: instead of a hard error, the variant is silently mapped to
+/// `StaticMode::Other(name)` and the card continues to load.
+///
+/// Usage: `#[serde(deserialize_with = "crate::types::statics::deserialize_static_mode_fwd")]`
+///
+/// # How it avoids infinite recursion
+/// - String values go through `FromStr`, which has an `Other(s)` fallback for
+///   unknown variants and never calls `<StaticMode as Deserialize>::deserialize`.
+/// - Non-string (object) values are fed to `serde_json::from_value::<StaticMode>`,
+///   which invokes the *derived* `StaticMode::Deserialize` impl directly (not this
+///   helper). No cycle is possible.
+pub fn deserialize_static_mode_fwd<'de, D>(d: D) -> Result<StaticMode, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize as _;
+    let raw: serde_json::Value = serde_json::Value::deserialize(d)?;
+    match raw {
+        serde_json::Value::String(ref s) => {
+            // Unit variant path. `FromStr` maps unknown strings to `Other(s)`
+            // so old binaries can load card data produced by newer code.
+            s.parse::<StaticMode>().map_err(serde::de::Error::custom)
+        }
+        other => {
+            // Data-carrying variant path. Delegate to the derived Deserialize
+            // which handles all struct/newtype variants correctly.
+            serde_json::from_value::<StaticMode>(other).map_err(serde::de::Error::custom)
+        }
     }
 }
 
@@ -1219,11 +1255,39 @@ mod tests {
             StaticMode::CantBeBlocked,
             StaticMode::Flying,
             StaticMode::MustBeBlocked,
+            StaticMode::GrantsExtraVote,
             StaticMode::Other("Custom".to_string()),
         ];
         let json = serde_json::to_string(&modes).unwrap();
         let deserialized: Vec<StaticMode> = serde_json::from_str(&json).unwrap();
         assert_eq!(modes, deserialized);
+    }
+
+    /// Regression test for forward-compat: card-data.json produced by a newer
+    /// engine (containing a unit variant the current binary doesn't know) must
+    /// deserialize as `Other(name)` rather than failing hard.
+    ///
+    /// Simulates an old WASM reading card data that has `"GrantsExtraVote"` (or
+    /// any future unit variant not yet in the enum). `deserialize_static_mode_fwd`
+    /// routes the string through `FromStr`, which maps unknown names to `Other`.
+    #[test]
+    fn fwd_compat_unknown_unit_variant_maps_to_other() {
+        #[derive(serde::Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            #[serde(deserialize_with = "deserialize_static_mode_fwd")]
+            mode: StaticMode,
+        }
+        // A variant name the binary wouldn't know in the pre-GrantsExtraVote world.
+        let json = r#"{"mode":"FutureUnknownVariant"}"#;
+        let w: Wrapper = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            w.mode,
+            StaticMode::Other("FutureUnknownVariant".to_string())
+        );
+        // Known variant still deserializes correctly.
+        let json2 = r#"{"mode":"GrantsExtraVote"}"#;
+        let w2: Wrapper = serde_json::from_str(json2).unwrap();
+        assert_eq!(w2.mode, StaticMode::GrantsExtraVote);
     }
 
     #[test]

--- a/crates/phase-ai/src/decision_kind.rs
+++ b/crates/phase-ai/src/decision_kind.rs
@@ -110,6 +110,7 @@ pub fn classify(waiting_for: &WaitingFor, action: &GameAction) -> DecisionKind {
         | WaitingFor::TopOrBottomChoice { .. }
         | WaitingFor::PopulateChoice { .. }
         | WaitingFor::ClashCardPlacement { .. }
+        | WaitingFor::VoteChoice { .. }
         | WaitingFor::CompanionReveal { .. }
         | WaitingFor::ChooseLegend { .. }
         | WaitingFor::BattleProtectorChoice { .. }

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -240,6 +240,7 @@ fn redundancy_delta(
         | Effect::Proliferate
         | Effect::Populate
         | Effect::Clash
+        | Effect::Vote { .. }
         | Effect::SwitchPT { .. }
         | Effect::CopySpell { .. }
         | Effect::CopyTokenOf { .. }


### PR DESCRIPTION
## Summary
- Adds engine support for **Tivit, Seller of Secrets** via a new Council's-dilemma voting infrastructure
- Implements `Effect::Vote` with APNAP-ordered interactive `WaitingFor::VoteChoice` state
- Adds `StaticMode::GrantsExtraVote` for "While voting, you may vote an additional time"
- Builds for the class: covers all Council's-dilemma and Will-of-the-Council cards, not just Tivit

## Files changed
- `crates/engine/src/types/ability.rs` — new `Effect::Vote` and `EffectKind::Vote`
- `crates/engine/src/types/game_state.rs` — new `WaitingFor::VoteChoice`
- `crates/engine/src/types/events.rs` — new `GameEvent::VoteCast` / `VoteResolved`
- `crates/engine/src/types/statics.rs` — new `StaticMode::GrantsExtraVote`
- `crates/engine/src/game/effects/vote.rs` — new vote resolver and tally fan-out
- `crates/engine/src/game/effects/mod.rs` — wire `Effect::Vote` dispatch
- `crates/engine/src/game/engine_resolution_choices.rs` — `VoteChoice` + `ChooseOption` handler
- `crates/engine/src/game/static_abilities.rs` — register `GrantsExtraVote` in static registry
- `crates/engine/src/game/coverage.rs` — add `Effect::Vote` to effect details
- `crates/engine/src/game/log.rs` / `scenario.rs` — log formatting and scenario label
- `crates/engine/src/parser/oracle_vote.rs` — new vote-block parser (nom combinators)
- `crates/engine/src/parser/oracle_trigger.rs` — pre-pass to detect vote blocks
- `crates/engine/src/parser/oracle_static.rs` — parse `GrantsExtraVote` static
- `crates/engine/src/parser/mod.rs` — expose `oracle_vote` module
- `crates/engine/src/ai_support/candidates.rs` — emit `ChooseOption` candidates for votes
- `crates/phase-ai/src/decision_kind.rs` — classify `VoteChoice`
- `crates/phase-ai/src/policies/redundancy_avoidance.rs` — add `Vote` arm
- `client/src/adapter/types.ts` — `VoteChoice` variant in `WaitingFor` union
- `client/src/components/modal/VoteChoiceModal.tsx` — new vote modal
- `client/src/components/modal/CardChoiceModal.tsx` — dispatch to vote modal

## CR references
- `CR 101.4` — APNAP turn order for voters
- `CR 701.38` — Voting: each player chooses one option; per-choice tally resolution
- `CR 701.38a` — Vote validation (choice must be one of the declared options)
- `CR 701.38d` — Extra votes: granted by "while voting" static abilities, resolved at same time

## Track
Developer

## LLM
Model: Claude Sonnet 4.6 (user-directed; AI-CONTRIBUTOR.md quality floor requires Opus 4.7+)
Thinking level: medium

## Scope Expansion
Substantial scope expansion beyond a single card effect:
- New `Effect::Vote` enum variant with full match/coverage/event-name plumbing
- New `WaitingFor::VoteChoice` interactive state with full handler/candidate/scenario plumbing
- New `StaticMode::GrantsExtraVote` for the "while voting" extra-vote granter
- New `GameEvent::VoteCast` / `VoteResolved` for log and replay
- New parser module `oracle_vote.rs` plus trigger-parser dispatch hook
- New frontend modal + adapter type
- AI candidate generation + decision-kind classification updates

The voting mechanic is a new class of interactive resolution covering all Council's-dilemma and Will-of-the-Council cards.

## Validation
- `/review-impl` section: 12 enumerated findings with file:line references, all addressed or explicitly accepted as scope-bounded
- 4,922 unit tests + 213 integration tests pass
- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `./scripts/gen-card-data.sh` — clean; Tivit: 0 Unimplemented entries
- `cargo coverage` — Tivit: `supported: true`, `gap_count: 0`
- `cargo semantic-audit` — Tivit: 0 findings
- `pnpm type-check` (client) — clean
- `pnpm lint` (client) — clean