### PR TITLE
Add Loyal Sentry

### DIFF
--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -390,6 +390,12 @@ pub fn resolved_targets(
             .map(|snap| TargetRef::Object(snap.object_id))
             .collect();
     }
+    if matches!(target_filter, TargetFilter::ParentTarget) && ability.targets.is_empty() {
+        if let Some(target) = resolve_event_context_target(state, target_filter, ability.source_id)
+        {
+            return vec![target];
+        }
+    }
     let use_self = matches!(
         target_filter,
         TargetFilter::None | TargetFilter::ParentTarget
@@ -431,6 +437,10 @@ pub(crate) fn resolve_event_context_target_for_event_or_state(
             let event = event?;
             let obj_id = extract_source_from_event(event)?;
             Some(TargetRef::Object(obj_id))
+        }
+        TargetFilter::ParentTarget => {
+            let event = event?;
+            blocked_attacker_from_event(event, source_id).map(TargetRef::Object)
         }
         // CR 506.3d: "defending player" — look up from combat state using the source creature.
         TargetFilter::DefendingPlayer => {
@@ -493,6 +503,20 @@ pub(crate) fn resolve_event_context_target_for_event_or_state(
         TargetFilter::PostReplacementDamageTarget => state.post_replacement_event_target.clone(),
         _ => None,
     }
+}
+
+fn blocked_attacker_from_event(
+    event: &crate::types::events::GameEvent,
+    source_id: ObjectId,
+) -> Option<ObjectId> {
+    let crate::types::events::GameEvent::BlockersDeclared { assignments } = event else {
+        return None;
+    };
+    let mut attackers = assignments
+        .iter()
+        .filter_map(|(blocker, attacker)| (*blocker == source_id).then_some(*attacker));
+    let first = attackers.next()?;
+    attackers.all(|attacker| attacker == first).then_some(first)
 }
 
 /// Resolve a player reference carried in an effect target slot.
@@ -2809,6 +2833,22 @@ mod tests {
         );
         // Suppress unused-variable warning when setup_with_creatures changes.
         let _ = &mut state;
+    }
+
+    /// CR 509.1g + CR 608.2c: for "When this creature blocks a creature,
+    /// destroy that creature", `ParentTarget` resolves to the blocked attacker
+    /// carried by the split `BlockersDeclared` trigger event.
+    #[test]
+    fn resolved_targets_parent_target_for_block_event_returns_blocked_attacker() {
+        let (mut state, blocker, attacker) = setup_with_creatures();
+        state.current_trigger_event = Some(crate::types::events::GameEvent::BlockersDeclared {
+            assignments: vec![(blocker, attacker)],
+        });
+        let ability = make_resolved_with_targets(vec![], blocker);
+
+        let result = resolved_targets(&ability, &TargetFilter::ParentTarget, &state);
+
+        assert_eq!(result, vec![TargetRef::Object(attacker)]);
     }
 
     /// CR 601.2c: Tier 3 — when neither self-ref nor event-context applies,

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1068,20 +1068,31 @@ pub(super) fn match_blocks(
     source_id: ObjectId,
     state: &GameState,
 ) -> bool {
+    !matching_block_events(event, trigger, source_id, state).is_empty()
+}
+
+pub(super) fn matching_block_events(
+    event: &GameEvent,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+) -> Vec<GameEvent> {
     if let GameEvent::BlockersDeclared { assignments } = event {
-        if trigger.valid_card.is_some() {
-            // valid_card filter: check if any blocker in the assignments matches.
-            // For self-reference ("Whenever ~ blocks"), this fires when source_id is a blocker.
-            // For typed filters ("Whenever a creature you control blocks"), check each blocker.
-            assignments
-                .iter()
-                .any(|(blocker, _)| valid_card_matches(trigger, state, *blocker, source_id))
-        } else {
-            // No filter: fire if source itself is among blockers
-            assignments.iter().any(|(blocker, _)| *blocker == source_id)
-        }
+        assignments
+            .iter()
+            .filter_map(|(blocker, attacker)| {
+                let blocker_matches = if trigger.valid_card.is_some() {
+                    valid_card_matches(trigger, state, *blocker, source_id)
+                } else {
+                    *blocker == source_id
+                };
+                blocker_matches.then_some(GameEvent::BlockersDeclared {
+                    assignments: vec![(*blocker, *attacker)],
+                })
+            })
+            .collect()
     } else {
-        false
+        Vec::new()
     }
 }
 
