### PR TITLE
Partial: Ghostfire

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1603,10 +1603,13 @@ pub(crate) fn parse_oracle_ir(
             }
         }
 
-        // Some instants/sorceries carry self color-defining CDA lines
-        // (e.g., "~ is colorless."). Intercept only that narrow class so we
-        // do not steal ordinary spell instruction lines that happen to have
-        // static-like phrasing.
+        // CR 604.3 + CR 604.3a + CR 105.2c: Some instants/sorceries carry
+        // self color-defining characteristic-defining abilities (e.g.,
+        // "~ is colorless.") that define the source's own color in all zones.
+        // Intercept only this narrow class before spell-effect lowering.
+        //
+        // Intercept only that narrow class so we do not steal ordinary spell
+        // instruction lines that happen to have static-like phrasing.
         if is_spell {
             let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
             let is_self_color_cda = defs.len() == 1

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1599,20 +1599,28 @@ pub(crate) fn parse_oracle_ir(
                         i += 2;
                         continue;
                     }
-
-                    // Some instants/sorceries carry static text lines that define their own
-                    // characteristics (e.g., "~ is colorless."). Parse these as statics
-                    // before the spell-resolution catch-all consumes the line as an effect.
-                    if is_spell {
-                        let defs =
-                            parse_static_line_with_graveyard_keyword_continuation(&static_line);
-                        if !defs.is_empty() {
-                            result.statics.extend(defs);
-                            i += 1;
-                            continue;
-                        }
-                    }
                 }
+            }
+        }
+
+        // Some instants/sorceries carry self color-defining CDA lines
+        // (e.g., "~ is colorless."). Intercept only that narrow class so we
+        // do not steal ordinary spell instruction lines that happen to have
+        // static-like phrasing.
+        if is_spell {
+            let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
+            let is_self_color_cda = defs.len() == 1
+                && defs[0].characteristic_defining
+                && defs[0].affected == Some(TargetFilter::SelfRef)
+                && defs[0].modifications.len() == 1
+                && matches!(
+                    defs[0].modifications[0],
+                    ContinuousModification::SetColor { .. }
+                );
+            if is_self_color_cda {
+                result.statics.extend(defs);
+                i += 1;
+                continue;
             }
         }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1599,6 +1599,19 @@ pub(crate) fn parse_oracle_ir(
                         i += 2;
                         continue;
                     }
+
+                    // Some instants/sorceries carry static text lines that define their own
+                    // characteristics (e.g., "~ is colorless."). Parse these as statics
+                    // before the spell-resolution catch-all consumes the line as an effect.
+                    if is_spell {
+                        let defs =
+                            parse_static_line_with_graveyard_keyword_continuation(&static_line);
+                        if !defs.is_empty() {
+                            result.statics.extend(defs);
+                            i += 1;
+                            continue;
+                        }
+                    }
                 }
             }
         }
@@ -4026,6 +4039,42 @@ mod tests {
         );
         assert_eq!(r.abilities.len(), 1);
         assert_eq!(r.abilities[0].kind, AbilityKind::Spell);
