### PR TITLE
Add Vizier of Remedies

### DIFF
--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -19,7 +19,7 @@ use crate::types::ability::{
     QuantityRef, ResolvedAbility, RoundingMode, TargetFilter, TargetRef, TypeFilter, ZoneRef,
 };
 use crate::types::card_type::CoreType;
-use crate::types::counter::{parse_counter_type, CounterMatch, CounterType};
+use crate::types::counter::{parse_counter_type, CounterType};
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{ManaColor, ManaCost};
@@ -1398,7 +1398,7 @@ fn resolve_ref(
                 .iter()
                 .filter(|record| {
                     counter_added_actor_matches(actor, controller, record.actor)
-                        && counter_match_matches(counters, &record.counter_type)
+                        && counters.matches(&record.counter_type)
                         && matches_target_filter_on_counter_added_record(
                             state,
                             record,
@@ -1605,13 +1605,6 @@ fn counter_added_actor_matches(scope: &CountScope, controller: PlayerId, actor: 
         CountScope::Controller => actor == controller,
         CountScope::All => true,
         CountScope::Opponents => actor != controller,
-    }
-}
-
-fn counter_match_matches(counter_match: &CounterMatch, counter_type: &CounterType) -> bool {
-    match counter_match {
-        CounterMatch::Any => true,
-        CounterMatch::OfType(expected) => expected == counter_type,
     }
 }
 
@@ -2343,7 +2336,7 @@ mod tests {
         TypedFilter,
     };
     use crate::types::card_type::{CoreType, Supertype};
-    use crate::types::counter::CounterType;
+    use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::events::PlayerActionKind;
     use crate::types::game_state::{
         DamageRecord, ExileLink, ExileLinkKind, ManaSpentSourceSnapshot, ZoneChangeRecord,

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -2176,6 +2176,31 @@ pub fn find_applicable_replacements(
                     {
                         continue;
                     }
+                    // CR 122.1a + CR 614.1a: Counter-type filter on AddCounter
+                    // replacements. Hardened Scales ("+1/+1 counters") must not
+                    // fire on -1/-1 counter additions, and Vizier of Remedies
+                    // ("-1/-1 counters") must not fire on +1/+1 counter additions
+                    // — the printed Oracle text names a specific counter type as
+                    // the discriminator, so the engine honors that here.
+                    // `None` and `Some(CounterMatch::Any)` accept any counter
+                    // type (Doubling Season, modern wording).
+                    if let (
+                        Some(ref m),
+                        ProposedEvent::AddCounter {
+                            counter_type: ev_ct,
+                            ..
+                        },
+                    ) = (&repl_def.counter_match, event)
+                    {
+                        match m {
+                            crate::types::counter::CounterMatch::Any => {}
+                            crate::types::counter::CounterMatch::OfType(expected) => {
+                                if expected != ev_ct {
+                                    continue;
+                                }
+                            }
+                        }
+                    }
                     candidates.push(rid);
                 }
             }
@@ -5926,5 +5951,172 @@ mod tests {
             ),
             "draw step draws by the non-active player must replace"
         );
+    }
+
+    /// CR 122.1a + CR 614.1a: A counter-replacement that names "+1/+1
+    /// counters" in its Oracle text (Hardened Scales) must NOT fire on a
+    /// -1/-1 counter addition. The runtime gate honors `counter_match`
+    /// when the proposed event is `AddCounter`.
+    #[test]
+    fn counter_match_filters_hardened_scales_from_minus_one_minus_one_event() {
+        use crate::types::counter::{CounterMatch, CounterType};
+
+        let source = ObjectId(1);
+        let target = ObjectId(2);
+
+        let repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(crate::types::ability::QuantityModification::Plus { value: 1 })
+            .counter_match(CounterMatch::OfType(CounterType::Plus1Plus1));
+        let mut state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
+        // The proposed AddCounter event targets a separate creature on the
+        // battlefield owned by the same player so any controller-scoped
+        // checks in the registry pass through unchanged.
+        let mut creature = crate::game::game_object::GameObject::new(
+            target,
+            CardId(2),
+            PlayerId(0),
+            "C".into(),
+            Zone::Battlefield,
+        );
+        creature
+            .card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
+        state.objects.insert(target, creature);
+        state.battlefield.push_back(target);
+
+        let registry = build_replacement_registry();
+        let proposed = ProposedEvent::AddCounter {
+            actor: PlayerId(0),
+            object_id: target,
+            counter_type: CounterType::Minus1Minus1,
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &proposed, &registry).is_empty(),
+            "Hardened-Scales-class replacement must not fire on -1/-1 counter additions"
+        );
+
+        // Sanity: the same replacement DOES fire on a +1/+1 counter event.
+        let proposed_p1p1 = ProposedEvent::AddCounter {
+            actor: PlayerId(0),
+            object_id: target,
+            counter_type: CounterType::Plus1Plus1,
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert_eq!(
+            find_applicable_replacements(&state, &proposed_p1p1, &registry).len(),
+            1,
+            "Hardened-Scales-class replacement must fire on +1/+1 counter additions"
+        );
+    }
+
+    /// CR 122.1a + CR 614.1a: Vizier of Remedies's "-1/-1 counters"
+    /// replacement must fire on a -1/-1 counter addition, but not on a
+    /// +1/+1 counter addition. Mirrors the Hardened Scales test in the
+    /// opposite direction.
+    #[test]
+    fn counter_match_filters_vizier_from_plus_one_plus_one_event() {
+        use crate::types::counter::{CounterMatch, CounterType};
+
+        let source = ObjectId(10);
+        let target = ObjectId(20);
+
+        let repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(crate::types::ability::QuantityModification::Minus { value: 1 })
+            .counter_match(CounterMatch::OfType(CounterType::Minus1Minus1));
+        let mut state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
+        let mut creature = crate::game::game_object::GameObject::new(
+            target,
+            CardId(2),
+            PlayerId(0),
+            "C".into(),
+            Zone::Battlefield,
+        );
+        creature
+            .card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
+        state.objects.insert(target, creature);
+        state.battlefield.push_back(target);
+
+        let registry = build_replacement_registry();
+
+        let proposed_p1p1 = ProposedEvent::AddCounter {
+            actor: PlayerId(0),
+            object_id: target,
+            counter_type: CounterType::Plus1Plus1,
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &proposed_p1p1, &registry).is_empty(),
+            "Vizier-class replacement must not fire on +1/+1 counter additions"
+        );
+
+        let proposed_m1m1 = ProposedEvent::AddCounter {
+            actor: PlayerId(0),
+            object_id: target,
+            counter_type: CounterType::Minus1Minus1,
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert_eq!(
+            find_applicable_replacements(&state, &proposed_m1m1, &registry).len(),
+            1,
+            "Vizier-class replacement must fire on -1/-1 counter additions"
+        );
+    }
+
+    /// CR 614.1a + CR 122.1a: Counter-agnostic replacements (Doubling Season's
+    /// modern wording: "those counters") leave `counter_match = None` and
+    /// continue to match every counter type — current behavior is preserved.
+    #[test]
+    fn counter_match_none_matches_any_counter_type() {
+        use crate::types::counter::CounterType;
+
+        let source = ObjectId(30);
+        let target = ObjectId(40);
+
+        let repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(crate::types::ability::QuantityModification::Double);
+        // Note: counter_match is left as None.
+        let mut state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
+        let mut creature = crate::game::game_object::GameObject::new(
+            target,
+            CardId(2),
+            PlayerId(0),
+            "C".into(),
+            Zone::Battlefield,
+        );
+        creature
+            .card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
+        state.objects.insert(target, creature);
+        state.battlefield.push_back(target);
+
+        let registry = build_replacement_registry();
+        for ct in [
+            CounterType::Plus1Plus1,
+            CounterType::Minus1Minus1,
+            CounterType::Loyalty,
+            CounterType::Generic("charge".to_string()),
+        ] {
+            let proposed = ProposedEvent::AddCounter {
+                actor: PlayerId(0),
+                object_id: target,
+                counter_type: ct.clone(),
+                count: 1,
+                applied: HashSet::new(),
+            };
+            assert_eq!(
+                find_applicable_replacements(&state, &proposed, &registry).len(),
+                1,
+                "counter_match=None must accept any counter type, including {ct:?}"
+            );
+        }
     }
 }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -2185,20 +2185,15 @@ pub fn find_applicable_replacements(
                     // `None` and `Some(CounterMatch::Any)` accept any counter
                     // type (Doubling Season, modern wording).
                     if let (
-                        Some(ref m),
+                        Some(m),
                         ProposedEvent::AddCounter {
                             counter_type: ev_ct,
                             ..
                         },
                     ) = (&repl_def.counter_match, event)
                     {
-                        match m {
-                            crate::types::counter::CounterMatch::Any => {}
-                            crate::types::counter::CounterMatch::OfType(expected) => {
-                                if expected != ev_ct {
-                                    continue;
-                                }
-                            }
+                        if !m.matches(ev_ct) {
+                            continue;
                         }
                     }
                     candidates.push(rid);

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -11358,6 +11358,85 @@ mod tests {
             r.parse_warnings
         );
     }
+
+    /// CR 614.1a + CR 122.1a: End-to-end check that Vizier of Remedies
+    /// parses cleanly through `parse_oracle_text` (the canonical entry
+    /// point used by the card-data pipeline) and produces a single
+    /// AddCounter replacement gated to -1/-1 counters on creatures the
+    /// controller controls. The full card must be fully supported (zero
+    /// gaps) — this is what flips the runtime `supported: true` flag in
+    /// `card-data.json`.
+    #[test]
+    fn vizier_of_remedies_parses_to_single_counter_replacement() {
+        use crate::game::coverage::{card_face_gaps, card_face_has_unimplemented_parts};
+        use crate::types::ability::QuantityModification;
+        use crate::types::card::CardFace;
+        use crate::types::counter::{CounterMatch, CounterType};
+
+        let oracle = "If one or more -1/-1 counters would be put on a creature you control, that many -1/-1 counters minus one are put on it instead.";
+        let parsed = parse_oracle_text(
+            oracle,
+            "Vizier of Remedies",
+            &[],
+            &["Creature".to_string()],
+            &["Human".to_string(), "Cleric".to_string()],
+        );
+
+        assert!(
+            parsed.abilities.is_empty(),
+            "no spell abilities expected, got {:?}",
+            parsed.abilities
+        );
+        assert!(
+            parsed.triggers.is_empty(),
+            "no triggered abilities expected, got {:?}",
+            parsed.triggers
+        );
+        assert_eq!(
+            parsed.replacements.len(),
+            1,
+            "expected exactly one replacement, got {:?}",
+            parsed.replacements
+        );
+
+        let repl = &parsed.replacements[0];
+        assert_eq!(repl.event, ReplacementEvent::AddCounter);
+        assert_eq!(
+            repl.quantity_modification,
+            Some(QuantityModification::Minus { value: 1 }),
+            "Vizier subtracts 1 from the counter count (saturating at 0 — CR 122.1a)"
+        );
+        assert_eq!(
+            repl.counter_match,
+            Some(CounterMatch::OfType(CounterType::Minus1Minus1)),
+            "Vizier must be gated to -1/-1 counters specifically"
+        );
+        assert!(matches!(
+            repl.valid_card,
+            Some(TargetFilter::Typed(TypedFilter {
+                ref type_filters,
+                controller: Some(ControllerRef::You),
+                ..
+            })) if type_filters == &vec![TypeFilter::Creature]
+        ));
+
+        // Coverage gate: build a CardFace from the parsed result and verify
+        // the engine reports zero gaps (i.e. this is a fully-supported card).
+        let face = CardFace {
+            name: "Vizier of Remedies".to_string(),
+            replacements: parsed.replacements.clone(),
+            ..CardFace::default()
+        };
+        assert!(
+            !card_face_has_unimplemented_parts(&face),
+            "Vizier of Remedies must report no Unimplemented parts"
+        );
+        assert!(
+            card_face_gaps(&face).is_empty(),
+            "Vizier of Remedies must have zero coverage gaps, got: {:?}",
+            card_face_gaps(&face)
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 364
 expression: "&ir"
 ---
 {
@@ -70,6 +71,10 @@ expression: "&ir"
         "quantity_modification": {
           "type": "Plus",
           "value": 1
+        },
+        "counter_match": {
+          "type": "OfType",
+          "data": "P1P1"
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_lowered.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 365
 expression: "&lowered"
 ---
 {
@@ -71,6 +72,10 @@ expression: "&lowered"
       "quantity_modification": {
         "type": "Plus",
         "value": 1
+      },
+      "counter_match": {
+        "type": "OfType",
+        "data": "P1P1"
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -31,6 +31,7 @@ use crate::types::ability::{
     ManaReplacementScope, PreventionAmount, QuantityExpr, QuantityRef, ReplacementCondition,
     ReplacementDefinition, ReplacementMode, StaticCondition, TargetFilter, TypeFilter, TypedFilter,
 };
+use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::mana::{ManaColor, ManaCost, ManaType};
 use crate::types::replacements::ReplacementEvent;
 use crate::types::zones::Zone;
@@ -3403,8 +3404,12 @@ fn token_description_to_spec(
 }
 
 /// CR 614.1a: Parse counter addition replacement effects.
-/// Handles "twice that many ... counters" (Primal Vigor, Doubling Season)
-/// and "that many plus N ... counters" (Hardened Scales, Branching Evolution).
+/// Handles "twice that many ... counters" (Primal Vigor, Doubling Season),
+/// "that many plus N ... counters" (Hardened Scales, Branching Evolution),
+/// and "that many ... counters minus N" (Vizier of Remedies). The runtime
+/// applier saturates at 0 because counters are markers per CR 122.1 — you
+/// can't put a negative number of markers on a permanent — and the
+/// -1/-1-specific P/T semantics live in CR 122.1a / CR 613.4c.
 fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<ReplacementDefinition> {
     use crate::types::ability::QuantityModification;
 
@@ -3415,8 +3420,15 @@ fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<Replace
         // Delegate to nom_primitives::parse_number (input already lowercase)
         let (_rem, value) = nom_primitives::parse_number.parse(rest).ok()?;
         QuantityModification::Plus { value }
+    } else if let Some(rest) = strip_after(lower, "that many minus ") {
+        // "that many minus one ... counters are put on it instead"
+        // Direct "minus" form — symmetric to the "plus" form above.
+        let (_rem, value) = nom_primitives::parse_number.parse(rest).ok()?;
+        QuantityModification::Minus { value }
     } else {
-        let rest = strip_after(lower, "that many minus ")?;
+        // Vizier of Remedies form: "that many <type> counters minus one are put on it instead".
+        // The "minus N" follows the counter-type token rather than preceding it.
+        let rest = strip_after(lower, " counters minus ")?;
         let (_rem, value) = nom_primitives::parse_number.parse(rest).ok()?;
         QuantityModification::Minus { value }
     };
@@ -3434,7 +3446,43 @@ fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<Replace
         ));
     }
 
+    // CR 122.1a + CR 614.1a: When the Oracle text names a specific counter type
+    // ("+1/+1 counters", "-1/-1 counters", "loyalty counters", …), restrict the
+    // replacement to that counter type so Hardened Scales doesn't fire on -1/-1
+    // counter additions and Vizier of Remedies doesn't fire on +1/+1 counter
+    // additions. Counter-agnostic wordings ("those counters" — Doubling Season)
+    // leave `counter_match = None`, preserving the legacy any-counter behavior.
+    if let Some(ct) = extract_replacement_counter_type(lower) {
+        def = def.counter_match(CounterMatch::OfType(ct));
+    }
+
     Some(def)
+}
+
+/// CR 122.1a + CR 614.1a: Extract the counter-type token named in a counter
+/// replacement's Oracle text. Anchors on the "one or more <type> counter[s]"
+/// phrase that scopes the replaced event to a specific counter type and
+/// delegates the type token to `parse_counter_type_typed` (the single nom
+/// authority for counter type recognition). Returns `None` for counter-
+/// agnostic wordings such as Doubling Season's "if an effect would put one
+/// or more counters on a permanent you control" — in that case the
+/// replacement applies to every counter type, matching the printed behavior.
+fn extract_replacement_counter_type(lower: &str) -> Option<CounterType> {
+    // Compose nom end-to-end:
+    //   <any prefix> "one or more " <counter-type-token> " counter"[s]
+    // The leading `take_until("one or more ")` advances to the anchor without
+    // delegating to `str::find` for parsing dispatch. The trailing-noun guard
+    // (` counter` / ` counters`) prevents a counter-agnostic phrasing
+    // ("one or more counters") from accidentally consuming a recognized
+    // counter-type stem (e.g. the named-counter list contains "stun").
+    let mut combinator = (
+        take_until::<_, _, OracleError<'_>>("one or more "),
+        tag("one or more "),
+        nom_primitives::parse_counter_type_typed,
+        alt((tag(" counters"), tag(" counter"))),
+    )
+        .map(|(_, _, ct, _): (&str, &str, CounterType, &str)| ct);
+    combinator.parse(lower).ok().map(|(_rest, ct)| ct)
 }
 
 /// CR 614.1a: Parse damage redirection replacement effects.
@@ -6959,6 +7007,21 @@ mod tests {
     }
 
     #[test]
+    fn counter_agnostic_one_or_more_does_not_set_counter_match() {
+        // CR 614.1a + CR 122.1: Sanity check — "if an effect would put one
+        // or more counters on a permanent you control" (Doubling Season's
+        // modern wording) must NOT be treated as type-specific. The
+        // counter-agnostic wording leaves counter_match = None so the
+        // replacement matches every counter type.
+        let def = parse_replacement_line(
+            "If an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
+            "Doubling Season",
+        )
+        .unwrap();
+        assert_eq!(def.counter_match, None);
+    }
+
+    #[test]
     fn counter_doubling_replacement_current_oracle_wording() {
         let def = parse_replacement_line(
             "If an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
@@ -6977,6 +7040,66 @@ mod tests {
                 controller: Some(ControllerRef::You),
                 ..
             })) if type_filters == vec![TypeFilter::Permanent]
+        ));
+        // CR 122.1a + CR 614.1a: Doubling Season's modern wording uses "those
+        // counters" — counter-agnostic, so no `counter_match` is set.
+        assert_eq!(def.counter_match, None);
+    }
+
+    #[test]
+    fn counter_plus_one_replacement_hardened_scales() {
+        // CR 614.1a + CR 122.1a: Hardened Scales — "+1/+1 counters" specifically.
+        let def = parse_replacement_line(
+            "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
+            "Hardened Scales",
+        )
+        .unwrap();
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Plus { value: 1 })
+        );
+        assert_eq!(
+            def.counter_match,
+            Some(CounterMatch::OfType(CounterType::Plus1Plus1))
+        );
+        assert!(matches!(
+            def.valid_card,
+            Some(TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller: Some(ControllerRef::You),
+                ..
+            })) if type_filters == vec![TypeFilter::Creature]
+        ));
+    }
+
+    #[test]
+    fn counter_minus_one_replacement_vizier_of_remedies() {
+        // CR 614.1a + CR 122.1a: Vizier of Remedies — "-1/-1 counters"
+        // specifically. The "minus one" follows the type token in this
+        // wording (vs. Hardened Scales's "that many plus one"), so the
+        // parser falls through to the " counters minus " branch.
+        let def = parse_replacement_line(
+            "If one or more -1/-1 counters would be put on a creature you control, that many -1/-1 counters minus one are put on it instead.",
+            "Vizier of Remedies",
+        )
+        .unwrap();
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Minus { value: 1 })
+        );
+        assert_eq!(
+            def.counter_match,
+            Some(CounterMatch::OfType(CounterType::Minus1Minus1))
+        );
+        assert!(matches!(
+            def.valid_card,
+            Some(TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller: Some(ControllerRef::You),
+                ..
+            })) if type_filters == vec![TypeFilter::Creature]
         ));
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8202,6 +8202,17 @@ pub struct ReplacementDefinition {
     /// orthogonal — a single replacement may set either, but not both.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ensure_token_specs: Option<Vec<crate::types::proposed_event::TokenSpec>>,
+    /// CR 614.1a + CR 122.1a: Counter-type discriminator for `AddCounter`
+    /// replacements that explicitly name a counter type in their Oracle text
+    /// ("If one or more +1/+1 counters …" — Hardened Scales; "If one or more
+    /// -1/-1 counters …" — Vizier of Remedies). When set to
+    /// `Some(CounterMatch::OfType(ct))`, the replacement only fires for
+    /// `ProposedEvent::AddCounter` events whose `counter_type == ct`.
+    /// `None` (and the redundant `Some(CounterMatch::Any)`) match any
+    /// counter type — used by Doubling Season ("those counters") and other
+    /// counter-agnostic replacements.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub counter_match: Option<CounterMatch>,
 }
 
 impl ReplacementDefinition {
@@ -8233,6 +8244,7 @@ impl ReplacementDefinition {
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: None,
         }
     }
 
