### PR TITLE
Fix The Earth King search trigger count

### DIFF
--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -804,6 +804,10 @@ pub(crate) fn extract_amount_from_event(event: &crate::types::events::GameEvent)
         GameEvent::CounterAdded { count, .. } => Some(*count as i32),
         GameEvent::CounterRemoved { count, .. } => Some(*count as i32),
         GameEvent::Discarded { .. } => Some(1),
+        // CR 508.1m + CR 603.2c: Batched attack-trigger context stores the
+        // attackers that satisfied the trigger subject, so "that many" reads
+        // the size of that contextual attack event.
+        GameEvent::AttackersDeclared { attacker_ids, .. } => Some(attacker_ids.len() as i32),
         // CR 706.2: the final number of a die roll is its result. Lets
         // `EventContextAmount` resolve "where X is the result" pump effects.
         GameEvent::DieRolled { result, .. } => Some(*result as i32),

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -980,24 +980,7 @@ fn attack_target_matches(
     source_id: ObjectId,
 ) -> bool {
     if let Some(filter) = trigger.attack_target_filter.as_ref() {
-        let type_matches = matches!(
-            (filter, target),
-            (
-                crate::types::triggers::AttackTargetFilter::Player,
-                crate::game::combat::AttackTarget::Player(_)
-            ) | (
-                crate::types::triggers::AttackTargetFilter::Planeswalker,
-                crate::game::combat::AttackTarget::Planeswalker(_)
-            ) | (
-                crate::types::triggers::AttackTargetFilter::PlayerOrPlaneswalker,
-                crate::game::combat::AttackTarget::Player(_)
-                    | crate::game::combat::AttackTarget::Planeswalker(_)
-            ) | (
-                crate::types::triggers::AttackTargetFilter::Battle,
-                crate::game::combat::AttackTarget::Battle(_)
-            )
-        );
-        if !type_matches {
+        if !attack_target_type_matches(target, filter) {
             return false;
         }
     }
@@ -1011,7 +994,30 @@ fn attack_target_matches(
     }
 }
 
-fn attack_target_defending_player(
+pub(super) fn attack_target_type_matches(
+    target: crate::game::combat::AttackTarget,
+    filter: &crate::types::triggers::AttackTargetFilter,
+) -> bool {
+    matches!(
+        (filter, target),
+        (
+            crate::types::triggers::AttackTargetFilter::Player,
+            crate::game::combat::AttackTarget::Player(_)
+        ) | (
+            crate::types::triggers::AttackTargetFilter::Planeswalker,
+            crate::game::combat::AttackTarget::Planeswalker(_)
+        ) | (
+            crate::types::triggers::AttackTargetFilter::PlayerOrPlaneswalker,
+            crate::game::combat::AttackTarget::Player(_)
+                | crate::game::combat::AttackTarget::Planeswalker(_)
+        ) | (
+            crate::types::triggers::AttackTargetFilter::Battle,
+            crate::game::combat::AttackTarget::Battle(_)
+        )
+    )
+}
+
+pub(super) fn attack_target_defending_player(
     state: &GameState,
     target: crate::game::combat::AttackTarget,
     fallback_defending_player: PlayerId,
@@ -2225,11 +2231,26 @@ pub(super) fn match_you_attack(
     source_id: ObjectId,
     state: &GameState,
 ) -> bool {
-    let GameEvent::AttackersDeclared { attacker_ids, .. } = event else {
-        return false;
+    !matching_you_attack_pairs(event, trigger, source_id, state).is_empty()
+}
+
+pub(super) fn matching_you_attack_pairs(
+    event: &GameEvent,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+) -> Vec<(ObjectId, crate::game::combat::AttackTarget)> {
+    let GameEvent::AttackersDeclared {
+        attacker_ids,
+        defending_player,
+        attacks,
+        ..
+    } = event
+    else {
+        return Vec::new();
     };
     if attacker_ids.is_empty() {
-        return false;
+        return Vec::new();
     }
     // CR 506.2: the active player is the attacking player; all attackers in
     // a single AttackersDeclared batch share one controller.
@@ -2237,29 +2258,55 @@ pub(super) fn match_you_attack(
         .iter()
         .find_map(|id| state.objects.get(id).map(|o| o.controller))
     else {
-        return false;
+        return Vec::new();
     };
     // CR 603.2c: the player-scope gate (valid_target). No filter ⇒ legacy
     // "attackers controlled by the trigger's source controller" semantics.
-    let player_ok = if trigger.valid_target.is_some() {
-        valid_player_matches(trigger, state, attacking_player, source_id)
-    } else {
-        let source_controller = state.objects.get(&source_id).map(|o| o.controller);
-        Some(attacking_player) == source_controller
+    let player_ok = match trigger.valid_target.as_ref() {
+        // Parser legacy for "one or more creatures attack a player": the
+        // attacked-player type is represented as `TargetFilter::Player`, not
+        // as attacking-player scope. The per-attack target filter below handles
+        // it, so keep the attacking-player gate permissive here.
+        Some(TargetFilter::Player) => true,
+        Some(_) => valid_player_matches(trigger, state, attacking_player, source_id),
+        None => {
+            let source_controller = state.objects.get(&source_id).map(|o| o.controller);
+            Some(attacking_player) == source_controller
+        }
     };
     if !player_ok {
-        return false;
+        return Vec::new();
     }
 
-    // CR 508.1 + CR 603.2c: the attacker-type gate (valid_card). "Attack with one
-    // or more <TYPE>" fires iff at least one attacker in the batch matches the
-    // type filter. No filter ⇒ any attacker (current behavior preserved).
-    match &trigger.valid_card {
-        None => true,
-        Some(filter) => attacker_ids
-            .iter()
-            .any(|id| target_filter_matches_object(state, *id, filter, source_id)),
-    }
+    attacker_ids
+        .iter()
+        .filter_map(|id| {
+            if trigger
+                .valid_card
+                .as_ref()
+                .is_some_and(|filter| !target_filter_matches_object(state, *id, filter, source_id))
+            {
+                return None;
+            }
+            let target = attacks
+                .iter()
+                .find_map(|(attacker_id, target)| (*attacker_id == *id).then_some(*target))
+                .unwrap_or(crate::game::combat::AttackTarget::Player(*defending_player));
+            if trigger
+                .attack_target_filter
+                .as_ref()
+                .is_some_and(|filter| !attack_target_type_matches(target, filter))
+            {
+                return None;
+            }
+            if matches!(trigger.valid_target, Some(TargetFilter::Player))
+                && !matches!(target, crate::game::combat::AttackTarget::Player(_))
+            {
+                return None;
+            }
+            Some((*id, target))
+        })
+        .collect()
 }
 
 /// CR 725.1: Matches when a player becomes the monarch.

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -176,8 +176,8 @@ fn matching_batched_trigger_events(
                 check_trigger_condition(state, condition, controller, Some(obj_id), Some(candidate))
             })
         })
-        .map(|candidate| {
-            contextual_batched_trigger_event(state, candidate, trig_def, obj_id, controller)
+        .filter_map(|candidate| {
+            contextual_batched_trigger_event(state, candidate, trig_def, obj_id)
         })
         .collect()
 }
@@ -187,51 +187,46 @@ fn contextual_batched_trigger_event(
     event: &GameEvent,
     trig_def: &TriggerDefinition,
     obj_id: ObjectId,
-    controller: PlayerId,
-) -> GameEvent {
+) -> Option<GameEvent> {
     let GameEvent::AttackersDeclared {
-        attacker_ids,
-        defending_player,
-        attacks,
+        defending_player, ..
     } = event
     else {
-        return event.clone();
+        return Some(event.clone());
     };
-    if !matches!(trig_def.mode, TriggerMode::YouAttack | TriggerMode::Attacks) {
-        return event.clone();
-    }
 
-    let filter_ctx = FilterContext::from_source_with_controller(obj_id, controller);
-    let matching_attackers: Vec<_> = attacker_ids
+    let matching_attacks = match trig_def.mode {
+        TriggerMode::Attacks => {
+            super::trigger_matchers::matching_attack_events(event, trig_def, obj_id, state)
+                .into_iter()
+                .flat_map(|event| match event {
+                    GameEvent::AttackersDeclared { attacks, .. } => attacks,
+                    _ => Vec::new(),
+                })
+                .collect()
+        }
+        TriggerMode::YouAttack => {
+            super::trigger_matchers::matching_you_attack_pairs(event, trig_def, obj_id, state)
+        }
+        _ => return Some(event.clone()),
+    };
+
+    let matching_attackers: Vec<_> = matching_attacks
         .iter()
-        .copied()
-        .filter(|id| {
-            trig_def
-                .valid_card
-                .as_ref()
-                .is_none_or(|filter| matches_target_filter(state, *id, filter, &filter_ctx))
-        })
+        .map(|(attacker_id, _)| *attacker_id)
         .collect();
-
     if matching_attackers.is_empty() {
-        return event.clone();
+        return None;
     }
-
-    let matching_set: HashSet<_> = matching_attackers.iter().copied().collect();
-    let matching_attacks: Vec<_> = attacks
-        .iter()
-        .copied()
-        .filter(|(attacker_id, _)| matching_set.contains(attacker_id))
-        .collect();
 
     // CR 603.2c + CR 608.2c: batched "one or more ... attack" triggers fire
     // once, but later "that many" text refers to the members of that matching
     // event subset, not every attacker in the declaration.
-    GameEvent::AttackersDeclared {
+    Some(GameEvent::AttackersDeclared {
         attacker_ids: matching_attackers,
         defending_player: *defending_player,
         attacks: matching_attacks,
-    }
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -11707,6 +11702,119 @@ pub mod tests {
                 assert_eq!(*count, 2, "two power-4+ attackers set the search cap");
                 assert!(*up_to, "The Earth King's search is up to that many");
                 assert_eq!(cards.len(), 3, "all three basic lands remain legal choices");
+            }
+            other => panic!("expected SearchChoice, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn batched_attack_context_filters_attacked_target_type() {
+        use crate::game::combat::AttackTarget;
+
+        fn add_basic_land(state: &mut GameState, name: &str) {
+            let id = create_object(
+                state,
+                CardId(state.next_object_id),
+                PlayerId(0),
+                name.to_string(),
+                Zone::Library,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types
+                .supertypes
+                .push(crate::types::card_type::Supertype::Basic);
+        }
+
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        let source = make_creature(&mut state, PlayerId(0), "Attack Trigger Source", 4, 4);
+        let mut trigger =
+            TriggerDefinition::new(TriggerMode::YouAttack).execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::SearchLibrary {
+                    filter: TargetFilter::Typed(TypedFilter::land().properties(vec![
+                        FilterProp::HasSupertype {
+                            value: crate::types::card_type::Supertype::Basic,
+                        },
+                    ])),
+                    count: QuantityExpr::up_to(QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount,
+                    }),
+                    reveal: false,
+                    target_player: None,
+                    selection_constraint: SearchSelectionConstraint::None,
+                    split: None,
+                },
+            ));
+        trigger.batched = true;
+        trigger.valid_card = Some(TargetFilter::Typed(TypedFilter::creature().properties(
+            vec![FilterProp::PtComparison {
+                stat: PtStat::Power,
+                scope: PtValueScope::Current,
+                comparator: Comparator::GE,
+                value: QuantityExpr::Fixed { value: 4 },
+            }],
+        )));
+        trigger.attack_target_filter = Some(AttackTargetFilter::Player);
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .trigger_definitions
+            .push(trigger);
+
+        let attacks_player = make_creature(&mut state, PlayerId(0), "Attacks Player", 4, 4);
+        let attacks_planeswalker =
+            make_creature(&mut state, PlayerId(0), "Attacks Planeswalker", 5, 5);
+        let small_attacks_player =
+            make_creature(&mut state, PlayerId(0), "Small Attacks Player", 3, 3);
+        let planeswalker = create_object(
+            &mut state,
+            CardId(9000),
+            PlayerId(1),
+            "Target Planeswalker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&planeswalker)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Planeswalker);
+        add_basic_land(&mut state, "Plains");
+        add_basic_land(&mut state, "Island");
+        add_basic_land(&mut state, "Forest");
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::AttackersDeclared {
+                attacker_ids: vec![attacks_player, attacks_planeswalker, small_attacks_player],
+                defending_player: PlayerId(1),
+                attacks: vec![
+                    (attacks_player, AttackTarget::Player(PlayerId(1))),
+                    (
+                        attacks_planeswalker,
+                        AttackTarget::Planeswalker(planeswalker),
+                    ),
+                    (small_attacks_player, AttackTarget::Player(PlayerId(1))),
+                ],
+            }],
+        );
+
+        assert_eq!(state.stack.len(), 1, "filtered attack trigger should fire");
+        let mut events = Vec::new();
+        crate::game::stack::resolve_top(&mut state, &mut events);
+
+        match &state.waiting_for {
+            WaitingFor::SearchChoice { count, .. } => {
+                assert_eq!(
+                    *count, 1,
+                    "only the power-4+ creature attacking a player contributes to that-many"
+                );
             }
             other => panic!("expected SearchChoice, got {other:?}"),
         }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -176,8 +176,62 @@ fn matching_batched_trigger_events(
                 check_trigger_condition(state, condition, controller, Some(obj_id), Some(candidate))
             })
         })
-        .cloned()
+        .map(|candidate| {
+            contextual_batched_trigger_event(state, candidate, trig_def, obj_id, controller)
+        })
         .collect()
+}
+
+fn contextual_batched_trigger_event(
+    state: &GameState,
+    event: &GameEvent,
+    trig_def: &TriggerDefinition,
+    obj_id: ObjectId,
+    controller: PlayerId,
+) -> GameEvent {
+    let GameEvent::AttackersDeclared {
+        attacker_ids,
+        defending_player,
+        attacks,
+    } = event
+    else {
+        return event.clone();
+    };
+    if !matches!(trig_def.mode, TriggerMode::YouAttack | TriggerMode::Attacks) {
+        return event.clone();
+    }
+
+    let filter_ctx = FilterContext::from_source_with_controller(obj_id, controller);
+    let matching_attackers: Vec<_> = attacker_ids
+        .iter()
+        .copied()
+        .filter(|id| {
+            trig_def
+                .valid_card
+                .as_ref()
+                .is_none_or(|filter| matches_target_filter(state, *id, filter, &filter_ctx))
+        })
+        .collect();
+
+    if matching_attackers.is_empty() {
+        return event.clone();
+    }
+
+    let matching_set: HashSet<_> = matching_attackers.iter().copied().collect();
+    let matching_attacks: Vec<_> = attacks
+        .iter()
+        .copied()
+        .filter(|(attacker_id, _)| matching_set.contains(attacker_id))
+        .collect();
+
+    // CR 603.2c + CR 608.2c: batched "one or more ... attack" triggers fire
+    // once, but later "that many" text refers to the members of that matching
+    // event subset, not every attacker in the declaration.
+    GameEvent::AttackersDeclared {
+        attacker_ids: matching_attackers,
+        defending_player: *defending_player,
+        attacks: matching_attacks,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3499,9 +3553,10 @@ pub mod tests {
         AggregateFunction, ChosenAttribute, ChosenSubtypeKind, CommanderOwnership, Comparator,
         ContinuousModification, ControllerRef, DelayedTriggerCondition, Duration, Effect,
         FilterProp, GainLifePlayer, KickerVariant, MultiTargetSpec, PaymentCost, PlayerFilter,
-        PlayerScope, QuantityExpr, QuantityRef, ResolvedAbility, SharedQuality,
-        SharedQualityRelation, StaticCondition, StaticDefinition, TargetFilter, TargetRef,
-        TriggerCondition, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
+        PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, ResolvedAbility,
+        SearchSelectionConstraint, SharedQuality, SharedQualityRelation, StaticCondition,
+        StaticDefinition, TargetFilter, TargetRef, TriggerCondition, TriggerConstraint,
+        TriggerDefinition, TypeFilter, TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -11552,6 +11607,109 @@ pub mod tests {
             trigger_fires(true),
             "subject-led God-filter trigger MUST fire when a God attacks"
         );
+    }
+
+    /// Issue #1055: The Earth King stores "that many" as EventContextAmount.
+    /// For a batched attack trigger, that amount is the number of attackers
+    /// that matched the trigger subject, not the raw number of all attackers.
+    #[test]
+    fn issue_1055_batched_attack_search_uses_matching_attacker_count() {
+        use crate::game::combat::AttackTarget;
+
+        fn add_basic_land(state: &mut GameState, name: &str) -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(state.next_object_id),
+                PlayerId(0),
+                name.to_string(),
+                Zone::Library,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types
+                .supertypes
+                .push(crate::types::card_type::Supertype::Basic);
+            id
+        }
+
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        let source = make_creature(&mut state, PlayerId(0), "The Earth King", 4, 4);
+        let mut trigger =
+            TriggerDefinition::new(TriggerMode::YouAttack).execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::SearchLibrary {
+                    filter: TargetFilter::Typed(TypedFilter::land().properties(vec![
+                        FilterProp::HasSupertype {
+                            value: crate::types::card_type::Supertype::Basic,
+                        },
+                    ])),
+                    count: QuantityExpr::up_to(QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount,
+                    }),
+                    reveal: false,
+                    target_player: None,
+                    selection_constraint: SearchSelectionConstraint::None,
+                    split: None,
+                },
+            ));
+        trigger.batched = true;
+        trigger.valid_card = Some(TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::PtComparison {
+                    stat: PtStat::Power,
+                    scope: PtValueScope::Current,
+                    comparator: Comparator::GE,
+                    value: QuantityExpr::Fixed { value: 4 },
+                }]),
+        ));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .trigger_definitions
+            .push(trigger);
+
+        let big_one = make_creature(&mut state, PlayerId(0), "Big One", 4, 4);
+        let big_two = make_creature(&mut state, PlayerId(0), "Big Two", 5, 5);
+        let small = make_creature(&mut state, PlayerId(0), "Small", 3, 3);
+        add_basic_land(&mut state, "Plains");
+        add_basic_land(&mut state, "Island");
+        add_basic_land(&mut state, "Forest");
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::AttackersDeclared {
+                attacker_ids: vec![big_one, big_two, small],
+                defending_player: PlayerId(1),
+                attacks: vec![
+                    (big_one, AttackTarget::Player(PlayerId(1))),
+                    (big_two, AttackTarget::Player(PlayerId(1))),
+                    (small, AttackTarget::Player(PlayerId(1))),
+                ],
+            }],
+        );
+
+        assert_eq!(state.stack.len(), 1, "The Earth King trigger should fire");
+        let mut events = Vec::new();
+        crate::game::stack::resolve_top(&mut state, &mut events);
+
+        match &state.waiting_for {
+            WaitingFor::SearchChoice {
+                count,
+                up_to,
+                cards,
+                ..
+            } => {
+                assert_eq!(*count, 2, "two power-4+ attackers set the search cap");
+                assert!(*up_to, "The Earth King's search is up to that many");
+                assert_eq!(cards.len(), 3, "all three basic lands remain legal choices");
+            }
+            other => panic!("expected SearchChoice, got {other:?}"),
+        }
     }
 
     /// Issue #501 (class coverage): The Tenth Doctor's `Allons-y!` attack


### PR DESCRIPTION
## Summary

Fixes #1055 by making batched attack-trigger context carry only the attackers that matched the trigger subject. This makes The Earth King's "that many" search count use the number of attacking creatures with power 4 or greater, not every attacker declared.

## Files changed

- `crates/engine/src/game/triggers.rs`
- `crates/engine/src/game/targeting.rs`

## CR references

- CR 508.1m - abilities that trigger on attackers being declared trigger.
- CR 603.2c - an ability triggers once each time its trigger event occurs.
- CR 608.2c - later text can modify the meaning of earlier text during resolution.

## Track

Developer

## LLM

Model: GPT-5 Codex
Thinking: medium

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy --all-targets -- -D warnings` - clean
- `cargo test -p engine` - clean (8514 unit tests, 440 integration tests, 7 doctests ignored)
- `./scripts/gen-card-data.sh` - clean

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
