### PR TITLE
fix/urzas saga phase two nested quote

### DIFF
--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -610,9 +610,16 @@ pub fn apply_create_token_after_replacement(
             }
             obj.tapped = enter_tapped.resolve(spec.tapped);
 
-            // CR 113.3d: Apply static abilities from the token definition.
-            for static_def in &spec.static_abilities {
-                obj.static_definitions.push(static_def.clone());
+            // CR 113.3d + CR 613.1: Apply static abilities from the token
+            // definition. Mirror onto `base_static_definitions` so the
+            // layers-reset (`base_*` → `*`) at the start of each layers pass
+            // doesn't wipe them before layer 7 reads dynamic P/T grants.
+            if !spec.static_abilities.is_empty() {
+                Arc::make_mut(&mut obj.base_static_definitions)
+                    .extend(spec.static_abilities.iter().cloned());
+                for static_def in &spec.static_abilities {
+                    obj.static_definitions.push(static_def.clone());
+                }
             }
         }
 
@@ -2397,6 +2404,90 @@ mod tests {
                 .effect,
             Effect::Explore
         ));
+    }
+
+    #[test]
+    fn apply_create_token_mirrors_static_abilities_to_base() {
+        // Urza's Saga's chapter II creates a 0/0 Construct whose only saving
+        // grace is "+1/+1 for each artifact you control". CR 613.1 resets
+        // `static_definitions` from `base_static_definitions` at the start of
+        // every layers pass — if the resolver only writes to live `*` and not
+        // `base_*`, the boost is wiped before layer 7c reads it and the token
+        // dies as a 0/0 to SBAs (CR 704.5f). Both must be populated.
+        use crate::types::ability::{
+            ContinuousModification, QuantityExpr, QuantityRef, StaticDefinition, TargetFilter,
+            TypedFilter,
+        };
+        use crate::types::card_type::CoreType;
+        use crate::types::proposed_event::TokenSpec;
+        use std::collections::HashSet;
+
+        let boost = StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![
+                ContinuousModification::AddDynamicPower {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(TypedFilter::new(
+                            crate::types::ability::TypeFilter::Artifact,
+                        )),
+                        },
+                    },
+                },
+                ContinuousModification::AddDynamicToughness {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(TypedFilter::new(
+                            crate::types::ability::TypeFilter::Artifact,
+                        )),
+                        },
+                    },
+                },
+            ]);
+
+        let mut state = GameState::new_two_player(42);
+        let spec = TokenSpec {
+            display_name: "Construct".to_string(),
+            script_name: "Construct".to_string(),
+            power: Some(0),
+            toughness: Some(0),
+            core_types: vec![CoreType::Artifact, CoreType::Creature],
+            subtypes: vec!["Construct".to_string()],
+            supertypes: vec![],
+            colors: vec![],
+            keywords: vec![],
+            static_abilities: vec![boost],
+            enter_with_counters: vec![],
+            tapped: false,
+            enters_attacking: false,
+            sacrifice_at: None,
+            source_id: ObjectId(100),
+            controller: PlayerId(0),
+        };
+
+        let event = ProposedEvent::CreateToken {
+            owner: PlayerId(0),
+            spec: Box::new(spec),
+            enter_tapped: crate::types::proposed_event::EtbTapState::Unspecified,
+            count: 1,
+            applied: HashSet::new(),
+        };
+
+        let mut events = vec![];
+        apply_create_token_after_replacement(&mut state, event, &mut events);
+
+        let id = state.last_created_token_ids[0];
+        let obj = &state.objects[&id];
+        assert_eq!(
+            obj.static_definitions.len(),
+            1,
+            "live static_definitions must carry the boost"
+        );
+        assert_eq!(
+            obj.base_static_definitions.len(),
+            1,
+            "base_static_definitions must mirror live so the layers reset (CR 613.1) preserves it"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -2429,8 +2429,8 @@ mod tests {
                     value: QuantityExpr::Ref {
                         qty: QuantityRef::ObjectCount {
                             filter: TargetFilter::Typed(TypedFilter::new(
-                            crate::types::ability::TypeFilter::Artifact,
-                        )),
+                                crate::types::ability::TypeFilter::Artifact,
+                            )),
                         },
                     },
                 },