+    }
+
+    #[test]
+    fn ghostfire_has_self_color_cda_and_spell_damage() {
+        let r = parse(
+            "Ghostfire is colorless.\nGhostfire deals 3 damage to any target.",
+            "Ghostfire",
+            &[],
+            &["Instant"],
+            &[],
+        );
+
+        assert_eq!(r.statics.len(), 1, "expected one self color CDA static");
+        let static_def = &r.statics[0];
+        assert!(static_def.characteristic_defining);
+        assert_eq!(static_def.affected, Some(TargetFilter::SelfRef));
+        assert_eq!(
+            static_def.modifications,
+            vec![ContinuousModification::SetColor { colors: vec![] }]
+        );
+        assert_eq!(
+            static_def.active_zones,
+            vec![
+                Zone::Library,
+                Zone::Hand,
+                Zone::Battlefield,
+                Zone::Graveyard,
+                Zone::Stack,
+                Zone::Exile,
+                Zone::Command,
+            ]
+        );
+
+        assert_eq!(r.abilities.len(), 1, "expected one spell ability");
+        assert_eq!(r.abilities[0].kind, AbilityKind::Spell);
+        assert!(matches!(*r.abilities[0].effect, Effect::DealDamage { .. }));
     }
 
     /// CR 115.1 + CR 701.9b: "random target X" — the parser stamps

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -10243,76 +10243,7 @@ fn parse_self_subject_is_color_cda(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
-    let (after_subject, subject_lower) = terminated(
-        take_until::<_, _, OracleError<'_>>(" is "),
-        tag::<_, _, OracleError<'_>>(" is "),
-    )
-    .parse(tp.lower)
-    .ok()?;
-
-    let (after_predicate, predicate_lower) = alt((
-        terminated(take_until::<_, _, OracleError<'_>>("."), tag(".")),
-        rest,
-    ))
-    .parse(after_subject)
-    .ok()?;
-    eof::<_, OracleError<'_>>(after_predicate).ok()?;
-
-    let matches_subject = |pattern: &str| {
-        nom_tag_lower(subject_lower, subject_lower, pattern).is_some_and(|rest| rest.is_empty())
-    };
-
-    let is_explicit_self = matches_subject("~")
-        || matches_subject("this card")
-        || SELF_REF_TYPE_PHRASES
-            .iter()
-            .any(|phrase| matches_subject(phrase));
-
-    if !is_explicit_self {
-        let (_, subject_words) =
-            separated_list1(space1::<_, OracleError<'_>>, alpha1::<_, OracleError<'_>>)
-                .parse(subject_lower)
-                .ok()?;
-
-        let has_nonself_subject_word = subject_words.iter().any(|word| {
-            matches!(
-                *word,
-                "all"
-                    | "each"
-                    | "enchanted"
-                    | "equipped"
-                    | "target"
-                    | "other"
-                    | "creature"
-                    | "creatures"
-                    | "permanent"
-                    | "permanents"
-                    | "land"
-                    | "lands"
-                    | "artifact"
-                    | "artifacts"
-                    | "enchantment"
-                    | "enchantments"
-                    | "planeswalker"
-                    | "planeswalkers"
-                    | "battle"
-                    | "battles"
-                    | "player"
-                    | "players"
-                    | "opponent"
-                    | "opponents"
-                    | "spells"
-                    | "cards"
-                    | "tokens"
-            )
-        });
-
-        if has_nonself_subject_word {
-            return None;
-        }
-    }
-
-    let colors = parse_color_predicate(predicate_lower)?;
+    let (_, colors) = parse_self_subject_is_color_cda_line(tp.lower).ok()?;
 
     Some(
         StaticDefinition::continuous()
@@ -10330,6 +10261,47 @@ fn parse_self_subject_is_color_cda(
             .cda()
             .description(description.to_string()),
     )
+}
+
+fn parse_self_subject_is_color_cda_line(input: &str) -> OracleResult<'_, Vec<ManaColor>> {
+    let (after_subject, _) = parse_self_color_subject(input)?;
+    let (after_predicate, predicate_lower) = alt((
+        terminated(take_until::<_, _, OracleError<'_>>("."), tag(".")),
+        rest,
+    ))
+    .parse(after_subject)?;
+    eof::<_, OracleError<'_>>(after_predicate)?;
+    let Some(colors) = parse_color_predicate(predicate_lower) else {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            predicate_lower,
+            nom::error::ErrorKind::Fail,
+        )));
+    };
+    Ok((after_predicate, colors))
+}
+
+fn parse_self_color_subject(input: &str) -> OracleResult<'_, ()> {
+    let (rest, _) = alt((
+        value((), tag::<_, _, OracleError<'_>>("~")),
+        value((), tag("this card")),
+        value((), tag("this spell")),
+        parse_self_ref_type_subject,
+    ))
+    .parse(input)?;
+    let (rest, _) = tag(" is ").parse(rest)?;
+    Ok((rest, ()))
+}
+
+fn parse_self_ref_type_subject(input: &str) -> OracleResult<'_, ()> {
+    for phrase in SELF_REF_TYPE_PHRASES {
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(*phrase).parse(input) {
+            return Ok((rest, ()));
+        }
+    }
+    Err(nom::Err::Error(nom::error::Error::new(
+        input,
+        nom::error::ErrorKind::Fail,
+    )))
 }
 
 /// CR 305.7: Parse "[Subject] lands are [type]" land type-changing static abilities.
