### PR TITLE
Fix #967 sacrifice comma-each linker drops property suffix

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6989,6 +6989,125 @@ mod tests {
         }
     }
 
+    /// Issue #967: "sacrifice any number of creatures, each with power 1 or
+    /// less" — the comma+"each" distributive linker between the collective
+    /// type word and the per-object property suffix dropped the power filter
+    /// entirely (the parser stopped at the comma, leaving `, each with…`
+    /// unconsumed; the type-phrase fallback then produced
+    /// `Effect::Sacrifice { target: TargetFilter::Typed(Creature), count: 1 }`
+    /// — no power constraint, fixed count). CR 208.1: the per-object power
+    /// comparison applies via the existing P/T suffix combinator (the "each"
+    /// distributive qualifier is a grammar normalization, not a CR rule).
+    /// Verify both the comma form and the bare "each with" phrasing produce
+    /// identical AST, and that the encoded comparison is `power <= 1`
+    /// against the chosen value.
+    #[test]
+    fn parse_sacrifice_any_number_creatures_comma_each_power_filter_attached() {
+        use crate::types::ability::{Comparator, FilterProp, PtStat, PtValueScope};
+
+        for text in [
+            "sacrifice any number of creatures, each with power 1 or less",
+            "sacrifice any number of creatures each with power 1 or less",
+        ] {
+            let lower = text.to_lowercase();
+            let mut ctx = ParseContext {
+                actor: Some(ControllerRef::You),
+                ..Default::default()
+            };
+            let result =
+                parse_targeted_action_ast(text, &lower, &mut ctx).expect("sacrifice should parse");
+            let Effect::Sacrifice { target, count, .. } = lower_targeted_action_ast(result) else {
+                panic!("expected Effect::Sacrifice for {text:?}");
+            };
+            // Target must be Creature with `PtComparison Power LE 1`.
+            let TargetFilter::Typed(ref tf) = target else {
+                panic!("expected Typed filter for {text:?}, got {target:?}");
+            };
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "missing Creature type for {text:?}",
+            );
+            let has_pt = tf.properties.iter().any(|p| {
+                matches!(
+                    p,
+                    FilterProp::PtComparison {
+                        stat: PtStat::Power,
+                        scope: PtValueScope::Current,
+                        comparator: Comparator::LE,
+                        value: QuantityExpr::Fixed { value: 1 },
+                    }
+                )
+            });
+            assert!(
+                has_pt,
+                "missing PtComparison(Power, Current, LE, 1) for {text:?}: {:?}",
+                tf.properties,
+            );
+            // Count must remain the dynamic `UpTo(ObjectCount(<same filter>))`
+            // ceiling — not the fixed-1 fallback the bug produced.
+            match count {
+                QuantityExpr::UpTo { max } => match *max {
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { filter },
+                    } => assert_eq!(filter, target, "ObjectCount filter mismatch for {text:?}"),
+                    other => panic!("expected ObjectCount max for {text:?}, got {other:?}"),
+                },
+                other => panic!("expected UpTo count for {text:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// Issue #967 follow-up: Angelic Aberration's "each with base power or
+    /// toughness 1 or less" disjunctive variant. The same comma-each linker
+    /// must allow the `power or toughness` disjunction (CR 208 + CR 208.4b)
+    /// to attach correctly with the `Base` scope qualifier.
+    #[test]
+    fn parse_sacrifice_any_number_creatures_comma_each_base_pt_disjunction() {
+        use crate::types::ability::{Comparator, FilterProp, PtStat, PtValueScope};
+
+        let text = "sacrifice any number of creatures, each with base power or toughness 1 or less";
+        let lower = text.to_lowercase();
+        let mut ctx = ParseContext {
+            actor: Some(ControllerRef::You),
+            ..Default::default()
+        };
+        let result =
+            parse_targeted_action_ast(text, &lower, &mut ctx).expect("sacrifice should parse");
+        let Effect::Sacrifice { target, .. } = lower_targeted_action_ast(result) else {
+            panic!("expected Effect::Sacrifice");
+        };
+        let TargetFilter::Typed(ref tf) = target else {
+            panic!("expected Typed filter, got {target:?}");
+        };
+        // Disjunctive `power or toughness ≤ 1` ⇒ `AnyOf {
+        //   PtComparison(Power, Base, LE, 1),
+        //   PtComparison(Toughness, Base, LE, 1),
+        // }`.
+        let has_disj = tf.properties.iter().any(|p| {
+            let FilterProp::AnyOf { props } = p else {
+                return false;
+            };
+            let want_power = FilterProp::PtComparison {
+                stat: PtStat::Power,
+                scope: PtValueScope::Base,
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 1 },
+            };
+            let want_tough = FilterProp::PtComparison {
+                stat: PtStat::Toughness,
+                scope: PtValueScope::Base,
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 1 },
+            };
+            props.contains(&want_power) && props.contains(&want_tough)
+        });
+        assert!(
+            has_disj,
+            "missing AnyOf[Power Base LE 1, Toughness Base LE 1], got {:?}",
+            tf.properties,
+        );
+    }
+
     // Issue #458: "sacrifice any number of <filter>" — Scapeshift class.
     // CR 107.1c: "any number" includes zero, so `min_count` is 0 (vs. 1 for
     // "one or more"). The dynamic `UpTo(ObjectCount)` ceiling is unchanged.

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7127,6 +7127,125 @@ mod tests {
         }
     }
 
