### PR TITLE
fix(engine): synthesize Dethrone keyword into attack trigger

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -1976,6 +1976,10 @@ fn is_myriad_attack_trigger(t: &TriggerDefinition) -> bool {
 fn is_dethrone_attack_trigger(t: &TriggerDefinition) -> bool {
     if !matches!(t.mode, TriggerMode::Attacks)
         || !matches!(t.valid_card, Some(TargetFilter::SelfRef))
+        || !matches!(
+            t.attack_target_filter,
+            Some(crate::types::triggers::AttackTargetFilter::Player)
+        )
     {
         return false;
     }
@@ -2242,14 +2246,18 @@ fn build_dethrone_trigger() -> TriggerDefinition {
         },
     };
 
-    TriggerDefinition::new(TriggerMode::Attacks)
+    let mut trigger = TriggerDefinition::new(TriggerMode::Attacks)
         .valid_card(TargetFilter::SelfRef)
         .condition(condition)
         .execute(put_counter)
         .description(
             "CR 702.105a: Dethrone — whenever ~ attacks the player with the most life or tied for most life, put a +1/+1 counter on ~."
                 .to_string(),
-        )
+        );
+    // CR 702.105a: Dethrone only triggers when attacking a player, not a
+    // planeswalker or battle.
+    trigger.attack_target_filter = Some(crate::types::triggers::AttackTargetFilter::Player);
+    trigger
 }
 
 /// CR 702.100a: Evolve — "Whenever a creature you control enters, if that
@@ -5598,6 +5606,14 @@ mod dethrone_tests {
             matches!(trigger.valid_card, Some(TargetFilter::SelfRef)),
             "valid_card must be SelfRef so the trigger fires only when this \
              creature attacks"
+        );
+
+        // CR 702.105a: Dethrone only triggers when attacking a player.
+        assert_eq!(
+            trigger.attack_target_filter,
+            Some(crate::types::triggers::AttackTargetFilter::Player),
+            "attack_target_filter must be Player so the trigger fires only \
+             when attacking a player, not a planeswalker or battle"
         );
 
         let Some(execute) = trigger.execute.as_deref() else {

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8,9 +8,9 @@ use crate::types::ability::{
     AggregateFunction, CardPlayMode, CastVariantPaid, ChoiceType, Comparator,
     ContinuousModification, ControllerRef, CopyRetargetPermission, CounterTriggerFilter, Duration,
     Effect, FilterProp, KickerVariant, ManaContribution, ManaProduction, ModalSelectionCondition,
-    ModalSelectionConstraint, NinjutsuVariant, ObjectScope, PtStat, PtValue, PtValueScope,
-    QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition, RuntimeHandler,
-    SearchSelectionConstraint, StaticDefinition, TargetChoiceTiming, TargetFilter,
+    ModalSelectionConstraint, NinjutsuVariant, ObjectScope, PlayerScope, PtStat, PtValue,
+    PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition,
+    RuntimeHandler, SearchSelectionConstraint, StaticDefinition, TargetChoiceTiming, TargetFilter,
     TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
 };
 use crate::types::card::{CardFace, CardLayout};
@@ -149,6 +149,7 @@ impl KeywordTriggerInstaller {
                 "M1M1", "-1/-1", "702.79a",
             )],
             Keyword::Annihilator(n) => vec![build_annihilator_trigger(*n)],
+            Keyword::Dethrone => vec![build_dethrone_trigger()],
             Keyword::Evolve => vec![build_evolve_trigger()],
             Keyword::Myriad => vec![build_myriad_trigger()],
             Keyword::Soulbond => build_soulbond_triggers(),
@@ -177,6 +178,7 @@ impl KeywordTriggerInstaller {
                 is_dies_return_with_counter_trigger(trigger, &CounterType::Minus1Minus1)
             }
             Keyword::Annihilator(_) => is_annihilator_attack_trigger(trigger),
+            Keyword::Dethrone => is_dethrone_attack_trigger(trigger),
             Keyword::Evolve => is_evolve_trigger(trigger),
             Keyword::Myriad => is_myriad_attack_trigger(trigger),
             Keyword::Soulbond => is_soulbond_trigger(trigger),
@@ -1787,7 +1789,12 @@ pub fn synthesize_persist(face: &mut CardFace) {
 pub fn synthesize_annihilator(face: &mut CardFace) {
     KeywordTriggerInstaller::install_matching(face, |kw| matches!(kw, Keyword::Annihilator(_)));
 }
-
+/// CR 702.105a: Dethrone — an attack trigger that fires whenever this creature
+/// attacks the player with the most life or tied for most life, putting a +1/+1
+/// counter on it. CR 702.105b: each instance triggers separately.
+pub fn synthesize_dethrone(face: &mut CardFace) {
+    KeywordTriggerInstaller::install_matching(face, |kw| matches!(kw, Keyword::Dethrone));
+}
 /// CR 702.100a: Evolve — an ETB trigger that fires whenever another creature you
 /// control enters with greater power or toughness than the Evolve creature,
 /// putting a +1/+1 counter on it. CR 702.100d: each instance triggers
@@ -1962,7 +1969,28 @@ fn is_myriad_attack_trigger(t: &TriggerDefinition) -> bool {
             ability.optional && matches!(ability.effect.as_ref(), Effect::Myriad)
         })
 }
