### PR TITLE
fix(planeswalker): loyalty activation at announcement + im::HashMap (#807 followup)

### DIFF
--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -218,10 +218,12 @@ pub(crate) fn handle_select_targets(
 
     if let Some(ability_index) = pending.activation_ability_index {
         if let Some(ref activation_cost) = pending.activation_cost {
+            // CR 606.4 / CR 602.2b: Pay the activation cost through the single
+            // cost-resolution authority. CR 606.3 announcement-time marking for
+            // loyalty abilities lives in `planeswalker::handle_activate_loyalty`
+            // — this call site MUST NOT branch on cost shape (single-authority
+            // principle: callers dispatch activation, they never inspect costs).
             pay_ability_cost(state, player, pending.object_id, activation_cost, events)?;
-            if matches!(activation_cost, AbilityCost::Loyalty { .. }) {
-                super::planeswalker::record_loyalty_activation(state, pending.object_id, player);
-            }
         }
 
         let assigned_targets = flatten_targets_in_chain(&ability);
@@ -316,14 +318,10 @@ pub(crate) fn handle_choose_target(
 
             if let Some(ability_index) = pending.activation_ability_index {
                 if let Some(ref activation_cost) = pending.activation_cost {
+                    // CR 606.4 / CR 602.2b: Single-authority cost payment. CR 606.3
+                    // marking happens in `planeswalker::handle_activate_loyalty` at
+                    // announcement time — this site MUST NOT branch on cost shape.
                     pay_ability_cost(state, player, pending.object_id, activation_cost, events)?;
-                    if matches!(activation_cost, AbilityCost::Loyalty { .. }) {
-                        super::planeswalker::record_loyalty_activation(
-                            state,
-                            pending.object_id,
-                            player,
-                        );
-                    }
                 }
 
                 let assigned_targets = flatten_targets_in_chain(&ability);

--- a/crates/engine/src/game/planeswalker.rs
+++ b/crates/engine/src/game/planeswalker.rs
@@ -138,6 +138,16 @@ pub fn handle_activate_loyalty(
     // Build a ResolvedAbility for the stack from the typed definition
     let resolved = build_pw_resolved(ability_def, pw_id, player);
 
+    // CR 606.3 + CR 602.2a + CR 601.2a: Loyalty-ability activation is recorded at
+    // *announcement time* — once legality checks pass, the activation is committed
+    // and the planeswalker is "marked as having had a loyalty ability activated
+    // this turn" regardless of which downstream branch (auto-target, random-target,
+    // or TargetSelection) finishes the activation. This is the single record site
+    // for the per-permanent counter (`loyalty_activations_this_turn`) and the
+    // per-player counter (`loyalty_abilities_activated_this_turn`); downstream
+    // resolvers MUST NOT re-record, otherwise the targeted path double-counts.
+    record_loyalty_activation(state, pw_id, player);
+
     // CR 602.2b + CR 601.2c: Targets are announced before costs are paid.
     // If this ability requires targets, prompt for selection first.
     let target_slots = build_target_slots(state, &resolved)?;
@@ -212,7 +222,7 @@ pub fn handle_activate_loyalty(
 /// control changes (it's a property of the permanent, not the activator).
 /// CR 603.4: The per-player counter is keyed by the player who activated —
 /// "you activated a loyalty ability" reads as the *activator's* history.
-pub(super) fn record_loyalty_activation(state: &mut GameState, pw_id: ObjectId, player: PlayerId) {
+fn record_loyalty_activation(state: &mut GameState, pw_id: ObjectId, player: PlayerId) {
     if let Some(obj) = state.objects.get_mut(&pw_id) {
         obj.loyalty_activations_this_turn = obj.loyalty_activations_this_turn.saturating_add(1);
     }
@@ -258,12 +268,15 @@ fn finalize_loyalty_activation(
     events: &mut Vec<GameEvent>,
 ) -> WaitingFor {
     // CR 606.4: Single authority for loyalty cost payment.
+    // CR 606.3 marking happens in `handle_activate_loyalty` at announcement time,
+    // not here — see the note there. Re-recording here would double-count the
+    // targeted path (which announces, returns TargetSelection, then funnels back
+    // through this finalizer after the player chooses targets).
     let cost = crate::types::ability::AbilityCost::Loyalty {
         amount: loyalty_cost,
     };
     super::casting::pay_ability_cost(state, player, pw_id, &cost, events)
         .expect("loyalty validation passed in handle_activate_loyalty");
-    record_loyalty_activation(state, pw_id, player);
 
     let assigned_targets = flatten_targets_in_chain(&resolved);
     emit_targeting_events(state, &assigned_targets, pw_id, player, events);

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -20757,11 +20757,22 @@ mod tests {
 
     #[test]
     fn effect_shuffle_their_library() {
+        // CR 608.2c: "their" in "shuffle their library" is an anaphoric
+        // reference to the player target bound earlier in the same instruction
+        // (Visions: "Look at the top five cards of target player's library.
+        // You may then have that player shuffle that library."). PR #796
+        // moved this arm — together with "that player's" / "that" / "his or
+        // her" — from `TargetFilter::Player` to `TargetFilter::ParentTarget`
+        // so the shuffle resolves against the spell's existing player target
+        // rather than re-selecting one. This test had the pre-#796
+        // expectation; updated to track the new semantics. The
+        // building-block-level coverage lives in
+        // `imperative::parse_shuffle_possessive_library_siblings`.
         let e = parse_effect("Shuffle their library");
         assert!(matches!(
             e,
             Effect::Shuffle {
-                target: TargetFilter::Player
+                target: TargetFilter::ParentTarget
             }
         ));
     }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3607,16 +3607,16 @@ pub struct GameState {
     /// Read by `QuantityRef::LoyaltyAbilitiesActivatedThisTurn` for intervening-if
     /// conditions like The Chain Veil's "if you activated a loyalty ability of
     /// a planeswalker this turn". Cleared at turn start.
-    #[serde(default)]
-    pub loyalty_abilities_activated_this_turn: HashMap<PlayerId, u32>,
+    #[serde(default, skip_serializing_if = "im::HashMap::is_empty")]
+    pub loyalty_abilities_activated_this_turn: im::HashMap<PlayerId, u32>,
     /// CR 606.3: Per-player extra loyalty-activation grants for this turn —
     /// each entry raises the per-permanent CR 606.3 cap for every planeswalker
     /// the player controls. Populated by the
     /// `Effect::GrantExtraLoyaltyActivations` resolver (The Chain Veil's
     /// activated ability). Consumed by
     /// `planeswalker::can_activate_loyalty_ability`. Cleared at turn start.
-    #[serde(default)]
-    pub extra_loyalty_activations_this_turn: HashMap<PlayerId, u32>,
+    #[serde(default, skip_serializing_if = "im::HashMap::is_empty")]
+    pub extra_loyalty_activations_this_turn: im::HashMap<PlayerId, u32>,
     /// CR 603.4: Per-ability per-turn resolution counter.
     /// Keyed by `(source_id, ability_index)` — identifies a specific printed
     /// ability on a specific source object. Incremented at the top of
@@ -4317,8 +4317,8 @@ impl GameState {
             activated_abilities_this_turn: HashMap::new(),
             activated_abilities_this_game: HashMap::new(),
             crew_activated_this_turn: HashSet::new(),
-            loyalty_abilities_activated_this_turn: HashMap::new(),
-            extra_loyalty_activations_this_turn: HashMap::new(),
+            loyalty_abilities_activated_this_turn: im::HashMap::new(),
+            extra_loyalty_activations_this_turn: im::HashMap::new(),
             ability_resolutions_this_turn: HashMap::new(),
             graveyard_cast_permissions_used: HashSet::new(),
             graveyard_cast_permissions_used_per_type: HashSet::new(),


### PR DESCRIPTION
Follow-up to #807 (Chain Veil). Addresses Gemini review feedback and **unbreaks `main` CI**, which currently has two failing engine tests introduced by the merged version.

## What's broken on main right now

1. `parser::oracle_effect::tests::effect_shuffle_their_library` — bisected to #796 (Visions), which intentionally changed the shuffle-library possessive arm from `TargetFilter::Player` → `TargetFilter::ParentTarget` (anaphoric reading per CR 608.2c) but missed updating this older mirror test in `oracle_effect/mod.rs`.
2. `game::planeswalker::tests::targeted_loyalty_ability_returns_target_selection` — #807's counter refactor only recorded loyalty activations inside `finalize_loyalty_activation`, which never runs on the `TargetSelection` branch.

## Changes

### `fix(planeswalker)` (commit `ef11af9`)

- **CR 606.3 + CR 602.2a**: Mark the planeswalker as having had a loyalty ability activated *at announcement time* — once legality checks pass in `handle_activate_loyalty`, before any branch (auto-target, random-target, TargetSelection) finishes. The previous code only recorded inside \`finalize_loyalty_activation\`, so the targeted path returned with the counter still at 0. Adding the early mark required removing the call from \`finalize_loyalty_activation\` and from \`casting_targets.rs\` to avoid double-counting (the old boolean was idempotent; the counter is not).
- **Single authority for ability costs**: \`casting_targets.rs\` no longer branches on \`AbilityCost::Loyalty\` to call \`record_loyalty_activation\`. CR 606.3 marking lives in \`planeswalker::handle_activate_loyalty\` exclusively. The cost-payment site obeys the single-authority principle (callers dispatch activation; they never inspect cost shape).
- **\`im::HashMap\` for hot fields** (CLAUDE.md "Persistent-container hot fields"): Migrated \`loyalty_abilities_activated_this_turn\` and \`extra_loyalty_activations_this_turn\` from \`std::HashMap\` → \`im::HashMap\`. APIs are identical, so no call-site changes in \`planeswalker.rs\`, \`turns.rs\`, \`quantity.rs\`, or \`grant_extra_loyalty_activations.rs\`.

### `test(parser)` (commit `5710860`)

Aligned the stale \`effect_shuffle_their_library\` assertion with #796's \`TargetFilter::ParentTarget\` semantics and added a CR 608.2c annotation pointing at \`imperative::parse_shuffle_possessive_library_siblings\` for the building-block-level coverage.

## Deferred

Gemini's medium-priority note about \`parse_single_loyalty_permission\` using verbatim sentence-fragment tags. Chain Veil's wording is highly idiosyncratic; decomposing into independently composable axes risks regressing the parse without unlocking new cards. Left as a TODO for a future architecture pass.

## Verification

- \`cargo fmt --all\`: clean
- \`cargo clippy --all-targets -- -D warnings\`: clean
- \`cargo test -p engine planeswalker\`: **36 unit + 3 integration tests pass**, including the previously failing \`targeted_loyalty_ability_returns_target_selection\`, \`loyalty_activation_resets_at_turn_start\`, \`chain_veil_grant_raises_per_planeswalker_cap\`, \`chain_veil_grant_applies_to_each_planeswalker_independently\`.
- \`cargo test -p engine\`: 8155/8156 pass on this branch alone; remaining failure (\`contains_self_or_object_pronoun_includes_tilde\`) is fixed by the parallel #809 follow-up PR.
- \`./scripts/gen-card-data.sh\`: clean (44624 cards), Chain Veil still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)