### PR TITLE
Parse 'Whenever a creature explores' trigger and scope by valid_card (CR 701.44)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1954,20 +1954,26 @@ pub(super) fn match_always(
     true
 }
 
-/// Explored: fires when a creature explores.
+/// CR 701.44: "Whenever [subject] explores" — fires when a creature explores and
+/// the exploring creature matches the trigger's `valid_card` filter. When
+/// `valid_card` is `None` the trigger is unscoped (fires for any explore).
+/// The `EffectResolved { source_id }` event carries the exploring creature's
+/// object ID, which is tested against the filter (e.g. `Controlled` for
+/// "a creature you control").
 pub(super) fn match_explored(
     event: &GameEvent,
-    _trigger: &TriggerDefinition,
-    _source_id: ObjectId,
-    _state: &GameState,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
 ) -> bool {
-    matches!(
-        event,
-        GameEvent::EffectResolved {
-            kind: EffectKind::Explore,
-            ..
-        }
-    )
+    let GameEvent::EffectResolved {
+        kind: EffectKind::Explore,
+        source_id: exploring_id,
+    } = event
+    else {
+        return false;
+    };
+    valid_card_matches(trigger, state, *exploring_id, source_id)
 }
 
 /// CR 702.110a: "When this creature exploits" = source is the exploiter.
