### PR TITLE
fix: run SBAs in reconcile_terminal_result when a player has pending lethal (#962)

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -37,10 +37,10 @@ use super::match_flow;
 use super::mulligan;
 use super::planeswalker;
 use super::priority;
-use super::sba;
 use super::public_state::{
     bump_state_revision, finalize_public_state, mark_public_state_all_dirty, sync_waiting_for,
 };
+use super::sba;
 use super::triggers;
 use super::turn_control;
 use super::turns;
@@ -218,13 +218,9 @@ fn has_pending_lethal_player(state: &GameState) -> bool {
     }
 
     if let Some(threshold) = state.format_config.commander_damage_threshold {
-        let cmd_damage = state
-            .commander_damage
-            .iter()
-            .any(|entry| {
-                entry.damage >= threshold as u32
-                    && !state.eliminated_players.contains(&entry.player)
-            });
+        let cmd_damage = state.commander_damage.iter().any(|entry| {
+            entry.damage >= threshold as u32 && !state.eliminated_players.contains(&entry.player)
+        });
         if cmd_damage {
             return true;
         }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -159,16 +159,15 @@ pub fn apply(
 }
 
 fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
-    // Safety net (fixes #962): If any player has a lethal condition (life <= 0,
-    // drew from empty library, 10+ poison, or lethal commander damage) but has
-    // not yet been eliminated, run SBAs now. Per CR 704.3, SBAs normally only
-    // fire when a player would receive priority, but skipping them here causes
-    // softlocks where the game waits on a dead player for a non-priority choice.
+    // Safety net (fixes #962): If a player-loss SBA would eliminate a player,
+    // run SBAs now. CR 704.3 normally checks SBAs when a player would receive
+    // priority, but skipping them here can leave the engine waiting on a dead
+    // player for a non-priority choice.
     //
-    // This is intentionally conservative: the guard only triggers when there is
-    // genuinely an uneliminated player in a lethal state, so normal continuation
-    // flows (DiscardChoice, EffectZoneChoice, etc.) are unaffected.
-    if has_pending_lethal_player(state) {
+    // The predicate lives in `sba` so it shares the same CR 101.2 "can't lose"
+    // exception as the real player-loss SBA checks, and stays narrower than the
+    // full SBA loop to avoid unrelated mid-resolution SBA prompts.
+    if sba::has_pending_player_loss_sba(state) {
         sba::check_state_based_actions(state, &mut result.events);
         // SBA may have advanced waiting_for (e.g., GameOver, or Priority for
         // the next living player). Sync the result.
@@ -180,53 +179,6 @@ fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
         match_flow::handle_game_over_transition(state);
         result.waiting_for = state.waiting_for.clone();
     }
-}
-
-/// Returns `true` if any non-eliminated player satisfies a lethal SBA condition:
-/// - Life total <= 0 (CR 704.5a)
-/// - Drew from an empty library (CR 704.5b)
-/// - 10+ poison counters (CR 704.5c)
-/// - 21+ commander damage from a single commander (CR 704.6c)
-///
-/// This does NOT account for "can't lose the game" effects — that check lives
-/// inside the full SBA pass itself, which is fine: calling `check_state_based_actions`
-/// when no player actually needs elimination is a no-op (the SBA loop exits on the
-/// first iteration with `any_performed == false`).
-fn has_pending_lethal_player(state: &GameState) -> bool {
-    let dominated_by_life = state
-        .players
-        .iter()
-        .any(|p| !p.is_eliminated && !p.is_phased_out() && p.life <= 0);
-    if dominated_by_life {
-        return true;
-    }
-
-    let drew_empty = state
-        .players
-        .iter()
-        .any(|p| !p.is_eliminated && p.drew_from_empty_library);
-    if drew_empty {
-        return true;
-    }
-
-    let poison = state
-        .players
-        .iter()
-        .any(|p| !p.is_eliminated && p.poison_counters >= 10);
-    if poison {
-        return true;
-    }
-
-    if let Some(threshold) = state.format_config.commander_damage_threshold {
-        let cmd_damage = state.commander_damage.iter().any(|entry| {
-            entry.damage >= threshold as u32 && !state.eliminated_players.contains(&entry.player)
-        });
-        if cmd_damage {
-            return true;
-        }
-    }
-
-    false
 }
 
 fn remember_public_reveals(state: &mut GameState, events: &[GameEvent]) {
@@ -5556,11 +5508,13 @@ mod tests {
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ControllerRef, Effect,
         GainLifePlayer, ManaContribution, ManaProduction, ManaSpendRestriction, QuantityExpr,
-        ResolvedAbility, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter,
+        ResolvedAbility, StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter,
+        TypedFilter,
     };
     use crate::types::card_type::CardType;
     use crate::types::card_type::CoreType;
     use crate::types::counter::CounterType;
+    use crate::types::format::FormatConfig;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::TriggerMode;
@@ -5591,6 +5545,105 @@ mod tests {
         remember_public_reveals(&mut state, &events);
 
         assert!(state.public_revealed_cards.contains(&card_id));
+    }
+
+    #[test]
+    fn terminal_reconcile_does_not_run_sbas_for_cant_lose_player() {
+        let mut state = GameState::new(FormatConfig::commander(), 2, 42);
+        let protected = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Platinum Angel".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&protected)
+            .expect("protected source exists")
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantLoseTheGame).affected(
+                TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::You)),
+            ));
+
+        let commander = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Kaalia".to_string(),
+            Zone::Command,
+        );
+        let commander_obj = state
+            .objects
+            .get_mut(&commander)
+            .expect("commander object exists");
+        commander_obj.is_commander = true;
+        commander_obj.card_types.core_types.push(CoreType::Creature);
+        let mut move_events = Vec::new();
+        zones::move_to_zone(&mut state, commander, Zone::Battlefield, &mut move_events);
+        zones::move_to_zone(&mut state, commander, Zone::Graveyard, &mut move_events);
+
+        // CR 101.2 + CR 704.5a: Platinum Angel means P0 cannot lose from
+        // 0-or-less life. The
+        // non-priority DiscardChoice should therefore remain active; otherwise
+        // the full SBA loop would notice the unrelated dead commander and
+        // replace the choice with CommanderZoneChoice.
+        state.players[0].life = 0;
+        state.waiting_for = WaitingFor::DiscardChoice {
+            player: PlayerId(0),
+            count: 1,
+            cards: Vec::new(),
+            source_id: ObjectId(999),
+            effect_kind: EffectKind::DiscardCard,
+            up_to: false,
+            unless_filter: None,
+        };
+        let original_waiting_for = state.waiting_for.clone();
+        let mut result = ActionResult {
+            events: Vec::new(),
+            waiting_for: original_waiting_for.clone(),
+            log_entries: Vec::new(),
+        };
+
+        reconcile_terminal_result(&mut state, &mut result);
+
+        assert_eq!(state.waiting_for, original_waiting_for);
+        assert_eq!(result.waiting_for, original_waiting_for);
+        assert!(!state.players[0].is_eliminated);
+        assert_eq!(state.objects[&commander].zone, Zone::Graveyard);
+    }
+
+    #[test]
+    fn terminal_reconcile_runs_player_loss_sba_for_unprotected_player() {
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 0;
+        state.waiting_for = WaitingFor::DiscardChoice {
+            player: PlayerId(0),
+            count: 1,
+            cards: Vec::new(),
+            source_id: ObjectId(999),
+            effect_kind: EffectKind::DiscardCard,
+            up_to: false,
+            unless_filter: None,
+        };
+        let mut result = ActionResult {
+            events: Vec::new(),
+            waiting_for: state.waiting_for.clone(),
+            log_entries: Vec::new(),
+        };
+
+        reconcile_terminal_result(&mut state, &mut result);
+
+        // CR 704.5a: An unprotected player at 0 life loses before the engine
+        // keeps waiting for that player's non-priority discard choice.
+        assert!(state.players[0].is_eliminated);
+        assert!(matches!(
+            result.waiting_for,
+            WaitingFor::GameOver {
+                winner: Some(PlayerId(1)),
+                ..
+            }
+        ));
     }
 
     /// Create a DealDamage ability for testing.

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -37,6 +37,7 @@ use super::match_flow;
 use super::mulligan;
 use super::planeswalker;
 use super::priority;
