### PR TITLE
Partial: Abeyance

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1,7 +1,8 @@
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, ControllerRef, Effect, ModalChoice,
+    AbilityCondition, AbilityDefinition, ControllerRef, Effect, GameRestriction, ModalChoice,
     ModalSelectionCondition, ModalSelectionConstraint, QuantityExpr, QuantityRef, ResolvedAbility,
-    SpellContext, TargetChoiceTiming, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+    RestrictionPlayerScope, SpellContext, TargetChoiceTiming, TargetFilter, TargetRef, TypeFilter,
+    TypedFilter,
 };
 #[cfg(test)]
 use crate::types::counter::CounterType;
@@ -1113,11 +1114,22 @@ fn multi_target_slot_count(
         .min(legal_target_count)
 }
 
-/// CR 109.4 + CR 115.1: Returns true if any filter inside `effect` references
-/// `ControllerRef::TargetPlayer`. Used to surface a companion
-/// `TargetFilter::Player` target slot for mass-placement effects like
-/// `PutCounterAll { target: Typed { controller: TargetPlayer, .. } }`.
+/// CR 109.4 + CR 115.1: Returns true if `effect` needs a companion
+/// `TargetFilter::Player` target slot. This covers filters that reference
+/// `ControllerRef::TargetPlayer` and restriction effects whose affected player
+/// scope is the declared "target player".
 fn effect_references_target_player(effect: &Effect) -> bool {
+    if let Effect::AddRestriction {
+        restriction:
+            GameRestriction::ProhibitActivity {
+                affected_players: RestrictionPlayerScope::TargetedPlayer,
+                ..
+            },
+    } = effect
+    {
+        return true;
+    }
+
     if let Effect::Attach { attachment, target } = effect {
         return filter_references_target_player(attachment)
             || filter_references_target_player(target);
@@ -2841,8 +2853,9 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AbilityCost, AbilityKind, CounterTransferMode, Duration, Effect, FilterProp,
-        LibraryPosition, ModalChoice, ModalSelectionConstraint, MultiTargetSpec, PtValue,
-        QuantityExpr, QuantityRef, SearchSelectionConstraint, TargetFilter, TargetRef, TypeFilter,
+        GameRestriction, LibraryPosition, ModalChoice, ModalSelectionConstraint, MultiTargetSpec,
+        ProhibitedActivity, PtValue, QuantityExpr, QuantityRef, RestrictionExpiry,
+        RestrictionPlayerScope, SearchSelectionConstraint, TargetFilter, TargetRef, TypeFilter,
         TypedFilter, UnlessPayModifier,
     };
     use crate::types::card_type::CoreType;
@@ -3299,6 +3312,73 @@ mod tests {
             vec![p_b],
             "DamageAll should get target 1 (the second player slot)"
         );
+    }
+
+    #[test]
+    fn add_restriction_targeted_player_surfaces_one_slot_and_that_player_inherits_it() {
+        use crate::types::statics::ActivationExemption;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(0xABE),
+            PlayerId(0),
+            "Abeyance".to_string(),
+            Zone::Stack,
+        );
+
+        let root = ResolvedAbility::new(
+            Effect::AddRestriction {
+                restriction: GameRestriction::ProhibitActivity {
+                    source: ObjectId(0),
+                    affected_players: RestrictionPlayerScope::TargetedPlayer,
+                    expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::CastSpells { spell_filter: None },
+                },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        )
+        .sub_ability(ResolvedAbility::new(
+            Effect::AddRestriction {
+                restriction: GameRestriction::ProhibitActivity {
+                    source: ObjectId(0),
+                    affected_players: RestrictionPlayerScope::ParentTargetedPlayer,
+                    expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::ActivateAbilities {
+                        exemption: ActivationExemption::ManaAbilities,
+                    },
+                },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        ));
+
+        let slots = build_target_slots(&state, &root).expect("target slots should build");
+        assert_eq!(
+            slots.len(),
+            1,
+            "\"target player\" declares one target; the \"that player\" tail inherits it"
+        );
+
+        let mut resolved = root;
+        assign_targets_in_chain(&state, &mut resolved, &[TargetRef::Player(PlayerId(1))])
+            .expect("single selected player should assign to the root restriction");
+
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &resolved, &mut events, 0)
+            .expect("restriction chain should resolve");
+
+        assert_eq!(state.restrictions.len(), 2);
+        assert!(state.restrictions.iter().all(|restriction| matches!(
+            restriction,
+            GameRestriction::ProhibitActivity {
+                affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(1)),
+                ..
+            }
+        )));
     }
 
     #[test]

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -206,6 +206,10 @@ fn is_blocked_by_cast_only_from_zones(
                 let caster_affected = match affected_players {
                     RestrictionPlayerScope::AllPlayers => true,
                     RestrictionPlayerScope::SpecificPlayer(player) => *player == caster,
+                    RestrictionPlayerScope::TargetedPlayer => {
+                        debug_assert!(false, "TargetedPlayer should be resolved by add_restriction");
+                        false
+                    }
                     RestrictionPlayerScope::OpponentsOfSourceController => {
                         source_controller.is_some_and(|controller| controller != caster)
                     }
@@ -214,16 +218,22 @@ fn is_blocked_by_cast_only_from_zones(
             }
             GameRestriction::DamagePreventionDisabled { .. } => false,
             GameRestriction::CantCastSpells { .. } => false,
+            GameRestriction::CantActivateAbilities { .. } => false,
         })
 }
 
 /// CR 101.2: Check if a CantCastSpells restriction prevents the given player
 /// from casting any spells. E.g., Silence: "Your opponents can't cast spells this turn."
