### PR TITLE
fix(parser): consume "A deck can have any number" deck-construction line

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -8674,6 +8674,294 @@ mod tests {
         }
     }
 
+    // CR 120 (damage), CR 510.1 (combat damage step), CR 603.6c
+    // (combat-damage triggers), CR 701.23a/b/d (search library /
+    // fail-to-find), CR 100.2a / CR 717.1d / CR 903.5b (deck-construction
+    // overrides — verified silently consumed by Step 1's parser fix).
+    //
+    // Tempest Hawk's combat-damage trigger:
+    //   "Whenever this creature deals combat damage to a player, you may
+    //    search your library for a card named Tempest Hawk, reveal it,
+    //    put it into your hand, then shuffle."
+    //
+    // The AST shape: TriggerMode::DamageDone with damage_kind = CombatOnly,
+    // valid_target = Player, optional = true, execute chain =
+    // SearchLibrary → ChangeZone(Library→Hand) → Shuffle. The shape is
+    // identical to Squadron Hawk's ETB-triggered search, so we reuse the
+    // search-and-shuffle assertion structure; only the trigger source
+    // (combat damage vs ETB) differs.
+    const TEMPEST_HAWK_ORACLE: &str = "Flying\nWhenever this creature deals combat damage to a player, you may search your library for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.\nA deck can have any number of cards named Tempest Hawk.";
+
+    fn add_tempest_hawk_to_library(state: &mut GameState, card_id: u64) -> ObjectId {
+        let hawk = create_object(
+            state,
+            CardId(card_id),
+            PlayerId(0),
+            "Tempest Hawk".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&hawk).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+        }
+        hawk
+    }
+
+    /// Set up a board where a Tempest Hawk on the battlefield is the sole
+    /// attacker against PlayerId(1), and advance combat through declare-
+    /// attackers / declare-blockers so the damage step is about to fire.
+    /// Returns (state, attacking hawk, hawks in library).
+    fn setup_tempest_hawk_attack(library_hawk_ids: &[u64]) -> (GameState, ObjectId, Vec<ObjectId>) {
+        use crate::game::combat::AttackTarget;
+        use crate::types::mana::ManaColor;
+
+        let mut state = new_game(42);
+        state.turn_number = 5;
+        state.phase = Phase::DeclareAttackers;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        let attacker = create_object(
+            &mut state,
+            CardId(700),
+            PlayerId(0),
+            "Tempest Hawk".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&attacker).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+            obj.color = vec![ManaColor::White];
+            obj.base_color = vec![ManaColor::White];
+            obj.entered_battlefield_turn = Some(4);
+        }
+        apply_oracle_to_object(&mut state, attacker, "Tempest Hawk", TEMPEST_HAWK_ORACLE);
+
+        let library_hawks: Vec<ObjectId> = library_hawk_ids
+            .iter()
+            .map(|id| add_tempest_hawk_to_library(&mut state, *id))
+            .collect();
+
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: vec![attacker],
+            valid_attack_targets: vec![AttackTarget::Player(PlayerId(1))],
+        };
+
+        apply_as_current(
+            &mut state,
+            GameAction::DeclareAttackers {
+                attacks: vec![(attacker, AttackTarget::Player(PlayerId(1)))],
+            },
+        )
+        .unwrap();
+
+        (state, attacker, library_hawks)
+    }
+
+    /// Advance combat from DeclareAttackers (just submitted) through to the
+    /// point where Tempest Hawk's `you may` combat-damage trigger has been
+    /// pushed onto the stack and is being resolved (engine is at
+    /// `WaitingFor::OptionalEffectChoice`).
+    fn advance_to_tempest_hawk_optional_choice(state: &mut GameState) {
+        for _ in 0..16 {
+            if matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }) {
+                return;
+            }
+            apply_as_current(state, GameAction::PassPriority).unwrap();
+        }
+        panic!(
+            "expected WaitingFor::OptionalEffectChoice for Tempest Hawk's combat-damage trigger, \
+             got {:?} after exhausting priority passes",
+            state.waiting_for
+        );
+    }
+
+    #[test]
+    fn tempest_hawk_combat_damage_optional_accept_finds_named_card() {
+        // Accept path: Tempest Hawk deals combat damage to PlayerId(1),
+        // the optional `you may search` trigger is accepted, the
+        // SearchChoice exposes only Tempest Hawks from the library, and
+        // SelectCards moves the chosen hawk to hand with a Shuffle event.
+        let (mut state, _attacker, library_hawks) = setup_tempest_hawk_attack(&[701, 702, 703]);
+
+        // Sanity: also drop a non-Hawk into the library to confirm the
+        // SearchChoice filters by name.
+        let nonmatch = create_object(
+            &mut state,
+            CardId(799),
+            PlayerId(0),
+            "Storm Crow".to_string(),
+            Zone::Library,
+        );
+
+        advance_to_tempest_hawk_optional_choice(&mut state);
+        assert_eq!(
+            state.players[1].life, 18,
+            "Tempest Hawk should have dealt 2 combat damage to PlayerId(1)"
+        );
+
+        apply_as_current(
+            &mut state,
+            GameAction::DecideOptionalEffect { accept: true },
+        )
+        .unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::SearchChoice {
+                player,
+                cards,
+                count,
+                reveal,
+                ..
+            } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(*count, 1);
+                assert!(*reveal);
+                for hawk in &library_hawks {
+                    assert!(
+                        cards.contains(hawk),
+                        "SearchChoice must offer library Tempest Hawk {hawk:?}, got {cards:?}"
+                    );
+                }
+                assert!(
+                    !cards.contains(&nonmatch),
+                    "SearchChoice must not offer non-Tempest-Hawk card {nonmatch:?}"
+                );
+            }
+            other => {
+                panic!("expected SearchChoice after accepting Tempest Hawk trigger, got {other:?}")
+            }
+        }
+
+        let chosen = library_hawks[0];
+        let result = apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: vec![chosen],
+            },
+        )
+        .unwrap();
+
+        assert!(
+            state.stack.is_empty(),
+            "stack must be empty after resolving search"
+        );
+        assert_eq!(state.objects[&chosen].zone, Zone::Hand);
+        assert!(state.players[0].hand.contains(&chosen));
+        assert!(!state.players[0].library.contains(&chosen));
+        for other in &library_hawks[1..] {
+            assert_eq!(state.objects[other].zone, Zone::Library);
+        }
+        assert!(
+            result.events.iter().any(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Shuffle,
+                    ..
+                }
+            )),
+            "library must be shuffled at end of the trigger chain (CR 701.19)"
+        );
+    }
+
+    #[test]
+    fn tempest_hawk_combat_damage_optional_decline_leaves_library_untouched() {
+        // Decline path: declining the `you may` trigger must leave the
+        // library and hand untouched and clear the stack — no search,
+        // no shuffle.
+        let (mut state, _attacker, library_hawks) = setup_tempest_hawk_attack(&[711, 712]);
+
+        advance_to_tempest_hawk_optional_choice(&mut state);
+
+        let result = apply_as_current(
+            &mut state,
+            GameAction::DecideOptionalEffect { accept: false },
+        )
+        .unwrap();
+
+        assert!(state.stack.is_empty());
+        for hawk in &library_hawks {
+            assert_eq!(state.objects[hawk].zone, Zone::Library);
+            assert!(state.players[0].library.contains(hawk));
+            assert!(!state.players[0].hand.contains(hawk));
+        }
+        assert!(
+            !result.events.iter().any(|event| matches!(
+                event,
+                GameEvent::PlayerPerformedAction {
+                    action: PlayerActionKind::SearchedLibrary,
+                    ..
+                } | GameEvent::CardsRevealed { .. }
+                    | GameEvent::EffectResolved {
+                        kind: EffectKind::Shuffle,
+                        ..
+                    }
+            )),
+            "declining the trigger must produce no search/reveal/shuffle events"
+        );
+    }
+
+    #[test]
+    fn tempest_hawk_combat_damage_accept_with_empty_library_resolves_cleanly() {
+        // Fail-to-find path: accepting the search with zero Tempest Hawks
+        // in the library must resolve cleanly per CR 701.23b (player may
+        // search and find nothing; library still shuffles per CR 701.23d).
+        let (mut state, _attacker, _) = setup_tempest_hawk_attack(&[]);
+        // Non-matching filler so the library is not literally empty —
+        // this isolates "no card matching the filter" from "library empty".
+        let filler = create_object(
+            &mut state,
+            CardId(720),
+            PlayerId(0),
+            "Storm Crow".to_string(),
+            Zone::Library,
+        );
+
+        advance_to_tempest_hawk_optional_choice(&mut state);
+
+        apply_as_current(
+            &mut state,
+            GameAction::DecideOptionalEffect { accept: true },
+        )
+        .unwrap();
+
+        // Engine may either (a) skip straight past SearchChoice because no
+        // cards match, or (b) expose an empty/zero SearchChoice that
+        // resolves to SelectCards { cards: vec![] }. Handle both.
+        if matches!(state.waiting_for, WaitingFor::SearchChoice { .. }) {
+            let result =
+                apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] }).unwrap();
+            assert!(
+                result.events.iter().any(|event| matches!(
+                    event,
+                    GameEvent::EffectResolved {
+                        kind: EffectKind::Shuffle,
+                        ..
+                    }
+                )),
+                "library must shuffle even when the search finds nothing"
+            );
+        }
+
+        assert!(
+            state.stack.is_empty(),
+            "stack must drain even on fail-to-find"
+        );
+        assert_eq!(state.objects[&filler].zone, Zone::Library);
+        assert!(state.players[0].hand.is_empty());
+    }
+
     #[test]
     fn fizzle_target_removed_before_resolution() {
         use crate::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -8931,29 +8931,38 @@ mod tests {
 
         advance_to_tempest_hawk_optional_choice(&mut state);
 
-        apply_as_current(
+        let result = apply_as_current(
             &mut state,
             GameAction::DecideOptionalEffect { accept: true },
         )
         .unwrap();
 
+        let mut events = result.events;
+
         // Engine may either (a) skip straight past SearchChoice because no
-        // cards match, or (b) expose an empty/zero SearchChoice that
-        // resolves to SelectCards { cards: vec![] }. Handle both.
+        // cards match, in which case the shuffle event is emitted by the
+        // DecideOptionalEffect call above, or (b) expose an empty/zero
+        // SearchChoice that resolves to SelectCards { cards: vec![] }, in
+        // which case the shuffle event is emitted by SelectCards. Combine
+        // events from both possible paths so the shuffle assertion holds
+        // regardless of which branch the engine takes (CR 701.24 still
+        // applies — the library shuffles even on fail-to-find).
         if matches!(state.waiting_for, WaitingFor::SearchChoice { .. }) {
-            let result =
+            let select_result =
                 apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] }).unwrap();
-            assert!(
-                result.events.iter().any(|event| matches!(
-                    event,
-                    GameEvent::EffectResolved {
-                        kind: EffectKind::Shuffle,
-                        ..
-                    }
-                )),
-                "library must shuffle even when the search finds nothing"
-            );
+            events.extend(select_result.events);
         }