@@ -8311,6 +8323,15 @@ impl ReplacementDefinition {
 
     pub fn quantity_modification(mut self, modification: QuantityModification) -> Self {
         self.quantity_modification = Some(modification);
+        self
+    }
+
+    /// CR 614.1a + CR 122.1a: Restrict an `AddCounter` replacement to a specific
+    /// counter type (e.g., Vizier of Remedies's `-1/-1` filter). Replacements
+    /// whose Oracle text doesn't name a specific counter type leave this `None`,
+    /// which matches every counter type (current behavior for Doubling Season).
+    pub fn counter_match(mut self, m: CounterMatch) -> Self {
+        self.counter_match = Some(m);
         self
     }
 

--- a/crates/engine/src/types/counter.rs
+++ b/crates/engine/src/types/counter.rs
@@ -105,6 +105,22 @@ pub enum CounterMatch {
     OfType(CounterType),
 }
 
+impl CounterMatch {
+    /// CR 122.1: Boolean predicate — does this matcher accept a counter of
+    /// the given type? `Any` accepts every type; `OfType(t)` accepts only
+    /// counters of `t`. Predicates that need to *sum* counter quantities
+    /// (rather than test a single type) should match on the variants
+    /// directly because the `Any` case sums across all entries on an
+    /// object — this helper is for the boolean axis only.
+    #[inline]
+    pub fn matches(&self, counter_type: &CounterType) -> bool {
+        match self {
+            CounterMatch::Any => true,
+            CounterMatch::OfType(expected) => expected == counter_type,
+        }
+    }
+}
+
 pub fn parse_counter_type(text: &str) -> CounterType {
     let trimmed = text.trim().trim_end_matches(" counter").trim();
     match trimmed {

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -92,6 +92,7 @@ pub fn convert_as_enters(
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: None,
         });
     }
     Ok(out)
@@ -170,6 +171,7 @@ pub fn convert_replace_would_enter(
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: None,
         });
     }
     Ok(out)
