### PR TITLE
fix/copy card graveyard

### DIFF
--- a/client/src/components/board/GameBoard.tsx
+++ b/client/src/components/board/GameBoard.tsx
@@ -7,6 +7,7 @@ import { useCanActForWaitingState, usePerspectivePlayerId, usePlayerId } from ".
 import { sortCreaturesForBlockers } from "../../viewmodel/blockerSorting.ts";
 import {
   buildPlayerBattlefieldView,
+  getWaitingForObjectChoiceIds,
   getOpponentIds,
 } from "../../viewmodel/gameStateView.ts";
 import { BoardInteractionContext } from "./BoardInteractionContext.tsx";
@@ -88,24 +89,11 @@ export function GameBoard() {
       }
     }
 
-    if (
-      waitingFor?.type === "TargetSelection"
-      || waitingFor?.type === "TriggerTargetSelection"
-    ) {
-      for (const target of waitingFor.data.selection.current_legal_targets) {
-        if ("Object" in target) {
-          validTargetObjectIds.add(target.Object);
-        }
-      }
-    } else if (waitingFor?.type === "CopyTargetChoice") {
-      for (const objectId of waitingFor.data.valid_targets) {
-        validTargetObjectIds.add(objectId);
-      }
-    } else if (waitingFor?.type === "ExploreChoice") {
-      for (const objectId of waitingFor.data.choosable) {
-        validTargetObjectIds.add(objectId);
-      }
-    } else if (waitingFor?.type === "TapCreaturesForManaAbility" || waitingFor?.type === "TapCreaturesForSpellCost") {
+    for (const objectId of getWaitingForObjectChoiceIds(waitingFor)) {
+      validTargetObjectIds.add(objectId);
+    }
+
+    if (waitingFor?.type === "TapCreaturesForManaAbility" || waitingFor?.type === "TapCreaturesForSpellCost") {
       for (const objectId of waitingFor.data.creatures) {
         selectableManaCostCreatureIds.add(objectId);
       }

--- a/client/src/components/zone/GraveyardPile.tsx
+++ b/client/src/components/zone/GraveyardPile.tsx
@@ -1,7 +1,7 @@
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
-import { usePlayerId } from "../../hooks/usePlayerId.ts";
-import type { TargetRef } from "../../adapter/types.ts";
+import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
+import { getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
 
 const EMPTY: readonly number[] = [];
 
@@ -43,16 +43,13 @@ export function GraveyardPile({ playerId, onClick }: GraveyardPileProps) {
     return state.objects[gy[gy.length - 1]]?.name ?? null;
   });
 
-  // Check if any graveyard card is a valid target during targeting
-  const currentPlayerId = usePlayerId();
+  // Check if any graveyard card is selectable for the current engine prompt.
+  const canActForWaitingState = useCanActForWaitingState();
   const hasTargetableCards = useGameStore((s) => {
-    const wf = s.gameState?.waiting_for;
-    if (!wf) return false;
-    if (wf.type !== "TargetSelection" && wf.type !== "TriggerTargetSelection") return false;
-    if (wf.data.player !== currentPlayerId) return false;
-    const legalTargets: TargetRef[] = wf.data.selection.current_legal_targets;
+    if (!canActForWaitingState) return false;
+    const objectChoiceIds = new Set(getWaitingForObjectChoiceIds(s.waitingFor));
     const gy = s.gameState?.players[playerId]?.graveyard ?? [];
-    return gy.some((id) => legalTargets.some((t) => "Object" in t && t.Object === id));
+    return gy.some((id) => objectChoiceIds.has(id));
   });
 
   const count = graveyard.length;

--- a/client/src/components/zone/ZoneIndicator.tsx
+++ b/client/src/components/zone/ZoneIndicator.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from "../../stores/gameStore.ts";
-import { usePlayerId } from "../../hooks/usePlayerId.ts";
+import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
+import { getPlayerZoneIds, getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
 
 interface ZoneIndicatorProps {
   zone: "graveyard" | "exile";
@@ -14,25 +15,23 @@ const ZONE_LABELS: Record<string, string> = {
 
 export function ZoneIndicator({ zone, playerId, onClick }: ZoneIndicatorProps) {
   const myId = usePlayerId();
+  const canActForWaitingState = useCanActForWaitingState();
   const count = useGameStore((s) => {
-    const state = s.gameState;
-    if (!state) return 0;
+    return getPlayerZoneIds(s.gameState, zone, playerId).length;
+  });
 
-    if (zone === "graveyard") {
-      return state.players[playerId]?.graveyard.length ?? 0;
-    }
-
-    // Exile: filter by owner
-    return state.exile.filter((id) => {
-      const obj = state.objects[id];
-      return obj?.owner === playerId;
-    }).length;
+  const hasSelectableCards = useGameStore((s) => {
+    if (!canActForWaitingState) return false;
+    const objectChoiceIds = new Set(getWaitingForObjectChoiceIds(s.waitingFor));
+    return getPlayerZoneIds(s.gameState, zone, playerId).some((id) => objectChoiceIds.has(id));
   });
 
   return (
     <button
       onClick={onClick}
-      className="cursor-pointer rounded bg-gray-800 px-2 py-0.5 text-xs text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-200"
+      className={`cursor-pointer rounded bg-gray-800 px-2 py-0.5 text-xs text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-200 ${
+        hasSelectableCards ? "ring-2 ring-amber-400/60 shadow-[0_0_12px_3px_rgba(201,176,55,0.8)]" : ""
+      }`}
     >
       {playerId !== myId ? "Opp " : ""}{ZONE_LABELS[zone]} ({count})
     </button>

--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -10,7 +10,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { useCanActForWaitingState, usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
-import { getPlayerZoneIds } from "../../viewmodel/gameStateView.ts";
+import { getPlayerZoneIds, getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
 
 interface ZoneViewerProps {
   zone: "graveyard" | "exile";
@@ -48,27 +48,14 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
   const isMyZone = playerId === currentPlayerId;
   const hasPriority = waitingFor?.type === "Priority" && canActForWaitingState;
 
-  const isHumanTargetSelection =
-    (waitingFor?.type === "TargetSelection"
-      || waitingFor?.type === "TriggerTargetSelection"
-      || waitingFor?.type === "CopyTargetChoice")
-    && canActForWaitingState;
   const currentLegalTargets = useMemo(() => {
     const targets = new Set<number>();
-    if (!isHumanTargetSelection) return targets;
-    if (waitingFor.type === "CopyTargetChoice") {
-      for (const objectId of waitingFor.data.valid_targets) {
-        targets.add(objectId);
-      }
-      return targets;
-    }
-    for (const target of waitingFor.data.selection.current_legal_targets) {
-      if ("Object" in target) {
-        targets.add(target.Object);
-      }
+    if (!canActForWaitingState) return targets;
+    for (const objectId of getWaitingForObjectChoiceIds(waitingFor)) {
+      targets.add(objectId);
     }
     return targets;
-  }, [isHumanTargetSelection, waitingFor]);
+  }, [canActForWaitingState, waitingFor]);
 
   return (
     <ModalPanelShell

--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -49,11 +49,19 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
   const hasPriority = waitingFor?.type === "Priority" && canActForWaitingState;
 
   const isHumanTargetSelection =
-    (waitingFor?.type === "TargetSelection" || waitingFor?.type === "TriggerTargetSelection")
+    (waitingFor?.type === "TargetSelection"
+      || waitingFor?.type === "TriggerTargetSelection"
+      || waitingFor?.type === "CopyTargetChoice")
     && canActForWaitingState;
   const currentLegalTargets = useMemo(() => {
     const targets = new Set<number>();
     if (!isHumanTargetSelection) return targets;
+    if (waitingFor.type === "CopyTargetChoice") {
+      for (const objectId of waitingFor.data.valid_targets) {
+        targets.add(objectId);
+      }
+      return targets;
+    }
     for (const target of waitingFor.data.selection.current_legal_targets) {
       if ("Object" in target) {
         targets.add(target.Object);

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -89,6 +89,7 @@ import {
 import { GameProvider } from "../providers/GameProvider.tsx";
 import { useCanActForWaitingState, usePerspectivePlayerId, usePlayerId } from "../hooks/usePlayerId.ts";
 import { abilityChoiceLabel, additionalCostChoices } from "../viewmodel/costLabel.ts";
+import { getWaitingForObjectChoiceIds } from "../viewmodel/gameStateView.ts";
 import { gameButtonClass } from "../components/ui/buttonStyles.ts";
 import { cardImageLookup } from "../services/cardImageLookup.ts";
 
@@ -725,23 +726,18 @@ function GamePageContent({
     }
   }, []);
 
-  // Auto-open graveyard/exile viewer when the engine is waiting for a target in that zone
+  // Auto-open graveyard/exile viewer when the engine is waiting for an object choice in that zone.
   useEffect(() => {
     if (!objects) return;
     const wf = engineWaitingFor;
-    if (
-      (wf?.type !== "TargetSelection" && wf?.type !== "TriggerTargetSelection")
-      || !canActForWaitingState
-    ) return;
+    if (!canActForWaitingState) return;
 
-    const legalTargets = wf.data.selection.current_legal_targets;
     // Collect distinct (zone, owner) groupings so we don't trap the user in one
     // graveyard when the effect can target either player's graveyard (e.g. Soul-Guide Lantern).
     const groups = new Set<string>();
     let firstHit: { zone: "graveyard" | "exile"; playerId: number } | null = null;
-    for (const t of legalTargets) {
-      if (!("Object" in t)) continue;
-      const obj = objects[t.Object];
+    for (const objectId of getWaitingForObjectChoiceIds(wf)) {
+      const obj = objects[objectId];
       if (!obj) continue;
       if (obj.zone !== "Graveyard" && obj.zone !== "Exile") continue;
       const zone: "graveyard" | "exile" = obj.zone === "Graveyard" ? "graveyard" : "exile";
@@ -749,7 +745,7 @@ function GamePageContent({
       if (!firstHit) firstHit = { zone, playerId: obj.owner };
     }
     // Only auto-open when there's a single zone+owner to open. Otherwise the
-    // zone pile glow (GraveyardPile hasTargetableCards) prompts the user to pick.
+    // zone control glow prompts the user to pick.
     if (groups.size === 1 && firstHit) {
       setViewingZone(firstHit);
     }

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -3,6 +3,7 @@ import type {
   GameState,
   ObjectId,
   PlayerId,
+  WaitingFor,
 } from "../adapter/types";
 import {
   groupByName,
@@ -38,6 +39,24 @@ export function getPlayerZoneIds(
     return gameState.players[playerId]?.graveyard ?? [];
   }
   return gameState.exile.filter((id) => gameState.objects[id]?.owner === playerId);
+}
+
+export function getWaitingForObjectChoiceIds(
+  waitingFor: WaitingFor | null | undefined,
+): ObjectId[] {
+  switch (waitingFor?.type) {
+    case "TargetSelection":
+    case "TriggerTargetSelection":
+      return waitingFor.data.selection.current_legal_targets.flatMap((target) =>
+        "Object" in target ? [target.Object] : [],
+      );
+    case "CopyTargetChoice":
+      return waitingFor.data.valid_targets;
+    case "ExploreChoice":
+      return waitingFor.data.choosable;
+    default:
+      return [];
+  }
 }
 
 export function buildPlayerBattlefieldView(


### PR DESCRIPTION
Found a bug where selecting target for Superior Spider-Man from graveyard didn't work.

- ZoneViewer only treated TargetSelection / TriggerTargetSelection as targeting states, so cards like Superior Spider-Man (which use `WaitingFor::CopyTargetChoice` to pick a creature card from a graveyard) showed the prompt but every graveyard card was inert.
- Extended the modal's legal-target derivation to also read CopyTargetChoice.valid_targets. Engine path was already correct.