@@ -7349,6 +7355,80 @@ mod tests {
         assert!(
             match_changes_zone(&opp_milled_event, &trigger, source, &state),
             "trigger must fire when an opponent's creature card is milled"
+        );
+    }
+
+    /// CR 701.44: match_explored fires when the exploring creature passes the
+    /// valid_card filter. With valid_card = Some(Controlled), only a creature
+    /// owned by the trigger controller should fire; events from other
+    /// controllers must not.
+    #[test]
+    fn explored_trigger_filters_by_controller() {
+        let mut state = setup();
+        let trigger_source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Wildgrowth Walker".to_string(),
+            Zone::Battlefield,
+        );
+        let my_creature = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Merfolk Branchwalker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&my_creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        let opp_creature = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Branchwalker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&opp_creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let mut trigger = make_trigger(TriggerMode::Explored);
+        trigger.valid_card = Some(TargetFilter::Controlled);
+
+        let my_explore = GameEvent::EffectResolved {
+            kind: EffectKind::Explore,
+            source_id: my_creature,
+        };
+        assert!(
+            match_explored(&my_explore, &trigger, trigger_source, &state),
+            "trigger must fire when a creature you control explores"
+        );
+
+        let opp_explore = GameEvent::EffectResolved {
+            kind: EffectKind::Explore,
+            source_id: opp_creature,
+        };
+        assert!(
+            !match_explored(&opp_explore, &trigger, trigger_source, &state),
+            "trigger must not fire when an opponent's creature explores"
+        );
+
+        let non_explore = GameEvent::EffectResolved {
+            kind: EffectKind::Draw,
+            source_id: my_creature,
+        };
+        assert!(
+            !match_explored(&non_explore, &trigger, trigger_source, &state),
+            "trigger must not fire for non-Explore events"
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -4906,6 +4906,8 @@ fn try_parse_event(
         Mutates,
         ExploitsCreature,
         Exploits,
+        // CR 701.44: "explores" — the creature performs the explore action.
+        Explores,
         Transforms,
         Stations,
         SaddlesOrCrews,
@@ -4969,6 +4971,9 @@ fn try_parse_event(
             // CR 702.110b: "exploits a creature" — exploit trigger
             value(SimpleEvent::ExploitsCreature, tag("exploits a creature")),
             value(SimpleEvent::Exploits, tag("exploits")),
+            // CR 701.44: "explores" — explore trigger. The subject is the
+            // exploring creature (e.g. "a creature you control").
+            value(SimpleEvent::Explores, tag("explores")),
             // CR 712.14: "transforms" / "transforms into"
             value(SimpleEvent::Transforms, tag("transforms")),
             // CR 702.184a: "stations ~" — actor-side Station trigger.
@@ -5047,6 +5052,13 @@ fn try_parse_event(
             }
             SimpleEvent::ExploitsCreature | SimpleEvent::Exploits => {
                 def.mode = TriggerMode::Exploited;
+                def.valid_card = Some(subject.clone());
+            }
+            // CR 701.44: "explores" — fires when the named creature explores.
+            // valid_card carries the subject filter ("a creature you control",
+            // "this creature", etc.) so match_explored can scope it correctly.
+            SimpleEvent::Explores => {
+                def.mode = TriggerMode::Explored;
                 def.valid_card = Some(subject.clone());
             }
             SimpleEvent::Transforms => {
@@ -20098,5 +20110,56 @@ mod snapshot_tests {
         );
         assert_eq!(def.mode, TriggerMode::Exerted);
         assert!(def.valid_card.is_some());
+    }
+
+    /// CR 701.44: "Whenever a creature you control explores" — explore trigger
+    /// scoped to the controller's creatures. Cards: Wildgrowth Walker, Shadowed
+    /// Caravel, Lurking Chupacabra, Merfolk Cave-Diver.
+    /// The trigger mode must be Explored and valid_card must capture the creature
+    /// filter so match_explored can restrict firing to the right controller.
+    #[test]
+    fn trigger_creature_you_control_explores() {
+        let def = parse_trigger_line(
+            "Whenever a creature you control explores, put a +1/+1 counter on this creature.",
+            "Wildgrowth Walker",
+        );
+        assert_eq!(
+            def.mode,
+            TriggerMode::Explored,
+            "expected Explored mode, got {:?}",
+            def.mode
+        );
+        assert!(
+            def.valid_card.is_some(),
+            "valid_card must be set for controller-scoped explore trigger"
+        );
+        // The filter must describe a creature (not just any permanent).
+        let Some(TargetFilter::Typed(tf)) = def.valid_card else {
+            panic!(
+                "expected Typed creature filter for valid_card, got {:?}",
+                def.valid_card
+            );
+        };
+        assert!(
+            tf.type_filters.contains(&TypeFilter::Creature),
+            "valid_card filter must include Creature type, got {:?}",
+            tf.type_filters
+        );
+    }
+
+    /// CR 701.44: "Whenever ~ explores" — self-referential explore trigger.
+    /// Verifies SelfRef is preserved for cards that fire on their own explore.
+    #[test]
+    fn trigger_self_explores() {
+        let def = parse_trigger_line(
+            "Whenever ~ explores, put a +1/+1 counter on ~.",
+            "Jadelight Ranger",
+        );
+        assert_eq!(def.mode, TriggerMode::Explored);
+        assert_eq!(
+            def.valid_card,
+            Some(TargetFilter::SelfRef),
+            "self-referential explore trigger must use SelfRef"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two-part fix enabling the engine to parse and correctly scope **"Whenever a creature you control explores"** triggered abilities.

### Root cause

**Parser**: The `SimpleEvent` dispatch table in `parse_simple_event` had no arm for `"explores"`, so the trigger fell through all parse paths and was emitted as `TriggerMode::Unknown`.

**Matcher**: `match_explored` ignored both the `TriggerDefinition` and `GameState`, firing for every `EffectResolved { kind: Explore }` event — including explores triggered by the opponent's creatures.

### Changes

**`crates/engine/src/parser/oracle_trigger.rs`**

- Add `Explores` variant to the local `SimpleEvent` enum.
- Add `value(SimpleEvent::Explores, tag("explores"))` to `parse_simple_event`.
- Add match arm: `def.mode = TriggerMode::Explored; def.valid_card = Some(subject.clone())`.

**`crates/engine/src/game/trigger_matchers.rs`**

- Rewrite `match_explored` to destructure the event, extract the exploring creature's `source_id`, and call `valid_card_matches` to apply the subject filter.

### Affected cards

| Card | Oracle text |
|---|---|
| Wildgrowth Walker | Whenever a creature you control explores, … |
| Shadowed Caravel | Whenever a creature you control explores, … |
| Lurking Chupacabra | Whenever a creature you control explores, … |
| Merfolk Cave-Diver | Whenever a creature you control explores, … |

### Tests added

- `oracle_trigger::trigger_creature_you_control_explores` — mode, valid_card presence, Creature type filter
- `oracle_trigger::trigger_self_explores` — SelfRef preservation
- `trigger_matchers::explored_trigger_filters_by_controller` — controller scoping; fires for own, not opponent's explore

🤖 Generated with [Claude Code](https://claude.com/claude-code)