@@ -231,6 +233,7 @@ pub fn convert_replace_would_deal_damage(
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: None,
         });
     }
     Ok(out)
@@ -601,6 +604,7 @@ pub fn convert_replace_would_draw(
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: None,
         });
     }
     Ok(out)
@@ -719,6 +723,7 @@ pub fn convert_replace_would_put_into_graveyard(
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: None,
         });
     }
     Ok(out)
@@ -936,6 +941,7 @@ pub fn convert_as_put_into_graveyard_from_anywhere(
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: None,
         });
     }
     Ok(out)
@@ -988,6 +994,12 @@ pub fn convert_replace_would_put_counters(
     actions: &[ReplacementActionWouldPutCounters],
 ) -> ConvResult<Vec<ReplacementDefinition>> {
     let valid_card = counter_event_to_valid_card(event)?;
+    // CR 122.1a + CR 614.1a: When the schema event names a specific counter
+    // type ("CountersOfTypeWouldBePointOnAPermanent"), restrict the
+    // replacement to that counter type so Hardened Scales (+1/+1) doesn't
+    // fire on -1/-1 counter additions and Vizier of Remedies (-1/-1)
+    // doesn't fire on +1/+1 counter additions.
+    let counter_match = counter_event_to_counter_match(event)?;
     let mut out = Vec::new();
     for act in actions {
         let modification = counter_action_to_modification(act)?;
@@ -1016,9 +1028,30 @@ pub fn convert_replace_would_put_counters(
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: counter_match.clone(),
         });
     }
     Ok(out)
