### PR TITLE
Edited the return to hand function as a casting cost in order to fix the mazes end bug and future bugs like it 

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -2664,10 +2664,109 @@ mod tests {
         UnlessPayModifier,
     };
     use crate::types::card_type::CoreType;
-    use crate::types::game_state::{GameState, TargetSelectionConstraint, TargetSelectionSlot};
+    use crate::types::game_state::{
+        GameState, StackEntryKind, TargetSelectionConstraint, TargetSelectionSlot, WaitingFor,
+    };
     use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
+    use crate::types::mana::{ManaCost, ManaType, ManaUnit};
     use crate::types::player::PlayerId;
     use crate::types::zones::Zone;
+    use crate::types::{FormatConfig, GameAction};
+    //mazes end test for self bounce lands
+    #[test]
+    fn mazes_end_search_resolves_after_self_bounce_cost() {
+        let format = FormatConfig::duel_commander();
+        let mut state = GameState::new(format, 2, 2);
+        let mazes_end = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Maze's End".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&mazes_end).expect("Maze's End");
+            obj.card_types.core_types.push(CoreType::Land);
+            std::sync::Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::SearchLibrary {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::new(TypeFilter::Land)
+                                .with_type(TypeFilter::Subtype("Gate".to_string())),
+                        ),
+                        count: QuantityExpr::Fixed { value: 1 },
+                        reveal: false,
+                        target_player: None,
+                        selection_constraint: SearchSelectionConstraint::None,
+                    },
+                )
+                .cost(AbilityCost::Composite {
+                    costs: vec![
+                        AbilityCost::Mana {
+                            cost: ManaCost::Cost {
+                                shards: Vec::new(),
+                                generic: 3,
+                            },
+                        },
+                        AbilityCost::Tap,
+                        AbilityCost::ReturnToHand {
+                            count: 1,
+                            filter: Some(TargetFilter::SelfRef),
+                        },
+                    ],
+                }),
+            );
+        }
+        for _ in 0..3 {
+            state.players[0].mana_pool.add(ManaUnit::new(
+                ManaType::Colorless,
+                ObjectId(999),
+                false,
+                Vec::new(),
+            ));
+        }
+
+        let waiting = crate::game::casting::handle_activate_ability(
+            &mut state,
+            PlayerId(0),
+            mazes_end,
+            0,
+            &mut Vec::new(),
+        )
+        .expect("Maze's End activation should begin");
+        assert!(
+            matches!(waiting, WaitingFor::ReturnToHandForCost { .. }),
+            "self-bounce cost should request a return-to-hand selection"
+        );
+        state.waiting_for = waiting;
+
+        crate::game::engine::apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: vec![mazes_end],
+            },
+        )
+        .expect("paying the self-bounce cost should finish activation");
+
+        assert_eq!(state.objects[&mazes_end].zone, Zone::Hand);
+        assert!(
+            state.players[0].hand.contains(&mazes_end),
+            "Maze's End is returned to hand as an activation cost"
+        );
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "Maze's End ability should be on the stack"
+        );
+        match &state.stack[0].kind {
+            StackEntryKind::ActivatedAbility { source_id, ability } => {
+                assert_eq!(*source_id, mazes_end);
+                assert!(matches!(ability.effect, Effect::SearchLibrary { .. }));
+            }
+            other => panic!("expected Maze's End activated ability on stack, got {other:?}"),
+        }
+    }
 
     #[test]
     fn build_chained_resolved_preserves_mode_sub_abilities() {

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -2713,6 +2713,7 @@ mod tests {
                         AbilityCost::ReturnToHand {
                             count: 1,
                             filter: Some(TargetFilter::SelfRef),
+                            from_zone: Some(Zone::Battlefield),
                         },
                     ],
                 }),

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -5114,13 +5114,14 @@ pub(crate) fn find_eligible_exile_for_cost_targets(
 fn find_return_to_hand_cost(cost: &AbilityCost) -> Option<(u32, Option<&TargetFilter>)> {
     match cost {
         // CR 118.12: This helper currently only handles the default
-        // battlefield-source shape (`from_zone: None`). Cards with
-        // `from_zone: Some(_)` use the unless-cost path in
+        // battlefield-source shape (`from_zone: None`) and its explicit
+        // spelling (`from_zone: Some(Battlefield)`). Cards with other
+        // `from_zone` values use the unless-cost path in
         // `engine_payment_choices.rs`, not the activation-cost path here.
         AbilityCost::ReturnToHand {
             count,
             filter,
-            from_zone: None,
+            from_zone: None | Some(Zone::Battlefield),
         } => Some((*count, filter.as_ref())),
         AbilityCost::ReturnToHand {
             from_zone: Some(_), ..

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -508,7 +508,7 @@ pub(crate) fn handle_sacrifice_for_cost(
 pub(crate) fn handle_return_to_hand_for_cost(
     state: &mut GameState,
     player: PlayerId,
-    pending: PendingCast,
+    mut pending: PendingCast,
     count: usize,
     legal_permanents: &[ObjectId],
     chosen: &[ObjectId],
@@ -526,6 +526,16 @@ pub(crate) fn handle_return_to_hand_for_cost(
             return Err(EngineError::InvalidAction(
                 "Selected permanent not eligible to return".to_string(),
             ));
+        }
+    }
+
+    if pending.activation_ability_index.is_some() {
+        if let Some(cost) = pending.activation_cost.take() {
+            // CR 118.3 + CR 602.2h: A player pays an activated ability's total
+            // cost before that ability becomes activated. For self-bounce costs
+            // such as Maze's End, pay automatic components like {T} while the
+            // source is still on the battlefield, then perform the chosen return.
+            super::casting::pay_ability_cost(state, player, pending.object_id, &cost, events)?;
         }
     }
 


### PR DESCRIPTION
Mazes end was getting returned to hand before the tap cost was paid and therefore it tried to tap it while in hand and failed with an error. This patch fixes that