### PR TITLE
Parse 'Whenever you win a coin flip' trigger and gate on won==true (CR 705.1)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2289,15 +2289,18 @@ pub(super) fn match_rolled_die(
     }
 }
 
-/// CR 705: Match coin flip events.
+/// CR 705.1: "Whenever [player] wins a coin flip" — fires only on a winning
+/// flip (won == true). The player who flipped the coin is checked against
+/// valid_target (Controller for "you win", unset for "a player wins").
 pub(super) fn match_flipped_coin(
     event: &GameEvent,
     trigger: &TriggerDefinition,
     source_id: ObjectId,
     state: &GameState,
 ) -> bool {
-    if let GameEvent::CoinFlipped { player_id, .. } = event {
-        valid_player_matches(trigger, state, *player_id, source_id)
+    if let GameEvent::CoinFlipped { player_id, won } = event {
+        // CR 705.1: only fire when the relevant player won the flip.
+        *won && valid_player_matches(trigger, state, *player_id, source_id)
     } else {
         false
     }
@@ -7405,6 +7408,52 @@ mod tests {
         assert!(
             match_changes_zone(&opp_milled_event, &trigger, source, &state),
             "parsed Undead Alchemist trigger must fire when an opponent's creature is milled"
+        );
+    }
+
+    /// CR 705.1: match_flipped_coin fires only when won == true.
+    /// When the controller wins (won=true, player_id=controller) it fires.
+    /// When the controller loses (won=false) it does not.
+    /// When an opponent wins it does not fire (with Controller scoping).
+    #[test]
+    fn flipped_coin_fires_only_on_win() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Tavern Scoundrel".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut trigger = make_trigger(TriggerMode::FlippedCoin);
+        trigger.valid_target = Some(TargetFilter::Controller);
+
+        let win_event = GameEvent::CoinFlipped {
+            player_id: PlayerId(0),
+            won: true,
+        };
+        assert!(
+            match_flipped_coin(&win_event, &trigger, source, &state),
+            "trigger must fire when controller wins a coin flip"
+        );
+
+        let lose_event = GameEvent::CoinFlipped {
+            player_id: PlayerId(0),
+            won: false,
+        };
+        assert!(
+            !match_flipped_coin(&lose_event, &trigger, source, &state),
+            "trigger must not fire when controller loses a coin flip"
+        );
+
+        let opp_wins_event = GameEvent::CoinFlipped {
+            player_id: PlayerId(1),
+            won: true,
+        };
+        assert!(
+            !match_flipped_coin(&opp_wins_event, &trigger, source, &state),
+            "trigger must not fire when opponent wins (Controller scoping)"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -6916,6 +6916,31 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         return Some((TriggerMode::LifeLost, def));
     }
 
+    // CR 705.1 + CR 603.2: "Whenever you win a coin flip" — fires when a coin
+    // flips and the controller is the winner (won == true). Cards: Tavern
+    // Scoundrel, Chance Encounter, Toothy and Zndrsplt, Setzer, Wandering Gambler.
+    // valid_target = Controller scopes the player; match_flipped_coin checks won.
+    if matches!(
+        lower,
+        "whenever you win a coin flip" | "when you win a coin flip"
+    ) {
+        let mut def = make_base();
+        def.mode = TriggerMode::FlippedCoin;
+        def.valid_target = Some(TargetFilter::Controller);
+        return Some((TriggerMode::FlippedCoin, def));
+    }
+
+    // CR 705.1: "Whenever a player wins a coin flip" — any player wins.
+    // Cards: Okaun, Eye of Chaos; Zndrsplt, Eye of Wisdom.
+    if matches!(
+        lower,
+        "whenever a player wins a coin flip" | "when a player wins a coin flip"
+    ) {
+        let mut def = make_base();
+        def.mode = TriggerMode::FlippedCoin;
+        return Some((TriggerMode::FlippedCoin, def));
+    }
+
     // CR 601.2: "Whenever you cast a/an [type] spell [post-spell modifier]" — extract
     // the spell filter. Handles pre-spell type qualifier, post-spell modifier
     // (e.g. "with {X} in its mana cost", CR 107.3 + CR 202.1), or both.
@@ -20098,5 +20123,48 @@ mod snapshot_tests {
         );
         assert_eq!(def.mode, TriggerMode::Exerted);
         assert!(def.valid_card.is_some());
+    }
+
+    /// CR 705.1: "Whenever you win a coin flip" — Tavern Scoundrel, Chance
+    /// Encounter, Toothy and Zndrsplt, Setzer. Must produce FlippedCoin with
+    /// valid_target = Controller so match_flipped_coin can scope it to the
+    /// controller's winning flips.
+    #[test]
+    fn trigger_you_win_a_coin_flip() {
+        let def = parse_trigger_line(
+            "Whenever you win a coin flip, create two Treasure tokens.",
+            "Tavern Scoundrel",
+        );
+        assert_eq!(
+            def.mode,
+            TriggerMode::FlippedCoin,
+            "expected FlippedCoin mode, got {:?}",
+            def.mode
+        );
+        assert_eq!(
+            def.valid_target,
+            Some(TargetFilter::Controller),
+            "valid_target must be Controller to scope to the player"
+        );
+    }
+
+    /// CR 705.1: "Whenever a player wins a coin flip" — Okaun, Eye of Chaos;
+    /// Zndrsplt, Eye of Wisdom. No valid_target restriction (fires for any player).
+    #[test]
+    fn trigger_a_player_wins_a_coin_flip() {
+        let def = parse_trigger_line(
+            "Whenever a player wins a coin flip, draw a card.",
+            "Zndrsplt, Eye of Wisdom",
+        );
+        assert_eq!(
+            def.mode,
+            TriggerMode::FlippedCoin,
+            "expected FlippedCoin mode, got {:?}",
+            def.mode
+        );
+        assert_eq!(
+            def.valid_target, None,
+            "valid_target must be None (any player wins)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two-part fix enabling the engine to parse **"Whenever you win a coin flip"** triggered abilities and correctly gate them on the outcome of the flip.

### Root cause

**Parser**: `try_parse_player_trigger` had no arm for `"win a coin flip"` text, so these triggers fell through to `TriggerMode::Unknown`.

**Matcher**: `match_flipped_coin` fired on ANY `CoinFlipped` event regardless of the `won` field — meaning it would (incorrectly) fire even when the player *lost* the flip.

### Changes

**`crates/engine/src/parser/oracle_trigger.rs`**

Add two arms to `try_parse_player_trigger`:

```rust
// "whenever you win a coin flip" — Controller-scoped win trigger
if matches!(lower, "whenever you win a coin flip" | ...) {
    def.mode = TriggerMode::FlippedCoin;
    def.valid_target = Some(TargetFilter::Controller);
    ...
}
// "whenever a player wins a coin flip" — any player, unscoped
if matches!(lower, "whenever a player wins a coin flip" | ...) {
    def.mode = TriggerMode::FlippedCoin;
    ...
}
```

**`crates/engine/src/game/trigger_matchers.rs`**

Update `match_flipped_coin` to require `won == true`:

```rust
if let GameEvent::CoinFlipped { player_id, won } = event {
    *won && valid_player_matches(trigger, state, *player_id, source_id)
}
```

### Affected cards

| Card | Oracle text |
|---|---|
| Tavern Scoundrel | Whenever you win a coin flip, create two Treasure tokens |
| Chance Encounter | Whenever you win a coin flip, put a luck counter on this enchantment |
| Toothy and Zndrsplt | Whenever you win a coin flip, put a +1/+1 counter on this creature |
| Setzer, Wandering Gambler | Whenever you win a coin flip, create two tapped Treasure tokens |
| Okaun, Eye of Chaos | Whenever a player wins a coin flip, double ~'s power and toughness until end of turn |
| Zndrsplt, Eye of Wisdom | Whenever a player wins a coin flip, draw a card |

### Tests added

- `oracle_trigger::trigger_you_win_a_coin_flip`
- `oracle_trigger::trigger_a_player_wins_a_coin_flip`
- `trigger_matchers::flipped_coin_fires_only_on_win`

🤖 Generated with [Claude Code](https://claude.com/claude-code)