### PR TITLE
Add Beyond the Quiet

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6551,6 +6551,46 @@ mod tests {
     }
 
     #[test]
+    fn end_to_end_beyond_the_quiet_no_spacecraft_gap() {
+        let r = parse(
+            "Exile all creatures and Spacecraft.",
+            "Beyond the Quiet",
+            &[],
+            &["Sorcery"],
+            &[],
+        );
+        assert_eq!(r.abilities.len(), 1);
+        assert!(
+            !has_unimplemented(&r.abilities[0]),
+            "Beyond the Quiet should not produce Unimplemented effects: {:?}",
+            r.abilities[0]
+        );
+        match &*r.abilities[0].effect {
+            Effect::ChangeZoneAll {
+                destination,
+                target,
+                ..
+            } => {
+                assert_eq!(*destination, Zone::Exile);
+                match target {
+                    TargetFilter::Or { filters } => {
+                        assert_eq!(filters.len(), 2);
+                        assert_eq!(filters[0], TargetFilter::Typed(TypedFilter::creature()));
+                        assert_eq!(
+                            filters[1],
+                            TargetFilter::Typed(
+                                TypedFilter::default().subtype("Spacecraft".to_string())
+                            )
+                        );
+                    }
+                    other => panic!("expected Creature/Spacecraft Or filter, got {other:?}"),
+                }
+            }
+            other => panic!("expected ChangeZoneAll, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn end_to_end_suspend_sorcery_no_unimplemented() {
         // CR 702.62a: "Suspend N—{cost}" on a sorcery must not produce Unimplemented.
         // Ancestral Vision: "Suspend 4—{U}\nTarget player draws three cards."

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6520,6 +6520,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_exile_all_creatures_and_spacecraft() {
+        let input = "exile all creatures and Spacecraft";
+        let lower = input.to_lowercase();
+        let result = parse_zone_counter_ast(input, &lower, &mut ParseContext::default());
+        let Some(ZoneCounterImperativeAst::Exile {
+            origin: None,
+            target: TargetFilter::Or { filters },
+            all: true,
+            enter_with_counters,
+        }) = result
+        else {
+            panic!("{input}: expected mass exile type union, got {result:?}");
+        };
+
+        assert!(enter_with_counters.is_empty());
+        assert_eq!(filters.len(), 2);
+        assert_eq!(filters[0], TargetFilter::Typed(TypedFilter::creature()));
+        assert_eq!(
+            filters[1],
+            TargetFilter::Typed(TypedFilter::default().subtype("Spacecraft".to_string()))
+        );
+    }
+
+    #[test]
     fn parse_exile_from_your_hand_handles_article_variants() {
         for (input, expected_type) in [
             ("exile an instant card from your hand", TypeFilter::Instant),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24715,6 +24715,34 @@ mod tests {
     }
 
     #[test]
+    fn exile_all_creatures_and_spacecraft_lowers_to_mass_zone_change() {
+        let def = parse_effect_chain("Exile all creatures and Spacecraft.", AbilityKind::Spell);
+        match &*def.effect {
+            Effect::ChangeZoneAll {
+                destination,
+                target,
+                ..
+            } => {
+                assert_eq!(*destination, Zone::Exile);
+                match target {
+                    TargetFilter::Or { filters } => {
+                        assert_eq!(filters.len(), 2);
+                        assert_eq!(filters[0], TargetFilter::Typed(TypedFilter::creature()));
+                        assert_eq!(
+                            filters[1],
+                            TargetFilter::Typed(
+                                TypedFilter::default().subtype("Spacecraft".to_string())
+                            )
+                        );
+                    }
+                    other => panic!("expected Creature/Spacecraft Or filter, got {other:?}"),
+                }
+            }
+            other => panic!("expected ChangeZoneAll, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parse_put_on_top_or_bottom_possessive() {
         // "Target creature's owner puts it on their choice of the top or bottom of their library."
         let def = parse_effect_chain(

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -7074,6 +7074,32 @@ mod tests {
     }
 
     #[test]
+    fn spacecraft_artifact_subtype() {
+        let (f, _) = parse_type_phrase("Spacecraft");
+        assert_eq!(
+            f,
+            TargetFilter::Typed(TypedFilter::default().subtype("Spacecraft".to_string()))
+        );
+    }
+
+    #[test]
+    fn creatures_and_spacecraft_type_union() {
+        let (f, rest) = parse_type_phrase("creatures and Spacecraft");
+        match f {
+            TargetFilter::Or { ref filters } => {
+                assert_eq!(filters.len(), 2);
+                assert_eq!(filters[0], TargetFilter::Typed(TypedFilter::creature()));
+                assert_eq!(
+                    filters[1],
+                    TargetFilter::Typed(TypedFilter::default().subtype("Spacecraft".to_string()))
+                );
+            }
+            other => panic!("Expected Or filter, got {:?}", other),
+        }
+        assert_eq!(rest.trim(), "");
+    }
+
+    #[test]
     fn forest_land_subtype() {
         let (f, _) = parse_type_phrase("forest");
         match f {

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1038,6 +1038,7 @@ const SUBTYPES: &[&str] = &[
     "Junk",
     "Map",
     "Powerstone",
+    "Spacecraft",
     "Treasure",
     "Vehicle",
     // ── Enchantment subtypes ──
@@ -1250,18 +1251,20 @@ pub fn parse_subtype(text: &str) -> Option<(String, usize)> {
 
 /// Infer the core type for a known subtype name.
 ///
-/// Artifact subtypes (Treasure, Food, Clue, Blood, Gold, Map, Equipment, Vehicle)
-/// map to `CoreType::Artifact`. Land subtypes (Forest, Plains, etc.) map to
-/// `CoreType::Land`. Enchantment subtypes (Aura, Saga, etc.) map to
-/// `CoreType::Enchantment`. Returns `None` for creature subtypes (the caller's
-/// existing default) or unknown subtypes.
+/// Artifact subtypes (Treasure, Food, Clue, Blood, Gold, Map, Equipment,
+/// Spacecraft, Vehicle) map to `CoreType::Artifact`. Land subtypes (Forest,
+/// Plains, etc.) map to `CoreType::Land`. Enchantment subtypes (Aura, Saga,
+/// etc.) map to `CoreType::Enchantment`. Returns `None` for creature subtypes
+/// (the caller's existing default) or unknown subtypes.
 ///
 /// Used by lord-pattern parsers to avoid defaulting all subtypes to Creature.
 pub fn infer_core_type_for_subtype(subtype: &str) -> Option<CoreType> {
     match subtype {
         // Artifact subtypes (CR 205.3g)
         "Treasure" | "Food" | "Clue" | "Blood" | "Gold" | "Map" | "Junk" | "Powerstone"
-        | "Equipment" | "Vehicle" | "Fortification" | "Contraption" => Some(CoreType::Artifact),
+        | "Equipment" | "Spacecraft" | "Vehicle" | "Fortification" | "Contraption" => {
+            Some(CoreType::Artifact)
+        }
         // Land subtypes (CR 205.3i)
         "Forest" | "Plains" | "Island" | "Mountain" | "Swamp" | "Desert" | "Gate" | "Locus"
         | "Cave" | "Sphere" | "Mine" | "Tower" | "Power-Plant" => Some(CoreType::Land),
@@ -2466,6 +2469,14 @@ mod tests {
             parse_subtype("equipment"),
             Some(("Equipment".to_string(), 9))
         );
+        assert_eq!(
+            parse_subtype("Spacecraft"),
+            Some(("Spacecraft".to_string(), 10))
+        );
+        assert_eq!(
+            parse_subtype("spacecrafts"),
+            Some(("Spacecraft".to_string(), 11))
+        );
         assert_eq!(parse_subtype("forest"), Some(("Forest".to_string(), 6)));
         assert_eq!(parse_subtype("aura"), Some(("Aura".to_string(), 4)));
     }
@@ -2485,6 +2496,14 @@ mod tests {
             Some(("Goblin".to_string(), 6))
         );
         assert_eq!(parse_subtype("goblinking"), None);
+    }
+
+    #[test]
+    fn infer_core_type_for_spacecraft_subtype() {
+        assert_eq!(
+            infer_core_type_for_subtype("Spacecraft"),
+            Some(CoreType::Artifact)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds engine support for **Beyond the Quiet**.

## Files changed
- crates/engine/src/parser/oracle.rs
- crates/engine/src/parser/oracle_effect/imperative.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/parser/oracle_target.rs
- crates/engine/src/parser/oracle_util.rs

## CR references
- CR 205.3g

## Track
Non-developer

## LLM
Model: codex-5
Thinking: medium

## Verification
Local verification skipped — see CI status checks.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.