### PR TITLE
Fix #954 multiplayer first-turn draw (CR 103.8c)

### DIFF
--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1157,10 +1157,34 @@ pub fn finish_cleanup_discard(
     false
 }
 
-/// CR 103.8a: The player who goes first skips their first draw step.
-/// CR 614.1b + CR 614.10: Also skip if a "skip your draw step" static is active.
+/// CR 103.8: Whether the player who goes first skips their first draw step.
+/// - CR 103.8a: In a two-player game, the player who plays first skips it.
+/// - CR 103.8b: In Two-Headed Giant, the team who plays first skips it.
+/// - CR 103.8c: In all other multiplayer games (Free-for-All, 3+ player
+///   Commander, etc.) no player skips the draw step of their first turn.
+///
+/// The two-player check uses `state.players.len() == 2` rather than the
+/// game format, because a two-player Commander game is still a two-player
+/// game per CR 903.2 (Commander supports both two-player and multiplayer
+/// setups) — the skip rule applies to it.
+///
+/// The shared-team-turns check uses `state.format_config.team_based` to
+/// match the engine's existing precedent in `game/players.rs`,
+/// `game/elimination.rs`, and `game/priority.rs`. Semantically this gates
+/// on "any shared-team-turns format" (CR 805) — currently only Two-Headed
+/// Giant (CR 810; CR 810.6 specifically restates the first-team draw
+/// skip), but the predicate stays aligned with how every other engine
+/// site recognises team-based turn structure.
+fn first_player_skips_first_draw(state: &GameState) -> bool {
+    state.format_config.team_based || state.players.len() == 2
+}
+
+/// CR 103.8 + CR 614.1b + CR 614.10: Whether the active player should skip
+/// the draw step right now. Combines the first-turn rule above with any
+/// "skip your draw step" static / one-shot replacements.
 pub fn should_skip_draw(state: &GameState) -> bool {
-    state.turn_number == 1 || should_skip_step_static(state, Phase::Draw)
+    (state.turn_number == 1 && first_player_skips_first_draw(state))
+        || should_skip_step_static(state, Phase::Draw)
 }
 
 /// CR 614.1b + CR 614.10: Check whether the active player should skip the given step
@@ -1300,11 +1324,16 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 };
             }
             Phase::Draw => {
-                // CR 103.7a: The first player skips their first-turn draw step
-                // entirely — no draw, no triggers, no priority.
+                // CR 103.8: The starting player skips their first-turn draw
+                // step only in a two-player game (CR 103.8a) or Two-Headed
+                // Giant (CR 103.8b) — not in 3+ player multiplayer
+                // (CR 103.8c). `first_player_skips_first_draw` encodes this
+                // gate so it stays in sync with `should_skip_draw`.
                 // CR 614.10a + CR 614.1b: Other "skip your draw step" effects
                 // (replacements or static abilities) also remove the whole step.
-                if state.turn_number == 1 || should_skip_step_now(state, Phase::Draw) {
+                if (state.turn_number == 1 && first_player_skips_first_draw(state))
+                    || should_skip_step_now(state, Phase::Draw)
+                {
                     advance_phase(state, events);
                     continue;
                 }
@@ -3131,6 +3160,65 @@ mod tests {
         assert!(!should_skip_draw(&state));
     }
 
+    /// CR 103.8c: In multiplayer games other than Two-Headed Giant, the
+    /// starting player does NOT skip their first draw step. Issue #954 —
+    /// engine previously hardcoded the 2-player rule and silently dropped the
+    /// first-turn draw in 3+ player Commander.
+    #[test]
+    fn multiplayer_starting_player_does_not_skip_first_draw() {
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::commander(), 4, 42);
+        state.turn_number = 1;
+        assert!(
+            !should_skip_draw(&state),
+            "CR 103.8c: 4-player Commander game must not skip the starting \
+             player's first draw step",
+        );
+
+        // Sanity: a 3-player free-for-all is also multiplayer.
+        let mut state3 = GameState::new(FormatConfig::standard(), 3, 42);
+        state3.turn_number = 1;
+        assert!(
+            !should_skip_draw(&state3),
+            "CR 103.8c: 3-player game must not skip the starting player's \
+             first draw step",
+        );
+    }
+
+    /// CR 103.8b: In Two-Headed Giant the team who plays first DOES skip
+    /// their first draw step, even though the game has 4 players.
+    #[test]
+    fn two_headed_giant_first_team_skips_first_draw() {
+        use crate::types::format::{FormatConfig, GameFormat};
+
+        let mut config = FormatConfig::standard();
+        config.format = GameFormat::TwoHeadedGiant;
+        config.team_based = true;
+        let mut state = GameState::new(config, 4, 42);
+        state.turn_number = 1;
+        assert!(
+            should_skip_draw(&state),
+            "CR 103.8b: Two-Headed Giant first team must skip the first \
+             draw step",
+        );
+    }
+
+    /// CR 103.8a: A two-player Commander game is still a two-player game per
+    /// CR 903.2; the first player skips their first draw step.
+    #[test]
+    fn two_player_commander_still_skips_first_draw() {
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::commander(), 2, 42);
+        state.turn_number = 1;
+        assert!(
+            should_skip_draw(&state),
+            "CR 103.8a + CR 903.2: 2-player Commander still skips the first \
+             player's first draw step",
+        );
+    }
+
     /// End-to-end: drive the engine through End-step priority passes and verify
     /// that with > 7 cards in hand, the resulting WaitingFor is DiscardToHandSize.
     /// Mirrors the user-visible flow (no direct execute_cleanup call).