+}
+
+/// CR 122.1a + CR 614.1a: Map a schema `ReplacableEventWouldPutCounters` to
+/// the engine's `CounterMatch` discriminator. The schema's
+/// `CountersOfTypeWouldBePointOnAPermanent(counter, _)` carries a typed
+/// counter — translate it through the canonical
+/// `filter::counter_type_to_engine` and wrap as `CounterMatch::OfType(...)`.
+/// All other event shapes (counter-agnostic phrasings) return `None`,
+/// matching every counter type in the runtime.
+fn counter_event_to_counter_match(
+    event: &ReplacableEventWouldPutCounters,
+) -> ConvResult<Option<engine::types::counter::CounterMatch>> {
+    use ReplacableEventWouldPutCounters as E;
+    match event {
+        E::CountersOfTypeWouldBePointOnAPermanent(counter, _) => {
+            let ct = crate::convert::filter::counter_type_to_engine(counter)?;
+            Ok(Some(engine::types::counter::CounterMatch::OfType(ct)))
+        }
+        _ => Ok(None),
+    }
 }
 
 /// CR 614.1a: Decompose a `ReplacableEventWouldPutCounters` event into a
@@ -1176,6 +1209,7 @@ pub fn convert_replace_would_gain_life(
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: None,
         });
     }
     Ok(out)
