### PR TITLE
Add Heed the Mists

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24082,6 +24082,49 @@ mod tests {
         ));
     }
 
+    /// CR 701.17a + CR 701.17c + CR 608.2c: "Mill a card, then draw cards equal
+    /// to the milled card's mana value." — Heed the Mists.
+    ///
+    /// The `Mill` effect must chain (via `sub_ability`) to a `Draw` effect
+    /// whose count is `QuantityExpr::Ref { ObjectManaValue { CostPaidObject } }`.
+    /// `CostPaidObject` is correct because the milled card is the event-context
+    /// object whose LKI snapshot is consulted at resolution (CR 608.2h).
+    #[test]
+    fn mill_then_draw_equal_to_milled_card_mana_value() {
+        let def = parse_effect_chain(
+            "Mill a card, then draw cards equal to the milled card's mana value.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(&*def.effect, Effect::Mill { .. }),
+            "outer effect must be Mill, got {:?}",
+            def.effect
+        );
+        let draw = def
+            .sub_ability
+            .as_deref()
+            .expect("Mill must chain to a Draw sub_ability");
+        match &*draw.effect {
+            Effect::Draw { count, target } => {
+                assert_eq!(
+                    *target,
+                    TargetFilter::Controller,
+                    "Draw target must be Controller"
+                );
+                assert_eq!(
+                    *count,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectManaValue {
+                            scope: ObjectScope::CostPaidObject,
+                        },
+                    },
+                    "Draw count must be ObjectManaValue{{CostPaidObject}}"
+                );
+            }
+            other => panic!("expected Draw sub_ability, got {other:?}"),
+        }
+    }
+
     #[test]
     fn parse_play_from_exile_while_exiled_with_any_mana_permission() {
         let def = parse_effect_chain(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24082,13 +24082,14 @@ mod tests {
         ));
     }
 
-    /// CR 701.17a + CR 701.17c + CR 608.2c: "Mill a card, then draw cards equal
-    /// to the milled card's mana value." — Heed the Mists.
+    /// CR 701.17a + CR 701.17c + CR 400.7j + CR 608.2c: "Mill a card, then draw
+    /// cards equal to the milled card's mana value." — Heed the Mists.
     ///
     /// The `Mill` effect must chain (via `sub_ability`) to a `Draw` effect
     /// whose count is `QuantityExpr::Ref { ObjectManaValue { CostPaidObject } }`.