@@ -2438,8 +2438,8 @@ mod tests {
                     value: QuantityExpr::Ref {
                         qty: QuantityRef::ObjectCount {
                             filter: TargetFilter::Typed(TypedFilter::new(
-                            crate::types::ability::TypeFilter::Artifact,
-                        )),
+                                crate::types::ability::TypeFilter::Artifact,
+                            )),
                         },
                     },
                 },

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -559,41 +559,97 @@ fn parse_token_name_clause(text: &str) -> (Option<String>, &str) {
 /// Handles patterns like:
 /// - `and "This token can't block."` → `[StaticDefinition::new(StaticMode::CantBlock)]`
 /// - `and "This creature can't block."` → same
-/// - `and '~ can't block.'` → same
+/// - `with 'This token gets +1/+1 for each artifact you control.'` → continuous
+///   `BoostByCount`-style modifications.
+///
+/// Double-quoted spans are unambiguous and parsed greedily. Single-quoted spans
+/// only appear when the token-creation effect is itself nested inside a
+/// double-quoted activated ability ("This Saga gains \"…create a token with
+/// 'X.'\""). They are extracted only via a structurally-anchored single pass:
+/// the opening `'` must follow a phrase boundary (`with `, `and `, `or `, or
+/// `, `) and the closing `'` is the last `'` in the text. This pairing rule
+/// guarantees that any `'` inside the span (apostrophes from "can't" /
+/// possessives) is never mistaken for the close quote.
 fn extract_token_static_abilities(text: &str, token_name: &str) -> Vec<StaticDefinition> {
     let mut statics = Vec::new();
 
-    // Look for quoted ability text between double quotes.
-    // Single quotes are unreliable because "can't" contains an apostrophe.
-    for (open, close) in [('"', '"')] {
-        let search = text;
-        let mut pos = 0;
-        while pos < search.len() {
-            if let Some(start) = search[pos..].find(open) {
-                let abs_start = pos + start + open.len_utf8();
-                if let Some(end) = search[abs_start..].find(close) {
-                    let quoted = &search[abs_start..abs_start + end];
-                    let ability_text = quoted.trim();
-                    let normalized;
-                    let static_text = if token_name.is_empty() {
-                        ability_text
-                    } else {
-                        normalized = normalize_card_name_refs(ability_text, token_name);
-                        &normalized
-                    };
-                    statics.extend(parse_static_line_multi(static_text));
+    // Pass 1: double-quoted abilities — unambiguous delimiters.
+    let mut pos = 0;
+    while pos < text.len() {
+        let Some(start) = text[pos..].find('"') else {
+            break;
+        };
+        let abs_start = pos + start + '"'.len_utf8();
+        let Some(end) = text[abs_start..].find('"') else {
+            break;
+        };
+        let quoted = &text[abs_start..abs_start + end];
+        push_parsed_statics(quoted.trim(), token_name, &mut statics);
+        pos = abs_start + end + '"'.len_utf8();
+    }
 
-                    pos = abs_start + end + close.len_utf8();
-                } else {
-                    break;
-                }
-            } else {
-                break;
-            }
+    // Pass 2: single-quoted abilities (nested inside a double-quoted
+    // activated ability). Skipped when double-quoted spans were found —
+    // Oracle text never mixes both delimiters at the same nesting level.
+    if statics.is_empty() {
+        if let Some(span) = find_anchored_single_quoted_span(text) {
+            push_parsed_statics(span.trim(), token_name, &mut statics);
         }
     }
 
     statics
+}
+
+fn push_parsed_statics(ability_text: &str, token_name: &str, out: &mut Vec<StaticDefinition>) {
+    let normalized;
+    let static_text = if token_name.is_empty() {
+        ability_text
+    } else {
+        normalized = normalize_card_name_refs(ability_text, token_name);
+        &normalized
+    };
+    out.extend(parse_static_line_multi(static_text));
+}
+
+/// Locate a single-quoted ability span in `text`, returning the content
+/// between the open and close quotes (exclusive).
+///
+/// Anchoring rules (both must hold):
+///   - The opening `'` must immediately follow one of the phrase boundaries
+///     `with `, `and `, `or `, `, ` — at the start of `text` or preceded by
+///     whitespace (so apostrophes embedded in possessives like "creature's"
+///     cannot pose as opening quotes).
+///   - The closing `'` is the last `'` in `text` (so any internal apostrophe
+///     from contractions or possessives is treated as content, not delimiter).
+fn find_anchored_single_quoted_span(text: &str) -> Option<&str> {
+    let close = text.rfind('\'')?;
+    let prefix = &text[..close];
+
+    // Phrase anchors paired (start-of-text form, mid-text form). The mid-text
+    // form requires a leading space; the start form does not.
+    const ANCHORS: &[(&str, &str)] = &[
+        ("with '", " with '"),
+        ("and '", " and '"),
+        ("or '", " or '"),
+        (", '", ", '"),
+    ];
+    let mut earliest: Option<usize> = None;
+    for &(start_anchor, mid_anchor) in ANCHORS {
+        if prefix.starts_with(start_anchor) {
+            let open = start_anchor.len();
+            earliest = Some(earliest.map_or(open, |prev| prev.min(open)));
+        }
+        if let Some(pos) = prefix.find(mid_anchor) {
+            let open = pos + mid_anchor.len();
+            earliest = Some(earliest.map_or(open, |prev| prev.min(open)));
+        }
+    }
+
+    let open = earliest?;
+    if close <= open {
+        return None;
+    }
+    Some(&text[open..close])
 }
 
 fn extract_token_where_x_expression(text: &str) -> Option<String> {
@@ -868,11 +924,34 @@ mod tests {
     }
 
     #[test]
-    fn extract_static_no_false_positive_on_single_quotes() {
-        // Single quotes around "can't" are ambiguous (apostrophe = close quote).
-        // Only double quotes reliably delimit abilities in Oracle text.
+    fn extract_static_single_quoted_ability_with_apostrophe_content() {
+        use crate::types::ability::TargetFilter;
+        use crate::types::statics::StaticMode;
+
+        // Anchored single-quoted span: open `'` follows `and `, close `'`
+        // is the last apostrophe. The internal apostrophe in "can't" is
+        // treated as content, not a delimiter.
         let statics = extract_token_static_abilities("and '~ can't block.'", "");
-        assert!(statics.is_empty());
+        assert_eq!(statics.len(), 1);
+        assert_eq!(statics[0].mode, StaticMode::CantBlock);
+        assert_eq!(statics[0].affected, Some(TargetFilter::SelfRef));
+    }
+
+    #[test]
+    fn extract_static_single_quoted_boost_by_count() {
+        // Urza's Saga's chapter II ability: the create-token clause is itself
+        // nested inside a double-quoted activated ability, so the granted
+        // static uses single quotes. The Construct token must enter with the
+        // +1/+1 modifier or it dies to SBAs as a 0/0 immediately.
+        let statics = extract_token_static_abilities(
+            "with 'This token gets +1/+1 for each artifact you control.'",
+            "Construct",
+        );
+        assert_eq!(
+            statics.len(),
+            1,
+            "expected one continuous static from single-quoted ability, got {statics:?}",
+        );
     }
 
     #[test]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -22,3 +22,4 @@ mod rules;
 mod swans_prevention_followup;
 mod tempt_with_discovery;
 mod ureni_attack_trigger;
+mod urzas_saga_chapter_two;

--- a/crates/engine/tests/integration/urzas_saga_chapter_two.rs
+++ b/crates/engine/tests/integration/urzas_saga_chapter_two.rs
@@ -1,0 +1,179 @@
+//! Integration test: Urza's Saga chapter II.
+//!
+//! Chapter II grants the Saga a `{2}, {T}: Create a 0/0 colorless Construct
+//! artifact creature token with "This token gets +1/+1 for each artifact you
+//! control."` activated ability. The token enters as 0/0; only the +1/+1
+//! boost saves it from SBAs (CR 704.5f). This test exercises the full
+//! pipeline: parser populates `static_abilities` on the Token effect → token
+//! resolver mirrors them onto `base_static_definitions` → layer 7c reads the
+//! `AddDynamicPower` modification and computes effective power from the
+//! artifact count → SBA leaves the token alive.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, ContinuousModification, ControllerRef, Effect,
+    PtValue, QuantityExpr, QuantityRef, StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+/// Fill a player's mana pool directly.
+fn add_mana(
+    runner: &mut engine::game::scenario::GameRunner,
+    player: PlayerId,
+    color: ManaType,
+    count: usize,
+) {
+    let state = runner.state_mut();
+    let p = state.players.iter_mut().find(|p| p.id == player).unwrap();
+    for _ in 0..count {
+        p.mana_pool
+            .add(ManaUnit::new(color, ObjectId(0), false, Vec::new()));
+    }
+}
+
+/// Build the granted activated ability that chapter II would install on the
+/// Saga: `{2}, {T}: Create a 0/0 colorless Construct artifact creature token
+/// with "This token gets +1/+1 for each artifact you control."`
+fn chapter_two_granted_ability() -> AbilityDefinition {
+    let artifact_filter = TargetFilter::Typed(
+        TypedFilter::new(TypeFilter::Artifact).controller(ControllerRef::You),
+    );
+
+    let boost = StaticDefinition::continuous()
+        .affected(TargetFilter::SelfRef)
+        .modifications(vec![
+            ContinuousModification::AddDynamicPower {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: artifact_filter.clone(),
+                    },
+                },
+            },
+            ContinuousModification::AddDynamicToughness {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: artifact_filter,
+                    },
+                },
+            },
+        ]);
+
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Token {
+            name: "Construct".to_string(),
+            power: PtValue::Fixed(0),
+            toughness: PtValue::Fixed(0),
+            types: vec![
+                "Artifact".to_string(),
+                "Creature".to_string(),
+                "Construct".to_string(),
+            ],
+            colors: vec![],
+            keywords: vec![] as Vec<Keyword>,
+            tapped: false,
+            count: QuantityExpr::Fixed { value: 1 },
+            owner: TargetFilter::Controller,
+            attach_to: None,
+            enters_attacking: false,
+            supertypes: vec![],
+            static_abilities: vec![boost],
+            enter_with_counters: vec![],
+        },
+    )
+    .cost(AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![],
+                    generic: 2,
+                },
+            },
+            AbilityCost::Tap,
+        ],
+    })
+}
+
+#[test]
+fn chapter_two_construct_survives_sba_via_self_count_boost() {
+    // Set up Urza's Saga as a battlefield permanent with the chapter II
+    // ability already granted (skipping the "increment lore counter →
+    // CounterAdded trigger → grant" flow that's exercised elsewhere).
+    let scenario = GameScenario::new();
+    let mut runner = scenario.build();
+    let saga_id = {
+        let state = runner.state_mut();
+        let card_id = CardId(state.next_object_id);
+        let id = zones::create_object(state, card_id, P0, "Urza's Saga".to_string(), Zone::Battlefield);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Land);
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.card_types.subtypes.push("Saga".to_string());
+        obj.card_types.subtypes.push("Urza's".to_string());
+        obj.base_card_types = obj.card_types.clone();
+        obj.summoning_sick = false;
+        std::sync::Arc::make_mut(&mut obj.abilities).push(chapter_two_granted_ability());
+        std::sync::Arc::make_mut(&mut obj.base_abilities).push(chapter_two_granted_ability());
+        state.layers_dirty = true;
+        id
+    };
+
+
+    add_mana(&mut runner, P0, ManaType::Colorless, 2);
+
+    // Activate the granted {2}, {T} ability.
+    let pre_count = runner.state().objects.len();
+    let result = runner.act(GameAction::ActivateAbility {
+        source_id: saga_id,
+        ability_index: 0,
+    });
+    assert!(
+        result.is_ok(),
+        "chapter II ability activation must succeed: {:?}",
+        result.err()
+    );
+
+    // Resolve the ability on the stack — this should create the Construct.
+    runner.resolve_top();
+
+    // Find the newly-created Construct token.
+    let state = runner.state();
+    assert!(
+        state.objects.len() > pre_count,
+        "a new token object must exist after resolving chapter II's activated ability \
+         (pre={pre_count}, post={})",
+        state.objects.len()
+    );
+
+    let construct = state
+        .objects
+        .values()
+        .find(|o| o.is_token && o.name == "Construct")
+        .expect("Construct token must be on the battlefield after resolution");
+
+    assert_eq!(
+        construct.zone,
+        Zone::Battlefield,
+        "Construct must enter the battlefield, not be sent straight to the graveyard"
+    );
+
+    // The Construct counts itself as the only artifact P0 controls, so its
+    // effective P/T after layer 7c is 1/1 — enough to survive SBAs.
+    assert_eq!(
+        construct.power,
+        Some(1),
+        "Construct must have +1 power from the self-counted artifact static (it itself is an artifact)"
+    );
+    assert_eq!(
+        construct.toughness,
+        Some(1),
+        "Construct must have +1 toughness — without this it dies to CR 704.5f as a 0/0"
+    );
+}

