### PR TITLE
Add Melira's Keepers

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -6416,7 +6416,14 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                 effective_lower.contains("token") && effective_lower.contains("instead")
             }
             ReplacementEvent::AddCounter => {
-                effective_lower.contains("counter") && effective_lower.contains("instead")
+                (effective_lower.contains("counter") && effective_lower.contains("instead"))
+                    // CR 614.6 + CR 122.1: counter-prohibition replacements
+                    // (Melira's Keepers class — "can't have counters put on it")
+                    // are CR 614.6 "event never happens" replacements, not
+                    // "X instead Y" rewrites, so they don't match the
+                    // "counter ... instead" surface above.
+                    || (effective_lower.contains("can't have")
+                        && effective_lower.contains("counter"))
             }
             ReplacementEvent::ProduceMana => {
                 effective_lower.contains("tapped for mana") && effective_lower.contains("instead")

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -1815,4 +1815,249 @@ mod tests {
             "obj.loyalty must mirror the doubled counter count"
         );
     }
+
+    /// CR 614.6 + CR 614.7 + CR 122.1: Melira's Keepers class — a permanent
+    /// carrying a self-targeted `AddCounter` replacement with
+    /// `QuantityModification::Prevent` must fully suppress incoming
+    /// counter-placement events. The replaced event "never happens"
+    /// (CR 614.6); no counters land, no `CounterAdded` event fires.
+    ///
+    /// Helper for the suite of Melira's Keepers tests: installs the
+    /// counter-prohibition replacement on `target_id`. Returns nothing — the
+    /// caller exercises `add_counter_with_replacement` directly to drive the
+    /// pipeline.
+    fn install_no_counters_replacement(state: &mut GameState, target_id: ObjectId) {
+        use crate::types::ability::{QuantityModification, ReplacementDefinition};
+        use crate::types::replacements::ReplacementEvent;
+        let mut repl = ReplacementDefinition::new(ReplacementEvent::AddCounter);
+        repl.valid_card = Some(TargetFilter::SelfRef);
+        repl.quantity_modification = Some(QuantityModification::Prevent);
+        repl.description = Some("~ can't have counters put on it.".to_string());
+        state
+            .objects
+            .get_mut(&target_id)
+            .unwrap()
+            .replacement_definitions
+            .push(repl);
+    }
+
+    #[test]
+    fn meliras_keepers_prevents_plus1_plus1_counter_placement() {
+        // CR 122.1a + CR 614.6: A +1/+1 counter is a counter (CR 122.1) — the
+        // replacement must apply to ANY counter type, including +1/+1.
+        let mut state = GameState::new_two_player(42);
+        let keepers_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Melira's Keepers".to_string(),
+            Zone::Battlefield,
+        );
+        install_no_counters_replacement(&mut state, keepers_id);
+
+        let mut events = Vec::new();
+        add_counter_with_replacement(
+            &mut state,
+            PlayerId(0),
+            keepers_id,
+            CounterType::Plus1Plus1,
+            3,
+            &mut events,
+        );
+
+        assert!(
+            state.objects[&keepers_id]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0)
+                == 0,
+            "no +1/+1 counters may land on Melira's Keepers"
+        );
+    }
+
+    #[test]
+    fn meliras_keepers_prevents_minus1_minus1_counter_placement() {
+        // CR 122.1a + CR 614.6: -1/-1 counters are also counters; the
+        // replacement is counter-type-agnostic, so it suppresses these too.
+        let mut state = GameState::new_two_player(42);
+        let keepers_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Melira's Keepers".to_string(),
+            Zone::Battlefield,
+        );
+        install_no_counters_replacement(&mut state, keepers_id);
+
+        let mut events = Vec::new();
+        add_counter_with_replacement(
+            &mut state,
+            PlayerId(0),
+            keepers_id,
+            CounterType::Minus1Minus1,
+            2,
+            &mut events,
+        );
+
+        assert!(
+            state.objects[&keepers_id]
+                .counters
+                .get(&CounterType::Minus1Minus1)
+                .copied()
+                .unwrap_or(0)
+                == 0,
+            "no -1/-1 counters may land on Melira's Keepers"
+        );
+    }
+
+    #[test]
+    fn meliras_keepers_prevents_arbitrary_counter_types() {
+        // CR 122.1 + CR 614.6: counter-agnostic — every CounterType variant
+        // routes through the same `AddCounter` proposed event, so the
+        // replacement suppresses charge / poison / generic counters identically.
+        let mut state = GameState::new_two_player(42);
+        let keepers_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Melira's Keepers".to_string(),
+            Zone::Battlefield,
+        );
+        install_no_counters_replacement(&mut state, keepers_id);
+
+        let mut events = Vec::new();
+        // Charge counter — generic named counter, not P/T-affecting.
+        add_counter_with_replacement(
+            &mut state,
+            PlayerId(0),
+            keepers_id,
+            CounterType::Generic("charge".to_string()),
+            1,
+            &mut events,
+        );
+
+        assert!(
+            state.objects[&keepers_id].counters.is_empty(),
+            "no counters of any type may land on Melira's Keepers"
+        );
+    }
+
+    #[test]
+    fn meliras_keepers_does_not_affect_other_creatures() {
+        // CR 614.1a + TargetFilter::SelfRef: the replacement is scoped to the
+        // source object only. Other creatures the same controller controls
+        // receive counters normally.
+        let mut state = GameState::new_two_player(42);
+        let keepers_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Melira's Keepers".to_string(),
+            Zone::Battlefield,
+        );
+        install_no_counters_replacement(&mut state, keepers_id);
+
+        let bystander_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Bystander".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut events = Vec::new();
+        add_counter_with_replacement(
+            &mut state,
+            PlayerId(0),
+            bystander_id,
+            CounterType::Plus1Plus1,
+            2,
+            &mut events,
+        );
+
+        assert_eq!(
+            state.objects[&bystander_id]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(2),
+            "the bystander must receive +1/+1 counters normally; the replacement is self-scoped"
+        );
+        assert!(
+            state.objects[&keepers_id].counters.is_empty(),
+            "Melira's Keepers must not have any counters from a placement targeting another object"
+        );
+    }
+
+    #[test]
+    fn meliras_keepers_replacement_filtered_when_source_off_battlefield() {
+        // CR 113.6 + CR 614.1: A replacement provided by a permanent functions
+        // only while that permanent is on the battlefield (or in another
+        // zone-of-function that opted in via `active_zones`). When the source
+        // moves to a non-battlefield zone, `find_applicable_replacements`
+        // filters it out via its `zones_to_scan` gate (currently Battlefield
+        // and Command) — counter placement on that very object (now in the
+        // graveyard, unreachable as a counter target in practice) is no
+        // longer suppressed by the SelfRef-scoped replacement.
+        //
+        // We exercise this by setting the source's zone to Graveyard and then
+        // proposing an AddCounter event directly against the now-off-battlefield
+        // object id. The applier path must skip the replacement (zone gate)
+        // and the count must land.
+        //
+        // CR 122.2 normally erases counters on zone change, but for the
+        // purpose of verifying the replacement gate we route the event
+        // through the same `add_counter_with_replacement` entrypoint.
+        let mut state = GameState::new_two_player(42);
+        let keepers_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Melira's Keepers".to_string(),
+            Zone::Battlefield,
+        );
+        install_no_counters_replacement(&mut state, keepers_id);
+
+        // Sanity: while on the battlefield, counters are prevented.
+        {
+            let mut events = Vec::new();
+            add_counter_with_replacement(
+                &mut state,
+                PlayerId(0),
+                keepers_id,
+                CounterType::Plus1Plus1,
+                1,
+                &mut events,
+            );
+            assert!(
+                state.objects[&keepers_id].counters.is_empty(),
+                "battlefield-resident Keepers must suppress counters (sanity check)"
+            );
+        }
+
+        // Move the source out of the battlefield — the zone gate in
+        // `find_applicable_replacements` (`zones_to_scan` = Battlefield +
+        // Command) must now filter the replacement out.
+        state.objects.get_mut(&keepers_id).unwrap().zone = Zone::Graveyard;
+
+        let mut events = Vec::new();
+        add_counter_with_replacement(
+            &mut state,
+            PlayerId(0),
+            keepers_id,
+            CounterType::Plus1Plus1,
+            1,
+            &mut events,
+        );
+
+        assert_eq!(
+            state.objects[&keepers_id]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(1),
+            "off-battlefield source's SelfRef replacement must not fire"
+        );
+    }
 }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -910,6 +910,11 @@ fn gain_life_applier(
                 QuantityModification::Double => amount.saturating_mul(2),
                 QuantityModification::Plus { value } => amount.saturating_add(value),
                 QuantityModification::Minus { value } => amount.saturating_sub(value),
+                // CR 614.6 + CR 614.7: No life-gain replacement uses Prevent
+                // today (Tainted Remedy converts gain → loss via execute chain),
+                // but the variant composes here for symmetry — fully suppress
+                // the gain event.
+                QuantityModification::Prevent => return ApplyResult::Prevented,
             };
             return ApplyResult::Modified(ProposedEvent::LifeGain {
                 player_id,
@@ -1104,6 +1109,11 @@ fn add_counter_applier(
             QuantityModification::Double => count.saturating_mul(2),
             QuantityModification::Plus { value } => count.saturating_add(value),
             QuantityModification::Minus { value } => count.saturating_sub(value),
+            // CR 614.6 + CR 614.7 + CR 122.1: "~ can't have counters put on it."
+            // — the proposed counter-placement event never happens
+            // (Melira's Keepers class). The replacement fires, but its outcome
+            // is to fully suppress the event rather than scale the count.
+            QuantityModification::Prevent => return ApplyResult::Prevented,
         };
         ApplyResult::Modified(ProposedEvent::AddCounter {
             actor,
@@ -1202,6 +1212,12 @@ fn create_token_applier(
             Some(QuantityModification::Double) => count.saturating_mul(2),
             Some(QuantityModification::Plus { value }) => count.saturating_add(value),
             Some(QuantityModification::Minus { value }) => count.saturating_sub(value),
+            // CR 614.6 + CR 614.7 + CR 111.1: No printed token-creation
+            // replacement uses Prevent today, but the variant composes here for
+            // symmetry — fully suppress the token-creation event so any future
+            // "tokens can't be created" replacement slots in without re-touching
+            // this applier.
+            Some(QuantityModification::Prevent) => return ApplyResult::Prevented,
             None => count,
         };
 

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -394,6 +394,14 @@ const REPLACEMENT_CONTAINS_PATTERNS: &[&str] = &[
     // `parse_replacement_line` even when its suffix carries a static keyword
     // pattern like "has haste" that would otherwise classify it as static.
     "become a copy of",
+    // CR 614.6 + CR 614.7 + CR 122.1: Self-targeted counter-prohibition
+    // replacements ("~ can't have counters put on it." — Melira's Keepers
+    // class). The line lacks "would"/"instead" so it does not match the
+    // damage/destroy/draw replacement surface phrases, and the static
+    // classifier's `can't have ` pattern (if any) would otherwise miscategorize
+    // it as a static. Routing it as a replacement keeps it in the CR 614
+    // pipeline where `add_counter_applier` short-circuits the proposed event.
+    "can't have counters put on",
 ];
 
 pub(crate) fn is_replacement_pattern(lower: &str) -> bool {

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4,8 +4,8 @@ use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::char;
-use nom::combinator::{opt, peek, value};
-use nom::sequence::{pair, preceded};
+use nom::combinator::{all_consuming, opt, peek, value};
+use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
 
 use super::oracle_effect::become_copy_except::parse_except_clause;
@@ -3808,20 +3808,21 @@ fn parse_no_counters_replacement(
     // The parser receives normalized text where "this creature" / "this
     // permanent" etc. have already been replaced by `~` (engine-internal
     // self-reference convention; CR 201.5 governs the underlying "object
-    // refers to itself by name" semantics). The combinator matches the
-    // entire line as a single shape so adjacent text (e.g., an "as long as
-    // ~ is tapped" prefix) is correctly rejected — those compose via the
-    // outer dispatch in `parse_replacement_line_inner`, not here.
-    let trimmed = norm_lower.trim().trim_end_matches('.');
-    let mut combinator = (
-        tag::<_, _, OracleError<'_>>("~ can't have counters put on "),
-        alt((tag("it"), tag("them"))),
-    )
-        .map(|(_, _): (&str, &str)| ());
-    let (rest, ()) = combinator.parse(trimmed).ok()?;
-    if !rest.trim().is_empty() {
-        return None;
-    }
+    // refers to itself by name" semantics). `all_consuming` enforces that
+    // the combinator matches the entire line as a single shape so adjacent
+    // text (e.g., an "as long as ~ is tapped" prefix) is correctly
+    // rejected — those compose via the outer dispatch in
+    // `parse_replacement_line_inner`, not here. `terminated(.., opt(tag(".")))`
+    // absorbs the optional trailing period inside the combinator, keeping
+    // the entire dispatch in idiomatic nom.
+    let mut combinator = all_consuming(terminated(
+        (
+            tag::<_, _, OracleError<'_>>("~ can't have counters put on "),
+            alt((tag("it"), tag("them"))),
+        ),
+        opt(tag(".")),
+    ));
+    combinator.parse(norm_lower.trim()).ok()?;
 
     Some(
         ReplacementDefinition::new(ReplacementEvent::AddCounter)

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -401,6 +401,18 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         }
     }
 
+    // --- Counter-prohibition replacement: "~ can't have counters put on it." ---
+    // CR 614.6 + CR 614.7 + CR 122.1: A self-targeted counter-placement
+    // prohibition. The proposed `AddCounter` event never happens
+    // (CR 614.6 — "if an event is replaced, it never happens"). Melira's
+    // Keepers class. The Solemnity-class global variant (no player gets
+    // counters anywhere) lifts the SelfRef scope to a wider filter and is
+    // out of scope for this PR — the typed shape (Prevent + valid_card)
+    // composes cleanly for it.
+    if let Some(def) = parse_no_counters_replacement(&norm_lower, &text) {
+        return Some(def);
+    }
+
     // --- Damage redirection: "all damage that would be dealt to [target] is dealt to ~ instead" ---
     // CR 614.1a: Replacement effects that redirect damage to a different recipient.
     if let Some(def) = parse_damage_redirection_replacement(&norm_lower, &text) {
@@ -3752,6 +3764,71 @@ fn extract_replacement_counter_type(lower: &str) -> Option<CounterType> {
     )
         .map(|(_, _, ct, _): (&str, &str, CounterType, &str)| ct);
     combinator.parse(lower).ok().map(|(_rest, ct)| ct)
+}
+
+/// CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Parse a self-targeted
+/// counter-prohibition replacement effect.
+///
+/// CR 113.6i is the authorizing rule: "An object's ability that states
+/// counters can't be put on that object functions as that object is entering
+/// the battlefield in addition to functioning while that object is on the
+/// battlefield." CR 614.17 is the "can't" effects framework — these aren't
+/// strictly replacement effects, but follow similar rules — which is why we
+/// model the prohibition through the replacement pipeline. CR 614.6/614.7
+/// describe the resulting "event never happens" outcome; CR 122.1 names the
+/// counter-placement event the prohibition suppresses.
+///
+/// Recognizes:
+/// - `~ can't have counters put on it.` (Melira's Keepers — Human Scout)
+/// - `~ can't have counters put on them.` (plural-pronoun variants)
+///
+/// The engine produces a `ReplacementDefinition` keyed on
+/// `ReplacementEvent::AddCounter` with `valid_card: SelfRef` and
+/// `quantity_modification: Some(QuantityModification::Prevent)`, so
+/// `add_counter_applier` short-circuits to `ApplyResult::Prevented` (CR
+/// 614.6: replaced events never happen) and `apply_counter_addition` is
+/// never reached.
+///
+/// `norm_lower` is the lowercased, self-ref-normalized text (i.e. "this
+/// creature" → "~"). `original_text` is the unmodified Oracle line used for
+/// the `description` field.
+///
+/// The combinator is composed end-to-end with nom: a typed `alt` over the
+/// two pronoun variants ("on it" / "on them") gated by the fixed
+/// "~ can't have counters put " prefix, followed by an optional trailing
+/// period. No `find()`/`split_once()`/`contains()` for dispatch — the
+/// classifier-level `scan_contains` only routes the line to this parser;
+/// the parser itself uses nom combinators throughout.
+fn parse_no_counters_replacement(
+    norm_lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    use crate::types::ability::QuantityModification;
+
+    // The parser receives normalized text where "this creature" / "this
+    // permanent" etc. have already been replaced by `~` (engine-internal
+    // self-reference convention; CR 201.5 governs the underlying "object
+    // refers to itself by name" semantics). The combinator matches the
+    // entire line as a single shape so adjacent text (e.g., an "as long as
+    // ~ is tapped" prefix) is correctly rejected — those compose via the
+    // outer dispatch in `parse_replacement_line_inner`, not here.
+    let trimmed = norm_lower.trim().trim_end_matches('.');
+    let mut combinator = (
+        tag::<_, _, OracleError<'_>>("~ can't have counters put on "),
+        alt((tag("it"), tag("them"))),
+    )
+        .map(|(_, _): (&str, &str)| ());
+    let (rest, ()) = combinator.parse(trimmed).ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    Some(
+        ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .valid_card(TargetFilter::SelfRef)
+            .quantity_modification(QuantityModification::Prevent)
+            .description(original_text.to_string()),
+    )
 }
 
 /// CR 614.1a: Parse damage redirection replacement effects.
@@ -7691,6 +7768,63 @@ mod tests {
                 ..
             })) if type_filters == vec![TypeFilter::Creature]
         ));
+    }
+
+    #[test]
+    fn no_counters_replacement_melira_keepers() {
+        // CR 614.6 + CR 614.7 + CR 122.1: Melira's Keepers — Human Scout that
+        // can't be counter-targeted. The Oracle line is normalized to "~ can't
+        // have counters put on it." before reaching the parser; the resulting
+        // replacement is self-targeted (valid_card: SelfRef) and uses the
+        // `Prevent` quantity-modification variant so the applier returns
+        // ApplyResult::Prevented.
+        use crate::types::ability::QuantityModification;
+        let def = parse_replacement_line(
+            "This creature can't have counters put on it.",
+            "Melira's Keepers",
+        )
+        .expect("Melira's Keepers replacement must parse");
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Prevent)
+        );
+        // CR 122.1: counter-type-agnostic — applies to every counter type
+        // (loyalty, charge, +1/+1, -1/-1, …).
+        assert_eq!(def.counter_match, None);
+    }
+
+    #[test]
+    fn no_counters_replacement_tilde_form() {
+        // The parser receives self-ref-normalized text. Verify the typed form
+        // ("~ can't have counters put on it.") parses identically — the
+        // upstream normalization step is the single authority for the
+        // "this creature" → "~" rewrite.
+        use crate::types::ability::QuantityModification;
+        let def = parse_replacement_line("~ can't have counters put on it.", "Some Creature")
+            .expect("tilde-form must parse");
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Prevent)
+        );
+    }
+
+    #[test]
+    fn no_counters_replacement_rejects_non_self_subject() {
+        // CR 614.1a: the parser must NOT match the global "creatures can't
+        // have counters put on them" wording — that is a different (wider)
+        // replacement class (Solemnity-style) which is intentionally out of
+        // scope for this PR. The current scope is strictly self-targeted.
+        // A non-self subject must fall through to the unimplemented path
+        // rather than silently lower into a SelfRef replacement.
+        let def = parse_replacement_line("Creatures can't have counters put on them.", "Test Card");
+        assert!(
+            def.is_none(),
+            "non-self subject must not match the SelfRef-scoped parser"
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9457,6 +9457,26 @@ pub enum QuantityModification {
     Plus { value: u32 },
     /// count.saturating_sub(value) — Vizier of Remedies (-1)
     Minus { value: u32 },
+    /// CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the
+    /// quantity event with nothing — the proposed `AddCounter` / `CreateToken`
+    /// event "never happens" (CR 614.6).
+    ///
+    /// CR 113.6i is the *authorizing* rule for permanent-scoped counter
+    /// prohibitions ("an object's ability that states counters can't be put on
+    /// that object functions as that object is entering the battlefield in
+    /// addition to functioning while that object is on the battlefield").
+    /// CR 614.17 is the framework for "can't" effects — they aren't replacement
+    /// effects but follow similar rules — which is why we model the prohibition
+    /// through the replacement pipeline. CR 122.1 ("a counter is a marker
+    /// placed on an object or player") identifies the placement event the
+    /// prohibition suppresses; CR 614.6/614.7 govern the resulting "event
+    /// never happens" outcome.
+    ///
+    /// Used by self-targeted counter-prohibition replacements ("~ can't have
+    /// counters put on it." — Melira's Keepers). Composes with `valid_card:
+    /// SelfRef` for permanent-scoped protection and with player-scope filters
+    /// for the future Solemnity-class global variant.
+    Prevent,
 }
 
 /// CR 106.3 + CR 614.1a: Mana-production replacement payload.

--- a/crates/phase-ai/src/features/plus_one_counters.rs
+++ b/crates/phase-ai/src/features/plus_one_counters.rs
@@ -253,8 +253,13 @@ fn effect_places_plus_one_counter(e: &&Effect) -> bool {
 }
 
 /// True if this replacement definition modifies the quantity of +1/+1 counters
-/// placed. Matches `ReplacementEvent::AddCounter` with a non-None
-/// `quantity_modification`. CR 614.1a.
+/// placed. Matches `ReplacementEvent::AddCounter` with a counter-scaling
+/// `quantity_modification` (`Double` / `Plus` / `Minus`). CR 614.1a.
+///
+/// Excludes `QuantityModification::Prevent` (CR 614.6 + CR 614.7) — those
+/// replacements *suppress* counter placement entirely (Melira's Keepers class)
+/// rather than scale a P1P1 payoff, so a deck containing one is NOT exhibiting
+/// a +1/+1-counters commitment signal.
 ///
 /// Note: `ReplacementEvent::AddCounter` is a unit variant with no counter-type
 /// discriminator, so this predicate cannot distinguish a P1P1 doubler from
@@ -262,7 +267,16 @@ fn effect_places_plus_one_counter(e: &&Effect) -> bool {
 /// practice this is fine — a deck running counter-quantity replacements is
 /// almost certainly running them for the deck's primary counter type.
 pub(crate) fn replacement_modifies_p1p1_counters_parts(rep: &ReplacementDefinition) -> bool {
-    rep.event == ReplacementEvent::AddCounter && rep.quantity_modification.is_some()
+    use engine::types::ability::QuantityModification;
+    rep.event == ReplacementEvent::AddCounter
+        && matches!(
+            rep.quantity_modification,
+            Some(
+                QuantityModification::Double
+                    | QuantityModification::Plus { .. }
+                    | QuantityModification::Minus { .. }
+            )
+        )
 }
 
 fn replacement_modifies_p1p1_counters(rep: &ReplacementDefinition) -> bool {

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -1,32 +1,32 @@
 {
   "sources": [
-    "crates/engine/src/types/format.rs",
-    "crates/engine/src/types/actions.rs",
-    "crates/engine/src/types/replacements.rs",
-    "crates/engine/src/types/identifiers.rs",
-    "crates/engine/src/types/events.rs",
-    "crates/engine/src/types/proposed_event.rs",
-    "crates/engine/src/types/keywords.rs",
-    "crates/engine/src/types/statics.rs",
-    "crates/engine/src/types/triggers.rs",
-    "crates/engine/src/types/definitions.rs",
-    "crates/engine/src/types/ability.rs",
-    "crates/engine/src/types/log.rs",
-    "crates/engine/src/types/game_state.rs",
-    "crates/engine/src/types/phase.rs",
-    "crates/engine/src/types/counter.rs",
-    "crates/engine/src/types/mod.rs",
-    "crates/engine/src/types/layers.rs",
     "crates/engine/src/types/match_config.rs",
+    "crates/engine/src/types/statics.rs",
+    "crates/engine/src/types/mana.rs",
     "crates/engine/src/types/card.rs",
     "crates/engine/src/types/player.rs",
-    "crates/engine/src/types/mana.rs",
-    "crates/engine/src/types/zones.rs",
+    "crates/engine/src/types/events.rs",
+    "crates/engine/src/types/actions.rs",
+    "crates/engine/src/types/log.rs",
+    "crates/engine/src/types/game_state.rs",
+    "crates/engine/src/types/format.rs",
+    "crates/engine/src/types/layers.rs",
     "crates/engine/src/types/attribution.rs",
-    "crates/engine/src/types/card_type.rs"
+    "crates/engine/src/types/identifiers.rs",
+    "crates/engine/src/types/mod.rs",
+    "crates/engine/src/types/zones.rs",
+    "crates/engine/src/types/keywords.rs",
+    "crates/engine/src/types/replacements.rs",
+    "crates/engine/src/types/phase.rs",
+    "crates/engine/src/types/ability.rs",
+    "crates/engine/src/types/proposed_event.rs",
+    "crates/engine/src/types/counter.rs",
+    "crates/engine/src/types/definitions.rs",
+    "crates/engine/src/types/card_type.rs",
+    "crates/engine/src/types/triggers.rs"
   ],
   "enum_count": 223,
-  "variant_count": 2598,
+  "variant_count": 2599,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -408,13 +408,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8185,
+      "line": 8202,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 8203,
+          "line": 8220,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -431,7 +431,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 8217,
+          "line": 8234,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -442,7 +442,7 @@
         },
         {
           "name": "IfYouDo",
-          "line": 8219,
+          "line": 8236,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you do\" — sub_ability executes only if the parent optional effect was performed.",
@@ -452,7 +452,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 8227,
+          "line": 8244,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -462,7 +462,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 8230,
+          "line": 8247,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -474,7 +474,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 8234,
+          "line": 8251,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -487,7 +487,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 8237,
+          "line": 8254,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -500,7 +500,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 8240,
+          "line": 8257,
           "kind": "struct",
           "field_names": [
             "color",
@@ -514,7 +514,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 8246,
+          "line": 8263,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -527,7 +527,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 8254,
+          "line": 8271,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -538,7 +538,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 8257,
+          "line": 8274,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -551,7 +551,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 8262,
+          "line": 8279,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -565,7 +565,7 @@
         },
         {
           "name": "IfAPlayerDoes",
-          "line": 8265,
+          "line": 8282,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d: \"If a player does\" / \"if they do\" — gates sub_ability on whether any prompted opponent accepted an \"any opponent may\" optional effect.",
@@ -575,7 +575,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 8269,
+          "line": 8286,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -589,7 +589,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 8278,
+          "line": 8295,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -603,7 +603,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 8283,
+          "line": 8300,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -613,7 +613,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 8285,
+          "line": 8302,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -623,7 +623,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 8288,
+          "line": 8305,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -633,7 +633,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 8292,
+          "line": 8309,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -645,7 +645,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 8297,
+          "line": 8314,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -659,7 +659,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 8305,
+          "line": 8322,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -671,7 +671,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 8310,
+          "line": 8327,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -687,7 +687,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 8322,
+          "line": 8339,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -700,7 +700,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 8326,
+          "line": 8343,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -710,7 +710,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 8334,
+          "line": 8351,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -723,7 +723,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 8339,
+          "line": 8356,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -736,7 +736,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 8344,
+          "line": 8361,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -748,7 +748,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 8350,
+          "line": 8367,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -760,7 +760,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 8354,
+          "line": 8371,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -774,7 +774,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 8357,
+          "line": 8374,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -784,7 +784,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 8366,
+          "line": 8383,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -797,7 +797,7 @@
         },
         {
           "name": "And",
-          "line": 8371,
+          "line": 8388,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -809,7 +809,7 @@
         },
         {
           "name": "Or",
-          "line": 8376,
+          "line": 8393,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -821,7 +821,7 @@
         },
         {
           "name": "Not",
-          "line": 8384,
+          "line": 8401,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -833,7 +833,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 8388,
+          "line": 8405,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -843,7 +843,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 8390,
+          "line": 8407,
           "kind": "struct",
           "field_names": [
             "state"
@@ -855,7 +855,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 8400,
+          "line": 8417,
           "kind": "struct",
           "field_names": [
             "n"
@@ -867,7 +867,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 8403,
+          "line": 8420,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -1018,19 +1018,22 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 3990,
+          "line": 3997,
           "kind": "struct",
           "field_names": [
             "count",
             "counter_type",
             "target"
           ],
-          "doc": "",
-          "cr_refs": []
+          "doc": "CR 122.1 + CR 601.2h: Remove `count` counters matching `counter_type` as an additional cost. `CounterMatch::Any` is the untyped \"remove a counter\" form (Loch Mare's `{1}{U}, Remove a counter from ~`); the payment path sums across every counter type on the chosen permanent and resolves to a concrete kind at payment time. `CounterMatch::OfType` is the typed form (\"remove a +1/+1 counter\", \"remove a charge counter\"), scoped to a single counter kind.",
+          "cr_refs": [
+            "CR 122.1",
+            "CR 601.2h"
+          ]
         },
         {
           "name": "PayEnergy",
-          "line": 3996,
+          "line": 4003,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1040,7 +1043,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4000,
+          "line": 4007,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1053,7 +1056,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4008,
+          "line": 4015,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1067,7 +1070,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4017,
+          "line": 4024,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1077,7 +1080,7 @@
         },
         {
           "name": "Mill",
-          "line": 4018,
+          "line": 4025,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1087,7 +1090,7 @@
         },
         {
           "name": "Exert",
-          "line": 4021,
+          "line": 4028,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1095,7 +1098,7 @@
         },
         {
           "name": "Blight",
-          "line": 4024,
+          "line": 4031,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1105,7 +1108,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4027,
+          "line": 4034,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1116,7 +1119,7 @@
         },
         {
           "name": "Behold",
-          "line": 4035,
+          "line": 4042,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1128,7 +1131,7 @@
         },
         {
           "name": "Composite",
-          "line": 4041,
+          "line": 4048,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1138,7 +1141,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4058,
+          "line": 4065,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1151,7 +1154,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4062,
+          "line": 4069,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1161,7 +1164,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4067,
+          "line": 4074,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1174,7 +1177,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4074,
+          "line": 4081,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1186,7 +1189,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4090,
+          "line": 4097,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1200,7 +1203,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4095,
+          "line": 4102,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1213,13 +1216,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7385,
+      "line": 7402,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 7387,
+          "line": 7404,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1227,7 +1230,7 @@
         },
         {
           "name": "Activated",
-          "line": 7388,
+          "line": 7405,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1235,7 +1238,7 @@
         },
         {
           "name": "Database",
-          "line": 7389,
+          "line": 7406,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1243,7 +1246,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 7392,
+          "line": 7409,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1251,7 +1254,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 7398,
+          "line": 7415,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1264,7 +1267,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7533,
+      "line": 7550,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1272,7 +1275,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 7535,
+          "line": 7552,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1282,7 +1285,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 7537,
+          "line": 7554,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1351,13 +1354,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7545,
+      "line": 7562,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 7546,
+          "line": 7563,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1365,7 +1368,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 7547,
+          "line": 7564,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1373,7 +1376,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 7548,
+          "line": 7565,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1381,7 +1384,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 7549,
+          "line": 7566,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1389,7 +1392,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 7550,
+          "line": 7567,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1397,7 +1400,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 7551,
+          "line": 7568,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1405,7 +1408,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 7552,
+          "line": 7569,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1413,7 +1416,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 7553,
+          "line": 7570,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1421,7 +1424,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 7554,
+          "line": 7571,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1429,7 +1432,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 7555,
+          "line": 7572,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1439,7 +1442,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 7558,
+          "line": 7575,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1449,7 +1452,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 7562,
+          "line": 7579,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1459,7 +1462,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 7564,
+          "line": 7581,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1471,7 +1474,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 7569,
+          "line": 7586,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1485,7 +1488,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 7580,
+          "line": 7597,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1499,7 +1502,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 7593,
+          "line": 7610,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1512,13 +1515,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4299,
+      "line": 4306,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 4302,
+          "line": 4309,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"you may [cost]\" — player decides whether to pay. If paid, `SpellContext::additional_cost_paid` is set to true.",
@@ -1526,7 +1529,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4308,
+          "line": 4315,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1542,7 +1545,7 @@
         },
         {
           "name": "Choice",
-          "line": 4315,
+          "line": 4322,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1550,7 +1553,7 @@
         },
         {
           "name": "Required",
-          "line": 4317,
+          "line": 4324,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -2706,13 +2709,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7601,
+      "line": 7618,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 7602,
+          "line": 7619,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2720,7 +2723,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 7603,
+          "line": 7620,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2728,7 +2731,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 7604,
+          "line": 7621,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2736,7 +2739,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 7605,
+          "line": 7622,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2744,7 +2747,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 7606,
+          "line": 7623,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2752,7 +2755,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 7607,
+          "line": 7624,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2760,7 +2763,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 7608,
+          "line": 7625,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2768,7 +2771,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 7609,
+          "line": 7626,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2776,7 +2779,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 7610,
+          "line": 7627,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2784,7 +2787,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 7611,
+          "line": 7628,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2792,7 +2795,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 7612,
+          "line": 7629,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2800,7 +2803,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 7613,
+          "line": 7630,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2808,7 +2811,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 7614,
+          "line": 7631,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2816,7 +2819,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 7615,
+          "line": 7632,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2824,7 +2827,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 7616,
+          "line": 7633,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2832,7 +2835,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 7617,
+          "line": 7634,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3597,7 +3600,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9500,
+      "line": 9525,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -3605,7 +3608,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 9501,
+          "line": 9526,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3613,7 +3616,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 9502,
+          "line": 9527,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3864,13 +3867,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9899,
+      "line": 9924,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 9900,
+          "line": 9925,
           "kind": "struct",
           "field_names": [
             "values"
@@ -3880,7 +3883,7 @@
         },
         {
           "name": "SetName",
-          "line": 9907,
+          "line": 9932,
           "kind": "struct",
           "field_names": [
             "name"
@@ -3894,7 +3897,7 @@
         },
         {
           "name": "AddPower",
-          "line": 9910,
+          "line": 9935,
           "kind": "struct",
           "field_names": [
             "value"
@@ -3904,7 +3907,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 9913,
+          "line": 9938,
           "kind": "struct",
           "field_names": [
             "value"
@@ -3914,7 +3917,7 @@
         },
         {
           "name": "SetPower",
-          "line": 9916,
+          "line": 9941,
           "kind": "struct",
           "field_names": [
             "value"
@@ -3924,7 +3927,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 9919,
+          "line": 9944,
           "kind": "struct",
           "field_names": [
             "value"
@@ -3934,7 +3937,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 9922,
+          "line": 9947,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -3944,7 +3947,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 9925,
+          "line": 9950,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -3954,7 +3957,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 9928,
+          "line": 9953,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -3964,7 +3967,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 9935,
+          "line": 9960,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -3976,7 +3979,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 9938,
+          "line": 9963,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3984,7 +3987,7 @@
         },
         {
           "name": "AddType",
-          "line": 9939,
+          "line": 9964,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -3994,7 +3997,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 9942,
+          "line": 9967,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4004,7 +4007,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 9945,
+          "line": 9970,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4014,7 +4017,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 9948,
+          "line": 9973,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4024,7 +4027,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 9955,
+          "line": 9980,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4037,7 +4040,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 9961,
+          "line": 9986,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4050,7 +4053,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 9965,
+          "line": 9990,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4060,7 +4063,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 9969,
+          "line": 9994,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4070,7 +4073,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 9976,
+          "line": 10001,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4082,7 +4085,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 9981,
+          "line": 10006,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4094,7 +4097,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 9985,
+          "line": 10010,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4106,7 +4109,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 9989,
+          "line": 10014,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4118,7 +4121,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 9994,
+          "line": 10019,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4131,7 +4134,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 10000,
+          "line": 10025,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4139,7 +4142,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 10003,
+          "line": 10028,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4150,7 +4153,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 10006,
+          "line": 10031,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4160,7 +4163,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 10011,
+          "line": 10036,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4170,7 +4173,7 @@
         },
         {
           "name": "SetColor",
-          "line": 10012,
+          "line": 10037,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4180,7 +4183,7 @@
         },
         {
           "name": "AddColor",
-          "line": 10015,
+          "line": 10040,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4190,7 +4193,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 10020,
+          "line": 10045,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4200,7 +4203,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 10034,
+          "line": 10059,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4215,7 +4218,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 10038,
+          "line": 10063,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4225,7 +4228,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 10041,
+          "line": 10066,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -4235,7 +4238,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 10043,
+          "line": 10068,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -4245,7 +4248,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 10045,
+          "line": 10070,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -4255,7 +4258,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 10048,
+          "line": 10073,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -4265,7 +4268,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 10051,
+          "line": 10076,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -4277,7 +4280,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 10065,
+          "line": 10090,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -4289,7 +4292,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 10073,
+          "line": 10098,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4304,7 +4307,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 10082,
+          "line": 10107,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4319,7 +4322,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 10096,
+          "line": 10121,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -4508,13 +4511,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4552,
+      "line": 4559,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 4553,
+          "line": 4560,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4525,7 +4528,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6234,
+      "line": 6251,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -4534,7 +4537,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 6236,
+          "line": 6253,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -4542,7 +4545,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 6238,
+          "line": 6255,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -4666,7 +4669,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4109,
+      "line": 4116,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -4674,62 +4677,6 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4110,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TapsSelf",
-          "line": 4111,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "UntapsSelf",
-          "line": 4112,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SacrificesPermanent",
-          "line": 4113,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysLife",
-          "line": 4114,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysLoyalty",
-          "line": 4115,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Discards",
-          "line": 4116,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ExilesCards",
           "line": 4117,
           "kind": "unit",
           "field_names": [],
@@ -4737,7 +4684,7 @@
           "cr_refs": []
         },
         {
-          "name": "TapsOtherCreatures",
+          "name": "TapsSelf",
           "line": 4118,
           "kind": "unit",
           "field_names": [],
@@ -4745,7 +4692,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemovesCounters",
+          "name": "UntapsSelf",
           "line": 4119,
           "kind": "unit",
           "field_names": [],
@@ -4753,7 +4700,7 @@
           "cr_refs": []
         },
         {
-          "name": "PaysEnergy",
+          "name": "SacrificesPermanent",
           "line": 4120,
           "kind": "unit",
           "field_names": [],
@@ -4761,7 +4708,7 @@
           "cr_refs": []
         },
         {
-          "name": "PaysSpeed",
+          "name": "PaysLife",
           "line": 4121,
           "kind": "unit",
           "field_names": [],
@@ -4769,7 +4716,7 @@
           "cr_refs": []
         },
         {
-          "name": "ReturnsToHand",
+          "name": "PaysLoyalty",
           "line": 4122,
           "kind": "unit",
           "field_names": [],
@@ -4777,7 +4724,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unattaches",
+          "name": "Discards",
           "line": 4123,
           "kind": "unit",
           "field_names": [],
@@ -4785,7 +4732,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mills",
+          "name": "ExilesCards",
           "line": 4124,
           "kind": "unit",
           "field_names": [],
@@ -4793,7 +4740,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutsCounters",
+          "name": "TapsOtherCreatures",
           "line": 4125,
           "kind": "unit",
           "field_names": [],
@@ -4801,7 +4748,7 @@
           "cr_refs": []
         },
         {
-          "name": "Reveals",
+          "name": "RemovesCounters",
           "line": 4126,
           "kind": "unit",
           "field_names": [],
@@ -4809,7 +4756,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exerts",
+          "name": "PaysEnergy",
           "line": 4127,
           "kind": "unit",
           "field_names": [],
@@ -4817,8 +4764,64 @@
           "cr_refs": []
         },
         {
-          "name": "KeywordCost",
+          "name": "PaysSpeed",
           "line": 4128,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ReturnsToHand",
+          "line": 4129,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unattaches",
+          "line": 4130,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Mills",
+          "line": 4131,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PutsCounters",
+          "line": 4132,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Reveals",
+          "line": 4133,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Exerts",
+          "line": 4134,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "KeywordCost",
+          "line": 4135,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5176,7 +5179,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9406,
+      "line": 9423,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -5184,7 +5187,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 9408,
+          "line": 9425,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -5192,7 +5195,7 @@
         },
         {
           "name": "Triple",
-          "line": 9410,
+          "line": 9427,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -5200,7 +5203,7 @@
         },
         {
           "name": "Plus",
-          "line": 9412,
+          "line": 9429,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5210,7 +5213,7 @@
         },
         {
           "name": "Minus",
-          "line": 9419,
+          "line": 9436,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5223,7 +5226,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 9423,
+          "line": 9440,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -5233,7 +5236,7 @@
         },
         {
           "name": "SetTo",
-          "line": 9429,
+          "line": 9446,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5248,7 +5251,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4533,
+      "line": 4540,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -5256,7 +5259,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 4535,
+          "line": 4542,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -5264,7 +5267,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 4538,
+          "line": 4545,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -5278,7 +5281,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9488,
+      "line": 9513,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -5286,7 +5289,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 9490,
+          "line": 9515,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -5294,7 +5297,7 @@
         },
         {
           "name": "Player",
-          "line": 9492,
+          "line": 9517,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5304,7 +5307,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 9495,
+          "line": 9520,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5317,7 +5320,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9479,
+      "line": 9504,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -5325,7 +5328,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 9480,
+          "line": 9505,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5333,7 +5336,7 @@
         },
         {
           "name": "Opponent",
-          "line": 9481,
+          "line": 9506,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5341,7 +5344,7 @@
         },
         {
           "name": "Specific",
-          "line": 9482,
+          "line": 9507,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6036,13 +6039,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4571,
+      "line": 4578,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 4573,
+          "line": 4580,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -6054,7 +6057,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 4579,
+          "line": 4586,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -6069,7 +6072,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 4590,
+          "line": 4597,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6081,7 +6084,7 @@
         },
         {
           "name": "Draw",
-          "line": 4610,
+          "line": 4617,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6097,7 +6100,7 @@
         },
         {
           "name": "Pump",
-          "line": 4616,
+          "line": 4623,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6109,7 +6112,7 @@
         },
         {
           "name": "PairWith",
-          "line": 4627,
+          "line": 4634,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6122,7 +6125,7 @@
         },
         {
           "name": "Destroy",
-          "line": 4630,
+          "line": 4637,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6133,7 +6136,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 4638,
+          "line": 4645,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6145,7 +6148,7 @@
         },
         {
           "name": "Counter",
-          "line": 4642,
+          "line": 4649,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6156,7 +6159,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 4660,
+          "line": 4667,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6170,7 +6173,7 @@
         },
         {
           "name": "Token",
-          "line": 4664,
+          "line": 4671,
           "kind": "struct",
           "field_names": [
             "name",
@@ -6193,7 +6196,7 @@
         },
         {
           "name": "GainLife",
-          "line": 4702,
+          "line": 4709,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6204,7 +6207,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 4709,
+          "line": 4716,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6215,7 +6218,7 @@
         },
         {
           "name": "Tap",
-          "line": 4716,
+          "line": 4723,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6225,7 +6228,7 @@
         },
         {
           "name": "Untap",
-          "line": 4720,
+          "line": 4727,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6235,7 +6238,7 @@
         },
         {
           "name": "TapAll",
-          "line": 4725,
+          "line": 4732,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6247,7 +6250,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 4730,
+          "line": 4737,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6259,18 +6262,6 @@
         },
         {
           "name": "AddCounter",
-          "line": 4734,
-          "kind": "struct",
-          "field_names": [
-            "counter_type",
-            "count",
-            "target"
-          ],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RemoveCounter",
           "line": 4741,
           "kind": "struct",
           "field_names": [
@@ -6282,8 +6273,20 @@
           "cr_refs": []
         },
         {
+          "name": "RemoveCounter",
+          "line": 4748,
+          "kind": "struct",
+          "field_names": [
+            "counter_type",
+            "count",
+            "target"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Sacrifice",
-          "line": 4749,
+          "line": 4756,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6295,7 +6298,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 4770,
+          "line": 4777,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6306,7 +6309,7 @@
         },
         {
           "name": "Mill",
-          "line": 4776,
+          "line": 4783,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6318,7 +6321,7 @@
         },
         {
           "name": "Scry",
-          "line": 4793,
+          "line": 4800,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6333,7 +6336,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 4799,
+          "line": 4806,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6345,12 +6348,13 @@
         },
         {
           "name": "DamageAll",
-          "line": 4813,
+          "line": 4820,
           "kind": "struct",
           "field_names": [
             "amount",
             "target",
-            "player_filter"
+            "player_filter",
+            "damage_source"
           ],
           "doc": "CR 120.3: Deal uniform damage to every matching object and optionally every matching player, as one simultaneous damage event from a single source. The object set (`target`) and player set (`player_filter`) resolve within the same effect resolution, so replacement effects (CR 614) and prevention shields (CR 615) that watch \"the next damage dealt by [this source]\" observe a single coherent event across both sets.",
           "cr_refs": [
@@ -6361,7 +6365,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 4827,
+          "line": 4844,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6374,7 +6378,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 4831,
+          "line": 4848,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6385,7 +6389,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 4838,
+          "line": 4855,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6404,7 +6408,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 4876,
+          "line": 4893,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6417,7 +6421,7 @@
         },
         {
           "name": "Dig",
-          "line": 4889,
+          "line": 4906,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6436,7 +6440,7 @@
         },
         {
           "name": "GainControl",
-          "line": 4911,
+          "line": 4928,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6446,7 +6450,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 4915,
+          "line": 4932,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6457,7 +6461,7 @@
         },
         {
           "name": "Attach",
-          "line": 4921,
+          "line": 4938,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -6468,7 +6472,7 @@
         },
         {
           "name": "Surveil",
-          "line": 4936,
+          "line": 4953,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6483,7 +6487,7 @@
         },
         {
           "name": "Fight",
-          "line": 4942,
+          "line": 4959,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6494,7 +6498,7 @@
         },
         {
           "name": "Bounce",
-          "line": 4950,
+          "line": 4967,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6505,7 +6509,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 4963,
+          "line": 4980,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6520,7 +6524,7 @@
         },
         {
           "name": "Explore",
-          "line": 4971,
+          "line": 4988,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6528,7 +6532,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 4975,
+          "line": 4992,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6540,7 +6544,7 @@
         },
         {
           "name": "Investigate",
-          "line": 4980,
+          "line": 4997,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.136: Investigate — create a Clue artifact token.",
@@ -6550,7 +6554,7 @@
         },
         {
           "name": "Tribute",
-          "line": 4987,
+          "line": 5004,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6563,7 +6567,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 4993,
+          "line": 5010,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -6573,7 +6577,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 4995,
+          "line": 5012,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -6583,7 +6587,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 4996,
+          "line": 5013,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6591,7 +6595,7 @@
         },
         {
           "name": "Populate",
-          "line": 4998,
+          "line": 5015,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -6601,7 +6605,7 @@
         },
         {
           "name": "Clash",
-          "line": 5000,
+          "line": 5017,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -6611,7 +6615,7 @@
         },
         {
           "name": "Vote",
-          "line": 5015,
+          "line": 5032,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -6627,7 +6631,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 5059,
+          "line": 5076,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -6647,7 +6651,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 5078,
+          "line": 5095,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6659,7 +6663,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 5082,
+          "line": 5099,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6670,7 +6674,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 5092,
+          "line": 5109,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6690,7 +6694,7 @@
         },
         {
           "name": "Myriad",
-          "line": 5139,
+          "line": 5156,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -6700,7 +6704,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 5142,
+          "line": 5159,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6716,7 +6720,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 5152,
+          "line": 5169,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -6727,7 +6731,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 5158,
+          "line": 5175,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6739,7 +6743,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 5166,
+          "line": 5183,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6753,7 +6757,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 5173,
+          "line": 5190,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6765,7 +6769,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 5181,
+          "line": 5198,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -6778,7 +6782,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 5187,
+          "line": 5204,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -6791,7 +6795,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 5195,
+          "line": 5212,
           "kind": "struct",
           "field_names": [
             "source",
@@ -6808,7 +6812,7 @@
         },
         {
           "name": "Animate",
-          "line": 5213,
+          "line": 5230,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6823,7 +6827,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 5230,
+          "line": 5247,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -6833,7 +6837,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 5234,
+          "line": 5251,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -6845,7 +6849,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 5242,
+          "line": 5259,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -6862,7 +6866,7 @@
         },
         {
           "name": "Mana",
-          "line": 5260,
+          "line": 5277,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -6876,7 +6880,7 @@
         },
         {
           "name": "Discard",
-          "line": 5283,
+          "line": 5300,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6890,7 +6894,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 5305,
+          "line": 5322,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6900,7 +6904,7 @@
         },
         {
           "name": "Transform",
-          "line": 5309,
+          "line": 5326,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6910,7 +6914,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 5315,
+          "line": 5332,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -6924,7 +6928,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 5347,
+          "line": 5364,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -6940,7 +6944,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 5356,
+          "line": 5373,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6953,7 +6957,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 5377,
+          "line": 5394,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -6966,7 +6970,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5388,
+          "line": 5405,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6979,7 +6983,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 5393,
+          "line": 5410,
           "kind": "struct",
           "field_names": [
             "player",
@@ -6992,7 +6996,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 5402,
+          "line": 5419,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7003,7 +7007,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 5413,
+          "line": 5430,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7013,7 +7017,7 @@
         },
         {
           "name": "Choose",
-          "line": 5419,
+          "line": 5436,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -7024,7 +7028,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 5430,
+          "line": 5447,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -7037,7 +7041,7 @@
         },
         {
           "name": "Suspect",
-          "line": 5435,
+          "line": 5452,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7049,7 +7053,7 @@
         },
         {
           "name": "Connive",
-          "line": 5442,
+          "line": 5459,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7063,7 +7067,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 5450,
+          "line": 5467,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7075,7 +7079,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 5457,
+          "line": 5474,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7087,7 +7091,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 5462,
+          "line": 5479,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7099,7 +7103,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 5467,
+          "line": 5484,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -7109,7 +7113,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 5474,
+          "line": 5491,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7121,7 +7125,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 5481,
+          "line": 5498,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7133,7 +7137,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 5486,
+          "line": 5503,
           "kind": "struct",
           "field_names": [
             "level"
@@ -7145,7 +7149,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 5491,
+          "line": 5508,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -7159,7 +7163,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 5521,
+          "line": 5538,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -7173,7 +7177,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 5527,
+          "line": 5544,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -7185,7 +7189,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 5532,
+          "line": 5549,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7198,7 +7202,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 5539,
+          "line": 5556,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -7211,7 +7215,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 5548,
+          "line": 5565,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7224,7 +7228,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 5556,
+          "line": 5573,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -7238,7 +7242,7 @@
         },
         {
           "name": "PayCost",
-          "line": 5566,
+          "line": 5583,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -7251,7 +7255,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 5577,
+          "line": 5594,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7269,7 +7273,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 5607,
+          "line": 5624,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7285,7 +7289,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 5630,
+          "line": 5647,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: A player who meets this effect's condition loses the game. The affected player is determined by resolution context (controller's opponent if untargeted, or explicit target if targeted).",
@@ -7295,7 +7299,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 5632,
+          "line": 5649,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: The controller wins the game — all opponents lose.",
@@ -7305,7 +7309,7 @@
         },
         {
           "name": "RollDie",
-          "line": 5635,
+          "line": 5652,
           "kind": "struct",
           "field_names": [
             "sides",
@@ -7318,7 +7322,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 5641,
+          "line": 5658,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -7331,7 +7335,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 5653,
+          "line": 5670,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7345,7 +7349,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 5662,
+          "line": 5679,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -7357,7 +7361,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 5667,
+          "line": 5684,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -7367,7 +7371,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 5670,
+          "line": 5687,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -7377,7 +7381,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 5672,
+          "line": 5689,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -7389,17 +7393,18 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 5677,
+          "line": 5694,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 725.2: Take the initiative. Grants initiative designation and triggers venture into the Undercity.",
+          "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
           "cr_refs": [
-            "CR 725.2"
+            "CR 726.1",
+            "CR 726.2"
           ]
         },
         {
           "name": "ProcessRadCounters",
-          "line": 5680,
+          "line": 5697,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -7409,7 +7414,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 5683,
+          "line": 5700,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -7421,7 +7426,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 5700,
+          "line": 5717,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7440,7 +7445,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 5733,
+          "line": 5750,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -7455,7 +7460,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 5746,
+          "line": 5763,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -7469,7 +7474,7 @@
         },
         {
           "name": "Exploit",
-          "line": 5755,
+          "line": 5772,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7481,7 +7486,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 5760,
+          "line": 5777,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -7493,7 +7498,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 5765,
+          "line": 5782,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -7508,7 +7513,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 5777,
+          "line": 5794,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7520,7 +7525,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 5789,
+          "line": 5806,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7536,7 +7541,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 5800,
+          "line": 5817,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7553,7 +7558,7 @@
         },
         {
           "name": "Discover",
-          "line": 5828,
+          "line": 5845,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -7565,7 +7570,7 @@
         },
         {
           "name": "Cascade",
-          "line": 5840,
+          "line": 5857,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -7575,7 +7580,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 5844,
+          "line": 5861,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -7587,7 +7592,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 5849,
+          "line": 5866,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -7599,7 +7604,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 5862,
+          "line": 5879,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7611,7 +7616,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 5871,
+          "line": 5888,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7623,7 +7628,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 5880,
+          "line": 5897,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7633,7 +7638,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 5885,
+          "line": 5902,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -7643,7 +7648,7 @@
         },
         {
           "name": "Goad",
-          "line": 5891,
+          "line": 5908,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7655,7 +7660,7 @@
         },
         {
           "name": "Detain",
-          "line": 5898,
+          "line": 5915,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7667,7 +7672,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 5909,
+          "line": 5926,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -7681,7 +7686,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 5920,
+          "line": 5937,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7695,7 +7700,7 @@
         },
         {
           "name": "Manifest",
-          "line": 5935,
+          "line": 5952,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7708,7 +7713,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 5941,
+          "line": 5958,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -7718,7 +7723,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 5945,
+          "line": 5962,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7730,7 +7735,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 5954,
+          "line": 5971,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7743,7 +7748,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 5964,
+          "line": 5981,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7757,7 +7762,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 5976,
+          "line": 5993,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7773,7 +7778,7 @@
         },
         {
           "name": "Double",
-          "line": 5987,
+          "line": 6004,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -7787,7 +7792,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 5995,
+          "line": 6012,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -7799,7 +7804,7 @@
         },
         {
           "name": "Incubate",
-          "line": 6001,
+          "line": 6018,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7811,7 +7816,7 @@
         },
         {
           "name": "Amass",
-          "line": 6009,
+          "line": 6026,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -7824,7 +7829,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 6017,
+          "line": 6034,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7836,7 +7841,7 @@
         },
         {
           "name": "Bolster",
-          "line": 6023,
+          "line": 6040,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7848,7 +7853,7 @@
         },
         {
           "name": "Adapt",
-          "line": 6029,
+          "line": 6046,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7860,7 +7865,7 @@
         },
         {
           "name": "Learn",
-          "line": 6035,
+          "line": 6052,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -7870,7 +7875,7 @@
         },
         {
           "name": "Forage",
-          "line": 6037,
+          "line": 6054,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -7880,7 +7885,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6039,
+          "line": 6056,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -7892,7 +7897,7 @@
         },
         {
           "name": "Endure",
-          "line": 6044,
+          "line": 6061,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -7902,7 +7907,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 6049,
+          "line": 6066,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7914,7 +7919,7 @@
         },
         {
           "name": "Seek",
-          "line": 6054,
+          "line": 6071,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7928,7 +7933,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 6071,
+          "line": 6088,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7941,7 +7946,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 6078,
+          "line": 6095,
           "kind": "struct",
           "field_names": [
             "to"
@@ -7953,7 +7958,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 6083,
+          "line": 6100,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7966,7 +7971,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 6092,
+          "line": 6109,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7978,7 +7983,7 @@
         },
         {
           "name": "Conjure",
-          "line": 6099,
+          "line": 6116,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -7990,7 +7995,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 6120,
+          "line": 6137,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8004,7 +8009,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6131,
+          "line": 6148,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8091,13 +8096,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10525,
+      "line": 10550,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 10527,
+          "line": 10552,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8105,7 +8110,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 10529,
+          "line": 10554,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8113,7 +8118,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 10531,
+          "line": 10556,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8121,7 +8126,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 10533,
+          "line": 10558,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8129,7 +8134,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 10535,
+          "line": 10560,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8137,7 +8142,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 10537,
+          "line": 10562,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8148,148 +8153,12 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7043,
+      "line": 7060,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7044,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeSpeed",
-          "line": 7045,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DealDamage",
-          "line": 7046,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Draw",
-          "line": 7047,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Pump",
-          "line": 7048,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PairWith",
-          "line": 7049,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Destroy",
-          "line": 7050,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Counter",
-          "line": 7051,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterAll",
-          "line": 7052,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Token",
-          "line": 7053,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GainLife",
-          "line": 7054,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseLife",
-          "line": 7055,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Tap",
-          "line": 7056,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Untap",
-          "line": 7057,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddCounter",
-          "line": 7058,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RemoveCounter",
-          "line": 7059,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Sacrifice",
-          "line": 7060,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DiscardCard",
           "line": 7061,
           "kind": "unit",
           "field_names": [],
@@ -8297,7 +8166,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mill",
+          "name": "ChangeSpeed",
           "line": 7062,
           "kind": "unit",
           "field_names": [],
@@ -8305,7 +8174,7 @@
           "cr_refs": []
         },
         {
-          "name": "Scry",
+          "name": "DealDamage",
           "line": 7063,
           "kind": "unit",
           "field_names": [],
@@ -8313,7 +8182,7 @@
           "cr_refs": []
         },
         {
-          "name": "PumpAll",
+          "name": "Draw",
           "line": 7064,
           "kind": "unit",
           "field_names": [],
@@ -8321,7 +8190,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageAll",
+          "name": "Pump",
           "line": 7065,
           "kind": "unit",
           "field_names": [],
@@ -8329,7 +8198,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageEachPlayer",
+          "name": "PairWith",
           "line": 7066,
           "kind": "unit",
           "field_names": [],
@@ -8337,7 +8206,7 @@
           "cr_refs": []
         },
         {
-          "name": "DestroyAll",
+          "name": "Destroy",
           "line": 7067,
           "kind": "unit",
           "field_names": [],
@@ -8345,7 +8214,7 @@
           "cr_refs": []
         },
         {
-          "name": "TapAll",
+          "name": "Counter",
           "line": 7068,
           "kind": "unit",
           "field_names": [],
@@ -8353,7 +8222,7 @@
           "cr_refs": []
         },
         {
-          "name": "UntapAll",
+          "name": "CounterAll",
           "line": 7069,
           "kind": "unit",
           "field_names": [],
@@ -8361,7 +8230,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZone",
+          "name": "Token",
           "line": 7070,
           "kind": "unit",
           "field_names": [],
@@ -8369,7 +8238,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZoneAll",
+          "name": "GainLife",
           "line": 7071,
           "kind": "unit",
           "field_names": [],
@@ -8377,7 +8246,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dig",
+          "name": "LoseLife",
           "line": 7072,
           "kind": "unit",
           "field_names": [],
@@ -8385,7 +8254,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainControl",
+          "name": "Tap",
           "line": 7073,
           "kind": "unit",
           "field_names": [],
@@ -8393,7 +8262,7 @@
           "cr_refs": []
         },
         {
-          "name": "ControlNextTurn",
+          "name": "Untap",
           "line": 7074,
           "kind": "unit",
           "field_names": [],
@@ -8401,7 +8270,7 @@
           "cr_refs": []
         },
         {
-          "name": "Attach",
+          "name": "AddCounter",
           "line": 7075,
           "kind": "unit",
           "field_names": [],
@@ -8409,7 +8278,7 @@
           "cr_refs": []
         },
         {
-          "name": "AttachAll",
+          "name": "RemoveCounter",
           "line": 7076,
           "kind": "unit",
           "field_names": [],
@@ -8417,7 +8286,7 @@
           "cr_refs": []
         },
         {
-          "name": "Surveil",
+          "name": "Sacrifice",
           "line": 7077,
           "kind": "unit",
           "field_names": [],
@@ -8425,7 +8294,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fight",
+          "name": "DiscardCard",
           "line": 7078,
           "kind": "unit",
           "field_names": [],
@@ -8433,7 +8302,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bounce",
+          "name": "Mill",
           "line": 7079,
           "kind": "unit",
           "field_names": [],
@@ -8441,7 +8310,7 @@
           "cr_refs": []
         },
         {
-          "name": "BounceAll",
+          "name": "Scry",
           "line": 7080,
           "kind": "unit",
           "field_names": [],
@@ -8449,7 +8318,7 @@
           "cr_refs": []
         },
         {
-          "name": "Explore",
+          "name": "PumpAll",
           "line": 7081,
           "kind": "unit",
           "field_names": [],
@@ -8457,7 +8326,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExploreAll",
+          "name": "DamageAll",
           "line": 7082,
           "kind": "unit",
           "field_names": [],
@@ -8465,7 +8334,7 @@
           "cr_refs": []
         },
         {
-          "name": "Investigate",
+          "name": "DamageEachPlayer",
           "line": 7083,
           "kind": "unit",
           "field_names": [],
@@ -8473,7 +8342,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tribute",
+          "name": "DestroyAll",
           "line": 7084,
           "kind": "unit",
           "field_names": [],
@@ -8481,7 +8350,7 @@
           "cr_refs": []
         },
         {
-          "name": "TimeTravel",
+          "name": "TapAll",
           "line": 7085,
           "kind": "unit",
           "field_names": [],
@@ -8489,7 +8358,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomeMonarch",
+          "name": "UntapAll",
           "line": 7086,
           "kind": "unit",
           "field_names": [],
@@ -8497,7 +8366,7 @@
           "cr_refs": []
         },
         {
-          "name": "Proliferate",
+          "name": "ChangeZone",
           "line": 7087,
           "kind": "unit",
           "field_names": [],
@@ -8505,7 +8374,7 @@
           "cr_refs": []
         },
         {
-          "name": "Populate",
+          "name": "ChangeZoneAll",
           "line": 7088,
           "kind": "unit",
           "field_names": [],
@@ -8513,7 +8382,7 @@
           "cr_refs": []
         },
         {
-          "name": "Clash",
+          "name": "Dig",
           "line": 7089,
           "kind": "unit",
           "field_names": [],
@@ -8521,8 +8390,144 @@
           "cr_refs": []
         },
         {
-          "name": "Vote",
+          "name": "GainControl",
+          "line": 7090,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ControlNextTurn",
           "line": 7091,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Attach",
+          "line": 7092,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AttachAll",
+          "line": 7093,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Surveil",
+          "line": 7094,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Fight",
+          "line": 7095,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Bounce",
+          "line": 7096,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BounceAll",
+          "line": 7097,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Explore",
+          "line": 7098,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExploreAll",
+          "line": 7099,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Investigate",
+          "line": 7100,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Tribute",
+          "line": 7101,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TimeTravel",
+          "line": 7102,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomeMonarch",
+          "line": 7103,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Proliferate",
+          "line": 7104,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Populate",
+          "line": 7105,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Clash",
+          "line": 7106,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Vote",
+          "line": 7108,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -8532,7 +8537,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7093,
+          "line": 7110,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -8542,142 +8547,6 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7094,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopySpell",
-          "line": 7095,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopyTokenOf",
-          "line": 7096,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Myriad",
-          "line": 7097,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BecomeCopy",
-          "line": 7098,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseCard",
-          "line": 7099,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutCounter",
-          "line": 7100,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutCounterAll",
-          "line": 7101,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MultiplyCounter",
-          "line": 7102,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DoublePT",
-          "line": 7103,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DoublePTAll",
-          "line": 7104,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MoveCounters",
-          "line": 7105,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Animate",
-          "line": 7106,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RegisterBending",
-          "line": 7107,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GenericEffect",
-          "line": 7108,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Cleanup",
-          "line": 7109,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Mana",
-          "line": 7110,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Discard",
           "line": 7111,
           "kind": "unit",
           "field_names": [],
@@ -8685,7 +8554,7 @@
           "cr_refs": []
         },
         {
-          "name": "Shuffle",
+          "name": "CopySpell",
           "line": 7112,
           "kind": "unit",
           "field_names": [],
@@ -8693,7 +8562,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchLibrary",
+          "name": "CopyTokenOf",
           "line": 7113,
           "kind": "unit",
           "field_names": [],
@@ -8701,7 +8570,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchOutsideGame",
+          "name": "Myriad",
           "line": 7114,
           "kind": "unit",
           "field_names": [],
@@ -8709,7 +8578,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileTop",
+          "name": "BecomeCopy",
           "line": 7115,
           "kind": "unit",
           "field_names": [],
@@ -8717,7 +8586,7 @@
           "cr_refs": []
         },
         {
-          "name": "TargetOnly",
+          "name": "ChooseCard",
           "line": 7116,
           "kind": "unit",
           "field_names": [],
@@ -8725,7 +8594,7 @@
           "cr_refs": []
         },
         {
-          "name": "Choose",
+          "name": "PutCounter",
           "line": 7117,
           "kind": "unit",
           "field_names": [],
@@ -8733,7 +8602,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDamageSource",
+          "name": "PutCounterAll",
           "line": 7118,
           "kind": "unit",
           "field_names": [],
@@ -8741,7 +8610,7 @@
           "cr_refs": []
         },
         {
-          "name": "Suspect",
+          "name": "MultiplyCounter",
           "line": 7119,
           "kind": "unit",
           "field_names": [],
@@ -8749,7 +8618,7 @@
           "cr_refs": []
         },
         {
-          "name": "Connive",
+          "name": "DoublePT",
           "line": 7120,
           "kind": "unit",
           "field_names": [],
@@ -8757,7 +8626,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseOut",
+          "name": "DoublePTAll",
           "line": 7121,
           "kind": "unit",
           "field_names": [],
@@ -8765,7 +8634,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseIn",
+          "name": "MoveCounters",
           "line": 7122,
           "kind": "unit",
           "field_names": [],
@@ -8773,7 +8642,7 @@
           "cr_refs": []
         },
         {
-          "name": "ForceBlock",
+          "name": "Animate",
           "line": 7123,
           "kind": "unit",
           "field_names": [],
@@ -8781,7 +8650,7 @@
           "cr_refs": []
         },
         {
-          "name": "SolveCase",
+          "name": "RegisterBending",
           "line": 7124,
           "kind": "unit",
           "field_names": [],
@@ -8789,8 +8658,144 @@
           "cr_refs": []
         },
         {
-          "name": "BecomePrepared",
+          "name": "GenericEffect",
+          "line": 7125,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Cleanup",
           "line": 7126,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Mana",
+          "line": 7127,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Discard",
+          "line": 7128,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Shuffle",
+          "line": 7129,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SearchLibrary",
+          "line": 7130,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SearchOutsideGame",
+          "line": 7131,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExileTop",
+          "line": 7132,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TargetOnly",
+          "line": 7133,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Choose",
+          "line": 7134,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseDamageSource",
+          "line": 7135,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Suspect",
+          "line": 7136,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Connive",
+          "line": 7137,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseOut",
+          "line": 7138,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseIn",
+          "line": 7139,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ForceBlock",
+          "line": 7140,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SolveCase",
+          "line": 7141,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomePrepared",
+          "line": 7143,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -8800,7 +8805,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 7128,
+          "line": 7145,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -8810,142 +8815,6 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 7129,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDelayedTrigger",
-          "line": 7130,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddTargetReplacement",
-          "line": 7131,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddRestriction",
-          "line": 7132,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReduceNextSpellCost",
-          "line": 7133,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantNextSpellAbility",
-          "line": 7134,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddPendingETBCounters",
-          "line": 7135,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateEmblem",
-          "line": 7136,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PayCost",
-          "line": 7137,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastFromZone",
-          "line": 7138,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PreventDamage",
-          "line": 7139,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Regenerate",
-          "line": 7140,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseTheGame",
-          "line": 7141,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "WinTheGame",
-          "line": 7142,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RollDie",
-          "line": 7143,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoin",
-          "line": 7144,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoins",
-          "line": 7145,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoinUntilLose",
           "line": 7146,
           "kind": "unit",
           "field_names": [],
@@ -8953,7 +8822,7 @@
           "cr_refs": []
         },
         {
-          "name": "RingTemptsYou",
+          "name": "CreateDelayedTrigger",
           "line": 7147,
           "kind": "unit",
           "field_names": [],
@@ -8961,7 +8830,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureIntoDungeon",
+          "name": "AddTargetReplacement",
           "line": 7148,
           "kind": "unit",
           "field_names": [],
@@ -8969,7 +8838,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureInto",
+          "name": "AddRestriction",
           "line": 7149,
           "kind": "unit",
           "field_names": [],
@@ -8977,7 +8846,7 @@
           "cr_refs": []
         },
         {
-          "name": "TakeTheInitiative",
+          "name": "ReduceNextSpellCost",
           "line": 7150,
           "kind": "unit",
           "field_names": [],
@@ -8985,7 +8854,7 @@
           "cr_refs": []
         },
         {
-          "name": "ProcessRadCounters",
+          "name": "GrantNextSpellAbility",
           "line": 7151,
           "kind": "unit",
           "field_names": [],
@@ -8993,7 +8862,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantCastingPermission",
+          "name": "AddPendingETBCounters",
           "line": 7152,
           "kind": "unit",
           "field_names": [],
@@ -9001,7 +8870,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseFromZone",
+          "name": "CreateEmblem",
           "line": 7153,
           "kind": "unit",
           "field_names": [],
@@ -9009,7 +8878,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseObjectsIntoTrackedSet",
+          "name": "PayCost",
           "line": 7154,
           "kind": "unit",
           "field_names": [],
@@ -9017,7 +8886,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseAndSacrificeRest",
+          "name": "CastFromZone",
           "line": 7155,
           "kind": "unit",
           "field_names": [],
@@ -9025,7 +8894,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exploit",
+          "name": "PreventDamage",
           "line": 7156,
           "kind": "unit",
           "field_names": [],
@@ -9033,7 +8902,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainEnergy",
+          "name": "Regenerate",
           "line": 7157,
           "kind": "unit",
           "field_names": [],
@@ -9041,7 +8910,7 @@
           "cr_refs": []
         },
         {
-          "name": "GivePlayerCounter",
+          "name": "LoseTheGame",
           "line": 7158,
           "kind": "unit",
           "field_names": [],
@@ -9049,7 +8918,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseAllPlayerCounters",
+          "name": "WinTheGame",
           "line": 7159,
           "kind": "unit",
           "field_names": [],
@@ -9057,7 +8926,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileFromTopUntil",
+          "name": "RollDie",
           "line": 7160,
           "kind": "unit",
           "field_names": [],
@@ -9065,7 +8934,7 @@
           "cr_refs": []
         },
         {
-          "name": "RevealUntil",
+          "name": "FlipCoin",
           "line": 7161,
           "kind": "unit",
           "field_names": [],
@@ -9073,7 +8942,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discover",
+          "name": "FlipCoins",
           "line": 7162,
           "kind": "unit",
           "field_names": [],
@@ -9081,7 +8950,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cascade",
+          "name": "FlipCoinUntilLose",
           "line": 7163,
           "kind": "unit",
           "field_names": [],
@@ -9089,7 +8958,7 @@
           "cr_refs": []
         },
         {
-          "name": "MiracleCast",
+          "name": "RingTemptsYou",
           "line": 7164,
           "kind": "unit",
           "field_names": [],
@@ -9097,7 +8966,7 @@
           "cr_refs": []
         },
         {
-          "name": "MadnessCast",
+          "name": "VentureIntoDungeon",
           "line": 7165,
           "kind": "unit",
           "field_names": [],
@@ -9105,7 +8974,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutAtLibraryPosition",
+          "name": "VentureInto",
           "line": 7166,
           "kind": "unit",
           "field_names": [],
@@ -9113,7 +8982,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDrawnThisTurnPayOrTopdeck",
+          "name": "TakeTheInitiative",
           "line": 7167,
           "kind": "unit",
           "field_names": [],
@@ -9121,7 +8990,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutOnTopOrBottom",
+          "name": "ProcessRadCounters",
           "line": 7168,
           "kind": "unit",
           "field_names": [],
@@ -9129,7 +8998,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiftDelivery",
+          "name": "GrantCastingPermission",
           "line": 7169,
           "kind": "unit",
           "field_names": [],
@@ -9137,7 +9006,7 @@
           "cr_refs": []
         },
         {
-          "name": "Goad",
+          "name": "ChooseFromZone",
           "line": 7170,
           "kind": "unit",
           "field_names": [],
@@ -9145,7 +9014,7 @@
           "cr_refs": []
         },
         {
-          "name": "Detain",
+          "name": "ChooseObjectsIntoTrackedSet",
           "line": 7171,
           "kind": "unit",
           "field_names": [],
@@ -9153,7 +9022,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeControl",
+          "name": "ChooseAndSacrificeRest",
           "line": 7172,
           "kind": "unit",
           "field_names": [],
@@ -9161,7 +9030,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeTargets",
+          "name": "Exploit",
           "line": 7173,
           "kind": "unit",
           "field_names": [],
@@ -9169,7 +9038,7 @@
           "cr_refs": []
         },
         {
-          "name": "Incubate",
+          "name": "GainEnergy",
           "line": 7174,
           "kind": "unit",
           "field_names": [],
@@ -9177,7 +9046,7 @@
           "cr_refs": []
         },
         {
-          "name": "Amass",
+          "name": "GivePlayerCounter",
           "line": 7175,
           "kind": "unit",
           "field_names": [],
@@ -9185,7 +9054,7 @@
           "cr_refs": []
         },
         {
-          "name": "Monstrosity",
+          "name": "LoseAllPlayerCounters",
           "line": 7176,
           "kind": "unit",
           "field_names": [],
@@ -9193,7 +9062,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bolster",
+          "name": "ExileFromTopUntil",
           "line": 7177,
           "kind": "unit",
           "field_names": [],
@@ -9201,7 +9070,7 @@
           "cr_refs": []
         },
         {
-          "name": "Adapt",
+          "name": "RevealUntil",
           "line": 7178,
           "kind": "unit",
           "field_names": [],
@@ -9209,7 +9078,7 @@
           "cr_refs": []
         },
         {
-          "name": "Manifest",
+          "name": "Discover",
           "line": 7179,
           "kind": "unit",
           "field_names": [],
@@ -9217,7 +9086,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "Cascade",
           "line": 7180,
           "kind": "unit",
           "field_names": [],
@@ -9225,7 +9094,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExtraTurn",
+          "name": "MiracleCast",
           "line": 7181,
           "kind": "unit",
           "field_names": [],
@@ -9233,7 +9102,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextTurn",
+          "name": "MadnessCast",
           "line": 7182,
           "kind": "unit",
           "field_names": [],
@@ -9241,7 +9110,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextStep",
+          "name": "PutAtLibraryPosition",
           "line": 7183,
           "kind": "unit",
           "field_names": [],
@@ -9249,7 +9118,7 @@
           "cr_refs": []
         },
         {
-          "name": "AdditionalPhase",
+          "name": "ChooseDrawnThisTurnPayOrTopdeck",
           "line": 7184,
           "kind": "unit",
           "field_names": [],
@@ -9257,7 +9126,7 @@
           "cr_refs": []
         },
         {
-          "name": "Double",
+          "name": "PutOnTopOrBottom",
           "line": 7185,
           "kind": "unit",
           "field_names": [],
@@ -9265,7 +9134,7 @@
           "cr_refs": []
         },
         {
-          "name": "RuntimeHandled",
+          "name": "GiftDelivery",
           "line": 7186,
           "kind": "unit",
           "field_names": [],
@@ -9273,7 +9142,7 @@
           "cr_refs": []
         },
         {
-          "name": "Learn",
+          "name": "Goad",
           "line": 7187,
           "kind": "unit",
           "field_names": [],
@@ -9281,7 +9150,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "Detain",
           "line": 7188,
           "kind": "unit",
           "field_names": [],
@@ -9289,7 +9158,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "ExchangeControl",
           "line": 7189,
           "kind": "unit",
           "field_names": [],
@@ -9297,7 +9166,7 @@
           "cr_refs": []
         },
         {
-          "name": "Endure",
+          "name": "ChangeTargets",
           "line": 7190,
           "kind": "unit",
           "field_names": [],
@@ -9305,7 +9174,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlightEffect",
+          "name": "Incubate",
           "line": 7191,
           "kind": "unit",
           "field_names": [],
@@ -9313,7 +9182,7 @@
           "cr_refs": []
         },
         {
-          "name": "Seek",
+          "name": "Amass",
           "line": 7192,
           "kind": "unit",
           "field_names": [],
@@ -9321,7 +9190,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetLifeTotal",
+          "name": "Monstrosity",
           "line": 7193,
           "kind": "unit",
           "field_names": [],
@@ -9329,7 +9198,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetDayNight",
+          "name": "Bolster",
           "line": 7194,
           "kind": "unit",
           "field_names": [],
@@ -9337,7 +9206,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveControl",
+          "name": "Adapt",
           "line": 7195,
           "kind": "unit",
           "field_names": [],
@@ -9345,7 +9214,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveFromCombat",
+          "name": "Manifest",
           "line": 7196,
           "kind": "unit",
           "field_names": [],
@@ -9353,7 +9222,7 @@
           "cr_refs": []
         },
         {
-          "name": "Conjure",
+          "name": "ManifestDread",
           "line": 7197,
           "kind": "unit",
           "field_names": [],
@@ -9361,7 +9230,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseOneOf",
+          "name": "ExtraTurn",
           "line": 7198,
           "kind": "unit",
           "field_names": [],
@@ -9369,7 +9238,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unimplemented",
+          "name": "SkipNextTurn",
           "line": 7199,
           "kind": "unit",
           "field_names": [],
@@ -9377,8 +9246,144 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "SkipNextStep",
+          "line": 7200,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AdditionalPhase",
           "line": 7201,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Double",
+          "line": 7202,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RuntimeHandled",
+          "line": 7203,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Learn",
+          "line": 7204,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Forage",
+          "line": 7205,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CollectEvidence",
+          "line": 7206,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Endure",
+          "line": 7207,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BlightEffect",
+          "line": 7208,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Seek",
+          "line": 7209,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetLifeTotal",
+          "line": 7210,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetDayNight",
+          "line": 7211,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GiveControl",
+          "line": 7212,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RemoveFromCombat",
+          "line": 7213,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Conjure",
+          "line": 7214,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseOneOf",
+          "line": 7215,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unimplemented",
+          "line": 7216,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 7218,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -9386,7 +9391,7 @@
         },
         {
           "name": "Crew",
-          "line": 7203,
+          "line": 7220,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -9396,7 +9401,7 @@
         },
         {
           "name": "Station",
-          "line": 7205,
+          "line": 7222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -9406,7 +9411,7 @@
         },
         {
           "name": "Saddle",
-          "line": 7207,
+          "line": 7224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -9416,7 +9421,7 @@
         },
         {
           "name": "Reveal",
-          "line": 7209,
+          "line": 7226,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -9424,7 +9429,7 @@
         },
         {
           "name": "Transform",
-          "line": 7210,
+          "line": 7227,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9432,7 +9437,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 7211,
+          "line": 7228,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9440,7 +9445,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 7212,
+          "line": 7229,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14874,7 +14879,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10131,
+      "line": 10156,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -14883,7 +14888,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 10133,
+          "line": 10158,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -14896,7 +14901,7 @@
         },
         {
           "name": "Crew",
-          "line": 10139,
+          "line": 10164,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -14909,7 +14914,7 @@
         },
         {
           "name": "Saddle",
-          "line": 10145,
+          "line": 10170,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -14922,7 +14927,7 @@
         },
         {
           "name": "Station",
-          "line": 10153,
+          "line": 10178,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -16023,7 +16028,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8477,
+      "line": 8494,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -16033,7 +16038,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 8479,
+          "line": 8496,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -16043,7 +16048,7 @@
         },
         {
           "name": "Second",
-          "line": 8482,
+          "line": 8499,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -16292,13 +16297,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4519,
+      "line": 4526,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 4520,
+          "line": 4527,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16306,7 +16311,7 @@
         },
         {
           "name": "Bottom",
-          "line": 4521,
+          "line": 4528,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16314,7 +16319,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 4523,
+          "line": 4530,
           "kind": "struct",
           "field_names": [
             "n"
@@ -17191,7 +17196,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9450,
+      "line": 9475,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -17200,7 +17205,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 9453,
+          "line": 9478,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -17212,7 +17217,7 @@
         },
         {
           "name": "Multiply",
-          "line": 9456,
+          "line": 9481,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -17460,7 +17465,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9462,
+      "line": 9487,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -17469,7 +17474,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 9465,
+          "line": 9490,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -17477,7 +17482,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 9467,
+          "line": 9492,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -17888,13 +17893,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7464,
+      "line": 7481,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 7466,
+          "line": 7483,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -17906,7 +17911,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 7469,
+          "line": 7486,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -17924,13 +17929,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7444,
+      "line": 7461,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 7445,
+          "line": 7462,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17938,7 +17943,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 7448,
+          "line": 7465,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -17953,7 +17958,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 7455,
+          "line": 7472,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -17963,7 +17968,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 7458,
+          "line": 7475,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -18231,7 +18236,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9026,
+      "line": 9043,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -18241,7 +18246,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 9028,
+          "line": 9045,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -18249,7 +18254,7 @@
         },
         {
           "name": "Equals",
-          "line": 9030,
+          "line": 9047,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -18257,7 +18262,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 9033,
+          "line": 9050,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -18265,7 +18270,7 @@
         },
         {
           "name": "OneOf",
-          "line": 9035,
+          "line": 9052,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -19808,7 +19813,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9561,
+      "line": 9586,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -19817,7 +19822,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 9562,
+          "line": 9587,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -19825,7 +19830,7 @@
         },
         {
           "name": "Resolved",
-          "line": 9563,
+          "line": 9588,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20466,7 +20471,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9436,
+      "line": 9453,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -20474,7 +20479,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 9438,
+          "line": 9455,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -20482,7 +20487,7 @@
         },
         {
           "name": "Plus",
-          "line": 9440,
+          "line": 9457,
           "kind": "struct",
           "field_names": [
             "value"
@@ -20492,13 +20497,25 @@
         },
         {
           "name": "Minus",
-          "line": 9442,
+          "line": 9459,
           "kind": "struct",
           "field_names": [
             "value"
           ],
           "doc": "count.saturating_sub(value) — Vizier of Remedies (-1)",
           "cr_refs": []
+        },
+        {
+          "name": "Prevent",
+          "line": 9467,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6). Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers; CR 122.1 \"a counter is a marker placed on an object\" — placement is what we suppress). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
+          "cr_refs": [
+            "CR 122.1",
+            "CR 614.6",
+            "CR 614.7"
+          ]
         }
       ],
       "sibling_clusters": []
@@ -21314,7 +21331,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7981,
+      "line": 7998,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -21323,7 +21340,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 7985,
+          "line": 8002,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -21336,13 +21353,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8840,
+      "line": 8857,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UnlessControlsSubtype",
-          "line": 8844,
+          "line": 8861,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -21352,7 +21369,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 8851,
+          "line": 8868,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21365,7 +21382,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 8856,
+          "line": 8873,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21377,7 +21394,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 8861,
+          "line": 8878,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -21390,7 +21407,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 8864,
+          "line": 8881,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -21402,7 +21419,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 8867,
+          "line": 8884,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -21412,7 +21429,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 8870,
+          "line": 8887,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -21423,7 +21440,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 8878,
+          "line": 8895,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -21436,7 +21453,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 8892,
+          "line": 8909,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -21449,7 +21466,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 8901,
+          "line": 8918,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -21459,7 +21476,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 8907,
+          "line": 8924,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -21471,7 +21488,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 8912,
+          "line": 8929,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -21483,7 +21500,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 8917,
+          "line": 8934,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -21494,7 +21511,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 8926,
+          "line": 8943,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -21506,7 +21523,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 8933,
+          "line": 8950,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -21520,7 +21537,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 8941,
+          "line": 8958,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -21530,7 +21547,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 8946,
+          "line": 8963,
           "kind": "struct",
           "field_names": [
             "source"
@@ -21544,7 +21561,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 8950,
+          "line": 8967,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -21557,7 +21574,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 8955,
+          "line": 8972,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -21568,7 +21585,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 8966,
+          "line": 8983,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -21581,7 +21598,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 8977,
+          "line": 8994,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -21593,7 +21610,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 8982,
+          "line": 8999,
           "kind": "struct",
           "field_names": [
             "text"
@@ -21997,13 +22014,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9527,
+      "line": 9552,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 9530,
+          "line": 9555,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -22011,7 +22028,7 @@
         },
         {
           "name": "Optional",
-          "line": 9532,
+          "line": 9557,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -22021,7 +22038,7 @@
         },
         {
           "name": "MayCost",
-          "line": 9539,
+          "line": 9564,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -22038,7 +22055,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9515,
+      "line": 9540,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 614.1a"
@@ -22046,7 +22063,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 9517,
+          "line": 9542,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source's controller.",
@@ -22054,7 +22071,7 @@
         },
         {
           "name": "Opponent",
-          "line": 9519,
+          "line": 9544,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source's controller.",
@@ -22062,7 +22079,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 9521,
+          "line": 9546,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -22609,7 +22626,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4560,
+      "line": 4567,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -22617,7 +22634,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 4562,
+          "line": 4569,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -22627,7 +22644,7 @@
         },
         {
           "name": "Decrease",
-          "line": 4564,
+          "line": 4571,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -22640,13 +22657,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4369,
+      "line": 4376,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 4370,
+          "line": 4377,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22654,7 +22671,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 4371,
+          "line": 4378,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22662,7 +22679,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 4372,
+          "line": 4379,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22670,7 +22687,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 4374,
+          "line": 4381,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -24165,7 +24182,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7946,
+      "line": 7963,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -24173,7 +24190,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 7954,
+          "line": 7971,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -24181,7 +24198,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 7959,
+          "line": 7976,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -24350,7 +24367,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7634,
+      "line": 7651,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -24360,7 +24377,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 7636,
+          "line": 7653,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24368,7 +24385,7 @@
         },
         {
           "name": "Resolution",
-          "line": 7637,
+          "line": 7654,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24785,13 +24802,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10113,
+      "line": 10138,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 10114,
+          "line": 10139,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24799,7 +24816,7 @@
         },
         {
           "name": "Player",
-          "line": 10115,
+          "line": 10140,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24944,13 +24961,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8563,
+      "line": 8580,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 8566,
+          "line": 8583,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -24960,7 +24977,7 @@
         },
         {
           "name": "LostLife",
-          "line": 8568,
+          "line": 8585,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -24968,7 +24985,7 @@
         },
         {
           "name": "Descended",
-          "line": 8570,
+          "line": 8587,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -24976,7 +24993,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 8572,
+          "line": 8589,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24986,7 +25003,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 8574,
+          "line": 8591,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -24996,7 +25013,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 8576,
+          "line": 8593,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -25006,7 +25023,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 8586,
+          "line": 8603,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25019,7 +25036,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 8589,
+          "line": 8606,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -25030,7 +25047,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 8592,
+          "line": 8609,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -25040,7 +25057,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 8596,
+          "line": 8613,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -25052,7 +25069,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 8599,
+          "line": 8616,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -25062,7 +25079,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 8602,
+          "line": 8619,
           "kind": "struct",
           "field_names": [
             "level"
@@ -25074,7 +25091,7 @@
         },
         {
           "name": "WasCast",
-          "line": 8607,
+          "line": 8624,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you cast it\" — zoneless cast check (unlike CastFromZone which requires a specific zone). CR 701.57a: Used by Discover ETB triggers. Negation (\"if it wasn't cast\") is expressed via `Not { Box::new(WasCast) }`.",
@@ -25084,7 +25101,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8612,
+          "line": 8629,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -25099,7 +25116,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 8626,
+          "line": 8643,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -25109,7 +25126,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 8632,
+          "line": 8649,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -25124,7 +25141,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 8636,
+          "line": 8653,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -25135,7 +25152,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 8640,
+          "line": 8657,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -25146,7 +25163,7 @@
         },
         {
           "name": "WasType",
-          "line": 8645,
+          "line": 8662,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -25159,7 +25176,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 8648,
+          "line": 8665,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -25171,7 +25188,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 8652,
+          "line": 8669,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -25184,7 +25201,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 8656,
+          "line": 8673,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25196,7 +25213,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 8660,
+          "line": 8677,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -25206,7 +25223,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 8663,
+          "line": 8680,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -25218,7 +25235,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 8667,
+          "line": 8684,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25230,7 +25247,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 8670,
+          "line": 8687,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -25242,7 +25259,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 8676,
+          "line": 8693,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -25252,7 +25269,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 8679,
+          "line": 8696,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -25262,7 +25279,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 8682,
+          "line": 8699,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -25272,7 +25289,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 8689,
+          "line": 8706,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -25284,7 +25301,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 8694,
+          "line": 8711,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -25296,7 +25313,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 8698,
+          "line": 8715,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -25306,7 +25323,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 8703,
+          "line": 8720,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -25318,7 +25335,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 8709,
+          "line": 8726,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -25328,7 +25345,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 8714,
+          "line": 8731,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -25338,7 +25355,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 8717,
+          "line": 8734,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -25348,7 +25365,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 8720,
+          "line": 8737,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -25358,7 +25375,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 8722,
+          "line": 8739,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -25370,7 +25387,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 8725,
+          "line": 8742,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -25380,7 +25397,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 8729,
+          "line": 8746,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -25390,7 +25407,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 8733,
+          "line": 8750,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25403,7 +25420,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 8736,
+          "line": 8753,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -25413,7 +25430,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 8740,
+          "line": 8757,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -25426,7 +25443,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 8743,
+          "line": 8760,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -25439,7 +25456,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 8745,
+          "line": 8762,
           "kind": "struct",
           "field_names": [
             "color",
@@ -25452,7 +25469,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 8747,
+          "line": 8764,
           "kind": "struct",
           "field_names": [
             "text"
@@ -25464,7 +25481,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 8749,
+          "line": 8766,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -25476,7 +25493,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 8753,
+          "line": 8770,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -25490,7 +25507,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 8755,
+          "line": 8772,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -25500,7 +25517,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 8760,
+          "line": 8777,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -25515,7 +25532,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 8771,
+          "line": 8788,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -25531,7 +25548,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 8786,
+          "line": 8803,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -25543,7 +25560,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 8789,
+          "line": 8806,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25556,7 +25573,7 @@
         },
         {
           "name": "AttackersDeclaredMin",
-          "line": 8802,
+          "line": 8819,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25572,7 +25589,7 @@
         },
         {
           "name": "NoneOfAttackersTargetedYou",
-          "line": 8807,
+          "line": 8824,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 603.4: Intervening-if \"if none of those creatures attacked you\". Reads the triggering `AttackersDeclared` event's per-attacker `AttackTarget` tuples (CR 508.1b) and returns true iff no attacker in the batch targeted the trigger's controller directly (`AttackTarget::Player(trigger_controller)`).",
@@ -25584,7 +25601,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 8817,
+          "line": 8834,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -25596,7 +25613,7 @@
         },
         {
           "name": "And",
-          "line": 8821,
+          "line": 8838,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -25606,7 +25623,7 @@
         },
         {
           "name": "Or",
-          "line": 8823,
+          "line": 8840,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -25616,7 +25633,7 @@
         },
         {
           "name": "Not",
-          "line": 8833,
+          "line": 8850,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -25632,13 +25649,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8988,
+      "line": 9005,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 8990,
+          "line": 9007,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -25646,7 +25663,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 8992,
+          "line": 9009,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -25654,7 +25671,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 8994,
+          "line": 9011,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -25662,7 +25679,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 8999,
+          "line": 9016,
           "kind": "struct",
           "field_names": [
             "n",
@@ -25673,7 +25690,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 9006,
+          "line": 9023,
           "kind": "struct",
           "field_names": [
             "n"
@@ -25683,7 +25700,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 9008,
+          "line": 9025,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -25691,7 +25708,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 9012,
+          "line": 9029,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -25701,7 +25718,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 9014,
+          "line": 9031,
           "kind": "struct",
           "field_names": [
             "level"
@@ -25713,7 +25730,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 9017,
+          "line": 9034,
           "kind": "struct",
           "field_names": [
             "max"
@@ -27588,7 +27605,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6443,
+      "line": 6460,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -27597,7 +27614,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 6446,
+          "line": 6463,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -27607,7 +27624,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 6450,
+          "line": 6467,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -27617,7 +27634,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 6458,
+          "line": 6475,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",


### PR DESCRIPTION
## Summary
Adds engine support for **Melira's Keepers** (Creature — Human Scout, {1}{G}{G}, 2/2, *"This creature can't have counters put on it."*).

<img width="744" height="1039" alt="image" src="https://github.com/user-attachments/assets/ab6a5b4b-87b8-4e4b-80fe-ecc9f9599030" />

Introduces a new `QuantityModification::Prevent` variant on the replacement-effect pipeline. The typed shape — `ReplacementEvent::AddCounter` keyed on `valid_card: SelfRef` with `quantity_modification: Prevent` — composes cleanly with the existing replacement infrastructure and unlocks Tatterkite (identical Oracle text) in the same change. The Solemnity-class global variant lifts `SelfRef` to a wider filter and is a natural future extension that composes through the same variant.

## Files changed
- `crates/engine/src/types/ability.rs` — new `QuantityModification::Prevent` variant
- `crates/engine/src/game/replacement.rs` — `Prevent` arms in `gain_life_applier`, `add_counter_applier`, `create_token_applier`
- `crates/engine/src/game/effects/counters.rs` — 5 engine tests (P1P1 / M1M1 / arbitrary counter type / other-creature unaffected / off-battlefield zone gate)
- `crates/engine/src/parser/oracle_replacement.rs` — `parse_no_counters_replacement` combinator + parser tests
- `crates/engine/src/parser/oracle_classifier.rs` — replacement classifier entry
- `crates/engine/src/game/coverage.rs` — audit heuristic for the new shape
- `crates/phase-ai/src/features/plus_one_counters.rs` — exclude `Prevent` from the P1P1-deck signal
- `data/engine-inventory.json` — regenerated

## CR references
- **CR 113.6i** — authorizing rule: counters-can't-be-put-on-it functions as the object enters the battlefield in addition to while on the battlefield.
- **CR 614.17** — "can't" effects framework (not strictly replacement effects, but follow similar rules) — why we model the prohibition through the replacement pipeline.
- **CR 614.6 / CR 614.7** — replaced events never happen; replacement effects that would replace a non-event do nothing.
- **CR 614.1a** — replacement effects use "instead."
- **CR 122.1 / CR 122.2** — counter placement / zone-change counter erasure.
- **CR 113.6** — static abilities only function from the appropriate zone.
- **CR 111.1** — token-creation event (Prevent composes for the future "tokens can't be created" variant).
- **CR 201.5** — engine self-reference normalization (`"this creature"` → `~`).

All CR numbers verified against `docs/MagicCompRules.txt`.

## Track
Non-developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Verification
Local verification skipped — see CI status checks.

The engine-implementer subagent (which had a Rust toolchain available) reported its own internal verification clean: `cargo fmt --all` OK, `cargo clippy -p engine --all-targets -- -D warnings` OK, `cargo clippy -p phase-ai --all-targets -- -D warnings` OK, `cargo test -p engine` 7,981 unit + 408 integration tests pass, `cargo test -p phase-ai` 627+14+12+2+1 tests pass, `./scripts/gen-card-data.sh` Melira's Keepers parses with `{ event: AddCounter, valid_card: SelfRef, quantity_modification: Prevent }`, `./scripts/check-parser-combinators.sh` clean, `cargo coverage` Melira's Keepers + Tatterkite both `supported: true, gap_count: 0`, `cargo semantic-audit` zero findings on either.

GitHub Actions will re-run all of the above on this PR.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.