### PR TITLE
Add counter-put trigger conversions (CR 122.6)

### DIFF
--- a/crates/mtgish-import/src/convert/trigger.rs
+++ b/crates/mtgish-import/src/convert/trigger.rs
@@ -286,6 +286,17 @@ pub fn convert(t: &Trigger) -> ConvResult<TriggerDefinition> {
         Trigger::WhenAPermanentIsDestroyed(filter) => {
             TriggerDefinition::new(TriggerMode::Destroyed).valid_card(convert_permanents(filter)?)
         }
+
+        // CR 702.110b: Exploit trigger — "whenever [source] exploits [target]".
+        // Engine `TriggerMode::Exploited` mirrors the native parser at
+        // oracle_trigger.rs:5230. `valid_card` constrains the exploiting
+        // permanent (the source); the exploited-target filter (`_target`) is
+        // dropped — engine `TriggerDefinition` has no exploited-target axis today.
+        Trigger::WhenAPermanentExploitsAPermanent(source, _target) => {
+            TriggerDefinition::new(TriggerMode::Exploited)
+                .valid_card(convert_permanents(source)?)
+        }
+
         // CR 701.9: Discard triggers — "when [players] discards [cards]". Engine
         // TriggerDefinition::Discarded has no valid_player or discarded-card
         // filter axis today, so dropping the player/card constraints fires the
@@ -335,6 +346,25 @@ pub fn convert(t: &Trigger) -> ConvResult<TriggerDefinition> {
             def.constraint = Some(TriggerConstraint::OncePerTurn);
             def
         }
+        // CR 305.1 + CR 603.2: "Whenever [a player] plays a land" — fires when
+        // a player puts a land card onto the battlefield from their hand as a
+        // special action (CR 305.1). Engine `TriggerMode::LandPlayed` mirrors
+        // the native parser at oracle_trigger.rs:6982. `valid_target` carries
+        // the player filter when the player axis is not `AnyPlayer`; the
+        // `_lands` arg is always `IsCardtype::Land` in practice (all lands are
+        // lands) and adds no additional constraint beyond the mode itself, so
+        // it is dropped.
+        Trigger::WhenAPlayerPlaysALand(players, _lands) => {
+            let mut def = TriggerDefinition::new(TriggerMode::LandPlayed);
+            if !matches!(players.as_ref(), Players::AnyPlayer) {
+                let controller = players_to_controller(players)?;
+                def.valid_target = Some(TargetFilter::Typed(
+                    TypedFilter::default().controller(controller),
+                ));
+            }
+            def
+        }
+
         // CR 702.37c (Morph) + CR 701.40b (Turn Face Up): "Whenever [permanent]
         // is turned face up" — fires when a face-down permanent flips face up
         // via the morph activation (or any other Turn-Face-Up effect, e.g.
@@ -584,6 +614,26 @@ pub fn convert(t: &Trigger) -> ConvResult<TriggerDefinition> {
         // above (e.g. AtTheBeginningOfAPlayersUpkeep).
         Trigger::AtTheBeginningOfAPlayersFirstMainPhase(_players) => {
             TriggerDefinition::new(TriggerMode::Phase).phase(Phase::PreCombatMain)
+        }
+
+        // CR 505.1 + CR 603.2b: "At the beginning of [a player's] postcombat
+        // (second) main phase" — the main phase after the combat phase. Engine
+        // `Phase::PostCombatMain` mirrors the native parser's mapping at
+        // oracle_trigger.rs:9063 ("postcombat main phase" / "second main phase").
+        // The `_players` axis is dropped, mirroring the convention on all other
+        // phase arms (e.g. AtTheBeginningOfAPlayersUpkeep).
+        Trigger::AtTheBeginningOfAPlayersSecondMainPhase(_players) => {
+            TriggerDefinition::new(TriggerMode::Phase).phase(Phase::PostCombatMain)
+        }
+
+        // CR 511.2 + CR 603.2b: "At end of combat" / "at the end of combat" —
+        // triggers as the end of combat step begins (CR 511.2). Engine
+        // `Phase::EndCombat` mirrors the native parser's mapping at
+        // oracle_trigger.rs:6820. No `_players` arm because this variant
+        // carries no player axis — it always fires for the active player's
+        // end of combat step.
+        Trigger::AtTheEndOfCombat => {
+            TriggerDefinition::new(TriggerMode::Phase).phase(Phase::EndCombat)
         }
 
         // CR ???: Specialize is a Strixhaven Mystical Archive / Lost Caverns

--- a/crates/mtgish-import/src/convert/trigger.rs
+++ b/crates/mtgish-import/src/convert/trigger.rs
@@ -6,13 +6,13 @@
 //! the highest-frequency are mapped here; the long tail fails strict and
 //! shows up in the report.
 
-use engine::types::ability::{DamageKindFilter, TriggerConstraint};
+use engine::types::ability::{CounterTriggerFilter, DamageKindFilter, TriggerConstraint};
 use engine::types::triggers::TriggerMode;
 use engine::types::{Phase, TargetFilter, TriggerDefinition, TypedFilter, Zone};
 
 use crate::convert::filter::{
     cards_in_graveyard_to_filter, cards_to_filter, convert as convert_permanents,
-    players_to_controller, spells_to_filter,
+    counter_type_to_engine, players_to_controller, spells_to_filter,
 };
 use crate::convert::result::{ConvResult, ConversionGap};
 use crate::schema::types::{CardsInHand, Comparison, GameNumber, Players, Trigger};
@@ -295,6 +295,71 @@ pub fn convert(t: &Trigger) -> ConvResult<TriggerDefinition> {
         Trigger::WhenAPermanentExploitsAPermanent(source, _target) => {
             TriggerDefinition::new(TriggerMode::Exploited)
                 .valid_card(convert_permanents(source)?)
+        }
+
+        // CR 122.6 + CR 603.2: "Whenever [one or more] counter[s] [of type X]
+        // are put on [permanents]" triggers. Engine `match_counter_added` fires on
+        // `GameEvent::CounterAdded` for both `CounterAdded` (single-counter Oracle
+        // phrasing) and `CounterAddedAll` (batched "one or more" Oracle phrasing).
+        // `CounterTriggerFilter` narrows by counter type when the variant carries one.
+        // Player-scoped variants (`WhenAPlayer*`) have no player-filter axis in
+        // `match_counter_added` today; strict-fail preserves rules correctness.
+        Trigger::WhenACounterIsPutOnAPermanent(permanents) => {
+            TriggerDefinition::new(TriggerMode::CounterAdded)
+                .valid_card(convert_permanents(permanents)?)
+        }
+        Trigger::WhenACounterOfTypeIsPutOnAPermanent(ct, permanents) => {
+            TriggerDefinition::new(TriggerMode::CounterAdded)
+                .counter_filter(CounterTriggerFilter {
+                    counter_type: counter_type_to_engine(ct)?,
+                    threshold: None,
+                })
+                .valid_card(convert_permanents(permanents)?)
+        }
+        Trigger::WhenAnyNumberOfCountersArePutOnAPermanent(permanents) => {
+            TriggerDefinition::new(TriggerMode::CounterAddedAll)
+                .valid_card(convert_permanents(permanents)?)
+        }
+        Trigger::WhenAnyNumberOfCountersOfTypeArePutOnAPermanent(ct, permanents)
+        | Trigger::WhenAnyNumberOfCountersOfTypeArePutOnAnyNumberOfPermanents(ct, permanents) => {
+            TriggerDefinition::new(TriggerMode::CounterAddedAll)
+                .counter_filter(CounterTriggerFilter {
+                    counter_type: counter_type_to_engine(ct)?,
+                    threshold: None,
+                })
+                .valid_card(convert_permanents(permanents)?)
+        }
+        // CR 122.6 + CR 603.2 + CR 603.10: "for the first time each turn" variant
+        // adds a per-turn frequency gate via `TriggerConstraint::OncePerTurn`.
+        Trigger::WhenAnyNumberOfCountersArePutOnAPermanentForTheFirstTimeEachTurn(permanents) => {
+            TriggerDefinition::new(TriggerMode::CounterAddedAll)
+                .valid_card(convert_permanents(permanents)?)
+                .constraint(TriggerConstraint::OncePerTurn)
+        }
+        Trigger::WhenAnyNumberOfCountersOfTypeArePutOnAPermanentForTheFirstTimeEachTurn(
+            ct,
+            permanents,
+        ) => {
+            TriggerDefinition::new(TriggerMode::CounterAddedAll)
+                .counter_filter(CounterTriggerFilter {
+                    counter_type: counter_type_to_engine(ct)?,
+                    threshold: None,
+                })
+                .valid_card(convert_permanents(permanents)?)
+                .constraint(TriggerConstraint::OncePerTurn)
+        }
+        // CR 122.6: Player-scoped counter-put triggers ("whenever YOU put counters…").
+        // Engine `match_counter_added` tracks no actor; silently firing on any putter
+        // would be rules-incorrect. Strict-fail until the engine gains a player-filter
+        // axis on counter-put events.
+        Trigger::WhenAPlayerPutsACounterOnAPermanent(..)
+        | Trigger::WhenAPlayerPutsACounterOfTypeOnAPermanent(..)
+        | Trigger::WhenAPlayerPutsAnyNumberOfCountersOfTypeOnAPermanent(..)
+        | Trigger::WhenAPlayerPutsAnyNumberOfGenericCountersOnAPermanent(..) => {
+            return Err(ConversionGap::EnginePrerequisiteMissing {
+                engine_type: "match_counter_added",
+                needed_variant: "player-filter axis on counter-put trigger".into(),
+            });
         }
 
         // CR 701.9: Discard triggers — "when [players] discards [cards]". Engine


### PR DESCRIPTION
## Summary

Wires six schema `Trigger` variants for "counter put on permanent" events in `crates/mtgish-import/src/convert/trigger.rs`, unlocking ~36 cards previously dropped by the converter.

| Trigger variant | Engine mapping | CR | Cards |
|---|---|---|---|
| `WhenACounterIsPutOnAPermanent` | `CounterAdded` | 122.6 | 1 |
| `WhenACounterOfTypeIsPutOnAPermanent` | `CounterAdded` + `CounterTriggerFilter` | 122.6 | 4 |
| `WhenAnyNumberOfCountersArePutOnAPermanent` | `CounterAddedAll` | 122.6 | 1 |
| `WhenAnyNumberOfCountersOfTypeArePutOnAPermanent` | `CounterAddedAll` + filter | 122.6 | 28 |
| `WhenAnyNumberOfCountersOfTypeArePutOnAnyNumberOfPermanents` | `CounterAddedAll` + filter | 122.6 | 2 |
| `WhenAnyNumberOf*ForTheFirstTimeEachTurn` | same + `OncePerTurn` | 122.6 + 603.10 | 3 |

Example cards now supported:
- **+1/+1 counter triggers**: Basking Broodscale, Benthic Biomancer, Constable of the Realm, Shalai and Hallar
- **-1/-1 counter triggers**: Auntie Ool Cursewretch, Wickersmith's Tools
- **Other typed**: Flourishing Defenses (-1/-1 counters on creatures)
- **Untyped batch**: Putrid Hexhag, Stalwart Successor

## Design notes

- `CounterAdded` and `CounterAddedAll` both route through the existing `match_counter_added` matcher, which already handles `CounterTriggerFilter` type narrowing (CR 122.6 + CR 714.2a). No engine changes needed.
- "A counter" (single) Oracle phrasing maps to `CounterAdded`; "one or more counters" phrasing maps to `CounterAddedAll`. Mirrors the conventions in the native oracle_trigger.rs parser.
- `counter_type_to_engine` from `filter.rs` is reused to convert schema `CounterType` -> engine `CounterType`. `CounterTriggerFilter` from `engine::types::ability` (already used by `saga.rs`).
- Player-scoped variants (`WhenAPlayerPuts*`, ~17 cards) strict-fail with `EnginePrerequisiteMissing`. Engine `match_counter_added` tracks no actor; silently firing on any putter would also fire on opponents' counter placements — rules-incorrect per CR 122.6a.

## Files changed

- `crates/mtgish-import/src/convert/trigger.rs`: +2 imports, +6 converter arms, +1 strict-fail arm for 4 player-scoped variants (67 lines net)

## CR references

- CR 122.6: "Some spells and abilities refer to counters being put on an object."
- CR 122.6a: Player attribution for counter-put events.
- CR 603.2: Triggered ability trigger conditions.
- CR 603.10: "Once per turn" trigger frequency constraint.

## LLM configuration

- Model: Claude Sonnet 4.6
- Thinking: medium
- Track: non-developer (no local toolchain; CI validates)

## Verification

- [ ] CI clippy passes
- [ ] CI test-engine passes
- [ ] CI card-data generation shows ~36 newly-supported cards

Generated with [Claude Code](https://claude.com/claude-code)