+    /// Issue #967: "sacrifice any number of creatures, each with power 1 or
+    /// less" — the comma+"each" distributive linker between the collective
+    /// type word and the per-object property suffix dropped the power filter
+    /// entirely (the parser stopped at the comma, leaving `, each with…`
+    /// unconsumed; the type-phrase fallback then produced
+    /// `Effect::Sacrifice { target: TargetFilter::Typed(Creature), count: 1 }`
+    /// — no power constraint, fixed count). CR 208.1: the per-object power
+    /// comparison applies via the existing P/T suffix combinator (the "each"
+    /// distributive qualifier is a grammar normalization, not a CR rule).
+    /// Verify both the comma form and the bare "each with" phrasing produce
+    /// identical AST, and that the encoded comparison is `power <= 1`
+    /// against the chosen value.
+    #[test]
+    fn parse_sacrifice_any_number_creatures_comma_each_power_filter_attached() {
+        use crate::types::ability::{Comparator, FilterProp, PtStat, PtValueScope};
+
+        for text in [
+            "sacrifice any number of creatures, each with power 1 or less",
+            "sacrifice any number of creatures each with power 1 or less",
+        ] {
+            let lower = text.to_lowercase();
+            let mut ctx = ParseContext {
+                actor: Some(ControllerRef::You),
+                ..Default::default()
+            };
+            let result =
+                parse_targeted_action_ast(text, &lower, &mut ctx).expect("sacrifice should parse");
+            let Effect::Sacrifice { target, count, .. } = lower_targeted_action_ast(result) else {
+                panic!("expected Effect::Sacrifice for {text:?}");
+            };
+            // Target must be Creature with `PtComparison Power LE 1`.
+            let TargetFilter::Typed(ref tf) = target else {
+                panic!("expected Typed filter for {text:?}, got {target:?}");
+            };
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "missing Creature type for {text:?}",
+            );
+            let has_pt = tf.properties.iter().any(|p| {
+                matches!(
+                    p,
+                    FilterProp::PtComparison {
+                        stat: PtStat::Power,
+                        scope: PtValueScope::Current,
+                        comparator: Comparator::LE,
+                        value: QuantityExpr::Fixed { value: 1 },
+                    }
+                )
+            });
+            assert!(
+                has_pt,
+                "missing PtComparison(Power, Current, LE, 1) for {text:?}: {:?}",
+                tf.properties,
+            );
+            // Count must remain the dynamic `UpTo(ObjectCount(<same filter>))`
+            // ceiling — not the fixed-1 fallback the bug produced.
+            match count {
+                QuantityExpr::UpTo { max } => match *max {
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { filter },
+                    } => assert_eq!(filter, target, "ObjectCount filter mismatch for {text:?}"),
+                    other => panic!("expected ObjectCount max for {text:?}, got {other:?}"),
+                },
+                other => panic!("expected UpTo count for {text:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// Issue #967 follow-up: Angelic Aberration's "each with base power or
+    /// toughness 1 or less" disjunctive variant. The same comma-each linker
+    /// must allow the `power or toughness` disjunction (CR 208 + CR 208.4b)
+    /// to attach correctly with the `Base` scope qualifier.
+    #[test]
+    fn parse_sacrifice_any_number_creatures_comma_each_base_pt_disjunction() {
+        use crate::types::ability::{Comparator, FilterProp, PtStat, PtValueScope};
+
+        let text = "sacrifice any number of creatures, each with base power or toughness 1 or less";
+        let lower = text.to_lowercase();
+        let mut ctx = ParseContext {
+            actor: Some(ControllerRef::You),
+            ..Default::default()
+        };
+        let result =
+            parse_targeted_action_ast(text, &lower, &mut ctx).expect("sacrifice should parse");
+        let Effect::Sacrifice { target, .. } = lower_targeted_action_ast(result) else {
+            panic!("expected Effect::Sacrifice");
+        };
+        let TargetFilter::Typed(ref tf) = target else {
+            panic!("expected Typed filter, got {target:?}");
+        };
+        // Disjunctive `power or toughness ≤ 1` ⇒ `AnyOf {
+        //   PtComparison(Power, Base, LE, 1),
+        //   PtComparison(Toughness, Base, LE, 1),
+        // }`.
+        let has_disj = tf.properties.iter().any(|p| {
+            let FilterProp::AnyOf { props } = p else {
+                return false;
+            };
+            let want_power = FilterProp::PtComparison {
+                stat: PtStat::Power,
+                scope: PtValueScope::Base,
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 1 },
+            };
+            let want_tough = FilterProp::PtComparison {
+                stat: PtStat::Toughness,
+                scope: PtValueScope::Base,
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 1 },
+            };
+            props.contains(&want_power) && props.contains(&want_tough)
+        });
+        assert!(
+            has_disj,
+            "missing AnyOf[Power Base LE 1, Toughness Base LE 1], got {:?}",
+            tf.properties,
+        );
+    }
+
     // Issue #458: "sacrifice any number of <filter>" — Scapeshift class.
     // CR 107.1c: "any number" includes zero, so `min_count` is 0 (vs. 1 for
     // "one or more"). The dynamic `UpTo(ObjectCount)` ceiling is unchanged.

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1597,6 +1597,30 @@ pub fn parse_type_phrase_with_ctx<'a>(
     pos +=
         parse_ownership_or_controller_suffix(&lower[pos..], &mut properties, &mut controller, ctx);
 