+
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Shuffle,
+                    ..
+                }
+            )),
+            "library must shuffle even when the search finds nothing (CR 701.24)"
+        );
 
         assert!(
             state.stack.is_empty(),

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5510,6 +5510,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::game::combat::AttackTarget;
     use crate::game::game_object::{BackFaceData, RoomDoor};
     use crate::game::zones::create_object;
     use crate::parser::oracle::parse_oracle_text;
@@ -5524,7 +5525,7 @@ mod tests {
     use crate::types::counter::CounterType;
     use crate::types::format::FormatConfig;
     use crate::types::identifiers::{CardId, ObjectId};
-    use crate::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+    use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::TriggerMode;
 
     /// Create a simple test ability definition.
@@ -8718,9 +8719,6 @@ mod tests {
     /// attackers / declare-blockers so the damage step is about to fire.
     /// Returns (state, attacking hawk, hawks in library).
     fn setup_tempest_hawk_attack(library_hawk_ids: &[u64]) -> (GameState, ObjectId, Vec<ObjectId>) {
-        use crate::game::combat::AttackTarget;
-        use crate::types::mana::ManaColor;
-
         let mut state = new_game(42);
         state.turn_number = 5;
         state.phase = Phase::DeclareAttackers;

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -8674,10 +8674,11 @@ mod tests {
         }
     }
 
-    // CR 120 (damage), CR 510.1 (combat damage step), CR 603.6c
-    // (combat-damage triggers), CR 701.23a/b/d (search library /
-    // fail-to-find), CR 100.2a / CR 717.1d / CR 903.5b (deck-construction
-    // overrides — verified silently consumed by Step 1's parser fix).
+    // CR 120 (damage), CR 510.1 (combat damage step), CR 510.3a
+    // (combat-damage triggers go on the stack), CR 701.23a/b/d (search
+    // library / fail-to-find), CR 701.24 (shuffle), CR 100.2a /
+    // CR 903.5b (deck-construction overrides — verified silently consumed
+    // by Step 1's parser fix).
     //
     // Tempest Hawk's combat-damage trigger:
     //   "Whenever this creature deals combat damage to a player, you may
@@ -8871,7 +8872,7 @@ mod tests {
                     ..
                 }
             )),
-            "library must be shuffled at end of the trigger chain (CR 701.19)"
+            "library must be shuffled at end of the trigger chain (CR 701.24)"
         );
     }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1,6 +1,6 @@
 use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