+use super::sba;
 use super::public_state::{
     bump_state_revision, finalize_public_state, mark_public_state_all_dirty, sync_waiting_for,
 };
@@ -158,11 +159,78 @@ pub fn apply(
 }
 
 fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
+    // Safety net (fixes #962): If any player has a lethal condition (life <= 0,
+    // drew from empty library, 10+ poison, or lethal commander damage) but has
+    // not yet been eliminated, run SBAs now. Per CR 704.3, SBAs normally only
+    // fire when a player would receive priority, but skipping them here causes
+    // softlocks where the game waits on a dead player for a non-priority choice.
+    //
+    // This is intentionally conservative: the guard only triggers when there is
+    // genuinely an uneliminated player in a lethal state, so normal continuation
+    // flows (DiscardChoice, EffectZoneChoice, etc.) are unaffected.
+    if has_pending_lethal_player(state) {
+        sba::check_state_based_actions(state, &mut result.events);
+        // SBA may have advanced waiting_for (e.g., GameOver, or Priority for
+        // the next living player). Sync the result.
+        result.waiting_for = state.waiting_for.clone();
+    }
+
     super::elimination::ensure_game_over_if_terminal(state, &mut result.events);
     if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
         match_flow::handle_game_over_transition(state);
         result.waiting_for = state.waiting_for.clone();
     }
