### PR TITLE
Add Scheming Aspirant

### DIFF
--- a/crates/engine/src/game/effects/proliferate.rs
+++ b/crates/engine/src/game/effects/proliferate.rs
@@ -64,6 +64,12 @@ pub fn resolve(
             kind: EffectKind::from(&ability.effect),
             source_id: ability.source_id,
         });
+        // CR 701.34a: Emit player-action event so proliferate triggers fire
+        // even when there are no eligible targets.
+        events.push(GameEvent::PlayerPerformedAction {
+            player_id: ability.controller,
+            action: crate::types::events::PlayerActionKind::Proliferate,
+        });
         return Ok(());
     }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::types::ability::{EffectKind, KeywordAction, TargetRef};
 use crate::types::actions::GameAction;
-use crate::types::events::{BendingType, GameEvent, ManaTapState};
+use crate::types::events::{BendingType, GameEvent, ManaTapState, PlayerActionKind};
 use crate::types::game_state::{
     ActionResult, AutoPassMode, AutoPassRequest, ConvokeMode, GameState, StackEntry,
     StackEntryKind, WaitingFor,
@@ -3545,6 +3545,10 @@ fn apply_action(
             events.push(GameEvent::EffectResolved {
                 kind: crate::types::ability::EffectKind::Proliferate,
                 source_id: ObjectId(0), // Source not tracked through choice state
+            });
+            events.push(GameEvent::PlayerPerformedAction {
+                player_id: p,
+                action: PlayerActionKind::Proliferate,
             });
             state.waiting_for = WaitingFor::Priority { player: p };
             state.priority_player = p;

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3546,6 +3546,11 @@ fn apply_action(
                 kind: crate::types::ability::EffectKind::Proliferate,
                 source_id: ObjectId(0), // Source not tracked through choice state
             });
+            // CR 701.34a: Emit player-action event so proliferate triggers fire.
+            events.push(GameEvent::PlayerPerformedAction {
+                player_id: p,
+                action: crate::types::events::PlayerActionKind::Proliferate,
+            });
             state.waiting_for = WaitingFor::Priority { player: p };
             state.priority_player = p;
             effects::drain_pending_continuation(state, &mut events);

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -79,6 +79,7 @@ pub fn trigger_matcher(mode: TriggerMode) -> Option<TriggerMatcher> {
         TriggerMode::Cycled => match_cycled,
         TriggerMode::CycledOrDiscarded => match_cycled_or_discarded,
         TriggerMode::Shuffled => match_shuffled,
+        TriggerMode::Proliferate => match_proliferate,
         TriggerMode::Revealed => match_revealed,
         TriggerMode::TapsForMana => match_taps_for_mana,
         TriggerMode::ChangesController => match_changes_controller,
@@ -150,7 +151,6 @@ pub fn trigger_matcher(mode: TriggerMode) -> Option<TriggerMatcher> {
         | TriggerMode::ConjureAll
         | TriggerMode::Vote
         | TriggerMode::BecomeRenowned
-        | TriggerMode::Proliferate
         | TriggerMode::Abandoned
         | TriggerMode::ClaimPrize
         | TriggerMode::CrankContraption
@@ -377,7 +377,6 @@ pub fn build_trigger_registry() -> HashMap<TriggerMode, TriggerMatcher> {
         TriggerMode::ConjureAll,
         TriggerMode::Vote,
         TriggerMode::BecomeRenowned,
-        TriggerMode::Proliferate,
         TriggerMode::Abandoned,
         TriggerMode::ClaimPrize,
         TriggerMode::CrankContraption,
@@ -1800,6 +1799,23 @@ pub(super) fn match_shuffled(
     let GameEvent::PlayerPerformedAction {
         player_id,
         action: PlayerActionKind::ShuffledLibrary,
+    } = event
+    else {
+        return false;
+    };
+    valid_player_matches(trigger, state, *player_id, source_id)
+}
+
+/// CR 701.34a: Proliferate — fires when a player proliferates.
+pub(super) fn match_proliferate(
+    event: &GameEvent,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+) -> bool {
+    let GameEvent::PlayerPerformedAction {
+        player_id,
+        action: PlayerActionKind::Proliferate,
     } = event
     else {
         return false;
@@ -5095,6 +5111,46 @@ mod tests {
         };
         let trigger = make_trigger(TriggerMode::Shuffled);
         assert!(!match_shuffled(&event, &trigger, ObjectId(1), &state));
+    }
+
+    #[test]
+    fn proliferate_matches_player_performed_action_event() {
+        let state = setup();
+        let event = GameEvent::PlayerPerformedAction {
+            player_id: PlayerId(0),
+            action: PlayerActionKind::Proliferate,
+        };
+        let trigger = make_trigger(TriggerMode::Proliferate);
+        assert!(match_proliferate(&event, &trigger, ObjectId(1), &state));
+    }
+
+    #[test]
+    fn proliferate_rejects_opponent_when_valid_target_is_controller() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Scheming Aspirant".to_string(),
+            Zone::Battlefield,
+        );
+        // "Whenever you proliferate" — valid_target filters for controller
+        let mut trigger = make_trigger(TriggerMode::Proliferate);
+        trigger.valid_target = Some(TargetFilter::Controller);
+
+        // Controller proliferates — should fire
+        let self_event = GameEvent::PlayerPerformedAction {
+            player_id: PlayerId(0),
+            action: PlayerActionKind::Proliferate,
+        };
+        assert!(match_proliferate(&self_event, &trigger, source, &state));
+
+        // Opponent proliferates — should NOT fire
+        let opp_event = GameEvent::PlayerPerformedAction {
+            player_id: PlayerId(1),
+            action: PlayerActionKind::Proliferate,
+        };
+        assert!(!match_proliferate(&opp_event, &trigger, source, &state));
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -4008,6 +4008,27 @@ mod tests {
     }
 
     #[test]
+    fn player_performed_action_matches_proliferate() {
+        let mut state = setup();
+        let source_id = create_object(
+            &mut state,
+            CardId(15),
+            PlayerId(0),
+            "Scheming Aspirant".to_string(),
+            Zone::Battlefield,
+        );
+        let trigger = parse_trigger_line(
+            "Whenever you proliferate, each opponent loses 2 life and you gain 2 life.",
+            "Scheming Aspirant",
+        );
+        let event = GameEvent::PlayerPerformedAction {
+            player_id: PlayerId(0),
+            action: PlayerActionKind::Proliferate,
+        };
+        assert!(match_player_action(&event, &trigger, source_id, &state));
+    }
+
+    #[test]
     fn changes_zone_dies_matches() {
         let state = setup();
         let mut trigger = make_trigger(TriggerMode::ChangesZone);

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -13805,8 +13805,6 @@ mod pipeline_snapshot_tests {
 
     #[test]
     fn pipeline_scheming_aspirant_proliferate_trigger() {
-        use crate::types::triggers::TriggerMode;
-
         let result = pipeline_parse(
             "Whenever you proliferate, each opponent loses 2 life and you gain 2 life.",
             "Scheming Aspirant",
@@ -13815,8 +13813,12 @@ mod pipeline_snapshot_tests {
         );
         assert_eq!(result.triggers.len(), 1);
         let trigger = &result.triggers[0];
-        assert_eq!(trigger.mode, TriggerMode::Proliferate);
+        assert_eq!(trigger.mode, TriggerMode::PlayerPerformedAction);
         assert_eq!(trigger.valid_target, Some(TargetFilter::Controller));
+        assert_eq!(
+            trigger.player_actions,
+            Some(vec![crate::types::events::PlayerActionKind::Proliferate])
+        );
         // Verify the execute body is LoseLife + GainLife
         let exec = trigger.execute.as_ref().expect("execute body");
         assert!(

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -13802,4 +13802,33 @@ mod pipeline_snapshot_tests {
             other => panic!("expected Destroy, got {:?}", other),
         }
     }
+
+    #[test]
+    fn pipeline_scheming_aspirant_proliferate_trigger() {
+        use crate::types::triggers::TriggerMode;
+
+        let result = pipeline_parse(
+            "Whenever you proliferate, each opponent loses 2 life and you gain 2 life.",
+            "Scheming Aspirant",
+            &["Creature"],
+            &["Human", "Noble"],
+        );
+        assert_eq!(result.triggers.len(), 1);
+        let trigger = &result.triggers[0];
+        assert_eq!(trigger.mode, TriggerMode::Proliferate);
+        assert_eq!(trigger.valid_target, Some(TargetFilter::Controller));
+        // Verify the execute body is LoseLife + GainLife
+        let exec = trigger.execute.as_ref().expect("execute body");
+        assert!(
+            matches!(exec.effect.as_ref(), Effect::LoseLife { .. }),
+            "expected LoseLife, got {:?}",
+            exec.effect
+        );
+        let sub = exec.sub_ability.as_ref().expect("sub_ability");
+        assert!(
+            matches!(sub.effect.as_ref(), Effect::GainLife { .. }),
+            "expected GainLife, got {:?}",
+            sub.effect
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -6880,11 +6880,6 @@ fn try_parse_player_action_trigger(lower: &str) -> Option<(TriggerMode, TriggerD
                 def.mode = TriggerMode::Shuffled;
                 return Some((TriggerMode::Shuffled, def));
             }
-            // CR 701.34a: Proliferate — player-action trigger.
-            [PlayerActionKind::Proliferate] => {
-                def.mode = TriggerMode::Proliferate;
-                return Some((TriggerMode::Proliferate, def));
-            }
             _ => {
                 def.mode = TriggerMode::PlayerPerformedAction;
                 def.player_actions = Some(actions.clone());
@@ -6914,6 +6909,9 @@ fn parse_player_action_list(text: &str) -> Option<Vec<PlayerActionKind>> {
 }
 
 fn parse_player_action_phrase(text: &str) -> Option<PlayerActionKind> {
+    if let Ok(("", action)) = parse_proliferate_player_action(text) {
+        return Some(action);
+    }
     match text {
         "search your library" | "searches their library" => Some(PlayerActionKind::SearchedLibrary),
         "scry" | "scries" => Some(PlayerActionKind::Scry),
@@ -6927,10 +6925,17 @@ fn parse_player_action_phrase(text: &str) -> Option<PlayerActionKind> {
         | "shuffle his or her library"
         | "shuffles a library"
         | "shuffle a library" => Some(PlayerActionKind::ShuffledLibrary),
-        // CR 701.34a: Proliferate — choose permanents/players with counters.
-        "proliferate" | "proliferates" => Some(PlayerActionKind::Proliferate),
         _ => None,
     }
+}
+
+fn parse_proliferate_player_action(input: &str) -> OracleResult<'_, PlayerActionKind> {
+    // CR 701.34a: Proliferate — choose permanents/players with counters.
+    all_consuming(alt((
+        value(PlayerActionKind::Proliferate, tag("proliferate")),
+        value(PlayerActionKind::Proliferate, tag("proliferates")),
+    )))
+    .parse(input)
 }
 
 /// Parse "whenever you cast your Nth spell each turn" (or "in a turn") and
@@ -12654,8 +12659,12 @@ mod tests {
             "Whenever you proliferate, each opponent loses 2 life and you gain 2 life.",
             "Scheming Aspirant",
         );
-        assert_eq!(def.mode, TriggerMode::Proliferate);
+        assert_eq!(def.mode, TriggerMode::PlayerPerformedAction);
         assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+        assert_eq!(
+            def.player_actions,
+            Some(vec![PlayerActionKind::Proliferate])
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -6868,6 +6868,11 @@ fn try_parse_player_action_trigger(lower: &str) -> Option<(TriggerMode, TriggerD
                 def.mode = TriggerMode::Shuffled;
                 return Some((TriggerMode::Shuffled, def));
             }
+            // CR 701.34a: Proliferate — player-action trigger.
+            [PlayerActionKind::Proliferate] => {
+                def.mode = TriggerMode::Proliferate;
+                return Some((TriggerMode::Proliferate, def));
+            }
             _ => {
                 def.mode = TriggerMode::PlayerPerformedAction;
                 def.player_actions = Some(actions.clone());
@@ -6910,6 +6915,8 @@ fn parse_player_action_phrase(text: &str) -> Option<PlayerActionKind> {
         | "shuffle his or her library"
         | "shuffles a library"
         | "shuffle a library" => Some(PlayerActionKind::ShuffledLibrary),
+        // CR 701.34a: Proliferate — choose permanents/players with counters.
+        "proliferate" | "proliferates" => Some(PlayerActionKind::Proliferate),
         _ => None,
     }
 }
@@ -12624,6 +12631,18 @@ mod tests {
             "Surveillance Monitor",
         );
         assert_eq!(def.mode, TriggerMode::CollectEvidence);
+        assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+    }
+
+    #[test]
+    fn trigger_you_proliferate() {
+        // Scheming Aspirant (ONE): "Whenever you proliferate, each opponent loses 2 life
+        // and you gain 2 life."
+        let def = parse_trigger_line(
+            "Whenever you proliferate, each opponent loses 2 life and you gain 2 life.",
+            "Scheming Aspirant",
+        );
+        assert_eq!(def.mode, TriggerMode::Proliferate);
         assert_eq!(def.valid_target, Some(TargetFilter::Controller));
     }
 

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -85,6 +85,8 @@ pub enum PlayerActionKind {
     CollectEvidence,
     /// CR 701.24a: A player shuffled their library.
     ShuffledLibrary,
+    /// CR 701.34a: A player proliferated.
+    Proliferate,
 }
 
 /// CR 701.30d: Result of a clash — whether the controller won, lost, or tied.


### PR DESCRIPTION
## Summary
Wires `TriggerMode::Proliferate` through the player-action trigger parser so that "Whenever you proliferate" is recognized as a trigger condition (CR 701.34a ). This unlocks **Scheming Aspirant**, **Ezuri, Stalker of Spheres**, **Territorial Gorger**, and other cards with proliferate triggers.

## Files changed
- `crates/engine/src/types/events.rs`
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/parser/oracle.rs`

## CR references
- CR 701.34a (Proliferate — choose permanents/players with counters)

## Track
Non-developer

## Verification
- `cargo fmt --all` — clean
- `check-parser-combinators.sh` — pass
- `cargo check -p engine --tests` — pass

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