-use nom::bytes::complete::{tag, take_until};
+use nom::bytes::complete::{tag, take_until, take_while};
 use nom::combinator::{all_consuming, opt, value};
 use nom::Parser;
 use serde::{Deserialize, Serialize};
@@ -185,7 +185,6 @@ pub(crate) fn is_commander_permission_sentence(line: &str) -> bool {
 // recognizer matches this exact phrase shape to avoid false-positives
 // against legitimate "up to N cards named ..." patterns (e.g. Seven Dwarves).
 fn parse_deck_can_have_any_number_sentence(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
-    use nom::bytes::complete::take_while;
     let (input, _) = tag("a deck can have any number of cards named ").parse(input)?;
     let (input, subject) = take_while(|c: char| {
         c.is_alphanumeric() || c == ' ' || c == '\'' || c == ',' || c == '-' || c == '~'

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -177,6 +177,41 @@ pub(crate) fn is_commander_permission_sentence(line: &str) -> bool {
     parsed
 }
 
+// CR 100.2a / CR 717.1d / CR 903.5b: Deck-construction overrides like
+// "A deck can have any number of cards named X." (Tempest Hawk, Rat Colony,
+// Relentless Rats, Persistent Petitioners, Shadowborn Apostle, etc.) are
+// deck-construction metadata, not in-game abilities. They have no runtime
+// effect to resolve. CR 107.1c defines "any number of" — the recognizer
+// matches this exact phrase shape to avoid false-positives against
+// legitimate "up to N cards named ..." patterns (e.g. Seven Dwarves).
+fn parse_deck_can_have_any_number_sentence(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
+    use nom::bytes::complete::take_while;
+    let (input, _) = tag("a deck can have any number of cards named ").parse(input)?;
+    let (input, subject) = take_while(|c: char| {
+        c.is_alphanumeric() || c == ' ' || c == '\'' || c == ',' || c == '-' || c == '~'
+    })
+    .parse(input)?;
+    if subject.trim().is_empty() {
+        return Err(nom::Err::Error(OracleError::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let (input, _) = opt(tag(".")).parse(input)?;
+    Ok((input, ()))
+}
+
+/// Recognizer for "A deck can have any number of cards named X." —
+/// deck-construction text consumed silently by the parser so it does not
+/// fall through to `Effect::Unimplemented { name: "static_structure", .. }`.
+pub(crate) fn is_deck_construction_any_number_sentence(line: &str) -> bool {
+    let lower = line.trim().to_ascii_lowercase();
+    let parsed = all_consuming(parse_deck_can_have_any_number_sentence)
+        .parse(lower.as_str())
+        .is_ok();
+    parsed
+}
+
 /// Whether Oracle text explicitly permits this card to be a commander.
 pub fn oracle_text_allows_commander(oracle_text: &str, card_name: &str) -> bool {
     let normalized = normalize_card_name_refs(oracle_text, card_name);
@@ -773,7 +808,10 @@ fn is_spell_resolution_instruction_line(
     let loyalty_snap = ctx.diagnostics.len();
     let is_loyalty = try_parse_loyalty_line(line, ctx).is_some();
     ctx.diagnostics.truncate(loyalty_snap);
-    if is_commander_permission_sentence(line) || is_loyalty {
+    if is_commander_permission_sentence(line)
+        || is_deck_construction_any_number_sentence(line)
+        || is_loyalty
+    {
         return false;
     }
 
@@ -1651,6 +1689,11 @@ pub(crate) fn parse_oracle_ir(
         }
 
         if is_commander_permission_sentence(&line) {
+            i += 1;
+            continue;
+        }
+
+        if is_deck_construction_any_number_sentence(&line) {
             i += 1;
             continue;
         }
@@ -4930,6 +4973,88 @@ mod tests {
         assert!(r.replacements.is_empty());
     }
 
+    // CR 100.2a / CR 717.1d / CR 903.5b: "A deck can have any number of cards
+    // named X." is deck-construction metadata, not an in-game ability. The
+    // recognizer must accept the raw card name, the engine's normalized
+    // self-reference "~", and reject "up to N" patterns (Seven Dwarves).
+    #[test]
+    fn deck_construction_any_number_sentence_positive_cases() {
+        assert!(is_deck_construction_any_number_sentence(
+            "A deck can have any number of cards named Tempest Hawk."
+        ));
+        assert!(is_deck_construction_any_number_sentence(
+            "A deck can have any number of cards named Relentless Rats."
+        ));
+        // After normalize_self_refs_for_static rewrites the card name to "~".
+        assert!(is_deck_construction_any_number_sentence(
+            "A deck can have any number of cards named ~."
+        ));
+        // Trailing period is optional.
+        assert!(is_deck_construction_any_number_sentence(
+            "A deck can have any number of cards named Tempest Hawk"
+        ));
+    }
+
+    #[test]
+    fn deck_construction_any_number_sentence_negative_cases() {
+        // Wrong determiner — must be "A deck", not "Your deck".
+        assert!(!is_deck_construction_any_number_sentence(
+            "Your deck can have any number of cards named X."
+        ));
+        // "Up to seven" is a different deck-construction pattern (Seven Dwarves).
+        // It must NOT be silently consumed by this recognizer.
+        assert!(!is_deck_construction_any_number_sentence(
+            "A deck can have up to seven cards named Seven Dwarves."
+        ));
+        // Unrelated static lines must not match.
+        assert!(!is_deck_construction_any_number_sentence(
+            "Creatures you control get +1/+1."
+        ));
+        // Empty subject after the "named " prefix.
+        assert!(!is_deck_construction_any_number_sentence(
+            "A deck can have any number of cards named ."
+        ));
+        assert!(!is_deck_construction_any_number_sentence(
+            "A deck can have any number of cards named"
+        ));
+    }
+
+    #[test]
+    fn tempest_hawk_oracle_text_produces_no_unimplemented_static() {
+        // Full Oracle text fixture for Tempest Hawk — the bug surface from
+        // GitHub issue #1074. Before the fix, the "A deck can have any number
+        // of cards named Tempest Hawk." line fell through to
+        // Effect::Unimplemented { name: "static_structure", .. }. After the
+        // fix, it must be silently consumed.
+        let r = parse(
+            "Flying\n\
+             Whenever this creature deals combat damage to a player, you may search your library for a card named Tempest Hawk, reveal it, put it into your hand, then shuffle.\n\
+             A deck can have any number of cards named Tempest Hawk.",
+            "Tempest Hawk",
+            &[Keyword::Flying],
+            &["Creature"],
+            &["Bird"],
+        );
+
+        // No ability should be Unimplemented with name "static_structure".
+        let static_unimplemented: Vec<&AbilityDefinition> = r
+            .abilities
+            .iter()
+            .filter(|a| {
+                matches!(
+                    &*a.effect,
+                    Effect::Unimplemented { name, .. } if name == "static_structure"
+                )
+            })
+            .collect();
+        assert!(
+            static_unimplemented.is_empty(),
+            "deck-construction line must be silently consumed, but produced \
+             {} static_structure Unimplemented entries: {:#?}",
+            static_unimplemented.len(),
+            static_unimplemented
+        );
+    }
     #[test]
     fn oracle_text_allows_commander_uses_commander_permission_parser() {
         assert!(oracle_text_allows_commander(

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -177,13 +177,13 @@ pub(crate) fn is_commander_permission_sentence(line: &str) -> bool {
     parsed
 }
 
-// CR 100.2a / CR 717.1d / CR 903.5b: Deck-construction overrides like
-// "A deck can have any number of cards named X." (Tempest Hawk, Rat Colony,
-// Relentless Rats, Persistent Petitioners, Shadowborn Apostle, etc.) are
-// deck-construction metadata, not in-game abilities. They have no runtime
-// effect to resolve. CR 107.1c defines "any number of" — the recognizer
-// matches this exact phrase shape to avoid false-positives against
-// legitimate "up to N cards named ..." patterns (e.g. Seven Dwarves).
+// CR 100.2a / CR 903.5b: Deck-construction overrides like "A deck can have
+// any number of cards named X." (Tempest Hawk, Rat Colony, Relentless Rats,
+// Persistent Petitioners, Shadowborn Apostle, etc.) are deck-construction
+// metadata that override CR 100.2a's four-of limit and the CR 903.5b
+// Commander singleton rule. They have no runtime effect to resolve. The
+// recognizer matches this exact phrase shape to avoid false-positives
+// against legitimate "up to N cards named ..." patterns (e.g. Seven Dwarves).
 fn parse_deck_can_have_any_number_sentence(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
     use nom::bytes::complete::take_while;
     let (input, _) = tag("a deck can have any number of cards named ").parse(input)?;
@@ -4973,10 +4973,10 @@ mod tests {
         assert!(r.replacements.is_empty());
     }
 
-    // CR 100.2a / CR 717.1d / CR 903.5b: "A deck can have any number of cards
-    // named X." is deck-construction metadata, not an in-game ability. The
-    // recognizer must accept the raw card name, the engine's normalized
-    // self-reference "~", and reject "up to N" patterns (Seven Dwarves).
+    // CR 100.2a / CR 903.5b: "A deck can have any number of cards named X."
+    // is deck-construction metadata, not an in-game ability. The recognizer
+    // must accept the raw card name, the engine's normalized self-reference
+    // "~", and reject "up to N" patterns (Seven Dwarves).
     #[test]
     fn deck_construction_any_number_sentence_positive_cases() {
         assert!(is_deck_construction_any_number_sentence(


### PR DESCRIPTION
Closes #1074.

## Summary
Tempest Hawk's `"A deck can have any number of cards named Tempest Hawk."` parsed to `Effect::Unimplemented { name: "static_structure" }`, leaving a noisy entry in `card-data.json`. This PR mirrors the existing `is_commander_permission_sentence` precedent in `oracle.rs`: a nom recognizer (`is_deck_construction_any_number_sentence`) silently consumes the line at both `is_effect_sentence_candidate` and the `parse_oracle_text` dispatch loop. Generalizes to Rat Colony, Relentless Rats, Persistent Petitioners, and Shadowborn Apostle while correctly leaving Seven Dwarves' distinct `"up to seven"` phrase alone.

## Investigator note — what the user reported vs. what this fixes
The issue title says Commander decks with multiple Tempest Hawks were rejected. The investigator could not reproduce that against current engine code: `validate_name_deck_for_format` (the public function the WASM binding calls) already accepts both 5× Tempest Hawk in Commander and 8× Tempest Hawk in Standard because `has_deck_limit_override` does an Oracle-text substring scan independent of the parser AST. **The visible bug surface this PR fixes is the parser fallthrough.** If the user still sees deck rejection in the running app, the next probe is `client/src/constants/game.ts::hasUnlimitedCopies` (frontend's own client-side check, possibly stale relative to the engine) — see follow-ups.

## Files changed
- crates/engine/src/parser/oracle.rs
- crates/engine/src/game/engine.rs

## CR references
- CR 100.2a — four-of constructed deck rule
- CR 903.5b — Commander singleton rule
- CR 701.23a/b/d — search library, fail-to-find
- CR 120 — damage
- CR 510.1 — combat damage step
- CR 510.3a — triggered abilities from damage put on stack before AP gets priority
- CR 701.24 — shuffle

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Verification
Verification chain (all green):
- `doc-guardian` — PASS after CR-annotation fix commit (61c8babb6)
- `code-reviewer` — PASS after same fix
- `qa-tester` — 10162 workspace tests pass, 86.0% coverage (29894/34771), no semantic-audit regressions, parser-gap analyzer no longer flags the "any number" pattern
- `/verify` — `validate_name_deck_for_format` exercised with 4 deck scenarios; Commander 5× and Standard 8× Tempest Hawk both accepted, non-overriding-card controls correctly rejected

Local commands:
- `cargo fmt --all -- --check` — clean
- `cargo test -p engine` — 9063 pass / 0 fail
- `cargo clippy --all-targets -- -D warnings` — clean (from verification chain)

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

## Out-of-scope follow-ups
Flagged here so they don't get lost; not addressed in this PR:

1. **Seven Dwarves' `"A deck can have up to seven cards named X"` sibling pattern** still falls through the static parser. Could be a count-parameterized extension of the new recognizer or a sibling recognizer. Distinct enough to warrant a separate issue.
2. **`commander.rs::validate_commander_deck`** re-enforces singleton without consulting `has_deck_limit_override` — misleading dead-code-like behavior the investigator flagged. Out of scope for #1074.
3. **`client/src/constants/game.ts::hasUnlimitedCopies`** — frontend's own client-side override list. If users continue to see deck rejection after this lands, this is the next probe (frontend logic should defer to engine state per CLAUDE.md).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p engine` (9063 pass / 0 fail)
- [x] Parser unit tests: "any number" positive + negative ("up to seven") + integration on full Tempest Hawk Oracle text
- [x] Engine integration tests: combat-damage trigger chain (accept-finds-named / decline / empty-library-fail-to-find)
- [x] `jq` audit of regenerated `card-data.json` for Tempest Hawk, Rat Colony, Relentless Rats, Persistent Petitioners, Shadowborn Apostle
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)