-
+/// Idempotency-shape predicate for `synthesize_dethrone`. True iff `trigger`
+/// is the synthesized Dethrone attack-trigger shape (`TriggerMode::Attacks`
+/// + `valid_card = SelfRef` + execute = PutCounter(P1P1) on SelfRef
+/// + condition = DefendingPlayer life >= AllPlayers max life).
+fn is_dethrone_attack_trigger(t: &TriggerDefinition) -> bool {
+    if !matches!(t.mode, TriggerMode::Attacks)
+        || !matches!(t.valid_card, Some(TargetFilter::SelfRef))
+    {
+        return false;
+    }
+    let Some(execute) = t.execute.as_deref() else {
+        return false;
+    };
+    matches!(
+        &*execute.effect,
+        Effect::PutCounter {
+            counter_type: CounterType::Plus1Plus1,
+            target: TargetFilter::SelfRef,
+            ..
+        }
+    ) && t.condition.is_some()
+}
 fn is_echo_trigger(t: &TriggerDefinition) -> bool {
     matches!(t.mode, TriggerMode::PayEcho)
         && t.phase == Some(Phase::Upkeep)
@@ -2172,6 +2200,56 @@ fn build_annihilator_trigger(n: u32) -> TriggerDefinition {
             "CR 702.86a: Annihilator {n} — whenever ~ attacks, defending player sacrifices {n} permanent{}.",
             if n == 1 { "" } else { "s" }
         ))
+}
+
+/// CR 702.105a: Dethrone — "Whenever a creature with dethrone attacks the
+/// player with the most life or tied for most life, put a +1/+1 counter on
+/// that creature."
+///
+/// Build-for-the-class: keyed entirely on `Keyword::Dethrone`, so every printed
+/// Dethrone card and every creature granted Dethrone at runtime gets an identical
+/// trigger. CR 702.105b: each instance triggers separately.
+fn build_dethrone_trigger() -> TriggerDefinition {
+    // CR 122.1: put a single +1/+1 counter on the Dethrone creature itself.
+    let put_counter = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PutCounter {
+            counter_type: CounterType::Plus1Plus1,
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::SelfRef,
+        },
+    )
+    .description("Put a +1/+1 counter on this creature".to_string());
+
+    // CR 702.105a: "attacks the player with the most life or tied for most
+    // life". The defending player's life total must be >= the maximum life
+    // total among all players. This is an intervening-if condition checked
+    // at both detection and resolution per CR 603.4.
+    let condition = TriggerCondition::QuantityComparison {
+        lhs: QuantityExpr::Ref {
+            qty: QuantityRef::LifeTotal {
+                player: PlayerScope::DefendingPlayer,
+            },
+        },
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Ref {
+            qty: QuantityRef::LifeTotal {
+                player: PlayerScope::AllPlayers {
+                    aggregate: AggregateFunction::Max,
+                    exclude: None,
+                },
+            },
+        },
+    };
+
+    TriggerDefinition::new(TriggerMode::Attacks)
+        .valid_card(TargetFilter::SelfRef)
+        .condition(condition)
+        .execute(put_counter)
+        .description(
+            "CR 702.105a: Dethrone — whenever ~ attacks the player with the most life or tied for most life, put a +1/+1 counter on ~."
+                .to_string(),
+        )
 }
 
 /// CR 702.100a: Evolve — "Whenever a creature you control enters, if that
