### PR TITLE
Add Dragonborn Champion

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -716,6 +716,7 @@ pub(super) fn match_damage_done(
         source_id: dmg_source,
         target,
         is_combat,
+        amount,
         ..
     } = event
     {
@@ -729,6 +730,16 @@ pub(super) fn match_damage_done(
             DamageKindFilter::CombatOnly if !is_combat => return false,
             DamageKindFilter::NoncombatOnly if *is_combat => return false,
             _ => {}
+        }
+        // CR 603.2 + CR 120.1: Optional per-event damage-amount threshold
+        // ("…deals 5 or more damage to a player"). When set, only damage events
+        // whose amount satisfies the comparator vs the threshold fire the
+        // trigger. CR 120.1 events carry a single nonnegative amount, so the
+        // u32→i32 widening here cannot truncate.
+        if let Some((cmp, threshold)) = trigger.damage_amount {
+            if !cmp.evaluate(*amount as i32, threshold as i32) {
+                return false;
+            }
         }
         // Check valid_target for damage target filtering (e.g. "to an opponent")
         if let Some(ref vt) = trigger.valid_target {
@@ -2111,11 +2122,23 @@ pub(super) fn match_damage_received(
     _state: &GameState,
 ) -> bool {
     if let GameEvent::DamageDealt {
-        target, is_combat, ..
+        target,
+        is_combat,
+        amount,
+        ..
     } = event
     {
         if matches!(trigger.damage_kind, DamageKindFilter::CombatOnly) && !is_combat {
             return false;
+        }
+        // CR 603.2 + CR 120.1: Per-event damage-amount threshold. Mirrors
+        // `match_damage_done` so a "is dealt N or more damage" trigger sets
+        // `damage_amount` once and the field's semantics is uniform across
+        // every damage-event matcher.
+        if let Some((cmp, threshold)) = trigger.damage_amount {
+            if !cmp.evaluate(*amount as i32, threshold as i32) {
+                return false;
+            }
         }
         match target {
             TargetRef::Object(target_id) => {
@@ -2135,6 +2158,12 @@ pub(super) fn match_damage_received(
 }
 
 /// CR 120.10: ExcessDamage — fires when the trigger source deals excess damage to a permanent.
+///
+/// Intentionally ignores `trigger.damage_amount`: that field gates on the raw
+/// dealt `amount`, while excess-damage triggers semantically gate on the
+/// `excess` field (the portion beyond lethal/loyalty/defense). No printed card
+/// composes these two thresholds, and the parser does not emit
+/// `damage_amount` on `ExcessDamage` modes.
 pub(super) fn match_excess_damage(
     event: &GameEvent,
     _trigger: &TriggerDefinition,
@@ -2146,6 +2175,8 @@ pub(super) fn match_excess_damage(
 }
 
 /// CR 120.10: ExcessDamageAll — fires when any source deals excess damage to a permanent.
+///
+/// See `match_excess_damage` for why `trigger.damage_amount` is not consulted.
 pub(super) fn match_excess_damage_all(
     event: &GameEvent,
     _trigger: &TriggerDefinition,
@@ -2779,8 +2810,8 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::parser::oracle_trigger::parse_trigger_line;
     use crate::types::ability::{
-        ControllerRef, FilterProp, QuantityExpr, ResolvedAbility, TargetFilter, TriggerDefinition,
-        TypeFilter, TypedFilter,
+        Comparator, ControllerRef, FilterProp, QuantityExpr, ResolvedAbility, TargetFilter,
+        TriggerDefinition, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
     use crate::types::events::{GameEvent, ManaTapState, PlayerActionKind};
@@ -5825,6 +5856,127 @@ mod tests {
             excess: 0,
         };
         assert!(match_damage_done(&event_opp, &trigger, source_id, &state));
+    }
+
+    // ── damage_amount threshold (CR 603.2 + CR 120.1) ─────────────
+    //
+    // Building-block tests: the matcher must apply the optional
+    // `(Comparator, threshold)` filter to the `DamageDealt` event's `amount`
+    // independently of the source/target/damage-kind axes. Exercises the
+    // common `GE` comparator (covers Dragonborn Champion's "5 or more" form)
+    // plus the orthogonal `EQ` comparator to prove the field is a true
+    // comparator slot, not a hard-coded GE check.
+    #[test]
+    fn damage_amount_ge_threshold_rejects_below() {
+        let state = setup();
+        let mut trigger = make_trigger(TriggerMode::DamageDone);
+        trigger.damage_amount = Some((Comparator::GE, 5));
+
+        let event = GameEvent::DamageDealt {
+            source_id: ObjectId(1),
+            target: TargetRef::Player(PlayerId(0)),
+            amount: 4,
+            is_combat: false,
+            excess: 0,
+        };
+        assert!(!match_damage_done(&event, &trigger, ObjectId(1), &state));
+    }
+
+    #[test]
+    fn damage_amount_ge_threshold_accepts_at_or_above() {
+        let state = setup();
+        let mut trigger = make_trigger(TriggerMode::DamageDone);
+        trigger.damage_amount = Some((Comparator::GE, 5));
+
+        for amount in [5, 7, 100] {
+            let event = GameEvent::DamageDealt {
+                source_id: ObjectId(1),
+                target: TargetRef::Player(PlayerId(0)),
+                amount,
+                is_combat: false,
+                excess: 0,
+            };
+            assert!(
+                match_damage_done(&event, &trigger, ObjectId(1), &state),
+                "expected amount={amount} to satisfy GE 5"
+            );
+        }
+    }
+
+    #[test]
+    fn damage_amount_none_passes_any_amount() {
+        let state = setup();
+        let trigger = make_trigger(TriggerMode::DamageDone);
+        assert_eq!(trigger.damage_amount, None);
+
+        for amount in [0, 1, 99] {
+            let event = GameEvent::DamageDealt {
+                source_id: ObjectId(1),
+                target: TargetRef::Player(PlayerId(0)),
+                amount,
+                is_combat: false,
+                excess: 0,
+            };
+            assert!(match_damage_done(&event, &trigger, ObjectId(1), &state));
+        }
+    }
+
+    // CR 603.2 + CR 120.1: `match_damage_received` must apply the same
+    // `damage_amount` threshold as `match_damage_done` so the field's
+    // semantics is uniform across damage-event matchers. Without this gate, a
+    // future "Whenever ~ is dealt N or more damage" trigger would silently
+    // drop its threshold.
+    #[test]
+    fn damage_received_amount_ge_threshold_rejects_below_and_accepts_at_or_above() {
+        let mut state = setup();
+        // The DamageReceived matcher checks the *target* against `source_id`,
+        // so the trigger's source object must equal the damage target.
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            String::new(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::DamageReceived);
+        trigger.damage_amount = Some((Comparator::GE, 3));
+
+        for (amount, expect) in [(2u32, false), (3, true), (10, true)] {
+            let event = GameEvent::DamageDealt {
+                source_id: ObjectId(99),
+                target: TargetRef::Object(source_id),
+                amount,
+                is_combat: false,
+                excess: 0,
+            };
+            assert_eq!(
+                match_damage_received(&event, &trigger, source_id, &state),
+                expect,
+                "amount={amount} GE 3"
+            );
+        }
+    }
+
+    #[test]
+    fn damage_amount_eq_threshold_only_matches_exact() {
+        let state = setup();
+        let mut trigger = make_trigger(TriggerMode::DamageDone);
+        trigger.damage_amount = Some((Comparator::EQ, 3));
+
+        for (amount, expect) in [(2, false), (3, true), (4, false)] {
+            let event = GameEvent::DamageDealt {
+                source_id: ObjectId(1),
+                target: TargetRef::Player(PlayerId(0)),
+                amount,
+                is_combat: false,
+                excess: 0,
+            };
+            assert_eq!(
+                match_damage_done(&event, &trigger, ObjectId(1), &state),
+                expect,
+                "amount={amount} EQ 3"
+            );
+        }
     }
 
     // ── Work Item 4: Transforms Into Self ─────────────────────────

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -4462,33 +4462,31 @@ fn try_parse_event(
         return Some((TriggerMode::ChangesZone, def));
     }
 
-    // CR 120.1: "deals combat damage" / "deal combat damage" (plural for &-names)
-    if let Ok((after, ())) = alt((
-        value((), tag::<_, _, OracleError<'_>>("deals combat damage")),
-        value((), tag("deal combat damage")),
+    // CR 120.1 + CR 120.3 + CR 603.2: Subject-led damage trigger —
+    //   "deal[s] [combat|noncombat] [N or more] damage [to <recipient>]".
+    // Composed from three independent axes:
+    //   * damage-kind adjective   → `DamageKindFilter::{CombatOnly, NoncombatOnly}`
+    //   * "N or more" quantifier  → `damage_amount = Some((GE, N))`
+    //   * recipient "to <…>"      → `valid_target` via `parse_damage_to_qualifier`
+    // Singular ("deals") and plural ("deal", for &-names) collapse into one
+    // verb alternative. Unlocks Deus of Calamity ("~ deals 6 or more damage to
+    // an opponent") in addition to the established "deals damage" / "deals
+    // combat damage" classes — same handler, no new arm.
+    if let Ok((after_verb, ())) = alt((
+        value((), tag::<_, _, OracleError<'_>>("deals ")),
+        value((), tag("deal ")),
     ))
     .parse(rest)
     {
-        let mut def = make_base();
-        def.mode = TriggerMode::DamageDone;
-        def.damage_kind = DamageKindFilter::CombatOnly;
-        def.valid_source = Some(subject.clone());
-        def.valid_target = parse_damage_to_qualifier(after);
-        return Some((TriggerMode::DamageDone, def));
-    }
-
-    // CR 120.1: "deals damage" / "deal damage" (plural for &-names)
-    if let Ok((after, ())) = alt((
-        value((), tag::<_, _, OracleError<'_>>("deals damage")),
-        value((), tag("deal damage")),
-    ))
-    .parse(rest)
-    {
-        let mut def = make_base();
-        def.mode = TriggerMode::DamageDone;
-        def.valid_source = Some(subject.clone());
-        def.valid_target = parse_damage_to_qualifier(after);
-        return Some((TriggerMode::DamageDone, def));
+        if let Ok((after_damage, (kind, amount))) = parse_damage_predicate_tail(after_verb) {
+            let mut def = make_base();
+            def.mode = TriggerMode::DamageDone;
+            def.damage_kind = kind;
+            def.damage_amount = amount;
+            def.valid_source = Some(subject.clone());
+            def.valid_target = parse_damage_to_qualifier(after_damage);
+            return Some((TriggerMode::DamageDone, def));
+        }
     }
 
     // CR 508.1a: "~ and at least N other creatures attack" (Battalion/Pack Tactics)
@@ -5090,6 +5088,159 @@ fn try_parse_named_trigger_mode(lower: &str) -> Option<(TriggerMode, TriggerDefi
     None
 }
 
+/// CR 120.1 + CR 120.3 + CR 603.2: "Whenever a source [you control] deals
+/// [combat/noncombat] [N or more] damage to <recipient>, …" — the source-led
+/// damage-event trigger class. Composes four independent axes (source filter ×
+/// damage kind × amount threshold × recipient filter) so adding a new
+/// recipient or a new source qualifier is a one-line change to the relevant
+/// sub-combinator, not a new arm here.
+///
+/// Returns `None` when the line doesn't match the source-led damage shape so
+/// the dispatcher can fall through to the next pattern.
+fn try_parse_source_deals_damage_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinition)> {
+    // CR 603.1: "When"/"Whenever" lead-in for triggered ability syntax.
+    let (rest, _) = alt((
+        value((), tag::<_, _, OracleError<'_>>("whenever ")),
+        value((), tag("when ")),
+    ))
+    .parse(lower)
+    .ok()?;
+
+    // Source subject — must match before "deals".
+    let (rest, source_filter) = parse_damage_source_subject(rest).ok()?;
+
+    let (rest, _) = tag::<_, _, OracleError<'_>>("deals ").parse(rest).ok()?;
+
+    // Shared predicate tail: optional kind, optional "N or more", "damage".
+    let (after_damage, (damage_kind, threshold)) = parse_damage_predicate_tail(rest).ok()?;
+
+    // Recipient: " to <recipient>" — `parse_damage_to_qualifier` consumes the
+    // leading " to " itself, so pass the remainder including the space.
+    let valid_target = parse_damage_to_qualifier(after_damage)?;
+
+    let mut def = make_base();
+    def.mode = TriggerMode::DamageDone;
+    def.damage_kind = damage_kind;
+    def.valid_source = Some(source_filter);
+    def.valid_target = Some(valid_target);
+    def.damage_amount = threshold;
+    Some((TriggerMode::DamageDone, def))
+}
+
+/// CR 109.4 + CR 120.1: Parse the source subject of a damage trigger up to (but
+/// not including) the trailing `"deals "` verb. Returns the matching
+/// `TargetFilter` and the remainder beginning at `"deals "`.
+///
+/// Composable axes:
+///   * article         — "a " | "an "
+///   * other-prefix    — optional "another "  → `FilterProp::Another`
+///   * color qualifier — optional ManaColor   → `FilterProp::HasColor`
+///   * head noun       — "source" (the only damage-source head noun in printed cards today)
+///   * controller      — optional " you control" → `ControllerRef::You`
+fn parse_damage_source_subject(input: &str) -> OracleResult<'_, TargetFilter> {
+    use crate::parser::oracle_nom::primitives::parse_color;
+
+    // CR 109.4: leading article is mandatory in printed damage-source phrases
+    // ("a source", "an opponent's source" — the latter not in any printed card
+    // today, deferred). Word boundary on the trailing space.
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("a "),
+        tag::<_, _, OracleError<'_>>("an "),
+    ))
+    .parse(input)?;
+
+    // Optional "another " → FilterProp::Another. CR 109.4 governs object
+    // identity in references; "another" reads "an object distinct from the
+    // ability source" and is enforced by `FilterProp::Another` at the
+    // `game/filter.rs` runtime evaluator.
+    let (rest, another) = opt(value(
+        FilterProp::Another,
+        tag::<_, _, OracleError<'_>>("another "),
+    ))
+    .parse(rest)?;
+
+    // Optional color qualifier ("red source you control"). `parse_color` is the
+    // shared color-word combinator and has no internal word boundary; the
+    // mandatory `tag(" ")` after it is structural — without it `parse_color`
+    // would match the "red" prefix of "redirect" / "redacted" / etc. and
+    // misclassify the subject.
+    let (rest, color) = opt(terminated(parse_color, tag(" "))).parse(rest)?;
+
+    let (rest, _) = tag::<_, _, OracleError<'_>>("source").parse(rest)?;
+
+    // Optional " you control" controller scope. Absence → no controller
+    // restriction (matches any source — Phyrexian Obliterator class, deferred).
+    let (rest, controller) = opt(value(
+        ControllerRef::You,
+        tag::<_, _, OracleError<'_>>(" you control"),
+    ))
+    .parse(rest)?;
+
+    // Require trailing space before the "deals" verb so we don't match
+    // "sourceless" / "sourced".
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest)?;
+
+    let mut typed = TypedFilter::default();
+    if let Some(c) = controller {
+        typed = typed.controller(c);
+    }
+    let mut props = Vec::new();
+    if let Some(p) = another {
+        props.push(p);
+    }
+    if let Some(col) = color {
+        props.push(FilterProp::HasColor { color: col });
+    }
+    if !props.is_empty() {
+        typed.properties = props;
+    }
+    Ok((rest, TargetFilter::Typed(typed)))
+}
+
+/// CR 120.3: Parse the damage-kind adjective (`"combat "` / `"noncombat "`).
+/// Each branch consumes its trailing space so the caller can chain directly
+/// into `tag("damage")`.
+fn parse_damage_kind_adjective(input: &str) -> OracleResult<'_, DamageKindFilter> {
+    alt((
+        value(DamageKindFilter::CombatOnly, tag("combat ")),
+        value(DamageKindFilter::NoncombatOnly, tag("noncombat ")),
+    ))
+    .parse(input)
+}
+
+/// CR 120.1 + CR 120.3 + CR 603.2: Compose the predicate tail that follows the
+/// damage verb (`"deal"` / `"deals"`) — optional kind adjective, optional
+/// "N or more" amount quantifier, and the mandatory `"damage"` head noun.
+/// Returns the parsed kind/amount pair and the remainder after `"damage"` so
+/// the caller can hand it to `parse_damage_to_qualifier`.
+///
+/// Used by both the source-led grammar (`try_parse_source_deals_damage_trigger`)
+/// and the subject-led grammar in `try_parse_event`. Keeping the tail in one
+/// combinator means a new kind (e.g. "noncreature damage") or a new comparator
+/// (e.g. "less than N", "exactly N") is added in exactly one place.
+fn parse_damage_predicate_tail(
+    input: &str,
+) -> OracleResult<'_, (DamageKindFilter, Option<(Comparator, u32)>)> {
+    let (rest, kind) = opt(parse_damage_kind_adjective).parse(input)?;
+    let (rest, amount) = opt(parse_damage_amount_quantifier).parse(rest)?;
+    let (rest, _) = tag("damage").parse(rest)?;
+    Ok((rest, (kind.unwrap_or(DamageKindFilter::Any), amount)))
+}
+
+/// CR 603.2 + CR 120.1: Parse a damage-amount quantifier
+/// ("`5 or more `") and return the resulting `(Comparator, threshold)` pair to
+/// store on `TriggerDefinition::damage_amount`. The trailing space is consumed
+/// so the caller can chain directly into `tag("damage")`.
+///
+/// Today only `"N or more"` is printed in the Oracle corpus for damage triggers;
+/// `"exactly N"` and `"less than N"` slot in here via the same axis when needed.
+fn parse_damage_amount_quantifier(input: &str) -> OracleResult<'_, (Comparator, u32)> {
+    use crate::parser::oracle_nom::primitives::parse_number;
+    let (rest, n) = parse_number(input)?;
+    let (rest, _) = tag(" or more ").parse(rest)?;
+    Ok((rest, (Comparator::GE, n)))
+}
+
 fn try_parse_special_trigger_pattern(lower: &str) -> Option<(TriggerMode, TriggerDefinition)> {
     if let Some(result) = try_parse_self_or_another_controlled_subtype_enters(lower) {
         return Some(result);
@@ -5148,23 +5299,19 @@ fn try_parse_special_trigger_pattern(lower: &str) -> Option<(TriggerMode, Trigge
         return Some(result);
     }
 
-    // CR 120.2b: "a source you control deals noncombat damage to an opponent"
-    for prefix in [
-        "whenever a source you control deals noncombat damage to an opponent",
-        "when a source you control deals noncombat damage to an opponent",
-    ] {
-        if lower == prefix {
-            let mut def = make_base();
-            def.mode = TriggerMode::DamageDone;
-            def.damage_kind = DamageKindFilter::NoncombatOnly;
-            def.valid_source = Some(TargetFilter::Typed(
-                TypedFilter::default().controller(ControllerRef::You),
-            ));
-            def.valid_target = Some(TargetFilter::Typed(
-                TypedFilter::default().controller(ControllerRef::Opponent),
-            ));
-            return Some((TriggerMode::DamageDone, def));
-        }
+    // CR 120.1 + CR 120.3: "a source [you control] deals [combat/noncombat]
+    // [N or more] damage to <recipient>". One combinator-driven parser that
+    // composes four independent axes:
+    //   * source filter   — `parse_source_subject` ("a source", "a source you control",
+    //                       "another source you control", "a <color> source you control")
+    //   * damage kind     — `DamageKindFilter` axis (any / combat-only / noncombat-only)
+    //   * amount threshold — optional "N or more " quantifier → `damage_amount`
+    //   * recipient       — `parse_damage_to_qualifier` (player / opponent / planeswalker / you / …)
+    // Covers Dragonborn Champion ("…deals 5 or more damage to a player, draw a card")
+    // and the earlier-shipped "source you control deals noncombat damage to an
+    // opponent" pattern (Virtue of Courage) without a second arm.
+    if let Some(result) = try_parse_source_deals_damage_trigger(lower) {
+        return Some(result);
     }
 
     fn parse_source_deals_damage_to_self(input: &str) -> OracleResult<'_, ()> {
@@ -14473,6 +14620,47 @@ mod tests {
                 ..
             }))
         ));
+        // No amount threshold on Virtue of Courage's trigger.
+        assert_eq!(def.damage_amount, None);
+    }
+
+    // CR 603.2 + CR 120.1: "Whenever a source you control deals N or more
+    // damage to <recipient>" — exercises the amount-threshold axis added for
+    // Dragonborn Champion. Building-block test: it verifies the parser emits
+    // `damage_amount = Some((GE, N))` together with the source/recipient
+    // filters, regardless of the specific card.
+    #[test]
+    fn trigger_source_deals_n_or_more_damage_to_player() {
+        let def = parse_trigger_line(
+            "Whenever a source you control deals 5 or more damage to a player, draw a card.",
+            "Dragonborn Champion",
+        );
+        assert_eq!(def.mode, TriggerMode::DamageDone);
+        assert_eq!(def.damage_kind, DamageKindFilter::Any);
+        assert_eq!(def.damage_amount, Some((Comparator::GE, 5)));
+        assert!(matches!(
+            def.valid_source,
+            Some(TargetFilter::Typed(TypedFilter {
+                controller: Some(ControllerRef::You),
+                ..
+            }))
+        ));
+        assert_eq!(def.valid_target, Some(TargetFilter::Player));
+    }
+
+    // Same general parser must also accept the no-threshold + noncombat-kind
+    // form (Virtue of Courage style) — proves the threshold axis is optional
+    // and composes orthogonally with the damage-kind axis.
+    #[test]
+    fn trigger_source_deals_noncombat_damage_to_player_no_threshold() {
+        let def = parse_trigger_line(
+            "Whenever a source you control deals noncombat damage to a player, draw a card.",
+            "Test",
+        );
+        assert_eq!(def.mode, TriggerMode::DamageDone);
+        assert_eq!(def.damage_kind, DamageKindFilter::NoncombatOnly);
+        assert_eq!(def.damage_amount, None);
+        assert_eq!(def.valid_target, Some(TargetFilter::Player));
     }
 
     // ── Work Item 4: Transforms Into Self ─────────────────────────

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -5101,7 +5101,7 @@ fn try_parse_named_trigger_mode(lower: &str) -> Option<(TriggerMode, TriggerDefi
 }
 
 /// CR 120.1 + CR 120.3 + CR 603.2: "Whenever a source [you control] deals
-/// [combat/noncombat] [N or more] damage to <recipient>, …" — the source-led
+/// [combat/noncombat] [N or more] damage [to <recipient>], …" — the source-led
 /// damage-event trigger class. Composes four independent axes (source filter ×
 /// damage kind × amount threshold × recipient filter) so adding a new
 /// recipient or a new source qualifier is a one-line change to the relevant
@@ -5126,15 +5126,22 @@ fn try_parse_source_deals_damage_trigger(lower: &str) -> Option<(TriggerMode, Tr
     // Shared predicate tail: optional kind, optional "N or more", "damage".
     let (after_damage, (damage_kind, threshold)) = parse_damage_predicate_tail(rest).ok()?;
 
-    // Recipient: " to <recipient>" — `parse_damage_to_qualifier` consumes the
-    // leading " to " itself, so pass the remainder including the space.
-    let valid_target = parse_damage_to_qualifier(after_damage)?;
-
     let mut def = make_base();
     def.mode = TriggerMode::DamageDone;
     def.damage_kind = damage_kind;
     def.valid_source = Some(source_filter);
-    def.valid_target = Some(valid_target);
+    // Optional recipient: "to <recipient>" narrows the damage target; absence
+    // means any damage target may satisfy the event. If a "to ..." tail exists
+    // but is not one of this parser's recipient qualifiers, leave the line for
+    // narrower parsers such as "a source deals damage to this creature".
+    let valid_target = parse_damage_to_qualifier(after_damage);
+    let has_recipient_tail = preceded(opt(space1), tag::<_, _, OracleError<'_>>("to "))
+        .parse(after_damage)
+        .is_ok();
+    if has_recipient_tail && valid_target.is_none() {
+        return None;
+    }
+    def.valid_target = valid_target;
     def.damage_amount = threshold;
     Some((TriggerMode::DamageDone, def))
 }
@@ -5147,11 +5154,9 @@ fn try_parse_source_deals_damage_trigger(lower: &str) -> Option<(TriggerMode, Tr
 ///   * article         — "a " | "an "
 ///   * other-prefix    — optional "another "  → `FilterProp::Another`
 ///   * color qualifier — optional ManaColor   → `FilterProp::HasColor`
-///   * head noun       — "source" (the only damage-source head noun in printed cards today)
+///   * head noun       — "source" | supported object type head nouns
 ///   * controller      — optional " you control" → `ControllerRef::You`
 fn parse_damage_source_subject(input: &str) -> OracleResult<'_, TargetFilter> {
-    use crate::parser::oracle_nom::primitives::parse_color;
-
     // CR 109.4: leading article is mandatory in printed damage-source phrases
     // ("a source", "an opponent's source" — the latter not in any printed card
     // today, deferred). Word boundary on the trailing space.
@@ -5176,9 +5181,18 @@ fn parse_damage_source_subject(input: &str) -> OracleResult<'_, TargetFilter> {
     // mandatory `tag(" ")` after it is structural — without it `parse_color`
     // would match the "red" prefix of "redirect" / "redacted" / etc. and
     // misclassify the subject.
-    let (rest, color) = opt(terminated(parse_color, tag(" "))).parse(rest)?;
+    let (rest, color) = opt(terminated(nom_primitives::parse_color, tag(" "))).parse(rest)?;
 
-    let (rest, _) = tag::<_, _, OracleError<'_>>("source").parse(rest)?;
+    let (rest, head_type) = alt((
+        value(None, tag::<_, _, OracleError<'_>>("source")),
+        value(Some(TypeFilter::Creature), tag("creature")),
+        value(Some(TypeFilter::Artifact), tag("artifact")),
+        value(Some(TypeFilter::Enchantment), tag("enchantment")),
+        value(Some(TypeFilter::Planeswalker), tag("planeswalker")),
+        value(Some(TypeFilter::Battle), tag("battle")),
+        value(Some(TypeFilter::Land), tag("land")),
+    ))
+    .parse(rest)?;
 
     // Optional " you control" controller scope. Absence → no controller
     // restriction (matches any source — Phyrexian Obliterator class, deferred).
@@ -5192,7 +5206,7 @@ fn parse_damage_source_subject(input: &str) -> OracleResult<'_, TargetFilter> {
     // "sourceless" / "sourced".
     let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest)?;
 
-    let mut typed = TypedFilter::default();
+    let mut typed = head_type.map_or_else(TypedFilter::default, TypedFilter::new);
     if let Some(c) = controller {
         typed = typed.controller(c);
     }
@@ -5222,14 +5236,14 @@ fn parse_damage_kind_adjective(input: &str) -> OracleResult<'_, DamageKindFilter
 
 /// CR 120.1 + CR 120.3 + CR 603.2: Compose the predicate tail that follows the
 /// damage verb (`"deal"` / `"deals"`) — optional kind adjective, optional
-/// "N or more" amount quantifier, and the mandatory `"damage"` head noun.
+/// amount quantifier, and the mandatory `"damage"` head noun.
 /// Returns the parsed kind/amount pair and the remainder after `"damage"` so
 /// the caller can hand it to `parse_damage_to_qualifier`.
 ///
 /// Used by both the source-led grammar (`try_parse_source_deals_damage_trigger`)
 /// and the subject-led grammar in `try_parse_event`. Keeping the tail in one
 /// combinator means a new kind (e.g. "noncreature damage") or a new comparator
-/// (e.g. "less than N", "exactly N") is added in exactly one place.
+/// (e.g. "less than N") is added in exactly one place.
 fn parse_damage_predicate_tail(
     input: &str,
 ) -> OracleResult<'_, (DamageKindFilter, Option<(Comparator, u32)>)> {
@@ -5240,17 +5254,27 @@ fn parse_damage_predicate_tail(
 }
 
 /// CR 603.2 + CR 120.1: Parse a damage-amount quantifier
-/// ("`5 or more `") and return the resulting `(Comparator, threshold)` pair to
-/// store on `TriggerDefinition::damage_amount`. The trailing space is consumed
-/// so the caller can chain directly into `tag("damage")`.
+/// ("`5 or more `" / "`exactly 5 `") and return the resulting
+/// `(Comparator, threshold)` pair to store on `TriggerDefinition::damage_amount`.
+/// The trailing space is consumed so the caller can chain directly into
+/// `tag("damage")`.
 ///
-/// Today only `"N or more"` is printed in the Oracle corpus for damage triggers;
-/// `"exactly N"` and `"less than N"` slot in here via the same axis when needed.
+/// `"less than N"` slots in here via the same axis when needed.
 fn parse_damage_amount_quantifier(input: &str) -> OracleResult<'_, (Comparator, u32)> {
-    use crate::parser::oracle_nom::primitives::parse_number;
-    let (rest, n) = parse_number(input)?;
-    let (rest, _) = tag(" or more ").parse(rest)?;
-    Ok((rest, (Comparator::GE, n)))
+    fn parse_or_more(input: &str) -> OracleResult<'_, (Comparator, u32)> {
+        let (rest, n) = nom_primitives::parse_number(input)?;
+        let (rest, _) = tag(" or more ").parse(rest)?;
+        Ok((rest, (Comparator::GE, n)))
+    }
+
+    fn parse_exactly(input: &str) -> OracleResult<'_, (Comparator, u32)> {
+        let (rest, _) = tag("exactly ").parse(input)?;
+        let (rest, n) = nom_primitives::parse_number(rest)?;
+        let (rest, _) = tag(" ").parse(rest)?;
+        Ok((rest, (Comparator::EQ, n)))
+    }
+
+    alt((parse_exactly, parse_or_more)).parse(input)
 }
 
 fn try_parse_special_trigger_pattern(lower: &str) -> Option<(TriggerMode, TriggerDefinition)> {
@@ -14657,6 +14681,54 @@ mod tests {
                 ..
             }))
         ));