@@ -18344,15 +18316,8 @@ mod tests {
     }
 
     #[test]
-    fn static_cardname_is_colorless_parses_as_self_cda() {
-        // Card-name form should route to the same self-CDA shape as "~".
-        let def = parse_static_line("Ghostfire is colorless.").unwrap();
-        assert_eq!(def.affected, Some(TargetFilter::SelfRef));
-        assert!(def.characteristic_defining);
-        assert_eq!(
-            def.modifications,
-            vec![ContinuousModification::SetColor { colors: vec![] }]
-        );
+    fn static_raw_cardname_is_colorless_is_not_contextless_self_cda() {
+        assert!(parse_static_line("Ghostfire is colorless.").is_none());
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -10243,41 +10243,36 @@ fn parse_self_subject_is_color_cda(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
-    let (subject_tp, predicate_tp) = tp.split_around(" is ")?;
-    let subject_lower = subject_tp.lower.trim();
+    let (after_subject, subject_lower) = terminated(
+        take_until::<_, _, OracleError<'_>>(" is "),
+        tag::<_, _, OracleError<'_>>(" is "),
+    )
+    .parse(tp.lower)
+    .ok()?;
 
-    let is_explicit_self = subject_lower == "~"
-        || subject_lower == "this card"
-        || SELF_REF_TYPE_PHRASES.contains(&subject_lower);
+    let (after_predicate, predicate_lower) = alt((
+        terminated(take_until::<_, _, OracleError<'_>>("."), tag(".")),
+        rest,
+    ))
+    .parse(after_subject)
+    .ok()?;
+    eof::<_, OracleError<'_>>(after_predicate).ok()?;
 
-    // Reject obvious non-self class subjects so this branch does not steal
-    // global or attached-object "is" lines from their dedicated parsers.
-    let is_obvious_non_self = nom_tag_lower(subject_lower, subject_lower, "all ").is_some()
-        || nom_tag_lower(subject_lower, subject_lower, "each ").is_some()
-        || nom_tag_lower(subject_lower, subject_lower, "enchanted ").is_some()
-        || nom_tag_lower(subject_lower, subject_lower, "equipped ").is_some()
-        || nom_tag_lower(subject_lower, subject_lower, "target ").is_some()
-        || nom_tag_lower(subject_lower, subject_lower, "other ").is_some()
-        || nom_primitives::scan_contains(subject_lower, " creature")
-        || nom_primitives::scan_contains(subject_lower, "creature ")
-        || nom_primitives::scan_contains(subject_lower, "permanent")
-        || nom_primitives::scan_contains(subject_lower, "land")
-        || nom_primitives::scan_contains(subject_lower, "artifact")
-        || nom_primitives::scan_contains(subject_lower, "enchantment")
-        || nom_primitives::scan_contains(subject_lower, "planeswalker")
-        || nom_primitives::scan_contains(subject_lower, "battle")
-        || nom_primitives::scan_contains(subject_lower, "player")
-        || nom_primitives::scan_contains(subject_lower, "opponent")
-        || nom_primitives::scan_contains(subject_lower, "spells")
-        || nom_primitives::scan_contains(subject_lower, "cards")
-        || nom_primitives::scan_contains(subject_lower, "tokens");
+    let matches_subject = |pattern: &str| {
+        nom_tag_lower(subject_lower, subject_lower, pattern).is_some_and(|rest| rest.is_empty())
+    };
 
-    if !is_explicit_self && is_obvious_non_self {
+    let is_explicit_self = matches_subject("~")
+        || matches_subject("this card")
+        || SELF_REF_TYPE_PHRASES
+            .iter()
+            .any(|phrase| matches_subject(phrase));
+
+    if !is_explicit_self {
         return None;
     }
 
-    let predicate = predicate_tp.lower.trim().trim_end_matches('.');
-    let colors = parse_color_predicate(predicate)?;
+    let colors = parse_color_predicate(predicate_lower)?;
 
     Some(
         StaticDefinition::continuous()

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -10269,7 +10269,47 @@ fn parse_self_subject_is_color_cda(
             .any(|phrase| matches_subject(phrase));
 
     if !is_explicit_self {
-        return None;
+        let (_, subject_words) =
+            separated_list1(space1::<_, OracleError<'_>>, alpha1::<_, OracleError<'_>>)
+                .parse(subject_lower)
+                .ok()?;
+
+        let has_nonself_subject_word = subject_words.iter().any(|word| {
+            matches!(
+                *word,
+                "all"
+                    | "each"
+                    | "enchanted"
+                    | "equipped"
+                    | "target"
+                    | "other"
+                    | "creature"
+                    | "creatures"
+                    | "permanent"
+                    | "permanents"
+                    | "land"
+                    | "lands"
+                    | "artifact"
+                    | "artifacts"
+                    | "enchantment"
+                    | "enchantments"
+                    | "planeswalker"
+                    | "planeswalkers"
+                    | "battle"
+                    | "battles"
+                    | "player"
+                    | "players"
+                    | "opponent"
+                    | "opponents"
+                    | "spells"
+                    | "cards"
+                    | "tokens"
+            )
+        });
+
+        if has_nonself_subject_word {
+            return None;
+        }
     }
 
     let colors = parse_color_predicate(predicate_lower)?;

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -1414,6 +1414,14 @@ fn parse_static_line_inner(text: &str, inverted: InvertedAsLongAs) -> Option<Sta
         );
     }
 
+    // CR 604.3 + CR 604.3a + CR 105.2c + CR 613.1e: Self-scoped
+    // characteristic-defining color line ("~ is colorless.",
+    // "~ is white and blue."). CDAs function in all zones and define the
+    // source object's own color characteristic.
+    if let Some(def) = parse_self_subject_is_color_cda(&tp, &text) {
+        return Some(def);
+    }
+
     // --- CDA: "~'s power is equal to the number of card types among cards in all graveyards
     //     and its toughness is equal to that number plus 1" (Tarmogoyf) ---
     if let Some(def) = parse_cda_pt_equality(tp.lower, tp.original) {
@@ -10225,6 +10233,70 @@ fn parse_color_predicate(text: &str) -> Option<Vec<ManaColor>> {
     parse_color_list(text)
 }
 
+/// CR 604.3 + CR 604.3a + CR 105.2c + CR 613.1e: Parse self-referential
+/// "[self subject] is [color expression]." lines into a color CDA.
+///
+/// This covers the class of card text that defines the source object's own
+/// color as a characteristic (Ghostfire-style), not global/class filters
+/// handled by `parse_all_subject_are_color`.
+fn parse_self_subject_is_color_cda(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    let (subject_tp, predicate_tp) = tp.split_around(" is ")?;
+    let subject_lower = subject_tp.lower.trim();
+
+    let is_explicit_self = subject_lower == "~"
+        || subject_lower == "this card"
+        || SELF_REF_TYPE_PHRASES.contains(&subject_lower);
+
+    // Reject obvious non-self class subjects so this branch does not steal
+    // global or attached-object "is" lines from their dedicated parsers.
+    let is_obvious_non_self = nom_tag_lower(subject_lower, subject_lower, "all ").is_some()
+        || nom_tag_lower(subject_lower, subject_lower, "each ").is_some()
+        || nom_tag_lower(subject_lower, subject_lower, "enchanted ").is_some()
+        || nom_tag_lower(subject_lower, subject_lower, "equipped ").is_some()
+        || nom_tag_lower(subject_lower, subject_lower, "target ").is_some()
+        || nom_tag_lower(subject_lower, subject_lower, "other ").is_some()
+        || nom_primitives::scan_contains(subject_lower, " creature")
+        || nom_primitives::scan_contains(subject_lower, "creature ")
+        || nom_primitives::scan_contains(subject_lower, "permanent")
+        || nom_primitives::scan_contains(subject_lower, "land")
+        || nom_primitives::scan_contains(subject_lower, "artifact")
+        || nom_primitives::scan_contains(subject_lower, "enchantment")
+        || nom_primitives::scan_contains(subject_lower, "planeswalker")
+        || nom_primitives::scan_contains(subject_lower, "battle")
+        || nom_primitives::scan_contains(subject_lower, "player")
+        || nom_primitives::scan_contains(subject_lower, "opponent")
+        || nom_primitives::scan_contains(subject_lower, "spells")
+        || nom_primitives::scan_contains(subject_lower, "cards")
+        || nom_primitives::scan_contains(subject_lower, "tokens");
+
+    if !is_explicit_self && is_obvious_non_self {
+        return None;
+    }
+
+    let predicate = predicate_tp.lower.trim().trim_end_matches('.');
+    let colors = parse_color_predicate(predicate)?;
+
+    Some(
+        StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::SetColor { colors }])
+            .active_zones(vec![
+                Zone::Library,
+                Zone::Hand,
+                Zone::Battlefield,
+                Zone::Graveyard,
+                Zone::Stack,
+                Zone::Exile,
+                Zone::Command,
+            ])
+            .cda()
+            .description(description.to_string()),
+    )
+}
+
 /// CR 305.7: Parse "[Subject] lands are [type]" land type-changing static abilities.
 /// Handles replacement ("Nonbasic lands are Mountains"), additive ("Each land is a
 /// Swamp in addition to its other land types"), and all-basic-types ("Lands you control
@@ -18209,6 +18281,55 @@ mod tests {
             "expected a land-type modification, got {:?}",
             def.modifications
         );
+    }
+
+    #[test]
+    fn static_self_is_colorless_is_cda_all_zones() {
+        // CR 604.3 + CR 604.3a + CR 105.2c: Ghostfire-style self color CDA.
+        let def = parse_static_line("~ is colorless.").unwrap();
+        assert_eq!(def.mode, StaticMode::Continuous);
+        assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+        assert!(def.characteristic_defining);
+        assert_eq!(
+            def.modifications,
+            vec![ContinuousModification::SetColor { colors: vec![] }]
+        );
+        assert_eq!(
+            def.active_zones,
+            vec![
+                Zone::Library,
+                Zone::Hand,
+                Zone::Battlefield,
+                Zone::Graveyard,
+                Zone::Stack,
+                Zone::Exile,
+                Zone::Command,
+            ]
+        );
+    }
+
+    #[test]
+    fn static_cardname_is_colorless_parses_as_self_cda() {
+        // Card-name form should route to the same self-CDA shape as "~".
+        let def = parse_static_line("Ghostfire is colorless.").unwrap();
+        assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+        assert!(def.characteristic_defining);
+        assert_eq!(
+            def.modifications,
+            vec![ContinuousModification::SetColor { colors: vec![] }]
+        );
+    }
+
+    #[test]
+    fn static_self_is_multicolor_cda() {
+        let def = parse_static_line("~ is white and blue.").unwrap();
+        assert_eq!(
+            def.modifications,
+            vec![ContinuousModification::SetColor {
+                colors: vec![ManaColor::White, ManaColor::Blue]
+            }]
+        );
+        assert!(def.characteristic_defining);
     }
 
     // --- Group A: Chosen color/type creature pump ---


### PR DESCRIPTION
## Summary
Adds engine support for **Ghostfire**.

## Files changed
- crates/engine/src/parser/oracle.rs
- crates/engine/src/parser/oracle_static.rs

## CR references
- CR 105.2c
- CR 604.3
- CR 604.3a
- CR 613.1e

## Track
Developer

## LLM
Model: GPT-5.3-Codex
Thinking: medium

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo test -p engine ghostfire_has_self_color_cda_and_spell_damage` — 1 passed / 0 failed
- `cargo test -p engine static_self_is_colorless_is_cda_all_zones` — 1 passed / 0 failed
- `cargo clippy-strict` — failed to complete cleanly in this environment after retries (build repeatedly stalled at `Building [..] 337/396: engine, engine(test)`)
- `cargo test -p engine` — blocked by cargo lock while `cargo clippy-strict` was stalled
- `./scripts/gen-card-data.sh` — not run (blocked by unresolved clippy/test stage)
- `cargo coverage` — not run (blocked by unresolved clippy/test stage)
- `cargo semantic-audit` — not run (blocked by unresolved clippy/test stage)

## Scope Expansion
Implemented class-level support for self-referential color-defining static lines (e.g., "~ is colorless.", "~ is white and blue.") as CDAs that function in all zones, rather than a Ghostfire-only special case.

## Validation Failures
None.

## CI Failures
Local Developer-track verification could not be completed end-to-end: `cargo clippy-strict` repeatedly stalled at `337/396` in this environment after retries, which blocked full `cargo test -p engine`, `gen-card-data`, `coverage`, and `semantic-audit` steps. Targeted Ghostfire regression tests and parser gate checks passed.