### PR TITLE
Fix Gornog target controller for relative-clause attack triggers

### DIFF
--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -626,7 +626,7 @@ pub(super) fn parse_subject_application(
         .parse(lower.as_str())
         .is_ok()
     {
-        let (filter, _) = parse_target(&subject["another ".len()..]);
+        let (filter, _) = parse_target_with_ctx(&subject["another ".len()..], ctx);
         let filter = add_another_property(filter);
         return subject_filter_application(filter, true);
     }
@@ -652,7 +652,7 @@ pub(super) fn parse_subject_application(
     {
         let (target_text, multi_target) = super::strip_optional_target_prefix(subject);
         if multi_target.is_some() {
-            let (filter, _) = parse_target(target_text);
+            let (filter, _) = parse_target_with_ctx(target_text, ctx);
             let mut application = subject_filter_application(filter, true)?;
             application.multi_target = multi_target;
             return Some(application);
@@ -670,7 +670,7 @@ pub(super) fn parse_subject_application(
             .parse(after_prefix)
             .is_ok()
         {
-            let (filter, _) = parse_target(target_text);
+            let (filter, _) = parse_target_with_ctx(target_text, ctx);
             let mut application = subject_filter_application(filter, true)?;
             application.multi_target = Some(MultiTargetSpec::unlimited(0));
             return Some(application);
@@ -692,7 +692,7 @@ pub(super) fn parse_subject_application(
             {
                 let consumed = lower.len() - after_prefix.len();
                 let target_text = &subject[consumed..];
-                let (filter, _) = parse_target(target_text);
+                let (filter, _) = parse_target_with_ctx(target_text, ctx);
                 let mut application = subject_filter_application(filter, true)?;
                 application.multi_target = Some(MultiTargetSpec::fixed(min, max));
                 return Some(application);
@@ -3266,6 +3266,49 @@ mod tests {
             app.affected
         );
         assert_eq!(app.multi_target, Some(MultiTargetSpec::unlimited(0)),);
+    }
+
+    #[test]
+    fn parse_subject_another_target_honors_relative_player_scope() {
+        let mut ctx = ParseContext {
+            relative_player_scope: Some(ControllerRef::TargetPlayer),
+            ..ParseContext::default()
+        };
+        let result =
+            parse_subject_application("another target creature that player controls", &mut ctx);
+        assert!(result.is_some());
+        let app = result.unwrap();
+        assert!(
+            matches!(app.affected, TargetFilter::Typed(ref t)
+                if t.type_filters.contains(&TypeFilter::Creature)
+                && t.controller == Some(ControllerRef::TargetPlayer)
+                && t.properties.iter().any(|prop| matches!(prop, FilterProp::Another))),
+            "should parse another creature controlled by target player, got {:?}",
+            app.affected
+        );
+    }
+
+    #[test]
+    fn parse_subject_up_to_one_target_honors_relative_player_scope() {
+        let mut ctx = ParseContext {
+            relative_player_scope: Some(ControllerRef::TargetPlayer),
+            ..ParseContext::default()
+        };
+        let result =
+            parse_subject_application("up to one target creature that player controls", &mut ctx);
+        assert!(result.is_some());
+        let app = result.unwrap();
+        assert!(
+            matches!(app.affected, TargetFilter::Typed(ref t)
+                if t.type_filters.contains(&TypeFilter::Creature)
+                && t.controller == Some(ControllerRef::TargetPlayer)),
+            "should parse creature controlled by target player, got {:?}",
+            app.affected
+        );
+        assert_eq!(
+            app.multi_target,
+            Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }))
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -27,7 +27,7 @@ use super::super::oracle_static::{
     classify_block_exception, parse_additive_type_clause_modifications,
     parse_chosen_qualifier_subject, parse_continuous_modifications, parse_static_line_multi,
 };
-use super::super::oracle_target::{parse_target, parse_type_phrase};
+use super::super::oracle_target::{parse_target, parse_target_with_ctx, parse_type_phrase};
 use super::super::oracle_util::{
     parse_number, TextPair, SELF_REF_PARSE_ONLY_PHRASES, SELF_REF_TYPE_PHRASES,
 };
@@ -634,7 +634,16 @@ pub(super) fn parse_subject_application(
         .parse(lower.as_str())
         .is_ok()
     {
-        let (filter, _) = parse_target(subject);
+        // CR 109.4 + CR 115.1 + CR 603.2: thread the parse context so that
+        // controller-suffix resolution inside `parse_target` (notably the
+        // "that player controls" relative reference) can see the enclosing
+        // trigger's `relative_player_scope` and emit
+        // `ControllerRef::TargetPlayer` for the attacked / damaged player
+        // instead of falling back to `You`. Without `ctx`, the subject-form
+        // path of "target creature that player controls becomes …" (Gornog,
+        // the Red Reaper) silently bound the target to the trigger
+        // controller's own creatures.
+        let (filter, _) = parse_target_with_ctx(subject, ctx);
         return subject_filter_application(filter, true);
     }
     if tag::<_, _, OracleError<'_>>("up to ")

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -462,14 +462,18 @@ fn strip_first_time_each_turn_qualifier(condition: &str) -> (String, bool) {
 }
 
 /// CR 109.4 + CR 115.1 + CR 506.2: Detect a trigger condition that introduces
-/// a player target — currently the "you/an opponent/a player attack(s) a player"
-/// family. When this returns true, follow-on possessive references inside the
-/// effect ("that player controls/owns") refer to that introduced player and the
-/// parser pushes a relative-player scope so they emit `ControllerRef::TargetPlayer`.
+/// a player target — currently the "[subject] attack(s) a player" family
+/// (CR 506.2 / CR 508.1a) and the "[subject] deals [combat] damage to a player"
+/// family (CR 120.3). When this returns true, follow-on possessive references
+/// inside the effect ("that player controls/owns") refer to that introduced
+/// player and the parser pushes a relative-player scope so they emit
+/// `ControllerRef::TargetPlayer`.
 ///
-/// Built from composable nom alternatives so adding new condition shapes
-/// (combat-damage-to-a-player, "deals damage to a player", etc.) is a one-line
-/// change to the inner `alt()`.
+/// Built from composable nom alternatives so adding new condition shapes is a
+/// one-line change to the inner `alt()`. The attack/damage scans both accept
+/// any subject prefix (verb-phrase only), so relative-clause subjects like
+/// "one or more Warriors you control" and "a creature you control" match
+/// without needing an explicit-actor variant per subject shape.
 fn condition_introduces_target_player(cond_lower: &str) -> bool {
     use nom::bytes::complete::tag;
     use nom::combinator::value;
@@ -521,6 +525,21 @@ fn condition_introduces_target_player(cond_lower: &str) -> bool {
                 {
                     return true;
                 }
+            }
+        }
+        // CR 506.2 + CR 508.1a: "[anything] attack[s] a player" — same subject
+        // permissiveness as the damage scan below. Covers cases where the
+        // actor is wrapped in a relative clause that the explicit actor branch
+        // above cannot match, e.g. "one or more Warriors you control attack a
+        // player" (Gornog, the Red Reaper) or "a creature you control attacks
+        // a player". The verb phrase alone is unambiguous in trigger-condition
+        // text — "attack" never appears as a noun before "a player" here.
+        if let Ok((after_verb, ())) = parse_attack_verb(remaining) {
+            if tag::<_, _, OracleError<'_>>("a player")
+                .parse(after_verb)
+                .is_ok()
+            {
+                return true;
             }
         }
         // CR 120.3: "[anything] deals [combat] damage to a player" — introduces
@@ -19750,6 +19769,38 @@ mod tests {
                 other => panic!("expected Typed filter, got {other:?}"),
             },
             other => panic!("expected Tap effect, got {other:?}"),
+        }
+    }
+
+    /// CR 109.4 + CR 115.1 + CR 506.2: Gornog's "Whenever one or more Warriors
+    /// you control attack a player, target creature that player controls
+    /// becomes a Coward" introduces the attacked player through a relative-
+    /// clause subject ("Warriors you control") rather than a bare actor. The
+    /// effect's "that player controls" must still resolve to
+    /// `ControllerRef::TargetPlayer` so the UI offers the attacked player's
+    /// creatures, not the trigger controller's. Regression test for #1054 — the
+    /// subject-permissive scan in `condition_introduces_target_player` is the
+    /// fix site.
+    #[test]
+    fn gornog_one_or_more_warriors_attack_uses_target_player_controller() {
+        use crate::types::ability::Effect;
+
+        let def = parse_trigger_line(
+            "Whenever one or more Warriors you control attack a player, target creature that player controls becomes a Coward.",
+            "Gornog, the Red Reaper",
+        );
+        assert_eq!(def.mode, TriggerMode::YouAttack);
+        let execute = def.execute.as_deref().expect("execute ability");
+        match execute.effect.as_ref() {
+            Effect::GenericEffect { target, .. } => match target {
+                Some(TargetFilter::Typed(t)) => assert_eq!(
+                    t.controller,
+                    Some(ControllerRef::TargetPlayer),
+                    "GenericEffect target should reference the attacked player",
+                ),
+                other => panic!("expected Some(Typed) target filter, got {other:?}"),
+            },
+            other => panic!("expected GenericEffect, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes a target-controller resolution bug on **Gornog, the Red Reaper** and the broader "[X] you control attack a player, [effect] that player controls" trigger class. Before this change, targets generated by the effect were bound to the trigger controller's own permanents instead of the attacked player's, so the UI offered the wrong choices and resolution would never produce the intended on-opponent transformation. Two surgical parser fixes restore the correct `ControllerRef::TargetPlayer` binding without changing engine resolution logic.

Closes #1054

## Root cause
- `condition_introduces_target_player` in `oracle_trigger.rs` recognized only explicit-actor "[subject] attacks a player" shapes (e.g. `~`, `you`, `an opponent`). Relative-clause subjects like "one or more Warriors you control attack a player" or "a creature you control attacks a player" fell through, so the parser never pushed the relative-player scope and downstream "that player" references defaulted to `ControllerRef::You`.
- `parse_subject_application` in `oracle_effect/subject.rs` called the context-less `parse_target` for subject-form targets ("target creature that player controls becomes …"). With no `ParseContext`, the controller-suffix resolver could not see the trigger's `relative_player_scope` and emitted `ControllerRef::You` even when the trigger condition correctly introduced a target player. Threading `parse_target_with_ctx(subject, ctx)` restores the context link.

## Class coverage
The fix is built for the class, not the card. Other cards with the same condition shape that benefit from (or rely on) the same parser path:
- **Gornog, the Red Reaper** — direct target of #1054.
- **Attuma, Atlantean Warlord** — "Whenever one or more Merfolk you control attack a player, …" (same condition shape).
- **Jin Sakai, Ghost of Tsushima** — "Whenever a creature you control attacks a player, if no other creatures are attacking that player, …" (same relative-clause subject family with a "that player" reference inside the condition).

## Files changed
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/parser/oracle_effect/subject.rs`

## CR references
- CR 109.4 — head-noun / object identity
- CR 115.1 — target requirements and `ControllerRef` resolution
- CR 120.3 — combat-damage-to-a-player trigger subject
- CR 506.2 — attacking-player identity
- CR 508.1a — "attack a player" declaration shape
- CR 603.2 — trigger condition evaluation and relative-player scope

## Tests
- New: `gornog_one_or_more_warriors_attack_uses_target_player_controller` in `oracle_trigger.rs` — regression test for #1054 verifying the parsed `GenericEffect` target's `controller` is `Some(ControllerRef::TargetPlayer)`.
- Existing negative scope test still passes — non-attack-player triggers must NOT push the relative-player scope.
- Full engine suite: 10,056 / 10,056 pass.
- clippy clean, fmt clean, parser-combinator gate clean, coverage 85.86%.

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Verification
- \`cargo fmt --all\` — clean
- \`cargo clippy-strict\` — clean
- \`./scripts/check-parser-combinators.sh\` — clean
- \`cargo test -p engine\` — 10,056 pass / 0 fail
- coverage 85.86% — stable, no regression

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

## Known follow-ups
Surfaced by code-reviewer during this review but explicitly **out of scope** for this PR — recommend filing as a separate issue:

- **Goad-imperative path bug (same root-cause family).** The imperative arms at `oracle_effect/imperative.rs:5236` and `:5241` use the context-less `parse_target` while their condition recognizers do push a relative-player scope. This is the same `parse_target` vs `parse_target_with_ctx` asymmetry as the subject-form path fixed here, and is suspected to affect Marisi, Breaker of the Coil ("goad each creature that player controls") and Seifer-family goad-on-damage cards. Worth filing a follow-up issue so the imperative branch gets the same context-threading treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)