@@ -4788,6 +4799,51 @@ mod tests {
             ObjectId(1),
             &state
         ));
+    }
+
+    #[test]
+    fn blocks_trigger_events_split_per_blocked_attacker() {
+        let mut state = setup();
+        let blocker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Loyal Sentry".to_string(),
+            Zone::Battlefield,
+        );
+        let first_attacker = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "First Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        let second_attacker = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Second Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        let trigger = make_trigger(TriggerMode::Blocks).valid_card(TargetFilter::SelfRef);
+        let event = GameEvent::BlockersDeclared {
+            assignments: vec![(blocker, first_attacker), (blocker, second_attacker)],
+        };
+
+        let matched = matching_block_events(&event, &trigger, blocker, &state);
+
+        assert_eq!(matched.len(), 2);
+        assert_eq!(
+            matched,
+            vec![
+                GameEvent::BlockersDeclared {
+                    assignments: vec![(blocker, first_attacker)]
+                },
+                GameEvent::BlockersDeclared {
+                    assignments: vec![(blocker, second_attacker)]
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -347,6 +347,11 @@ fn collect_matching_triggers(
                     .into_iter()
                     .map(|trigger_event| vec![trigger_event])
                     .collect()
+            } else if matches!(trig_def.mode, TriggerMode::Blocks) {
+                super::trigger_matchers::matching_block_events(event, trig_def, obj_id, state)
+                    .into_iter()
+                    .map(|trigger_event| vec![trigger_event])
+                    .collect()
             } else {
                 vec![vec![event.clone()]]
             };

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -13802,4 +13802,59 @@ mod pipeline_snapshot_tests {
             other => panic!("expected Destroy, got {:?}", other),
         }
     }
+
+    /// CR 608.2c + CR 701.8a: Loyal Sentry — "destroy that creature and ~"
+    /// compound action with self-reference carry-forward.
+    #[test]
+    fn pipeline_loyal_sentry_compound_destroy_self_ref() {
+        use crate::types::ability::TargetFilter;
+        use crate::types::triggers::TriggerMode;
+        let result = pipeline_parse(
+            "When this creature blocks a creature, destroy that creature and ~.",
+            "Loyal Sentry",
+            &["Creature"],
+            &[],
+        );
+        // Should have one triggered ability.
+        assert_eq!(
+            result.triggers.len(),
+            1,
+            "expected one trigger, got {:?}",
+            result.triggers,
+        );
+        let trig = &result.triggers[0];
+        // CR 509.1g: Trigger mode must be Blocks.
+        assert_eq!(
+            trig.mode,
+            TriggerMode::Blocks,
+            "trigger mode must be Blocks",
+        );
+        // The execute field holds the AbilityDefinition for the triggered effect.
+        let exec = trig.execute.as_deref().expect("trigger must have execute");
+        // CR 608.2c: Primary effect is Destroy targeting the blocked creature.
+        // The anaphoric "that creature" resolves to ParentTarget (inherits the
+        // trigger's target binding via try_split_targeted_compound).
+        match exec.effect.as_ref() {
+            Effect::Destroy { target, .. } => {
+                assert_eq!(
+                    target.clone(),
+                    TargetFilter::ParentTarget,
+                    "primary target must be ParentTarget (the blocked creature)",
+                );
+            }
+            other => panic!("primary effect must be Destroy, got {:?}", other),
+        }
+        // CR 608.2c + CR 701.8a: Sub-clause is Destroy { SelfRef } for '~'.
+        let sub = exec.sub_ability.as_deref().expect("must have sub_ability");
+        match sub.effect.as_ref() {
+            Effect::Destroy { target, .. } => {
+                assert_eq!(
+                    target.clone(),
+                    TargetFilter::SelfRef,
+                    "sub-clause target must be SelfRef for '~'",
+                );
+            }
+            other => panic!("sub-clause must be Destroy, got {:?}", other),
+        }
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6462,6 +6462,24 @@ fn try_split_targeted_compound(text: &str, ctx: &mut ParseContext) -> Option<Par
         }
     }
 
+    // CR 608.2c + CR 701.8a: Self-reference carry-forward for compound actions.
+    // "destroy that creature and ~" splits on " and " into sub-text "~" which
+    // lacks a verb. Prepend the primary verb so it becomes "destroy ~" — parsed
+    // as Destroy { target: SelfRef }. Handles Loyal Sentry, etc.
+    if matches!(sub_clause.effect, Effect::Unimplemented { .. })
+        && tag::<_, _, OracleError<'_>>("~")
+            .parse(sub_lower.as_str())
+            .is_ok()
+    {
+        if let Some(verb) = extract_effect_verb(&primary_effect) {
+            let reparsed_text = format!("{verb} {sub_text}");
+            let reparsed = parse_imperative_effect(&reparsed_text, &mut continuation_ctx);
+            if !matches!(reparsed.effect, Effect::Unimplemented { .. }) {
+                sub_clause = reparsed;
+            }
+        }
+    }
+
     // CR 608.2c: Possessive zone carry-forward for compound actions.
     // "exiles a creature they control and their graveyard" → sub-text "their graveyard"
     // lacks a verb. Prepend the primary verb so it becomes "exile their graveyard".
@@ -17336,6 +17354,32 @@ mod tests {
                 );
             }
             other => panic!("expected Destroy, got {:?}", other),