@@ -3417,6 +3505,46 @@ mod tests {
         // Card should still be in library
         assert!(state.players[0].library.contains(&id));
         assert!(!state.players[0].hand.contains(&id));
+    }
+
+    /// CR 103.8c + issue #954: In a 4-player Commander game, the starting
+    /// player must draw on their first turn — `auto_advance` should not skip
+    /// the draw step. Mirrors `auto_advance_skips_draw_on_first_turn` (the
+    /// 2-player case) and pins the call-site gate at the `Phase::Draw` arm
+    /// of the auto_advance loop, complementing the predicate-level tests.
+    ///
+    /// Starts directly at `Phase::Draw` (rather than `Phase::Untap`) so the
+    /// `Phase::Draw` arm executes before auto_advance returns at the next
+    /// priority window — the 2-player mirror test passes vacuously because
+    /// auto_advance pauses at the Upkeep priority window before the Draw
+    /// arm is reached, but here we need to confirm the Draw arm actually
+    /// performs the turn-based draw.
+    #[test]
+    fn auto_advance_does_not_skip_draw_on_first_turn_in_multiplayer() {
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::commander(), 4, 42);
+        state.phase = Phase::Draw;
+        state.turn_number = 1;
+        state.active_player = PlayerId(0);
+
+        // Add a card to library (should be drawn — multiplayer does not skip).
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Card".to_string(),
+            Zone::Library,
+        );
+
+        let mut events = Vec::new();
+        auto_advance(&mut state, &mut events);
+
+        assert!(
+            state.players[0].hand.contains(&id),
+            "CR 103.8c: 4-player Commander must perform the first-turn draw",
+        );
+        assert!(!state.players[0].library.contains(&id));
     }
 
     #[test]

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -4,6 +4,7 @@ use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{ReplacementDefinition, RestrictionExpiry};
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
+use crate::types::format::GameFormat;
 use crate::types::game_state::{AutoPassMode, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::phase::Phase;
@@ -1168,15 +1169,11 @@ pub fn finish_cleanup_discard(
 /// game per CR 903.2 (Commander supports both two-player and multiplayer
 /// setups) — the skip rule applies to it.
 ///
-/// The shared-team-turns check uses `state.format_config.team_based` to
-/// match the engine's existing precedent in `game/players.rs`,
-/// `game/elimination.rs`, and `game/priority.rs`. Semantically this gates
-/// on "any shared-team-turns format" (CR 805) — currently only Two-Headed
-/// Giant (CR 810; CR 810.6 specifically restates the first-team draw
-/// skip), but the predicate stays aligned with how every other engine
-/// site recognises team-based turn structure.
+/// The team case intentionally checks the format enum rather than the broader
+/// `team_based` axis: CR 103.8b names Two-Headed Giant specifically, while
+/// CR 805 shared-team-turns can be used by other multiplayer variants.
 fn first_player_skips_first_draw(state: &GameState) -> bool {
-    state.format_config.team_based || state.players.len() == 2
+    matches!(state.format_config.format, GameFormat::TwoHeadedGiant) || state.players.len() == 2
 }
 
 /// CR 103.8 + CR 614.1b + CR 614.10: Whether the active player should skip
@@ -3190,12 +3187,9 @@ mod tests {
     /// their first draw step, even though the game has 4 players.
     #[test]
     fn two_headed_giant_first_team_skips_first_draw() {
-        use crate::types::format::{FormatConfig, GameFormat};
+        use crate::types::format::FormatConfig;
 
-        let mut config = FormatConfig::standard();
-        config.format = GameFormat::TwoHeadedGiant;
-        config.team_based = true;
-        let mut state = GameState::new(config, 4, 42);
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
         state.turn_number = 1;
         assert!(
             should_skip_draw(&state),


### PR DESCRIPTION
## Summary

Fixes #954. In Commander multiplayer games (3+ players), the starting player was incorrectly skipping their first-turn draw step — applying the CR 103.8a two-player rule unconditionally. Per CR 103.8c, multiplayer games other than Two-Headed Giant do NOT skip the first draw.

- Replace the bare `state.turn_number == 1` skip predicate (in both `should_skip_draw` and the `auto_advance` `Phase::Draw` arm) with `first_player_skips_first_draw`, gated on `state.format_config.team_based || state.players.len() == 2`.
- The `team_based` axis matches the engine's existing precedent in `elimination.rs`, `priority.rs`, and `players.rs` — keeps the new predicate aligned with how the engine already classifies shared-team-turns formats.
- Two-player Commander still correctly skips (CR 103.8a + CR 903.2). Two-Headed Giant still correctly skips (CR 103.8b + CR 810.6 — first team skips even with 4 players). 3+ player free-for-all or 3+ player Commander correctly does NOT skip.

## Files changed

| File | Change |
|------|--------|
| `crates/engine/src/game/turns.rs` | New `first_player_skips_first_draw` predicate gated on `team_based || players.len() == 2`. Both `should_skip_draw` and the inline `auto_advance` Draw-arm check delegate to it. Three predicate-level tests + one `auto_advance` integration test added. |

## CR references

- **CR 103.8 / 103.8a / 103.8b / 103.8c** — first-turn draw skip per game format
- **CR 805** — Shared Team Turns Option (semantic gate for `team_based`)
- **CR 810 / 810.6** — Two-Headed Giant first-team draw skip (the only `team_based: true` format today)
- **CR 903.2** — Commander supports both two-player and multiplayer setups
- **CR 614.1b / 614.10 / 614.10a** — other "skip your draw step" effects (statics + one-shot replacements) preserved unchanged

## Track

Developer (full local verification)

## LLM

Claude Opus 4.7 (Claude Code) — medium thinking

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo test -p engine --lib` (8414 passing — 3 new predicate tests + 1 new auto_advance integration test)
- [x] `cargo test -p phase-ai`
- [x] doc-guardian audit clean (CR annotations verified against `docs/MagicCompRules.txt`)
- [x] code-reviewer audit clean (after one fix round addressing CR 805→810 cross-reference, `team_based` precedent alignment, and the `auto_advance` integration test gap)
- [x] qa-tester: READY FOR PR

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None (pre-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