+        assert_eq!(def.valid_target, Some(TargetFilter::Player));
+    }
+
+    #[test]
+    fn trigger_source_deals_n_or_more_damage_without_recipient() {
+        let def = parse_trigger_line(
+            "Whenever a source you control deals 5 or more damage, draw a card.",
+            "Test",
+        );
+        assert_eq!(def.mode, TriggerMode::DamageDone);
+        assert_eq!(def.damage_amount, Some((Comparator::GE, 5)));
+        assert!(matches!(
+            def.valid_source,
+            Some(TargetFilter::Typed(TypedFilter {
+                controller: Some(ControllerRef::You),
+                ..
+            }))
+        ));
+        assert_eq!(def.valid_target, None);
+    }
+
+    #[test]
+    fn trigger_creature_source_deals_n_or_more_damage_to_player() {
+        let def = parse_trigger_line(
+            "Whenever a creature you control deals 5 or more damage to a player, draw a card.",
+            "Test",
+        );
+        assert_eq!(def.mode, TriggerMode::DamageDone);
+        assert_eq!(def.damage_amount, Some((Comparator::GE, 5)));
+        match def.valid_source {
+            Some(TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller: Some(ControllerRef::You),
+                ..
+            })) => assert_eq!(type_filters, vec![TypeFilter::Creature]),
+            other => panic!("expected controlled creature source filter, got {other:?}"),
+        }
+        assert_eq!(def.valid_target, Some(TargetFilter::Player));
+    }
+
+    #[test]
+    fn trigger_source_deals_exactly_n_damage_to_player() {
+        let def = parse_trigger_line(
+            "Whenever a source you control deals exactly 5 damage to a player, draw a card.",
+            "Test",
+        );
+        assert_eq!(def.mode, TriggerMode::DamageDone);
+        assert_eq!(def.damage_amount, Some((Comparator::EQ, 5)));
         assert_eq!(def.valid_target, Some(TargetFilter::Player));
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9534,6 +9534,14 @@ pub struct TriggerDefinition {
     /// Typed player actions for PlayerPerformedAction trigger mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub player_actions: Option<Vec<PlayerActionKind>>,
+    /// CR 603.2 + CR 120.1: Per-event damage-amount threshold for damage triggers
+    /// ("…deals 5 or more damage to a player"). When `Some((cmp, n))`, the
+    /// matcher requires the `DamageDealt` event's `amount` to satisfy
+    /// `amount cmp n`. `None` means no amount restriction. Applies to all
+    /// damage-event trigger modes (`DamageDone`, `DamageDoneOnce`, `DamageAll`,
+    /// `DamageDealtOnce`); ignored by other modes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub damage_amount: Option<(Comparator, u32)>,
 }
 
 impl TriggerDefinition {
@@ -9563,6 +9571,7 @@ impl TriggerDefinition {
             expend_threshold: None,
             attack_target_filter: None,
             player_actions: None,
+            damage_amount: None,
         }
     }
 
@@ -11528,6 +11537,7 @@ mod tests {
             expend_threshold: None,
             attack_target_filter: None,
             player_actions: None,
+            damage_amount: None,
         };
         let json = serde_json::to_string(&trigger).unwrap();
         let deserialized: TriggerDefinition = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary
Adds engine support for **Dragonborn Champion**.

## Files changed
- `crates/engine/src/types/ability.rs`
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/game/trigger_matchers.rs`

## CR references
- `CR 109.4` — object identity in references
- `CR 120.1` — objects can deal damage; source identity
- `CR 120.3` — combat vs noncombat damage results
- `CR 603.1` — trigger ability syntax
- `CR 603.2` — event matching for trigger firing (authorizes the per-event amount gate)

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Verification
- `cargo fmt --all` — clean
- `cargo clippy-strict` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo test -p engine` — 8771 pass / 0 fail (8345 lib + 426 integration)
- `./scripts/gen-card-data.sh` — `Dragonborn Champion`: 0 Unimplemented entries (script gates on bash 4 `mapfile`; ran the equivalent `target/tool/oracle-gen data --stats` instead — Dragonborn Champion parses with `mode: DamageDone`, `damage_amount: [GE, 5]`, `valid_source: {Typed, controller: You}`, `valid_target: Player`, `Draw 1` execute)
- `cargo coverage` — `Dragonborn Champion`: `supported: true`, `gap_count: 0`
- `cargo semantic-audit` — `Dragonborn Champion`: 0 findings

## Scope Expansion
Parameterized the existing damage-event trigger pipeline on a per-event amount threshold (`TriggerDefinition.damage_amount: Option<(Comparator, u32)>`) so the class "Whenever a [source filter] deals [N] or more [kind] damage to [recipient]" parses generically. Replaced the existing two-string special case for Virtue of Courage with a composable source-led grammar combinator, and generalized the subject-led `deals damage` arm over kind and amount — this incidentally unlocks **Deus of Calamity** ("Whenever this creature deals 6 or more damage to an opponent, destroy target land that player controls."), which previously parsed as `Unknown`. The threshold gate was also plumbed into `match_damage_received` for matcher uniformity across all damage-event modes; `match_excess_damage` deliberately does not consult it (it gates on `excess`, not raw `amount`, per CR 120.10).

## Validation Failures
None.

## CI Failures
None.