--- a/crates/engine/tests/integration/urzas_saga_chapter_two.rs
+++ b/crates/engine/tests/integration/urzas_saga_chapter_two.rs
@@ -42,9 +42,8 @@ fn add_mana(
 /// Saga: `{2}, {T}: Create a 0/0 colorless Construct artifact creature token
 /// with "This token gets +1/+1 for each artifact you control."`
 fn chapter_two_granted_ability() -> AbilityDefinition {
-    let artifact_filter = TargetFilter::Typed(
-        TypedFilter::new(TypeFilter::Artifact).controller(ControllerRef::You),
-    );
+    let artifact_filter =
+        TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact).controller(ControllerRef::You));
 
     let boost = StaticDefinition::continuous()
         .affected(TargetFilter::SelfRef)
@@ -111,7 +110,13 @@ fn chapter_two_construct_survives_sba_via_self_count_boost() {
     let saga_id = {
         let state = runner.state_mut();
         let card_id = CardId(state.next_object_id);
-        let id = zones::create_object(state, card_id, P0, "Urza's Saga".to_string(), Zone::Battlefield);
+        let id = zones::create_object(
+            state,
+            card_id,
+            P0,
+            "Urza's Saga".to_string(),
+            Zone::Battlefield,
+        );
         let obj = state.objects.get_mut(&id).unwrap();
         obj.card_types.core_types.push(CoreType::Land);
         obj.card_types.core_types.push(CoreType::Enchantment);
@@ -124,7 +129,6 @@ fn chapter_two_construct_survives_sba_via_self_count_boost() {
         state.layers_dirty = true;
         id
     };
-
 
     add_mana(&mut runner, P0, ManaType::Colorless, 2);
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                           
   
  Fix Urza's Saga chapter II creating a 0/0 Construct that immediately died to SBAs. Two cooperating bugs:                                                             
                                                            
  **Parser** (`parser/oracle_effect/token.rs`): `extract_token_static_abilities` only matched double-quoted spans. Chapter II's Oracle text nests the create-token     
  clause inside a double-quoted activated ability (`This Saga gains "...with 'This token gets +1/+1...'"`), so the inner ability uses single quotes — silently dropped,
   leaving the Token effect's `static_abilities` field empty.                                                                                                          
                                                            
  Added a structurally-anchored single-quote pass: open `'` must follow `with `/`and `/`or `/`, `, close `'` is the last `'` in the text. That pairing rule keeps      
  internal apostrophes (`can't`, `creature's`) safe as content, never delimiter. Generalises to the whole class of nested grant-create-token-with-ability cards.
                                                                                                                                                                       
  **Engine** (`game/effects/token.rs`): `apply_create_token_after_replacement` only wrote the spec's static abilities to live `static_definitions`, not                
  `base_static_definitions`. The layers reset at `layers.rs:519` (`obj.static_definitions = Arc::clone(&obj.base_static_definitions)`) wiped the boost on every pass
  before layer 7c could read it. The 0/0 Construct then died to CR 704.5f.                                                                                             
                                                            
  Mirrored the spec's static abilities onto `base_static_definitions` so the layers reset preserves them — same pattern already used for Role token statics at         
  `token.rs:1326`.
                                                                                                                                                                       
  ## Test plan                                              

  - [x] Parser unit tests: `extract_static_single_quoted_ability_with_apostrophe_content`, `extract_static_single_quoted_boost_by_count`                               
  - [x] Engine unit test: `apply_create_token_mirrors_static_abilities_to_base`
  - [ ] End-to-end integration test: `chapter_two_construct_survives_sba_via_self_count_boost` — activates the granted `{2}, {T}` ability, resolves it, asserts the    
  Construct enters the battlefield as a 1/1 (counting itself) and survives SBAs                                                                                        
  - [x] `cargo test -p engine` (6016 tests pass), `cargo clippy -p engine --all-targets -- -D warnings`, `cargo fmt --all -- --check`                                  
  - [x] Manual: load Urza's Saga, advance to chapter II, pay {2}{T}, confirm Construct token appears on the battlefield                                                
                                                                                                                         