### PR TITLE
Fix Dosan + City of Solitude casting/activation prohibitions

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -6974,6 +6974,10 @@ pub fn can_activate_ability_now(
     if is_blocked_by_cant_be_activated(state, player, source_id, &ability_def) {
         return false;
     }
+    // CR 602.5 + CR 117.1b: Time-axis activation prohibition (City of Solitude class).
+    if is_blocked_by_cant_activate_during(state, player, &ability_def) {
+        return false;
+    }
     if is_blocked_by_cant_activate_abilities(state, player, &ability_def) {
         return false;
     }
@@ -7095,6 +7099,14 @@ pub fn handle_activate_ability(
     if is_blocked_by_cant_be_activated(state, player, source_id, &ability_def) {
         return Err(EngineError::ActionNotAllowed(
             "Activated abilities of this permanent can't be activated (CR 602.5)".to_string(),
+        ));
+    }
+    // CR 602.5 + CR 117.1b: Reject activation if any CantActivateDuring static
+    // prohibits activation during the current turn condition (City of Solitude class).
+    if is_blocked_by_cant_activate_during(state, player, &ability_def) {
+        return Err(EngineError::ActionNotAllowed(
+            "Activated abilities can't be activated during this turn (CR 602.5 + CR 117.1b)"
+                .to_string(),
         ));
     }
     if is_blocked_by_cant_activate_abilities(state, player, &ability_def) {
@@ -7835,57 +7847,129 @@ fn is_blocked_by_cant_be_activated(
     false
 }
 
+/// CR 117.1 + CR 604.1: Evaluate a `CastingProhibitionCondition` against the
+/// current game state from the perspective of the static's source permanent
+/// and the prospective caster/activator.
+///
+/// Single-authority condition evaluator shared by `is_blocked_by_cant_cast_during`
+/// (CR 601.2) and `is_blocked_by_cant_activate_during` (CR 602.5). Inline
+/// matching at the two call sites is forbidden — every new
+/// `CastingProhibitionCondition` variant lands here exactly once.
+///
+/// `source_controller` is the controller of the static's source permanent (used
+/// to bind possessive timing references such as "during your turn" — CR 109.5).
+/// `caster` is the player whose action is being legality-checked (used for
+/// timing predicates that scope to the active actor such as `NotSorcerySpeed`
+/// or the distributive `NotDuringAffectedPlayersTurn`).
+fn evaluate_casting_prohibition_condition(
+    state: &GameState,
+    when: &CastingProhibitionCondition,
+    source_controller: PlayerId,
+    caster: PlayerId,
+) -> bool {
+    use crate::types::phase::Phase;
+    match when {
+        // CR 109.5: "during your turn" — bound to the static's source controller.
+        CastingProhibitionCondition::DuringYourTurn => state.active_player == source_controller,
+        // CR 506.1: "during combat" — any combat phase, game-wide.
+        CastingProhibitionCondition::DuringCombat => matches!(
+            state.phase,
+            Phase::BeginCombat
+                | Phase::DeclareAttackers
+                | Phase::DeclareBlockers
+                | Phase::CombatDamage
+                | Phase::EndCombat
+        ),
+        // CR 109.5 + CR 117.1a + CR 604.1: "only during your turn" — blocked
+        // when it is NOT the source-controller's turn (Fires of Invention's
+        // "your turn"). Differs from `NotDuringAffectedPlayersTurn`: this
+        // binds to the static source's controller per CR 109.5.
+        CastingProhibitionCondition::NotDuringYourTurn => state.active_player != source_controller,
+        // CR 102.1 + CR 117.1a + CR 604.1: "only during their own turn" —
+        // distributive per-affected-player binding (Dosan / City of Solitude).
+        // Blocked when it is NOT the *caster's* turn. The pronoun "their own"
+        // is not governed by CR 109.5 (which binds "you/your"); the
+        // distributive reading follows from CR 102.1 + the template structure
+        // of "[every player] can [action] only during their own [time]".
+        CastingProhibitionCondition::NotDuringAffectedPlayersTurn => state.active_player != caster,
+        // CR 117.1a + CR 117.1b: "only any time they could cast a sorcery"
+        // — blocked when not at sorcery speed (active player's main phase
+        // + empty stack + caster is the active player).
+        CastingProhibitionCondition::NotSorcerySpeed => {
+            let at_sorcery_speed = state.active_player == caster
+                && matches!(state.phase, Phase::PreCombatMain | Phase::PostCombatMain)
+                && state.stack.is_empty();
+            !at_sorcery_speed
+        }
+    }
+}
+
 /// CR 101.2: Check if any CantCastDuring static on the battlefield prevents the
 /// given player from casting spells during the current turn/phase.
 /// E.g., Teferi, Time Raveler: "Your opponents can't cast spells during your turn."
 /// E.g., Basandra, Battle Seraph: "Players can't cast spells during combat."
+/// E.g., Dosan, the Falling Leaf (`who=AllPlayers, when=NotDuringAffectedPlayersTurn`):
+///   each player can only cast on their own turn.
 fn is_blocked_by_cant_cast_during(state: &GameState, caster: PlayerId) -> bool {
-    use crate::types::phase::Phase;
-
     // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_active_statics`.
     for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
-        {
-            let StaticMode::CantCastDuring { ref who, ref when } = def.mode else {
-                continue;
-            };
+        let StaticMode::CantCastDuring { ref who, ref when } = def.mode else {
+            continue;
+        };
+        // CR 101.2: Check if the caster is in the affected scope.
+        if !casting_prohibition_scope_matches(who, caster, bf_obj, state) {
+            continue;
+        }
+        // CR 109.5 / CR 102.1: Bind the timing predicate via the single-authority
+        // evaluator. The (source_controller, caster) pair is passed verbatim;
+        // each `CastingProhibitionCondition` arm picks the binding it needs.
+        if evaluate_casting_prohibition_condition(state, when, bf_obj.controller, caster) {
+            return true;
+        }
+    }
+    false
+}
 
-            // CR 101.2: Check if the caster is in the affected scope.
-            if !casting_prohibition_scope_matches(who, caster, bf_obj, state) {
-                continue;
-            }
-
-            // Check if the current game state matches the timing condition.
-            let condition_met = match when {
-                CastingProhibitionCondition::DuringYourTurn => {
-                    // "During your turn" = the static controller's turn is active.
-                    state.active_player == bf_obj.controller
+/// CR 602.5 + CR 117.1b: Check if any active `CantActivateDuring` static on
+/// the battlefield prevents the given player from activating the given
+/// activated ability during the current turn condition.
+///
+/// E.g., City of Solitude — both casting and activating are prohibited unless
+/// it's the affected player's own turn.
+///
+/// CR 605.1a: When the static carries `exemption: ManaAbilities`, abilities
+/// classified as mana abilities (CR 605.1a) by `mana_abilities::is_mana_ability`
+/// bypass the prohibition. City of Solitude emits `ActivationExemption::None`
+/// per its 2009-10-01 ruling ("This stops players from activating mana
+/// abilities") — mana abilities are NOT exempt for that card.
+fn is_blocked_by_cant_activate_during(
+    state: &GameState,
+    activator: PlayerId,
+    activating_ability: &AbilityDefinition,
+) -> bool {
+    // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_active_statics`.
+    for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
+        let StaticMode::CantActivateDuring {
+            ref who,
+            ref when,
+            ref exemption,
+        } = def.mode
+        else {
+            continue;
+        };
+        if !casting_prohibition_scope_matches(who, activator, bf_obj, state) {
+            continue;
+        }
+        if !evaluate_casting_prohibition_condition(state, when, bf_obj.controller, activator) {
+            continue;
+        }
+        // CR 605.1a: Apply the exemption gate via the single classifier authority.
+        match exemption {
+            ActivationExemption::None => return true,
+            ActivationExemption::ManaAbilities => {
+                if !super::mana_abilities::is_mana_ability(activating_ability) {
+                    return true;
                 }
-                CastingProhibitionCondition::DuringCombat => {
-                    matches!(
-                        state.phase,
-                        Phase::BeginCombat
-                            | Phase::DeclareAttackers
-                            | Phase::DeclareBlockers
-                            | Phase::CombatDamage
-                            | Phase::EndCombat
-                    )
-                }
-                CastingProhibitionCondition::NotDuringYourTurn => {
-                    // CR 117.1a + CR 604.1: "can cast spells only during your turn"
-                    // = blocked when it is NOT the controller's turn.
-                    state.active_player != bf_obj.controller
-                }
-                CastingProhibitionCondition::NotSorcerySpeed => {
-                    // CR 117.1: "can cast spells only any time they could cast a sorcery"
-                    // Blocked when NOT at sorcery speed: active player's main phase + empty stack.
-                    let at_sorcery_speed = state.active_player == caster
-                        && matches!(state.phase, Phase::PreCombatMain | Phase::PostCombatMain)
-                        && state.stack.is_empty();
-                    !at_sorcery_speed
-                }
-            };
-            if condition_met {
-                return true;
             }
         }
     }
@@ -24926,5 +25010,353 @@ mod tests {
             ManaCost::generic(3),
             "Trinisphere must floor a free spell's zero mana component to {{3}}"
         );
+    }
+
+    // === CR 117.1 + CR 602.5 + CR 605.1a: shared condition evaluator &
+    //     CantActivateDuring runtime tests ===
+
+    /// Attach a `CantActivateDuring` static to a freshly-created permanent on the battlefield.
+    fn add_cant_activate_during_permanent(
+        state: &mut GameState,
+        controller: PlayerId,
+        who: ProhibitionScope,
+        when: CastingProhibitionCondition,
+        exemption: ActivationExemption,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(state.next_object_id),
+            controller,
+            "Activation Prohibitor".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantActivateDuring {
+                who,
+                when,
+                exemption,
+            }));
+        id
+    }
+
+    /// CR 117.1 + CR 604.1: Exhaustive coverage of every
+    /// `CastingProhibitionCondition` arm via the single-authority evaluator.
+    /// Verifies the binding axis is correct for each variant.
+    #[test]
+    fn evaluate_casting_prohibition_condition_all_arms() {
+        let mut state = setup_game_at_main_phase();
+        // Active player is P0 in PreCombatMain with an empty stack.
+        let p0 = PlayerId(0);
+        let p1 = PlayerId(1);
+
+        // CR 109.5: DuringYourTurn — bound to source controller.
+        // Active player is P0; source controller=P0 → true; source controller=P1 → false.
+        assert!(evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::DuringYourTurn,
+            p0,
+            p0,
+        ));
+        assert!(!evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::DuringYourTurn,
+            p1,
+            p0,
+        ));
+
+        // CR 506.1: DuringCombat — false in PreCombatMain.
+        assert!(!evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::DuringCombat,
+            p0,
+            p0,
+        ));
+        // Same predicate is true in a combat phase.
+        state.phase = Phase::DeclareAttackers;
+        assert!(evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::DuringCombat,
+            p0,
+            p0,
+        ));
+        state.phase = Phase::PreCombatMain;
+
+        // CR 109.5: NotDuringYourTurn — blocked when active player != source controller.
+        // Active player=P0; source controller=P0 → not blocked. Source controller=P1 → blocked.
+        assert!(!evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::NotDuringYourTurn,
+            p0,
+            p0,
+        ));
+        assert!(evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::NotDuringYourTurn,
+            p1,
+            p0,
+        ));
+
+        // CR 102.1: NotDuringAffectedPlayersTurn — blocked when active player != caster.
+        // Active player=P0; caster=P0 → not blocked. Caster=P1 → blocked.
+        assert!(!evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+            p0, // source_controller — irrelevant for this arm
+            p0,
+        ));
+        assert!(evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+            p0,
+            p1,
+        ));
+
+        // CR 117.1b: NotSorcerySpeed — blocked unless caster is active player +
+        // main phase + empty stack.
+        // setup_game_at_main_phase sets active=P0, PreCombatMain, empty stack.
+        assert!(!evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::NotSorcerySpeed,
+            p0,
+            p0,
+        ));
+        // Caster=P1 on P0's turn → not at sorcery speed → blocked.
+        assert!(evaluate_casting_prohibition_condition(
+            &state,
+            &CastingProhibitionCondition::NotSorcerySpeed,
+            p0,
+            p1,
+        ));
+    }
+
+    /// CR 102.1 + CR 601.2: Dosan's `CantCastDuring(AllPlayers, NotDuringAffectedPlayersTurn)`
+    /// must produce a 4-quadrant blocking matrix per the distributive binding:
+    /// each player is blocked when it is NOT their own turn, regardless of who controls Dosan.
+    #[test]
+    fn cant_cast_during_dosan_per_affected_player_matrix() {
+        let mut state = setup_game_at_main_phase();
+        let p0 = PlayerId(0);
+        let p1 = PlayerId(1);
+        // Dosan on P0's battlefield.
+        add_cant_cast_during_permanent(
+            &mut state,
+            p0,
+            ProhibitionScope::AllPlayers,
+            CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+        );
+
+        // (A) active=P0, caster=P0 → not blocked (it IS the caster's turn).
+        state.active_player = p0;
+        assert!(
+            !is_blocked_by_cant_cast_during(&state, p0),
+            "P0 must NOT be blocked on their own turn"
+        );
+        // (B) active=P0, caster=P1 → blocked (not P1's turn).
+        assert!(
+            is_blocked_by_cant_cast_during(&state, p1),
+            "P1 must be blocked on P0's turn"
+        );
+        // (C) active=P1, caster=P0 → blocked (not P0's turn).
+        state.active_player = p1;
+        assert!(
+            is_blocked_by_cant_cast_during(&state, p0),
+            "P0 must be blocked on P1's turn"
+        );
+        // (D) active=P1, caster=P1 → not blocked (it IS the caster's turn).
+        assert!(
+            !is_blocked_by_cant_cast_during(&state, p1),
+            "P1 must NOT be blocked on their own turn"
+        );
+    }
+
+    /// CR 102.1 + CR 602.5: City of Solitude's activate-half emits
+    /// `CantActivateDuring(AllPlayers, NotDuringAffectedPlayersTurn, None)`.
+    /// The activation-blocking matrix mirrors the cast matrix.
+    #[test]
+    fn cant_activate_during_city_of_solitude_per_affected_player_matrix() {
+        let mut state = setup_game_at_main_phase();
+        let p0 = PlayerId(0);
+        let p1 = PlayerId(1);
+        add_cant_activate_during_permanent(
+            &mut state,
+            p0,
+            ProhibitionScope::AllPlayers,
+            CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+            ActivationExemption::None,
+        );
+        // Use a non-mana ability for the 4-quadrant matrix so the exemption gate
+        // does not short-circuit.
+        let ability = AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Activated,
+            crate::types::ability::Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )
+        .cost(crate::types::ability::AbilityCost::Tap);
+
+        // (A) active=P0, activator=P0 → NOT blocked.
+        state.active_player = p0;
+        assert!(!is_blocked_by_cant_activate_during(&state, p0, &ability));
+        // (B) active=P0, activator=P1 → blocked.
+        assert!(is_blocked_by_cant_activate_during(&state, p1, &ability));
+        // (C) active=P1, activator=P0 → blocked.
+        state.active_player = p1;
+        assert!(is_blocked_by_cant_activate_during(&state, p0, &ability));
+        // (D) active=P1, activator=P1 → NOT blocked.
+        assert!(!is_blocked_by_cant_activate_during(&state, p1, &ability));
+    }
+
+    /// CR 605.1a + City of Solitude 2009-10-01 ruling: City of Solitude emits
+    /// `ActivationExemption::None`, so mana abilities ARE blocked (not exempt).
+    #[test]
+    fn city_of_solitude_blocks_mana_abilities_per_2009_ruling() {
+        let mut state = setup_game_at_main_phase();
+        let p0 = PlayerId(0);
+        let p1 = PlayerId(1);
+        // City of Solitude on P0's battlefield.
+        add_cant_activate_during_permanent(
+            &mut state,
+            p0,
+            ProhibitionScope::AllPlayers,
+            CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+            ActivationExemption::None,
+        );
+        let mana_ability = make_tap_for_green_mana_ability();
+        // Verify this IS classified as a mana ability (sanity).
+        assert!(
+            super::super::mana_abilities::is_mana_ability(&mana_ability),
+            "Sanity: {{T}}: Add {{G}} must classify as a mana ability"
+        );
+        // On P0's turn, P1's mana ability is blocked because P0's turn ≠ P1's turn.
+        state.active_player = p0;
+        assert!(
+            is_blocked_by_cant_activate_during(&state, p1, &mana_ability),
+            "City of Solitude must block P1's mana ability on P0's turn (exemption=None)"
+        );
+    }
+
+    /// CR 605.1a contrast: when `ActivationExemption::ManaAbilities` is set, mana
+    /// abilities bypass the prohibition. Guards the exemption gate's mana-ability
+    /// branch in `is_blocked_by_cant_activate_during`.
+    #[test]
+    fn cant_activate_during_with_mana_exemption_permits_mana_abilities() {
+        let mut state = setup_game_at_main_phase();
+        let p0 = PlayerId(0);
+        let p1 = PlayerId(1);
+        // Hypothetical permanent: same shape as City of Solitude but mana-ability exempt.
+        add_cant_activate_during_permanent(
+            &mut state,
+            p0,
+            ProhibitionScope::AllPlayers,
+            CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+            ActivationExemption::ManaAbilities,
+        );
+        let mana_ability = make_tap_for_green_mana_ability();
+        // On P0's turn, P1's mana ability must NOT be blocked because the exemption
+        // permits mana abilities — even though the timing predicate is satisfied.
+        state.active_player = p0;
+        assert!(
+            !is_blocked_by_cant_activate_during(&state, p1, &mana_ability),
+            "ManaAbilities exemption must permit P1's mana ability"
+        );
+        // Non-mana ability is still blocked.
+        let non_mana_ability = AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Activated,
+            crate::types::ability::Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )
+        .cost(crate::types::ability::AbilityCost::Tap);
+        assert!(
+            is_blocked_by_cant_activate_during(&state, p1, &non_mana_ability),
+            "Non-mana ability still blocked under timing predicate"
+        );
+    }
+
+    /// CR 601.2: Fires of Invention emits ONLY a `CantCastDuring` — its activate-side
+    /// must remain unaffected. Regression guard for the parser rewrite.
+    #[test]
+    fn fires_of_invention_does_not_block_ability_activations() {
+        let mut state = setup_game_at_main_phase();
+        let p1 = PlayerId(1);
+        // Fires-like: cast-only prohibition, controller binding.
+        add_cant_cast_during_permanent(
+            &mut state,
+            PlayerId(0),
+            ProhibitionScope::Controller,
+            CastingProhibitionCondition::NotDuringYourTurn,
+        );
+        let ability = AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Activated,
+            crate::types::ability::Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )
+        .cost(crate::types::ability::AbilityCost::Tap);
+        // No `CantActivateDuring` on the battlefield, so the activate gate is a no-op.
+        assert!(
+            !is_blocked_by_cant_activate_during(&state, p1, &ability),
+            "Fires of Invention is CantCastDuring only; activations must be unaffected"
+        );
+    }
+
+    /// CR 601.2 + Dosan 2004-12-01 ruling ("doesn't stop activated or triggered abilities"):
+    /// Dosan emits ONLY a `CantCastDuring`, never a `CantActivateDuring`. The runtime gate
+    /// must never spuriously block activations from a Dosan-only static loadout.
+    #[test]
+    fn dosan_does_not_block_ability_activations_per_2004_ruling() {
+        let mut state = setup_game_at_main_phase();
+        let p0 = PlayerId(0);
+        let p1 = PlayerId(1);
+        // Dosan-like static — cast-only.
+        add_cant_cast_during_permanent(
+            &mut state,
+            p0,
+            ProhibitionScope::AllPlayers,
+            CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+        );
+        let ability = AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Activated,
+            crate::types::ability::Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )
+        .cost(crate::types::ability::AbilityCost::Tap);
+        // Active player is P0; P1 tries to activate. Without a CantActivateDuring static,
+        // the activation must NOT be blocked.
+        assert!(
+            !is_blocked_by_cant_activate_during(&state, p1, &ability),
+            "Dosan's cast-only prohibition must not affect activations (2004-12-01 ruling)"
+        );
+    }
+
+    /// CR 602.5 + CR 117.1b: Display/FromStr round-trip preserves the (who, when) axes.
+    /// `exemption` is data-carrying and defaults to `None` (mirrors `CantBeActivated`).
+    #[test]
+    fn cant_activate_during_display_from_str_roundtrip() {
+        use std::str::FromStr;
+        let original = StaticMode::CantActivateDuring {
+            who: ProhibitionScope::AllPlayers,
+            when: CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+            exemption: ActivationExemption::None,
+        };
+        let displayed = original.to_string();
+        let parsed = StaticMode::from_str(&displayed).expect("round-trip must parse");
+        assert!(matches!(
+            parsed,
+            StaticMode::CantActivateDuring {
+                who: ProhibitionScope::AllPlayers,
+                when: CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+                ..
+            }
+        ));
     }
 }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -7800,7 +7800,7 @@ fn is_blocked_from_casting_from_zone(
 ///   prohibits activation of opponent-controlled artifacts' activated abilities.
 /// - Pithing Needle (`source_filter=HasChosenName, exemption=ManaAbilities`): prohibits
 ///   activation of named-card sources except their mana abilities.
-fn is_blocked_by_cant_be_activated(
+pub(super) fn is_blocked_by_cant_be_activated(
     state: &GameState,
     caster: PlayerId,
     activating_source_id: ObjectId,
@@ -7942,7 +7942,7 @@ fn is_blocked_by_cant_cast_during(state: &GameState, caster: PlayerId) -> bool {
 /// bypass the prohibition. City of Solitude emits `ActivationExemption::None`
 /// per its 2009-10-01 ruling ("This stops players from activating mana
 /// abilities") — mana abilities are NOT exempt for that card.
-fn is_blocked_by_cant_activate_during(
+pub(super) fn is_blocked_by_cant_activate_during(
     state: &GameState,
     activator: PlayerId,
     activating_ability: &AbilityDefinition,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -6380,11 +6380,10 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                 effective_lower.contains("can't cast spells during")
                     || effective_lower.contains("can cast spells only during")
             }
-            // CR 602.5 + CR 117.1b: City of Solitude class. Both "cast spells and
-            // activate abilities" and bare "activate abilities" phrasings.
+            // CR 602.5 + CR 117.1b: City of Solitude class — "activate abilities
+            // only during" covers both bare and "and activate abilities" phrasings.
             StaticMode::CantActivateDuring { .. } => {
                 effective_lower.contains("activate abilities only during")
-                    || effective_lower.contains("and activate abilities only during")
             }
             StaticMode::PerTurnCastLimit { .. } => {
                 effective_lower.contains("can't cast more than")

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -65,6 +65,9 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             | StaticMode::CantBeBlockedExceptBy { .. }
             // CR 602.5 + CR 603.2a: CantBeActivated carries `who` + `source_filter`.
             | StaticMode::CantBeActivated { .. }
+            // CR 602.5 + CR 117.1b: CantActivateDuring carries `who`, `when`, and `exemption`.
+            // Runtime enforcement is in casting.rs::is_blocked_by_cant_activate_during().
+            | StaticMode::CantActivateDuring { .. }
             // CR 701.23 + CR 609.3: CantSearchLibrary carries `cause`.
             | StaticMode::CantSearchLibrary { .. }
             // CR 603.2g: SuppressTriggers carries `source_filter` + `events`.
@@ -6376,6 +6379,12 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
             StaticMode::CantCastDuring { .. } => {
                 effective_lower.contains("can't cast spells during")
                     || effective_lower.contains("can cast spells only during")
+            }
+            // CR 602.5 + CR 117.1b: City of Solitude class. Both "cast spells and
+            // activate abilities" and bare "activate abilities" phrasings.
+            StaticMode::CantActivateDuring { .. } => {
+                effective_lower.contains("activate abilities only during")
+                    || effective_lower.contains("and activate abilities only during")
             }
             StaticMode::PerTurnCastLimit { .. } => {
                 effective_lower.contains("can't cast more than")

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -402,6 +402,24 @@ pub fn activate_mana_ability(
             required_zone
         )));
     }
+    // CR 602.5: enforce activation prohibitions at the executor, not just at
+    // legal-action filtering — a buggy or hostile client may submit
+    // `GameAction::ActivateAbility` directly. The mana-ability fast path must
+    // honor the same static-ability gates that `casting::handle_activate_ability`
+    // applies on the non-mana path, so City of Solitude (CantActivateDuring with
+    // exemption: None) and any future CantBeActivated with exemption: None block
+    // mana activations as the rules require.
+    if super::casting::is_blocked_by_cant_be_activated(state, player, source_id, ability_def) {
+        return Err(EngineError::ActionNotAllowed(
+            "Activated abilities of this permanent can't be activated (CR 602.5)".to_string(),
+        ));
+    }
+    if super::casting::is_blocked_by_cant_activate_during(state, player, ability_def) {
+        return Err(EngineError::ActionNotAllowed(
+            "Activated abilities can't be activated during this turn (CR 602.5 + CR 117.1b)"
+                .to_string(),
+        ));
+    }
     super::restrictions::check_activation_restrictions(
         state,
         player,
@@ -6817,5 +6835,80 @@ mod tests {
                 "Food Chain mana must carry the Creature spell-type restriction"
             );
         }
+    }
+
+    /// CR 602.5: the mana-ability executor must reject submissions that violate
+    /// an active `CantActivateDuring` static, not only the legal-action filter.
+    /// Discriminating end-to-end test against the City of Solitude class: a
+    /// hostile/buggy client submitting `activate_mana_ability` directly must
+    /// receive `EngineError::ActionNotAllowed`.
+    #[test]
+    fn city_of_solitude_rejects_mana_ability_at_executor() {
+        use crate::types::statics::{ActivationExemption, CastingProhibitionCondition};
+
+        let mut state = GameState::new_two_player(42);
+        let p0 = PlayerId(0);
+        let p1 = PlayerId(1);
+        state.active_player = p0;
+        state.phase = Phase::PreCombatMain;
+
+        // P0 controls a City of Solitude analogue (AllPlayers / NotDuringAffectedPlayersTurn
+        // / exemption: None — per the 2009-10-01 ruling).
+        let prohibitor = create_object(
+            &mut state,
+            CardId(1),
+            p0,
+            "City of Solitude".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&prohibitor)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantActivateDuring {
+                who: ProhibitionScope::AllPlayers,
+                when: CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+                exemption: ActivationExemption::None,
+            }));
+
+        // P1 controls a Forest-like permanent with a tap-for-green mana ability.
+        let forest = create_object(
+            &mut state,
+            CardId(2),
+            p1,
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        let mana_ability = make_mana_ability(ManaProduction::Fixed {
+            colors: vec![ManaColor::Green],
+            contribution: ManaContribution::Base,
+        });
+        Arc::make_mut(&mut state.objects.get_mut(&forest).unwrap().abilities)
+            .push(mana_ability.clone());
+
+        // On P0's turn, P1 attempts to activate the mana ability directly through
+        // the executor. The CR 602.5 gate at the top of `activate_mana_ability`
+        // must reject before any cost is paid or mana is produced.
+        let mut events = Vec::new();
+        let err = activate_mana_ability(
+            &mut state,
+            forest,
+            p1,
+            0,
+            &mana_ability,
+            &mut events,
+            ManaAbilityResume::Priority,
+            None,
+        )
+        .expect_err("City of Solitude must reject P1's mana ability at the executor on P0's turn");
+        assert!(
+            matches!(err, EngineError::ActionNotAllowed(_)),
+            "expected ActionNotAllowed, got {err:?}"
+        );
+        // No mana was produced and the ability source was not tapped.
+        assert_eq!(state.players[1].mana_pool.total(), 0);
+        assert!(!state.objects.get(&forest).unwrap().tapped);
+        assert!(events.is_empty());
     }
 }

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -186,6 +186,9 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     registry.insert(StaticMode::CantCastFrom, handle_rule_mod);
     // Note: CantCastDuring is a data-carrying variant — runtime enforcement will be in
     // casting.rs. Coverage support is via is_data_carrying_static().
+    // Note: CantActivateDuring is a data-carrying variant — runtime enforcement is in
+    // casting.rs::is_blocked_by_cant_activate_during(). Coverage support is via
+    // is_data_carrying_static(). Like CantBeActivated, parameterized — no registry entry.
     // Note: PerTurnCastLimit is a data-carrying variant — runtime enforcement is in
     // casting.rs::is_blocked_by_per_turn_cast_limit(). Coverage support is via is_data_carrying_static().
 

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -217,6 +217,11 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     "can't draw more than",
     "can't draw cards",
     "can cast spells only during",
+    // CR 602.5 + CR 117.1b: City of Solitude class — combined cast+activate
+    // prohibition. The conjunction "and activate abilities" is the
+    // discriminator; we route through the static parser so
+    // `parse_cast_and_activate_only_during` emits the paired statics.
+    "and activate abilities only during",
     "activated abilities can't be activated",
     "to cast spells or activate abilities",
     // CR 602.5 + CR 603.2a: Clarion/Karn-class global filter-scoped activation prohibition.

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -51,6 +51,114 @@ use crate::types::statics::{
 };
 use crate::types::zones::Zone;
 
+/// CR 109.5 vs CR 102.1 + structural distributive: the pronoun-binding axis
+/// of an "only during X turn(s)" prohibition.
+///
+/// - `SourceRelative` ≡ "your turn" — CR 109.5 binds to the static's source
+///   controller (Fires of Invention).
+/// - `PerAffected` ≡ "their own turn(s)" — distributive per-affected-player
+///   binding (Dosan, City of Solitude). The CompRules don't carve out a
+///   specific pronoun rule for "their"; the distributive reading follows from
+///   CR 102.1 + the template structure of "[every player] can [action] only
+///   during their own [time]".
+///
+/// This enum is parser-internal — it never appears on `StaticMode`. The
+/// resulting `CastingProhibitionCondition` (`NotDuringYourTurn` vs
+/// `NotDuringAffectedPlayersTurn`) carries the binding axis into the runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WhenKind {
+    SourceRelative,
+    PerAffected,
+}
+
+/// Parse the trailing `"only during {your | their own} turn(s?)"` clause and
+/// return the typed binding axis.
+///
+/// Composed from nested `alt()` calls — one axis per choice — not enumerated
+/// as 4 full-string permutations. Adding "his or her" or "each player's own"
+/// is a single new `value(WhenKind::_, tag("..."))` arm.
+///
+/// Grammar:
+///   "only during " (`"your"` | `"their own"`) " turn" `"s"?` `"."?`
+///
+/// Returns `(remaining_input, WhenKind)` on success.
+fn parse_when_clause(input: &str) -> OracleResult<'_, WhenKind> {
+    let (input, _) = tag::<_, _, OracleError<'_>>("only during ").parse(input)?;
+    let (input, kind) = alt((
+        value(WhenKind::SourceRelative, tag("your")),
+        value(WhenKind::PerAffected, tag("their own")),
+    ))
+    .parse(input)?;
+    let (input, _) = tag(" turn").parse(input)?;
+    let (input, _) = opt(tag("s")).parse(input)?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+    Ok((input, kind))
+}
+
+/// Map a `WhenKind` to its `CastingProhibitionCondition`. Single-authority
+/// mapper so the binding axis lives in exactly one place.
+fn when_kind_to_condition(kind: WhenKind) -> CastingProhibitionCondition {
+    match kind {
+        WhenKind::SourceRelative => CastingProhibitionCondition::NotDuringYourTurn,
+        WhenKind::PerAffected => CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+    }
+}
+
+/// CR 601.2 + CR 602.5 + CR 117.1a + CR 117.1b: Parse "[subject] can cast spells
+/// and activate abilities only during {your | their own} turn(s)" — City of
+/// Solitude class. Emits TWO statics (cast-half + activate-half) so the
+/// runtime gates dispatch independently.
+///
+/// Subject → scope via the shared `strip_casting_prohibition_subject` helper.
+/// Trailing "only during X turn(s)" → typed `WhenKind` via the same shared
+/// `parse_when_clause` combinator that the cast-only branch uses.
+///
+/// Grammar:
+///   <SUBJECT> "can cast spells and activate abilities " parse_when_clause
+fn parse_cast_and_activate_only_during(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<Vec<StaticDefinition>> {
+    let lower = tp.lower;
+    if !nom_primitives::scan_contains(lower, "can cast spells and activate abilities only during") {
+        return None;
+    }
+    // Subject → scope.
+    let (who, after_subject) = strip_casting_prohibition_subject(lower)?;
+    // Verb phrase + shared when-clause combinator.
+    fn parse_predicate(i: &str) -> OracleResult<'_, WhenKind> {
+        let (i, _) =
+            tag::<_, _, OracleError<'_>>("can cast spells and activate abilities ").parse(i)?;
+        let (i, kind) = parse_when_clause(i)?;
+        Ok((i, kind))
+    }
+    let (rest, kind) = parse_predicate(after_subject).ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    let when = when_kind_to_condition(kind);
+
+    // Preserve full Oracle text on both emitted statics' `description`.
+    // CR 605.1a: City of Solitude per its 2009-10-01 ruling blocks mana
+    // abilities — emit `ActivationExemption::None`. Future printings that
+    // carve out mana abilities ("...except mana abilities") may extend the
+    // parser to detect the exemption suffix; today no printed card uses that
+    // shape.
+    Some(vec![
+        StaticDefinition::new(StaticMode::CantCastDuring {
+            who: who.clone(),
+            when: when.clone(),
+        })
+        .description(text.to_string()),
+        StaticDefinition::new(StaticMode::CantActivateDuring {
+            who,
+            when,
+            exemption: ActivationExemption::None,
+        })
+        .description(text.to_string()),
+    ])
+}
+
 /// Try matching a nom `tag()` against the lowercase text, returning the remaining original-case
 /// text on success. This bridges nom's exact-match combinators with the TextPair dual-string
 /// pattern used throughout the parser.
