### PR TITLE
Fix Keyword::Landwalk Display per CR 702.14a (follow-up to #814)

### DIFF
--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1368,7 +1368,9 @@ impl fmt::Display for Keyword {
                 "Swamp" => write!(f, "Swampwalk"),
                 "Mountain" => write!(f, "Mountainwalk"),
                 "Forest" => write!(f, "Forestwalk"),
-                "Legendary" | "Nonbasic" | "Snow" => write!(f, "{subtype} Landwalk"),
+                "Legendary" | "Nonbasic" | "Snow" | "Artifact" => {
+                    write!(f, "{subtype} Landwalk")
+                }
                 other => write!(f, "{other}walk"),
             },
             Keyword::Flying => write!(f, "Flying"),

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1355,16 +1355,21 @@ impl fmt::Display for Keyword {
         match self {
             Keyword::FirstStrike => write!(f, "First Strike"),
             Keyword::DoubleStrike => write!(f, "Double Strike"),
+            // CR 702.14a: Landwalk surfaces in Oracle text as "[type]walk" when
+            // [type] is a land subtype (Plainswalk, Desertwalk, Gatewalk, ...).
+            // When [type] is a supertype or non-land card type, the canonical
+            // phrasing is "[type] landwalk" (Legendary landwalk, Nonbasic landwalk,
+            // Snow landwalk, artifact landwalk). Capitalize "Landwalk" in the
+            // composed form so the rendered label matches the title-case style
+            // used by the rest of this Display impl (e.g. "First Strike").
             Keyword::Landwalk(subtype) => match subtype.as_str() {
                 "Plains" => write!(f, "Plainswalk"),
                 "Island" => write!(f, "Islandwalk"),
                 "Swamp" => write!(f, "Swampwalk"),
                 "Mountain" => write!(f, "Mountainwalk"),
                 "Forest" => write!(f, "Forestwalk"),
-                "Legendary" => write!(f, "Legendary landwalk"),
-                "Nonbasic" => write!(f, "Nonbasic landwalk"),
-                "Snow" => write!(f, "Snow landwalk"),
-                other => write!(f, "{other} landwalk"),
+                "Legendary" | "Nonbasic" | "Snow" => write!(f, "{subtype} Landwalk"),
+                other => write!(f, "{other}walk"),
             },
             Keyword::Flying => write!(f, "Flying"),
             Keyword::Trample => write!(f, "Trample"),

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -2303,6 +2303,22 @@ mod tests {
     }
 
     #[test]
+    fn display_landwalk_uses_oracle_spelling_for_subtypes_and_card_types() {
+        assert_eq!(
+            Keyword::Landwalk("Island".to_string()).to_string(),
+            "Islandwalk"
+        );
+        assert_eq!(
+            Keyword::Landwalk("Snow".to_string()).to_string(),
+            "Snow Landwalk"
+        );
+        assert_eq!(
+            Keyword::Landwalk("Artifact".to_string()).to_string(),
+            "Artifact Landwalk"
+        );
+    }
+
+    #[test]
     fn parse_parameterized_keywords_as_mana_cost() {
         // Cost-bearing keywords now parse to ManaCost
         let kicker = Keyword::from_str("Kicker:1G").unwrap();


### PR DESCRIPTION
## Summary
Follow-up to #814. The round-2 `/gemini review` on #814 flagged two MEDIUM items that landed in `main` unaddressed at merge time. This PR applies the one that's a clean, isolated fix; the other is evaluated and deferred with rationale below.

## Files changed
- `crates/engine/src/types/keywords.rs`

## CR references
- `CR 702.14a` — Landwalk surfaces as "[type]walk" for land subtypes; "[type] landwalk" for supertypes / non-land card types.

## Track
Non-developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Verification
Local verification skipped — see CI status checks.

## Review items from #814 evaluated

1. **Applied — `Keyword::Landwalk` Display violates CR 702.14a** (`crates/engine/src/types/keywords.rs:1368` in #814).
   The non-basic fallback rendered `"{subtype} landwalk"`, but CR 702.14a specifies `"[type]walk"` for land subtypes (Desertwalk, Gatewalk, …). The supertype arms (`Legendary` / `Nonbasic` / `Snow`) keep the two-word form per CR 702.14c, but capitalized as `"Landwalk"` to match the title-case style of the rest of this `Display` impl (`First Strike`, `Double Strike`, `Swampwalk`).

2. **Deferred — `ChoiceType` lost `Hash`** (`crates/engine/src/types/ability.rs:132` in #814).
   The reviewer's suggested fix is to re-derive `Hash` on `ChoiceType`, which transitively requires `Keyword: Hash`. `Keyword` has ~80 parameterized variants whose payloads include `HexproofFilter`, `TargetFilter`, `ProtectionTarget`, `CyclingCost`, `FlashbackCost`, `WardCost`, `PartnerType`, `CompanionCondition`, `EvokeCost`, `BuybackCost`, `TypedFilter`, `AbilityCost`, `QuantityExpr`, `GiftKind`, `BloodthirstValue`, `CounterType`, `ActivationCadence`, and others — propagating `Hash` cascades across roughly twenty sibling types, several of them across crates.

   `rg "ChoiceType" --type rust | rg -i "HashMap|HashSet|\\bhash\\("` returns no concrete `Hash`-requiring consumer of `ChoiceType` in the workspace today, so the regression the reviewer flagged ("state caching, AI scoring, networking adapters that rely on hashing") is speculative rather than load-bearing. Restoring the derive is straightforward to revisit the moment such a consumer appears, and at that point the broader `Keyword: Hash` change can be staged deliberately rather than smuggled in as a follow-up to a card PR. Filing as a known gap rather than expanding scope here.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

Refs #814.