### PR TITLE
fix: propagate player identity in shuffle events for trigger filtering

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -16,11 +16,17 @@ use crate::types::zones::Zone;
 
 /// CR 401.3: Shuffle a player's library using the game's seeded RNG.
 /// Reusable helper for auto-shuffle after zone moves to Library.
-pub fn shuffle_library(state: &mut GameState, player: PlayerId) {
+pub fn shuffle_library(state: &mut GameState, player: PlayerId, events: &mut Vec<GameEvent>) {
     let GameState { players, rng, .. } = state;
     if let Some(p) = players.iter_mut().find(|p| p.id == player) {
         crate::util::im_ext::shuffle_vector(&mut p.library, rng);
     }
+    // CR 701.24a: Emit player-action event so trigger matchers can filter
+    // by the identity of the shuffling player.
+    events.push(GameEvent::PlayerPerformedAction {
+        player_id: player,
+        action: crate::types::events::PlayerActionKind::ShuffledLibrary,
+    });
 }
 
 /// CR 701.17c + CR 603.7: For a `TrackedSet` / `TrackedSetFiltered` target,
@@ -152,7 +158,7 @@ pub(crate) fn deliver_replaced_zone_change(
         if to == Zone::Library {
             let owner = state.objects.get(&object_id).map(|o| o.owner);
             if let Some(owner) = owner {
-                shuffle_library(state, owner);
+                shuffle_library(state, owner, events);
             }
         }
         // Track cards exiled by the source. Some linked exiles return when the

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -9139,13 +9139,33 @@ mod tests {
         let mut events = Vec::new();
         resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
 
-        // Shuffle emits no ZoneChanged events; the accumulator must be EMPTY
-        // (cleared at depth=0 entry, not extended by stale state).
+        // Stale state (SearchedLibrary) must be cleared at depth=0 entry.
+        // Shuffle now emits PlayerPerformedAction { ShuffledLibrary } which is
+        // correctly accumulated "this way" — only the pre-polluted stale
+        // actions must be gone.
+        let stale_action = crate::types::events::PlayerActionKind::SearchedLibrary;
         assert!(
-            state.player_actions_this_way.is_empty(),
-            "depth=0 chain entry must clear player_actions_this_way; \
+            !state
+                .player_actions_this_way
+                .contains(&(PlayerId(0), stale_action)),
+            "depth=0 chain entry must clear stale player_actions_this_way; \
              leaking across top-level resolutions would cause spurious counts \
              in 'opponent who [verbed] this way' references on subsequent spells"
+        );
+        assert!(
+            !state
+                .player_actions_this_way
+                .contains(&(PlayerId(1), stale_action)),
+            "stale P1 SearchedLibrary must also be cleared"
+        );
+        // The shuffle action itself IS expected in the accumulator — it
+        // happened "this way" during the current resolution.
+        let shuffle_action = crate::types::events::PlayerActionKind::ShuffledLibrary;
+        assert!(
+            state
+                .player_actions_this_way
+                .contains(&(PlayerId(0), shuffle_action)),
+            "ShuffledLibrary from current resolution must be accumulated"
         );
     }
 

--- a/crates/engine/src/game/effects/shuffle.rs
+++ b/crates/engine/src/game/effects/shuffle.rs
@@ -1,5 +1,5 @@
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter};
-use crate::types::events::GameEvent;
+use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::GameState;
 
 /// CR 701.24a: Shuffle — randomize the cards in a library.
@@ -50,6 +50,14 @@ pub fn resolve(
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::Shuffle,
         source_id: ability.source_id,
+    });
+
+    // CR 701.24a: Emit player-action event so trigger matchers (e.g.
+    // Cosi's Trickster: "Whenever an opponent shuffles their library")
+    // can filter by the identity of the shuffling player.
+    events.push(GameEvent::PlayerPerformedAction {
+        player_id: target_player,
+        action: PlayerActionKind::ShuffledLibrary,
     });
 
     Ok(())

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -126,7 +126,7 @@ pub fn apply_debug_action(
 
         DebugAction::ShuffleLibrary { player_id } => {
             validate_player(state, player_id)?;
-            shuffle_library(state, player_id);
+            shuffle_library(state, player_id, events);
         }
 
         DebugAction::Proliferate { player_id } => {

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -681,7 +681,7 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 .filter(|obj| obj.zone == Zone::Library)
                 .map(|obj| obj.owner)
             {
-                effects::change_zone::shuffle_library(state, owner);
+                effects::change_zone::shuffle_library(state, owner, events);
             }
         }
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1783,20 +1783,24 @@ pub(super) fn match_cycled_or_discarded(
     }
 }
 