-fn is_blocked_by_cant_cast_spells(state: &GameState, caster: PlayerId) -> bool {
+fn is_blocked_by_cant_cast_spells(
+    state: &GameState,
+    caster: PlayerId,
+    spell_obj: Option<&super::game_object::GameObject>,
+) -> bool {
     state.restrictions.iter().any(|restriction| {
         let GameRestriction::CantCastSpells {
             source,
             affected_players,
+            spell_filter,
             ..
         } = restriction
         else {
@@ -233,11 +243,92 @@ fn is_blocked_by_cant_cast_spells(state: &GameState, caster: PlayerId) -> bool {
             .objects
             .get(source)
             .map(|source_obj| source_obj.controller);
-        match affected_players {
+        let caster_affected = match affected_players {
             RestrictionPlayerScope::AllPlayers => true,
             RestrictionPlayerScope::SpecificPlayer(player) => *player == caster,
+            RestrictionPlayerScope::TargetedPlayer => {
+                debug_assert!(
+                    false,
+                    "TargetedPlayer should be resolved by add_restriction"
+                );
+                false
+            }
             RestrictionPlayerScope::OpponentsOfSourceController => {
                 source_controller.is_some_and(|controller| controller != caster)
+            }
+        };
+        caster_affected && {
+            if let Some(filter) = spell_filter {
+                let Some(spell_obj) = spell_obj else {
+                    return false;
+                };
+                let spell_record = SpellCastRecord {
+                    name: spell_obj.name.clone(),
+                    core_types: spell_obj.card_types.core_types.clone(),
+                    supertypes: spell_obj.card_types.supertypes.clone(),
+                    subtypes: spell_obj.card_types.subtypes.clone(),
+                    keywords: spell_obj.keywords.clone(),
+                    colors: spell_obj.color.clone(),
+                    mana_value: spell_obj.mana_cost.mana_value(),
+                    has_x_in_cost: super::casting_costs::cost_has_x(&spell_obj.mana_cost),
+                    from_zone: spell_obj.zone,
+                    cast_variant: crate::types::game_state::CastingVariant::Normal,
+                };
+                super::filter::spell_record_matches_filter(
+                    &spell_record,
+                    filter,
+                    source_controller.unwrap_or(caster),
+                    &state.all_creature_types,
+                )
+            } else {
+                true
+            }
+        }
+    })
+}
+
+/// CR 602.5 + CR 605.1a: Temporary game restrictions can prohibit activating
+/// abilities, optionally exempting mana abilities via the single classifier.
+fn is_blocked_by_cant_activate_abilities(
+    state: &GameState,
+    caster: PlayerId,
+    activating_ability: &AbilityDefinition,
+) -> bool {
+    state.restrictions.iter().any(|restriction| {
+        let GameRestriction::CantActivateAbilities {
+            source,
+            affected_players,
+            exemption,
+            ..
+        } = restriction
+        else {
+            return false;
+        };
+        let source_controller = state
+            .objects
+            .get(source)
+            .map(|source_obj| source_obj.controller);
+        let caster_affected = match affected_players {
+            RestrictionPlayerScope::AllPlayers => true,
+            RestrictionPlayerScope::SpecificPlayer(player) => *player == caster,
+            RestrictionPlayerScope::TargetedPlayer => {
+                debug_assert!(
+                    false,
+                    "TargetedPlayer should be resolved by add_restriction"
+                );
+                false
+            }
+            RestrictionPlayerScope::OpponentsOfSourceController => {
+                source_controller.is_some_and(|controller| controller != caster)
+            }
+        };
+        if !caster_affected {
+            return false;
+        }
+        match exemption {
+            ActivationExemption::None => true,
+            ActivationExemption::ManaAbilities => {
+                !super::mana_abilities::is_mana_ability(activating_ability)
             }
         }
     })
@@ -331,18 +422,13 @@ pub fn spell_objects_available_to_cast(state: &GameState, player: PlayerId) -> V
         }
     }
 
-    // CR 101.2: If a CantCastSpells restriction blocks this player, no spells are available.
-    if is_blocked_by_cant_cast_spells(state, player) {
-        return vec![];
-    }
-
     objects
         .into_iter()
         .filter(|obj_id| {
-            state
-                .objects
-                .get(obj_id)
-                .is_some_and(|obj| !is_blocked_by_cast_only_from_zones(state, obj, player))
+            state.objects.get(obj_id).is_some_and(|obj| {
+                !is_blocked_by_cast_only_from_zones(state, obj, player)
+                    && !is_blocked_by_cant_cast_spells(state, player, Some(obj))
+            })
         })
         .collect()
 }
@@ -1659,7 +1745,7 @@ fn prepare_spell_cast_with_variant_override_inner(
 
     // CR 101.2: Temporary blanket prohibition — "can't cast spells this turn."
     // E.g., Silence: "Your opponents can't cast spells this turn."
-    if mode == CastingMode::Actual && is_blocked_by_cant_cast_spells(state, player) {
+    if mode == CastingMode::Actual && is_blocked_by_cant_cast_spells(state, player, Some(obj)) {
         return Err(EngineError::ActionNotAllowed(
             "A temporary effect prevents you from casting spells this turn".to_string(),
         ));
@@ -6662,6 +6748,9 @@ pub fn can_activate_ability_now(
     if is_blocked_by_cant_be_activated(state, player, source_id, &ability_def) {
         return false;
     }
+    if is_blocked_by_cant_activate_abilities(state, player, &ability_def) {
+        return false;
+    }
     if restrictions::check_activation_restrictions(
         state,
         player,
@@ -6780,6 +6869,11 @@ pub fn handle_activate_ability(
     if is_blocked_by_cant_be_activated(state, player, source_id, &ability_def) {
         return Err(EngineError::ActionNotAllowed(
             "Activated abilities of this permanent can't be activated (CR 602.5)".to_string(),
+        ));
+    }
+    if is_blocked_by_cant_activate_abilities(state, player, &ability_def) {
+        return Err(EngineError::ActionNotAllowed(
+            "A temporary effect prevents activating this ability".to_string(),
         ));
     }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -200,6 +200,13 @@ fn restriction_scope_matches_player(
             );
             false
         }
+        RestrictionPlayerScope::ParentTargetedPlayer => {
+            debug_assert!(
+                false,
+                "ParentTargetedPlayer should be resolved by add_restriction"
+            );
+            false
+        }
         RestrictionPlayerScope::OpponentsOfSourceController => {
             source_controller.is_some_and(|controller| controller != caster)
         }
@@ -7776,9 +7783,10 @@ mod tests {
         CastVariantPaid, CastingPermission, ChosenAttribute, ChosenSubtypeKind, Comparator,
         ContinuousModification, ControllerRef, CostCategory, FilterProp, GainLifePlayer,
         GameRestriction, KickerVariant, ManaContribution, ManaProduction, ManaSpendPermission,
-        ManaSpendRestriction, ModalSelectionCondition, ModalSelectionConstraint, QuantityExpr,
-        RestrictionExpiry, RestrictionPlayerScope, SearchSelectionConstraint, StaticCondition,
-        StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
+        ManaSpendRestriction, ModalSelectionCondition, ModalSelectionConstraint,
+        ProhibitedActivity, QuantityExpr, RestrictionExpiry, RestrictionPlayerScope,
+        SearchSelectionConstraint, StaticCondition, StaticDefinition, TargetFilter, TypeFilter,
+        TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::{CoreType, Supertype};
@@ -8643,6 +8651,93 @@ mod tests {
             };
         }
         obj_id
+    }
+
+    #[test]
+    fn prohibit_activity_cast_spells_filter_blocks_only_matching_spell_types() {
+        // CR 101.2 + CR 601.2a: Abeyance-style restrictions can prohibit only
+        // the matching spell class while leaving other spell types castable.
+        let mut state = setup_game_at_main_phase();
+        let source = create_object(
+            &mut state,
+            CardId(0xA8E1),
+            PlayerId(1),
+            "Abeyance Source".to_string(),
+            Zone::Exile,
+        );
+        state.restrictions.push(GameRestriction::ProhibitActivity {
+            source,
+            affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(0)),
+            expiry: RestrictionExpiry::EndOfTurn,
+            activity: ProhibitedActivity::CastSpells {
+                spell_filter: Some(TargetFilter::Or {
+                    filters: vec![
+                        TargetFilter::Typed(TypedFilter::new(TypeFilter::Instant)),
+                        TargetFilter::Typed(TypedFilter::new(TypeFilter::Sorcery)),
+                    ],
+                }),
+            },
+        });
+
+        let instant = create_instant_in_hand(&mut state, PlayerId(0));
+        let sorcery = create_sorcery_in_hand(&mut state, PlayerId(0));
+        let creature = create_creature_spell_in_hand(&mut state, PlayerId(0));
+        add_mana(&mut state, PlayerId(0), ManaType::Red, 8);
+        add_mana(&mut state, PlayerId(0), ManaType::Blue, 8);
+
+        assert!(!can_cast_object_now(&state, PlayerId(0), instant));
+        assert!(!can_cast_object_now(&state, PlayerId(0), sorcery));
+        assert!(can_cast_object_now(&state, PlayerId(0), creature));
+    }
+
+    #[test]
+    fn prohibit_activity_activate_abilities_blocks_non_mana_but_exempts_mana() {
+        // CR 602.5 + CR 605.1a: Abeyance prohibits non-mana activated abilities
+        // while leaving mana abilities available.
+        let mut state = setup_game_at_main_phase();
+        let source = create_object(
+            &mut state,
+            CardId(0xA8E2),
+            PlayerId(1),
+            "Abeyance Source".to_string(),
+            Zone::Exile,
+        );
+        state.restrictions.push(GameRestriction::ProhibitActivity {
+            source,
+            affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(0)),
+            expiry: RestrictionExpiry::EndOfTurn,
+            activity: ProhibitedActivity::ActivateAbilities {
+                exemption: ActivationExemption::ManaAbilities,
+            },
+        });
+
+        let non_mana_source = add_artifact_with_activated_ability(&mut state, PlayerId(0));
+        let mana_source = create_object(
+            &mut state,
+            CardId(0xA8E3),
+            PlayerId(0),
+            "Mana Rock".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&mana_source).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.entered_battlefield_turn = Some(0);
+            Arc::make_mut(&mut obj.abilities).push(make_tap_for_green_mana_ability());
+        }
+
+        assert!(!can_activate_ability_now(
+            &state,
+            PlayerId(0),
+            non_mana_source,
+            0
+        ));
+        assert!(can_activate_ability_now(
+            &state,
+            PlayerId(0),
+            mana_source,
+            0
+        ));
     }
 
     fn create_gloomlake_verge(state: &mut GameState, player: PlayerId) -> ObjectId {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1,7 +1,7 @@
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AdditionalCost, CardPlayMode,
     CastTimingPermission, CastingPermission, ChoiceType, ContinuousModification, Duration, Effect,
-    GameRestriction, ModalSelectionCondition, QuantityExpr, ResolvedAbility,
+    GameRestriction, ModalSelectionCondition, ProhibitedActivity, QuantityExpr, ResolvedAbility,
     RestrictionPlayerScope, StaticDefinition, TargetFilter, TargetRef,
 };
 use crate::types::card::LayoutKind;
@@ -184,6 +184,44 @@ fn append_to_ability_def_sub_chain(ability: &mut AbilityDefinition, next: Abilit
 
 /// CR 101.2 + CR 601.2a: Temporary restrictions can limit which zones affected
 /// players may cast spells from.
+fn restriction_scope_matches_player(
+    source_controller: Option<PlayerId>,
+    affected_players: &RestrictionPlayerScope,
+    caster: PlayerId,
+) -> bool {
+    // CR 101.2: Restriction scope defines who is affected by the prohibition.
+    match affected_players {
+        RestrictionPlayerScope::AllPlayers => true,
+        RestrictionPlayerScope::SpecificPlayer(player) => *player == caster,
+        RestrictionPlayerScope::TargetedPlayer => {
+            debug_assert!(
+                false,
+                "TargetedPlayer should be resolved by add_restriction"
+            );
+            false
+        }
+        RestrictionPlayerScope::OpponentsOfSourceController => {
+            source_controller.is_some_and(|controller| controller != caster)
+        }
+    }
+}
+
+/// CR 601.2a: Build the spell-record projection used by prohibition filters.
+fn spell_record_for_restrictions(spell_obj: &super::game_object::GameObject) -> SpellCastRecord {
+    SpellCastRecord {
+        name: spell_obj.name.clone(),
+        core_types: spell_obj.card_types.core_types.clone(),
+        supertypes: spell_obj.card_types.supertypes.clone(),
+        subtypes: spell_obj.card_types.subtypes.clone(),
+        keywords: spell_obj.keywords.clone(),
+        colors: spell_obj.color.clone(),
+        mana_value: spell_obj.mana_cost.mana_value(),
+        has_x_in_cost: super::casting_costs::cost_has_x(&spell_obj.mana_cost),
+        from_zone: spell_obj.zone,
+        cast_variant: crate::types::game_state::CastingVariant::Normal,
+    }
+}
+
 fn is_blocked_by_cast_only_from_zones(
     state: &GameState,
     obj: &crate::game::game_object::GameObject,
@@ -193,32 +231,21 @@ fn is_blocked_by_cast_only_from_zones(
         .restrictions
         .iter()
         .any(|restriction| match restriction {
-            GameRestriction::CastOnlyFromZones {
+            GameRestriction::ProhibitActivity {
                 source,
                 affected_players,
-                allowed_zones,
+                activity: ProhibitedActivity::CastOnlyFromZones { allowed_zones },
                 ..
             } => {
                 let source_controller = state
                     .objects
                     .get(source)
                     .map(|source_obj| source_obj.controller);
-                let caster_affected = match affected_players {
-                    RestrictionPlayerScope::AllPlayers => true,
-                    RestrictionPlayerScope::SpecificPlayer(player) => *player == caster,
-                    RestrictionPlayerScope::TargetedPlayer => {
-                        debug_assert!(false, "TargetedPlayer should be resolved by add_restriction");
-                        false
-                    }
-                    RestrictionPlayerScope::OpponentsOfSourceController => {
-                        source_controller.is_some_and(|controller| controller != caster)
-                    }
-                };
+                let caster_affected =
+                    restriction_scope_matches_player(source_controller, affected_players, caster);
                 caster_affected && !allowed_zones.contains(&obj.zone)
             }
-            GameRestriction::DamagePreventionDisabled { .. } => false,
-            GameRestriction::CantCastSpells { .. } => false,
-            GameRestriction::CantActivateAbilities { .. } => false,
+            _ => false,
         })
 }
 
@@ -229,11 +256,13 @@ fn is_blocked_by_cant_cast_spells(
     caster: PlayerId,
     spell_obj: Option<&super::game_object::GameObject>,
 ) -> bool {
+    let spell_record = spell_obj.map(spell_record_for_restrictions);
+
     state.restrictions.iter().any(|restriction| {
-        let GameRestriction::CantCastSpells {
+        let GameRestriction::ProhibitActivity {
             source,
             affected_players,
-            spell_filter,
+            activity: ProhibitedActivity::CastSpells { spell_filter },
             ..
         } = restriction
         else {
@@ -243,47 +272,22 @@ fn is_blocked_by_cant_cast_spells(
             .objects
             .get(source)
             .map(|source_obj| source_obj.controller);
-        let caster_affected = match affected_players {
-            RestrictionPlayerScope::AllPlayers => true,
-            RestrictionPlayerScope::SpecificPlayer(player) => *player == caster,
-            RestrictionPlayerScope::TargetedPlayer => {
-                debug_assert!(
-                    false,
-                    "TargetedPlayer should be resolved by add_restriction"
-                );
-                false
+        let caster_affected =
+            restriction_scope_matches_player(source_controller, affected_players, caster);
+
+        // CR 101.2: Once scope matches, filter-matching spells are prohibited.
+        caster_affected
+            && match spell_filter {
+                Some(filter) => spell_record.as_ref().is_some_and(|record| {
+                    super::filter::spell_record_matches_filter(
+                        record,
+                        filter,
+                        source_controller.unwrap_or(caster),
+                        &state.all_creature_types,
+                    )
+                }),
+                None => true,
             }
-            RestrictionPlayerScope::OpponentsOfSourceController => {
-                source_controller.is_some_and(|controller| controller != caster)
-            }
-        };
-        caster_affected && {
-            if let Some(filter) = spell_filter {
-                let Some(spell_obj) = spell_obj else {
-                    return false;
-                };
-                let spell_record = SpellCastRecord {
-                    name: spell_obj.name.clone(),
-                    core_types: spell_obj.card_types.core_types.clone(),
-                    supertypes: spell_obj.card_types.supertypes.clone(),
-                    subtypes: spell_obj.card_types.subtypes.clone(),
-                    keywords: spell_obj.keywords.clone(),
-                    colors: spell_obj.color.clone(),
-                    mana_value: spell_obj.mana_cost.mana_value(),
-                    has_x_in_cost: super::casting_costs::cost_has_x(&spell_obj.mana_cost),
-                    from_zone: spell_obj.zone,
-                    cast_variant: crate::types::game_state::CastingVariant::Normal,
-                };
-                super::filter::spell_record_matches_filter(
-                    &spell_record,
-                    filter,
-                    source_controller.unwrap_or(caster),
-                    &state.all_creature_types,
-                )
-            } else {
-                true
-            }
-        }
     })
 }
 
@@ -295,10 +299,10 @@ fn is_blocked_by_cant_activate_abilities(
     activating_ability: &AbilityDefinition,
 ) -> bool {
     state.restrictions.iter().any(|restriction| {
-        let GameRestriction::CantActivateAbilities {
+        let GameRestriction::ProhibitActivity {
             source,
             affected_players,
-            exemption,
+            activity: ProhibitedActivity::ActivateAbilities { exemption },
             ..
         } = restriction
         else {
@@ -308,26 +312,15 @@ fn is_blocked_by_cant_activate_abilities(
             .objects
             .get(source)
             .map(|source_obj| source_obj.controller);
-        let caster_affected = match affected_players {
-            RestrictionPlayerScope::AllPlayers => true,
-            RestrictionPlayerScope::SpecificPlayer(player) => *player == caster,
-            RestrictionPlayerScope::TargetedPlayer => {
-                debug_assert!(
-                    false,
-                    "TargetedPlayer should be resolved by add_restriction"
-                );
-                false
-            }
-            RestrictionPlayerScope::OpponentsOfSourceController => {
-                source_controller.is_some_and(|controller| controller != caster)
-            }
-        };
+        let caster_affected =
+            restriction_scope_matches_player(source_controller, affected_players, caster);
         if !caster_affected {
             return false;
         }
         match exemption {
             ActivationExemption::None => true,
             ActivationExemption::ManaAbilities => {
+                // CR 605.1a: Mana abilities are exempt from this prohibition.
                 !super::mana_abilities::is_mana_ability(activating_ability)
             }
         }
@@ -16187,11 +16180,13 @@ mod tests {
             "Restriction Source".to_string(),
             Zone::Exile,
         );
-        state.restrictions.push(GameRestriction::CastOnlyFromZones {
+        state.restrictions.push(GameRestriction::ProhibitActivity {
             source,
             affected_players,
-            allowed_zones: vec![Zone::Hand],
             expiry: RestrictionExpiry::UntilPlayerNextTurn { player: controller },
+            activity: ProhibitedActivity::CastOnlyFromZones {
+                allowed_zones: vec![Zone::Hand],
+            },
         });
         source
     }

--- a/crates/engine/src/game/effects/add_restriction.rs
+++ b/crates/engine/src/game/effects/add_restriction.rs
@@ -32,14 +32,40 @@ fn fill_runtime_fields(restriction: &mut GameRestriction, ability: &ResolvedAbil
     match restriction {
         GameRestriction::DamagePreventionDisabled { source, .. }
         | GameRestriction::CastOnlyFromZones { source, .. }
-        | GameRestriction::CantCastSpells { source, .. } => {
+        | GameRestriction::CantCastSpells { source, .. }
+        | GameRestriction::CantActivateAbilities { source, .. } => {
             *source = ability.source_id;
         }
     }
 
+    let resolved_target_player = ability.target_player();
+
+    match restriction {
+        GameRestriction::CastOnlyFromZones {
+            affected_players, ..
+        }
+        | GameRestriction::CantCastSpells {
+            affected_players, ..
+        }
+        | GameRestriction::CantActivateAbilities {
+            affected_players, ..
+        } => {
+            if matches!(
+                affected_players,
+                crate::types::ability::RestrictionPlayerScope::TargetedPlayer
+            ) {
+                *affected_players = crate::types::ability::RestrictionPlayerScope::SpecificPlayer(
+                    resolved_target_player,
+                );
+            }
+        }
+        GameRestriction::DamagePreventionDisabled { .. } => {}
+    }
+
     match restriction {
         GameRestriction::CastOnlyFromZones { expiry, .. }
-        | GameRestriction::CantCastSpells { expiry, .. } => {
+        | GameRestriction::CantCastSpells { expiry, .. }
+        | GameRestriction::CantActivateAbilities { expiry, .. } => {
             if let Some(crate::types::ability::Duration::UntilNextTurnOf {
                 player: crate::types::ability::PlayerScope::Controller,
             }) = ability.duration.as_ref()
@@ -57,7 +83,7 @@ fn fill_runtime_fields(restriction: &mut GameRestriction, ability: &ResolvedAbil
 mod tests {
     use super::*;
     use crate::types::ability::{
-        Duration, GameRestriction, RestrictionExpiry, RestrictionPlayerScope,
+        Duration, GameRestriction, RestrictionExpiry, RestrictionPlayerScope, TargetRef,
     };
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
@@ -137,6 +163,37 @@ mod tests {
                 allowed_zones,
                 expiry: RestrictionExpiry::UntilPlayerNextTurn { player: PlayerId(1) },
             } if allowed_zones == &vec![Zone::Hand]
+        ));
+    }
+
+    #[test]
+    fn targeted_player_scope_is_resolved_on_restrictions() {
+        let mut state = GameState::new_two_player(42);
+
+        let ability = ResolvedAbility::new(
+            Effect::AddRestriction {
+                restriction: GameRestriction::CantActivateAbilities {
+                    source: ObjectId(0),
+                    affected_players: RestrictionPlayerScope::TargetedPlayer,
+                    exemption: crate::types::statics::ActivationExemption::ManaAbilities,
+                    expiry: RestrictionExpiry::EndOfTurn,
+                },
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            ObjectId(7),
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(matches!(
+            &state.restrictions[0],
+            GameRestriction::CantActivateAbilities {
+                source: ObjectId(7),
+                affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(1)),
+                ..
+            }
         ));
     }
 }

--- a/crates/engine/src/game/effects/add_restriction.rs
+++ b/crates/engine/src/game/effects/add_restriction.rs
@@ -31,9 +31,7 @@ pub fn resolve(
 fn fill_runtime_fields(restriction: &mut GameRestriction, ability: &ResolvedAbility) {
     match restriction {
         GameRestriction::DamagePreventionDisabled { source, .. }
-        | GameRestriction::CastOnlyFromZones { source, .. }
-        | GameRestriction::CantCastSpells { source, .. }
-        | GameRestriction::CantActivateAbilities { source, .. } => {
+        | GameRestriction::ProhibitActivity { source, .. } => {
             *source = ability.source_id;
         }
     }
@@ -41,13 +39,7 @@ fn fill_runtime_fields(restriction: &mut GameRestriction, ability: &ResolvedAbil
     let resolved_target_player = ability.target_player();
 
     match restriction {
-        GameRestriction::CastOnlyFromZones {
-            affected_players, ..
-        }
-        | GameRestriction::CantCastSpells {
-            affected_players, ..
-        }
-        | GameRestriction::CantActivateAbilities {
+        GameRestriction::ProhibitActivity {
             affected_players, ..
         } => {
             if matches!(
@@ -63,9 +55,7 @@ fn fill_runtime_fields(restriction: &mut GameRestriction, ability: &ResolvedAbil
     }
 
     match restriction {
-        GameRestriction::CastOnlyFromZones { expiry, .. }
-        | GameRestriction::CantCastSpells { expiry, .. }
-        | GameRestriction::CantActivateAbilities { expiry, .. } => {
+        GameRestriction::ProhibitActivity { expiry, .. } => {
             if let Some(crate::types::ability::Duration::UntilNextTurnOf {
                 player: crate::types::ability::PlayerScope::Controller,
             }) = ability.duration.as_ref()
@@ -83,7 +73,8 @@ fn fill_runtime_fields(restriction: &mut GameRestriction, ability: &ResolvedAbil
 mod tests {
     use super::*;
     use crate::types::ability::{
-        Duration, GameRestriction, RestrictionExpiry, RestrictionPlayerScope, TargetRef,
+        Duration, GameRestriction, ProhibitedActivity, RestrictionExpiry, RestrictionPlayerScope,
+        TargetRef,
     };
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
@@ -137,11 +128,13 @@ mod tests {
 
         let ability = ResolvedAbility::new(
             Effect::AddRestriction {
-                restriction: GameRestriction::CastOnlyFromZones {
+                restriction: GameRestriction::ProhibitActivity {
                     source: ObjectId(0),
                     affected_players: RestrictionPlayerScope::OpponentsOfSourceController,
-                    allowed_zones: vec![Zone::Hand],
                     expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::CastOnlyFromZones {
+                        allowed_zones: vec![Zone::Hand],
+                    },
                 },
             },
             vec![],
@@ -157,11 +150,11 @@ mod tests {
 
         assert!(matches!(
             &state.restrictions[0],
-            GameRestriction::CastOnlyFromZones {
+            GameRestriction::ProhibitActivity {
                 source: ObjectId(9),
                 affected_players: RestrictionPlayerScope::OpponentsOfSourceController,
-                allowed_zones,
                 expiry: RestrictionExpiry::UntilPlayerNextTurn { player: PlayerId(1) },
+                activity: ProhibitedActivity::CastOnlyFromZones { allowed_zones },
             } if allowed_zones == &vec![Zone::Hand]
         ));
     }
@@ -172,11 +165,13 @@ mod tests {
 
         let ability = ResolvedAbility::new(
             Effect::AddRestriction {
-                restriction: GameRestriction::CantActivateAbilities {
+                restriction: GameRestriction::ProhibitActivity {
                     source: ObjectId(0),
                     affected_players: RestrictionPlayerScope::TargetedPlayer,
-                    exemption: crate::types::statics::ActivationExemption::ManaAbilities,
                     expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::ActivateAbilities {
+                        exemption: crate::types::statics::ActivationExemption::ManaAbilities,
+                    },
                 },
             },
             vec![TargetRef::Player(PlayerId(1))],
@@ -189,9 +184,10 @@ mod tests {
 
         assert!(matches!(
             &state.restrictions[0],
-            GameRestriction::CantActivateAbilities {
+            GameRestriction::ProhibitActivity {
                 source: ObjectId(7),
                 affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(1)),
+                activity: ProhibitedActivity::ActivateAbilities { .. },
                 ..
             }
         ));

--- a/crates/engine/src/game/effects/add_restriction.rs
+++ b/crates/engine/src/game/effects/add_restriction.rs
@@ -45,6 +45,7 @@ fn fill_runtime_fields(restriction: &mut GameRestriction, ability: &ResolvedAbil
             if matches!(
                 affected_players,
                 crate::types::ability::RestrictionPlayerScope::TargetedPlayer
+                    | crate::types::ability::RestrictionPlayerScope::ParentTargetedPlayer
             ) {
                 *affected_players = crate::types::ability::RestrictionPlayerScope::SpecificPlayer(
                     resolved_target_player,
@@ -168,6 +169,40 @@ mod tests {
                 restriction: GameRestriction::ProhibitActivity {
                     source: ObjectId(0),
                     affected_players: RestrictionPlayerScope::TargetedPlayer,
+                    expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::ActivateAbilities {
+                        exemption: crate::types::statics::ActivationExemption::ManaAbilities,
+                    },
+                },
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            ObjectId(7),
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(matches!(
+            &state.restrictions[0],
+            GameRestriction::ProhibitActivity {
+                source: ObjectId(7),
+                affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(1)),
+                activity: ProhibitedActivity::ActivateAbilities { .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parent_targeted_player_scope_is_resolved_from_inherited_target() {
+        let mut state = GameState::new_two_player(42);
+
+        let ability = ResolvedAbility::new(
+            Effect::AddRestriction {
+                restriction: GameRestriction::ProhibitActivity {
+                    source: ObjectId(0),
+                    affected_players: RestrictionPlayerScope::ParentTargetedPlayer,
                     expiry: RestrictionExpiry::EndOfTurn,
                     activity: ProhibitedActivity::ActivateAbilities {
                         exemption: crate::types::statics::ActivationExemption::ManaAbilities,

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1997,6 +1997,7 @@ fn is_prevention_disabled(state: &GameState, proposed: &ProposedEvent) -> bool {
         },
         GameRestriction::CastOnlyFromZones { .. } => false,
         GameRestriction::CantCastSpells { .. } => false,
+        GameRestriction::CantActivateAbilities { .. } => false,
     })
 }
 

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1995,9 +1995,7 @@ fn is_prevention_disabled(state: &GameState, proposed: &ProposedEvent) -> bool {
                 )
             }
         },
-        GameRestriction::CastOnlyFromZones { .. } => false,
-        GameRestriction::CantCastSpells { .. } => false,
-        GameRestriction::CantActivateAbilities { .. } => false,
+        GameRestriction::ProhibitActivity { .. } => false,
     })
 }
 

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -582,9 +582,7 @@ pub fn execute_untap_with_choices(
         use crate::types::ability::GameRestriction;
 
         match restriction {
-            GameRestriction::CastOnlyFromZones { expiry, .. }
-            | GameRestriction::CantCastSpells { expiry, .. }
-            | GameRestriction::CantActivateAbilities { expiry, .. } => {
+            GameRestriction::ProhibitActivity { expiry, .. } => {
                 !matches!(expiry, RestrictionExpiry::UntilPlayerNextTurn { player } if *player == active)
             }
             GameRestriction::DamagePreventionDisabled { .. } => true,
@@ -945,9 +943,7 @@ pub fn execute_cleanup(state: &mut GameState, events: &mut Vec<GameEvent>) -> Op
         use crate::types::ability::{GameRestriction, RestrictionExpiry};
         match r {
             GameRestriction::DamagePreventionDisabled { expiry, .. }
-            | GameRestriction::CastOnlyFromZones { expiry, .. }
-            | GameRestriction::CantCastSpells { expiry, .. }
-            | GameRestriction::CantActivateAbilities { expiry, .. } => {
+            | GameRestriction::ProhibitActivity { expiry, .. } => {
                 !matches!(expiry, RestrictionExpiry::EndOfTurn)
             }
         }
@@ -3791,7 +3787,9 @@ mod tests {
 
     #[test]
     fn execute_untap_prunes_until_player_next_turn_restrictions() {
-        use crate::types::ability::{GameRestriction, RestrictionExpiry, RestrictionPlayerScope};
+        use crate::types::ability::{
+            GameRestriction, ProhibitedActivity, RestrictionExpiry, RestrictionPlayerScope,
+        };
         use crate::types::identifiers::{CardId, ObjectId};
 
         let mut state = GameState::new_two_player(42);
@@ -3803,12 +3801,14 @@ mod tests {
             "Avatar's Wrath".to_string(),
             Zone::Exile,
         );
-        state.restrictions.push(GameRestriction::CastOnlyFromZones {
+        state.restrictions.push(GameRestriction::ProhibitActivity {
             source,
             affected_players: RestrictionPlayerScope::OpponentsOfSourceController,
-            allowed_zones: vec![Zone::Hand],
             expiry: RestrictionExpiry::UntilPlayerNextTurn {
                 player: PlayerId(1),
+            },
+            activity: ProhibitedActivity::CastOnlyFromZones {
+                allowed_zones: vec![Zone::Hand],
             },
         });
         state

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -583,7 +583,8 @@ pub fn execute_untap_with_choices(
 
         match restriction {
             GameRestriction::CastOnlyFromZones { expiry, .. }
-            | GameRestriction::CantCastSpells { expiry, .. } => {
+            | GameRestriction::CantCastSpells { expiry, .. }
+            | GameRestriction::CantActivateAbilities { expiry, .. } => {
                 !matches!(expiry, RestrictionExpiry::UntilPlayerNextTurn { player } if *player == active)
             }
             GameRestriction::DamagePreventionDisabled { .. } => true,
@@ -945,7 +946,8 @@ pub fn execute_cleanup(state: &mut GameState, events: &mut Vec<GameEvent>) -> Op
         match r {
             GameRestriction::DamagePreventionDisabled { expiry, .. }
             | GameRestriction::CastOnlyFromZones { expiry, .. }
-            | GameRestriction::CantCastSpells { expiry, .. } => {
+            | GameRestriction::CantCastSpells { expiry, .. }
+            | GameRestriction::CantActivateAbilities { expiry, .. } => {
                 !matches!(expiry, RestrictionExpiry::EndOfTurn)
             }
         }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -10438,7 +10438,10 @@ mod tests {
         assert!(matches!(
             *r.abilities[1].effect,
             Effect::AddRestriction {
-                restriction: crate::types::ability::GameRestriction::CastOnlyFromZones { .. }
+                restriction: crate::types::ability::GameRestriction::ProhibitActivity {
+                    activity: crate::types::ability::ProhibitedActivity::CastOnlyFromZones { .. },
+                    ..
+                }
             }
         ));
         assert_eq!(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -48,10 +48,10 @@ use crate::types::ability::{
     DamageModification, DamageSource, DelayedTriggerCondition, Duration, Effect, FilterProp,
     GainLifePlayer, GameRestriction, ManaProduction, ManaSpendPermission, MultiTargetSpec,
     ObjectProperty, ObjectScope, PaymentCost, PlayerFilter, PlayerScope, PreventionAmount,
-    PreventionScope, PtValue, QuantityExpr, QuantityRef, ReplacementDefinition, RestrictionExpiry,
-    RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition, SubAbilityLink,
-    TargetChoiceTiming, TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition,
-    TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition,
+    PreventionScope, ProhibitedActivity, PtValue, QuantityExpr, QuantityRef, ReplacementDefinition,
+    RestrictionExpiry, RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition,
+    SubAbilityLink, TargetChoiceTiming, TargetFilter, TargetSelectionMode, TriggerCondition,
+    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterType;
@@ -1480,11 +1480,13 @@ fn try_parse_cast_only_from_zones_restriction(tp: TextPair<'_>) -> Option<Parsed
 
     Some(ParsedEffectClause {
         effect: Effect::AddRestriction {
-            restriction: GameRestriction::CastOnlyFromZones {
+            restriction: GameRestriction::ProhibitActivity {
                 source: ObjectId(0),
                 affected_players,
-                allowed_zones: vec![Zone::Hand],
                 expiry,
+                activity: ProhibitedActivity::CastOnlyFromZones {
+                    allowed_zones: vec![Zone::Hand],
+                },
             },
         },
         duration,
@@ -1594,11 +1596,11 @@ fn try_parse_cant_cast_spells_effect(tp: TextPair<'_>) -> Option<ParsedEffectCla
 
     Some(ParsedEffectClause {
         effect: Effect::AddRestriction {
-            restriction: GameRestriction::CantCastSpells {
+            restriction: GameRestriction::ProhibitActivity {
                 source: ObjectId(0),
                 affected_players,
-                spell_filter,
                 expiry,
+                activity: ProhibitedActivity::CastSpells { spell_filter },
             },
         },
         duration,
@@ -1666,11 +1668,13 @@ fn try_parse_cant_activate_non_mana_abilities_effect(
 
     Some(ParsedEffectClause {
         effect: Effect::AddRestriction {
-            restriction: GameRestriction::CantActivateAbilities {
+            restriction: GameRestriction::ProhibitActivity {
                 source: ObjectId(0),
                 affected_players,
-                exemption: ActivationExemption::ManaAbilities,
                 expiry: RestrictionExpiry::EndOfTurn,
+                activity: ProhibitedActivity::ActivateAbilities {
+                    exemption: ActivationExemption::ManaAbilities,
+                },
             },
         },
         duration: None,
@@ -27875,8 +27879,8 @@ mod tests {
         assert!(matches!(
             *def.effect,
             Effect::AddRestriction {
-                restriction: GameRestriction::CastOnlyFromZones {
-                    allowed_zones,
+                restriction: GameRestriction::ProhibitActivity {
+                    activity: ProhibitedActivity::CastOnlyFromZones { allowed_zones },
                     ..
                 }
             } if allowed_zones == vec![Zone::Hand]
@@ -27899,10 +27903,10 @@ mod tests {
         assert!(matches!(
             *def.effect,
             Effect::AddRestriction {
-                restriction: GameRestriction::CantCastSpells {
+                restriction: GameRestriction::ProhibitActivity {
                     affected_players: RestrictionPlayerScope::OpponentsOfSourceController,
-                    spell_filter: None,
                     expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::CastSpells { spell_filter: None },
                     ..
                 }
             }
@@ -27916,10 +27920,10 @@ mod tests {
         assert!(matches!(
             *def.effect,
             Effect::AddRestriction {
-                restriction: GameRestriction::CantCastSpells {
+                restriction: GameRestriction::ProhibitActivity {
                     affected_players: RestrictionPlayerScope::AllPlayers,
-                    spell_filter: None,
                     expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::CastSpells { spell_filter: None },
                     ..
                 }
             }
@@ -27936,9 +27940,11 @@ mod tests {
         assert!(matches!(
             *def.effect,
             Effect::AddRestriction {
-                restriction: GameRestriction::CantCastSpells {
+                restriction: GameRestriction::ProhibitActivity {
                     affected_players: RestrictionPlayerScope::TargetedPlayer,
-                    spell_filter: Some(_),
+                    activity: ProhibitedActivity::CastSpells {
+                        spell_filter: Some(_)
+                    },
                     ..
                 }
             }
@@ -27948,9 +27954,11 @@ mod tests {
         assert!(matches!(
             *sub.effect,
             Effect::AddRestriction {
-                restriction: GameRestriction::CantActivateAbilities {
+                restriction: GameRestriction::ProhibitActivity {
                     affected_players: RestrictionPlayerScope::TargetedPlayer,
-                    exemption: ActivationExemption::ManaAbilities,
+                    activity: ProhibitedActivity::ActivateAbilities {
+                        exemption: ActivationExemption::ManaAbilities,
+                    },
                     ..
                 }
             }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -61,7 +61,7 @@ use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
 use crate::types::replacements::ReplacementEvent;
-use crate::types::statics::{CastFrequency, StaticMode};
+use crate::types::statics::{ActivationExemption, CastFrequency, StaticMode};
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 
@@ -1502,30 +1502,94 @@ fn try_parse_cast_only_from_zones_restriction(tp: TextPair<'_>) -> Option<Parsed
 /// Must be called AFTER try_parse_cast_only_from_zones_restriction (which handles the more
 /// specific "can't cast spells from anywhere other than" variant).
 fn try_parse_cant_cast_spells_effect(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
-    // Must contain "can't cast spells" but NOT "can't cast spells from" (that's CastOnlyFromZones).
-    if !nom_primitives::scan_contains(tp.lower, "can't cast spells")
-        && !nom_primitives::scan_contains(tp.lower, "cannot cast spells")
-    {
-        return None;
-    }
-    if nom_primitives::scan_contains(tp.lower, "can't cast spells from")
-        || nom_primitives::scan_contains(tp.lower, "cannot cast spells from")
+    let (scope_tp, expiry, duration) = if let Some(((expiry, duration), rest_orig)) =
+        nom_on_lower(tp.original, tp.lower, |input| {
+            alt((
+                value(
+                    (
+                        RestrictionExpiry::EndOfTurn,
+                        Some(Duration::UntilNextTurnOf {
+                            player: PlayerScope::Controller,
+                        }),
+                    ),
+                    tag("until your next turn, "),
+                ),
+                value(
+                    (RestrictionExpiry::EndOfTurn, Some(Duration::UntilEndOfTurn)),
+                    tag("until end of turn, "),
+                ),
+                value((RestrictionExpiry::EndOfTurn, None), tag("this turn, ")),
+            ))
+            .parse(input)
+        }) {
+        let rest_lower = &tp.lower[tp.lower.len() - rest_orig.len()..];
+        (TextPair::new(rest_orig, rest_lower), expiry, duration)
+    } else {
+        (tp, RestrictionExpiry::EndOfTurn, None)
+    };
+
+    let (affected_players, rest_orig) = nom_on_lower(scope_tp.original, scope_tp.lower, |input| {
+        alt((
+            value(
+                RestrictionPlayerScope::OpponentsOfSourceController,
+                tag("your opponents"),
+            ),
+            value(
+                RestrictionPlayerScope::OpponentsOfSourceController,
+                tag("opponents"),
+            ),
+            value(
+                RestrictionPlayerScope::OpponentsOfSourceController,
+                tag("each opponent"),
+            ),
+            value(RestrictionPlayerScope::AllPlayers, tag("players")),
+            value(RestrictionPlayerScope::AllPlayers, tag("each player")),
+            value(RestrictionPlayerScope::TargetedPlayer, tag("target player")),
+            value(RestrictionPlayerScope::TargetedPlayer, tag("that player")),
+        ))
+        .parse(input)
+    })?;
+    let rest_lower = &scope_tp.lower[scope_tp.lower.len() - rest_orig.len()..];
+
+    let (spell_filter_text, remaining) = nom_on_lower(rest_orig, rest_lower, |input| {
+        alt((
+            value(None, tag(" can't cast spells")),
+            value(None, tag(" cannot cast spells")),
+            map(
+                preceded(
+                    tag(" can't cast "),
+                    nom::sequence::terminated(take_until(" spells"), tag(" spells")),
+                ),
+                |text: &str| Some(text.to_string()),
+            ),
+            map(
+                preceded(
+                    tag(" cannot cast "),
+                    nom::sequence::terminated(take_until(" spells"), tag(" spells")),
+                ),
+                |text: &str| Some(text.to_string()),
+            ),
+        ))
+        .parse(input)
+    })?;
+    let remaining_lower = &rest_lower[rest_lower.len() - remaining.len()..];
+
+    if tag::<_, _, OracleError<'_>>(" from")
+        .parse(remaining_lower)
+        .is_ok()
     {
         return None;
     }
 
-    // Determine affected player scope from subject prefix.
-    let affected_players = if alt((
-        tag::<_, _, OracleError<'_>>("your opponents"),
-        tag("opponents"),
-        tag("each opponent"),
-    ))
-    .parse(tp.lower)
-    .is_ok()
-    {
-        RestrictionPlayerScope::OpponentsOfSourceController
-    } else {
-        RestrictionPlayerScope::AllPlayers
+    let spell_filter = match spell_filter_text {
+        None => None,
+        Some(text) => {
+            let (filter, rem) = parse_type_phrase(text.trim());
+            if !rem.trim().is_empty() || matches!(filter, TargetFilter::Any) {
+                return None;
+            }
+            Some(filter)
+        }
     };
 
     Some(ParsedEffectClause {
@@ -1533,6 +1597,79 @@ fn try_parse_cant_cast_spells_effect(tp: TextPair<'_>) -> Option<ParsedEffectCla
             restriction: GameRestriction::CantCastSpells {
                 source: ObjectId(0),
                 affected_players,
+                spell_filter,
+                expiry,
+            },
+        },
+        duration,
+        sub_ability: None,
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
+fn try_parse_cant_activate_non_mana_abilities_effect(
+    tp: TextPair<'_>,
+) -> Option<ParsedEffectClause> {
+    let (affected_players, rest_orig) = nom_on_lower(tp.original, tp.lower, |input| {
+        alt((
+            value(
+                RestrictionPlayerScope::OpponentsOfSourceController,
+                tag("your opponents"),
+            ),
+            value(
+                RestrictionPlayerScope::OpponentsOfSourceController,
+                tag("opponents"),
+            ),
+            value(
+                RestrictionPlayerScope::OpponentsOfSourceController,
+                tag("each opponent"),
+            ),
+            value(RestrictionPlayerScope::AllPlayers, tag("players")),
+            value(RestrictionPlayerScope::AllPlayers, tag("each player")),
+            value(RestrictionPlayerScope::TargetedPlayer, tag("target player")),
+            value(RestrictionPlayerScope::TargetedPlayer, tag("that player")),
+        ))
+        .parse(input)
+    })?;
+    let rest_lower = &tp.lower[tp.lower.len() - rest_orig.len()..];
+
+    let (_, remaining) = nom_on_lower(rest_orig, rest_lower, |input| {
+        alt((
+            value(
+                (),
+                tag(" can't activate abilities that aren't mana abilities"),
+            ),
+            value(
+                (),
+                tag(" cannot activate abilities that aren't mana abilities"),
+            ),
+            value(
+                (),
+                tag(" can't activate abilities that are not mana abilities"),
+            ),
+            value(
+                (),
+                tag(" cannot activate abilities that are not mana abilities"),
+            ),
+        ))
+        .parse(input)
+    })?;
+
+    let remaining_lower = &rest_lower[rest_lower.len() - remaining.len()..];
+    if !remaining_lower.trim().is_empty() {
+        return None;
+    }
+
+    Some(ParsedEffectClause {
+        effect: Effect::AddRestriction {
+            restriction: GameRestriction::CantActivateAbilities {
+                source: ObjectId(0),
+                affected_players,
+                exemption: ActivationExemption::ManaAbilities,
                 expiry: RestrictionExpiry::EndOfTurn,
             },
         },
@@ -3028,6 +3165,10 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // CR 101.2: "Your opponents can't cast spells this turn" — blanket temporary prohibition.
     // Must run AFTER cast_only_from_zones (more specific "from zones" check).
     if let Some(clause) = try_parse_cant_cast_spells_effect(tp) {
+        return clause;
+    }
+
+    if let Some(clause) = try_parse_cant_activate_non_mana_abilities_effect(tp) {
         return clause;
     }
 
@@ -27760,6 +27901,7 @@ mod tests {
             Effect::AddRestriction {
                 restriction: GameRestriction::CantCastSpells {
                     affected_players: RestrictionPlayerScope::OpponentsOfSourceController,
+                    spell_filter: None,
                     expiry: RestrictionExpiry::EndOfTurn,
                     ..
                 }
@@ -27776,11 +27918,46 @@ mod tests {
             Effect::AddRestriction {
                 restriction: GameRestriction::CantCastSpells {
                     affected_players: RestrictionPlayerScope::AllPlayers,
+                    spell_filter: None,
                     expiry: RestrictionExpiry::EndOfTurn,
                     ..
                 }
             }
         ));
+    }
+
+    #[test]
+    fn abeyance_clause_chain_parses_both_restrictions() {
+        let def = parse_effect_chain(
+            "Until end of turn, target player can't cast instant or sorcery spells, and that player can't activate abilities that aren't mana abilities. Draw a card.",
+            AbilityKind::Spell,
+        );
+
+        assert!(matches!(
+            *def.effect,
+            Effect::AddRestriction {
+                restriction: GameRestriction::CantCastSpells {
+                    affected_players: RestrictionPlayerScope::TargetedPlayer,
+                    spell_filter: Some(_),
+                    ..
+                }
+            }
+        ));
+
+        let sub = def.sub_ability.expect("expected chained restriction");
+        assert!(matches!(
+            *sub.effect,
+            Effect::AddRestriction {
+                restriction: GameRestriction::CantActivateAbilities {
+                    affected_players: RestrictionPlayerScope::TargetedPlayer,
+                    exemption: ActivationExemption::ManaAbilities,
+                    ..
+                }
+            }
+        ));
+
+        let draw = sub.sub_ability.expect("expected trailing draw clause");
+        assert!(matches!(*draw.effect, Effect::Draw { .. }));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -1547,7 +1547,10 @@ fn try_parse_cant_cast_spells_effect(tp: TextPair<'_>) -> Option<ParsedEffectCla
             value(RestrictionPlayerScope::AllPlayers, tag("players")),
             value(RestrictionPlayerScope::AllPlayers, tag("each player")),
             value(RestrictionPlayerScope::TargetedPlayer, tag("target player")),
-            value(RestrictionPlayerScope::TargetedPlayer, tag("that player")),
+            value(
+                RestrictionPlayerScope::ParentTargetedPlayer,
+                tag("that player"),
+            ),
         ))
         .parse(input)
     })?;
@@ -1633,7 +1636,10 @@ fn try_parse_cant_activate_non_mana_abilities_effect(
             value(RestrictionPlayerScope::AllPlayers, tag("players")),
             value(RestrictionPlayerScope::AllPlayers, tag("each player")),
             value(RestrictionPlayerScope::TargetedPlayer, tag("target player")),
-            value(RestrictionPlayerScope::TargetedPlayer, tag("that player")),
+            value(
+                RestrictionPlayerScope::ParentTargetedPlayer,
+                tag("that player"),
+            ),
         ))
         .parse(input)
     })?;
@@ -27955,7 +27961,7 @@ mod tests {
             *sub.effect,
             Effect::AddRestriction {
                 restriction: GameRestriction::ProhibitActivity {
-                    affected_players: RestrictionPlayerScope::TargetedPlayer,
+                    affected_players: RestrictionPlayerScope::ParentTargetedPlayer,
                     activity: ProhibitedActivity::ActivateAbilities {
                         exemption: ActivationExemption::ManaAbilities,
                     },

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -18,7 +18,7 @@ use super::mana::{ManaColor, ManaCost, ManaType};
 use super::phase::Phase;
 use super::player::{PlayerCounterKind, PlayerId};
 use super::replacements::ReplacementEvent;
-use super::statics::{CastFrequency, StaticMode};
+use super::statics::{ActivationExemption, CastFrequency, StaticMode};
 use super::triggers::TriggerMode;
 use super::zones::Zone;
 use crate::types::events::PlayerActionKind;
@@ -1196,6 +1196,16 @@ pub enum GameRestriction {
     CantCastSpells {
         source: ObjectId,
         affected_players: RestrictionPlayerScope,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        spell_filter: Option<TargetFilter>,
+        expiry: RestrictionExpiry,
+    },
+    /// CR 101.2 + CR 602.5: A temporary effect prevents affected players from
+    /// activating abilities, optionally exempting mana abilities.
+    CantActivateAbilities {
+        source: ObjectId,
+        affected_players: RestrictionPlayerScope,
+        exemption: ActivationExemption,
         expiry: RestrictionExpiry,
     },
 }
@@ -1224,6 +1234,9 @@ pub enum RestrictionScope {
 pub enum RestrictionPlayerScope {
     AllPlayers,
     SpecificPlayer(PlayerId),
+    /// Placeholder used by parser lowering for effects that target a player.
+    /// Resolved to `SpecificPlayer` by `add_restriction` at resolution time.
+    TargetedPlayer,
     OpponentsOfSourceController,
 }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -791,25 +791,23 @@ impl<'de> serde::Deserialize<'de> for DevotionColors {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "type")]
 pub enum ManaProduction {
-    /// Produce an explicit fixed sequence of colored mana symbols (e.g. `{W}{U}`).
+    /// Produce one or more specific colors.
     Fixed {
         #[serde(default)]
         colors: Vec<ManaColor>,
-        /// CR 605.1a: Whether this is base or additional (e.g. Wild Growth,
-        /// Verdant Haven) mana.
+        /// CR 605.1a: Whether this is base or additional (e.g. Fertile Ground) mana.
         #[serde(
             default = "default_mana_contribution",
             skip_serializing_if = "is_default_mana_contribution"
         )]
         contribution: ManaContribution,
     },
-    /// Produce N colorless mana (e.g. `{C}`, `{C}{C}`).
+    /// Produce strictly colorless mana (e.g. "Add {C}").
     Colorless {
         #[serde(default = "default_quantity_one")]
         count: QuantityExpr,
     },
-    /// CR 106.1: Produce a mix of colorless and colored mana (e.g. `{C}{W}`, `{C}{C}{R}`).
-    /// Used by Ravnica bounce lands (Karoo, Azorius Chancery) and similar.
+    /// Produce a mixed bundle of fixed colorless + colored mana (e.g. "Add {C}{R}").
     Mixed {
         colorless_count: u32,
         colors: Vec<ManaColor>,
@@ -1183,31 +1181,29 @@ pub enum GameRestriction {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         scope: Option<RestrictionScope>,
     },
-    /// CR 101.2 + CR 601.2a: A temporary effect restricts affected players to casting
-    /// spells only from the listed zones until the restriction expires.
-    CastOnlyFromZones {
+    /// CR 101.2 + CR 601.2a + CR 602.5: A temporary effect prohibits one activity
+    /// axis for affected players until expiry.
+    ProhibitActivity {
         source: ObjectId,
         affected_players: RestrictionPlayerScope,
-        allowed_zones: Vec<Zone>,
         expiry: RestrictionExpiry,
+        activity: ProhibitedActivity,
     },
-    /// CR 101.2: A temporary effect prevents affected players from casting any spell
-    /// until the restriction expires. E.g., Silence: "Your opponents can't cast spells this turn."
-    CantCastSpells {
-        source: ObjectId,
-        affected_players: RestrictionPlayerScope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ProhibitedActivity {
+    /// CR 101.2 + CR 601.2a: Restrict casting to the listed zones.
+    CastOnlyFromZones { allowed_zones: Vec<Zone> },
+    /// CR 101.2: Prevent casting matching spells.
+    CastSpells {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         spell_filter: Option<TargetFilter>,
-        expiry: RestrictionExpiry,
     },
-    /// CR 101.2 + CR 602.5: A temporary effect prevents affected players from
-    /// activating abilities, optionally exempting mana abilities.
-    CantActivateAbilities {
-        source: ObjectId,
-        affected_players: RestrictionPlayerScope,
-        exemption: ActivationExemption,
-        expiry: RestrictionExpiry,
-    },
+    /// CR 101.2 + CR 602.5 + CR 605.1a: Prevent activating abilities, optionally
+    /// exempting mana abilities.
+    ActivateAbilities { exemption: ActivationExemption },
 }
 
 /// When a game restriction expires.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -1233,6 +1233,11 @@ pub enum RestrictionPlayerScope {
     /// Placeholder used by parser lowering for effects that target a player.
     /// Resolved to `SpecificPlayer` by `add_restriction` at resolution time.
     TargetedPlayer,
+    /// CR 608.2c: Anaphoric "that player" in a sub-ability reuses a player
+    /// target already chosen for an earlier instruction in the same chain.
+    /// Resolved to `SpecificPlayer` by `add_restriction` after parent target
+    /// propagation, without declaring a second target slot.
+    ParentTargetedPlayer,
     OpponentsOfSourceController,
 }
 

--- a/crates/mtgish-import/src/diff/ordering.rs
+++ b/crates/mtgish-import/src/diff/ordering.rs
@@ -190,9 +190,9 @@ pub const ORDERING_MANIFEST: &[((&str, &str), OrderingClass)] = &[
         OrderingClass::SetEquivalent,
     ),
     (("ManaProduction", "options"), OrderingClass::SetEquivalent),
-    // ----- GameRestriction allowed_zones -----
+    // ----- ProhibitedActivity allowed_zones -----
     (
-        ("GameRestriction", "allowed_zones"),
+        ("ProhibitedActivity", "allowed_zones"),
         OrderingClass::SetEquivalent,
     ),
     // ----- FilterProp variants with embedded Vec<...> -----

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -1,32 +1,32 @@
 {
   "sources": [
-    "crates/engine/src/types/match_config.rs",
-    "crates/engine/src/types/statics.rs",
-    "crates/engine/src/types/mana.rs",
-    "crates/engine/src/types/card.rs",
-    "crates/engine/src/types/player.rs",
-    "crates/engine/src/types/events.rs",
+    "crates/engine/src/types/format.rs",
     "crates/engine/src/types/actions.rs",
+    "crates/engine/src/types/replacements.rs",
+    "crates/engine/src/types/identifiers.rs",
+    "crates/engine/src/types/events.rs",
+    "crates/engine/src/types/proposed_event.rs",
+    "crates/engine/src/types/keywords.rs",
+    "crates/engine/src/types/statics.rs",
+    "crates/engine/src/types/triggers.rs",
+    "crates/engine/src/types/definitions.rs",
+    "crates/engine/src/types/ability.rs",
     "crates/engine/src/types/log.rs",
     "crates/engine/src/types/game_state.rs",
-    "crates/engine/src/types/format.rs",
-    "crates/engine/src/types/layers.rs",
-    "crates/engine/src/types/attribution.rs",
-    "crates/engine/src/types/identifiers.rs",
-    "crates/engine/src/types/mod.rs",
-    "crates/engine/src/types/zones.rs",
-    "crates/engine/src/types/keywords.rs",
-    "crates/engine/src/types/replacements.rs",
     "crates/engine/src/types/phase.rs",
-    "crates/engine/src/types/ability.rs",
-    "crates/engine/src/types/proposed_event.rs",
     "crates/engine/src/types/counter.rs",
-    "crates/engine/src/types/definitions.rs",
-    "crates/engine/src/types/card_type.rs",
-    "crates/engine/src/types/triggers.rs"
+    "crates/engine/src/types/mod.rs",
+    "crates/engine/src/types/layers.rs",
+    "crates/engine/src/types/match_config.rs",
+    "crates/engine/src/types/card.rs",
+    "crates/engine/src/types/player.rs",
+    "crates/engine/src/types/mana.rs",
+    "crates/engine/src/types/zones.rs",
+    "crates/engine/src/types/attribution.rs",
+    "crates/engine/src/types/card_type.rs"
   ],
-  "enum_count": 223,
-  "variant_count": 2599,
+  "enum_count": 224,
+  "variant_count": 2603,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -408,13 +408,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8202,
+      "line": 8216,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 8220,
+          "line": 8234,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -431,7 +431,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 8234,
+          "line": 8248,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -442,7 +442,7 @@
         },
         {
           "name": "IfYouDo",
-          "line": 8236,
+          "line": 8250,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you do\" — sub_ability executes only if the parent optional effect was performed.",
@@ -452,7 +452,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 8244,
+          "line": 8258,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -462,7 +462,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 8247,
+          "line": 8261,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -474,7 +474,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 8251,
+          "line": 8265,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -487,7 +487,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 8254,
+          "line": 8268,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -500,7 +500,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 8257,
+          "line": 8271,
           "kind": "struct",
           "field_names": [
             "color",
@@ -514,7 +514,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 8263,
+          "line": 8277,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -527,7 +527,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 8271,
+          "line": 8285,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -538,7 +538,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 8274,
+          "line": 8288,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -551,7 +551,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 8279,
+          "line": 8293,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -565,7 +565,7 @@
         },
         {
           "name": "IfAPlayerDoes",
-          "line": 8282,
+          "line": 8296,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d: \"If a player does\" / \"if they do\" — gates sub_ability on whether any prompted opponent accepted an \"any opponent may\" optional effect.",
@@ -575,7 +575,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 8286,
+          "line": 8300,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -589,7 +589,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 8295,
+          "line": 8309,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -603,7 +603,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 8300,
+          "line": 8314,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -613,7 +613,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 8302,
+          "line": 8316,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -623,7 +623,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 8305,
+          "line": 8319,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -633,7 +633,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 8309,
+          "line": 8323,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -645,7 +645,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 8314,
+          "line": 8328,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -659,7 +659,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 8322,
+          "line": 8336,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -671,7 +671,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 8327,
+          "line": 8341,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -687,7 +687,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 8339,
+          "line": 8353,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -700,7 +700,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 8343,
+          "line": 8357,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -710,7 +710,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 8351,
+          "line": 8365,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -723,7 +723,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 8356,
+          "line": 8370,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -736,7 +736,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 8361,
+          "line": 8375,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -748,7 +748,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 8367,
+          "line": 8381,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -760,7 +760,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 8371,
+          "line": 8385,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -774,7 +774,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 8374,
+          "line": 8388,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -784,7 +784,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 8383,
+          "line": 8397,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -797,7 +797,7 @@
         },
         {
           "name": "And",
-          "line": 8388,
+          "line": 8402,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -809,7 +809,7 @@
         },
         {
           "name": "Or",
-          "line": 8393,
+          "line": 8407,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -821,7 +821,7 @@
         },
         {
           "name": "Not",
-          "line": 8401,
+          "line": 8415,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -833,7 +833,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 8405,
+          "line": 8419,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -843,7 +843,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 8407,
+          "line": 8421,
           "kind": "struct",
           "field_names": [
             "state"
@@ -855,7 +855,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 8417,
+          "line": 8431,
           "kind": "struct",
           "field_names": [
             "n"
@@ -867,7 +867,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 8420,
+          "line": 8434,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -891,13 +891,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3930,
+      "line": 3944,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 3931,
+          "line": 3945,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -907,7 +907,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 3940,
+          "line": 3954,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -920,7 +920,7 @@
         },
         {
           "name": "Tap",
-          "line": 3943,
+          "line": 3957,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -928,7 +928,7 @@
         },
         {
           "name": "Untap",
-          "line": 3944,
+          "line": 3958,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -936,7 +936,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 3945,
+          "line": 3959,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -946,7 +946,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 3948,
+          "line": 3962,
           "kind": "struct",
           "field_names": [
             "target",
@@ -957,7 +957,7 @@
         },
         {
           "name": "PayLife",
-          "line": 3960,
+          "line": 3974,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -969,7 +969,7 @@
         },
         {
           "name": "Discard",
-          "line": 3963,
+          "line": 3977,
           "kind": "struct",
           "field_names": [
             "count",
@@ -982,7 +982,7 @@
         },
         {
           "name": "Exile",
-          "line": 3974,
+          "line": 3988,
           "kind": "struct",
           "field_names": [
             "count",
@@ -994,7 +994,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 3983,
+          "line": 3997,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1007,7 +1007,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 3986,
+          "line": 4000,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1018,7 +1018,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 3997,
+          "line": 4011,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1033,7 +1033,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 4003,
+          "line": 4017,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1043,7 +1043,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4007,
+          "line": 4021,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1056,7 +1056,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4015,
+          "line": 4029,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1070,7 +1070,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4024,
+          "line": 4038,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1080,7 +1080,7 @@
         },
         {
           "name": "Mill",
-          "line": 4025,
+          "line": 4039,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1090,7 +1090,7 @@
         },
         {
           "name": "Exert",
-          "line": 4028,
+          "line": 4042,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1098,7 +1098,7 @@
         },
         {
           "name": "Blight",
-          "line": 4031,
+          "line": 4045,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1108,7 +1108,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4034,
+          "line": 4048,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1119,7 +1119,7 @@
         },
         {
           "name": "Behold",
-          "line": 4042,
+          "line": 4056,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1131,7 +1131,7 @@
         },
         {
           "name": "Composite",
-          "line": 4048,
+          "line": 4062,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1141,7 +1141,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4065,
+          "line": 4079,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1154,7 +1154,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4069,
+          "line": 4083,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1164,7 +1164,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4074,
+          "line": 4088,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1177,7 +1177,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4081,
+          "line": 4095,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1189,7 +1189,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4097,
+          "line": 4111,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1203,7 +1203,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4102,
+          "line": 4116,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1216,13 +1216,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7402,
+      "line": 7416,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 7404,
+          "line": 7418,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1230,7 +1230,7 @@
         },
         {
           "name": "Activated",
-          "line": 7405,
+          "line": 7419,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1238,7 +1238,7 @@
         },
         {
           "name": "Database",
-          "line": 7406,
+          "line": 7420,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1246,7 +1246,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 7409,
+          "line": 7423,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1254,7 +1254,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 7415,
+          "line": 7429,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1267,7 +1267,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7550,
+      "line": 7564,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1275,7 +1275,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 7552,
+          "line": 7566,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1285,7 +1285,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 7554,
+          "line": 7568,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1354,13 +1354,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7562,
+      "line": 7576,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 7563,
+          "line": 7577,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1368,7 +1368,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 7564,
+          "line": 7578,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1376,7 +1376,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 7565,
+          "line": 7579,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1384,7 +1384,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 7566,
+          "line": 7580,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1392,7 +1392,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 7567,
+          "line": 7581,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1400,7 +1400,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 7568,
+          "line": 7582,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1408,7 +1408,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 7569,
+          "line": 7583,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1416,7 +1416,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 7570,
+          "line": 7584,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1424,7 +1424,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 7571,
+          "line": 7585,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1432,7 +1432,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 7572,
+          "line": 7586,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1442,7 +1442,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 7575,
+          "line": 7589,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1452,7 +1452,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 7579,
+          "line": 7593,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1462,7 +1462,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 7581,
+          "line": 7595,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1474,7 +1474,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 7586,
+          "line": 7600,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1488,7 +1488,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 7597,
+          "line": 7611,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1502,7 +1502,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 7610,
+          "line": 7624,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1515,13 +1515,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4306,
+      "line": 4320,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 4309,
+          "line": 4323,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"you may [cost]\" — player decides whether to pay. If paid, `SpellContext::additional_cost_paid` is set to true.",
@@ -1529,7 +1529,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4315,
+          "line": 4329,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1545,7 +1545,7 @@
         },
         {
           "name": "Choice",
-          "line": 4322,
+          "line": 4336,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1553,7 +1553,7 @@
         },
         {
           "name": "Required",
-          "line": 4324,
+          "line": 4338,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1564,7 +1564,7 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2908,
+      "line": 2922,
       "doc": "CR 107.3e: Aggregate function applied over a set of objects.",
       "cr_refs": [
         "CR 107.3e"
@@ -1572,7 +1572,7 @@
       "variants": [
         {
           "name": "Max",
-          "line": 2909,
+          "line": 2923,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1580,7 +1580,7 @@
         },
         {
           "name": "Min",
-          "line": 2910,
+          "line": 2924,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1588,7 +1588,7 @@
         },
         {
           "name": "Sum",
-          "line": 2911,
+          "line": 2925,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1687,7 +1687,7 @@
     },
     "AttachmentKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1583,
+      "line": 1597,
       "doc": "CR 301 / CR 303: Kinds of attachments to permanents. Used by `FilterProp::HasAttachment` and `QuantityRef::AttachmentsOnLeavingObject` to parameterize attachment-predicate checks.",
       "cr_refs": [
         "CR 301",
@@ -1696,7 +1696,7 @@
       "variants": [
         {
           "name": "Aura",
-          "line": 1585,
+          "line": 1599,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4: Aura — enchantment subtype that attaches via Enchant ability.",
@@ -1706,7 +1706,7 @@
         },
         {
           "name": "Equipment",
-          "line": 1587,
+          "line": 1601,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5: Equipment — artifact subtype that attaches via Equip ability.",
@@ -1890,13 +1890,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3922,
+      "line": 3936,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 3923,
+          "line": 3937,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1904,7 +1904,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 3924,
+          "line": 3938,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2164,13 +2164,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2439,
+      "line": 2453,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 2441,
+          "line": 2455,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -2184,7 +2184,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2443,
+          "line": 2457,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -2195,7 +2195,7 @@
         },
         {
           "name": "Objects",
-          "line": 2445,
+          "line": 2459,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -2287,7 +2287,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2450,
+      "line": 2464,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -2295,7 +2295,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 2452,
+          "line": 2466,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -2303,7 +2303,7 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 2454,
+          "line": 2468,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
@@ -2314,7 +2314,7 @@
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2460,
+      "line": 2474,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -2323,7 +2323,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 2462,
+          "line": 2476,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -2331,7 +2331,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 2464,
+          "line": 2478,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -2339,7 +2339,7 @@
         },
         {
           "name": "FromSource",
-          "line": 2466,
+          "line": 2480,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -2379,7 +2379,7 @@
     },
     "CastPermissionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1398,
+      "line": 1412,
       "doc": "CR 702.85a: Typed cast-time predicates attached to an `ExileWithAltCost` permission. Extend this enum when future mechanics need cast-time gating that cannot be evaluated at permission-grant time (e.g., X-cost spells whose mana value is only known after the caster chooses X).",
       "cr_refs": [
         "CR 702.85a"
@@ -2387,7 +2387,7 @@
       "variants": [
         {
           "name": "CascadeResultingMvBelow",
-          "line": 1409,
+          "line": 1423,
           "kind": "struct",
           "field_names": [
             "source_mv",
@@ -2400,7 +2400,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 1415,
+          "line": 1429,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -2417,7 +2417,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3896,
+      "line": 3910,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -2426,7 +2426,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 3899,
+          "line": 3913,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -2437,7 +2437,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3858,
+      "line": 3872,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -2448,7 +2448,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 3860,
+          "line": 3874,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -2459,7 +2459,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 3863,
+          "line": 3877,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -2469,7 +2469,7 @@
         },
         {
           "name": "Sneak",
-          "line": 3865,
+          "line": 3879,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -2479,7 +2479,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 3867,
+          "line": 3881,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -2489,7 +2489,7 @@
         },
         {
           "name": "Evoke",
-          "line": 3870,
+          "line": 3884,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -2499,7 +2499,7 @@
         },
         {
           "name": "Suspend",
-          "line": 3876,
+          "line": 3890,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -2509,7 +2509,7 @@
         },
         {
           "name": "Escape",
-          "line": 3881,
+          "line": 3895,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -2520,7 +2520,7 @@
         },
         {
           "name": "Foretell",
-          "line": 3884,
+          "line": 3898,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -2530,7 +2530,7 @@
         },
         {
           "name": "Bestow",
-          "line": 3889,
+          "line": 3903,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -2544,13 +2544,13 @@
     },
     "CastingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1238,
+      "line": 1252,
       "doc": "A permission granted to a `GameObject` allowing it to be cast under specific conditions. Stored in `GameObject::casting_permissions`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdventureCreature",
-          "line": 1240,
+          "line": 1254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.5: After Adventure resolves to exile, creature face castable from exile.",
@@ -2560,7 +2560,7 @@
         },
         {
           "name": "ExileWithAltCost",
-          "line": 1245,
+          "line": 1259,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -2576,7 +2576,7 @@
         },
         {
           "name": "PlayFromExile",
-          "line": 1279,
+          "line": 1293,
           "kind": "struct",
           "field_names": [
             "duration",
@@ -2595,7 +2595,7 @@
         },
         {
           "name": "ExileWithEnergyCost",
-          "line": 1305,
+          "line": 1319,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.3: Cast from exile by paying {E} equal to the card's mana value. Building block for Amped Raptor and similar energy-based casting mechanics.",
@@ -2605,7 +2605,7 @@
         },
         {
           "name": "ExileWithAltAbilityCost",
-          "line": 1314,
+          "line": 1328,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -2620,7 +2620,7 @@
         },
         {
           "name": "WarpExile",
-          "line": 1332,
+          "line": 1346,
           "kind": "struct",
           "field_names": [
             "castable_after_turn"
@@ -2632,7 +2632,7 @@
         },
         {
           "name": "Plotted",
-          "line": 1342,
+          "line": 1356,
           "kind": "struct",
           "field_names": [
             "turn_plotted"
@@ -2645,7 +2645,7 @@
         },
         {
           "name": "Foretold",
-          "line": 1348,
+          "line": 1362,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -2709,124 +2709,12 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7618,
+      "line": 7632,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 7619,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringCombat",
-          "line": 7620,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringOpponentsTurn",
-          "line": 7621,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourTurn",
-          "line": 7622,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourUpkeep",
-          "line": 7623,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringOpponentsUpkeep",
-          "line": 7624,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringAnyUpkeep",
-          "line": 7625,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourEndStep",
-          "line": 7626,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringOpponentsEndStep",
-          "line": 7627,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DeclareAttackersStep",
-          "line": 7628,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DeclareBlockersStep",
-          "line": 7629,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BeforeAttackersDeclared",
-          "line": 7630,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BeforeBlockersDeclared",
-          "line": 7631,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BeforeCombatDamage",
-          "line": 7632,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AfterCombat",
           "line": 7633,
           "kind": "unit",
           "field_names": [],
@@ -2834,8 +2722,120 @@
           "cr_refs": []
         },
         {
-          "name": "RequiresCondition",
+          "name": "DuringCombat",
           "line": 7634,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringOpponentsTurn",
+          "line": 7635,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringYourTurn",
+          "line": 7636,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringYourUpkeep",
+          "line": 7637,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringOpponentsUpkeep",
+          "line": 7638,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringAnyUpkeep",
+          "line": 7639,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringYourEndStep",
+          "line": 7640,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringOpponentsEndStep",
+          "line": 7641,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DeclareAttackersStep",
+          "line": 7642,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DeclareBlockersStep",
+          "line": 7643,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeAttackersDeclared",
+          "line": 7644,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeBlockersDeclared",
+          "line": 7645,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeCombatDamage",
+          "line": 7646,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AfterCombat",
+          "line": 7647,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RequiresCondition",
+          "line": 7648,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3600,7 +3600,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9525,
+      "line": 9551,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -3608,7 +3608,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 9526,
+          "line": 9552,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3616,7 +3616,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 9527,
+          "line": 9553,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3687,7 +3687,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3320,
+      "line": 3334,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -3695,7 +3695,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 3323,
+          "line": 3337,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -3706,7 +3706,7 @@
         },
         {
           "name": "Any",
-          "line": 3327,
+          "line": 3341,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -3810,13 +3810,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3220,
+      "line": 3234,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 3221,
+          "line": 3235,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3824,7 +3824,7 @@
         },
         {
           "name": "LT",
-          "line": 3222,
+          "line": 3236,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3832,7 +3832,7 @@
         },
         {
           "name": "GE",
-          "line": 3223,
+          "line": 3237,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3840,7 +3840,7 @@
         },
         {
           "name": "LE",
-          "line": 3224,
+          "line": 3238,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3848,7 +3848,7 @@
         },
         {
           "name": "EQ",
-          "line": 3225,
+          "line": 3239,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3856,7 +3856,7 @@
         },
         {
           "name": "NE",
-          "line": 3226,
+          "line": 3240,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3867,13 +3867,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9924,
+      "line": 9950,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 9925,
+          "line": 9951,
           "kind": "struct",
           "field_names": [
             "values"
@@ -3883,7 +3883,7 @@
         },
         {
           "name": "SetName",
-          "line": 9932,
+          "line": 9958,
           "kind": "struct",
           "field_names": [
             "name"
@@ -3897,7 +3897,7 @@
         },
         {
           "name": "AddPower",
-          "line": 9935,
+          "line": 9961,
           "kind": "struct",
           "field_names": [
             "value"
@@ -3907,7 +3907,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 9938,
+          "line": 9964,
           "kind": "struct",
           "field_names": [
             "value"
@@ -3917,7 +3917,7 @@
         },
         {
           "name": "SetPower",
-          "line": 9941,
+          "line": 9967,
           "kind": "struct",
           "field_names": [
             "value"
@@ -3927,7 +3927,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 9944,
+          "line": 9970,
           "kind": "struct",
           "field_names": [
             "value"
@@ -3937,7 +3937,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 9947,
+          "line": 9973,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -3947,7 +3947,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 9950,
+          "line": 9976,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -3957,7 +3957,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 9953,
+          "line": 9979,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -3967,7 +3967,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 9960,
+          "line": 9986,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -3979,7 +3979,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 9963,
+          "line": 9989,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3987,7 +3987,7 @@
         },
         {
           "name": "AddType",
-          "line": 9964,
+          "line": 9990,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -3997,7 +3997,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 9967,
+          "line": 9993,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4007,7 +4007,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 9970,
+          "line": 9996,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4017,7 +4017,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 9973,
+          "line": 9999,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4027,7 +4027,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 9980,
+          "line": 10006,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4040,7 +4040,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 9986,
+          "line": 10012,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4053,7 +4053,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 9990,
+          "line": 10016,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4063,7 +4063,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 9994,
+          "line": 10020,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4073,7 +4073,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 10001,
+          "line": 10027,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4085,7 +4085,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 10006,
+          "line": 10032,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4097,7 +4097,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 10010,
+          "line": 10036,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4109,7 +4109,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 10014,
+          "line": 10040,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4121,7 +4121,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 10019,
+          "line": 10045,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4134,7 +4134,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 10025,
+          "line": 10051,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4142,7 +4142,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 10028,
+          "line": 10054,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4153,7 +4153,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 10031,
+          "line": 10057,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4163,7 +4163,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 10036,
+          "line": 10062,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4173,7 +4173,7 @@
         },
         {
           "name": "SetColor",
-          "line": 10037,
+          "line": 10063,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4183,7 +4183,7 @@
         },
         {
           "name": "AddColor",
-          "line": 10040,
+          "line": 10066,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4193,7 +4193,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 10045,
+          "line": 10071,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4203,7 +4203,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 10059,
+          "line": 10085,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4218,7 +4218,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 10063,
+          "line": 10089,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4228,7 +4228,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 10066,
+          "line": 10092,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -4238,7 +4238,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 10068,
+          "line": 10094,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -4248,7 +4248,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 10070,
+          "line": 10096,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -4258,7 +4258,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 10073,
+          "line": 10099,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -4268,7 +4268,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 10076,
+          "line": 10102,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -4280,7 +4280,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 10090,
+          "line": 10116,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -4292,7 +4292,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 10098,
+          "line": 10124,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4307,7 +4307,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 10107,
+          "line": 10133,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4322,7 +4322,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 10121,
+          "line": 10147,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -4340,7 +4340,7 @@
     },
     "ControlPresence": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2996,
+      "line": 3010,
       "doc": "CR 109.4: Whether a player's controlled-permanent predicate is satisfied by the presence or the absence of a matching permanent. A typed two-variant enum — never a bool — so `PlayerFilter::ControlsPermanent` reads as self-documenting at every match site.",
       "cr_refs": [
         "CR 109.4"
@@ -4348,7 +4348,7 @@
       "variants": [
         {
           "name": "Controls",
-          "line": 2998,
+          "line": 3012,
           "kind": "unit",
           "field_names": [],
           "doc": "The player controls at least one permanent matching the filter.",
@@ -4356,7 +4356,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 3000,
+          "line": 3014,
           "kind": "unit",
           "field_names": [],
           "doc": "The player controls no permanent matching the filter.",
@@ -4367,13 +4367,13 @@
     },
     "ControllerRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1535,
+      "line": 1549,
       "doc": "Controller reference for filter matching.",
       "cr_refs": [],
       "variants": [
         {
           "name": "You",
-          "line": 1536,
+          "line": 1550,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4381,7 +4381,7 @@
         },
         {
           "name": "Opponent",
-          "line": 1537,
+          "line": 1551,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4389,7 +4389,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 1540,
+          "line": 1554,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: Filter controller is the current player being affected by an \"each player/opponent\" instruction during resolution.",
@@ -4400,7 +4400,7 @@
         },
         {
           "name": "TargetPlayer",
-          "line": 1547,
+          "line": 1561,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 115.1: Filter controller is the player chosen as a target of the enclosing ability (e.g., \"each creature target player controls\"). At resolution time, `filter_inner` reads the first `TargetRef::Player` from `ability.targets`. At target-selection time, `collect_target_slots` surfaces a companion `TargetFilter::Player` slot so the player is chosen as part of CR 601.2c / CR 603.3d target declaration.",
@@ -4413,7 +4413,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 1551,
+          "line": 1565,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 109.4: Filter controller is the controller of the parent object target inherited by this chained effect (\"that permanent's controller may sacrifice a land\").",
@@ -4424,7 +4424,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 1556,
+          "line": 1570,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Filter controller is the defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by intervening-if quantity checks such as \"defending player controls more lands than you.\"",
@@ -4435,7 +4435,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 1567,
+          "line": 1581,
           "kind": "struct",
           "field_names": [
             "index"
@@ -4448,7 +4448,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 1576,
+          "line": 1590,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 109.4: Filter controller is the player identified by the triggering event (the drawer, life-gainer, attacker, etc.). Resolved against `state.current_trigger_event` via `extract_player_from_event`. Mirrors `PlayerFilter::TriggeringPlayer` and `TargetFilter::TriggeringPlayer`. Used by control-relative trigger restrictions (\"an opponent who controls F draws a card\").",
@@ -4511,13 +4511,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4559,
+      "line": 4573,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 4560,
+          "line": 4574,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4528,7 +4528,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6251,
+      "line": 6265,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -4537,7 +4537,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 6253,
+          "line": 6267,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -4545,7 +4545,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 6255,
+          "line": 6269,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -4669,7 +4669,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4116,
+      "line": 4130,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -4677,118 +4677,6 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4117,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TapsSelf",
-          "line": 4118,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "UntapsSelf",
-          "line": 4119,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SacrificesPermanent",
-          "line": 4120,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysLife",
-          "line": 4121,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysLoyalty",
-          "line": 4122,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Discards",
-          "line": 4123,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ExilesCards",
-          "line": 4124,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TapsOtherCreatures",
-          "line": 4125,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RemovesCounters",
-          "line": 4126,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysEnergy",
-          "line": 4127,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysSpeed",
-          "line": 4128,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReturnsToHand",
-          "line": 4129,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Unattaches",
-          "line": 4130,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Mills",
           "line": 4131,
           "kind": "unit",
           "field_names": [],
@@ -4796,7 +4684,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutsCounters",
+          "name": "TapsSelf",
           "line": 4132,
           "kind": "unit",
           "field_names": [],
@@ -4804,7 +4692,7 @@
           "cr_refs": []
         },
         {
-          "name": "Reveals",
+          "name": "UntapsSelf",
           "line": 4133,
           "kind": "unit",
           "field_names": [],
@@ -4812,7 +4700,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exerts",
+          "name": "SacrificesPermanent",
           "line": 4134,
           "kind": "unit",
           "field_names": [],
@@ -4820,8 +4708,120 @@
           "cr_refs": []
         },
         {
-          "name": "KeywordCost",
+          "name": "PaysLife",
           "line": 4135,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PaysLoyalty",
+          "line": 4136,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Discards",
+          "line": 4137,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExilesCards",
+          "line": 4138,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TapsOtherCreatures",
+          "line": 4139,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RemovesCounters",
+          "line": 4140,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PaysEnergy",
+          "line": 4141,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PaysSpeed",
+          "line": 4142,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ReturnsToHand",
+          "line": 4143,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unattaches",
+          "line": 4144,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Mills",
+          "line": 4145,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PutsCounters",
+          "line": 4146,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Reveals",
+          "line": 4147,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Exerts",
+          "line": 4148,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "KeywordCost",
+          "line": 4149,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5119,7 +5119,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2920,
+      "line": 2934,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -5127,7 +5127,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 2923,
+          "line": 2937,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -5140,7 +5140,7 @@
     },
     "DamageKindFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1523,
+      "line": 1537,
       "doc": "Filter for damage type on trigger definitions. CR 120.3: Combat damage is dealt during the combat damage step; all other damage is noncombat.",
       "cr_refs": [
         "CR 120.3"
@@ -5148,7 +5148,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 1526,
+          "line": 1540,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches both combat and noncombat damage.",
@@ -5156,7 +5156,7 @@
         },
         {
           "name": "CombatOnly",
-          "line": 1528,
+          "line": 1542,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2a: Only combat damage (dealt as a result of combat).",
@@ -5166,7 +5166,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 1530,
+          "line": 1544,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2b: Only noncombat damage (dealt as an effect of a spell or ability).",
@@ -5179,7 +5179,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9423,
+      "line": 9437,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -5187,7 +5187,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 9425,
+          "line": 9439,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -5195,7 +5195,7 @@
         },
         {
           "name": "Triple",
-          "line": 9427,
+          "line": 9441,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -5203,7 +5203,7 @@
         },
         {
           "name": "Plus",
-          "line": 9429,
+          "line": 9443,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5213,7 +5213,7 @@
         },
         {
           "name": "Minus",
-          "line": 9436,
+          "line": 9450,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5226,7 +5226,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 9440,
+          "line": 9454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -5236,7 +5236,7 @@
         },
         {
           "name": "SetTo",
-          "line": 9446,
+          "line": 9460,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5251,7 +5251,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4540,
+      "line": 4554,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -5259,7 +5259,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 4542,
+          "line": 4556,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -5267,7 +5267,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 4545,
+          "line": 4559,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -5281,7 +5281,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9513,
+      "line": 9539,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -5289,7 +5289,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 9515,
+          "line": 9541,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -5297,7 +5297,7 @@
         },
         {
           "name": "Player",
-          "line": 9517,
+          "line": 9543,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5307,7 +5307,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 9520,
+          "line": 9546,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5320,7 +5320,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9504,
+      "line": 9530,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -5328,7 +5328,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 9505,
+          "line": 9531,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5336,7 +5336,7 @@
         },
         {
           "name": "Opponent",
-          "line": 9506,
+          "line": 9532,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5344,7 +5344,7 @@
         },
         {
           "name": "Specific",
-          "line": 9507,
+          "line": 9533,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -5659,7 +5659,7 @@
     },
     "DelayedTriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1424,
+      "line": 1438,
       "doc": "When a delayed triggered ability fires (CR 603.7).",
       "cr_refs": [
         "CR 603.7"
@@ -5667,7 +5667,7 @@
       "variants": [
         {
           "name": "AtNextPhase",
-          "line": 1427,
+          "line": 1441,
           "kind": "struct",
           "field_names": [
             "phase"
@@ -5679,7 +5679,7 @@
         },
         {
           "name": "AtNextPhaseForPlayer",
-          "line": 1430,
+          "line": 1444,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -5690,7 +5690,7 @@
         },
         {
           "name": "WhenLeavesPlay",
-          "line": 1432,
+          "line": 1446,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -5700,7 +5700,7 @@
         },
         {
           "name": "WhenDies",
-          "line": 1438,
+          "line": 1452,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -5712,7 +5712,7 @@
         },
         {
           "name": "WhenLeavesPlayFiltered",
-          "line": 1441,
+          "line": 1455,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -5724,7 +5724,7 @@
         },
         {
           "name": "WhenEntersBattlefield",
-          "line": 1444,
+          "line": 1458,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -5736,7 +5736,7 @@
         },
         {
           "name": "WhenDiesOrExiled",
-          "line": 1447,
+          "line": 1461,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -5746,7 +5746,7 @@
         },
         {
           "name": "WheneverEvent",
-          "line": 1452,
+          "line": 1466,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -5758,7 +5758,7 @@
         },
         {
           "name": "WhenNextEvent",
-          "line": 1456,
+          "line": 1470,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -5926,13 +5926,13 @@
     },
     "Duration": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1139,
+      "line": 1137,
       "doc": "Duration for temporary effects.  Player-axis variants are parameterized by `PlayerScope` per the workspace \"Parameterize, don't proliferate\" principle. `PlayerScope::Controller` recovers the legacy \"until your next turn\" / \"controller's next step\" semantics; future `Target` / `Opponent` / `AllPlayers` readings unblock cards whose duration is bound to a non-controller player.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilEndOfTurn",
-          "line": 1141,
+          "line": 1139,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of turn (cleanup step).",
@@ -5942,7 +5942,7 @@
         },
         {
           "name": "UntilEndOfCombat",
-          "line": 1143,
+          "line": 1141,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of combat phase.",
@@ -5952,7 +5952,7 @@
         },
         {
           "name": "UntilNextTurnOf",
-          "line": 1147,
+          "line": 1145,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5965,7 +5965,7 @@
         },
         {
           "name": "UntilHostLeavesPlay",
-          "line": 1152,
+          "line": 1150,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a: Effect expires when the source object leaves the battlefield.",
@@ -5975,7 +5975,7 @@
         },
         {
           "name": "UntilNextStepOf",
-          "line": 1158,
+          "line": 1156,
           "kind": "struct",
           "field_names": [
             "step",
@@ -5991,7 +5991,7 @@
         },
         {
           "name": "ForAsLongAs",
-          "line": 1164,
+          "line": 1162,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -6003,7 +6003,7 @@
         },
         {
           "name": "Permanent",
-          "line": 1167,
+          "line": 1165,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6039,13 +6039,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4578,
+      "line": 4592,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 4580,
+          "line": 4594,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -6057,7 +6057,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 4586,
+          "line": 4600,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -6072,7 +6072,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 4597,
+          "line": 4611,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6084,7 +6084,7 @@
         },
         {
           "name": "Draw",
-          "line": 4617,
+          "line": 4631,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6100,7 +6100,7 @@
         },
         {
           "name": "Pump",
-          "line": 4623,
+          "line": 4637,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6112,7 +6112,7 @@
         },
         {
           "name": "PairWith",
-          "line": 4634,
+          "line": 4648,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6125,7 +6125,7 @@
         },
         {
           "name": "Destroy",
-          "line": 4637,
+          "line": 4651,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6136,7 +6136,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 4645,
+          "line": 4659,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6148,7 +6148,7 @@
         },
         {
           "name": "Counter",
-          "line": 4649,
+          "line": 4663,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6159,7 +6159,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 4667,
+          "line": 4681,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6173,7 +6173,7 @@
         },
         {
           "name": "Token",
-          "line": 4671,
+          "line": 4685,
           "kind": "struct",
           "field_names": [
             "name",
@@ -6196,7 +6196,7 @@
         },
         {
           "name": "GainLife",
-          "line": 4709,
+          "line": 4723,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6207,7 +6207,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 4716,
+          "line": 4730,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6218,7 +6218,7 @@
         },
         {
           "name": "Tap",
-          "line": 4723,
+          "line": 4737,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6228,7 +6228,7 @@
         },
         {
           "name": "Untap",
-          "line": 4727,
+          "line": 4741,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6238,7 +6238,7 @@
         },
         {
           "name": "TapAll",
-          "line": 4732,
+          "line": 4746,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6250,7 +6250,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 4737,
+          "line": 4751,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6262,7 +6262,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 4741,
+          "line": 4755,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6274,7 +6274,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 4748,
+          "line": 4762,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6286,7 +6286,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 4756,
+          "line": 4770,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6298,7 +6298,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 4777,
+          "line": 4791,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6309,7 +6309,7 @@
         },
         {
           "name": "Mill",
-          "line": 4783,
+          "line": 4797,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6321,7 +6321,7 @@
         },
         {
           "name": "Scry",
-          "line": 4800,
+          "line": 4814,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6336,7 +6336,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 4806,
+          "line": 4820,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6348,7 +6348,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 4820,
+          "line": 4834,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6365,7 +6365,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 4844,
+          "line": 4858,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6378,7 +6378,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 4848,
+          "line": 4862,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6389,7 +6389,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 4855,
+          "line": 4869,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6408,7 +6408,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 4893,
+          "line": 4907,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6421,7 +6421,7 @@
         },
         {
           "name": "Dig",
-          "line": 4906,
+          "line": 4920,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6440,7 +6440,7 @@
         },
         {
           "name": "GainControl",
-          "line": 4928,
+          "line": 4942,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6450,7 +6450,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 4932,
+          "line": 4946,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6461,7 +6461,7 @@
         },
         {
           "name": "Attach",
-          "line": 4938,
+          "line": 4952,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -6472,7 +6472,7 @@
         },
         {
           "name": "Surveil",
-          "line": 4953,
+          "line": 4967,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6487,7 +6487,7 @@
         },
         {
           "name": "Fight",
-          "line": 4959,
+          "line": 4973,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6498,7 +6498,7 @@
         },
         {
           "name": "Bounce",
-          "line": 4967,
+          "line": 4981,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6509,7 +6509,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 4980,
+          "line": 4994,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6524,7 +6524,7 @@
         },
         {
           "name": "Explore",
-          "line": 4988,
+          "line": 5002,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6532,7 +6532,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 4992,
+          "line": 5006,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6544,7 +6544,7 @@
         },
         {
           "name": "Investigate",
-          "line": 4997,
+          "line": 5011,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.136: Investigate — create a Clue artifact token.",
@@ -6554,7 +6554,7 @@
         },
         {
           "name": "Tribute",
-          "line": 5004,
+          "line": 5018,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6567,7 +6567,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 5010,
+          "line": 5024,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -6577,7 +6577,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 5012,
+          "line": 5026,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -6587,7 +6587,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 5013,
+          "line": 5027,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6595,7 +6595,7 @@
         },
         {
           "name": "Populate",
-          "line": 5015,
+          "line": 5029,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -6605,7 +6605,7 @@
         },
         {
           "name": "Clash",
-          "line": 5017,
+          "line": 5031,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -6615,7 +6615,7 @@
         },
         {
           "name": "Vote",
-          "line": 5032,
+          "line": 5046,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -6631,7 +6631,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 5076,
+          "line": 5090,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -6651,7 +6651,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 5095,
+          "line": 5109,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6663,7 +6663,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 5099,
+          "line": 5113,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6674,7 +6674,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 5109,
+          "line": 5123,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6694,7 +6694,7 @@
         },
         {
           "name": "Myriad",
-          "line": 5156,
+          "line": 5170,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -6704,7 +6704,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 5159,
+          "line": 5173,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6720,7 +6720,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 5169,
+          "line": 5183,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -6731,7 +6731,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 5175,
+          "line": 5189,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6743,7 +6743,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 5183,
+          "line": 5197,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6757,7 +6757,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 5190,
+          "line": 5204,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6769,7 +6769,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 5198,
+          "line": 5212,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -6782,7 +6782,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 5204,
+          "line": 5218,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -6795,7 +6795,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 5212,
+          "line": 5226,
           "kind": "struct",
           "field_names": [
             "source",
@@ -6812,7 +6812,7 @@
         },
         {
           "name": "Animate",
-          "line": 5230,
+          "line": 5244,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6827,7 +6827,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 5247,
+          "line": 5261,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -6837,7 +6837,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 5251,
+          "line": 5265,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -6849,7 +6849,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 5259,
+          "line": 5273,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -6866,7 +6866,7 @@
         },
         {
           "name": "Mana",
-          "line": 5277,
+          "line": 5291,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -6880,7 +6880,7 @@
         },
         {
           "name": "Discard",
-          "line": 5300,
+          "line": 5314,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6894,7 +6894,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 5322,
+          "line": 5336,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6904,7 +6904,7 @@
         },
         {
           "name": "Transform",
-          "line": 5326,
+          "line": 5340,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6914,7 +6914,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 5332,
+          "line": 5346,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -6928,7 +6928,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 5364,
+          "line": 5378,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -6944,7 +6944,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 5373,
+          "line": 5387,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6957,7 +6957,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 5394,
+          "line": 5408,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -6970,7 +6970,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5405,
+          "line": 5419,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6983,7 +6983,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 5410,
+          "line": 5424,
           "kind": "struct",
           "field_names": [
             "player",
@@ -6996,7 +6996,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 5419,
+          "line": 5433,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7007,7 +7007,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 5430,
+          "line": 5444,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7017,7 +7017,7 @@
         },
         {
           "name": "Choose",
-          "line": 5436,
+          "line": 5450,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -7028,7 +7028,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 5447,
+          "line": 5461,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -7041,7 +7041,7 @@
         },
         {
           "name": "Suspect",
-          "line": 5452,
+          "line": 5466,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7053,7 +7053,7 @@
         },
         {
           "name": "Connive",
-          "line": 5459,
+          "line": 5473,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7067,7 +7067,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 5467,
+          "line": 5481,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7079,7 +7079,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 5474,
+          "line": 5488,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7091,7 +7091,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 5479,
+          "line": 5493,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7103,7 +7103,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 5484,
+          "line": 5498,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -7113,7 +7113,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 5491,
+          "line": 5505,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7125,7 +7125,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 5498,
+          "line": 5512,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7137,7 +7137,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 5503,
+          "line": 5517,
           "kind": "struct",
           "field_names": [
             "level"
@@ -7149,7 +7149,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 5508,
+          "line": 5522,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -7163,7 +7163,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 5538,
+          "line": 5552,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -7177,7 +7177,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 5544,
+          "line": 5558,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -7189,7 +7189,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 5549,
+          "line": 5563,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7202,7 +7202,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 5556,
+          "line": 5570,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -7215,7 +7215,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 5565,
+          "line": 5579,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7228,7 +7228,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 5573,
+          "line": 5587,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -7242,7 +7242,7 @@
         },
         {
           "name": "PayCost",
-          "line": 5583,
+          "line": 5597,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -7255,7 +7255,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 5594,
+          "line": 5608,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7273,7 +7273,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 5624,
+          "line": 5638,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7289,7 +7289,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 5647,
+          "line": 5661,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: A player who meets this effect's condition loses the game. The affected player is determined by resolution context (controller's opponent if untargeted, or explicit target if targeted).",
@@ -7299,7 +7299,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 5649,
+          "line": 5663,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: The controller wins the game — all opponents lose.",
@@ -7309,7 +7309,7 @@
         },
         {
           "name": "RollDie",
-          "line": 5652,
+          "line": 5666,
           "kind": "struct",
           "field_names": [
             "sides",
@@ -7322,7 +7322,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 5658,
+          "line": 5672,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -7335,7 +7335,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 5670,
+          "line": 5684,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7349,7 +7349,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 5679,
+          "line": 5693,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -7361,7 +7361,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 5684,
+          "line": 5698,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -7371,7 +7371,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 5687,
+          "line": 5701,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -7381,7 +7381,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 5689,
+          "line": 5703,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -7393,7 +7393,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 5694,
+          "line": 5708,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -7404,7 +7404,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 5697,
+          "line": 5711,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -7414,7 +7414,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 5700,
+          "line": 5714,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -7426,7 +7426,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 5717,
+          "line": 5731,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7445,7 +7445,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 5750,
+          "line": 5764,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -7460,7 +7460,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 5763,
+          "line": 5777,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -7474,7 +7474,7 @@
         },
         {
           "name": "Exploit",
-          "line": 5772,
+          "line": 5786,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7486,7 +7486,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 5777,
+          "line": 5791,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -7498,7 +7498,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 5782,
+          "line": 5796,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -7513,7 +7513,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 5794,
+          "line": 5808,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7525,7 +7525,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 5806,
+          "line": 5820,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7541,7 +7541,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 5817,
+          "line": 5831,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7558,7 +7558,7 @@
         },
         {
           "name": "Discover",
-          "line": 5845,
+          "line": 5859,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -7570,7 +7570,7 @@
         },
         {
           "name": "Cascade",
-          "line": 5857,
+          "line": 5871,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -7580,7 +7580,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 5861,
+          "line": 5875,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -7592,7 +7592,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 5866,
+          "line": 5880,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -7604,7 +7604,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 5879,
+          "line": 5893,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7616,7 +7616,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 5888,
+          "line": 5902,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7628,7 +7628,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 5897,
+          "line": 5911,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7638,7 +7638,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 5902,
+          "line": 5916,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -7648,7 +7648,7 @@
         },
         {
           "name": "Goad",
-          "line": 5908,
+          "line": 5922,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7660,7 +7660,7 @@
         },
         {
           "name": "Detain",
-          "line": 5915,
+          "line": 5929,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7672,7 +7672,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 5926,
+          "line": 5940,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -7686,7 +7686,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 5937,
+          "line": 5951,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7700,7 +7700,7 @@
         },
         {
           "name": "Manifest",
-          "line": 5952,
+          "line": 5966,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7713,7 +7713,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 5958,
+          "line": 5972,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -7723,7 +7723,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 5962,
+          "line": 5976,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7735,7 +7735,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 5971,
+          "line": 5985,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7748,7 +7748,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 5981,
+          "line": 5995,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7762,7 +7762,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 5993,
+          "line": 6007,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7778,7 +7778,7 @@
         },
         {
           "name": "Double",
-          "line": 6004,
+          "line": 6018,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -7792,7 +7792,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 6012,
+          "line": 6026,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -7804,7 +7804,7 @@
         },
         {
           "name": "Incubate",
-          "line": 6018,
+          "line": 6032,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7816,7 +7816,7 @@
         },
         {
           "name": "Amass",
-          "line": 6026,
+          "line": 6040,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -7829,7 +7829,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 6034,
+          "line": 6048,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7841,7 +7841,7 @@
         },
         {
           "name": "Bolster",
-          "line": 6040,
+          "line": 6054,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7853,7 +7853,7 @@
         },
         {
           "name": "Adapt",
-          "line": 6046,
+          "line": 6060,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7865,7 +7865,7 @@
         },
         {
           "name": "Learn",
-          "line": 6052,
+          "line": 6066,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -7875,7 +7875,7 @@
         },
         {
           "name": "Forage",
-          "line": 6054,
+          "line": 6068,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -7885,7 +7885,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6056,
+          "line": 6070,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -7897,7 +7897,7 @@
         },
         {
           "name": "Endure",
-          "line": 6061,
+          "line": 6075,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -7907,7 +7907,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 6066,
+          "line": 6080,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7919,7 +7919,7 @@
         },
         {
           "name": "Seek",
-          "line": 6071,
+          "line": 6085,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7933,7 +7933,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 6088,
+          "line": 6102,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7946,7 +7946,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 6095,
+          "line": 6109,
           "kind": "struct",
           "field_names": [
             "to"
@@ -7958,7 +7958,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 6100,
+          "line": 6114,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7971,7 +7971,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 6109,
+          "line": 6123,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7983,7 +7983,7 @@
         },
         {
           "name": "Conjure",
-          "line": 6116,
+          "line": 6130,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -7995,7 +7995,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 6137,
+          "line": 6151,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8009,7 +8009,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6148,
+          "line": 6162,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8096,13 +8096,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10550,
+      "line": 10576,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 10552,
+          "line": 10578,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8110,7 +8110,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 10554,
+          "line": 10580,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8118,7 +8118,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 10556,
+          "line": 10582,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8126,7 +8126,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 10558,
+          "line": 10584,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8134,7 +8134,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 10560,
+          "line": 10586,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8142,7 +8142,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 10562,
+          "line": 10588,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8153,124 +8153,12 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7060,
+      "line": 7074,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7061,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeSpeed",
-          "line": 7062,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DealDamage",
-          "line": 7063,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Draw",
-          "line": 7064,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Pump",
-          "line": 7065,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PairWith",
-          "line": 7066,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Destroy",
-          "line": 7067,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Counter",
-          "line": 7068,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterAll",
-          "line": 7069,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Token",
-          "line": 7070,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GainLife",
-          "line": 7071,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseLife",
-          "line": 7072,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Tap",
-          "line": 7073,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Untap",
-          "line": 7074,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddCounter",
           "line": 7075,
           "kind": "unit",
           "field_names": [],
@@ -8278,7 +8166,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveCounter",
+          "name": "ChangeSpeed",
           "line": 7076,
           "kind": "unit",
           "field_names": [],
@@ -8286,7 +8174,7 @@
           "cr_refs": []
         },
         {
-          "name": "Sacrifice",
+          "name": "DealDamage",
           "line": 7077,
           "kind": "unit",
           "field_names": [],
@@ -8294,7 +8182,7 @@
           "cr_refs": []
         },
         {
-          "name": "DiscardCard",
+          "name": "Draw",
           "line": 7078,
           "kind": "unit",
           "field_names": [],
@@ -8302,7 +8190,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mill",
+          "name": "Pump",
           "line": 7079,
           "kind": "unit",
           "field_names": [],
@@ -8310,7 +8198,7 @@
           "cr_refs": []
         },
         {
-          "name": "Scry",
+          "name": "PairWith",
           "line": 7080,
           "kind": "unit",
           "field_names": [],
@@ -8318,7 +8206,7 @@
           "cr_refs": []
         },
         {
-          "name": "PumpAll",
+          "name": "Destroy",
           "line": 7081,
           "kind": "unit",
           "field_names": [],
@@ -8326,7 +8214,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageAll",
+          "name": "Counter",
           "line": 7082,
           "kind": "unit",
           "field_names": [],
@@ -8334,7 +8222,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageEachPlayer",
+          "name": "CounterAll",
           "line": 7083,
           "kind": "unit",
           "field_names": [],
@@ -8342,7 +8230,7 @@
           "cr_refs": []
         },
         {
-          "name": "DestroyAll",
+          "name": "Token",
           "line": 7084,
           "kind": "unit",
           "field_names": [],
@@ -8350,7 +8238,7 @@
           "cr_refs": []
         },
         {
-          "name": "TapAll",
+          "name": "GainLife",
           "line": 7085,
           "kind": "unit",
           "field_names": [],
@@ -8358,7 +8246,7 @@
           "cr_refs": []
         },
         {
-          "name": "UntapAll",
+          "name": "LoseLife",
           "line": 7086,
           "kind": "unit",
           "field_names": [],
@@ -8366,7 +8254,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZone",
+          "name": "Tap",
           "line": 7087,
           "kind": "unit",
           "field_names": [],
@@ -8374,7 +8262,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZoneAll",
+          "name": "Untap",
           "line": 7088,
           "kind": "unit",
           "field_names": [],
@@ -8382,7 +8270,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dig",
+          "name": "AddCounter",
           "line": 7089,
           "kind": "unit",
           "field_names": [],
@@ -8390,7 +8278,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainControl",
+          "name": "RemoveCounter",
           "line": 7090,
           "kind": "unit",
           "field_names": [],
@@ -8398,7 +8286,7 @@
           "cr_refs": []
         },
         {
-          "name": "ControlNextTurn",
+          "name": "Sacrifice",
           "line": 7091,
           "kind": "unit",
           "field_names": [],
@@ -8406,7 +8294,7 @@
           "cr_refs": []
         },
         {
-          "name": "Attach",
+          "name": "DiscardCard",
           "line": 7092,
           "kind": "unit",
           "field_names": [],
@@ -8414,7 +8302,7 @@
           "cr_refs": []
         },
         {
-          "name": "AttachAll",
+          "name": "Mill",
           "line": 7093,
           "kind": "unit",
           "field_names": [],
@@ -8422,7 +8310,7 @@
           "cr_refs": []
         },
         {
-          "name": "Surveil",
+          "name": "Scry",
           "line": 7094,
           "kind": "unit",
           "field_names": [],
@@ -8430,7 +8318,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fight",
+          "name": "PumpAll",
           "line": 7095,
           "kind": "unit",
           "field_names": [],
@@ -8438,7 +8326,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bounce",
+          "name": "DamageAll",
           "line": 7096,
           "kind": "unit",
           "field_names": [],
@@ -8446,7 +8334,7 @@
           "cr_refs": []
         },
         {
-          "name": "BounceAll",
+          "name": "DamageEachPlayer",
           "line": 7097,
           "kind": "unit",
           "field_names": [],
@@ -8454,7 +8342,7 @@
           "cr_refs": []
         },
         {
-          "name": "Explore",
+          "name": "DestroyAll",
           "line": 7098,
           "kind": "unit",
           "field_names": [],
@@ -8462,7 +8350,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExploreAll",
+          "name": "TapAll",
           "line": 7099,
           "kind": "unit",
           "field_names": [],
@@ -8470,7 +8358,7 @@
           "cr_refs": []
         },
         {
-          "name": "Investigate",
+          "name": "UntapAll",
           "line": 7100,
           "kind": "unit",
           "field_names": [],
@@ -8478,7 +8366,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tribute",
+          "name": "ChangeZone",
           "line": 7101,
           "kind": "unit",
           "field_names": [],
@@ -8486,7 +8374,7 @@
           "cr_refs": []
         },
         {
-          "name": "TimeTravel",
+          "name": "ChangeZoneAll",
           "line": 7102,
           "kind": "unit",
           "field_names": [],
@@ -8494,7 +8382,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomeMonarch",
+          "name": "Dig",
           "line": 7103,
           "kind": "unit",
           "field_names": [],
@@ -8502,7 +8390,7 @@
           "cr_refs": []
         },
         {
-          "name": "Proliferate",
+          "name": "GainControl",
           "line": 7104,
           "kind": "unit",
           "field_names": [],
@@ -8510,7 +8398,7 @@
           "cr_refs": []
         },
         {
-          "name": "Populate",
+          "name": "ControlNextTurn",
           "line": 7105,
           "kind": "unit",
           "field_names": [],
@@ -8518,7 +8406,7 @@
           "cr_refs": []
         },
         {
-          "name": "Clash",
+          "name": "Attach",
           "line": 7106,
           "kind": "unit",
           "field_names": [],
@@ -8526,8 +8414,120 @@
           "cr_refs": []
         },
         {
-          "name": "Vote",
+          "name": "AttachAll",
+          "line": 7107,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Surveil",
           "line": 7108,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Fight",
+          "line": 7109,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Bounce",
+          "line": 7110,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BounceAll",
+          "line": 7111,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Explore",
+          "line": 7112,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExploreAll",
+          "line": 7113,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Investigate",
+          "line": 7114,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Tribute",
+          "line": 7115,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TimeTravel",
+          "line": 7116,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomeMonarch",
+          "line": 7117,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Proliferate",
+          "line": 7118,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Populate",
+          "line": 7119,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Clash",
+          "line": 7120,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Vote",
+          "line": 7122,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -8537,7 +8537,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7110,
+          "line": 7124,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -8547,118 +8547,6 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7111,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopySpell",
-          "line": 7112,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopyTokenOf",
-          "line": 7113,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Myriad",
-          "line": 7114,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BecomeCopy",
-          "line": 7115,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseCard",
-          "line": 7116,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutCounter",
-          "line": 7117,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutCounterAll",
-          "line": 7118,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MultiplyCounter",
-          "line": 7119,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DoublePT",
-          "line": 7120,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DoublePTAll",
-          "line": 7121,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MoveCounters",
-          "line": 7122,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Animate",
-          "line": 7123,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RegisterBending",
-          "line": 7124,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GenericEffect",
           "line": 7125,
           "kind": "unit",
           "field_names": [],
@@ -8666,7 +8554,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cleanup",
+          "name": "CopySpell",
           "line": 7126,
           "kind": "unit",
           "field_names": [],
@@ -8674,7 +8562,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mana",
+          "name": "CopyTokenOf",
           "line": 7127,
           "kind": "unit",
           "field_names": [],
@@ -8682,7 +8570,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discard",
+          "name": "Myriad",
           "line": 7128,
           "kind": "unit",
           "field_names": [],
@@ -8690,7 +8578,7 @@
           "cr_refs": []
         },
         {
-          "name": "Shuffle",
+          "name": "BecomeCopy",
           "line": 7129,
           "kind": "unit",
           "field_names": [],
@@ -8698,7 +8586,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchLibrary",
+          "name": "ChooseCard",
           "line": 7130,
           "kind": "unit",
           "field_names": [],
@@ -8706,7 +8594,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchOutsideGame",
+          "name": "PutCounter",
           "line": 7131,
           "kind": "unit",
           "field_names": [],
@@ -8714,7 +8602,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileTop",
+          "name": "PutCounterAll",
           "line": 7132,
           "kind": "unit",
           "field_names": [],
@@ -8722,7 +8610,7 @@
           "cr_refs": []
         },
         {
-          "name": "TargetOnly",
+          "name": "MultiplyCounter",
           "line": 7133,
           "kind": "unit",
           "field_names": [],
@@ -8730,7 +8618,7 @@
           "cr_refs": []
         },
         {
-          "name": "Choose",
+          "name": "DoublePT",
           "line": 7134,
           "kind": "unit",
           "field_names": [],
@@ -8738,7 +8626,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDamageSource",
+          "name": "DoublePTAll",
           "line": 7135,
           "kind": "unit",
           "field_names": [],
@@ -8746,7 +8634,7 @@
           "cr_refs": []
         },
         {
-          "name": "Suspect",
+          "name": "MoveCounters",
           "line": 7136,
           "kind": "unit",
           "field_names": [],
@@ -8754,7 +8642,7 @@
           "cr_refs": []
         },
         {
-          "name": "Connive",
+          "name": "Animate",
           "line": 7137,
           "kind": "unit",
           "field_names": [],
@@ -8762,7 +8650,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseOut",
+          "name": "RegisterBending",
           "line": 7138,
           "kind": "unit",
           "field_names": [],
@@ -8770,7 +8658,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseIn",
+          "name": "GenericEffect",
           "line": 7139,
           "kind": "unit",
           "field_names": [],
@@ -8778,7 +8666,7 @@
           "cr_refs": []
         },
         {
-          "name": "ForceBlock",
+          "name": "Cleanup",
           "line": 7140,
           "kind": "unit",
           "field_names": [],
@@ -8786,7 +8674,7 @@
           "cr_refs": []
         },
         {
-          "name": "SolveCase",
+          "name": "Mana",
           "line": 7141,
           "kind": "unit",
           "field_names": [],
@@ -8794,8 +8682,120 @@
           "cr_refs": []
         },
         {
-          "name": "BecomePrepared",
+          "name": "Discard",
+          "line": 7142,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Shuffle",
           "line": 7143,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SearchLibrary",
+          "line": 7144,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SearchOutsideGame",
+          "line": 7145,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExileTop",
+          "line": 7146,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TargetOnly",
+          "line": 7147,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Choose",
+          "line": 7148,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseDamageSource",
+          "line": 7149,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Suspect",
+          "line": 7150,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Connive",
+          "line": 7151,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseOut",
+          "line": 7152,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseIn",
+          "line": 7153,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ForceBlock",
+          "line": 7154,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SolveCase",
+          "line": 7155,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomePrepared",
+          "line": 7157,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -8805,7 +8805,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 7145,
+          "line": 7159,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -8815,118 +8815,6 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 7146,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDelayedTrigger",
-          "line": 7147,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddTargetReplacement",
-          "line": 7148,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddRestriction",
-          "line": 7149,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReduceNextSpellCost",
-          "line": 7150,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantNextSpellAbility",
-          "line": 7151,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddPendingETBCounters",
-          "line": 7152,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateEmblem",
-          "line": 7153,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PayCost",
-          "line": 7154,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastFromZone",
-          "line": 7155,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PreventDamage",
-          "line": 7156,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Regenerate",
-          "line": 7157,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseTheGame",
-          "line": 7158,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "WinTheGame",
-          "line": 7159,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RollDie",
           "line": 7160,
           "kind": "unit",
           "field_names": [],
@@ -8934,7 +8822,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoin",
+          "name": "CreateDelayedTrigger",
           "line": 7161,
           "kind": "unit",
           "field_names": [],
@@ -8942,7 +8830,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoins",
+          "name": "AddTargetReplacement",
           "line": 7162,
           "kind": "unit",
           "field_names": [],
@@ -8950,7 +8838,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoinUntilLose",
+          "name": "AddRestriction",
           "line": 7163,
           "kind": "unit",
           "field_names": [],
@@ -8958,7 +8846,7 @@
           "cr_refs": []
         },
         {
-          "name": "RingTemptsYou",
+          "name": "ReduceNextSpellCost",
           "line": 7164,
           "kind": "unit",
           "field_names": [],
@@ -8966,7 +8854,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureIntoDungeon",
+          "name": "GrantNextSpellAbility",
           "line": 7165,
           "kind": "unit",
           "field_names": [],
@@ -8974,7 +8862,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureInto",
+          "name": "AddPendingETBCounters",
           "line": 7166,
           "kind": "unit",
           "field_names": [],
@@ -8982,7 +8870,7 @@
           "cr_refs": []
         },
         {
-          "name": "TakeTheInitiative",
+          "name": "CreateEmblem",
           "line": 7167,
           "kind": "unit",
           "field_names": [],
@@ -8990,7 +8878,7 @@
           "cr_refs": []
         },
         {
-          "name": "ProcessRadCounters",
+          "name": "PayCost",
           "line": 7168,
           "kind": "unit",
           "field_names": [],
@@ -8998,7 +8886,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantCastingPermission",
+          "name": "CastFromZone",
           "line": 7169,
           "kind": "unit",
           "field_names": [],
@@ -9006,7 +8894,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseFromZone",
+          "name": "PreventDamage",
           "line": 7170,
           "kind": "unit",
           "field_names": [],
@@ -9014,7 +8902,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseObjectsIntoTrackedSet",
+          "name": "Regenerate",
           "line": 7171,
           "kind": "unit",
           "field_names": [],
@@ -9022,7 +8910,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseAndSacrificeRest",
+          "name": "LoseTheGame",
           "line": 7172,
           "kind": "unit",
           "field_names": [],
@@ -9030,7 +8918,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exploit",
+          "name": "WinTheGame",
           "line": 7173,
           "kind": "unit",
           "field_names": [],
@@ -9038,7 +8926,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainEnergy",
+          "name": "RollDie",
           "line": 7174,
           "kind": "unit",
           "field_names": [],
@@ -9046,7 +8934,7 @@
           "cr_refs": []
         },
         {
-          "name": "GivePlayerCounter",
+          "name": "FlipCoin",
           "line": 7175,
           "kind": "unit",
           "field_names": [],
@@ -9054,7 +8942,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseAllPlayerCounters",
+          "name": "FlipCoins",
           "line": 7176,
           "kind": "unit",
           "field_names": [],
@@ -9062,7 +8950,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileFromTopUntil",
+          "name": "FlipCoinUntilLose",
           "line": 7177,
           "kind": "unit",
           "field_names": [],
@@ -9070,7 +8958,7 @@
           "cr_refs": []
         },
         {
-          "name": "RevealUntil",
+          "name": "RingTemptsYou",
           "line": 7178,
           "kind": "unit",
           "field_names": [],
@@ -9078,7 +8966,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discover",
+          "name": "VentureIntoDungeon",
           "line": 7179,
           "kind": "unit",
           "field_names": [],
@@ -9086,7 +8974,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cascade",
+          "name": "VentureInto",
           "line": 7180,
           "kind": "unit",
           "field_names": [],
@@ -9094,7 +8982,7 @@
           "cr_refs": []
         },
         {
-          "name": "MiracleCast",
+          "name": "TakeTheInitiative",
           "line": 7181,
           "kind": "unit",
           "field_names": [],
@@ -9102,7 +8990,7 @@
           "cr_refs": []
         },
         {
-          "name": "MadnessCast",
+          "name": "ProcessRadCounters",
           "line": 7182,
           "kind": "unit",
           "field_names": [],
@@ -9110,7 +8998,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutAtLibraryPosition",
+          "name": "GrantCastingPermission",
           "line": 7183,
           "kind": "unit",
           "field_names": [],
@@ -9118,7 +9006,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDrawnThisTurnPayOrTopdeck",
+          "name": "ChooseFromZone",
           "line": 7184,
           "kind": "unit",
           "field_names": [],
@@ -9126,7 +9014,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutOnTopOrBottom",
+          "name": "ChooseObjectsIntoTrackedSet",
           "line": 7185,
           "kind": "unit",
           "field_names": [],
@@ -9134,7 +9022,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiftDelivery",
+          "name": "ChooseAndSacrificeRest",
           "line": 7186,
           "kind": "unit",
           "field_names": [],
@@ -9142,7 +9030,7 @@
           "cr_refs": []
         },
         {
-          "name": "Goad",
+          "name": "Exploit",
           "line": 7187,
           "kind": "unit",
           "field_names": [],
@@ -9150,7 +9038,7 @@
           "cr_refs": []
         },
         {
-          "name": "Detain",
+          "name": "GainEnergy",
           "line": 7188,
           "kind": "unit",
           "field_names": [],
@@ -9158,7 +9046,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeControl",
+          "name": "GivePlayerCounter",
           "line": 7189,
           "kind": "unit",
           "field_names": [],
@@ -9166,7 +9054,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeTargets",
+          "name": "LoseAllPlayerCounters",
           "line": 7190,
           "kind": "unit",
           "field_names": [],
@@ -9174,7 +9062,7 @@
           "cr_refs": []
         },
         {
-          "name": "Incubate",
+          "name": "ExileFromTopUntil",
           "line": 7191,
           "kind": "unit",
           "field_names": [],
@@ -9182,7 +9070,7 @@
           "cr_refs": []
         },
         {
-          "name": "Amass",
+          "name": "RevealUntil",
           "line": 7192,
           "kind": "unit",
           "field_names": [],
@@ -9190,7 +9078,7 @@
           "cr_refs": []
         },
         {
-          "name": "Monstrosity",
+          "name": "Discover",
           "line": 7193,
           "kind": "unit",
           "field_names": [],
@@ -9198,7 +9086,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bolster",
+          "name": "Cascade",
           "line": 7194,
           "kind": "unit",
           "field_names": [],
@@ -9206,7 +9094,7 @@
           "cr_refs": []
         },
         {
-          "name": "Adapt",
+          "name": "MiracleCast",
           "line": 7195,
           "kind": "unit",
           "field_names": [],
@@ -9214,7 +9102,7 @@
           "cr_refs": []
         },
         {
-          "name": "Manifest",
+          "name": "MadnessCast",
           "line": 7196,
           "kind": "unit",
           "field_names": [],
@@ -9222,7 +9110,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "PutAtLibraryPosition",
           "line": 7197,
           "kind": "unit",
           "field_names": [],
@@ -9230,7 +9118,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExtraTurn",
+          "name": "ChooseDrawnThisTurnPayOrTopdeck",
           "line": 7198,
           "kind": "unit",
           "field_names": [],
@@ -9238,7 +9126,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextTurn",
+          "name": "PutOnTopOrBottom",
           "line": 7199,
           "kind": "unit",
           "field_names": [],
@@ -9246,7 +9134,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextStep",
+          "name": "GiftDelivery",
           "line": 7200,
           "kind": "unit",
           "field_names": [],
@@ -9254,7 +9142,7 @@
           "cr_refs": []
         },
         {
-          "name": "AdditionalPhase",
+          "name": "Goad",
           "line": 7201,
           "kind": "unit",
           "field_names": [],
@@ -9262,7 +9150,7 @@
           "cr_refs": []
         },
         {
-          "name": "Double",
+          "name": "Detain",
           "line": 7202,
           "kind": "unit",
           "field_names": [],
@@ -9270,7 +9158,7 @@
           "cr_refs": []
         },
         {
-          "name": "RuntimeHandled",
+          "name": "ExchangeControl",
           "line": 7203,
           "kind": "unit",
           "field_names": [],
@@ -9278,7 +9166,7 @@
           "cr_refs": []
         },
         {
-          "name": "Learn",
+          "name": "ChangeTargets",
           "line": 7204,
           "kind": "unit",
           "field_names": [],
@@ -9286,7 +9174,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "Incubate",
           "line": 7205,
           "kind": "unit",
           "field_names": [],
@@ -9294,7 +9182,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "Amass",
           "line": 7206,
           "kind": "unit",
           "field_names": [],
@@ -9302,7 +9190,7 @@
           "cr_refs": []
         },
         {
-          "name": "Endure",
+          "name": "Monstrosity",
           "line": 7207,
           "kind": "unit",
           "field_names": [],
@@ -9310,7 +9198,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlightEffect",
+          "name": "Bolster",
           "line": 7208,
           "kind": "unit",
           "field_names": [],
@@ -9318,7 +9206,7 @@
           "cr_refs": []
         },
         {
-          "name": "Seek",
+          "name": "Adapt",
           "line": 7209,
           "kind": "unit",
           "field_names": [],
@@ -9326,7 +9214,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetLifeTotal",
+          "name": "Manifest",
           "line": 7210,
           "kind": "unit",
           "field_names": [],
@@ -9334,7 +9222,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetDayNight",
+          "name": "ManifestDread",
           "line": 7211,
           "kind": "unit",
           "field_names": [],
@@ -9342,7 +9230,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveControl",
+          "name": "ExtraTurn",
           "line": 7212,
           "kind": "unit",
           "field_names": [],
@@ -9350,7 +9238,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveFromCombat",
+          "name": "SkipNextTurn",
           "line": 7213,
           "kind": "unit",
           "field_names": [],
@@ -9358,7 +9246,7 @@
           "cr_refs": []
         },
         {
-          "name": "Conjure",
+          "name": "SkipNextStep",
           "line": 7214,
           "kind": "unit",
           "field_names": [],
@@ -9366,7 +9254,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseOneOf",
+          "name": "AdditionalPhase",
           "line": 7215,
           "kind": "unit",
           "field_names": [],
@@ -9374,7 +9262,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unimplemented",
+          "name": "Double",
           "line": 7216,
           "kind": "unit",
           "field_names": [],
@@ -9382,8 +9270,120 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "RuntimeHandled",
+          "line": 7217,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Learn",
           "line": 7218,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Forage",
+          "line": 7219,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CollectEvidence",
+          "line": 7220,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Endure",
+          "line": 7221,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BlightEffect",
+          "line": 7222,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Seek",
+          "line": 7223,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetLifeTotal",
+          "line": 7224,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetDayNight",
+          "line": 7225,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GiveControl",
+          "line": 7226,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RemoveFromCombat",
+          "line": 7227,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Conjure",
+          "line": 7228,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseOneOf",
+          "line": 7229,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unimplemented",
+          "line": 7230,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 7232,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -9391,7 +9391,7 @@
         },
         {
           "name": "Crew",
-          "line": 7220,
+          "line": 7234,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -9401,7 +9401,7 @@
         },
         {
           "name": "Station",
-          "line": 7222,
+          "line": 7236,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -9411,7 +9411,7 @@
         },
         {
           "name": "Saddle",
-          "line": 7224,
+          "line": 7238,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -9421,7 +9421,7 @@
         },
         {
           "name": "Reveal",
-          "line": 7226,
+          "line": 7240,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -9429,7 +9429,7 @@
         },
         {
           "name": "Transform",
-          "line": 7227,
+          "line": 7241,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9437,7 +9437,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 7228,
+          "line": 7242,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9445,7 +9445,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 7229,
+          "line": 7243,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9712,13 +9712,13 @@
     },
     "FilterProp": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1626,
+      "line": 1640,
       "doc": "Individual filter properties that can be combined in a Typed filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Token",
-          "line": 1628,
+          "line": 1642,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are tokens.",
@@ -9728,7 +9728,7 @@
         },
         {
           "name": "NonToken",
-          "line": 1630,
+          "line": 1644,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are not tokens.",
@@ -9738,7 +9738,7 @@
         },
         {
           "name": "Attacking",
-          "line": 1631,
+          "line": 1645,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9746,7 +9746,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1633,
+          "line": 1647,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Matches creatures that are blocking.",
@@ -9756,7 +9756,7 @@
         },
         {
           "name": "BlockingSource",
-          "line": 1636,
+          "line": 1650,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g: Matches creatures currently blocking the filter source. Used for \"creature(s) blocking it\" source-relative quantities and filters.",
@@ -9766,7 +9766,7 @@
         },
         {
           "name": "Unblocked",
-          "line": 1638,
+          "line": 1652,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Matches attacking creatures with no blockers assigned.",
@@ -9776,7 +9776,7 @@
         },
         {
           "name": "Tapped",
-          "line": 1639,
+          "line": 1653,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9784,7 +9784,7 @@
         },
         {
           "name": "Untapped",
-          "line": 1641,
+          "line": 1655,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 / CR 110.5: Untapped status as targeting qualifier.",
@@ -9795,7 +9795,7 @@
         },
         {
           "name": "WithKeyword",
-          "line": 1642,
+          "line": 1656,
           "kind": "struct",
           "field_names": [
             "value"
@@ -9805,7 +9805,7 @@
         },
         {
           "name": "HasKeywordKind",
-          "line": 1645,
+          "line": 1659,
           "kind": "struct",
           "field_names": [
             "value"
@@ -9815,7 +9815,7 @@
         },
         {
           "name": "WithoutKeyword",
-          "line": 1650,
+          "line": 1664,
           "kind": "struct",
           "field_names": [
             "value"
@@ -9827,7 +9827,7 @@
         },
         {
           "name": "WithoutKeywordKind",
-          "line": 1653,
+          "line": 1667,
           "kind": "struct",
           "field_names": [
             "value"
@@ -9837,7 +9837,7 @@
         },
         {
           "name": "CanEnchant",
-          "line": 1661,
+          "line": 1675,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9850,7 +9850,7 @@
         },
         {
           "name": "Counters",
-          "line": 1671,
+          "line": 1685,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -9864,7 +9864,7 @@
         },
         {
           "name": "Cmc",
-          "line": 1681,
+          "line": 1695,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -9877,7 +9877,7 @@
         },
         {
           "name": "ManaCostIn",
-          "line": 1688,
+          "line": 1702,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -9890,7 +9890,7 @@
         },
         {
           "name": "InZone",
-          "line": 1691,
+          "line": 1705,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -9900,7 +9900,7 @@
         },
         {
           "name": "Owned",
-          "line": 1694,
+          "line": 1708,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -9910,7 +9910,7 @@
         },
         {
           "name": "Foretold",
-          "line": 1700,
+          "line": 1714,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c-d: Matches cards in exile that have the foretold designation. This is a status of the exiled card, not equivalent to having the Foretell keyword or a generic exile casting permission.",
@@ -9920,7 +9920,7 @@
         },
         {
           "name": "EnchantedBy",
-          "line": 1701,
+          "line": 1715,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9928,7 +9928,7 @@
         },
         {
           "name": "EquippedBy",
-          "line": 1702,
+          "line": 1716,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9936,7 +9936,7 @@
         },
         {
           "name": "AttachedToSource",
-          "line": 1708,
+          "line": 1722,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the matched object's `attached_to` field equals the filter source's object ID. Inverse of `EnchantedBy`/`EquippedBy`, which check whether the source has an attachment. Used for \"Aura and Equipment attached to ~\" quantity clauses (Kellan, the Fae-Blooded) and for any compound filter whose subject is \"attached to <self>\".",
@@ -9947,7 +9947,7 @@
         },
         {
           "name": "AttachedToRecipient",
-          "line": 1722,
+          "line": 1736,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4 + CR 613.4c: True when the matched object's `attached_to` field equals the *recipient* of the resolving effect (the per-object `id` in a layer's affected list). Distinct from `AttachedToSource` — for an Aura/Equipment static \"Enchanted/Equipped creature gets +N/+M for each X attached to it\", the pronoun \"it\" refers to the affected creature, not to the static's source object. The recipient is supplied through `FilterContext::recipient_id`; when recipient is unknown (no per-recipient context), this prop evaluates to false. Covers ~25 cards: Strong Back, Mantle of the Ancients, Auramancer's Guise, Champion of the Flame, Bruenor Battlehammer's \"Each creature you control gets +2/+0 for each Equipment attached to it\", and the broader \"<subject> gets +N/+M for each Aura/Equipment attached to it\" family.",
@@ -9959,7 +9959,7 @@
         },
         {
           "name": "HasAttachment",
-          "line": 1734,
+          "line": 1748,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -9973,7 +9973,7 @@
         },
         {
           "name": "HasAnyAttachmentOf",
-          "line": 1745,
+          "line": 1759,
           "kind": "struct",
           "field_names": [
             "kinds",
@@ -9987,7 +9987,7 @@
         },
         {
           "name": "Another",
-          "line": 1751,
+          "line": 1765,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches any object that is NOT the trigger source (for \"another creature\" triggers).",
@@ -9995,7 +9995,7 @@
         },
         {
           "name": "Unpaired",
-          "line": 1753,
+          "line": 1767,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Matches objects that are not paired with another creature.",
@@ -10005,7 +10005,7 @@
         },
         {
           "name": "OtherThanTriggerObject",
-          "line": 1762,
+          "line": 1776,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 109.3: Matches any object that is NOT the object that caused the currently-evaluating trigger to fire (the \"triggering object\"). Distinct from `Another`, which excludes the *ability source*. Used for intervening-if count predicates like Valakut, the Molten Pinnacle's \"if you control at least five other Mountains\" — here \"other\" means \"other than the newly- entered Mountain,\" not \"other than Valakut.\" Resolves against `FilterContext::triggering_object_id`, populated at trigger-condition evaluation from the current `GameEvent`.",
@@ -10016,7 +10016,7 @@
         },
         {
           "name": "HasColor",
-          "line": 1764,
+          "line": 1778,
           "kind": "struct",
           "field_names": [
             "color"
@@ -10026,7 +10026,7 @@
         },
         {
           "name": "PowerLE",
-          "line": 1769,
+          "line": 1783,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10038,7 +10038,7 @@
         },
         {
           "name": "PowerGE",
-          "line": 1774,
+          "line": 1788,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10050,7 +10050,7 @@
         },
         {
           "name": "PowerGTSource",
-          "line": 1779,
+          "line": 1793,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: Matches objects whose power is strictly greater than the source object's power. Used for \"creatures with greater power\" blocking restrictions (relative comparison).",
@@ -10060,7 +10060,7 @@
         },
         {
           "name": "ColorCount",
-          "line": 1783,
+          "line": 1797,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -10073,7 +10073,7 @@
         },
         {
           "name": "HasSupertype",
-          "line": 1788,
+          "line": 1802,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10083,7 +10083,7 @@
         },
         {
           "name": "IsChosenCreatureType",
-          "line": 1793,
+          "line": 1807,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose subtypes include the source object's chosen creature type. Used for \"of the chosen type\" patterns (Cavern of Souls, Metallic Mimic).",
@@ -10091,7 +10091,7 @@
         },
         {
           "name": "MostPrevalentCreatureTypeIn",
-          "line": 1806,
+          "line": 1820,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -10105,7 +10105,7 @@
         },
         {
           "name": "IsChosenColor",
-          "line": 1815,
+          "line": 1829,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose colors include the source object's chosen color. Used for \"of the chosen color\" patterns (Hall of Triumph, Runed Stalactite). Reads `ChosenAttribute::Color` from the source permanent.",
@@ -10113,7 +10113,7 @@
         },
         {
           "name": "IsChosenCardType",
-          "line": 1819,
+          "line": 1833,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose core type includes the source object's chosen card type. Used for \"spells of the chosen type\" patterns (Archon of Valor's Reach). Reads `ChosenAttribute::CardType` from the source permanent.",
@@ -10121,7 +10121,7 @@
         },
         {
           "name": "IsChosenLandOrNonlandKind",
-          "line": 1824,
+          "line": 1838,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.2 + CR 608.2c: Matches objects by the transient \"land or nonland\" choice made earlier in the same resolving instruction sequence. Used by \"of the chosen kind\" library filters, where \"Land\" means cards with the land card type and \"Nonland\" means cards without it.",
@@ -10132,7 +10132,7 @@
         },
         {
           "name": "HasSingleTarget",
-          "line": 1827,
+          "line": 1841,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.7: Matches stack entries that have exactly one target. Used for \"with a single target\" qualifiers on retarget effects.",
@@ -10142,7 +10142,7 @@
         },
         {
           "name": "NotColor",
-          "line": 1830,
+          "line": 1844,
           "kind": "struct",
           "field_names": [
             "color"
@@ -10154,7 +10154,7 @@
         },
         {
           "name": "NotSupertype",
-          "line": 1835,
+          "line": 1849,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10166,7 +10166,7 @@
         },
         {
           "name": "Suspected",
-          "line": 1839,
+          "line": 1853,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.60b: Matches suspected creatures.",
@@ -10176,7 +10176,7 @@
         },
         {
           "name": "ToughnessGTPower",
-          "line": 1841,
+          "line": 1855,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: Matches creatures whose toughness is greater than their power.",
@@ -10186,7 +10186,7 @@
         },
         {
           "name": "ToughnessLE",
-          "line": 1845,
+          "line": 1859,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10198,7 +10198,7 @@
         },
         {
           "name": "ToughnessGE",
-          "line": 1849,
+          "line": 1863,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10210,7 +10210,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 1858,
+          "line": 1872,
           "kind": "struct",
           "field_names": [
             "props"
@@ -10220,7 +10220,7 @@
         },
         {
           "name": "Modified",
-          "line": 1870,
+          "line": 1884,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.9: A permanent is modified if it has one or more counters on it (CR 122), if it is equipped (CR 301.5), or if it is enchanted by an Aura that is controlled by that permanent's controller (CR 303.4).  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.9 names \"modified\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Modified` for \"modified creature(s)\" subjects, analogous to how `FilterProp::Suspected` models CR 701.60b's \"suspected\" status.",
@@ -10234,7 +10234,7 @@
         },
         {
           "name": "Historic",
-          "line": 1880,
+          "line": 1894,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: An object is historic if it has the legendary supertype, the artifact card type, or the Saga subtype.  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.6 names \"historic\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Historic` for \"historic permanent\" / \"historic spell\" / \"historic card\" subjects, mirroring `FilterProp::Modified` for CR 700.9's \"modified\" predicate.",
@@ -10245,7 +10245,7 @@
         },
         {
           "name": "DifferentNameFrom",
-          "line": 1884,
+          "line": 1898,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -10255,7 +10255,7 @@
         },
         {
           "name": "InAnyZone",
-          "line": 1889,
+          "line": 1903,
           "kind": "struct",
           "field_names": [
             "zones"
@@ -10267,7 +10267,7 @@
         },
         {
           "name": "SharesQuality",
-          "line": 1895,
+          "line": 1909,
           "kind": "struct",
           "field_names": [
             "quality",
@@ -10279,7 +10279,7 @@
         },
         {
           "name": "WasDealtDamageThisTurn",
-          "line": 1904,
+          "line": 1918,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1: Object was dealt damage during this turn. Checks `damage_marked > 0` (damage persists until cleanup step).",
@@ -10289,7 +10289,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 1907,
+          "line": 1921,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: Object entered the battlefield during this turn. Checks `entered_battlefield_turn == Some(current_turn)`.",
@@ -10299,7 +10299,7 @@
         },
         {
           "name": "ZoneChangedThisTurn",
-          "line": 1912,
+          "line": 1926,
           "kind": "struct",
           "field_names": [
             "from",
@@ -10313,7 +10313,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 1920,
+          "line": 1934,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Creature was declared as an attacker this turn. Checks `creatures_attacked_this_turn` tracking set on GameState.",
@@ -10323,7 +10323,7 @@
         },
         {
           "name": "BlockedThisTurn",
-          "line": 1923,
+          "line": 1937,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Creature was declared as a blocker this turn. Checks `creatures_blocked_this_turn` tracking set on GameState.",
@@ -10333,7 +10333,7 @@
         },
         {
           "name": "AttackedOrBlockedThisTurn",
-          "line": 1926,
+          "line": 1940,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a + CR 509.1a: Creature attacked or blocked this turn. Compound check used by \"that attacked or blocked this turn\" Oracle text.",
@@ -10344,7 +10344,7 @@
         },
         {
           "name": "FaceDown",
-          "line": 1929,
+          "line": 1943,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.2: Matches face-down objects on the battlefield. Used for \"face-down creature\" trigger subjects.",
@@ -10354,7 +10354,7 @@
         },
         {
           "name": "TargetsOnly",
-          "line": 1934,
+          "line": 1948,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -10366,7 +10366,7 @@
         },
         {
           "name": "Targets",
-          "line": 1940,
+          "line": 1954,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -10379,7 +10379,7 @@
         },
         {
           "name": "HasXInManaCost",
-          "line": 1949,
+          "line": 1963,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 202.1: Matches spells/objects whose printed mana cost contains an `{X}` shard. Used for \"spell with {X} in its mana cost\" qualifier on spell-cast triggers (Lattice Library, Nev the Practical Dean, Owlin Spiralmancer, Brass Infiniscope, Elementalist's Palette). Evaluated against `SpellCastRecord.has_x_in_cost` in the spell-history filter path and against `cost_has_x(&obj.mana_cost)` for live objects.",
@@ -10390,7 +10390,7 @@
         },
         {
           "name": "HasManaAbility",
-          "line": 1953,
+          "line": 1967,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1: Matches objects that have at least one ability classified as a mana ability by the engine's authoritative mana-ability classifier. Used for library filters such as \"artifact card with a mana ability\".",
@@ -10400,7 +10400,7 @@
         },
         {
           "name": "HasNoAbilities",
-          "line": 1957,
+          "line": 1971,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.1 + CR 113.3: Matches objects that currently have no abilities: no keyword, activated, triggered, replacement, or static abilities. Used for library filters such as \"creature card with no abilities\".",
@@ -10411,7 +10411,7 @@
         },
         {
           "name": "Named",
-          "line": 1961,
+          "line": 1975,
           "kind": "struct",
           "field_names": [
             "name"
@@ -10424,7 +10424,7 @@
         },
         {
           "name": "SameName",
-          "line": 1966,
+          "line": 1980,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects with the same name as a previously-referenced card. Used for \"search your library for a card with that name\" patterns.",
@@ -10432,7 +10432,7 @@
         },
         {
           "name": "SameNameAsParentTarget",
-          "line": 1979,
+          "line": 1993,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: Matches objects whose name equals the name of the resolving ability's first object target. Used by chained sub-abilities where a prior step targeted/exiled a card and the next step references \"cards with that name\" — e.g., Deadly Cover-Up's \"search ... for any number of cards with that name and exile them\" (the \"that name\" is the name of the card exiled by the immediately preceding effect, which is inherited as the first target via `TargetFilter::ParentTarget`).  Differs from `SameName` (which reads the source object's name): this reads from `ability.targets[0]` when that target is `TargetRef::Object`, looking up the name from `state.objects` (or `lki_cache` if the target has already left its zone).",
@@ -10442,7 +10442,7 @@
         },
         {
           "name": "NameMatchesAnyPermanent",
-          "line": 1986,
+          "line": 2000,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -10455,7 +10455,7 @@
         },
         {
           "name": "AttackingController",
-          "line": 1992,
+          "line": 2006,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1b: Matches attacking creatures whose defending player equals the filter's source controller (\"creatures attacking you\"). Distinct from `Attacking`, which matches any attacker regardless of defender.",
@@ -10465,7 +10465,7 @@
         },
         {
           "name": "IsCommander",
-          "line": 1999,
+          "line": 2013,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 903.3d: Matches permanents on the battlefield that are a commander. Reads `GameObject::is_commander`, set during deck construction per CR 903.3 (the legendary card designated as that deck's commander). Used for \"commander(s) you control\", \"your commander\" subject phrases and for \"target commander\" in commander-format effects (Codsworth, Falthis, Anara, Champions of Archery, etc.).",
@@ -10476,7 +10476,7 @@
         },
         {
           "name": "Other",
-          "line": 2000,
+          "line": 2014,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13032,13 +13032,13 @@
     },
     "GameRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1178,
+      "line": 1176,
       "doc": "A game-level restriction that modifies how rules are applied. Stored in `GameState::restrictions` and evaluated by relevant game systems.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DamagePreventionDisabled",
-          "line": 1180,
+          "line": 1178,
           "kind": "struct",
           "field_names": [
             "source",
@@ -13051,33 +13051,20 @@
           ]
         },
         {
-          "name": "CastOnlyFromZones",
-          "line": 1188,
+          "name": "ProhibitActivity",
+          "line": 1186,
           "kind": "struct",
           "field_names": [
             "source",
             "affected_players",
-            "allowed_zones",
-            "expiry"
+            "expiry",
+            "activity"
           ],
-          "doc": "CR 101.2 + CR 601.2a: A temporary effect restricts affected players to casting spells only from the listed zones until the restriction expires.",
+          "doc": "CR 101.2 + CR 601.2a + CR 602.5: A temporary effect prohibits one activity axis for affected players until expiry.",
           "cr_refs": [
             "CR 101.2",
-            "CR 601.2a"
-          ]
-        },
-        {
-          "name": "CantCastSpells",
-          "line": 1196,
-          "kind": "struct",
-          "field_names": [
-            "source",
-            "affected_players",
-            "expiry"
-          ],
-          "doc": "CR 101.2: A temporary effect prevents affected players from casting any spell until the restriction expires. E.g., Silence: \"Your opponents can't cast spells this turn.\"",
-          "cr_refs": [
-            "CR 101.2"
+            "CR 601.2a",
+            "CR 602.5"
           ]
         }
       ],
@@ -14879,7 +14866,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10156,
+      "line": 10182,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -14888,7 +14875,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 10158,
+          "line": 10184,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -14901,7 +14888,7 @@
         },
         {
           "name": "Crew",
-          "line": 10164,
+          "line": 10190,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -14914,7 +14901,7 @@
         },
         {
           "name": "Saddle",
-          "line": 10170,
+          "line": 10196,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -14927,7 +14914,7 @@
         },
         {
           "name": "Station",
-          "line": 10178,
+          "line": 10204,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -16028,7 +16015,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8494,
+      "line": 8508,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -16038,7 +16025,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 8496,
+          "line": 8510,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -16048,7 +16035,7 @@
         },
         {
           "name": "Second",
-          "line": 8499,
+          "line": 8513,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -16297,13 +16284,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4526,
+      "line": 4540,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 4527,
+          "line": 4541,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16311,7 +16298,7 @@
         },
         {
           "name": "Bottom",
-          "line": 4528,
+          "line": 4542,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16319,7 +16306,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 4530,
+          "line": 4544,
           "kind": "struct",
           "field_names": [
             "n"
@@ -16357,7 +16344,7 @@
     },
     "LinkedExileScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 930,
+      "line": 928,
       "doc": "CR 607.2a + CR 406.6 + CR 610.3: Which exile-link relation a mana ability reads when computing legal colors. Typed enum — never a bool — so future extensions (e.g. links to a different host than `~` itself) slot in cleanly.",
       "cr_refs": [
         "CR 406.6",
@@ -16367,7 +16354,7 @@
       "variants": [
         {
           "name": "ThisObject",
-          "line": 934,
+          "line": 932,
           "kind": "unit",
           "field_names": [],
           "doc": "Read `state.exile_links` keyed to this ability's source object (the activating permanent).",
@@ -17196,7 +17183,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9475,
+      "line": 9501,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -17205,7 +17192,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 9478,
+          "line": 9504,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -17217,7 +17204,7 @@
         },
         {
           "name": "Multiply",
-          "line": 9481,
+          "line": 9507,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -17304,35 +17291,33 @@
             "colors",
             "contribution"
           ],
-          "doc": "Produce an explicit fixed sequence of colored mana symbols (e.g. `{W}{U}`).",
+          "doc": "Produce one or more specific colors.",
           "cr_refs": []
         },
         {
           "name": "Colorless",
-          "line": 807,
+          "line": 806,
           "kind": "struct",
           "field_names": [
             "count"
           ],
-          "doc": "Produce N colorless mana (e.g. `{C}`, `{C}{C}`).",
+          "doc": "Produce strictly colorless mana (e.g. \"Add {C}\").",
           "cr_refs": []
         },
         {
           "name": "Mixed",
-          "line": 813,
+          "line": 811,
           "kind": "struct",
           "field_names": [
             "colorless_count",
             "colors"
           ],
-          "doc": "CR 106.1: Produce a mix of colorless and colored mana (e.g. `{C}{W}`, `{C}{C}{R}`). Used by Ravnica bounce lands (Karoo, Azorius Chancery) and similar.",
-          "cr_refs": [
-            "CR 106.1"
-          ]
+          "doc": "Produce a mixed bundle of fixed colorless + colored mana (e.g. \"Add {C}{R}\").",
+          "cr_refs": []
         },
         {
           "name": "AnyOneColor",
-          "line": 818,
+          "line": 816,
           "kind": "struct",
           "field_names": [
             "count",
@@ -17344,7 +17329,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 831,
+          "line": 829,
           "kind": "struct",
           "field_names": [
             "count",
@@ -17355,7 +17340,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 838,
+          "line": 836,
           "kind": "struct",
           "field_names": [
             "count",
@@ -17367,7 +17352,7 @@
         },
         {
           "name": "OpponentLandColors",
-          "line": 855,
+          "line": 853,
           "kind": "struct",
           "field_names": [
             "count"
@@ -17379,7 +17364,7 @@
         },
         {
           "name": "AnyTypeProduceableBy",
-          "line": 869,
+          "line": 867,
           "kind": "struct",
           "field_names": [
             "count",
@@ -17394,7 +17379,7 @@
         },
         {
           "name": "ChoiceAmongExiledColors",
-          "line": 879,
+          "line": 877,
           "kind": "struct",
           "field_names": [
             "source"
@@ -17408,7 +17393,7 @@
         },
         {
           "name": "ChoiceAmongCombinations",
-          "line": 889,
+          "line": 887,
           "kind": "struct",
           "field_names": [
             "options"
@@ -17421,7 +17406,7 @@
         },
         {
           "name": "AnyInCommandersColorIdentity",
-          "line": 899,
+          "line": 897,
           "kind": "struct",
           "field_names": [
             "count",
@@ -17436,7 +17421,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 915,
+          "line": 913,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -17450,7 +17435,7 @@
         },
         {
           "name": "TriggerEventManaType",
-          "line": 922,
+          "line": 920,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c + CR 106.3: Produce one mana of the same type as the mana produced by the triggering `ManaAdded` event. Used by `TapsForMana` triggers of the form \"add one mana of any type that land produced\" (Vorinclex, Voice of Hunger; Dictate of Karametra). Resolves from `state.current_trigger_event` at resolution time; emits no mana if the current trigger event is absent or not a `ManaAdded` event (CR 106.5).",
@@ -17465,7 +17450,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9487,
+      "line": 9513,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -17474,7 +17459,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 9490,
+          "line": 9516,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -17482,7 +17467,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 9492,
+          "line": 9518,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -17611,7 +17596,7 @@
     },
     "ManaSpendPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1353,
+      "line": 1367,
       "doc": "CR 609.4b: Permission modifying how mana may be spent to pay a cost.",
       "cr_refs": [
         "CR 609.4b"
@@ -17619,7 +17604,7 @@
       "variants": [
         {
           "name": "AnyTypeOrColor",
-          "line": 1357,
+          "line": 1371,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana may be spent as though it were mana of any type or color for this payment. This preserves the Oracle distinction without changing the actual mana spent.",
@@ -17630,13 +17615,13 @@
     },
     "ManaSpendRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1107,
+      "line": 1105,
       "doc": "Parse-time template for mana spend restrictions.  Unlike [`ManaRestriction`](super::mana::ManaRestriction) which carries concrete values on a `ManaUnit`, this enum is stored on `Effect::Mana` and resolved at production time by reading runtime state (e.g., chosen creature type from the source object).",
       "cr_refs": [],
       "variants": [
         {
           "name": "SpellOnly",
-          "line": 1109,
+          "line": 1107,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells.\"",
@@ -17644,7 +17629,7 @@
         },
         {
           "name": "SpellType",
-          "line": 1111,
+          "line": 1109,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast creature spells.\"",
@@ -17652,7 +17637,7 @@
         },
         {
           "name": "ChosenCreatureType",
-          "line": 1114,
+          "line": 1112,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast a creature spell of the chosen type.\" Resolved at runtime from the source's `chosen_creature_type()`.",
@@ -17660,7 +17645,7 @@
         },
         {
           "name": "SpellTypeOrAbilityActivation",
-          "line": 1118,
+          "line": 1116,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 106.12: \"Spend this mana only to cast creature spells or activate abilities of creatures.\" Combined restriction with OR semantics: allowed for spells of the type OR ability activations on permanents of the type. The `String` is the card type (e.g., \"Creature\").",
@@ -17670,7 +17655,7 @@
         },
         {
           "name": "ActivateOnly",
-          "line": 1121,
+          "line": 1119,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to activate abilities.\" Cannot be used to cast spells; only for ability activation costs.",
@@ -17678,7 +17663,7 @@
         },
         {
           "name": "XCostOnly",
-          "line": 1124,
+          "line": 1122,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only on costs that include {X}.\" Only permits spending on spells or abilities with {X} in their cost.",
@@ -17686,7 +17671,7 @@
         },
         {
           "name": "SpellWithKeywordKind",
-          "line": 1126,
+          "line": 1124,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback.\"",
@@ -17694,7 +17679,7 @@
         },
         {
           "name": "SpellWithKeywordKindFromZone",
-          "line": 1128,
+          "line": 1126,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -17893,13 +17878,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7481,
+      "line": 7495,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 7483,
+          "line": 7497,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -17911,7 +17896,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 7486,
+          "line": 7500,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -17929,13 +17914,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7461,
+      "line": 7475,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 7462,
+          "line": 7476,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17943,7 +17928,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 7465,
+          "line": 7479,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -17958,7 +17943,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 7472,
+          "line": 7486,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -17968,7 +17953,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 7475,
+          "line": 7489,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -18058,7 +18043,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3840,
+      "line": 3854,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -18068,7 +18053,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 3842,
+          "line": 3856,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -18078,7 +18063,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 3844,
+          "line": 3858,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -18091,13 +18076,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2928,
+      "line": 2942,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 2929,
+          "line": 2943,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18105,7 +18090,7 @@
         },
         {
           "name": "Toughness",
-          "line": 2930,
+          "line": 2944,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18113,7 +18098,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 2931,
+          "line": 2945,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18124,13 +18109,13 @@
     },
     "ObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2395,
+      "line": 2409,
       "doc": "Scope selector for object-axis quantities (Round Π-5). Picks WHICH object to read from when a `QuantityRef` (and future per-object conditions) is per-object. Mirrors `PlayerScope` for the player axis.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 2401,
+          "line": 2415,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.7 + CR 113.7a: The source object of the resolving ability — \"this creature\", \"~\", \"it\" (when \"it\" anaphors back to the source). CR 113.7 defines the source as the object that generated the ability; CR 113.7a keeps the ability (and thus its source reference) valid on the stack even after the source leaves its expected zone, via LKI.",
@@ -18141,7 +18126,7 @@
         },
         {
           "name": "Target",
-          "line": 2404,
+          "line": 2418,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The first object target of the resolving ability — \"that creature\", \"the creature\", \"it\" (when \"it\" anaphors back to a target).",
@@ -18151,7 +18136,7 @@
         },
         {
           "name": "Recipient",
-          "line": 2410,
+          "line": 2424,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4c + CR 115.10: The object currently receiving an effect. In layer evaluation this is the per-object recipient. Outside layers, it resolves to the first object target when present, then to the source. Used for recipient-relative \"its colors\" boosts such as Blessing of the Nephilim and Civic Saber.",
@@ -18162,7 +18147,7 @@
         },
         {
           "name": "EventSource",
-          "line": 2412,
+          "line": 2426,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: The object referenced by the current trigger event.",
@@ -18172,7 +18157,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2419,
+          "line": 2433,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: The specific untargeted object previously referred to by this ability's cost OR trigger condition. Resolved (first match wins) via `ResolvedAbility.cost_paid_object` → trigger-event source → `effect_context_object`. Subsumes the former `EventContextSource*` trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger referent are the two enumerated members of CR 608.2k's single clause).",
@@ -18185,7 +18170,7 @@
         },
         {
           "name": "Anaphoric",
-          "line": 2433,
+          "line": 2447,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: A deferred anaphoric pronoun (\"it\" / \"its\") whose object referent is bound at parse time. The parser remaps this to a concrete scope wherever it can — `Source` when the clause subject is the ability source, `Target` when the recipient is \"itself\". For triggered abilities no remap applies and `Anaphoric` survives to runtime, where it resolves identically to `CostPaidObject` (behavior-preserving — these cards parsed to `CostPaidObject` before this variant existed). General rules-correct runtime resolution of triggered-ability anaphora (e.g. \"its mana value\" after a reveal — see issue #511) is separate per-card parser work. Distinguishing this from an explicit cost-paid possessive (\"the sacrificed creature's power\", CR 608.2k -> `CostPaidObject`) is what prevents the subject-injection rewrite from clobbering correctly-scoped possessives.",
@@ -18236,7 +18221,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9043,
+      "line": 9057,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -18246,7 +18231,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 9045,
+          "line": 9059,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -18254,7 +18239,7 @@
         },
         {
           "name": "Equals",
-          "line": 9047,
+          "line": 9061,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -18262,7 +18247,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 9050,
+          "line": 9064,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -18270,7 +18255,7 @@
         },
         {
           "name": "OneOf",
-          "line": 9052,
+          "line": 9066,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -18306,7 +18291,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3566,
+      "line": 3580,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -18315,7 +18300,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 3567,
+          "line": 3581,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -18325,7 +18310,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3571,
+          "line": 3585,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -18335,7 +18320,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 3572,
+          "line": 3586,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18343,7 +18328,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3574,
+          "line": 3588,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -18353,7 +18338,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 3575,
+          "line": 3589,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -18363,7 +18348,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 3578,
+          "line": 3592,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -18374,7 +18359,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 3582,
+          "line": 3596,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -18384,7 +18369,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3586,
+          "line": 3600,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -18394,7 +18379,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 3588,
+          "line": 3602,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -18404,7 +18389,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 3589,
+          "line": 3603,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18412,7 +18397,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 3590,
+          "line": 3604,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -18422,7 +18407,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 3593,
+          "line": 3607,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -18432,7 +18417,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 3596,
+          "line": 3610,
           "kind": "struct",
           "field_names": [
             "color"
@@ -18442,7 +18427,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 3599,
+          "line": 3613,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18450,7 +18435,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 3600,
+          "line": 3614,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18458,7 +18443,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 3601,
+          "line": 3615,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18466,7 +18451,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 3602,
+          "line": 3616,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -18477,7 +18462,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 3606,
+          "line": 3620,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -18488,7 +18473,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 3610,
+          "line": 3624,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -18500,7 +18485,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3615,
+          "line": 3629,
           "kind": "struct",
           "field_names": [
             "count"
@@ -18510,7 +18495,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 3618,
+          "line": 3632,
           "kind": "struct",
           "field_names": [
             "count"
@@ -18520,7 +18505,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 3621,
+          "line": 3635,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -18530,7 +18515,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 3626,
+          "line": 3640,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -18542,7 +18527,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3635,
+          "line": 3649,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -18557,7 +18542,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 3640,
+          "line": 3654,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -18567,7 +18552,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 3643,
+          "line": 3657,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -18577,7 +18562,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 3646,
+          "line": 3660,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -18588,7 +18573,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 3650,
+          "line": 3664,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -18599,7 +18584,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 3654,
+          "line": 3668,
           "kind": "struct",
           "field_names": [
             "color",
@@ -18610,7 +18595,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 3658,
+          "line": 3672,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -18620,7 +18605,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 3661,
+          "line": 3675,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18628,7 +18613,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 3662,
+          "line": 3676,
           "kind": "struct",
           "field_names": [
             "name"
@@ -18638,7 +18623,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 3669,
+          "line": 3683,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -18651,7 +18636,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 3673,
+          "line": 3687,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -18661,7 +18646,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 3676,
+          "line": 3690,
           "kind": "struct",
           "field_names": [
             "power",
@@ -18672,7 +18657,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 3680,
+          "line": 3694,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18680,7 +18665,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 3681,
+          "line": 3695,
           "kind": "struct",
           "field_names": [
             "count"
@@ -18690,7 +18675,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 3684,
+          "line": 3698,
           "kind": "struct",
           "field_names": [
             "count"
@@ -18700,7 +18685,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 3687,
+          "line": 3701,
           "kind": "struct",
           "field_names": [
             "count"
@@ -18710,7 +18695,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 3690,
+          "line": 3704,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18718,7 +18703,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 3691,
+          "line": 3705,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18726,7 +18711,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 3692,
+          "line": 3706,
           "kind": "struct",
           "field_names": [
             "count"
@@ -18736,7 +18721,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 3698,
+          "line": 3712,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -18744,7 +18729,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 3701,
+          "line": 3715,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -18757,7 +18742,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 3705,
+          "line": 3719,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18765,7 +18750,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 3706,
+          "line": 3720,
           "kind": "struct",
           "field_names": [
             "count"
@@ -18775,7 +18760,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 3709,
+          "line": 3723,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18783,7 +18768,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 3710,
+          "line": 3724,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18791,7 +18776,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 3711,
+          "line": 3725,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18799,7 +18784,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 3712,
+          "line": 3726,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18807,7 +18792,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 3714,
+          "line": 3728,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -18817,7 +18802,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 3715,
+          "line": 3729,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18825,7 +18810,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 3716,
+          "line": 3730,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18833,7 +18818,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 3717,
+          "line": 3731,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18841,7 +18826,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 3718,
+          "line": 3732,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -18852,7 +18837,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 3722,
+          "line": 3736,
           "kind": "struct",
           "field_names": [
             "count"
@@ -18862,7 +18847,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 3727,
+          "line": 3741,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -18875,7 +18860,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 3732,
+          "line": 3746,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -18885,7 +18870,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 3740,
+          "line": 3754,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -18895,7 +18880,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 3753,
+          "line": 3767,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -18909,7 +18894,7 @@
         },
         {
           "name": "And",
-          "line": 3761,
+          "line": 3775,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -18922,7 +18907,7 @@
         },
         {
           "name": "Or",
-          "line": 3767,
+          "line": 3781,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -18935,7 +18920,7 @@
         },
         {
           "name": "Not",
-          "line": 3774,
+          "line": 3788,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -19095,7 +19080,7 @@
     },
     "PaymentCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3787,
+      "line": 3801,
       "doc": "CR 118.1: A cost paid as part of an effect's resolution. Distinct from AbilityCost (which gates activation before the colon).",
       "cr_refs": [
         "CR 118.1"
@@ -19103,7 +19088,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 3788,
+          "line": 3802,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -19113,7 +19098,7 @@
         },
         {
           "name": "Life",
-          "line": 3796,
+          "line": 3810,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -19126,7 +19111,7 @@
         },
         {
           "name": "Speed",
-          "line": 3800,
+          "line": 3814,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -19139,7 +19124,7 @@
         },
         {
           "name": "Energy",
-          "line": 3805,
+          "line": 3819,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -19151,7 +19136,7 @@
         },
         {
           "name": "AbilityCost",
-          "line": 3812,
+          "line": 3826,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -19164,7 +19149,7 @@
         },
         {
           "name": "ScaledMana",
-          "line": 3822,
+          "line": 3836,
           "kind": "struct",
           "field_names": [
             "base",
@@ -19181,7 +19166,7 @@
     },
     "PermissionGrantee": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1376,
+      "line": 1390,
       "doc": "CR 611.2a + CR 108.3: Identifies which player a `CastingPermission` is granted to at resolution time. Resolved to a concrete `PlayerId` by `grant_permission::resolve` before the permission is written to the target `GameObject`. Drives both `granted_to` binding and, for durations scoped to that player (e.g., `UntilNextTurnOf`), the prune step in `layers.rs`.  Default is `AbilityController` for all pre-existing parser call sites. Additional variants support compound-exile patterns where multiple objects are granted distinct permissions tied to different players: - `ObjectOwner` — Suspend Aggression: \"its owner may play it\". Each object   in the tracked set is granted to its own owner (CR 108.3). - `ParentTargetController` — Expedited Inheritance: \"its controller may   exile [N] ... They may play those cards\". The grant is tied to the   parent effect's player target rather than the triggered-ability controller.",
       "cr_refs": [
         "CR 108.3",
@@ -19190,7 +19175,7 @@
       "variants": [
         {
           "name": "AbilityController",
-          "line": 1379,
+          "line": 1393,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a default — the controller of the effect that created the grant.",
@@ -19200,7 +19185,7 @@
         },
         {
           "name": "ObjectOwner",
-          "line": 1381,
+          "line": 1395,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 — each iterated object's owner (per-object binding).",
@@ -19210,7 +19195,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 1383,
+          "line": 1397,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 — the player target of the parent effect in the chain.",
@@ -19472,13 +19457,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3006,
+      "line": 3020,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 3010,
+          "line": 3024,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -19488,7 +19473,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3012,
+          "line": 3026,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -19496,7 +19481,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3014,
+          "line": 3028,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -19506,7 +19491,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 3016,
+          "line": 3030,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -19514,7 +19499,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 3018,
+          "line": 3032,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -19522,7 +19507,7 @@
         },
         {
           "name": "All",
-          "line": 3020,
+          "line": 3034,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -19530,7 +19515,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 3022,
+          "line": 3036,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -19540,7 +19525,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 3025,
+          "line": 3039,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -19548,7 +19533,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 3029,
+          "line": 3043,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -19562,7 +19547,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 3035,
+          "line": 3049,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -19570,7 +19555,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3039,
+          "line": 3053,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -19581,7 +19566,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 3048,
+          "line": 3062,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -19592,7 +19577,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 3059,
+          "line": 3073,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -19605,7 +19590,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3071,
+          "line": 3085,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -19616,7 +19601,7 @@
         },
         {
           "name": "ControlsPermanent",
-          "line": 3077,
+          "line": 3091,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -19643,7 +19628,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2981,
+      "line": 2995,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -19653,7 +19638,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 2983,
+          "line": 2997,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -19661,7 +19646,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2985,
+          "line": 2999,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -19669,7 +19654,7 @@
         },
         {
           "name": "All",
-          "line": 2987,
+          "line": 3001,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -19680,7 +19665,7 @@
     },
     "PlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2343,
+      "line": 2357,
       "doc": "CR 102 + CR 119 + CR 402: Player axis for player-scoped quantity references.  Parameterizes the player whose hand size, life total, or other per-player scalar is being read. Replaces sibling enum variants like `LifeTotal` / `TargetLifeTotal` / `OpponentLifeTotal` and `HandSize` / `OpponentHandSize` with a single parameterized form.  Categorical-boundary check (per the \"Parameterize, don't proliferate\" principle): every variant is a player-relativity choice within a single CR section. Aggregate scopes (`Opponent`, `AllPlayers`) compose `AggregateFunction` to express max/min/sum across a population — they do not introduce a new abstraction layer.",
       "cr_refs": [
         "CR 102",
@@ -19690,7 +19675,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 2345,
+          "line": 2359,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 / CR 113.6: The controller of the source ability or effect.",
@@ -19701,7 +19686,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2349,
+          "line": 2363,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This keeps \"their\" quantities separate from \"you\" quantities.",
@@ -19712,7 +19697,7 @@
         },
         {
           "name": "Target",
-          "line": 2352,
+          "line": 2366,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 113.6 + CR 115.1: The first player target of the resolving ability (read from `ability.targets`).",
@@ -19724,7 +19709,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2356,
+          "line": 2370,
           "kind": "struct",
           "field_names": [
             "aggregate"
@@ -19737,7 +19722,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2361,
+          "line": 2375,
           "kind": "struct",
           "field_names": [
             "aggregate",
@@ -19750,7 +19735,7 @@
         },
         {
           "name": "RecipientController",
-          "line": 2375,
+          "line": 2389,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4m + CR 613.4c: The controller of the object currently receiving a layer effect. Used for Aura/Equipment statics such as \"enchanted creature gets +1/+1 for each card in its controller's hand\", where \"its\" refers to the enchanted creature, not the Aura.",
@@ -19761,7 +19746,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2381,
+          "line": 2395,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by attack-trigger intervening-if quantities such as \"no opponent has more life than that player.\"",
@@ -19772,7 +19757,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 2387,
+          "line": 2401,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"that opponent\" anaphoring the controller of a bounced/destroyed creature). The player-scalar-axis analogue of `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -19813,7 +19798,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9586,
+      "line": 9612,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -19822,7 +19807,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 9587,
+          "line": 9613,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -19830,7 +19815,7 @@
         },
         {
           "name": "Resolved",
-          "line": 9588,
+          "line": 9614,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -19917,6 +19902,54 @@
           "field_names": [],
           "doc": "The caller picked one complete mana sequence; the ability produces exactly these mana types in order.",
           "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "ProhibitedActivity": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 1196,
+      "doc": "",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "CastOnlyFromZones",
+          "line": 1198,
+          "kind": "struct",
+          "field_names": [
+            "allowed_zones"
+          ],
+          "doc": "CR 101.2 + CR 601.2a: Restrict casting to the listed zones.",
+          "cr_refs": [
+            "CR 101.2",
+            "CR 601.2a"
+          ]
+        },
+        {
+          "name": "CastSpells",
+          "line": 1200,
+          "kind": "struct",
+          "field_names": [
+            "spell_filter"
+          ],
+          "doc": "CR 101.2: Prevent casting matching spells.",
+          "cr_refs": [
+            "CR 101.2"
+          ]
+        },
+        {
+          "name": "ActivateAbilities",
+          "line": 1206,
+          "kind": "struct",
+          "field_names": [
+            "exemption"
+          ],
+          "doc": "CR 101.2 + CR 602.5 + CR 605.1a: Prevent activating abilities, optionally exempting mana abilities.",
+          "cr_refs": [
+            "CR 101.2",
+            "CR 602.5",
+            "CR 605.1a"
+          ]
         }
       ],
       "sibling_clusters": []
@@ -20355,13 +20388,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3088,
+      "line": 3102,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 3090,
+          "line": 3104,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -20371,7 +20404,7 @@
         },
         {
           "name": "Fixed",
-          "line": 3092,
+          "line": 3106,
           "kind": "struct",
           "field_names": [
             "value"
@@ -20381,7 +20414,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 3096,
+          "line": 3110,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -20395,7 +20428,7 @@
         },
         {
           "name": "Offset",
-          "line": 3103,
+          "line": 3117,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -20408,7 +20441,7 @@
         },
         {
           "name": "Multiply",
-          "line": 3108,
+          "line": 3122,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -20419,7 +20452,7 @@
         },
         {
           "name": "Sum",
-          "line": 3117,
+          "line": 3131,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -20429,7 +20462,7 @@
         },
         {
           "name": "UpTo",
-          "line": 3142,
+          "line": 3156,
           "kind": "struct",
           "field_names": [
             "max"
@@ -20442,7 +20475,7 @@
         },
         {
           "name": "Power",
-          "line": 3148,
+          "line": 3162,
           "kind": "struct",
           "field_names": [
             "base",
@@ -20455,7 +20488,7 @@
         },
         {
           "name": "Difference",
-          "line": 3163,
+          "line": 3177,
           "kind": "struct",
           "field_names": [
             "left",
@@ -20471,7 +20504,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9453,
+      "line": 9467,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -20479,7 +20512,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 9455,
+          "line": 9469,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -20487,7 +20520,7 @@
         },
         {
           "name": "Plus",
-          "line": 9457,
+          "line": 9471,
           "kind": "struct",
           "field_names": [
             "value"
@@ -20497,7 +20530,7 @@
         },
         {
           "name": "Minus",
-          "line": 9459,
+          "line": 9473,
           "kind": "struct",
           "field_names": [
             "value"
@@ -20507,12 +20540,14 @@
         },
         {
           "name": "Prevent",
-          "line": 9467,
+          "line": 9493,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6). Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers; CR 122.1 \"a counter is a marker placed on an object\" — placement is what we suppress). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
+          "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
           "cr_refs": [
+            "CR 113.6i",
             "CR 122.1",
+            "CR 614.17",
             "CR 614.6",
             "CR 614.7"
           ]
@@ -20522,13 +20557,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2472,
+      "line": 2486,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 2476,
+          "line": 2490,
           "kind": "struct",
           "field_names": [
             "player"
@@ -20540,7 +20575,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 2479,
+          "line": 2493,
           "kind": "struct",
           "field_names": [
             "player"
@@ -20552,7 +20587,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 2485,
+          "line": 2499,
           "kind": "struct",
           "field_names": [
             "player"
@@ -20564,7 +20599,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 2488,
+          "line": 2502,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -20572,7 +20607,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 2490,
+          "line": 2504,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -20582,7 +20617,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 2493,
+          "line": 2507,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -20592,7 +20627,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 2510,
+          "line": 2524,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -20606,7 +20641,7 @@
         },
         {
           "name": "PlayerCount",
-          "line": 2517,
+          "line": 2531,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -20616,7 +20651,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 2538,
+          "line": 2552,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -20629,7 +20664,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 2547,
+          "line": 2561,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -20642,7 +20677,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 2566,
+          "line": 2580,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -20659,7 +20694,7 @@
         },
         {
           "name": "Variable",
-          "line": 2571,
+          "line": 2585,
           "kind": "struct",
           "field_names": [
             "name"
@@ -20669,7 +20704,7 @@
         },
         {
           "name": "Power",
-          "line": 2578,
+          "line": 2592,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -20683,7 +20718,7 @@
         },
         {
           "name": "Toughness",
-          "line": 2583,
+          "line": 2597,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -20697,7 +20732,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 2589,
+          "line": 2603,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -20710,7 +20745,7 @@
         },
         {
           "name": "ObjectColorCount",
-          "line": 2595,
+          "line": 2609,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -20723,7 +20758,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 2600,
+          "line": 2614,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -20736,7 +20771,7 @@
         },
         {
           "name": "ManaSymbolsInManaCost",
-          "line": 2607,
+          "line": 2621,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -20750,7 +20785,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 2619,
+          "line": 2633,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -20762,7 +20797,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 2621,
+          "line": 2635,
           "kind": "struct",
           "field_names": [
             "function",
@@ -20776,7 +20811,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 2629,
+          "line": 2643,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -20786,7 +20821,7 @@
         },
         {
           "name": "Devotion",
-          "line": 2631,
+          "line": 2645,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -20798,7 +20833,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 2635,
+          "line": 2649,
           "kind": "struct",
           "field_names": [
             "source"
@@ -20810,7 +20845,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 2640,
+          "line": 2654,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -20821,7 +20856,7 @@
         },
         {
           "name": "ZoneCardCount",
-          "line": 2644,
+          "line": 2658,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -20835,7 +20870,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 2651,
+          "line": 2665,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -20847,7 +20882,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 2655,
+          "line": 2669,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -20857,7 +20892,7 @@
         },
         {
           "name": "ExiledFromHandThisResolution",
-          "line": 2661,
+          "line": 2675,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -20868,7 +20903,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 2665,
+          "line": 2679,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -20878,7 +20913,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 2680,
+          "line": 2694,
           "kind": "struct",
           "field_names": [
             "player"
@@ -20891,7 +20926,7 @@
         },
         {
           "name": "PartySize",
-          "line": 2689,
+          "line": 2703,
           "kind": "struct",
           "field_names": [
             "player"
@@ -20904,7 +20939,7 @@
         },
         {
           "name": "Speed",
-          "line": 2696,
+          "line": 2710,
           "kind": "struct",
           "field_names": [
             "player"
@@ -20916,7 +20951,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 2699,
+          "line": 2713,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -20926,7 +20961,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 2707,
+          "line": 2721,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -20940,7 +20975,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 2719,
+          "line": 2733,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -20952,7 +20987,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 2722,
+          "line": 2736,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -20965,7 +21000,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2729,
+          "line": 2743,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -20975,7 +21010,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 2735,
+          "line": 2749,
           "kind": "struct",
           "field_names": [
             "player",
@@ -20988,7 +21023,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 2740,
+          "line": 2754,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -20998,7 +21033,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 2746,
+          "line": 2760,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21010,7 +21045,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 2751,
+          "line": 2765,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21022,7 +21057,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 2754,
+          "line": 2768,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -21032,7 +21067,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 2758,
+          "line": 2772,
           "kind": "struct",
           "field_names": [
             "from",
@@ -21047,7 +21082,7 @@
         },
         {
           "name": "DamageDealtThisTurn",
-          "line": 2778,
+          "line": 2792,
           "kind": "struct",
           "field_names": [
             "source",
@@ -21064,7 +21099,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 2791,
+          "line": 2805,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -21072,7 +21107,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 2795,
+          "line": 2809,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Number of creatures the controller attacked with this turn. Used for \"if you attacked this turn\" and \"for each creature you attacked with this turn\" patterns.",
@@ -21082,7 +21117,7 @@
         },
         {
           "name": "DescendedThisTurn",
-          "line": 2797,
+          "line": 2811,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -21092,7 +21127,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 2800,
+          "line": 2814,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -21102,7 +21137,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 2814,
+          "line": 2828,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -21116,7 +21151,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 2825,
+          "line": 2839,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -21131,7 +21166,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 2834,
+          "line": 2848,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21144,7 +21179,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 2839,
+          "line": 2853,
           "kind": "struct",
           "field_names": [
             "player",
@@ -21158,7 +21193,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 2847,
+          "line": 2861,
           "kind": "struct",
           "field_names": [
             "player",
@@ -21172,7 +21207,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 2852,
+          "line": 2866,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -21182,7 +21217,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 2859,
+          "line": 2873,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -21192,7 +21227,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 2862,
+          "line": 2876,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -21203,7 +21238,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 2866,
+          "line": 2880,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -21213,7 +21248,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 2871,
+          "line": 2885,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -21227,7 +21262,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 2882,
+          "line": 2896,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -21238,7 +21273,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 2887,
+          "line": 2901,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -21248,7 +21283,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 2894,
+          "line": 2908,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21331,7 +21366,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7998,
+      "line": 8012,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -21340,7 +21375,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 8002,
+          "line": 8016,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -21353,13 +21388,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8857,
+      "line": 8871,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UnlessControlsSubtype",
-          "line": 8861,
+          "line": 8875,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -21369,7 +21404,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 8868,
+          "line": 8882,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21382,7 +21417,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 8873,
+          "line": 8887,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21394,7 +21429,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 8878,
+          "line": 8892,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -21407,7 +21442,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 8881,
+          "line": 8895,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -21419,7 +21454,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 8884,
+          "line": 8898,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -21429,7 +21464,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 8887,
+          "line": 8901,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -21440,7 +21475,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 8895,
+          "line": 8909,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -21453,7 +21488,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 8909,
+          "line": 8923,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -21466,7 +21501,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 8918,
+          "line": 8932,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -21476,7 +21511,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 8924,
+          "line": 8938,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -21488,7 +21523,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 8929,
+          "line": 8943,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -21500,7 +21535,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 8934,
+          "line": 8948,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -21511,7 +21546,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 8943,
+          "line": 8957,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -21523,7 +21558,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 8950,
+          "line": 8964,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -21537,7 +21572,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 8958,
+          "line": 8972,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -21547,7 +21582,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 8963,
+          "line": 8977,
           "kind": "struct",
           "field_names": [
             "source"
@@ -21561,7 +21596,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 8967,
+          "line": 8981,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -21574,7 +21609,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 8972,
+          "line": 8986,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -21585,7 +21620,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 8983,
+          "line": 8997,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -21598,7 +21633,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 8994,
+          "line": 9008,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -21610,7 +21645,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 8999,
+          "line": 9013,
           "kind": "struct",
           "field_names": [
             "text"
@@ -22014,13 +22049,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9552,
+      "line": 9578,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 9555,
+          "line": 9581,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -22028,7 +22063,7 @@
         },
         {
           "name": "Optional",
-          "line": 9557,
+          "line": 9583,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -22038,7 +22073,7 @@
         },
         {
           "name": "MayCost",
-          "line": 9564,
+          "line": 9590,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -22055,7 +22090,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9540,
+      "line": 9566,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 614.1a"
@@ -22063,7 +22098,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 9542,
+          "line": 9568,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source's controller.",
@@ -22071,7 +22106,7 @@
         },
         {
           "name": "Opponent",
-          "line": 9544,
+          "line": 9570,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source's controller.",
@@ -22079,7 +22114,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 9546,
+          "line": 9572,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -22090,13 +22125,13 @@
     },
     "RestrictionExpiry": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1206,
+      "line": 1212,
       "doc": "When a game restriction expires.",
       "cr_refs": [],
       "variants": [
         {
           "name": "EndOfTurn",
-          "line": 1207,
+          "line": 1213,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22104,7 +22139,7 @@
         },
         {
           "name": "EndOfCombat",
-          "line": 1208,
+          "line": 1214,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22112,7 +22147,7 @@
         },
         {
           "name": "UntilPlayerNextTurn",
-          "line": 1209,
+          "line": 1215,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22125,13 +22160,13 @@
     },
     "RestrictionPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1224,
+      "line": 1230,
       "doc": "Identifies which players are affected by a temporary game restriction.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 1225,
+          "line": 1231,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22139,15 +22174,33 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 1226,
+          "line": 1232,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
+          "name": "TargetedPlayer",
+          "line": 1235,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Placeholder used by parser lowering for effects that target a player. Resolved to `SpecificPlayer` by `add_restriction` at resolution time.",
+          "cr_refs": []
+        },
+        {
+          "name": "ParentTargetedPlayer",
+          "line": 1240,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 608.2c: Anaphoric \"that player\" in a sub-ability reuses a player target already chosen for an earlier instruction in the same chain. Resolved to `SpecificPlayer` by `add_restriction` after parent target propagation, without declaring a second target slot.",
+          "cr_refs": [
+            "CR 608.2c"
+          ]
+        },
+        {
           "name": "OpponentsOfSourceController",
-          "line": 1227,
+          "line": 1241,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22158,13 +22211,13 @@
     },
     "RestrictionScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1215,
+      "line": 1221,
       "doc": "Limits the scope of a game restriction to specific sources or targets.",
       "cr_refs": [],
       "variants": [
         {
           "name": "SourcesControlledBy",
-          "line": 1216,
+          "line": 1222,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -22172,7 +22225,7 @@
         },
         {
           "name": "SpecificSource",
-          "line": 1217,
+          "line": 1223,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -22180,7 +22233,7 @@
         },
         {
           "name": "DamageToTarget",
-          "line": 1218,
+          "line": 1224,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -22226,7 +22279,7 @@
     },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2901,
+      "line": 2915,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -22234,7 +22287,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 2902,
+          "line": 2916,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22242,7 +22295,7 @@
         },
         {
           "name": "Down",
-          "line": 2903,
+          "line": 2917,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22253,7 +22306,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3916,
+      "line": 3930,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -22261,7 +22314,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 3918,
+          "line": 3932,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -22398,13 +22451,13 @@
     },
     "SharedQuality": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1593,
+      "line": 1607,
       "doc": "Qualities that can be shared across multi-target selections. Used by `FilterProp::SharesQuality` for group constraint validation at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Name",
-          "line": 1595,
+          "line": 1609,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: object names compared by shared name.",
@@ -22414,7 +22467,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 1597,
+          "line": 1611,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: mana value.",
@@ -22424,7 +22477,7 @@
         },
         {
           "name": "Power",
-          "line": 1599,
+          "line": 1613,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: power.",
@@ -22434,7 +22487,7 @@
         },
         {
           "name": "Toughness",
-          "line": 1601,
+          "line": 1615,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: toughness.",
@@ -22444,7 +22497,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 1603,
+          "line": 1617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: sum of power and toughness.",
@@ -22454,7 +22507,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 1604,
+          "line": 1618,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22462,7 +22515,7 @@
         },
         {
           "name": "Color",
-          "line": 1605,
+          "line": 1619,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22470,7 +22523,7 @@
         },
         {
           "name": "CardType",
-          "line": 1606,
+          "line": 1620,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22478,7 +22531,7 @@
         },
         {
           "name": "LandType",
-          "line": 1608,
+          "line": 1622,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.6: land subtypes, including the five basic land types.",
@@ -22492,13 +22545,13 @@
     },
     "SharedQualityRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1613,
+      "line": 1627,
       "doc": "Relationship required by `FilterProp::SharesQuality`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Shares",
-          "line": 1615,
+          "line": 1629,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22506,7 +22559,7 @@
         },
         {
           "name": "DoesNotShare",
-          "line": 1616,
+          "line": 1630,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22592,7 +22645,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3259,
+      "line": 3273,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -22601,7 +22654,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 3261,
+          "line": 3275,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22613,7 +22666,7 @@
         },
         {
           "name": "Text",
-          "line": 3267,
+          "line": 3281,
           "kind": "struct",
           "field_names": [
             "description"
@@ -22626,7 +22679,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4567,
+      "line": 4581,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -22634,7 +22687,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 4569,
+          "line": 4583,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -22644,7 +22697,7 @@
         },
         {
           "name": "Decrease",
-          "line": 4571,
+          "line": 4585,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -22657,13 +22710,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4376,
+      "line": 4390,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 4377,
+          "line": 4391,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22671,7 +22724,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 4378,
+          "line": 4392,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22679,7 +22732,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 4379,
+          "line": 4393,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22687,7 +22740,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 4381,
+          "line": 4395,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -22761,13 +22814,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3333,
+      "line": 3347,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 3334,
+          "line": 3348,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -22778,7 +22831,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 3338,
+          "line": 3352,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22788,7 +22841,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 3344,
+          "line": 3358,
           "kind": "struct",
           "field_names": [
             "color"
@@ -22798,7 +22851,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3350,
+          "line": 3364,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22810,7 +22863,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 3356,
+          "line": 3370,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -22820,7 +22873,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 3358,
+          "line": 3372,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -22833,7 +22886,7 @@
         },
         {
           "name": "And",
-          "line": 3362,
+          "line": 3376,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -22843,7 +22896,7 @@
         },
         {
           "name": "Or",
-          "line": 3366,
+          "line": 3380,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -22853,7 +22906,7 @@
         },
         {
           "name": "Not",
-          "line": 3372,
+          "line": 3386,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -22863,7 +22916,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 3376,
+          "line": 3390,
           "kind": "struct",
           "field_names": [
             "state"
@@ -22875,7 +22928,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 3385,
+          "line": 3399,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -22891,7 +22944,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 3396,
+          "line": 3410,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -22906,7 +22959,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 3404,
+          "line": 3418,
           "kind": "struct",
           "field_names": [
             "level"
@@ -22918,7 +22971,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 3411,
+          "line": 3425,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22930,7 +22983,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 3415,
+          "line": 3429,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -22940,7 +22993,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3419,
+          "line": 3433,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -22951,7 +23004,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 3423,
+          "line": 3437,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -22962,7 +23015,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3427,
+          "line": 3441,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -22972,7 +23025,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 3429,
+          "line": 3443,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -22982,7 +23035,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 3432,
+          "line": 3446,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -22992,7 +23045,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 3434,
+          "line": 3448,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -23002,7 +23055,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 3437,
+          "line": 3451,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -23012,7 +23065,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 3443,
+          "line": 3457,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -23024,7 +23077,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 3451,
+          "line": 3465,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -23036,7 +23089,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3455,
+          "line": 3469,
           "kind": "struct",
           "field_names": [
             "count"
@@ -23048,7 +23101,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 3480,
+          "line": 3494,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -23066,7 +23119,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 3489,
+          "line": 3503,
           "kind": "struct",
           "field_names": [
             "text"
@@ -23076,7 +23129,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 3492,
+          "line": 3506,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23084,7 +23137,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3495,
+          "line": 3509,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -23094,7 +23147,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 3497,
+          "line": 3511,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -23104,7 +23157,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 3499,
+          "line": 3513,
           "kind": "struct",
           "field_names": [
             "level"
@@ -23116,7 +23169,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 3505,
+          "line": 3519,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -23130,7 +23183,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 3510,
+          "line": 3524,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -23140,7 +23193,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 3517,
+          "line": 3531,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23153,7 +23206,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 3522,
+          "line": 3536,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -23163,7 +23216,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 3526,
+          "line": 3540,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -23173,7 +23226,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 3530,
+          "line": 3544,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -23184,7 +23237,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 3534,
+          "line": 3548,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23196,7 +23249,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 3538,
+          "line": 3552,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -23206,7 +23259,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 3541,
+          "line": 3555,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -23218,7 +23271,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 3547,
+          "line": 3561,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -23229,7 +23282,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 3552,
+          "line": 3566,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ReduceCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -23240,7 +23293,7 @@
         },
         {
           "name": "None",
-          "line": 3553,
+          "line": 3567,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24182,7 +24235,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7963,
+      "line": 7977,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -24190,7 +24243,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 7971,
+          "line": 7985,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -24198,7 +24251,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 7976,
+          "line": 7990,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -24367,7 +24420,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7651,
+      "line": 7665,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -24377,7 +24430,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 7653,
+          "line": 7667,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24385,7 +24438,7 @@
         },
         {
           "name": "Resolution",
-          "line": 7654,
+          "line": 7668,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24396,13 +24449,13 @@
     },
     "TargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2138,
+      "line": 2152,
       "doc": "Typed target filter replacing all Forge filter strings and TargetSpec.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 2139,
+          "line": 2153,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24410,7 +24463,7 @@
         },
         {
           "name": "Any",
-          "line": 2140,
+          "line": 2154,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24418,7 +24471,7 @@
         },
         {
           "name": "Player",
-          "line": 2141,
+          "line": 2155,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24426,7 +24479,7 @@
         },
         {
           "name": "Controller",
-          "line": 2142,
+          "line": 2156,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24434,7 +24487,7 @@
         },
         {
           "name": "SelfRef",
-          "line": 2143,
+          "line": 2157,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24442,7 +24495,7 @@
         },
         {
           "name": "SourceOrPaired",
-          "line": 2146,
+          "line": 2160,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Resolves to the source object and the creature it is paired with. If the source is not paired, this matches no objects.",
@@ -24452,7 +24505,7 @@
         },
         {
           "name": "Typed",
-          "line": 2147,
+          "line": 2161,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24460,7 +24513,7 @@
         },
         {
           "name": "Not",
-          "line": 2148,
+          "line": 2162,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24470,7 +24523,7 @@
         },
         {
           "name": "Or",
-          "line": 2151,
+          "line": 2165,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -24480,7 +24533,7 @@
         },
         {
           "name": "And",
-          "line": 2154,
+          "line": 2168,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -24490,7 +24543,7 @@
         },
         {
           "name": "StackAbility",
-          "line": 2159,
+          "line": 2173,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -24500,7 +24553,7 @@
         },
         {
           "name": "StackSpell",
-          "line": 2165,
+          "line": 2179,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches spells on the stack (not activated/triggered abilities). CR 115.1a: Used by \"becomes the target of a spell\" triggers to filter source type.",
@@ -24510,7 +24563,7 @@
         },
         {
           "name": "SpecificObject",
-          "line": 2169,
+          "line": 2183,
           "kind": "struct",
           "field_names": [
             "id"
@@ -24520,7 +24573,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 2177,
+          "line": 2191,
           "kind": "struct",
           "field_names": [
             "id"
@@ -24533,7 +24586,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2183,
+          "line": 2197,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This is not the ability controller; \"you\" and \"your\" still refer to `controller`.",
@@ -24544,7 +24597,7 @@
         },
         {
           "name": "AttachedTo",
-          "line": 2186,
+          "line": 2200,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches the permanent that the trigger source (Equipment/Aura) is attached to. Used for \"equipped creature\" / \"enchanted creature\" trigger subjects.",
@@ -24552,7 +24605,7 @@
         },
         {
           "name": "LastCreated",
-          "line": 2189,
+          "line": 2203,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the most recently created token(s) from Effect::Token. Used for \"create X and [verb] it\" patterns (e.g. \"create a token and suspect it\").",
@@ -24560,7 +24613,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2193,
+          "line": 2207,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the resolving spell or ability. Used by effects such as \"the exiled card\" after an exile-as-cost clause.",
@@ -24571,7 +24624,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 2196,
+          "line": 2210,
           "kind": "struct",
           "field_names": [
             "id"
@@ -24583,7 +24636,7 @@
         },
         {
           "name": "TrackedSetFiltered",
-          "line": 2211,
+          "line": 2225,
           "kind": "struct",
           "field_names": [
             "id",
@@ -24597,7 +24650,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2217,
+          "line": 2231,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 610.3: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
@@ -24607,7 +24660,7 @@
         },
         {
           "name": "TriggeringSpellController",
-          "line": 2219,
+          "line": 2233,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the controller of the spell/ability that triggered this.",
@@ -24617,7 +24670,7 @@
         },
         {
           "name": "TriggeringSpellOwner",
-          "line": 2221,
+          "line": 2235,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the owner of the spell/ability that triggered this.",
@@ -24627,7 +24680,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 2223,
+          "line": 2237,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the player involved in the triggering event.",
@@ -24637,7 +24690,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 2225,
+          "line": 2239,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the source object of the triggering event.",
@@ -24647,7 +24700,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 2230,
+          "line": 2244,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the same target(s) as the parent ability. Used for anaphoric \"it\"/\"that creature\"/\"that player\" in compound effects (e.g., \"tap target creature and put a stun counter on it\"). At resolution time, the sub_ability chain inherits parent targets automatically.",
@@ -24655,7 +24708,7 @@
         },
         {
           "name": "ParentTargetSlot",
-          "line": 2235,
+          "line": 2249,
           "kind": "struct",
           "field_names": [
             "index"
@@ -24667,7 +24720,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2241,
+          "line": 2255,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Resolves to the controller of the parent ability's target object. Used for \"its controller\" in compound effects (e.g., \"counter target spell. Its controller loses 2 life.\"). At resolution time, looks up the controller of the first parent target.",
@@ -24677,7 +24730,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 2252,
+          "line": 2266,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 608.2c: Resolves to the *owner* of the parent ability's target object. Used for \"its owner\" anaphoric references where the acting player is the owner of a previously-mentioned permanent — e.g., Enslave's \"enchanted creature deals 1 damage to its owner\" or Bomb Squad's \"that creature deals 4 damage to its owner\". Resolution mirrors `ParentTargetController` (parent target slot → trigger-event source → AttachedTo host on source for Aura phase triggers), but returns the resolved object's `owner` rather than `controller` per CR 108.3.  Distinct from `Owner` (which always reads the source object's owner) and `ParentTargetController` (which returns the controller per CR 109.4).",
@@ -24689,7 +24742,7 @@
         },
         {
           "name": "OriginalController",
-          "line": 2273,
+          "line": 2287,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 + CR 608.2c: Resolves to the ability's *original* controller — the player who put the spell or ability on the stack — even when a surrounding `player_scope` iteration has rebound `ResolvedAbility::controller` to a different player for the current per-player iteration.  At resolution time, returns `ability.original_controller.unwrap_or(ability.controller)`. This mirrors the quantity-layer behavior in `resolve_quantity_with_targets`, where \"you\" / \"your\" quantities always read the original controller.  Used by parser-level distribution of compound subjects like \"you and that player each Y\" — the first half (\"you\") MUST resolve to the printed ability controller, not the iterated voter, even when the parent ability has `player_scope: PlayerFilter::VotedFor` (Master of Ceremonies pattern, CR 800.4g).  Distinct from `Controller` (which resolves to `ability.controller` and is rebound per-iteration by the player_scope driver in `resolve_ability_chain`). Distinct from `ParentTargetController` (parent's target's controller) and `PostReplacementSourceController` (replacement-context source's controller).",
@@ -24701,7 +24754,7 @@
         },
         {
           "name": "PostReplacementSourceController",
-          "line": 2292,
+          "line": 2306,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5 + CR 609.7: Resolves to the controller of the *prevented event's* damage source. Used by prevention follow-up sentences such as \"the source's controller draws cards equal to the damage prevented this way\" (Swans of Bryn Argoll) and \"deals damage to that source's controller\" (Deflecting Palm class). At resolution time, looks up `state.post_replacement_event_source` and returns its controller.  Distinct from `ParentTargetController` (which resolves via the parent ability's target slot) and `TriggeringSpellController` (which resolves via `state.current_trigger_event`, which is `None` during post-replacement resolution). Architectural twin of the quantity-side `last_effect_count` fallback at `replacement.rs:317` — both stash event context that lives outside the trigger window. The parser never emits this variant directly; the prevention follow-up call site rewrites `ParentTargetController` → `PostReplacementSourceController` via `each_target_filter_mut` after `parse_effect_chain` returns, so the surface phrase \"the source's controller\" can stay consolidated in `parse_target` for non-prevention callers.",
@@ -24712,7 +24765,7 @@
         },
         {
           "name": "PostReplacementDamageTarget",
-          "line": 2297,
+          "line": 2311,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5: Resolves to the player or permanent that was the target of the prevented damage event. Used by prevention follow-up sentences such as \"that player exiles that many cards\" where the affected player is the damage recipient, not the replacement source or damage source.",
@@ -24722,7 +24775,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2301,
+          "line": 2315,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Resolves to the defending player for the source attacking creature, looked up per attacker through `combat::defending_player_for_attacker`.",
@@ -24733,7 +24786,7 @@
         },
         {
           "name": "HasChosenName",
-          "line": 2304,
+          "line": 2318,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose name equals the source's ChosenAttribute::CardName. Used for \"card with the chosen name\" patterns.",
@@ -24741,7 +24794,7 @@
         },
         {
           "name": "ChosenDamageSource",
-          "line": 2308,
+          "line": 2322,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.7a: Matches the object stored as the source's chosen damage source. Resolution-time prevention effects should resolve this to `SpecificObject` when the shield is created so global shields do not depend on a live source.",
@@ -24751,7 +24804,7 @@
         },
         {
           "name": "Named",
-          "line": 2311,
+          "line": 2325,
           "kind": "struct",
           "field_names": [
             "name"
@@ -24761,7 +24814,7 @@
         },
         {
           "name": "Owner",
-          "line": 2319,
+          "line": 2333,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.3: Resolves to the owner of the object referenced by `source_id`. Used for \"its owner's library/hand/graveyard\" phrasings where the acting player must be the card's owner, not its current controller (e.g., Nexus of Fate's shuffle-back replacement when the card is under opposing control via Mind Control).",
@@ -24771,7 +24824,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2326,
+          "line": 2340,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.12a: Every player in the game (controller + opponents), polled in APNAP order. The unless-payer population for \"[Effect] unless any player pays ...\" clauses (Cleansing, Rhystic cycle, Soul Strings). Resolution is a sequential poll — the first player to pay prevents the effect — so this variant is only valid as an `UnlessPayModifier.payer`; it is never used as a target or affected filter.",
@@ -24802,13 +24855,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10138,
+      "line": 10164,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 10139,
+          "line": 10165,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24816,7 +24869,7 @@
         },
         {
           "name": "Player",
-          "line": 10140,
+          "line": 10166,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24844,7 +24897,7 @@
     },
     "TargetSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2117,
+      "line": 2131,
       "doc": "CR 115.1 + CR 701.9b: How a target slot's referent is selected.  CR 115.1: Default — the spell/ability's controller chooses each target. CR 701.9b: Some effects override the controller-choice default by requiring the game to make the selection (analogous to \"random discard\" — the affected player does not choose). Magic Oracle text expresses this with the modifier \"random target [predicate]\" appearing immediately before the target word (Mana Clash, Goblin Lyre, Pixie Queen, Vexing Sphinx, Maddening Hex, etc.).  Categorical-boundary check (per CLAUDE.md \"Parameterize, don't proliferate\"): this enum is the *selection-mode* axis — one level above the predicate (`TargetFilter`) and orthogonal to slot count (`MultiTargetSpec`). It does not belong on `TargetFilter` (which captures *what* matches), nor on `MultiTargetSpec` (which captures *how many*). It captures *who selects*.",
       "cr_refs": [
         "CR 115.1",
@@ -24853,7 +24906,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 2120,
+          "line": 2134,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The spell or ability's controller chooses each target.",
@@ -24863,7 +24916,7 @@
         },
         {
           "name": "Random",
-          "line": 2123,
+          "line": 2137,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9b (analogous): The game selects each target uniformly at random from the legal-target set. The controller does not choose.",
@@ -24961,13 +25014,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8580,
+      "line": 8594,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 8583,
+          "line": 8597,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -24977,7 +25030,7 @@
         },
         {
           "name": "LostLife",
-          "line": 8585,
+          "line": 8599,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -24985,7 +25038,7 @@
         },
         {
           "name": "Descended",
-          "line": 8587,
+          "line": 8601,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -24993,7 +25046,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 8589,
+          "line": 8603,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25003,7 +25056,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 8591,
+          "line": 8605,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -25013,7 +25066,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 8593,
+          "line": 8607,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -25023,7 +25076,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 8603,
+          "line": 8617,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25036,7 +25089,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 8606,
+          "line": 8620,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -25047,7 +25100,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 8609,
+          "line": 8623,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -25057,7 +25110,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 8613,
+          "line": 8627,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -25069,7 +25122,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 8616,
+          "line": 8630,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -25079,7 +25132,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 8619,
+          "line": 8633,
           "kind": "struct",
           "field_names": [
             "level"
@@ -25091,7 +25144,7 @@
         },
         {
           "name": "WasCast",
-          "line": 8624,
+          "line": 8638,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you cast it\" — zoneless cast check (unlike CastFromZone which requires a specific zone). CR 701.57a: Used by Discover ETB triggers. Negation (\"if it wasn't cast\") is expressed via `Not { Box::new(WasCast) }`.",
@@ -25101,7 +25154,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8629,
+          "line": 8643,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -25116,7 +25169,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 8643,
+          "line": 8657,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -25126,7 +25179,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 8649,
+          "line": 8663,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -25141,7 +25194,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 8653,
+          "line": 8667,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -25152,7 +25205,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 8657,
+          "line": 8671,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -25163,7 +25216,7 @@
         },
         {
           "name": "WasType",
-          "line": 8662,
+          "line": 8676,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -25176,7 +25229,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 8665,
+          "line": 8679,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -25188,7 +25241,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 8669,
+          "line": 8683,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -25201,7 +25254,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 8673,
+          "line": 8687,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25213,7 +25266,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 8677,
+          "line": 8691,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -25223,7 +25276,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 8680,
+          "line": 8694,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -25235,7 +25288,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 8684,
+          "line": 8698,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25247,7 +25300,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 8687,
+          "line": 8701,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -25259,7 +25312,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 8693,
+          "line": 8707,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -25269,7 +25322,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 8696,
+          "line": 8710,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -25279,7 +25332,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 8699,
+          "line": 8713,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -25289,7 +25342,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 8706,
+          "line": 8720,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -25301,7 +25354,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 8711,
+          "line": 8725,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -25313,7 +25366,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 8715,
+          "line": 8729,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -25323,7 +25376,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 8720,
+          "line": 8734,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -25335,7 +25388,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 8726,
+          "line": 8740,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -25345,7 +25398,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 8731,
+          "line": 8745,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -25355,7 +25408,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 8734,
+          "line": 8748,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -25365,7 +25418,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 8737,
+          "line": 8751,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -25375,7 +25428,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 8739,
+          "line": 8753,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -25387,7 +25440,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 8742,
+          "line": 8756,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -25397,7 +25450,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 8746,
+          "line": 8760,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -25407,7 +25460,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 8750,
+          "line": 8764,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25420,7 +25473,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 8753,
+          "line": 8767,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -25430,7 +25483,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 8757,
+          "line": 8771,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -25443,7 +25496,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 8760,
+          "line": 8774,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -25456,7 +25509,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 8762,
+          "line": 8776,
           "kind": "struct",
           "field_names": [
             "color",
@@ -25469,7 +25522,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 8764,
+          "line": 8778,
           "kind": "struct",
           "field_names": [
             "text"
@@ -25481,7 +25534,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 8766,
+          "line": 8780,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -25493,7 +25546,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 8770,
+          "line": 8784,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -25507,7 +25560,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 8772,
+          "line": 8786,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -25517,7 +25570,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 8777,
+          "line": 8791,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -25532,7 +25585,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 8788,
+          "line": 8802,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -25548,7 +25601,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 8803,
+          "line": 8817,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -25560,7 +25613,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 8806,
+          "line": 8820,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25573,7 +25626,7 @@
         },
         {
           "name": "AttackersDeclaredMin",
-          "line": 8819,
+          "line": 8833,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25589,7 +25642,7 @@
         },
         {
           "name": "NoneOfAttackersTargetedYou",
-          "line": 8824,
+          "line": 8838,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 603.4: Intervening-if \"if none of those creatures attacked you\". Reads the triggering `AttackersDeclared` event's per-attacker `AttackTarget` tuples (CR 508.1b) and returns true iff no attacker in the batch targeted the trigger's controller directly (`AttackTarget::Player(trigger_controller)`).",
@@ -25601,7 +25654,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 8834,
+          "line": 8848,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -25613,7 +25666,7 @@
         },
         {
           "name": "And",
-          "line": 8838,
+          "line": 8852,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -25623,7 +25676,7 @@
         },
         {
           "name": "Or",
-          "line": 8840,
+          "line": 8854,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -25633,7 +25686,7 @@
         },
         {
           "name": "Not",
-          "line": 8850,
+          "line": 8864,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -25649,13 +25702,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9005,
+      "line": 9019,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 9007,
+          "line": 9021,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -25663,7 +25716,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 9009,
+          "line": 9023,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -25671,7 +25724,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 9011,
+          "line": 9025,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -25679,7 +25732,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 9016,
+          "line": 9030,
           "kind": "struct",
           "field_names": [
             "n",
@@ -25690,7 +25743,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 9023,
+          "line": 9037,
           "kind": "struct",
           "field_names": [
             "n"
@@ -25700,7 +25753,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 9025,
+          "line": 9039,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -25708,7 +25761,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 9029,
+          "line": 9043,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -25718,7 +25771,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 9031,
+          "line": 9045,
           "kind": "struct",
           "field_names": [
             "level"
@@ -25730,7 +25783,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 9034,
+          "line": 9048,
           "kind": "struct",
           "field_names": [
             "max"
@@ -27275,13 +27328,13 @@
     },
     "TypeFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1496,
+      "line": 1510,
       "doc": "Type filter for card type matching in filters.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Creature",
-          "line": 1497,
+          "line": 1511,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27289,7 +27342,7 @@
         },
         {
           "name": "Land",
-          "line": 1498,
+          "line": 1512,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27297,7 +27350,7 @@
         },
         {
           "name": "Artifact",
-          "line": 1499,
+          "line": 1513,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27305,7 +27358,7 @@
         },
         {
           "name": "Enchantment",
-          "line": 1500,
+          "line": 1514,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27313,7 +27366,7 @@
         },
         {
           "name": "Instant",
-          "line": 1501,
+          "line": 1515,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27321,7 +27374,7 @@
         },
         {
           "name": "Sorcery",
-          "line": 1502,
+          "line": 1516,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27329,7 +27382,7 @@
         },
         {
           "name": "Planeswalker",
-          "line": 1503,
+          "line": 1517,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27337,7 +27390,7 @@
         },
         {
           "name": "Battle",
-          "line": 1505,
+          "line": 1519,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 310: Battle — a permanent type introduced in March of the Machine.",
@@ -27347,7 +27400,7 @@
         },
         {
           "name": "Permanent",
-          "line": 1506,
+          "line": 1520,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27355,7 +27408,7 @@
         },
         {
           "name": "Card",
-          "line": 1507,
+          "line": 1521,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27363,7 +27416,7 @@
         },
         {
           "name": "Any",
-          "line": 1508,
+          "line": 1522,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27371,7 +27424,7 @@
         },
         {
           "name": "Non",
-          "line": 1511,
+          "line": 1525,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.4b: Negation — matches objects whose type does NOT match the inner filter. \"noncreature\" → `Non(Box::new(Creature))`, \"non-Human\" → `Non(Box::new(Subtype(\"Human\")))`",
@@ -27381,7 +27434,7 @@
         },
         {
           "name": "Subtype",
-          "line": 1514,
+          "line": 1528,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.3: Matches objects with a specific subtype (creature type, land type, etc.). String because MTG has 250+ creature subtypes (CR 205.3m) with new ones each set.",
@@ -27392,7 +27445,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 1517,
+          "line": 1531,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2b: Disjunction — matches if ANY inner filter matches. \"creature or enchantment\" → `AnyOf(vec![Creature, Enchantment])`",
@@ -27471,7 +27524,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3286,
+      "line": 3300,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -27480,7 +27533,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 3288,
+          "line": 3302,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27488,7 +27541,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 3289,
+          "line": 3303,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27496,7 +27549,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 3290,
+          "line": 3304,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -27506,7 +27559,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 3293,
+          "line": 3307,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -27516,7 +27569,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 3305,
+          "line": 3319,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -27532,7 +27585,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2953,
+      "line": 2967,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -27545,7 +27598,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 2957,
+          "line": 2971,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27558,7 +27611,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 2961,
+          "line": 2975,
           "kind": "struct",
           "field_names": [
             "property",
@@ -27605,7 +27658,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6460,
+      "line": 6474,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -27614,7 +27667,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 6463,
+          "line": 6477,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -27624,7 +27677,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 6467,
+          "line": 6481,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -27634,7 +27687,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 6475,
+          "line": 6489,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",


### PR DESCRIPTION
## Summary
Adds engine support for **Abeyance**.

## Files changed
- crates/engine/src/types/ability.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/game/effects/add_restriction.rs
- crates/engine/src/game/casting.rs
- crates/engine/src/game/turns.rs
- crates/engine/src/game/replacement.rs

## CR references
- CR 101.2
- CR 602.5
- CR 605.1a

## Track
Developer

## LLM
Model: gpt-5.3-codex
Thinking: medium

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo check -p engine` — clean
- `cargo clippy-strict` — unresolved locally (build appears to stall at final test build stage)
- `cargo test -p engine` — unresolved locally (build appears to stall during engine test build)
- `./scripts/gen-card-data.sh` — not run due unresolved prior verification step
- `cargo coverage` — not run due unresolved prior verification step
- `cargo semantic-audit` — not run due unresolved prior verification step

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
Local developer-track verification could not be completed end-to-end in this environment:
- `cargo clippy-strict` repeatedly stalled at final test build stage
- `cargo test -p engine` repeatedly stalled during test build
Because Step 6 had unresolved verification failures, this PR is marked Partial.