@@ -1870,25 +1978,37 @@ fn parse_static_line_inner(text: &str, inverted: InvertedAsLongAs) -> Option<Sta
         return Some(def);
     }
 
-    // --- CR 117.1a + CR 604.1: "can cast spells only during your turn" ---
-    // E.g., Fires of Invention: "You can cast spells only during your turn."
-    // Must be checked AFTER PerTurnCastLimit (which handles "no more than N" in compound clauses)
-    // and BEFORE the generic CantCastDuring block (which matches "can't cast spells during").
-    // Guard: exclude compound lines containing "each turn" — those are split at the oracle.rs level
-    // so both CantCastDuring and PerTurnCastLimit are emitted independently.
-    if nom_primitives::scan_contains(tp.lower, "can cast spells only during your turn")
+    // --- CR 117.1a + CR 604.1: "[subject] can cast spells only during {your | their own} turn(s)" ---
+    // E.g., Fires of Invention: "You can cast spells only during your turn." → SourceRelative
+    // E.g., Dosan, the Falling Leaf: "Players can cast spells only during their own turns." → PerAffected
+    //
+    // Must be checked AFTER PerTurnCastLimit (which handles "no more than N" in compound
+    // clauses) and BEFORE the generic CantCastDuring block (which matches "can't cast
+    // spells during"). Guard: exclude compound lines containing "each turn" — those are
+    // split at the oracle.rs level so CantCastDuring and PerTurnCastLimit emit independently.
+    if nom_primitives::scan_contains(tp.lower, "can cast spells only during")
         && !nom_primitives::scan_contains(tp.lower, "each turn")
     {
-        let who = strip_casting_prohibition_subject(tp.lower)
-            .map(|(scope, _)| scope)
-            .unwrap_or(ProhibitionScope::Controller);
-        return Some(
-            StaticDefinition::new(StaticMode::CantCastDuring {
-                who,
-                when: CastingProhibitionCondition::NotDuringYourTurn,
-            })
-            .description(text.to_string()),
-        );
+        // Subject → scope, via the shared building block.
+        let (who, after_subject) = strip_casting_prohibition_subject(tp.lower)
+            .unwrap_or((ProhibitionScope::Controller, tp.lower));
+        // Predicate must be exactly "can cast spells " + parse_when_clause.
+        fn parse_predicate(i: &str) -> OracleResult<'_, WhenKind> {
+            let (i, _) = tag::<_, _, OracleError<'_>>("can cast spells ").parse(i)?;
+            let (i, kind) = parse_when_clause(i)?;
+            Ok((i, kind))
+        }
+        if let Ok((rest, kind)) = parse_predicate(after_subject) {
+            if rest.trim().is_empty() {
+                return Some(
+                    StaticDefinition::new(StaticMode::CantCastDuring {
+                        who,
+                        when: when_kind_to_condition(kind),
+                    })
+                    .description(text.to_string()),
+                );
+            }
+        }
     }
 
     // CR 117.1: "can cast spells only any time they could cast a sorcery"
