### PR TITLE
ADD: Aether Tradewinds

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17602,6 +17602,7 @@ fn extract_effect_verb(effect: &Effect) -> Option<&'static str> {
             origin: Some(Zone::Battlefield),
             ..
         } => Some("return"),
+        Effect::Bounce { .. } | Effect::BounceAll { .. } => Some("return"),
         Effect::Sacrifice { .. } => Some("sacrifice"),
         Effect::Tap { .. } | Effect::TapAll { .. } => Some("tap"),
         Effect::Untap { .. } | Effect::UntapAll { .. } => Some("untap"),
@@ -18021,11 +18022,7 @@ mod tests {
         );
 
         match &clause.effect {
-            Effect::ChangeZone {
-                destination,
-                target,
-                ..
-            } if *destination == Zone::Hand => {
+            Effect::Bounce { target, .. } => {
                 let tf = typed_leg(target).expect("primary return target should be typed");
                 assert_eq!(
                     tf.controller,
@@ -18033,18 +18030,14 @@ mod tests {
                     "primary return target should remain 'you control'",
                 );
             }
-            other => panic!("primary clause must be ChangeZone to hand, got {:?}", other),
+            other => panic!("primary clause must be Bounce, got {:?}", other),
         }
 
         let sub = clause
             .sub_ability
             .expect("must have sub_ability for compound return");
         match sub.effect.as_ref() {
-            Effect::ChangeZone {
-                destination,
-                target,
-                ..
-            } if *destination == Zone::Hand => {
+            Effect::Bounce { target, .. } => {
                 let tf = typed_leg(target).expect("sub return target should be typed");
                 assert_eq!(
                     tf.controller,
@@ -18052,7 +18045,7 @@ mod tests {
                     "sub return target should resolve to 'you don't control'",
                 );
             }
-            other => panic!("sub-clause must be ChangeZone to hand, got {:?}", other),
+            other => panic!("sub-clause must be Bounce, got {:?}", other),
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6664,10 +6664,16 @@ fn try_split_targeted_compound(text: &str, ctx: &mut ParseContext) -> Option<Par
     let mut sub_clause = parse_imperative_effect(sub_text, &mut continuation_ctx);
 
     // CR 608.2c: Verb carry-forward for bare "target X" clauses in compound actions.
-    // When the sub-text starts with "target" and parsed as Unimplemented, prepend
-    // the verb from the primary effect and re-parse. Handles "exile target creature
-    // and target artifact" where "target artifact" lacks a verb.
-    if matches!(sub_clause.effect, Effect::Unimplemented { .. })
+    // When the sub-text starts with "target" and parsed as Unimplemented or
+    // the structural TargetOnly wrapper, prepend the verb from the primary
+    // effect and re-parse. Handles "exile target creature and target artifact"
+    // where "target artifact" lacks a verb.
+    // Only this branch accepts TargetOnly: bare "target ..." is the only
+    // verbless head that lowers structurally to TargetOnly; the other
+    // carry-forward prefixes below ("up to", "all/each", "~", possessives)
+    // fall back as Unimplemented when the verb is omitted.
+    if (matches!(sub_clause.effect, Effect::Unimplemented { .. })
+        || matches!(sub_clause.effect, Effect::TargetOnly { .. }))
         && tag::<_, _, OracleError<'_>>("target ")
             .parse(sub_lower.as_str())
             .is_ok()
@@ -18004,6 +18010,49 @@ mod tests {
                 );
             }
             other => panic!("expected Destroy, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn compound_verb_carry_forward_return_target_only_tail_aether_tradewinds() {
+        let clause = parse_effect_clause(
+            "Return target permanent you control and target permanent you don't control to their owners' hands.",
+            &mut ParseContext::default(),
+        );
+
+        match &clause.effect {
+            Effect::ChangeZone {
+                destination,
+                target,
+                ..
+            } if *destination == Zone::Hand => {
+                let tf = typed_leg(target).expect("primary return target should be typed");
+                assert_eq!(
+                    tf.controller,
+                    Some(ControllerRef::You),
+                    "primary return target should remain 'you control'",
+                );
+            }
+            other => panic!("primary clause must be ChangeZone to hand, got {:?}", other),
+        }
+
+        let sub = clause
+            .sub_ability
+            .expect("must have sub_ability for compound return");
+        match sub.effect.as_ref() {
+            Effect::ChangeZone {
+                destination,
+                target,
+                ..
+            } if *destination == Zone::Hand => {
+                let tf = typed_leg(target).expect("sub return target should be typed");
+                assert_eq!(
+                    tf.controller,
+                    Some(ControllerRef::Opponent),
+                    "sub return target should resolve to 'you don't control'",
+                );
+            }
+            other => panic!("sub-clause must be ChangeZone to hand, got {:?}", other),
         }
     }
 


### PR DESCRIPTION
Tier: Standard

## Gate A
```text
status:0
```

## Anchored on
- crates/engine/src/parser/oracle_effect/mod.rs:6664 - existing bare "target X" verb carry-forward branch in compound actions.
- crates/engine/src/parser/oracle_effect/mod.rs:17602 - verb extraction now includes Bounce/BounceAll for "return" carry-forward.
- crates/engine/src/parser/oracle_effect/mod.rs:18014 - regression test for Aether Tradewinds compound "return ... and target ..." parsing.

## Summary
Adds parser/engine support for Aether Tradewinds by extending CR 608.2c compound verb carry-forward so a structural TargetOnly tail ("and target permanent you don't control") is reparsed with the leading verb as Bounce.

## Files changed
- crates/engine/src/parser/oracle_effect/mod.rs

## CR references
- CR 608.2c

## Track
Developer

## LLM
Model: codex-5.3
Thinking: medium

## Verification
- cargo fmt --all - clean
- ./scripts/check-parser-combinators.sh - clean (status:0)
- cargo test -p engine compound_verb_carry_forward_return_target_only_tail_aether_tradewinds -- --nocapture - clean (1 passed)
- cargo clippy-strict - clean
- cargo test -p engine - clean (unit + integration + doc tests)
- ./scripts/gen-card-data.sh - clean
- cargo coverage - clean (Coverage: 29903/34771 cards supported, 86.0%)
- cargo semantic-audit - clean (30367 cards audited; reports written to data/semantic-audit.json and data/semantic-audit.md)

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