@@ -3262,6 +3340,10 @@ pub fn synthesize_all(face: &mut CardFace) {
     // separately. Defending player resolved per-attacker via
     // `ControllerRef::DefendingPlayer` (CR 508.5 / 508.5a).
     synthesize_annihilator(face);
+    // CR 702.105a: Dethrone — attack trigger that puts a +1/+1 counter on the
+    // creature whenever it attacks the player with the most life or tied for
+    // most life. CR 702.105b: each instance triggers separately.
+    synthesize_dethrone(face);
     // CR 702.100a: Evolve — ETB trigger that puts a +1/+1 counter on the
     // creature whenever another creature you control enters with greater power
     // or toughness. CR 702.100d: each instance triggers separately.
@@ -5480,6 +5562,106 @@ mod annihilator_synthesis_tests {
                 .filter(|t| matches!(t.mode, TriggerMode::Attacks))
                 .count(),
             2
+        );
+    }
+}
+
+#[cfg(test)]
+mod dethrone_tests {
+    //! CR 702.105a: Dethrone synthesis tests. The synthesized trigger must be
+    //! `TriggerMode::Attacks` with `valid_card = SelfRef`, an intervening-if
+    //! condition comparing the defending player's life total against the maximum
+    //! life total among all players, and execute body `Effect::PutCounter` with
+    //! a single +1/+1 counter on `SelfRef`.
+    use super::*;
+
+    fn dethrone_face() -> CardFace {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Dethrone);
+        face
+    }
+
+    /// CR 702.105a: synthesizer emits an `Attacks` trigger with execute body
+    /// `Effect::PutCounter(P1P1)` on SelfRef and a life-total condition.
+    #[test]
+    fn synthesize_dethrone_adds_attack_trigger() {
+        let mut face = dethrone_face();
+        synthesize_dethrone(&mut face);
+
+        let trigger = face
+            .triggers
+            .iter()
+            .find(|t| is_dethrone_attack_trigger(t))
+            .expect("dethrone should add an Attacks trigger");
+
+        assert!(
+            matches!(trigger.valid_card, Some(TargetFilter::SelfRef)),
+            "valid_card must be SelfRef so the trigger fires only when this \
+             creature attacks"
+        );
+
+        let Some(execute) = trigger.execute.as_deref() else {
+            panic!("execute body required");
+        };
+        let Effect::PutCounter {
+            counter_type,
+            count,
+            target,
+        } = &*execute.effect
+        else {
+            panic!("execute body must be Effect::PutCounter");
+        };
+        assert_eq!(*counter_type, CounterType::Plus1Plus1);
+        assert!(matches!(count, QuantityExpr::Fixed { value: 1 }));
+        assert!(matches!(target, TargetFilter::SelfRef));
+
+        // Condition must be present (intervening-if).
+        assert!(
+            trigger.condition.is_some(),
+            "dethrone trigger must have an intervening-if condition"
+        );
+    }
+
+    /// Repeated synthesis must not duplicate the trigger (idempotency).
+    #[test]
+    fn synthesize_dethrone_is_idempotent() {
+        let mut face = dethrone_face();
+        synthesize_dethrone(&mut face);
+        synthesize_dethrone(&mut face);
+        let count = face
+            .triggers
+            .iter()
+            .filter(|t| is_dethrone_attack_trigger(t))
+            .count();
+        assert_eq!(count, 1, "dethrone trigger should be deduped");
+    }
+
+    /// Cards without Dethrone are unaffected.
+    #[test]
+    fn synthesize_dethrone_is_noop_without_keyword() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Flying);
+        synthesize_dethrone(&mut face);
+        assert!(face.triggers.is_empty());
+    }
+
+    /// CR 702.105b: "If a creature has multiple instances of dethrone, each
+    /// triggers separately." Two `Keyword::Dethrone` entries synthesize two
+    /// distinct triggers.
+    #[test]
+    fn synthesize_dethrone_emits_one_trigger_per_instance() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Dethrone);
+        face.keywords.push(Keyword::Dethrone);
+        synthesize_dethrone(&mut face);
+        let count = face
+            .triggers
+            .iter()
+            .filter(|t| is_dethrone_attack_trigger(t))
+            .count();
+        assert_eq!(
+            count, 2,
+            "each Dethrone instance must produce its own trigger"
         );
     }
 }


### PR DESCRIPTION
## Summary

CR 702.105a: Dethrone — whenever a creature with dethrone attacks the player with the most life or tied for most life, put a +1/+1 counter on that creature.

The keyword was parsed and recognized but never expanded into a triggered ability. This PR adds `synthesize_dethrone()` following the established Annihilator/Evolve/Myriad pattern.

## Changes

- **`build_dethrone_trigger()`**: Constructs a `TriggerMode::Attacks` trigger with:
  - `valid_card = SelfRef` (fires only when this creature attacks)
  - `QuantityComparison` intervening-if condition: `DefendingPlayer.LifeTotal >= AllPlayers(Max).LifeTotal`
  - Execute body: `Effect::PutCounter { P1P1, count: 1, target: SelfRef }`
- **`is_dethrone_attack_trigger()`**: Idempotency shape predicate
- **`synthesize_dethrone()`**: Public entry point using `KeywordTriggerInstaller`
- **Pipeline wiring**: Called after `synthesize_annihilator` in the main synthesis pipeline
- **`KeywordTriggerInstaller`**: `triggers_for` and `trigger_matches_keyword_kind` arms for granted-keyword symmetric removal
- **Unit tests**: Trigger shape validation, idempotency, noop-without-keyword, multiple-instance emission

## Testing

- `cargo check` passes locally
- 4 unit tests added covering the synthesis behavior

## Fixes

Fixes #1178
Fixes #1121