### PR TITLE
parser: consolidate pronoun guards into nom-based contains_object_pronoun (#809 followup)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -40,7 +40,7 @@ use super::super::oracle_target::{
     parse_target, parse_target_with_ctx, parse_type_phrase, resolve_pronoun_target,
 };
 use super::super::oracle_util::{
-    contains_possessive, contains_self_or_object_pronoun, parse_count_expr, parse_mana_symbols,
+    contains_object_pronoun, contains_possessive, parse_count_expr, parse_mana_symbols,
     parse_ordinal, split_around, starts_with_possessive, strip_after, TextPair,
 };
 
@@ -3373,12 +3373,13 @@ pub(super) fn parse_shuffle_ast(text: &str, lower: &str) -> Option<ShuffleImpera
     // their owner's / their owners' / your) are classified via nom combinators
     // so the lowered `ChangeZone` carries the correct `target` (SelfRef vs
     // ParentTarget) and `owner_library` flag. The `~` token is produced by
-    // `normalize_card_name_refs` for self-references; it is handled by
-    // `contains_self_or_object_pronoun` here (not `contains_object_pronoun`)
-    // because the anaphoric/self-reference distinction matters at other call
-    // sites (compound action splitting in `try_split_targeted_compound`).
-    if contains_self_or_object_pronoun(lower, "shuffle", "into")
-        || contains_self_or_object_pronoun(lower, "shuffles", "into")
+    // `normalize_card_name_refs` for self-references and is a member of
+    // `OBJECT_PRONOUNS`, so `contains_object_pronoun` accepts both anaphoric
+    // ("shuffle it into …") and self-referential ("shuffle ~ into …") forms.
+    // The downstream `alt()` below still distinguishes them: `~`/`it` →
+    // `SelfRef`, `them`/`that card`/`those cards` → `ParentTarget`.
+    if contains_object_pronoun(lower, "shuffle", "into")
+        || contains_object_pronoun(lower, "shuffles", "into")
     {
         // Pronoun classification. Walk word-boundaries, peel "shuffle"/
         // "shuffles" + " ", then alt() over the five recognized references.
@@ -3386,8 +3387,8 @@ pub(super) fn parse_shuffle_ast(text: &str, lower: &str) -> Option<ShuffleImpera
         // "~" is the self-reference token from `normalize_card_name_refs`);
         // "them" / "that card" / "those cards" → ParentTarget (refers to a
         // previously-bound target). The fall-through "SelfRef" arm only
-        // engages when the outer `contains_self_or_object_pronoun` guard
-        // somehow matched a pronoun the inner combinator didn't recognize —
+        // engages when the outer `contains_object_pronoun` guard somehow
+        // matched a pronoun the inner combinator didn't recognize —
         // defensive and also matches the existing "shuffle this creature
         // into …" form.
         let target = nom_primitives::scan_at_word_boundaries(lower, |input| {

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -531,22 +531,6 @@ const POSSESSIVES: &[&str] = &[
 /// into its owner's library" (Zenith cycle, Fblthp, etc.).
 pub const OBJECT_PRONOUNS: &[&str] = &["it", "them", "that card", "those cards", "~"];
 
-/// Object-style references that include both anaphoric pronouns (`OBJECT_PRONOUNS`)
-/// and the self-reference token `~` produced by `normalize_card_name_refs`.
-///
-/// Use this when a guard must accept both "shuffle it into …" (anaphoric, refers to a
-/// previously-bound target) and "shuffle ~ into …" (self-referential, refers to the
-/// source object — Green Sun's Zenith, the Beacon cycle, Nexus of Fate, etc.). The
-/// downstream classifier still distinguishes them: `~` → `TargetFilter::SelfRef`,
-/// `it`/`them`/`that card`/`those cards` → `ParentTarget` or `SelfRef` per the
-/// inner combinator.
-///
-/// Kept separate from `OBJECT_PRONOUNS` because the anaphoric / self-reference
-/// distinction matters at other call sites (compound action splitting in
-/// `try_split_targeted_compound`, etc.), where treating `~` as an anaphoric pronoun
-/// would mis-classify self-referential clauses.
-pub const SELF_AND_OBJECT_PRONOUNS: &[&str] = &["it", "them", "that card", "those cards", "~"];
-
 /// "this \<card_type\>" self-reference phrases in Oracle text.
 ///
 /// Used by: `parse_target` (object recognition), `subject.rs` (subject stripping),
@@ -645,20 +629,15 @@ pub fn starts_with_possessive(text: &str, prefix: &str, suffix: &str) -> bool {
 
 /// Check if `text` contains `"{prefix} {pronoun} {suffix}"` for any object pronoun variant.
 ///
-/// Matches anaphoric references like "shuffle it into", "put them onto", "exile that card from".
-pub fn contains_object_pronoun(text: &str, prefix: &str, suffix: &str) -> bool {
-    match_phrase_variants(text, prefix, suffix, OBJECT_PRONOUNS, |hay, needle| {
-        hay.contains(needle)
-    })
-}
-
-/// Like `contains_object_pronoun` but also matches the self-reference token `~`.
+/// Matches anaphoric references like "shuffle it into", "put them onto", "exile that card
+/// from", as well as the `~` self-reference token produced by `normalize_card_name_refs`
+/// for self-referential clauses like "shuffle ~ into its owner's library" (Green Sun's
+/// Zenith, Beacon cycle, Nexus of Fate). The full pronoun set is `OBJECT_PRONOUNS`.
 ///
-/// Use this in guards that need to accept both anaphoric references ("shuffle it
-/// into …") and self-references ("shuffle ~ into …" — Green Sun's Zenith, Beacon
-/// cycle, Nexus of Fate). The downstream classifier still distinguishes the two,
-/// so this only widens the gate, not the semantics.
-pub fn contains_self_or_object_pronoun(text: &str, prefix: &str, suffix: &str) -> bool {
+/// Uses word-boundary scanning so the pronoun must appear as a complete token — substring
+/// matches inside other words are rejected. This is the canonical anaphoric-pronoun guard
+/// for parsing dispatch.
+pub fn contains_object_pronoun(text: &str, prefix: &str, suffix: &str) -> bool {
     nom_primitives::scan_at_word_boundaries(text, |input| {
         let input = if prefix.is_empty() {
             input
@@ -667,7 +646,7 @@ pub fn contains_self_or_object_pronoun(text: &str, prefix: &str, suffix: &str) -
             let (input, _) = space1(input)?;
             input
         };
-        let (input, _) = parse_self_or_object_pronoun(input)?;
+        let (input, _) = parse_object_pronoun(input)?;
         let input = if suffix.is_empty() {
             input
         } else {
@@ -680,7 +659,7 @@ pub fn contains_self_or_object_pronoun(text: &str, prefix: &str, suffix: &str) -
     .is_some()
 }
 
-fn parse_self_or_object_pronoun(input: &str) -> OracleResult<'_, &str> {
+fn parse_object_pronoun(input: &str) -> OracleResult<'_, &str> {
     alt((
         tag("that card"),
         tag("those cards"),
@@ -2497,39 +2476,17 @@ mod tests {
             "into"
         ));
         // CR 201.5: "~" is the card-name placeholder used in self-shuffle effects
-        // (e.g. "shuffle ~ into its owner's library" — Black Sun's Zenith, Zenith cycle).
+        // (Green Sun's Zenith, Beacon cycle, Nexus of Fate). It is a member of
+        // `OBJECT_PRONOUNS` and must be accepted by this guard.
+        assert!(contains_object_pronoun("shuffle ~ into", "shuffle", "into"));
         assert!(contains_object_pronoun(
             "shuffle ~ into its owner's library",
             "shuffle",
             "into"
         ));
-    }
-
-    #[test]
-    fn contains_self_or_object_pronoun_includes_tilde() {
-        // The tilde self-reference token must be accepted in addition to all
-        // four object pronouns. This is the building-block guarantee that
-        // unlocks "shuffle ~ into …" for Green Sun's Zenith and the Beacon
-        // cycle without weakening the anaphoric-only `contains_object_pronoun`
-        // semantics used elsewhere.
-        assert!(contains_self_or_object_pronoun(
-            "shuffle ~ into",
-            "shuffle",
-            "into"
-        ));
-        assert!(contains_self_or_object_pronoun(
-            "shuffle it into",
-            "shuffle",
-            "into"
-        ));
-        assert!(contains_self_or_object_pronoun(
-            "shuffle them into",
-            "shuffle",
-            "into"
-        ));
-        // Negative: tilde must NOT make `contains_object_pronoun` accept self-references.
+        // Word-boundary scanning rejects substring-only matches inside other words.
         assert!(!contains_object_pronoun(
-            "shuffle ~ into",
+            "shuffle bit into",
             "shuffle",
             "into"
         ));


### PR DESCRIPTION
Follow-up to #809 (Green Sun's Zenith). Addresses Gemini review feedback by removing the sibling-function duplication left over from layering self-reference (\`~\`) support on top of the anaphoric pronoun guard.

## Why

After #803 added \`~\` to \`OBJECT_PRONOUNS\`, the GSZ PR's \`contains_self_or_object_pronoun\` and \`SELF_AND_OBJECT_PRONOUNS\` became exact duplicates of \`contains_object_pronoun\` / \`OBJECT_PRONOUNS\`. The \"distinction\" the GSZ doc-comments claimed no longer existed: both guards referenced the same five-pronoun list — only the implementation differed (substring \`.contains()\` vs nom word-boundary scan).

This is the textbook R3 (parameterize, don't proliferate) case where the parameterization axis turned out to be empty, so dedup beats parameter-passing.

## Changes

- Delete \`SELF_AND_OBJECT_PRONOUNS\` (unused, identical to \`OBJECT_PRONOUNS\`).
- Replace \`contains_object_pronoun\`'s substring \`.contains()\` body with the nom word-boundary scanner from the duplicate function. Word-boundary matching is stricter (rejects substring hits like \"bit\" inside other words) and aligns the dispatch guard with the parser's nom-first mandate.
- Delete \`contains_self_or_object_pronoun\` (now redundant). Rename internal helper \`parse_self_or_object_pronoun\` → \`parse_object_pronoun\`.
- Update the two call sites in \`oracle_effect/imperative.rs\` and refresh the surrounding comments to reflect that \`~\` is just another member of \`OBJECT_PRONOUNS\`, not a separate self-reference class.
- Fold the tilde tests into \`contains_object_pronoun_matches_variants\` and remove the bogus negative assertion that asserted the opposite of the documented behavior (it was failing on \`main\`).

**Net: -42 lines, one canonical pronoun guard.**

## Verification

- \`cargo fmt --all\`: clean
- \`cargo clippy --all-targets -- -D warnings\`: clean
- \`cargo test -p engine --lib parser::oracle\`: 4002 passed
- All pronoun-related tests pass. GSZ's \`SearchLibrary\` parse output unchanged in \`card-data.json\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)