### PR TITLE
Surface sideboard in deck builder and confirm saves

### DIFF
--- a/client/src/components/deck-builder/DeckBuilder.tsx
+++ b/client/src/components/deck-builder/DeckBuilder.tsx
@@ -79,6 +79,7 @@ export function DeckBuilder({
   const [searchResults, setSearchResults] = useState<ScryfallCard[]>([]);
   const [deckName, setDeckName] = useState("");
   const [savedDecks, setSavedDecks] = useState(listSavedDecks);
+  const [justSaved, setJustSaved] = useState(false);
   const [commanders, setCommanders] = useState<string[]>([]);
   const [isDeckViewExpanded, setIsDeckViewExpanded] = useState(initialDeckName !== null);
   const { cardDataCache, cacheCards } = useDeckCardData([
@@ -280,7 +281,14 @@ export function DeckBuilder({
     localStorage.setItem(STORAGE_KEY_PREFIX + deckName.trim(), data);
     stampDeckMeta(deckName.trim());
     setSavedDecks(listSavedDecks());
+    setJustSaved(true);
   };
+
+  useEffect(() => {
+    if (!justSaved) return;
+    const timer = setTimeout(() => setJustSaved(false), 1500);
+    return () => clearTimeout(timer);
+  }, [justSaved]);
 
   const handleLoad = useCallback(async (name: string) => {
     const parsed = loadSavedDeck(name);
@@ -430,16 +438,23 @@ export function DeckBuilder({
           <input
             type="text"
             value={deckName}
-            onChange={(e) => setDeckName(e.target.value)}
+            onChange={(e) => {
+              setDeckName(e.target.value);
+              if (justSaved) setJustSaved(false);
+            }}
             placeholder="Deck name..."
             className="w-40 rounded-xl border border-white/10 bg-black/18 px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:border-white/20 focus:outline-none"
           />
           <button
             onClick={handleSave}
             disabled={!deckName.trim()}
-            className="rounded-xl border border-white/10 bg-white/10 px-3 py-1.5 text-sm text-white hover:bg-white/14 disabled:opacity-40"
+            className={
+              justSaved
+                ? "rounded-xl border border-emerald-400/40 bg-emerald-500/20 px-3 py-1.5 text-sm text-emerald-200 disabled:opacity-40"
+                : "rounded-xl border border-white/10 bg-white/10 px-3 py-1.5 text-sm text-white hover:bg-white/14 disabled:opacity-40"
+            }
           >
-            Save
+            {justSaved ? "Saved ✓" : "Save"}
           </button>
           {savedDecks.length > 0 && (
             <select

--- a/client/src/components/deck-builder/DeckList.tsx
+++ b/client/src/components/deck-builder/DeckList.tsx
@@ -101,6 +101,7 @@ export function DeckList({
   const [showExportModal, setShowExportModal] = useState(false);
   const [exportFormat, setExportFormat] = useState<ExportFormat>("dck");
   const [copied, setCopied] = useState(false);
+  const [viewMode, setViewMode] = useState<"main" | "sideboard">("main");
   const mainTotal = totalCards(deck.main);
   const sideTotal = totalCards(deck.sideboard);
   const mainGroups = groupByType(deck.main);
@@ -152,6 +153,10 @@ export function DeckList({
     }
   }, [sideboardPolicy, sideTotal]);
 
+  useEffect(() => {
+    if (hideSideboard && viewMode === "sideboard") setViewMode("main");
+  }, [hideSideboard, viewMode]);
+
   const unsupportedMap = useMemo(() => {
     const map = new Map<string, UnsupportedCard>();
     for (const card of compatibility?.coverage?.unsupported_cards ?? []) {
@@ -198,14 +203,11 @@ export function DeckList({
 
   return (
     <div className="flex flex-col">
-      <div className="mb-2 flex items-center justify-between border-b border-white/8 pb-2">
-        <div>
+      <div className="mb-2 flex items-center justify-between gap-2 border-b border-white/8 pb-2">
+        <div className="min-w-0">
           <div className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">Current List</div>
-          <h3 className="mt-1 text-sm font-bold text-white">
-            Main Deck ({mainTotal} cards)
-          </h3>
         </div>
-        <div className="flex gap-1">
+        <div className="flex shrink-0 gap-1">
           <button
             onClick={() => setShowPasteModal(true)}
             className="rounded-xl border border-white/8 bg-black/18 px-2 py-1 text-xs text-gray-300 hover:bg-white/6"
@@ -230,6 +232,39 @@ export function DeckList({
           />
         </div>
       </div>
+
+      {/* Section selector: tab pair for Main / Sideboard. Full-width and
+          prominent so the sideboard view is discoverable even on the
+          narrow 256px right panel. Hidden when the format forbids a
+          sideboard (Commander/Brawl). */}
+      {!hideSideboard ? (
+        <div className="mb-2 grid grid-cols-2 gap-1 rounded-xl border border-white/10 bg-black/18 p-1">
+          <button
+            onClick={() => setViewMode("main")}
+            className={
+              viewMode === "main"
+                ? "rounded-lg bg-white/14 px-2 py-1 text-xs font-semibold text-white"
+                : "rounded-lg px-2 py-1 text-xs text-slate-300 hover:bg-white/6"
+            }
+          >
+            Main ({mainTotal})
+          </button>
+          <button
+            onClick={() => setViewMode("sideboard")}
+            className={
+              viewMode === "sideboard"
+                ? "rounded-lg bg-white/14 px-2 py-1 text-xs font-semibold text-white"
+                : "rounded-lg px-2 py-1 text-xs text-slate-300 hover:bg-white/6"
+            }
+          >
+            Sideboard ({sideTotal})
+          </button>
+        </div>
+      ) : (
+        <h3 className="mb-2 text-sm font-bold text-white">
+          Main Deck ({mainTotal} cards)
+        </h3>
+      )}
 
       {/* Warnings */}
       {warnings.length > 0 && (
@@ -297,43 +332,40 @@ export function DeckList({
         </div>
       )}
 
-      {/* Main deck grouped by type */}
+      {/* Main and sideboard share this column; the header toggle (mirroring
+          the "Show Browser" pattern) flips between them so the sideboard
+          can't be pushed off-screen by a long main deck. The sideboard
+          toggle itself is hidden for Commander/Brawl (SideboardPolicy::Forbidden). */}
       <div>
-        {(["Creatures", "Spells", "Lands"] as const).map((group) => (
-          <MoveList
-            key={group}
-            title={group}
-            entries={mainGroups[group]}
-            section="main"
-            onRemove={onRemoveCard}
-            onMove={onMoveCard}
-            onCardHover={onCardHover}
-            unsupportedMap={unsupportedMap}
-            onChooseArt={onChooseArt}
-          />
-        ))}
-
-        {/* Sideboard — always visible when the format permits one, so users
-            can discover and target it. Hidden entirely for Commander/Brawl
-            (SideboardPolicy::Forbidden) since those formats don't have a
-            sideboard concept. */}
-        {!hideSideboard && (
-          <div className="mt-3 border-t border-white/8 pt-2">
-            <MoveList
-              title={sideboardTitle}
-              entries={deck.sideboard}
-              section="sideboard"
-              onRemove={onRemoveCard}
-              onMove={onMoveCard}
-              onCardHover={onCardHover}
-              unsupportedMap={unsupportedMap}
-              alwaysShow
-              emptyHint="Hover a main-deck card and click → to move it here."
-              warning={sideboardWarning}
-              onChooseArt={onChooseArt}
-            />
-          </div>
-        )}
+        {viewMode === "main"
+          ? (["Creatures", "Spells", "Lands"] as const).map((group) => (
+              <MoveList
+                key={group}
+                title={group}
+                entries={mainGroups[group]}
+                section="main"
+                onRemove={onRemoveCard}
+                onMove={onMoveCard}
+                onCardHover={onCardHover}
+                unsupportedMap={unsupportedMap}
+                onChooseArt={onChooseArt}
+              />
+            ))
+          : !hideSideboard && (
+              <MoveList
+                title={sideboardTitle}
+                entries={deck.sideboard}
+                section="sideboard"
+                onRemove={onRemoveCard}
+                onMove={onMoveCard}
+                onCardHover={onCardHover}
+                unsupportedMap={unsupportedMap}
+                alwaysShow
+                emptyHint="Hover a main-deck card and click → to move it here."
+                warning={sideboardWarning}
+                onChooseArt={onChooseArt}
+              />
+            )}
       </div>
 
       {/* Paste import modal */}

--- a/client/src/components/deck-builder/DeckStack.tsx
+++ b/client/src/components/deck-builder/DeckStack.tsx
@@ -271,6 +271,7 @@ function DeckStackSectionLane({
   entries,
   emptyLabel,
   showTypeSections = false,
+  extraGroups,
   onAddCard,
   canAddCard,
   onRemoveCard,
@@ -283,6 +284,9 @@ function DeckStackSectionLane({
   entries: DeckStackItem[];
   emptyLabel: string;
   showTypeSections?: boolean;
+  /** Extra groups rendered after the type groups (e.g. Sideboard appended
+   *  to the Main Deck lane below the Lands subsection). */
+  extraGroups?: DeckStackTypeGroup[];
   onAddCard: (name: string) => void;
   canAddCard: (item: DeckStackItem) => boolean;
   onRemoveCard: (name: string, section: "main" | "sideboard") => void;
@@ -290,10 +294,13 @@ function DeckStackSectionLane({
   onCardHover?: (cardName: string | null, scryfallId?: string) => void;
   onContextMenu?: (cardName: string, x: number, y: number) => void;
 }) {
-  const typeGroups = useMemo(
-    () => showTypeSections ? buildTypeGroups(entries) : [{ key: "all", title: "", entries }],
-    [entries, showTypeSections],
-  );
+  const typeGroups = useMemo(() => {
+    const base = showTypeSections
+      ? buildTypeGroups(entries)
+      : [{ key: "all", title: "", entries }];
+    return extraGroups && extraGroups.length > 0 ? [...base, ...extraGroups] : base;
+  }, [entries, showTypeSections, extraGroups]);
+  const showGroupHeaders = showTypeSections || (extraGroups?.length ?? 0) > 0;
 
   return (
     <section className="flex min-w-0 flex-col rounded-[20px] border border-white/8 bg-black/14 px-3 py-3">
@@ -309,11 +316,11 @@ function DeckStackSectionLane({
           {emptyLabel}
         </div>
       ) : (
-        <div className="overflow-auto pb-1">
+        <div className="pb-1">
           <div className="flex min-w-0 flex-col gap-6">
             {typeGroups.map((group, groupIndex) => (
               <div key={group.key} className={groupIndex > 0 ? "pt-1" : undefined}>
-                {showTypeSections && (
+                {showGroupHeaders && (
                   <div className="mb-3 flex items-center gap-3">
                     <div className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-slate-500">
                       {group.title}
@@ -383,6 +390,17 @@ export function DeckStack({
   const artOverrides = usePreferencesStore((s) => s.artOverrides);
   const clearArtOverride = usePreferencesStore((s) => s.clearArtOverride);
 
+  // Sideboard renders as a "Sideboard" subsection appended to the Main Deck
+  // lane below the Lands subsection, so it shows up naturally as you scroll
+  // the visual stack.
+  const sideboardGroups = useMemo<DeckStackTypeGroup[]>(
+    () =>
+      sections.sideboard.length > 0
+        ? [{ key: "sideboard", title: "Sideboard", entries: sections.sideboard }]
+        : [],
+    [sections.sideboard],
+  );
+
   const [contextMenu, setContextMenu] = useState<{ cardName: string; x: number; y: number } | null>(null);
   const [pickerCard, setPickerCard] = useState<{ cardName: string; oracleId: string } | null>(null);
 
@@ -446,10 +464,15 @@ export function DeckStack({
             )}
             <DeckStackSectionLane
               title="Main Deck"
-              badge={`${mainDeckCount} cards`}
+              badge={
+                sideboardCount > 0
+                  ? `${mainDeckCount} main + ${sideboardCount} side`
+                  : `${mainDeckCount} cards`
+              }
               entries={sections.main}
               emptyLabel="Main deck cards will appear here."
               showTypeSections
+              extraGroups={sideboardGroups}
               onAddCard={onAddCard}
               canAddCard={canAddCard}
               onRemoveCard={onRemoveCard}
@@ -457,20 +480,6 @@ export function DeckStack({
               onCardHover={onCardHover}
               onContextMenu={handleContextMenu}
             />
-            {sideboardCount > 0 && (
-              <DeckStackSectionLane
-                title="Sideboard"
-                badge={`${sideboardCount} cards`}
-                entries={sections.sideboard}
-                emptyLabel="No sideboard cards."
-                onAddCard={onAddCard}
-                canAddCard={canAddCard}
-                onRemoveCard={onRemoveCard}
-                onRemoveCommander={onRemoveCommander}
-                onCardHover={onCardHover}
-                onContextMenu={handleContextMenu}
-              />
-            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Three deck-builder UX improvements grouped into one focused commit:

- **Sideboard surface in `DeckList`.** The compact 256px column gains a tabbed Main/Sideboard view so sideboard cards no longer get pushed off-screen. Tabs are hidden when the active format forbids a sideboard.
- **Sideboard subsection in `DeckStack`.** Sideboard renders as a labeled subsection of the Main Deck lane immediately after Lands, so it appears in the natural scroll flow instead of being shoved into a separate lane.
- **`DeckStackSectionLane` scroll fix.** Dropped the inner `overflow-auto` on the content wrapper. Combined with `flexbox min-height: auto` it was clamping the lane to the viewport and trapping vertical scroll, hiding everything below Lands. The outer scroll container in `DeckStack` now handles all vertical scrolling cleanly.
- **Save-button "Saved ✓" flash.** Emerald tint for ~1.5s after a successful save, mirroring the existing copy-to-clipboard pattern so users get immediate confirmation. Editing the deck name resets the flag so the confirmation never lingers over a stale name.

## Files changed

- `client/src/components/deck-builder/DeckBuilder.tsx` — save flash state, reset on name edit.
- `client/src/components/deck-builder/DeckList.tsx` — Main/Sideboard tabs, format-aware visibility.
- `client/src/components/deck-builder/DeckStack.tsx` — sideboard subsection in main lane, dropped inner overflow.

## Screenshots

<!--
SCREENSHOTS:
Drag the four PNGs from /tmp/phase-screenshots/ into the PR description in the GitHub web UI:
  01-sideboard-tab-empty.png   — DeckList compact column with new "Main / Sideboard" tabs (default Main view)
  02-sideboard-tab-active.png  — Sideboard tab clicked, sideboard cards listed in the same compact column
  03-deckstack-with-sideboard.png — Visual Deck Stack with the new "SIDEBOARD" subsection inside the Main Deck lane
  04-saved-confirmation.png    — Green "Saved" flash on the Save button after a successful save
-->

_Screenshots to be attached via the GitHub web UI — see staging notes in the unrendered comment above._

## Test plan

- [x] `pnpm run type-check` clean.
- [x] `pnpm lint` clean.
- [ ] Manual smoke (recommended): load any deck with a sideboard (e.g., Izzet Prowess), confirm:
  - Main / Sideboard tabs appear in the compact column on the right.
  - Switching to Sideboard shows only sideboard cards.
  - Visual Deck Stack scrolls past Lands into a labeled "SIDEBOARD" subsection.
  - Renaming the deck and clicking Save flashes the green "Saved" confirmation; editing the name afterward clears the flash.
<img width="1278" height="754" alt="01-sideboard-tab-empty" src="https://github.com/user-attachments/assets/99ab4998-cbf0-44da-abb6-4d2edc7808b9" />
<img width="1278" height="754" alt="02-sideboard-tab-active" src="https://github.com/user-attachments/assets/2de58cf3-574c-4610-9dd1-3f000f8af945" />
<img width="1278" height="754" alt="03-deckstack-with-sideboard" src="https://github.com/user-attachments/assets/8e3ae293-df63-45bd-ac73-1c17dd37ff40" />
<img width="1278" height="754" alt="04-saved-confirmation" src="https://github.com/user-attachments/assets/523bf9f9-d6be-4737-92ed-50b5f0c1bd0c" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)