+}
+
+/// Returns `true` if any non-eliminated player satisfies a lethal SBA condition:
+/// - Life total <= 0 (CR 704.5a)
+/// - Drew from an empty library (CR 704.5b)
+/// - 10+ poison counters (CR 704.5c)
+/// - 21+ commander damage from a single commander (CR 704.6c)
+///
+/// This does NOT account for "can't lose the game" effects — that check lives
+/// inside the full SBA pass itself, which is fine: calling `check_state_based_actions`
+/// when no player actually needs elimination is a no-op (the SBA loop exits on the
+/// first iteration with `any_performed == false`).
+fn has_pending_lethal_player(state: &GameState) -> bool {
+    let dominated_by_life = state
+        .players
+        .iter()
+        .any(|p| !p.is_eliminated && !p.is_phased_out() && p.life <= 0);
+    if dominated_by_life {
+        return true;
+    }
+
+    let drew_empty = state
+        .players
+        .iter()
+        .any(|p| !p.is_eliminated && p.drew_from_empty_library);
+    if drew_empty {
+        return true;
+    }
+
+    let poison = state
+        .players
+        .iter()
+        .any(|p| !p.is_eliminated && p.poison_counters >= 10);
+    if poison {
+        return true;
+    }
+
+    if let Some(threshold) = state.format_config.commander_damage_threshold {
+        let cmd_damage = state
+            .commander_damage
+            .iter()
+            .any(|entry| {
+                entry.damage >= threshold as u32
+                    && !state.eliminated_players.contains(&entry.player)
+            });
+        if cmd_damage {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn remember_public_reveals(state: &mut GameState, events: &[GameEvent]) {

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -271,6 +271,58 @@ fn player_has_cant_lose(state: &GameState, player_id: PlayerId) -> bool {
     )
 }
 
+/// CR 704.5a/704.5b/704.5c/704.6c: Whether a player-loss SBA would currently
+/// eliminate at least one non-eliminated player. This is intentionally narrower
+/// than running the full SBA loop: callers that are only trying to avoid waiting
+/// on a dead player during a non-priority continuation should not trigger
+/// unrelated SBA choice prompts such as commander-zone or legend-rule choices.
+pub(crate) fn has_pending_player_loss_sba(state: &GameState) -> bool {
+    let life_loss = state.players.iter().any(|player| {
+        // CR 704.5a: A player with 0 or less life loses the game.
+        !player.is_eliminated
+            && !player.is_phased_out()
+            && player.life <= 0
+            && !player_has_cant_lose(state, player.id)
+    });
+    if life_loss {
+        return true;
+    }
+
+    let drew_from_empty = state.players.iter().any(|player| {
+        // CR 704.5b: A player who attempted to draw from an empty library loses
+        // the game the next time state-based actions are checked.
+        !player.is_eliminated
+            && player.drew_from_empty_library
+            && !player_has_cant_lose(state, player.id)
+    });
+    if drew_from_empty {
+        return true;
+    }
+
+    let poison_loss = state.players.iter().any(|player| {
+        // CR 704.5c: A player with ten or more poison counters loses the game.
+        !player.is_eliminated
+            && player.poison_counters >= 10
+            && !player_has_cant_lose(state, player.id)
+    });
+    if poison_loss {
+        return true;
+    }
+
+    let threshold = match state.format_config.commander_damage_threshold {
+        Some(threshold) => threshold as u32,
+        None => return false,
+    };
+
+    state.commander_damage.iter().any(|entry| {
+        // CR 704.6c: In Commander, a player dealt 21+ combat damage by the same
+        // commander over the course of the game loses.
+        entry.damage >= threshold
+            && !state.eliminated_players.contains(&entry.player)
+            && !player_has_cant_lose(state, entry.player)
+    })
+}
+
 /// Check if a static ability from `source_controller` with the given `affected` filter
 /// applies to `player_id`.
 fn static_affects_player(


### PR DESCRIPTION
## Summary

Fixes #962 — AI opponent is dead but game continues (softlock).

## Root Cause

After any action resolves, the engine only runs state-based actions (SBAs) when the resulting `WaitingFor` is `Priority`. If an action returns a non-Priority state (`TargetSelection`, `DiscardChoice`, `EffectZoneChoice`, etc.), SBAs are skipped entirely. This means a player can be at 0 life (or have another lethal condition) but not yet be eliminated, causing the game to softlock waiting on a dead player for a non-priority choice.

## Fix

Add a `has_pending_lethal_player()` guard in `reconcile_terminal_result()` that detects uneliminated players with lethal conditions:
- Life total <= 0 (CR 704.5a)
- Drew from an empty library (CR 704.5b)
- 10+ poison counters (CR 704.5c)
- 21+ commander damage from a single commander (CR 704.6c)

When triggered, it runs the full SBA pass which properly eliminates the player and advances `WaitingFor` to `Priority` for the next living player (or `GameOver`).

## Safety

The guard is intentionally conservative:
- It only fires when there is genuinely an uneliminated player in a lethal state
- Normal continuation flows (`DiscardChoice`, `EffectZoneChoice`, etc.) are completely unaffected
- "Can't lose the game" effects are handled by the full SBA pass itself (the guard may trigger, but the SBA loop will exit as a no-op on the first iteration)
- The SBA function already handles all edge cases (legend rule pauses, commander zone choices, etc.) and is idempotent when no action is needed

## Changes

- `crates/engine/src/game/engine.rs`: Added `has_pending_lethal_player()` helper and integrated it into `reconcile_terminal_result()`
