### PR TITLE
Add Taught by Surrak

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4750,6 +4750,96 @@ mod tests {
         assert_eq!(r.triggers.len(), 1);
     }
 
+    /// CR 303.4 + CR 601.2i + CR 201.5: Taught by Surrak — a {4}{G} Aura with
+    /// a self-cast "draw a card" trigger and an `+2/+2 / haste` static grant on
+    /// the enchanted creature. The "Commander enchantment" line is a playtest
+    /// mechanic (Unknown Event set, 2023+) and remains intentionally
+    /// `Effect::Unimplemented` — implementing zone-following Aura attachment is
+    /// non-trivial new infrastructure that is out of scope for this card. The
+    /// remaining two abilities (cast trigger + aura static) MUST parse via the
+    /// existing class-level patterns.
+    #[test]
+    fn taught_by_surrak_class_patterns_parse() {
+        let oracle = "Commander enchantment (This aura enchants a commander creature, and remains attached to the creature as it moves between any face-up zones. You can cast it on a Commander in your command zone.)\nWhen you cast Taught by Surrak, draw a card.\nEnchanted creature gets +2/+2 and gains haste.";
+        let r = parse(oracle, "Taught by Surrak", &[], &["Enchantment"], &["Aura"]);
+
+        // CR 601.2i + CR 603.2: the cast trigger parses with TargetFilter::SelfRef
+        // on the source spell and Stack as the active zone (CR 117.2a + CR 113.6).
+        assert_eq!(r.triggers.len(), 1, "expected exactly one trigger");
+        let trigger = &r.triggers[0];
+        assert_eq!(trigger.mode, TriggerMode::SpellCast);
+        assert_eq!(trigger.valid_card, Some(TargetFilter::SelfRef));
+        assert!(trigger.trigger_zones.contains(&Zone::Stack));
+
+        // CR 121.1 + CR 603.2: the trigger's effect body is `Effect::Draw` for
+        // the controller (TargetFilter::Controller), count = 1.
+        let execute = trigger
+            .execute
+            .as_ref()
+            .expect("trigger should have execute body");
+        assert!(
+            !has_unimplemented(execute),
+            "trigger effect should be fully implemented, got {:?}",
+            execute.effect
+        );
+        let Effect::Draw { count, target, .. } = &*execute.effect else {
+            panic!(
+                "expected Effect::Draw in trigger body, got {:?}",
+                execute.effect
+            );
+        };
+        assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+        assert!(
+            matches!(target, TargetFilter::Controller),
+            "expected TargetFilter::Controller for 'draw a card' \
+             (the trigger's controller draws); got {target:?}",
+        );
+
+        // CR 303.4 + CR 613.1f + CR 613.4c: the aura's static grant — Haste
+        // (layer 6, ability-adding) and +2/+2 (layer 7c, P/T modification)
+        // applied to the enchanted creature (TypedFilter::creature() with the
+        // EnchantedBy property).
+        assert_eq!(r.statics.len(), 1, "expected exactly one static");
+        let static_def = &r.statics[0];
+        assert_eq!(static_def.mode, StaticMode::Continuous);
+        assert_eq!(
+            static_def.affected,
+            Some(TargetFilter::Typed(
+                TypedFilter::creature().properties(vec![FilterProp::EnchantedBy]),
+            ))
+        );
+        assert!(static_def
+            .modifications
+            .contains(&ContinuousModification::AddPower { value: 2 }));
+        assert!(static_def
+            .modifications
+            .contains(&ContinuousModification::AddToughness { value: 2 }));
+        assert!(static_def
+            .modifications
+            .contains(&ContinuousModification::AddKeyword {
+                keyword: Keyword::Haste,
+            }));
+
+        // CR n/a (playtest, Unknown Event): the "Commander enchantment" line is
+        // not implemented — it lands as Effect::Unimplemented carrying the
+        // original phrase. Verify the diagnostic is preserved (no silent drop)
+        // and that no spurious trigger/static was synthesized from it.
+        let unimplemented_count = r
+            .abilities
+            .iter()
+            .filter(|ab| matches!(&*ab.effect, Effect::Unimplemented { .. }))
+            .count();
+        assert_eq!(
+            unimplemented_count,
+            1,
+            "expected exactly one Unimplemented ability (the Commander \
+             enchantment playtest keyword line); got {} unimplemented \
+             out of {} total abilities",
+            unimplemented_count,
+            r.abilities.len()
+        );
+    }
+
     #[test]
     fn commander_permission_line_is_deck_construction_text() {
         let r = parse(

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -6178,10 +6178,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
     // combinator rather than 6 sibling `tag` arms.
     if nom_primitives::scan_at_word_boundaries(lower, |i| {
         preceded(
-            alt((
-                tag::<_, _, OracleError<'_>>("when "),
-                tag("whenever "),
-            )),
+            alt((tag::<_, _, OracleError<'_>>("when "), tag("whenever "))),
             alt((
                 tag("you cast this spell"),
                 tag("you cast ~"),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -6163,12 +6163,36 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         return Some((TriggerMode::SpellCopy, def));
     }
 
-    // "when you cast this spell" — self-cast trigger (fires from stack)
-    if scan_contains(lower, "when you cast this spell") || scan_contains(lower, "when ~ is cast") {
+    // CR 601.2i + CR 603.2: Self-cast trigger — "When you cast this spell",
+    // "When ~ is cast", or "When you cast ~" all describe the same trigger
+    // event (this spell being cast). The triggered ability fires as the spell
+    // is put onto the stack; per CR 117.2a and CR 113.6, the trigger's source
+    // is the stack object, so `trigger_zones = [Stack]`.
+    //
+    // Equivalent phrasings (Oracle-text variants seen across printings):
+    //   - "When you cast this spell"        (modern self-reference)
+    //   - "When ~ is cast"                  (passive form; older templating)
+    //   - "When you cast ~"                 (direct name reference after
+    //                                        `normalize_card_name_refs` ⇒ "~";
+    //                                        e.g. Taught by Surrak)
+    //
+    // The word-boundary `scan_contains` admits leading qualifiers (e.g.
+    // intervening-if prefixes) without anchoring the trigger to start-of-line.
+    let self_cast_phrases = [
+        "when you cast this spell",
+        "whenever you cast this spell",
+        "when ~ is cast",
+        "when you cast ~",
+        "whenever you cast ~",
+    ];
+    if self_cast_phrases
+        .iter()
+        .any(|phrase| scan_contains(lower, phrase))
+    {
         let mut def = make_base();
         def.mode = TriggerMode::SpellCast;
         def.valid_card = Some(TargetFilter::SelfRef);
-        // Cast triggers fire while the spell is on the stack
+        // CR 117.2a + CR 113.6: cast triggers fire while the spell is on the stack
         def.trigger_zones = vec![Zone::Stack];
         return Some((TriggerMode::SpellCast, def));
     }
@@ -10204,6 +10228,35 @@ mod tests {
             "When you cast this spell, draw cards equal to the greatest power among creatures you control.",
             "Hydroid Krasis",
         );
+        assert_eq!(def.mode, TriggerMode::SpellCast);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert!(def.trigger_zones.contains(&Zone::Stack));
+    }
+
+    /// CR 601.2i + CR 603.2: A self-cast trigger phrased as
+    /// "When you cast <CARDNAME>" must produce the same `TriggerMode::SpellCast`
+    /// shape (with `valid_card = SelfRef`) as the canonical "When you cast this
+    /// spell" templating. After `normalize_card_name_refs` (CR 201.5), the card
+    /// name becomes `~`, so the parser sees "when you cast ~" — a class-level
+    /// pattern covering every aura/permanent whose cast trigger references
+    /// itself by name.
+    #[test]
+    fn trigger_you_cast_self_by_name() {
+        let def = parse_trigger_line(
+            "When you cast Taught by Surrak, draw a card.",
+            "Taught by Surrak",
+        );
+        assert_eq!(def.mode, TriggerMode::SpellCast);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert!(def.trigger_zones.contains(&Zone::Stack));
+    }
+
+    /// CR 601.2i + CR 603.2: Mirror of `trigger_you_cast_self_by_name` for the
+    /// "Whenever" prefix. Both keywords are valid cast-time trigger phrasings
+    /// (CR 603.1) and must produce identical SpellCast definitions.
+    #[test]
+    fn trigger_whenever_you_cast_self_by_name() {
+        let def = parse_trigger_line("Whenever you cast Test Card, draw a card.", "Test Card");
         assert_eq!(def.mode, TriggerMode::SpellCast);
         assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
         assert!(def.trigger_zones.contains(&Zone::Stack));

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -6163,31 +6163,34 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         return Some((TriggerMode::SpellCopy, def));
     }
 
-    // CR 601.2i + CR 603.2: Self-cast trigger — "When you cast this spell",
-    // "When ~ is cast", or "When you cast ~" all describe the same trigger
-    // event (this spell being cast). The triggered ability fires as the spell
-    // is put onto the stack; per CR 117.2a and CR 113.6, the trigger's source
-    // is the stack object, so `trigger_zones = [Stack]`.
+    // CR 601.2i + CR 603.2: Self-cast trigger — all phrasings that describe
+    // *this spell being cast* fire the same event. The triggered ability fires
+    // as the spell is put onto the stack; per CR 117.2a and CR 113.6, the
+    // trigger's source is the stack object, so `trigger_zones = [Stack]`.
     //
-    // Equivalent phrasings (Oracle-text variants seen across printings):
-    //   - "When you cast this spell"        (modern self-reference)
-    //   - "When ~ is cast"                  (passive form; older templating)
-    //   - "When you cast ~"                 (direct name reference after
-    //                                        `normalize_card_name_refs` ⇒ "~";
-    //                                        e.g. Taught by Surrak)
-    //
-    // The word-boundary `scan_contains` admits leading qualifiers (e.g.
-    // intervening-if prefixes) without anchoring the trigger to start-of-line.
-    let self_cast_phrases = [
-        "when you cast this spell",
-        "whenever you cast this spell",
-        "when ~ is cast",
-        "when you cast ~",
-        "whenever you cast ~",
-    ];
-    if self_cast_phrases
-        .iter()
-        .any(|phrase| scan_contains(lower, phrase))
+    // Composed as a 2×3 cross product: {when, whenever} × {you cast this
+    // spell, you cast ~, ~ is cast}. After `normalize_card_name_refs`
+    // (CR 201.5) the card name becomes `~`, so direct-name references like
+    // "When you cast Taught by Surrak" reach this combinator as "when you
+    // cast ~". `scan_at_word_boundaries` admits leading qualifiers without
+    // anchoring the trigger to start-of-line. Per CLAUDE.md "Compose nom
+    // combinators, don't enumerate permutations" this is a single composed
+    // combinator rather than 6 sibling `tag` arms.
+    if nom_primitives::scan_at_word_boundaries(lower, |i| {
+        preceded(
+            alt((
+                tag::<_, _, OracleError<'_>>("when "),
+                tag("whenever "),
+            )),
+            alt((
+                tag("you cast this spell"),
+                tag("you cast ~"),
+                tag("~ is cast"),
+            )),
+        )
+        .parse(i)
+    })
+    .is_some()
     {
         let mut def = make_base();
         def.mode = TriggerMode::SpellCast;
@@ -10257,6 +10260,17 @@ mod tests {
     #[test]
     fn trigger_whenever_you_cast_self_by_name() {
         let def = parse_trigger_line("Whenever you cast Test Card, draw a card.", "Test Card");
+        assert_eq!(def.mode, TriggerMode::SpellCast);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert!(def.trigger_zones.contains(&Zone::Stack));
+    }
+
+    /// CR 601.2i + CR 603.2: Passive "Whenever ~ is cast" phrasing — the third
+    /// cell of the {when, whenever} × {you cast this spell, you cast ~, ~ is
+    /// cast} cross-product. Exercises the composed `alt × alt` combinator path.
+    #[test]
+    fn trigger_whenever_self_is_cast() {
+        let def = parse_trigger_line("Whenever Test Card is cast, draw a card.", "Test Card");
         assert_eq!(def.mode, TriggerMode::SpellCast);
         assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
         assert!(def.trigger_zones.contains(&Zone::Stack));


### PR DESCRIPTION
## Summary
Adds engine support for **Taught by Surrak**.

## Files changed
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/parser/oracle.rs`

## CR references
- CR 113.6, CR 117.2a — cast triggers fire from the stack object
- CR 121.1 — "draw a card" resolution
- CR 201.5 — card-name self-reference normalization
- CR 303.4 — Aura subtype + attachment
- CR 601.2i — triggered abilities at cast time
- CR 603.1, CR 603.2 — trigger condition/event semantics
- CR 613.1f — layer 6 (ability-adding, keyword counters)
- CR 613.4c — layer 7c (P/T modifications)

## Track
Non-developer

## LLM
Model: claude-opus-4-7
Thinking: high

## Verification
Local verification skipped — see CI status checks.

## Scope Expansion
The playtest mechanic "Commander enchantment" (Unknown Event set, 2023+) is left as `Effect::Unimplemented` on the first ability line. Implementing it would require new infrastructure beyond a single card: a follows-zones Aura keyword, attachment-tracking across battlefield ↔ command zone ↔ graveyard ↔ exile transitions, a casting-time predicate allowing the Aura to target a commander in the command zone (CR 901 + CR 303.4a), and frontend UI for the playtest-only restriction. The other two abilities (self-cast `draw a card` trigger, and `+2/+2 / gains haste` static grant on the enchanted creature) parse and resolve via existing class-level patterns.

The parser change is class-level: `try_parse_player_trigger` previously recognized only `"when you cast this spell"` and `"when ~ is cast"`. It now recognizes the full `{when, whenever} × {you cast this spell, you cast ~, ~ is cast}` cross-product as a composed nom combinator (`scan_at_word_boundaries` + `preceded(alt, alt)`), per CLAUDE.md's "Compose nom combinators, don't enumerate permutations." This benefits every aura/permanent whose cast trigger references itself by name.

## Validation Failures
None.

## CI Failures
None.