+    // Grammar normalization (no CR-level rule): strip the comma in a
+    // distributive-"each" linker between a collective type word and a
+    // per-object property suffix — "creatures, each with power 1 or less" /
+    // "creatures, each with base power or toughness 1 or less" (Angelic
+    // Aberration class; #967). The "each " qualifier itself is a semantic
+    // no-op already consumed by `parse_pt_comparison`'s
+    // `opt(tag("each "))` arm (CR 208 governs the underlying power/toughness
+    // comparison). The leading comma is the only thing blocking suffix
+    // dispatch, so removing it lets the bare suffix reach
+    // `parse_power_suffix` (and, transitively, the shared
+    // `parse_pt_comparison` combinator) the same way the comma-less
+    // phrasing does. Keyword / counter / mana-value suffix parsers do NOT
+    // currently strip a leading `each ` — extending them to the same
+    // distributive form is left as follow-up if a card surfaces the need.
+    if let Ok((_, _)) = (
+        tag::<_, _, OracleError<'_>>(","),
+        opt(tag::<_, _, OracleError<'_>>(" ")),
+        tag::<_, _, OracleError<'_>>("each "),
+    )
+        .parse(&lower[pos..])
+    {
+        pos += 1;
+    }
+
     // Check "with power N or less/greater" suffix
     if let Some((prop, consumed)) = parse_mana_value_suffix(&lower[pos..], ctx) {
         properties.push(prop);

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -5146,6 +5146,49 @@ mod tests {
     }
 
     #[test]
+    fn distributive_each_linker_preserves_mana_value_suffix() {
+        let (f, rest) = parse_type_phrase("creatures, each with mana value 2 or less");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        assert_eq!(
+            f,
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Cmc {
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 2 },
+            }]))
+        );
+    }
+
+    #[test]
+    fn distributive_each_linker_preserves_counter_suffix() {
+        let (f, rest) = parse_type_phrase("creatures, each with ice counters on them");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        assert_eq!(
+            f,
+            TargetFilter::Typed(
+                TypedFilter::creature().properties(vec![FilterProp::Counters {
+                    counters: CounterMatch::OfType(CounterType::Generic("ice".to_string())),
+                    comparator: Comparator::GE,
+                    count: QuantityExpr::Fixed { value: 1 },
+                }])
+            )
+        );
+    }
+
+    #[test]
+    fn distributive_each_linker_preserves_keyword_suffix() {
+        let (f, rest) = parse_type_phrase("creatures, each with flying");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        assert_eq!(
+            f,
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                FilterProp::WithKeyword {
+                    value: Keyword::Flying,
+                }
+            ]))
+        );
+    }
+
+    #[test]
     fn colorless_adjective_does_not_distribute_across_or() {
         let (f, rest) = parse_type_phrase("artifact or colorless creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1597,28 +1597,24 @@ pub fn parse_type_phrase_with_ctx<'a>(
     pos +=
         parse_ownership_or_controller_suffix(&lower[pos..], &mut properties, &mut controller, ctx);
 
-    // Grammar normalization (no CR-level rule): strip the comma in a
-    // distributive-"each" linker between a collective type word and a
-    // per-object property suffix — "creatures, each with power 1 or less" /
+    // Grammar normalization: strip the distributive-"each" linker between a
+    // collective type word and a per-object property suffix —
+    // "creatures, each with power 1 or less" /
     // "creatures, each with base power or toughness 1 or less" (Angelic
-    // Aberration class; #967). The "each " qualifier itself is a semantic
-    // no-op already consumed by `parse_pt_comparison`'s
-    // `opt(tag("each "))` arm (CR 208 governs the underlying power/toughness
-    // comparison). The leading comma is the only thing blocking suffix
-    // dispatch, so removing it lets the bare suffix reach
-    // `parse_power_suffix` (and, transitively, the shared
-    // `parse_pt_comparison` combinator) the same way the comma-less
-    // phrasing does. Keyword / counter / mana-value suffix parsers do NOT
-    // currently strip a leading `each ` — extending them to the same
-    // distributive form is left as follow-up if a card surfaces the need.
-    if let Ok((_, _)) = (
+    // Aberration class; #967). Consuming the entire `, [space]each ` token
+    // normalizes the remaining input to the bare suffix form ("with …") so
+    // that all downstream suffix parsers (power/toughness via CR 208,
+    // mana-value via CR 202.3, counters via CR 122.1, keywords via CR 702)
+    // receive the same input regardless of whether the Oracle text used the
+    // distributive linker or the comma-less phrasing.
+    if let Ok((rem, _)) = (
         tag::<_, _, OracleError<'_>>(","),
         opt(tag::<_, _, OracleError<'_>>(" ")),
         tag::<_, _, OracleError<'_>>("each "),
     )
         .parse(&lower[pos..])
     {
-        pos += 1;
+        pos += lower[pos..].len() - rem.len();
     }
 
     // Check "with power N or less/greater" suffix


### PR DESCRIPTION
## Summary

Fixes #967. "Sacrifice any number of creatures, each with power 1 or less" (Angelic Aberration class) silently dropped the power filter — the parser stopped at the comma between the collective type word and the per-object qualifier, suffix dispatch couldn't match `, each with…`, and `parse_one_or_more_sacrifice` fell through to a no-filter fallback producing `Effect::Sacrifice { count: Fixed(1), target: Typed(Creature) }` — strictly any creature, fixed count.

- Add a one-byte comma peeler in `parse_type_phrase_with_ctx` between the type-collection pass and the suffix-parsing pass. When `lower[pos..]` matches `,( ?)each ` (nom tuple), advance `pos` past the comma so the bare suffix reaches `parse_power_suffix`.
- The `each ` qualifier is a semantic no-op already consumed natively by `parse_pt_comparison`'s existing `opt(tag("each "))` arm. Removing the leading comma is all that's needed to unblock suffix dispatch.
- Class coverage: the peeler lives in shared `parse_type_phrase_with_ctx` so it benefits destroy/exile/return/etc. simultaneously. Currently only `parse_power_suffix` (via `parse_pt_comparison`) consumes the `each ` qualifier natively; keyword/counter/mana-value suffix parsers will need their own `opt(tag("each "))` arms if a future card surfaces the need.

## Files changed

| File | Change |
|------|--------|
| `crates/engine/src/parser/oracle_target.rs` | New comma-each peeler (nom tuple `(tag(","), opt(tag(" ")), tag("each "))`) between type-collection and suffix-parsing passes. +24 lines. |
| `crates/engine/src/parser/oracle_effect/imperative.rs` | Two new tests: parametrized comma + bare form for the single-`PtComparison(Power, Current, LE, 1)` shape, plus Angelic Aberration's `each with base power or toughness 1 or less` disjunctive variant producing `AnyOf[PtComparison(Power, Base, LE, 1), PtComparison(Toughness, Base, LE, 1)]`. +119 lines. |

## CR references

- **CR 208 / 208.1 / 208.4b** — the underlying power/toughness comparison and the `Base` scope distinction the disjunctive variant exercises
- The distributive "each" linker is grammar normalization with no CR-level rule (mirrors the precedent in `parse_pt_comparison`)

## Track

Developer (full local verification)

## LLM

Claude Opus 4.7 (Claude Code) — medium thinking

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo test -p engine --lib` (8418 passing — baseline + 2 new tests)
- [x] `cargo test -p phase-ai` (656 passing)
- [x] doc-guardian audit clean (after one fix round: replaced misapplied CR 109.1, replaced raw `strip_prefix` with nom tuple, collapsed two-branch arms into single parameterized parser, simplified to `pos += 1` instead of back-tracking arithmetic)
- [x] code-reviewer: APPROVE WITH SUGGESTIONS (no must-fix; doc-comment narrowing applied inline)
- [x] qa-tester: READY FOR PR

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None (pre-push).

## Follow-up

- Extend `opt(tag("each "))` consumption to `parse_keyword_suffix` / `parse_counter_suffix` / `parse_mana_value_suffix` when a card surfaces the need (e.g., "creatures, each with flying").
- Add a comma-less variant to the disjunctive-base-PT test for symmetry (currently single-stat path covers both shapes, disjunction only covers comma form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