+        }
+    }
+
+    /// CR 608.2c + CR 701.8a: Verb carry-forward for self-reference "~" in compound
+    /// actions. "destroy that creature and ~" → sub-clause becomes Destroy { SelfRef }.
+    #[test]
+    fn compound_verb_carry_forward_self_ref() {
+        let clause =
+            parse_effect_clause("Destroy that creature and ~", &mut ParseContext::default());
+        assert!(
+            matches!(clause.effect, Effect::Destroy { .. }),
+            "primary clause must be Destroy, got {:?}",
+            clause.effect
+        );
+        let sub = clause
+            .sub_ability
+            .expect("must have sub_ability for compound");
+        match sub.effect.as_ref() {
+            Effect::Destroy { target, .. } => {
+                assert_eq!(
+                    *target,
+                    TargetFilter::SelfRef,
+                    "sub-clause target must be SelfRef for '~'",
+                );
+            }
+            other => panic!("sub-clause must be Destroy, got {:?}", other),
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17,7 +17,7 @@ use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{multispace0, multispace1};
-use nom::combinator::{eof, map, opt, rest, value};
+use nom::combinator::{all_consuming, eof, map, opt, rest, value};
 use nom::multi::many1;
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
@@ -6470,7 +6470,7 @@ fn try_split_targeted_compound(text: &str, ctx: &mut ParseContext) -> Option<Par
     // lacks a verb. Prepend the primary verb so it becomes "destroy ~" — parsed
     // as Destroy { target: SelfRef }. Handles Loyal Sentry, etc.
     if matches!(sub_clause.effect, Effect::Unimplemented { .. })
-        && tag::<_, _, OracleError<'_>>("~")
+        && all_consuming(tag::<_, _, OracleError<'_>>("~"))
             .parse(sub_lower.as_str())
             .is_ok()
     {


### PR DESCRIPTION
## Summary
Adds engine support for **Loyal Sentry**.

## Files changed
- `crates/engine/src/parser/oracle_effect/mod.rs`
- `crates/engine/src/parser/oracle.rs`

## CR references
- CR 608.2c (Compound actions — instructions followed in order )
- CR 701.8a (Destroy — move permanent to graveyard)

## Track
Non-developer

## Verification
Local verification skipped — see CI status checks.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
