### PR TITLE
Parse compound enters-tapped doesn't-untap line

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1633,6 +1633,33 @@ pub(crate) fn parse_oracle_ir(
             }
         }
 
+        // Priority 6d: Compound "[~] enters tapped and doesn't untap during your
+        // untap step." carries TWO independent rules in one sentence — an
+        // ETB-tapped replacement (CR 614.1c) and a CantUntap static (CR 502.3).
+        // The "doesn't untap" substring makes Priority 7's `is_static_pattern`
+        // fire and consume the line, dropping the ETB-tapped half. Decompose so
+        // both parsers run.
+        // Corpus: Traxos, Scourge of Kroog; Grimgrin, Corpse-Born; Leviathan.
+        if (scan_contains(&lower, "enters tapped")
+            || scan_contains(&lower, "enters the battlefield tapped"))
+            && scan_contains(&lower, "doesn't untap during")
+        {
+            let mut consumed = false;
+            if let Some(rep_def) = parse_replacement_line(&line, card_name) {
+                result.replacements.push(rep_def);
+                consumed = true;
+            }
+            let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
+            if !defs.is_empty() {
+                result.statics.extend(defs);
+                consumed = true;
+            }
+            if consumed {
+                i += 1;
+                continue;
+            }
+        }
+
         // Priority 7: Static/continuous patterns
         // CR 611.2a + CR 611.3a: On permanents, "creatures you control get +1/+1"
         // is a static ability (CR 611.3a). On instants/sorceries, lines with an
@@ -10896,5 +10923,45 @@ mod pipeline_snapshot_tests {
             &[],
         );
         insta::assert_json_snapshot!(result);
+    }
+
+    /// CR 614.1c + CR 502.3: Same-line compound "[~] enters tapped and doesn't
+    /// untap during your untap step." must emit BOTH an ETB-tapped replacement
+    /// (CR 614.1c) and a CantUntap static (CR 502.3). Regression guard against
+    /// the prior bug where the static-pattern classifier consumed the line and
+    /// silently dropped the replacement half. Corpus: Traxos, Scourge of Kroog;
+    /// Grimgrin, Corpse-Born; Leviathan.
+    #[test]
+    fn pipeline_etb_tapped_and_cant_untap_compound_emits_both() {
+        use crate::types::replacements::ReplacementEvent;
+        use crate::types::statics::StaticMode;
+        let result = pipeline_parse(
+            "Trample\nTraxos enters tapped and doesn't untap during your untap step.\nWhenever you cast a historic spell, untap Traxos.",
+            "Traxos, Scourge of Kroog",
+            &["Artifact", "Creature"],
+            &["Construct"],
+        );
+        assert_eq!(
+            result.replacements.len(),
+            1,
+            "expected one ETB-tapped replacement, got {:?}",
+            result.replacements
+        );
+        assert!(
+            matches!(result.replacements[0].event, ReplacementEvent::Moved),
+            "replacement event must be Moved (ETB), got {:?}",
+            result.replacements[0].event
+        );
+        assert_eq!(
+            result.statics.len(),
+            1,
+            "expected one CantUntap static, got {:?}",
+            result.statics
+        );
+        assert_eq!(
+            result.statics[0].mode,
+            StaticMode::CantUntap,
+            "static mode must be CantUntap"
+        );
     }
 }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -30,9 +30,9 @@ use super::oracle_class::parse_class_oracle_text;
 use super::oracle_classifier::{
     has_roll_die_pattern, has_trigger_prefix, is_ability_activate_cost_static,
     is_cant_win_lose_compound, is_compound_turn_limit, is_defiler_cost_pattern,
-    is_flashback_equal_mana_cost, is_granted_static_line, is_instead_replacement_line,
-    is_opening_hand_begin_game, is_replacement_pattern, is_static_pattern, is_vehicle_tier_line,
-    lower_starts_with, should_defer_spell_to_effect,
+    is_enters_tapped_cant_untap_compound, is_flashback_equal_mana_cost, is_granted_static_line,
+    is_instead_replacement_line, is_opening_hand_begin_game, is_replacement_pattern,
+    is_static_pattern, is_vehicle_tier_line, lower_starts_with, should_defer_spell_to_effect,
 };
 use super::oracle_condition::parse_restriction_condition;
 use super::oracle_cost::{parse_oracle_cost, try_parse_cost_reduction};
@@ -1640,10 +1640,7 @@ pub(crate) fn parse_oracle_ir(
         // fire and consume the line, dropping the ETB-tapped half. Decompose so
         // both parsers run.
         // Corpus: Traxos, Scourge of Kroog; Grimgrin, Corpse-Born; Leviathan.
-        if (scan_contains(&lower, "enters tapped")
-            || scan_contains(&lower, "enters the battlefield tapped"))
-            && scan_contains(&lower, "doesn't untap during")
-        {
+        if is_enters_tapped_cant_untap_compound(&lower) {
             let mut consumed = false;
             if let Some(rep_def) = parse_replacement_line(&line, card_name) {
                 result.replacements.push(rep_def);
@@ -10847,6 +10844,8 @@ mod tests {
 #[cfg(test)]
 mod pipeline_snapshot_tests {
     use super::*;
+    use crate::types::replacements::ReplacementEvent;
+    use crate::types::statics::StaticMode;
 
     fn pipeline_parse(
         oracle_text: &str,
@@ -10933,8 +10932,6 @@ mod pipeline_snapshot_tests {
     /// Grimgrin, Corpse-Born; Leviathan.
     #[test]
     fn pipeline_etb_tapped_and_cant_untap_compound_emits_both() {
-        use crate::types::replacements::ReplacementEvent;
-        use crate::types::statics::StaticMode;
         let result = pipeline_parse(
             "Trample\nTraxos enters tapped and doesn't untap during your untap step.\nWhenever you cast a historic spell, untap Traxos.",
             "Traxos, Scourge of Kroog",

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -54,6 +54,15 @@ pub(crate) fn is_defiler_cost_pattern(lower: &str) -> bool {
         && scan_contains(lower, "life")
 }
 
+pub(crate) fn is_enters_tapped_cant_untap_compound(lower: &str) -> bool {
+    let has_enters_tapped = scan_contains(lower, "enters tapped")
+        || scan_contains(lower, "enters the battlefield tapped");
+    let has_cant_untap = scan_contains(lower, "doesn't untap during")
+        || scan_contains(lower, "doesn’t untap during");
+
+    has_enters_tapped && has_cant_untap
+}
+
 pub(crate) fn is_compound_turn_limit(lower: &str) -> bool {
     scan_contains(lower, "only during your turn")
         && scan_contains(lower, "and ")


### PR DESCRIPTION
Traxos, Scourge of Kroog; Grimgrin, Corpse-Born; and Leviathan now enter the battlefield tapped. Previously they came in untapped: the Oracle compound `"~ enters tapped and doesn't untap during your untap step."` packs two CR-separate rules (an ETB-tapped replacement per CR 614.1c and a CantUntap static per CR 502.3), and the parser's Priority 7 static dispatch matched on `"doesn't untap"`, consumed the whole line, and silently dropped the replacement half.

The fix adds a pre-Priority-7 carve-out in `parser/oracle.rs` that recognizes the compound and dispatches each half to its natural parser, mirroring the existing "as long as ..." carve-out one block below. Cards with the split-line form (Time Vault, Deep-Slumber Titan, Jasconian Isle, etc.) are unaffected, since each line is already parsed independently. A pipeline regression test in `pipeline_snapshot_tests` asserts both the `Moved` replacement and the `CantUntap` static emit for the compound.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