@@ -1294,6 +1328,7 @@ fn try_build_may_cost_pair(
         mana_replacement_scope: ManaReplacementScope::Any,
         additional_token_spec: None,
         ensure_token_specs: None,
+        counter_match: None,
     }))
 }
 

--- a/crates/phase-ai/src/cast_facts.rs
+++ b/crates/phase-ai/src/cast_facts.rs
@@ -466,6 +466,7 @@ mod tests {
             mana_replacement_scope: ManaReplacementScope::Any,
             additional_token_spec: None,
             ensure_token_specs: None,
+            counter_match: None,
         });
         object.replacement_definitions.push(ReplacementDefinition {
             destination_zone: None,


### PR DESCRIPTION
## Summary
Adds engine support for **Vizier of Remedies**.

The change extends the existing AddCounter replacement infrastructure with a typed `counter_match: Option<CounterMatch>` filter so replacements that name a specific counter type in their Oracle text only fire on matching events. Hardened Scales (+1/+1) no longer fires on -1/-1 counter additions, Vizier of Remedies (-1/-1) parses and applies correctly, and counter-agnostic wordings (Doubling Season's "those counters") preserve their existing match-any behavior. The fix is class-wide: it benefits Vizier, Hardened Scales, Branching Evolution, Conclave Mentor, Pir, and Solidarity of Heroes simultaneously.

The parser extracts the counter type via a pure-nom combinator anchored on `"one or more <type> counter[s]"` and delegates the type token to the existing `parse_counter_type_typed`. The mtgish-import converter mirrors the gate by translating `CountersOfTypeWouldBePointOnAPermanent` to `CounterMatch::OfType` so cards loaded via the typed AST also get the type filter.

## Files changed
- `crates/engine/src/types/ability.rs` — add `counter_match: Option<CounterMatch>` field + builder
- `crates/engine/src/parser/oracle_replacement.rs` — extract counter type via nom; handle "that many <type> counters minus N" form; tests
- `crates/engine/src/game/replacement.rs` — runtime gate filtering AddCounter replacements by counter type; tests
- `crates/engine/src/parser/oracle.rs` — end-to-end parse test for Vizier
- `crates/engine/src/parser/oracle_ir/snapshots/...conclave_mentor_*.snap` — snapshot updates reflecting new field
- `crates/mtgish-import/src/convert/replacement.rs` — typed-AST converter helper for `CounterMatch`; default `None` on all sites
- `crates/phase-ai/src/cast_facts.rs` — fixture compile fix

## CR references
- `CR 614.1a` — replacement effects using "instead" (authorizing rule for the family)
- `CR 122.1` — counters are markers (justifies `saturating_sub` floor at 0)
- `CR 122.1a` — +/- counter P/T semantics
- `CR 613.4c` — layer 7c P/T modification

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Verification
- `cargo fmt --all` — clean
- `cargo clippy --all-targets --workspace -- -D warnings` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo test -p engine` — 6602 pass / 0 fail / 1 ignored
- `cargo test -p mtgish-import` — all goldens pass
- `./scripts/gen-card-data.sh` — `Vizier of Remedies`: 0 Unimplemented entries
- `cargo coverage` — `Vizier of Remedies`: `supported: true`, `gap_count: 0`
- `cargo semantic-audit` — `Vizier of Remedies`: 0 findings

## Scope Expansion
The implementation grew beyond a single new effect. `QuantityModification::Minus { value }` was already present, but the engine had no counter-type filter on AddCounter replacements — every Hardened-Scales-class card would, if it shipped to runtime, incorrectly fire on -1/-1 counter additions; every Vizier-class card would incorrectly fire on +1/+1 counter additions; and the parser threw away the typed counter-type token from Oracle text. The expansion adds the typed `counter_match` field (reusing the existing `CounterMatch::{Any, OfType}` enum from `types/counter.rs` — no new variants invented), the parser extraction, the runtime gate, and the mtgish-import converter parallel path. The expansion is necessary for rules-correctness (CR 614.1a + CR 122.1a): the Oracle text explicitly names a counter type as the discriminator, so the engine must honor that.

## Validation Failures
None.

## CI Failures
None.