### PR TITLE
fix: filter modal modes with no legal targets before presenting choice

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -365,6 +365,59 @@ pub fn compute_unavailable_modes(
     unavailable
 }
 
+/// CR 700.2d: Extends `unavailable_modes` with mode indices whose targeting
+/// requirements cannot be satisfied on the current board. For each mode not
+/// already marked unavailable, builds the resolved ability for that single mode,
+/// computes its target slots, and checks whether a legal target assignment
+/// exists. Modes that require targets but have no legal assignment are appended
+/// to `unavailable_modes`.
+///
+/// This prevents the softlock where a player (or AI) selects a mode with no
+/// legal targets, causing `pending_trigger` to be consumed and then the
+/// targeting step to fail irrecoverably.
+pub fn filter_modes_by_target_legality(
+    state: &GameState,
+    source_id: ObjectId,
+    controller: PlayerId,
+    mode_abilities: &[AbilityDefinition],
+    modal: &ModalChoice,
+    unavailable_modes: &mut Vec<usize>,
+) {
+    let target_constraints = target_constraints_from_modal(modal);
+    for mode_idx in 0..modal.mode_count {
+        if unavailable_modes.contains(&mode_idx) {
+            continue;
+        }
+        let Some(def) = mode_abilities.get(mode_idx) else {
+            continue;
+        };
+        let resolved = build_resolved_from_def(def, source_id, controller);
+        let target_slots = match build_target_slots(state, &resolved) {
+            Ok(slots) => slots,
+            Err(_) => {
+                // build_target_slots returns Err when no legal targets exist
+                // for a required targeting slot — mark mode unavailable.
+                unavailable_modes.push(mode_idx);
+                continue;
+            }
+        };
+        // A mode with no target slots does not require targeting — always legal.
+        if target_slots.is_empty() {
+            continue;
+        }
+        if !has_legal_target_assignment_for_ability(
+            state,
+            &resolved,
+            &target_slots,
+            &target_constraints,
+        ) {
+            unavailable_modes.push(mode_idx);
+        }
+    }
+    unavailable_modes.sort_unstable();
+    unavailable_modes.dedup();
+}
+
 /// Records chosen mode indices for NoRepeat constraint enforcement.
 /// CR 700.2: Inserts into per-turn and/or per-game tracking maps.
 pub fn record_modal_mode_choices(

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -365,12 +365,12 @@ pub fn compute_unavailable_modes(
     unavailable
 }
 
-/// CR 700.2d: Extends `unavailable_modes` with mode indices whose targeting
-/// requirements cannot be satisfied on the current board. For each mode not
-/// already marked unavailable, builds the resolved ability for that single mode,
-/// computes its target slots, and checks whether a legal target assignment
-/// exists. Modes that require targets but have no legal assignment are appended
-/// to `unavailable_modes`.
+/// CR 700.2a-b + CR 700.2f: Extends `unavailable_modes` with mode indices
+/// whose targeting requirements cannot be satisfied on the current board. For
+/// each mode not already marked unavailable, builds the resolved ability for
+/// that single mode, computes its target slots, and checks whether a legal
+/// target assignment exists. Modes that require targets but have no legal
+/// assignment are appended to `unavailable_modes`.
 ///
 /// This prevents the softlock where a player (or AI) selects a mode with no
 /// legal targets, causing `pending_trigger` to be consumed and then the
@@ -3375,10 +3375,11 @@ pub fn validate_modal_indices(
                 "Duplicate mode index {idx}"
             )));
         }
-        // CR 700.2: Reject modes already chosen per NoRepeatThisTurn/NoRepeatThisGame.
+        // CR 700.2a-b: Reject modes unavailable due to prior selections or
+        // unsatisfied targeting requirements.
         if unavailable_modes.contains(&idx) {
             return Err(EngineError::InvalidAction(format!(
-                "Mode index {idx} is unavailable (already chosen)"
+                "Mode index {idx} is unavailable"
             )));
         }
     }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -7158,7 +7158,15 @@ pub fn handle_activate_ability(
                 ));
             }
         }
-        let unavailable_modes = compute_unavailable_modes(state, source_id, &modal);
+        let mut unavailable_modes = compute_unavailable_modes(state, source_id, &modal);
+        super::ability_utils::filter_modes_by_target_legality(
+            state,
+            source_id,
+            player,
+            &ability_def.mode_abilities,
+            &modal,
+            &mut unavailable_modes,
+        );
         // CR 700.2a / CR 700.2e: `AbilityModeChoice.player` is threaded
         // downstream as the activated ability's controller (cost payment,
         // stack `controller`, target selection — see `engine_modes.rs`), so

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -7167,6 +7167,14 @@ pub fn handle_activate_ability(
             &modal,
             &mut unavailable_modes,
         );
+        // CR 700.2a: The controller chooses modes while activating a modal
+        // ability. If every mode is illegal due to unavailable selections or
+        // unsatisfied targeting requirements, the ability cannot be activated.
+        if unavailable_modes.len() >= modal.mode_count {
+            return Err(EngineError::ActionNotAllowed(
+                "No legal modes available for activated ability".to_string(),
+            ));
+        }
         // CR 700.2a / CR 700.2e: `AbilityModeChoice.player` is threaded
         // downstream as the activated ability's controller (cost payment,
         // stack `controller`, target selection — see `engine_modes.rs`), so
@@ -13563,6 +13571,61 @@ mod tests {
             event,
             GameEvent::AbilityActivated { source_id, .. } if *source_id == source
         )));