-    /// `CostPaidObject` is correct because the milled card is the event-context
-    /// object whose LKI snapshot is consulted at resolution (CR 608.2h).
+    /// `CostPaidObject` is the existing parser scope for explicit possessive
+    /// prior-object references; at runtime it falls through to the
+    /// instruction-order moved object snapshot when no cost object is present.
     #[test]
     fn mill_then_draw_equal_to_milled_card_mana_value() {
         let def = parse_effect_chain(

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1334,18 +1334,29 @@ fn parse_object_mana_value_ref(input: &str) -> OracleResult<'_, QuantityRef> {
 /// CR 117.1 + CR 202.3: Cost-paid object's mana value.
 ///
 /// Composes the prefix grammar
-/// `[the] (sacrificed|exiled) (creature|card|permanent|artifact)'s (mana value|converted mana cost)`
+/// `[the] (sacrificed|exiled|discarded|milled) (creature|card|permanent|artifact)'s (mana value|converted mana cost)`
 /// into a single typed combinator. Each axis is a single `alt()` over
-/// independent variants — adding a new participle (e.g. "discarded"), a new
-/// noun, or the British spelling of "mana value" extends one alt branch
-/// rather than adding a new top-level arm.
+/// independent variants — adding a new participle, a new noun, or the British
+/// spelling of "mana value" extends one alt branch rather than adding a new
+/// top-level arm.
 ///
 /// Used by Food Chain ("1 plus the exiled creature's mana value"),
 /// Burnt Offering / Metamorphosis ("the sacrificed creature's mana value"),
+/// Heed the Mists / Mindshrieker ("the milled card's mana value"),
 /// and the broader cost-paid-by-property class.
+///
+/// CR 701.17a + CR 701.17c: "milled" card refers to the object that moved
+/// from the library to the graveyard; its mana value is read from LKI.
 fn parse_cost_paid_object_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = opt(tag("the ")).parse(input)?;
-    let (rest, _) = alt((tag("sacrificed "), tag("exiled "), tag("discarded "))).parse(rest)?;
+    let (rest, _) = alt((
+        tag("sacrificed "),
+        tag("exiled "),
+        tag("discarded "),
+        // CR 701.17a: "milled" — card moved library → graveyard by the mill action.
+        tag("milled "),
+    ))
+    .parse(rest)?;
     let (rest, _) = alt((
         tag("creature"),
         tag("card"),
@@ -4524,6 +4535,30 @@ mod tests {
                         ],
                     },
                 }
+            );
+        }
+    }
+
+    /// CR 701.17a + CR 701.17c: "the milled card's mana value" routes through
+    /// `parse_cost_paid_object_ref` (participle = "milled") and yields
+    /// `ObjectManaValue { CostPaidObject }`. Covers Heed the Mists and the
+    /// broader class of "milled card's <property>" CDA patterns.
+    #[test]
+    fn test_parse_milled_card_mana_value_ref() {
+        for phrase in [
+            "the milled card's mana value",
+            "the milled card's converted mana cost",
+            "milled card's mana value",
+        ] {
+            let (rest, q) = parse_quantity_ref(phrase)
+                .unwrap_or_else(|_| panic!("parse_quantity_ref({phrase:?}) should succeed"));
+            assert_eq!(rest, "", "phrase {phrase:?} should be fully consumed");
+            assert_eq!(
+                q,
+                QuantityRef::ObjectManaValue {
+                    scope: ObjectScope::CostPaidObject,
+                },
+                "phrase {phrase:?} must yield ObjectManaValue{{CostPaidObject}}"
             );
         }
     }

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1331,7 +1331,7 @@ fn parse_object_mana_value_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     Ok((rest, QuantityRef::ObjectManaValue { scope }))
 }
 
-/// CR 117.1 + CR 202.3: Cost-paid object's mana value.
+/// CR 608.2k + CR 202.3: Cost-paid object's mana value.
 ///
 /// Composes the prefix grammar
 /// `[the] (sacrificed|exiled|discarded|milled) (creature|card|permanent|artifact)'s (mana value|converted mana cost)`

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -415,10 +415,11 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         parse_life_gained_ref,
         parse_starting_life_ref,
         parse_object_mana_value_ref,
-        // CR 117.1 + CR 202.3: cost-paid object's mana value — must precede
-        // `parse_event_context_refs` so the cost-paid resolver wins over the
-        // generic event-source resolver for sacrificed/exiled possessives
-        // (Food Chain, Burnt Offering, Metamorphosis).
+        // CR 608.2k + CR 400.7j + CR 202.3: previously-referenced object's
+        // mana value — must precede `parse_event_context_refs` so the
+        // cost/effect referent resolver wins over the generic event-source
+        // resolver for sacrificed/exiled/milled possessives (Food Chain, Burnt
+        // Offering, Metamorphosis, Heed the Mists).
         parse_cost_paid_object_ref,
         parse_event_context_refs,
     ))
@@ -1331,7 +1332,7 @@ fn parse_object_mana_value_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     Ok((rest, QuantityRef::ObjectManaValue { scope }))
 }
 
-/// CR 608.2k + CR 202.3: Cost-paid object's mana value.
+/// CR 608.2k + CR 400.7j + CR 202.3: Previously-referenced object's mana value.
 ///
 /// Composes the prefix grammar
 /// `[the] (sacrificed|exiled|discarded|milled) (creature|card|permanent|artifact)'s (mana value|converted mana cost)`
@@ -1345,8 +1346,9 @@ fn parse_object_mana_value_ref(input: &str) -> OracleResult<'_, QuantityRef> {
 /// Heed the Mists / Mindshrieker ("the milled card's mana value"),
 /// and the broader cost-paid-by-property class.
 ///