@@ -2553,6 +2673,15 @@ fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition> {
     let stripped = strip_reminder_text(text);
     let lower = stripped.to_lowercase();
     let tp = TextPair::new(&stripped, &lower);
+
+    // CR 601.2 + CR 602.5: City of Solitude class — "can cast spells and
+    // activate abilities only during {your | their own} turn(s)". Emits both
+    // halves of the prohibition independently. Must run first so the cast-only
+    // branch (which matches "can cast spells only during") does not consume
+    // the line before the activate-half is emitted.
+    if let Some(defs) = parse_cast_and_activate_only_during(&tp, &stripped) {
+        return defs;
+    }
 
     if let Some(defs) = parse_cost_payment_prohibition_statics(&tp, &stripped) {
         return defs;
@@ -21546,5 +21675,131 @@ mod snapshot_tests {
             .is_none(),
             "non-2-life variants must not bind to PayLifeAsColoredMana"
         );
+    }
+
+    // === CR 117.1a + CR 102.1 + CR 109.5: "only during X turn(s)" parser tests ===
+
+    /// CR 109.5: Fires of Invention emits the source-relative binding
+    /// (`NotDuringYourTurn`) and does NOT emit a CantActivateDuring static.
+    /// Regression guard — parser rewrite must preserve bit-for-bit behavior.
+    #[test]
+    fn parses_fires_of_invention_cast_only_during_your_turn() {
+        let defs = parse_static_line_multi("You can cast spells only during your turn.");
+        let cast = defs
+            .iter()
+            .find(|d| matches!(&d.mode, StaticMode::CantCastDuring { .. }))
+            .expect("expected CantCastDuring");
+        match &cast.mode {
+            StaticMode::CantCastDuring { who, when } => {
+                assert_eq!(*who, ProhibitionScope::Controller);
+                assert_eq!(*when, CastingProhibitionCondition::NotDuringYourTurn);
+            }
+            _ => unreachable!(),
+        }
+        assert!(
+            !defs
+                .iter()
+                .any(|d| matches!(&d.mode, StaticMode::CantActivateDuring { .. })),
+            "Fires of Invention does NOT emit an activate-during static"
+        );
+    }
+
+    /// CR 102.1: Dosan emits `CantCastDuring(AllPlayers, NotDuringAffectedPlayersTurn)`
+    /// and per its 2004-12-01 ruling does NOT emit a CantActivateDuring static.
+    #[test]
+    fn parses_dosan_cast_only_during_their_own_turns() {
+        let defs = parse_static_line_multi("Players can cast spells only during their own turns.");
+        assert_eq!(defs.len(), 1, "expected exactly one static, got {defs:?}");
+        let cast = &defs[0];
+        match &cast.mode {
+            StaticMode::CantCastDuring { who, when } => {
+                assert_eq!(*who, ProhibitionScope::AllPlayers);
+                assert_eq!(
+                    *when,
+                    CastingProhibitionCondition::NotDuringAffectedPlayersTurn
+                );
+            }
+            other => panic!(
+                "expected CantCastDuring(AllPlayers, NotDuringAffectedPlayersTurn), got {other:?}"
+            ),
+        }
+        // Per Dosan's 2004-12-01 ruling: "doesn't stop activated or triggered abilities".
+        assert!(
+            !defs
+                .iter()
+                .any(|d| matches!(&d.mode, StaticMode::CantActivateDuring { .. })),
+            "Dosan must NOT emit an activate-during static"
+        );
+    }
+
+    /// CR 601.2 + CR 602.5: City of Solitude emits BOTH halves (cast + activate)
+    /// with `NotDuringAffectedPlayersTurn`, and the activate-half has
+    /// `ActivationExemption::None` per its 2009-10-01 ruling.
+    #[test]
+    fn parses_city_of_solitude_cast_and_activate_only_during_their_own_turns() {
+        let oracle = "Players can cast spells and activate abilities only during their own turns.";
+        let defs = parse_static_line_multi(oracle);
+        assert_eq!(
+            defs.len(),
+            2,
+            "City of Solitude must emit cast-half + activate-half, got {defs:?}"
+        );
+        let cast = defs
+            .iter()
+            .find(|d| matches!(&d.mode, StaticMode::CantCastDuring { .. }))
+            .expect("cast-half");
+        let activate = defs
+            .iter()
+            .find(|d| matches!(&d.mode, StaticMode::CantActivateDuring { .. }))
+            .expect("activate-half");
+        match &cast.mode {
+            StaticMode::CantCastDuring { who, when } => {
+                assert_eq!(*who, ProhibitionScope::AllPlayers);
+                assert_eq!(
+                    *when,
+                    CastingProhibitionCondition::NotDuringAffectedPlayersTurn
+                );
+            }
+            _ => unreachable!(),
+        }
+        match &activate.mode {
+            StaticMode::CantActivateDuring {
+                who,
+                when,
+                exemption,
+            } => {
+                assert_eq!(*who, ProhibitionScope::AllPlayers);
+                assert_eq!(
+                    *when,
+                    CastingProhibitionCondition::NotDuringAffectedPlayersTurn
+                );
+                // CR 605.1a: City of Solitude does NOT exempt mana abilities (2009-10-01 ruling).
+                assert_eq!(*exemption, ActivationExemption::None);
+            }
+            _ => unreachable!(),
+        }
+        // Both emitted statics carry the full Oracle text on `description`.
+        assert_eq!(cast.description.as_deref(), Some(oracle));
+        assert_eq!(activate.description.as_deref(), Some(oracle));
+    }
+
+    /// CR 117.1: Teferi-class regression — "only any time they could cast a sorcery"
+    /// remains a `NotSorcerySpeed` condition; the parser rewrite must not regress it.
+    #[test]
+    fn parses_teferi_cast_only_at_sorcery_speed_regression() {
+        let defs = parse_static_line_multi(
+            "Each opponent can cast spells only any time they could cast a sorcery.",
+        );
+        let s = defs
+            .iter()
+            .find(|d| matches!(&d.mode, StaticMode::CantCastDuring { .. }))
+            .expect("expected CantCastDuring for Teferi");
+        match &s.mode {
+            StaticMode::CantCastDuring { who, when } => {
+                assert_eq!(*who, ProhibitionScope::Opponents);
+                assert_eq!(*when, CastingProhibitionCondition::NotSorcerySpeed);
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -65,6 +65,12 @@ impl FromStr for ProhibitionScope {
 }
 
 /// CR 101.2: When the casting prohibition applies.
+///
+/// The "pronoun-binding" axis is encoded by the choice of `NotDuringYourTurn`
+/// vs `NotDuringAffectedPlayersTurn`. CR 109.5 binds the "you/your" pronoun to
+/// the static's source controller, while the distributive "their own" reading
+/// (from CR 102.1 plus the template structure of "[every player] can [action]
+/// only during their own [time]") binds the predicate per-affected caster.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CastingProhibitionCondition {
     /// "during your turn" — prohibition active on controller's turn.
@@ -75,6 +81,24 @@ pub enum CastingProhibitionCondition {
     /// — prohibition active when it is NOT the controller's turn.
     /// E.g., Fires of Invention: "You can cast spells only during your turn."
     NotDuringYourTurn,
+    /// CR 102.1 + CR 117.1a + CR 604.1: "only during their own turn(s)" —
+    /// distributive per-affected-player binding. The prohibition is active
+    /// whenever it is NOT the *affected* player's turn.
+    ///
+    /// Contrasts with `NotDuringYourTurn` which binds to the static's source
+    /// controller (CR 109.5 — "your turn" on Fires of Invention).
+    ///
+    /// **Why a separate variant, not a re-use of `NotDuringYourTurn`:**
+    /// `NotDuringYourTurn` says "blocked when it is NOT the source-controller's
+    /// turn" (CR 109.5). For Dosan ("Players can cast spells only during their
+    /// own turns.") the binding is per-affected-caster, not per-source: when
+    /// Alice has Dosan on the battlefield and Bob has priority on Alice's turn,
+    /// Bob is blocked because it's not *Bob's* turn — Alice's possessive doesn't
+    /// reach. The CompRules don't carve out a specific pronoun-binding rule for
+    /// "their" the way CR 109.5 governs "you/your"; the distributive reading
+    /// follows from CR 102.1 (active player definition) + the template structure
+    /// of "[every player] can [action] only during their own [time]".
+    NotDuringAffectedPlayersTurn,
     /// CR 117.1: "only any time they could cast a sorcery" — prohibition active when it is
     /// not sorcery speed (main phase + active player's turn + empty stack).
     /// E.g., Teferi, Time Raveler: "Each opponent can cast spells only any time they could
@@ -88,6 +112,9 @@ impl fmt::Display for CastingProhibitionCondition {
             CastingProhibitionCondition::DuringYourTurn => write!(f, "your_turn"),
             CastingProhibitionCondition::DuringCombat => write!(f, "combat"),
             CastingProhibitionCondition::NotDuringYourTurn => write!(f, "not_your_turn"),
+            CastingProhibitionCondition::NotDuringAffectedPlayersTurn => {
+                write!(f, "not_their_own_turn")
+            }
             CastingProhibitionCondition::NotSorcerySpeed => write!(f, "not_sorcery_speed"),
         }
     }
@@ -101,6 +128,7 @@ impl FromStr for CastingProhibitionCondition {
             "your_turn" => Ok(CastingProhibitionCondition::DuringYourTurn),
             "combat" => Ok(CastingProhibitionCondition::DuringCombat),
             "not_your_turn" => Ok(CastingProhibitionCondition::NotDuringYourTurn),
+            "not_their_own_turn" => Ok(CastingProhibitionCondition::NotDuringAffectedPlayersTurn),
             "not_sorcery_speed" => Ok(CastingProhibitionCondition::NotSorcerySpeed),
             other => Err(format!("unknown CastingProhibitionCondition: {other}")),
         }
@@ -612,6 +640,35 @@ pub enum StaticMode {
         who: ProhibitionScope,
         when: CastingProhibitionCondition,
     },
+    /// CR 602.5 + CR 117.1b: Continuous activation prohibition — prevents the
+    /// scoped player(s) from activating activated abilities during the specified
+    /// turn condition.
+    ///
+    /// E.g., City of Solitude: "Players can cast spells and activate abilities
+    /// only during their own turns." (Activation half — the cast half is emitted
+    /// as a sibling `CantCastDuring`.)
+    ///
+    /// Distinct from `CantBeActivated`:
+    /// - `CantBeActivated` narrows by **permanent** (which permanent's abilities
+    ///   are blocked) and has no time axis.
+    /// - `CantActivateDuring` narrows by **time** (which turn condition the
+    ///   prohibition is active under) and has no permanent narrowing — every
+    ///   activated ability is blocked when the timing predicate matches.
+    ///
+    /// `exemption: ActivationExemption` carries CR 605.1a's "unless they're mana
+    /// abilities" exemption. City of Solitude per its 2009-10-01 ruling
+    /// ("This stops players from activating mana abilities") emits
+    /// `ActivationExemption::None`. Field is present for structural parallelism
+    /// with `CantBeActivated` and `GameRestriction::ProhibitActivity::ActivateAbilities`.
+    ///
+    /// CR 605.3a permits mana ability activation at priority generally, but
+    /// per-card prohibitions override that general permission per CR 101.1.
+    CantActivateDuring {
+        who: ProhibitionScope,
+        when: CastingProhibitionCondition,
+        #[serde(default)]
+        exemption: ActivationExemption,
+    },
     /// CR 101.2 + CR 604.1: Per-turn casting limit — static ability generating a
     /// continuous "can't" effect that restricts how many spells a player may cast.
     /// E.g., Rule of Law: "Each player can't cast more than one spell each turn."
@@ -891,6 +948,7 @@ impl Hash for StaticMode {
             | StaticMode::MaximumHandSize { .. }
             | StaticMode::CastWithKeyword { .. }
             | StaticMode::CantBeActivated { .. }
+            | StaticMode::CantActivateDuring { .. }
             | StaticMode::CantSearchLibrary { .. }
             | StaticMode::SuppressTriggers { .. } => {}
             // All other variants are unit variants — discriminant suffices.
@@ -990,6 +1048,12 @@ impl fmt::Display for StaticMode {
             StaticMode::CantCastFrom => write!(f, "CantCastFrom"),
             StaticMode::CantCastDuring { who, when } => {
                 write!(f, "CantCastDuring({who},{when})")
+            }
+            // CR 602.5 + CR 117.1b: Diagnostic-only Display; `exemption` is data-carrying
+            // and omitted (mirrors `CantBeActivated`'s Display which also drops
+            // `source_filter` + `exemption`).
+            StaticMode::CantActivateDuring { who, when, .. } => {
+                write!(f, "CantActivateDuring({who},{when})")
             }
             StaticMode::PerTurnCastLimit { who, max, .. } => {
                 write!(f, "PerTurnCastLimit({who},{max})")
@@ -1373,6 +1437,26 @@ impl FromStr for StaticMode {
                             CastingProhibitionCondition::from_str(when_str),
                         ) {
                             return Ok(StaticMode::CantCastDuring { who, when });
+                        }
+                    }
+                    return Ok(StaticMode::Other(other.to_string()));
+                } else if let Some(inner) = other
+                    .strip_prefix("CantActivateDuring(")
+                    .and_then(|s| s.strip_suffix(')'))
+                {
+                    // CR 602.5 + CR 117.1b: Round-trip preserves the (who, when) axes;
+                    // `exemption` is data-carrying and defaults to `None` (mirrors the
+                    // `CantBeActivated` round-trip above — diagnostic-only).
+                    if let Some((who_str, when_str)) = inner.split_once(',') {
+                        if let (Ok(who), Ok(when)) = (
+                            ProhibitionScope::from_str(who_str),
+                            CastingProhibitionCondition::from_str(when_str),
+                        ) {
+                            return Ok(StaticMode::CantActivateDuring {
+                                who,
+                                when,
+                                exemption: ActivationExemption::None,
+                            });
                         }
                     }
                     return Ok(StaticMode::Other(other.to_string()));

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -485,7 +485,8 @@ pub(crate) fn static_mode_polarity(mode: &StaticMode) -> EffectPolarity {
         | StaticMode::MustAttack
         | StaticMode::MustBlock
         | StaticMode::CantGainLife
-        | StaticMode::CantBeActivated { .. } => EffectPolarity::Harmful,
+        | StaticMode::CantBeActivated { .. }
+        | StaticMode::CantActivateDuring { .. } => EffectPolarity::Harmful,
         // Beneficial: enhances the enchanted permanent
         StaticMode::CantBeBlocked
         | StaticMode::CantBeBlockedExceptBy { .. }


### PR DESCRIPTION
## Summary
Fixes engine support for **Dosan, the Falling Leaf** and **City of Solitude**, and closes a CR 602.5 enforcement hole at the mana-ability executor.

Adds `StaticMode::CantActivateDuring { who, when, exemption }` and a new `CastingProhibitionCondition::NotDuringAffectedPlayersTurn` variant for the per-affected-player distributive binding (CR 102.1), contrasting with the source-controller "your" binding (CR 109.5). Extracts a single-authority `evaluate_casting_prohibition_condition` consumed by both `is_blocked_by_cant_cast_during` and the new `is_blocked_by_cant_activate_during`. The new activation gate honors `ActivationExemption::ManaAbilities` via the single classifier authority `mana_abilities::is_mana_ability`.

Rewrites the "can cast spells only during {your | their own} turn(s)" parser through a shared composed-nom `parse_when_clause` combinator (typed `WhenKind` enum) — one combinator covers both binding axes and the singular/plural turn(s) suffix. Wires the cast+activate compound through `parse_cast_and_activate_only_during` in `parse_static_line_multi_inner` emitting both halves with the same who/when.

Cards fixed:
- **Dosan, the Falling Leaf** — was `Unimplemented(static_structure)`, now `CantCastDuring(AllPlayers, NotDuringAffectedPlayersTurn)`. Per Dosan's 2004-12-01 ruling, only casts are blocked (no `CantActivateDuring` emitted).
- **City of Solitude** — was `Unimplemented(unknown)`, now emits both `CantCastDuring` and `CantActivateDuring(exemption: None)` per the 2009-10-01 ruling that mana abilities are also blocked.
- **Fires of Invention** — bit-for-bit unchanged (regression-guarded).

The second commit closes a CR 602.5 hole: `mana_abilities::activate_mana_ability` previously bypassed the static-ability activation gates that `casting::handle_activate_ability` applied on the non-mana path. With City of Solitude (`exemption: None`) now in the engine, a hostile/buggy client submitting `GameAction::ActivateAbility` directly could activate a mana ability on the opponent's turn even though the ability is rules-prohibited. The fix exposes both `is_blocked_by_cant_be_activated` and `is_blocked_by_cant_activate_during` as `pub(super)` and calls them from the top of `activate_mana_ability`.

## Files changed
- crates/engine/src/types/statics.rs (+84)
- crates/engine/src/parser/oracle_classifier.rs (+5)
- crates/engine/src/parser/oracle_static.rs (+289)
- crates/engine/src/game/casting.rs (+518)
- crates/engine/src/game/coverage.rs (+8)
- crates/engine/src/game/static_abilities.rs (+3)
- crates/engine/src/game/mana_abilities.rs (+93)
- crates/phase-ai/src/policies/effect_classify.rs (+3 -1)

## CR references
- CR 102.1 — per-player distributive binding ("their own turn")
- CR 109.5 — possessive "your"/"their" binding to source controller
- CR 117.1a / 117.1b — timing of casts vs activations
- CR 506.1 — combat phase boundary
- CR 601.2 — casting a spell
- CR 602.5 — activating an activated ability (executor must reject)
- CR 604.1 — static-ability functioning gate
- CR 605.1a — mana-ability classification / exemption
- CR 702.26b — Indestructible static functioning gate (referenced, not modified)

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: high

## Verification
- `cargo fmt --all -- --check` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo clippy --all-targets -- -D warnings` (workspace) — clean
- `cargo test` workspace lib — 9629 passed / 0 failed / 1 ignored
- `cargo test -p phase-ai` — 657 passed
- 13 named tests for this change — all pass (4 parser + 8 runtime + 1 executor)
- `cargo coverage` — Dosan: `supported: true, gap_count: 0`; City of Solitude: `supported: true, gap_count: 0`; Fires of Invention: unchanged
- doc-guardian: PASS (all 12 CLAUDE.md pillars)
- `/review-engine-plan`: PASS (after one revision round)
- `/review-impl`: PASS
- code-reviewer: all blocking findings resolved

## Scope Expansion
The original task was to fix Dosan, the Falling Leaf. Scope expanded twice, both rules-correctness-driven per CLAUDE.md "build for the class, not the card":

1. **City of Solitude added as a sibling case.** Investigation showed Dosan and City of Solitude share the "only during their own turn" axis but differ on whether activations are also blocked (Dosan ruling: casts only; City of Solitude ruling: casts + non-mana activations). Building only the Dosan-shaped variant would have left the cast+activate compound pattern unaddressed, requiring a second pass for City of Solitude. Both are covered by the same parser + types in one pass.

2. **CR 602.5 mana-ability executor gate added.** Code-reviewer surfaced that introducing City of Solitude (the first card with `CantActivateDuring { exemption: None }`) exposed a pre-existing hole: `mana_abilities::activate_mana_ability` bypassed the activation-prohibition gates that `casting::handle_activate_ability` applied on the non-mana path. The AI/legal-action surface prevented the visible symptom, but per CR 602.5 the executor itself must reject. Fix is a 5-line guard at the top of the executor plus a `pub(super)` exposure of the gate functions.

## Validation Failures
None.

## CI Failures
None.