+    }
+
+    #[test]
+    fn activated_modal_with_no_legal_target_modes_rejects_activation() {
+        let mut state = setup_game_at_main_phase();
+        let source = create_object(
+            &mut state,
+            CardId(62),
+            PlayerId(0),
+            "Modal Pinger".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&source).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        Arc::make_mut(&mut obj.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "modal placeholder".to_string(),
+                    description: None,
+                },
+            )
+            .with_modal(
+                crate::types::ability::ModalChoice {
+                    min_choices: 1,
+                    max_choices: 1,
+                    mode_count: 1,
+                    mode_descriptions: vec!["Deal 1 damage to target creature.".to_string()],
+                    ..Default::default()
+                },
+                vec![AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::DealDamage {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Typed(TypedFilter {
+                            type_filters: vec![TypeFilter::Creature],
+                            controller: Some(ControllerRef::Opponent),
+                            properties: vec![],
+                        }),
+                        damage_source: None,
+                    },
+                )],
+            ),
+        );
+
+        let mut events = Vec::new();
+        let result = handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut events);
+
+        assert!(matches!(
+            result,
+            Err(EngineError::ActionNotAllowed(message))
+                if message == "No legal modes available for activated ability"
+        ));
+        assert!(events.is_empty());
+        assert!(state.stack.is_empty());
     }
 
     #[test]

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4027,10 +4027,19 @@ pub(super) fn begin_pending_trigger_target_selection(
                 modal,
                 &crate::types::ability::SpellContext::default(),
             );
-            let unavailable_modes = compute_unavailable_modes(state, trigger.source_id, &modal);
+            let mut unavailable_modes = compute_unavailable_modes(state, trigger.source_id, &modal);
+            super::ability_utils::filter_modes_by_target_legality(
+                state,
+                trigger.source_id,
+                trigger.controller,
+                &trigger.mode_abilities,
+                &modal,
+                &mut unavailable_modes,
+            );
 
-            // CR 700.2: All modes already chosen — ability cannot be put on the stack
-            // without a mode selection. Clear pending trigger and skip.
+            // CR 700.2d: All modes unavailable (previously chosen OR no legal
+            // targets) — ability cannot be put on the stack. Clear pending
+            // trigger and skip.
             if unavailable_modes.len() >= modal.mode_count {
                 state.pending_trigger = None;
                 return Ok(None);

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4017,7 +4017,7 @@ pub(super) fn begin_pending_trigger_target_selection(
         return Ok(None);
     };
 
-    // CR 700.2a: Modal trigger — prompt for mode selection before stack.
+    // CR 700.2b: Modal trigger — prompt for mode selection before stack.
     if let Some(ref modal) = trigger.modal {
         if !trigger.mode_abilities.is_empty() {
             let modal = modal_choice_for_player(
@@ -4037,7 +4037,7 @@ pub(super) fn begin_pending_trigger_target_selection(
                 &mut unavailable_modes,
             );
 
-            // CR 700.2d: All modes unavailable (previously chosen OR no legal
+            // CR 700.2b: All modes unavailable (previously chosen OR no legal
             // targets) — ability cannot be put on the stack. Clear pending
             // trigger and skip.
             if unavailable_modes.len() >= modal.mode_count {
@@ -11781,7 +11781,7 @@ mod trigger_target_tests {
         // Call the private function via the engine path.
         let result = begin_pending_trigger_target_selection(&mut state).unwrap();
 
-        // CR 700.2: All modes exhausted — no AbilityModeChoice produced.
+        // CR 700.2b: All modes exhausted — no AbilityModeChoice produced.
         assert!(result.is_none());
         // Pending trigger should be cleared.
         assert!(state.pending_trigger.is_none());


### PR DESCRIPTION
## Summary

**CR 700.2d**: When a modal triggered or activated ability is about to present a mode choice, each mode's targeting requirements are now checked against the current board state. Modes whose targeting slots cannot be legally satisfied are added to `unavailable_modes` before the choice is presented to the player/AI.

## Problem

This fixes the softlock described in #840:

1. A modal trigger fires (e.g. 'choose one' with a targeting mode)
2. The player/AI selects a mode that requires targets
3. `pending_trigger` is consumed by `handle_triggered_mode_choice`
4. `build_target_slots` fails because no legal targets exist for the chosen mode
5. The game state becomes irrecoverable — the trigger is gone but the ability never resolves

## Solution

Added `filter_modes_by_target_legality()` in `ability_utils.rs` which:
- For each available mode, builds the resolved ability for that single mode
- Computes its target slots via `build_target_slots`
- Checks whether a legal target assignment exists via `has_legal_target_assignment_for_ability`
- Marks modes without legal targets as unavailable

This function is called at both modal trigger (`engine.rs`) and modal activated ability (`casting.rs`) sites, immediately after `compute_unavailable_modes()`.

If all modes become unavailable (previously chosen OR no legal targets), the trigger is safely skipped (for triggers) or the ability cannot be activated (for activated abilities).

## Files Changed

- `crates/engine/src/game/ability_utils.rs` — new `filter_modes_by_target_legality()` function
- `crates/engine/src/game/engine.rs` — call site for modal triggered abilities
- `crates/engine/src/game/casting.rs` — call site for modal activated abilities

## Testing

- `cargo check -p engine` passes
- `cargo check -p engine --tests` passes

Fixes #840