-/// Shuffled: fires when a library is shuffled.
+/// CR 701.24a: Shuffled — fires when a player shuffles their library.
+/// Uses `PlayerPerformedAction { ShuffledLibrary }` to identify the acting
+/// player, then gates on `trigger.valid_target` (e.g. Cosi's Trickster:
+/// "Whenever an opponent shuffles their library").
 pub(super) fn match_shuffled(
     event: &GameEvent,
-    _trigger: &TriggerDefinition,
-    _source_id: ObjectId,
-    _state: &GameState,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
 ) -> bool {
-    matches!(
-        event,
-        GameEvent::EffectResolved {
-            kind: EffectKind::Shuffle,
-            ..
-        }
-    )
+    let GameEvent::PlayerPerformedAction {
+        player_id,
+        action: PlayerActionKind::ShuffledLibrary,
+    } = event
+    else {
+        return false;
+    };
+    valid_player_matches(trigger, state, *player_id, source_id)
 }
 
 /// Revealed: fires when a card is revealed.
@@ -4893,14 +4897,57 @@ mod tests {
     }
 
     #[test]
-    fn shuffled_matches_shuffled_event() {
+    fn shuffled_matches_player_performed_action_event() {
         let state = setup();
+        let event = GameEvent::PlayerPerformedAction {
+            player_id: PlayerId(0),
+            action: PlayerActionKind::ShuffledLibrary,
+        };
+        let trigger = make_trigger(TriggerMode::Shuffled);
+        assert!(match_shuffled(&event, &trigger, ObjectId(1), &state));
+    }
+
+    #[test]
+    fn shuffled_rejects_opponent_when_valid_target_is_controller() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Cosis Trickster".to_string(),
+            Zone::Battlefield,
+        );
+        // "Whenever an opponent shuffles" — valid_target filters for opponent
+        let mut trigger = make_trigger(TriggerMode::Shuffled);
+        trigger.valid_target = Some(TargetFilter::Typed(
+            TypedFilter::default().controller(crate::types::ability::ControllerRef::Opponent),
+        ));
+
+        // Opponent shuffles — should fire
+        let opp_event = GameEvent::PlayerPerformedAction {
+            player_id: PlayerId(1),
+            action: PlayerActionKind::ShuffledLibrary,
+        };
+        assert!(match_shuffled(&opp_event, &trigger, source, &state));
+
+        // Controller shuffles — should NOT fire
+        let self_event = GameEvent::PlayerPerformedAction {
+            player_id: PlayerId(0),
+            action: PlayerActionKind::ShuffledLibrary,
+        };
+        assert!(!match_shuffled(&self_event, &trigger, source, &state));
+    }
+
+    #[test]
+    fn shuffled_rejects_effect_resolved_event() {
+        let state = setup();
+        // The old EffectResolved event should no longer trigger match_shuffled
         let event = GameEvent::EffectResolved {
             kind: EffectKind::Shuffle,
             source_id: ObjectId(1),
         };
         let trigger = make_trigger(TriggerMode::Shuffled);
-        assert!(match_shuffled(&event, &trigger, ObjectId(1), &state));
+        assert!(!match_shuffled(&event, &trigger, ObjectId(1), &state));
     }
 
     #[test]

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -83,6 +83,8 @@ pub enum PlayerActionKind {
     Scry,
     Surveil,
     CollectEvidence,
+    /// CR 701.24a: A player shuffled their library.
+    ShuffledLibrary,
 }
 
 /// CR 701.30d: Result of a clash — whether the controller won, lost, or tied.


### PR DESCRIPTION
## Summary
Propagates player identity through shuffle events so that `match_shuffled` can correctly filter by `valid_target`. This enables cards like **Cosi's Trickster** ("Whenever an opponent shuffles their library") to distinguish which player performed the shuffle.

## Files changed
- `crates/engine/src/types/events.rs`
- `crates/engine/src/game/effects/shuffle.rs`
- `crates/engine/src/game/effects/change_zone.rs`
- `crates/engine/src/game/stack.rs`
- `crates/engine/src/game/engine_debug.rs`
- `crates/engine/src/game/trigger_matchers.rs`

## CR references
- CR 701.24a (Shuffle — randomize cards in a library)

## Track
Non-developer

## Verification
Local verification skipped — see CI status checks.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.