### PR TITLE
fix(ai): prevent ETB-self-bounce infinite cast loop (#563)

### DIFF
--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -522,12 +522,27 @@ fn resolved_candidate_targets(
 }
 
 /// ETB-self-undo bounce: the cast spell's immediate ETB trigger returns a
-/// creature to its owner's hand, but the only legal returnee on the
-/// battlefield is the source object itself (Whitemane Lion ruling: "If you
-/// don't control any other creature, you must return it") OR the candidate
-/// set is empty (the trigger fizzles entirely). In both cases the cast does
-/// not stick — the source either re-enters the caster's hand or contributes
-/// no on-resolution value beyond a vanilla body that didn't enter.
+/// creature to its owner's hand, but no other creature the AI controls is
+/// a legal target. The trigger either fizzles (if zero legal targets exist
+/// at resolution) or is forced to pick the source itself (Whitemane Lion
+/// ruling: "If you don't control any other creature, you must return it").
+/// Either way the cast does not stick — the source re-enters the caster's
+/// hand or contributes no on-resolution value beyond a vanilla body that
+/// didn't enter.
+///
+/// Why one branch suffices: this predicate is gated to
+/// `EffectOrigin::CastImmediateEtbTrigger`, which means the source is being
+/// evaluated *pre-cast* — still in hand, not yet on the battlefield.
+/// `resolved_candidate_targets` queries `state.battlefield`, so the source
+/// is never in the candidate set at cast-time. The "every candidate IS the
+/// source" subcase is therefore unreachable at this evaluation point — the
+/// `candidates.is_empty()` check is the correct and complete signal:
+///   * Empty candidates pre-cast => no other creature controlled => when the
+///     ETB resolves after the Lion enters, the Lion will be the only legal
+///     target (or there will be none, if the source died/left). Either way
+///     the cast is a no-op loop.
+///   * Non-empty candidates pre-cast => at least one creature other than the
+///     source is on the battlefield => legitimate target exists, no penalty.
 ///
 /// Categorical scope:
 ///   - Only fires when `origin == EffectOrigin::CastImmediateEtbTrigger`.
@@ -540,10 +555,9 @@ fn resolved_candidate_targets(
 ///     `Some(Zone::Hand)`). Library/Exile destinations are not handled by
 ///     this predicate.
 ///
-/// Returns `(BOUNCE_SELF_UNDO_DELTA, KIND_BOUNCE_SELF_UNDO, count)` on a
-/// confirmed self-undo; `None` otherwise. The `count` fact is 0 when the
-/// trigger fizzles and 1 when the source is the only legal return target —
-/// enough signal in traces to distinguish the two pathological subcases.
+/// Returns `(BOUNCE_SELF_UNDO_DELTA, KIND_BOUNCE_SELF_UNDO, 0)` on a
+/// confirmed self-undo; `None` otherwise. The `count` fact is 0 (no other
+/// legal targets at cast-time) — sufficient signal for trace attribution.
 fn bounce_self_undo_redundancy(
     state: &GameState,
     source_id: ObjectId,
@@ -554,22 +568,14 @@ fn bounce_self_undo_redundancy(
         return None;
     }
     let candidates = resolved_candidate_targets(state, source_id, target);
-    // CR 608.2b: if the candidate set is empty, the trigger has no legal
-    // target — the targeted ability is removed from the stack at resolution
-    // and does nothing. Penalise: the AI is paying mana for a trigger that
-    // fizzles.
+    // CR 608.2b: if no other creature the AI controls is a legal target,
+    // the trigger either fizzles (zero legal targets remain at resolution)
+    // or is forced to return the source itself (Whitemane Lion ruling). Both
+    // produce the same loop pathology; both are detected here by the
+    // empty-set check at cast-time, since the source is still in hand and
+    // cannot itself appear in the battlefield-queried candidate set.
     if candidates.is_empty() {
         return Some((BOUNCE_SELF_UNDO_DELTA, KIND_BOUNCE_SELF_UNDO, 0));
-    }
-    // Whitemane-Lion / Stonecloaker case: every candidate IS the source.
-    // The trigger must pick the source itself, bouncing the spell-just-cast
-    // back to hand. Net effect: spend mana, gain nothing, prime the loop.
-    if candidates.iter().all(|&id| id == source_id) {
-        return Some((
-            BOUNCE_SELF_UNDO_DELTA,
-            KIND_BOUNCE_SELF_UNDO,
-            candidates.len() as i64,
-        ));
     }
     None
 }
@@ -1382,22 +1388,20 @@ mod tests {
 
     #[test]
     fn whitemane_lion_self_undo_etb_penalised() {
-        // AI controls only the Lion (after it resolves it would be alone),
-        // so the "creature you control" ETB bounce has exactly one legal
-        // target: the Lion itself. Confirmed self-undo loop.
+        // AI is evaluating a cast of Whitemane Lion from hand. The AI
+        // currently controls no other creatures, so the "creature you
+        // control" ETB bounce will, after the Lion resolves, either fizzle
+        // or be forced to return the Lion itself (per the Lion ruling).
+        // Either way: self-undo loop. The Lion stays in hand for this
+        // test — `resolved_candidate_targets` queries the battlefield at
+        // cast-time and returns an empty set, which is the exact signal
+        // `bounce_self_undo_redundancy` keys off of.
         let mut state = GameState::new_two_player(0);
         let (obj_id, card_id) = make_etb_bouncer_in_hand(
             &mut state,
             "Whitemane Lion",
             TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
         );
-        // Simulate the on-resolution battlefield: the Lion is the sole
-        // creature the AI controls. (CastFacts walks `trigger_definitions`
-        // on the hand object; the candidate target set is computed against
-        // the current battlefield, so we add the source there too to
-        // emulate the post-ETB-resolution state.)
-        state.battlefield.push_back(obj_id);
-        state.objects.get_mut(&obj_id).unwrap().zone = Zone::Battlefield;
 
         let config = AiConfig::default();
         let ai_ctx = AiContext::empty(&config.weights);
@@ -1416,17 +1420,18 @@ mod tests {
 
     #[test]
     fn etb_bounce_with_other_creature_not_penalised() {
-        // AI controls the Lion AND another creature — the ETB bounce has a
-        // legitimate target other than itself, so it is NOT self-undoing.
+        // AI is casting Whitemane Lion from hand AND already controls
+        // another creature on the battlefield. The ETB bounce has a
+        // legitimate target other than the Lion itself, so it is NOT
+        // self-undoing — the candidate set is non-empty at cast-time.
         let mut state = GameState::new_two_player(0);
         let (obj_id, card_id) = make_etb_bouncer_in_hand(
             &mut state,
             "Whitemane Lion",
             TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
         );
-        state.battlefield.push_back(obj_id);
-        state.objects.get_mut(&obj_id).unwrap().zone = Zone::Battlefield;
-        // Add a second creature the AI controls.
+        // The other creature lives on the battlefield as the legitimate
+        // bounce target. `make_creature_with_ability` places it there.
         let _other = make_creature_with_ability(
             &mut state,
             "Other Creature",
@@ -1521,8 +1526,12 @@ mod tests {
         // `Some(Zone::Hand)` are self-undo loops, because only those land the
         // source back where it can be immediately re-cast. A bounce to library
         // is a different category (top-of-library setup, e.g., Crystal Shard
-        // variants) — `bounce_self_undo_redundancy` must NOT fire here even
-        // when the only legal target is the source itself.
+        // variants) — `bounce_self_undo_redundancy` must NOT fire here.
+        // Mirrors the Whitemane-Lion geometry (bouncer in hand, no other
+        // creatures controlled): if the destination-axis short-circuit in
+        // the `Effect::Bounce` match arm is missing, the predicate would
+        // emit a penalty via the empty-candidates branch and this test
+        // would fail.
         let mut state = GameState::new_two_player(0);
         let (obj_id, card_id) = make_etb_bouncer_in_hand_with_destination(
             &mut state,
@@ -1530,12 +1539,6 @@ mod tests {
             TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
             Some(Zone::Library),
         );
-        // Mirror the self-undo battlefield shape: the bouncer is the only
-        // creature controlled. Whitemane-Lion test geometry — if the
-        // destination-axis short-circuit is missing, this test will go
-        // negative and fail.
-        state.battlefield.push_back(obj_id);
-        state.objects.get_mut(&obj_id).unwrap().zone = Zone::Battlefield;
 
         let config = AiConfig::default();
         let ai_ctx = AiContext::empty(&config.weights);

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -65,6 +65,7 @@ use engine::types::game_state::{GameState, TransientContinuousEffect};
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
 use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
 
 use super::activation::turn_only;
 use super::context::PolicyContext;
@@ -77,6 +78,33 @@ use crate::features::DeckFeatures;
 /// stabilising lifegain; 30+ is deep into diminishing-returns territory
 /// where an extra 2-3 life is unlikely to affect the winning line.
 const LIFE_DIMINISHING_RETURNS: i32 = 30;
+
+/// Penalty delta applied when the ETB self-bounce predicate fires (Whitemane
+/// Lion class — see `bounce_self_undo_redundancy`). Promoted to a named
+/// constant so the magnitude is documented and traceable rather than a bare
+/// `-3.0` magic number at the predicate's `return` sites.
+const BOUNCE_SELF_UNDO_DELTA: f64 = -3.0;
+
+/// Origin layer for an effect being evaluated by the redundancy policy.
+///
+/// The redundancy semantics differ depending on whether the effect comes
+/// from the spell's primary ability chain, or from an immediate ETB trigger
+/// on a cast spell. Self-undo detection (Whitemane Lion class) only applies
+/// to ETB triggers: an activated/triggered bounce on an already-resolved
+/// permanent (Soulherder-style blink) is a legitimate value loop and must
+/// not be penalised. A typed enum here keeps the call-site intent
+/// self-documenting and leaves room to add further origin layers (e.g.,
+/// `ResolutionReplacement`, `LeavesBattlefieldTrigger`) without retrofitting
+/// a wider boolean parameter list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EffectOrigin {
+    /// Effect from `ctx.effects()` — the candidate's primary ability chain.
+    /// Used for activated abilities and the primary effects of cast spells.
+    PrimaryAbility,
+    /// Effect from `cast_facts.immediate_etb_triggers` on a `CastSpell`
+    /// candidate — fires only on the first ETB after the cast resolves.
+    CastImmediateEtbTrigger,
+}
 
 /// Reason kind emitted on every `Score` verdict. Per-arm detail lives in
 /// `PolicyReason.facts` (`source_id`, `effect_kind`, etc.).
@@ -93,12 +121,16 @@ const KIND_DRAW_ZERO: i64 = 4;
 const KIND_GENERIC_KEYWORD: i64 = 5;
 const KIND_ANIMATE_KEYWORDS: i64 = 6;
 const KIND_UNTAP: i64 = 7;
-/// CR 400.7 + CR 701.4: ETB-triggered self-bounce where the only legal
-/// returnee is the source itself (or no creature qualifies), so the trigger
-/// re-pings the spell back into the caster's hand. Whitemane Lion / Stonecloaker
-/// class — left unchecked, the AI casts and re-casts in a positive-scoring loop
-/// because `EtbValuePolicy` rewards the bounce without distinguishing self-undo
-/// from genuine blink value.
+/// CR 603.6a + CR 400.7 + CR 608.2b: ETB-triggered self-bounce where the
+/// only legal returnee is the source itself (or no creature qualifies). The
+/// trigger fires when the permanent enters the battlefield (CR 603.6a); on
+/// resolution, target legality is rechecked (CR 608.2b) and — because the
+/// permanent that resolved on the battlefield is a new object distinct from
+/// the spell that was cast (CR 400.7) — the only legal "creature you control"
+/// is the source itself, so it re-enters the caster's hand. Whitemane Lion /
+/// Stonecloaker class — left unchecked, the AI casts and re-casts in a
+/// positive-scoring loop because `EtbValuePolicy` rewards the bounce without
+/// distinguishing self-undo from genuine blink value.
 const KIND_BOUNCE_SELF_UNDO: i64 = 8;
 
 pub struct RedundancyAvoidancePolicy;
@@ -146,7 +178,7 @@ impl TacticalPolicy for RedundancyAvoidancePolicy {
                 effect,
                 source_id,
                 ctx.ai_player,
-                /* is_self_etb= */ false,
+                EffectOrigin::PrimaryAbility,
             ) {
                 total += delta;
                 last_fact = Some((kind_tag, extra));
@@ -154,11 +186,13 @@ impl TacticalPolicy for RedundancyAvoidancePolicy {
         }
 
         // CR 603.6a + CR 400.7: For permanent spell casts, also walk the
-        // immediate ETB-trigger effect chain. `ctx.effects()` only covers the
-        // spell's primary abilities — a vanilla creature whose only on-cast
-        // interaction is an ETB trigger (e.g., Whitemane Lion's "return a
-        // creature you control") would otherwise present an empty effect list
-        // here, blinding the policy to ETB-self-undo loops.
+        // immediate ETB-trigger effect chain. CR 603.6a says ETB abilities
+        // trigger when the permanent enters; CR 400.7 says the resolved
+        // permanent is a new object distinct from the spell. `ctx.effects()`
+        // only covers the spell's primary abilities — a vanilla creature
+        // whose only on-cast interaction is an ETB trigger (e.g., Whitemane
+        // Lion's "return a creature you control") would otherwise present an
+        // empty effect list here, blinding the policy to ETB-self-undo loops.
         if matches!(ctx.candidate.action, GameAction::CastSpell { .. }) {
             if let Some(facts) = ctx.cast_facts() {
                 for trigger in &facts.immediate_etb_triggers {
@@ -171,7 +205,7 @@ impl TacticalPolicy for RedundancyAvoidancePolicy {
                             effect,
                             source_id,
                             ctx.ai_player,
-                            /* is_self_etb= */ true,
+                            EffectOrigin::CastImmediateEtbTrigger,
                         ) {
                             total += delta;
                             last_fact = Some((kind_tag, extra));
@@ -211,16 +245,16 @@ impl TacticalPolicy for RedundancyAvoidancePolicy {
 ///   - Generic/Animate keyword: count of granted keywords already present
 ///   - Bounce self-undo: candidate-set size (0 = trigger fizzles, 1 = source-only)
 ///
-/// `is_self_etb` is set only when the effect comes from an immediate
-/// ETB-trigger on the cast spell itself. Most arms ignore it; the `Bounce`
-/// arm uses it to detect the ETB-self-undo class (Whitemane Lion) without
-/// penalising legitimate activated/triggered bounce abilities like Soulherder.
+/// `origin` records which layer the effect was pulled from. Most arms ignore
+/// it; the `Bounce` arm uses it to detect the ETB-self-undo class (Whitemane
+/// Lion) without penalising legitimate activated/triggered bounce abilities
+/// like Soulherder.
 fn redundancy_delta(
     state: &GameState,
     effect: &Effect,
     source_id: ObjectId,
     ai_player: PlayerId,
-    is_self_etb: bool,
+    origin: EffectOrigin,
 ) -> Option<(f64, i64, i64)> {
     match effect {
         Effect::Tap { target } => tap_redundancy(state, source_id, target),
@@ -257,9 +291,21 @@ fn redundancy_delta(
         Effect::Animate {
             keywords, target, ..
         } => animate_keyword_redundancy(state, source_id, keywords, target),
-        Effect::Bounce { target, .. } => {
-            bounce_self_undo_redundancy(state, source_id, target, is_self_etb)
-        }
+        // CR 603.6a + CR 400.7 + CR 608.2b: ETB-triggered self-bounce is only
+        // a self-undo loop when the destination is the owner's hand (the
+        // default for `Effect::Bounce`). Library/Exile destinations have
+        // their own value/concern axes — they don't refill the caster's hand
+        // for an immediate recast — so we route only hand-destined bounces
+        // through the self-undo predicate.
+        Effect::Bounce {
+            target,
+            destination,
+        } => match destination {
+            None | Some(Zone::Hand) => {
+                bounce_self_undo_redundancy(state, source_id, target, origin)
+            }
+            Some(_) => None,
+        },
 
         // ----- Variants with no shipped redundancy check -----
         //
@@ -483,35 +529,47 @@ fn resolved_candidate_targets(
 /// not stick — the source either re-enters the caster's hand or contributes
 /// no on-resolution value beyond a vanilla body that didn't enter.
 ///
-/// Only fires when `is_self_etb == true`. Activated/triggered abilities that
-/// happen to bounce a creature you control (Soulherder-style blink) must NOT
-/// be penalised — those are legitimate value loops, not self-undo.
+/// Categorical scope:
+///   - Only fires when `origin == EffectOrigin::CastImmediateEtbTrigger`.
+///     Activated/triggered abilities that happen to bounce a creature you
+///     control (Soulherder-style blink) must NOT be penalised — those are
+///     legitimate value loops, not self-undo.
+///   - The caller (the `Effect::Bounce` match arm in `redundancy_delta`) is
+///     responsible for restricting this predicate to bounces whose
+///     destination is the owner's hand (default `None` or explicit
+///     `Some(Zone::Hand)`). Library/Exile destinations are not handled by
+///     this predicate.
 ///
-/// Returns `(-3.0, KIND_BOUNCE_SELF_UNDO, count)` on a confirmed self-undo;
-/// `None` otherwise. The `count` fact is 0 when the trigger fizzles and 1
-/// when the source is the only legal return target — enough signal in traces
-/// to distinguish the two pathological subcases.
+/// Returns `(BOUNCE_SELF_UNDO_DELTA, KIND_BOUNCE_SELF_UNDO, count)` on a
+/// confirmed self-undo; `None` otherwise. The `count` fact is 0 when the
+/// trigger fizzles and 1 when the source is the only legal return target —
+/// enough signal in traces to distinguish the two pathological subcases.
 fn bounce_self_undo_redundancy(
     state: &GameState,
     source_id: ObjectId,
     target: &TargetFilter,
-    is_self_etb: bool,
+    origin: EffectOrigin,
 ) -> Option<(f64, i64, i64)> {
-    if !is_self_etb {
+    if origin != EffectOrigin::CastImmediateEtbTrigger {
         return None;
     }
     let candidates = resolved_candidate_targets(state, source_id, target);
-    // CR 603.6a: if the candidate set is empty, the trigger has no legal
-    // target — the bounce does nothing. Penalise: the AI is paying mana for
-    // a trigger that fizzles.
+    // CR 608.2b: if the candidate set is empty, the trigger has no legal
+    // target — the targeted ability is removed from the stack at resolution
+    // and does nothing. Penalise: the AI is paying mana for a trigger that
+    // fizzles.
     if candidates.is_empty() {
-        return Some((-3.0, KIND_BOUNCE_SELF_UNDO, 0));
+        return Some((BOUNCE_SELF_UNDO_DELTA, KIND_BOUNCE_SELF_UNDO, 0));
     }
     // Whitemane-Lion / Stonecloaker case: every candidate IS the source.
     // The trigger must pick the source itself, bouncing the spell-just-cast
     // back to hand. Net effect: spend mana, gain nothing, prime the loop.
     if candidates.iter().all(|&id| id == source_id) {
-        return Some((-3.0, KIND_BOUNCE_SELF_UNDO, candidates.len() as i64));
+        return Some((
+            BOUNCE_SELF_UNDO_DELTA,
+            KIND_BOUNCE_SELF_UNDO,
+            candidates.len() as i64,
+        ));
     }
     None
 }
@@ -1276,6 +1334,19 @@ mod tests {
         name: &str,
         bounce_target: TargetFilter,
     ) -> (ObjectId, CardId) {
+        make_etb_bouncer_in_hand_with_destination(state, name, bounce_target, None)
+    }
+
+    /// Variant of `make_etb_bouncer_in_hand` allowing the ETB-bounce
+    /// destination to be set explicitly. `None` matches the default
+    /// (owner's hand); `Some(Zone::Library)` covers top-of-library variants
+    /// used to verify the destination-axis short-circuit in the bounce arm.
+    fn make_etb_bouncer_in_hand_with_destination(
+        state: &mut GameState,
+        name: &str,
+        bounce_target: TargetFilter,
+        destination: Option<Zone>,
+    ) -> (ObjectId, CardId) {
         let card_id = CardId(state.objects.len() as u64 + 1);
         let obj_id = create_object(state, card_id, PlayerId(0), name.to_string(), Zone::Hand);
         let obj = state.objects.get_mut(&obj_id).unwrap();
@@ -1288,7 +1359,7 @@ mod tests {
                     AbilityKind::Spell,
                     Effect::Bounce {
                         target: bounce_target,
-                        destination: None,
+                        destination,
                     },
                 )),
         );
@@ -1385,8 +1456,8 @@ mod tests {
         // bounces "a creature you control". This is a legitimate value loop,
         // not self-undo — the policy must NOT penalise. Even if the only
         // legal target is the source itself, the activated/spell path runs
-        // `redundancy_delta` with `is_self_etb=false`, which short-circuits
-        // the bounce arm to `None`.
+        // `redundancy_delta` with `EffectOrigin::PrimaryAbility`, which
+        // short-circuits the bounce arm to `None`.
         let mut state = GameState::new_two_player(0);
         let obj_id = make_creature_with_ability(
             &mut state,
@@ -1441,6 +1512,43 @@ mod tests {
         assert!(
             delta <= -3.0,
             "ETB bounce with no legal target should emit delta <= -3.0; got {delta}"
+        );
+    }
+
+    #[test]
+    fn etb_bounce_to_library_not_penalised() {
+        // Categorical scope: only `destination == None` or
+        // `Some(Zone::Hand)` are self-undo loops, because only those land the
+        // source back where it can be immediately re-cast. A bounce to library
+        // is a different category (top-of-library setup, e.g., Crystal Shard
+        // variants) — `bounce_self_undo_redundancy` must NOT fire here even
+        // when the only legal target is the source itself.
+        let mut state = GameState::new_two_player(0);
+        let (obj_id, card_id) = make_etb_bouncer_in_hand_with_destination(
+            &mut state,
+            "Library Bouncer",
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            Some(Zone::Library),
+        );
+        // Mirror the self-undo battlefield shape: the bouncer is the only
+        // creature controlled. Whitemane-Lion test geometry — if the
+        // destination-axis short-circuit is missing, this test will go
+        // negative and fail.
+        state.battlefield.push_back(obj_id);
+        state.objects.get_mut(&obj_id).unwrap().zone = Zone::Battlefield;
+
+        let config = AiConfig::default();
+        let ai_ctx = AiContext::empty(&config.weights);
+        let decision = priority_decision();
+        let candidate = cast_candidate(obj_id, card_id);
+        let ctx = mk_ctx(&state, &decision, &candidate, &config, &ai_ctx);
+
+        let PolicyVerdict::Score { delta, .. } = RedundancyAvoidancePolicy.verdict(&ctx) else {
+            panic!("expected Score verdict");
+        };
+        assert_eq!(
+            delta, 0.0,
+            "ETB-bounce with destination=Library is not the self-undo class; got {delta}"
         );
     }
 

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -40,6 +40,18 @@
 //! - `Discard` — penalise "opponent discards" when opponent's hand is
 //!   known-empty (requires information-asymmetry handling).
 //! - Multi-turn projection (draw into a full hand when discard is coming).
+//!
+//! Deferred (issue #563 — Whitemane Lion ETB self-bounce loop):
+//! - **Per-turn cast cap (defence-in-depth)**: `MAX_ACTIVATIONS_PER_SOURCE_PER_TURN`
+//!   today only bounds `ActivateAbility`. Mirroring it as a
+//!   `spells_cast_this_turn_by_player[card_id]` cap would catch any future
+//!   loop class that slips past content-level redundancy detection, including
+//!   non-bounce self-undoing patterns. Tracked separately; not implemented here.
+//! - **Parser non-targeting fix**: Whitemane Lion's ETB ("return a creature
+//!   you control to its owner's hand") is non-targeting in Oracle terms,
+//!   but currently parses as a targeted Bounce. Fixing the parser would make
+//!   the AI choose correctly at resolution time without needing this policy
+//!   to short-circuit casts. Tracked separately as an oracle-parser issue.
 
 use engine::game::filter::{matches_target_filter, FilterContext};
 use engine::game::keywords::has_keyword;
@@ -57,6 +69,7 @@ use engine::types::player::PlayerId;
 use super::activation::turn_only;
 use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::cast_facts::collect_definition_effects;
 use crate::features::DeckFeatures;
 
 /// Life threshold at which further life gain is treated as redundant.
@@ -80,6 +93,13 @@ const KIND_DRAW_ZERO: i64 = 4;
 const KIND_GENERIC_KEYWORD: i64 = 5;
 const KIND_ANIMATE_KEYWORDS: i64 = 6;
 const KIND_UNTAP: i64 = 7;
+/// CR 400.7 + CR 701.4: ETB-triggered self-bounce where the only legal
+/// returnee is the source itself (or no creature qualifies), so the trigger
+/// re-pings the spell back into the caster's hand. Whitemane Lion / Stonecloaker
+/// class — left unchecked, the AI casts and re-casts in a positive-scoring loop
+/// because `EtbValuePolicy` rewards the bounce without distinguishing self-undo
+/// from genuine blink value.
+const KIND_BOUNCE_SELF_UNDO: i64 = 8;
 
 pub struct RedundancyAvoidancePolicy;
 
@@ -121,11 +141,43 @@ impl TacticalPolicy for RedundancyAvoidancePolicy {
         let mut total = 0.0;
         let mut last_fact: Option<(i64, i64)> = None;
         for effect in ctx.effects() {
-            if let Some((delta, kind_tag, extra)) =
-                redundancy_delta(ctx.state, effect, source_id, ctx.ai_player)
-            {
+            if let Some((delta, kind_tag, extra)) = redundancy_delta(
+                ctx.state,
+                effect,
+                source_id,
+                ctx.ai_player,
+                /* is_self_etb= */ false,
+            ) {
                 total += delta;
                 last_fact = Some((kind_tag, extra));
+            }
+        }
+
+        // CR 603.6a + CR 400.7: For permanent spell casts, also walk the
+        // immediate ETB-trigger effect chain. `ctx.effects()` only covers the
+        // spell's primary abilities — a vanilla creature whose only on-cast
+        // interaction is an ETB trigger (e.g., Whitemane Lion's "return a
+        // creature you control") would otherwise present an empty effect list
+        // here, blinding the policy to ETB-self-undo loops.
+        if matches!(ctx.candidate.action, GameAction::CastSpell { .. }) {
+            if let Some(facts) = ctx.cast_facts() {
+                for trigger in &facts.immediate_etb_triggers {
+                    let Some(execute) = trigger.execute.as_deref() else {
+                        continue;
+                    };
+                    for effect in collect_definition_effects(execute) {
+                        if let Some((delta, kind_tag, extra)) = redundancy_delta(
+                            ctx.state,
+                            effect,
+                            source_id,
+                            ctx.ai_player,
+                            /* is_self_etb= */ true,
+                        ) {
+                            total += delta;
+                            last_fact = Some((kind_tag, extra));
+                        }
+                    }
+                }
             }
         }
 
@@ -157,11 +209,18 @@ impl TacticalPolicy for RedundancyAvoidancePolicy {
 ///   - GainLife: current life total
 ///   - DealDamage/Draw: resolved quantity (0)
 ///   - Generic/Animate keyword: count of granted keywords already present
+///   - Bounce self-undo: candidate-set size (0 = trigger fizzles, 1 = source-only)
+///
+/// `is_self_etb` is set only when the effect comes from an immediate
+/// ETB-trigger on the cast spell itself. Most arms ignore it; the `Bounce`
+/// arm uses it to detect the ETB-self-undo class (Whitemane Lion) without
+/// penalising legitimate activated/triggered bounce abilities like Soulherder.
 fn redundancy_delta(
     state: &GameState,
     effect: &Effect,
     source_id: ObjectId,
     ai_player: PlayerId,
+    is_self_etb: bool,
 ) -> Option<(f64, i64, i64)> {
     match effect {
         Effect::Tap { target } => tap_redundancy(state, source_id, target),
@@ -198,6 +257,9 @@ fn redundancy_delta(
         Effect::Animate {
             keywords, target, ..
         } => animate_keyword_redundancy(state, source_id, keywords, target),
+        Effect::Bounce { target, .. } => {
+            bounce_self_undo_redundancy(state, source_id, target, is_self_etb)
+        }
 
         // ----- Variants with no shipped redundancy check -----
         //
@@ -234,7 +296,6 @@ fn redundancy_delta(
         | Effect::UnattachAll { .. }
         | Effect::Surveil { .. }
         | Effect::Fight { .. }
-        | Effect::Bounce { .. }
         | Effect::Explore
         | Effect::ExploreAll { .. }
         | Effect::Investigate
@@ -412,6 +473,47 @@ fn resolved_candidate_targets(
         .copied()
         .filter(|&obj_id| matches_target_filter(state, obj_id, target, &filter_ctx))
         .collect()
+}
+
+/// ETB-self-undo bounce: the cast spell's immediate ETB trigger returns a
+/// creature to its owner's hand, but the only legal returnee on the
+/// battlefield is the source object itself (Whitemane Lion ruling: "If you
+/// don't control any other creature, you must return it") OR the candidate
+/// set is empty (the trigger fizzles entirely). In both cases the cast does
+/// not stick — the source either re-enters the caster's hand or contributes
+/// no on-resolution value beyond a vanilla body that didn't enter.
+///
+/// Only fires when `is_self_etb == true`. Activated/triggered abilities that
+/// happen to bounce a creature you control (Soulherder-style blink) must NOT
+/// be penalised — those are legitimate value loops, not self-undo.
+///
+/// Returns `(-3.0, KIND_BOUNCE_SELF_UNDO, count)` on a confirmed self-undo;
+/// `None` otherwise. The `count` fact is 0 when the trigger fizzles and 1
+/// when the source is the only legal return target — enough signal in traces
+/// to distinguish the two pathological subcases.
+fn bounce_self_undo_redundancy(
+    state: &GameState,
+    source_id: ObjectId,
+    target: &TargetFilter,
+    is_self_etb: bool,
+) -> Option<(f64, i64, i64)> {
+    if !is_self_etb {
+        return None;
+    }
+    let candidates = resolved_candidate_targets(state, source_id, target);
+    // CR 603.6a: if the candidate set is empty, the trigger has no legal
+    // target — the bounce does nothing. Penalise: the AI is paying mana for
+    // a trigger that fizzles.
+    if candidates.is_empty() {
+        return Some((-3.0, KIND_BOUNCE_SELF_UNDO, 0));
+    }
+    // Whitemane-Lion / Stonecloaker case: every candidate IS the source.
+    // The trigger must pick the source itself, bouncing the spell-just-cast
+    // back to hand. Net effect: spend mana, gain nothing, prime the loop.
+    if candidates.iter().all(|&id| id == source_id) {
+        return Some((-3.0, KIND_BOUNCE_SELF_UNDO, candidates.len() as i64));
+    }
+    None
 }
 
 /// Tap-on-tapped: every candidate match is already `obj.tapped == true`.
@@ -1151,6 +1253,194 @@ mod tests {
         assert_eq!(
             delta, -6.0,
             "sub-ability chain with two zero-quantity effects should sum"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounce-self-undo (issue #563) coverage — Whitemane Lion class.
+    //
+    // The Lion ETB returns "a creature you control" — if you control no other
+    // creature, the Lion itself is the only legal target, so it re-enters
+    // your hand. The AI was looping on this because EtbValuePolicy scores the
+    // bounce positively, and no policy detected the self-undo.
+    // -----------------------------------------------------------------------
+
+    use engine::types::ability::{ControllerRef, TriggerDefinition, TypedFilter};
+    use engine::types::triggers::TriggerMode;
+
+    /// Helper: place a creature in hand with an ETB-triggered Bounce of the
+    /// given target filter, matching the Whitemane Lion shape. Returns the
+    /// hand object id and its card id, ready to construct a CastSpell candidate.
+    fn make_etb_bouncer_in_hand(
+        state: &mut GameState,
+        name: &str,
+        bounce_target: TargetFilter,
+    ) -> (ObjectId, CardId) {
+        let card_id = CardId(state.objects.len() as u64 + 1);
+        let obj_id = create_object(state, card_id, PlayerId(0), name.to_string(), Zone::Hand);
+        let obj = state.objects.get_mut(&obj_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.trigger_definitions.push(
+            TriggerDefinition::new(TriggerMode::ChangesZone)
+                .valid_card(TargetFilter::SelfRef)
+                .destination(Zone::Battlefield)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::Bounce {
+                        target: bounce_target,
+                        destination: None,
+                    },
+                )),
+        );
+        (obj_id, card_id)
+    }
+
+    fn cast_candidate(object_id: ObjectId, card_id: CardId) -> CandidateAction {
+        CandidateAction {
+            action: GameAction::CastSpell {
+                object_id,
+                card_id,
+                targets: Vec::new(),
+            },
+            metadata: ActionMetadata {
+                actor: Some(PlayerId(0)),
+                tactical_class: TacticalClass::Spell,
+            },
+        }
+    }
+
+    #[test]
+    fn whitemane_lion_self_undo_etb_penalised() {
+        // AI controls only the Lion (after it resolves it would be alone),
+        // so the "creature you control" ETB bounce has exactly one legal
+        // target: the Lion itself. Confirmed self-undo loop.
+        let mut state = GameState::new_two_player(0);
+        let (obj_id, card_id) = make_etb_bouncer_in_hand(
+            &mut state,
+            "Whitemane Lion",
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+        );
+        // Simulate the on-resolution battlefield: the Lion is the sole
+        // creature the AI controls. (CastFacts walks `trigger_definitions`
+        // on the hand object; the candidate target set is computed against
+        // the current battlefield, so we add the source there too to
+        // emulate the post-ETB-resolution state.)
+        state.battlefield.push_back(obj_id);
+        state.objects.get_mut(&obj_id).unwrap().zone = Zone::Battlefield;
+
+        let config = AiConfig::default();
+        let ai_ctx = AiContext::empty(&config.weights);
+        let decision = priority_decision();
+        let candidate = cast_candidate(obj_id, card_id);
+        let ctx = mk_ctx(&state, &decision, &candidate, &config, &ai_ctx);
+
+        let PolicyVerdict::Score { delta, .. } = RedundancyAvoidancePolicy.verdict(&ctx) else {
+            panic!("expected Score verdict");
+        };
+        assert!(
+            delta <= -3.0,
+            "Whitemane Lion ETB-self-undo should emit delta <= -3.0; got {delta}"
+        );
+    }
+
+    #[test]
+    fn etb_bounce_with_other_creature_not_penalised() {
+        // AI controls the Lion AND another creature — the ETB bounce has a
+        // legitimate target other than itself, so it is NOT self-undoing.
+        let mut state = GameState::new_two_player(0);
+        let (obj_id, card_id) = make_etb_bouncer_in_hand(
+            &mut state,
+            "Whitemane Lion",
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+        );
+        state.battlefield.push_back(obj_id);
+        state.objects.get_mut(&obj_id).unwrap().zone = Zone::Battlefield;
+        // Add a second creature the AI controls.
+        let _other = make_creature_with_ability(
+            &mut state,
+            "Other Creature",
+            Effect::Tap {
+                target: TargetFilter::SelfRef,
+            },
+        );
+
+        let config = AiConfig::default();
+        let ai_ctx = AiContext::empty(&config.weights);
+        let decision = priority_decision();
+        let candidate = cast_candidate(obj_id, card_id);
+        let ctx = mk_ctx(&state, &decision, &candidate, &config, &ai_ctx);
+
+        let PolicyVerdict::Score { delta, .. } = RedundancyAvoidancePolicy.verdict(&ctx) else {
+            panic!("expected Score verdict");
+        };
+        assert_eq!(
+            delta, 0.0,
+            "ETB-self-bounce with another legal target should not penalise; got {delta}"
+        );
+    }
+
+    #[test]
+    fn activated_bounce_yourcreature_not_penalised() {
+        // Soulherder-style: an ACTIVATED ability (not an ETB trigger) that
+        // bounces "a creature you control". This is a legitimate value loop,
+        // not self-undo — the policy must NOT penalise. Even if the only
+        // legal target is the source itself, the activated/spell path runs
+        // `redundancy_delta` with `is_self_etb=false`, which short-circuits
+        // the bounce arm to `None`.
+        let mut state = GameState::new_two_player(0);
+        let obj_id = make_creature_with_ability(
+            &mut state,
+            "Soulherder",
+            Effect::Bounce {
+                target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+                destination: None,
+            },
+        );
+
+        let config = AiConfig::default();
+        let ai_ctx = AiContext::empty(&config.weights);
+        let decision = priority_decision();
+        let candidate = activate_candidate(obj_id);
+        let ctx = mk_ctx(&state, &decision, &candidate, &config, &ai_ctx);
+
+        let PolicyVerdict::Score { delta, .. } = RedundancyAvoidancePolicy.verdict(&ctx) else {
+            panic!("expected Score verdict");
+        };
+        assert_eq!(
+            delta, 0.0,
+            "activated bounce-your-creature must not be penalised (Soulherder class); got {delta}"
+        );
+    }
+
+    #[test]
+    fn etb_bounce_no_legal_target_penalised() {
+        // AI has the Lion in hand but controls no creatures yet — the ETB
+        // bounce trigger will fizzle (no legal target). Penalise: AI is
+        // about to pay 2 mana for a vanilla 2/2 with a no-op trigger that
+        // contributes no value beyond the body. Detecting this prevents
+        // burning search budget on the cast when better lines exist.
+        let mut state = GameState::new_two_player(0);
+        let (obj_id, card_id) = make_etb_bouncer_in_hand(
+            &mut state,
+            "Whitemane Lion",
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+        );
+        // Do NOT push obj_id to battlefield — Lion is still in hand, and
+        // there are no creatures of any kind on the battlefield. The
+        // candidate target set is empty.
+
+        let config = AiConfig::default();
+        let ai_ctx = AiContext::empty(&config.weights);
+        let decision = priority_decision();
+        let candidate = cast_candidate(obj_id, card_id);
+        let ctx = mk_ctx(&state, &decision, &candidate, &config, &ai_ctx);
+
+        let PolicyVerdict::Score { delta, .. } = RedundancyAvoidancePolicy.verdict(&ctx) else {
+            panic!("expected Score verdict");
+        };
+        assert!(
+            delta <= -3.0,
+            "ETB bounce with no legal target should emit delta <= -3.0; got {delta}"
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes issue #563 — the AI's `RedundancyAvoidancePolicy` did not detect the
Whitemane Lion / Stonecloaker class, where a cast spell's immediate ETB
trigger bounces "a creature you control" and the only legal returnee is the
source itself. `EtbValuePolicy` rewarded the bounce while no policy detected
the self-undo, producing a positive net softmax score and infinite-cast
turns. This PR teaches `redundancy_delta` to walk the cast's
`immediate_etb_triggers`, detect the self-targeted bounce, and emit a
negative delta — closing the loop without affecting Soulherder-style
blink of other creatures.

## Files changed
- crates/phase-ai/src/policies/redundancy_avoidance.rs

## CR references
- CR 603.6a — ETB triggers fire when the permanent enters the battlefield
- CR 400.7 — a permanent that changes zones becomes a new object
- CR 608.2b — target legality is rechecked on resolution; ability is removed from the stack if no targets are legal

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (per qa-tester report)
- `cargo test -p phase-ai` — 662 pass / 0 fail (per qa-tester report)
- Pipeline outcomes:
  - doc-guardian: CLEAN after 1 fixup pass; all CR numbers verified vs `docs/MagicCompRules.txt`
  - code-reviewer: APPROVE WITH SUGGESTIONS (no blockers)
  - qa-tester: READY FOR PR

## Scope Expansion
None. Pure AI-policy fix in one file (`crates/phase-ai/src/policies/redundancy_avoidance.rs`). Deferred parser/engine work tracked in the module doc comment but explicitly NOT included.

## Validation Failures
None.

## CI Failures
A pre-existing engine test (`station_32_tdm_spacecraft_regression_suite` in `crates/engine/src/database/synthesis.rs:7102`) fails on `main` due to `card-data.json` drift (contains an `IfYouDo` variant the engine no longer accepts). This is unrelated to this branch and likely resolved by regenerating card data via `./scripts/gen-card-data.sh`. **Do not block this PR on it.**

## Known follow-ups (out of scope for this PR)
Suggestions from code-reviewer, deferred:

1. `matches!(... GameAction::CastSpell { .. })` does not match alt-cast variants (cascade, free-spell, sneak). Tracked as a known scope limit.
2. No integration-level test that the AI search actually stops looping in the Whitemane Lion repro; only unit-level proof that the policy emits the negative delta.
3. No coverage for `Effect::BounceAll` self-only ETB (separate variant).
4. Parser-side: Whitemane Lion's "return a creature you control" is mis-parsed as targeting (per CR 115.1 it is choose-on-resolution since there is no "target" keyword). Tracked as a deferred follow-up in the module doc.
5. Per-turn cast-history awareness (`spells_cast_this_turn_by_player`) for defence-in-depth — deferred in module doc.