-/// CR 701.17a + CR 701.17c: "milled" card refers to the object that moved
-/// from the library to the graveyard; its mana value is read from LKI.
+/// CR 701.17a + CR 701.17c + CR 400.7j: "milled" card refers to the
+/// object that moved from the library to the graveyard; its mana value is read
+/// from that public-zone object or LKI as needed.
 fn parse_cost_paid_object_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = opt(tag("the ")).parse(input)?;
     let (rest, _) = alt((

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -730,11 +730,6 @@ fn is_event_context_referent(prefix: &str) -> bool {
         "revealed",
         "drawn",
         "copied",
-        // CR 701.17a + CR 701.17c: "milled" is a past-participle event adjective —
-        // the milled card is the object that moved from library to graveyard as a
-        // result of the mill action. Heed the Mists: "draw cards equal to the
-        // milled card's mana value."
-        "milled",
     ];
     if prefix.starts_with("that ") || prefix.starts_with("the ") {
         let rest = prefix.split_once(' ').map_or("", |x| x.1);

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2698,9 +2698,9 @@ mod tests {
         assert_eq!(result, None);
     }
 
-    /// CR 701.17a + CR 701.17c: "the milled card's mana value" resolves to
-    /// `ObjectManaValue { CostPaidObject }` — the milled card is the event
-    /// context object whose LKI snapshot provides the mana value.
+    /// CR 701.17a + CR 701.17c + CR 400.7j: "the milled card's mana value"
+    /// resolves to `ObjectManaValue { CostPaidObject }` via the existing
+    /// previously-referenced-object quantity path.
     /// Heed the Mists: "draw cards equal to the milled card's mana value."
     #[test]
     fn event_context_milled_card_mana_value() {

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -730,6 +730,11 @@ fn is_event_context_referent(prefix: &str) -> bool {
         "revealed",
         "drawn",
         "copied",
+        // CR 701.17a + CR 701.17c: "milled" is a past-participle event adjective —
+        // the milled card is the object that moved from library to graveyard as a
+        // result of the mill action. Heed the Mists: "draw cards equal to the
+        // milled card's mana value."
+        "milled",
     ];
     if prefix.starts_with("that ") || prefix.starts_with("the ") {
         let rest = prefix.split_once(' ').map_or("", |x| x.1);
@@ -2696,6 +2701,23 @@ mod tests {
         // no partial-credit Sum that would silently undercount.
         let result = parse_for_each_clause_expr("card in your hand and each blorgon you control");
         assert_eq!(result, None);
+    }
+
+    /// CR 701.17a + CR 701.17c: "the milled card's mana value" resolves to
+    /// `ObjectManaValue { CostPaidObject }` — the milled card is the event
+    /// context object whose LKI snapshot provides the mana value.
+    /// Heed the Mists: "draw cards equal to the milled card's mana value."
+    #[test]
+    fn event_context_milled_card_mana_value() {
+        assert_eq!(
+            parse_event_context_quantity("the milled card's mana value"),
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::ObjectManaValue {
+                    scope: ObjectScope::CostPaidObject,
+                },
+            }),
+            "milled card's mana value must resolve to ObjectManaValue{{CostPaidObject}}"
+        );
     }
 
     /// CR 119.3 + CR 700.1: "for each of your opponents who lost life this


### PR DESCRIPTION
## Summary

Adds engine support for **Heed the Mists** by extending the mill cost-paid object parser to recognize the "milled" participle.

- `crates/engine/src/parser/oracle_nom/quantity.rs` — add `tag("milled ")` to `parse_cost_paid_object_ref` so "the milled card's mana value" parses to `QuantityRef::ObjectManaValue { scope: ObjectScope::CostPaidObject }`; fix pre-existing wrong CR annotation (117.1 → 608.2k)
- `crates/engine/src/parser/oracle_quantity.rs` — add parser test for milled-card mana value via fallback path; remove erroneous addition of "milled" to `event_adjectives` (cost-paid participles are explicitly excluded from that gate per design comment)
- `crates/engine/src/parser/oracle_effect/mod.rs` — add full-chain parser test for "Mill a card, then draw cards equal to the milled card's mana value."

## CR references

- CR 608.2k: effects still refer to previously-referenced objects
- CR 202.3: mana value definition
- CR 701.17a: mill action moves cards library → graveyard
- CR 701.17c: milled card can be found in the public zone it moved to

## Track

Non-developer

## LLM

Model: claude-sonnet-4-6  
Thinking: medium

## Verification

Local verification skipped — see CI status checks.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.