### PR TITLE
Add Ur-Drago

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1770,6 +1770,36 @@ pub fn is_landwalk_unblockable(
         return false;
     }
 
+    // CR 509.1b + CR 609.4 + CR 702.14c + CR 702.14d: Global
+    // IgnoreLandwalkForBlocking statics cancel the landwalk *restriction* for
+    // the named qualifier. The keyword itself remains on the attacker
+    // (CR 609.4 — "as though" is scoped to this effect). `game_active_statics`
+    // (battlefield + command zone) iterates both controllers' statics; the
+    // static is global (`affected = None`), so a canceller under either
+    // player's control suppresses the qualifier symmetrically.
+    let cancelled: HashSet<&str> = super::functioning_abilities::game_active_statics(state)
+        .filter_map(|(_src, sd)| match &sd.mode {
+            StaticMode::IgnoreLandwalkForBlocking { qualifier: Some(q) } => Some(q.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    #[cfg(debug_assertions)]
+    for q in &cancelled {
+        debug_assert!(
+            !q.is_empty(),
+            "IgnoreLandwalkForBlocking qualifier must match Keyword::Landwalk canonical form"
+        );
+    }
+
+    let qualifiers: Vec<&str> = qualifiers
+        .into_iter()
+        .filter(|q| !cancelled.contains(q))
+        .collect();
+    if qualifiers.is_empty() {
+        return false;
+    }
+
     // CR 702.14c: Check every land the defending player controls on the battlefield.
     for &obj_id in &state.battlefield {
         let Some(obj) = state.objects.get(&obj_id) else {
@@ -2784,6 +2814,125 @@ mod tests {
         let _island = create_land(&mut state, PlayerId(1), "Island", &["Island"], &[]);
 
         assert!(!can_block_pair(&state, blocker, attacker));
+    }
+
+    /// CR 509.1b + CR 609.4 + CR 702.14c: Ur-Drago's static cancels the swampwalk
+    /// blocking restriction. Attacker with swampwalk + defender controls a Swamp +
+    /// a permanent emitting `IgnoreLandwalkForBlocking(Swamp)` => blockable.
+    #[test]
+    fn swampwalk_cancelled_by_ur_drago_static() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Swampwalker", 2, 2);
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .keywords
+            .push(Keyword::Landwalk("Swamp".to_string()));
+        let blocker = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+        let _swamp = create_land(&mut state, PlayerId(1), "Swamp", &["Swamp"], &[]);
+        // Place an Ur-Drago-like permanent on the defender's side emitting the static.
+        let ur_drago = create_creature(&mut state, PlayerId(1), "Ur-Drago", 4, 4);
+        state
+            .objects
+            .get_mut(&ur_drago)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(
+                StaticMode::IgnoreLandwalkForBlocking {
+                    qualifier: Some("Swamp".to_string()),
+                },
+            ));
+
+        assert!(can_block_pair(&state, blocker, attacker));
+    }
+
+    /// CR 702.14d: A swampwalk canceller leaves an unrelated islandwalk intact.
+    #[test]
+    fn islandwalk_unaffected_by_swamp_canceller() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Islandwalker", 2, 2);
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .keywords
+            .push(Keyword::Landwalk("Island".to_string()));
+        let blocker = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+        let _island = create_land(&mut state, PlayerId(1), "Island", &["Island"], &[]);
+        let canceller = create_creature(&mut state, PlayerId(1), "Ur-Drago", 4, 4);
+        state
+            .objects
+            .get_mut(&canceller)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(
+                StaticMode::IgnoreLandwalkForBlocking {
+                    qualifier: Some("Swamp".to_string()),
+                },
+            ));
+
+        assert!(!can_block_pair(&state, blocker, attacker));
+    }
+
+    /// CR 702.14d: Qualifiers cancel independently — an attacker with both
+    /// swampwalk and islandwalk only loses the cancelled qualifier; the other
+    /// landwalk path remains active.
+    #[test]
+    fn multi_qualifier_attacker_preserves_other_landwalks() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Dual Walker", 2, 2);
+        let kws = &mut state.objects.get_mut(&attacker).unwrap().keywords;
+        kws.push(Keyword::Landwalk("Swamp".to_string()));
+        kws.push(Keyword::Landwalk("Island".to_string()));
+        let blocker = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+        let _swamp = create_land(&mut state, PlayerId(1), "Swamp", &["Swamp"], &[]);
+        let _island = create_land(&mut state, PlayerId(1), "Island", &["Island"], &[]);
+        let canceller = create_creature(&mut state, PlayerId(1), "Ur-Drago", 4, 4);
+        state
+            .objects
+            .get_mut(&canceller)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(
+                StaticMode::IgnoreLandwalkForBlocking {
+                    qualifier: Some("Swamp".to_string()),
+                },
+            ));
+
+        // Islandwalk path still active => attacker is unblockable.
+        assert!(!can_block_pair(&state, blocker, attacker));
+    }
+
+    /// CR 509.1b + CR 609.4: The static is global (`affected = None`); a canceller
+    /// on the ATTACKING player's side still suppresses the restriction.
+    #[test]
+    fn ur_drago_canceller_controller_independence() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Swampwalker", 2, 2);
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .keywords
+            .push(Keyword::Landwalk("Swamp".to_string()));
+        let blocker = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+        let _swamp = create_land(&mut state, PlayerId(1), "Swamp", &["Swamp"], &[]);
+        // Canceller is on the ATTACKING side, not defender.
+        let canceller = create_creature(&mut state, PlayerId(0), "Ur-Drago", 4, 4);
+        state
+            .objects
+            .get_mut(&canceller)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(
+                StaticMode::IgnoreLandwalkForBlocking {
+                    qualifier: Some("Swamp".to_string()),
+                },
+            ));
+
+        // Cancellation still applies regardless of controller.
+        assert!(can_block_pair(&state, blocker, attacker));
     }
 
     /// CR 702.14a: Legendary landwalk — defender controlling a legendary land makes

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -6477,6 +6477,17 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
             StaticMode::CanAttackWithDefender => {
                 effective_lower.contains("as though it didn't have defender")
             }
+            // CR 509.1b + CR 609.4 + CR 702.14c: qualifier-aware coverage for
+            // Ur-Drago's "creatures with <X>walk can be blocked as though they
+            // didn't have <X>walk." Anchor on the per-qualifier keyword token
+            // so unrelated landwalk lines don't false-match.
+            StaticMode::IgnoreLandwalkForBlocking { qualifier: Some(q) } => {
+                let kw = format!("{}walk", q.to_ascii_lowercase());
+                effective_lower.contains(&format!("creatures with {kw}"))
+                    && effective_lower.contains("as though they didn't have")
+                    && effective_lower.contains(&kw)
+            }
+            StaticMode::IgnoreLandwalkForBlocking { qualifier: None } => false,
             StaticMode::CanActivateAbilitiesAsThoughHaste => {
                 effective_lower.contains("as though those creatures had haste")
                     || effective_lower.contains("as though that creature had haste")
@@ -6504,6 +6515,15 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                     StaticMode::CanAttackWithDefender => {
                         effective_lower.contains("as though it didn't have defender")
                     }
+                    // CR 509.1b + CR 609.4 + CR 702.14c: mirror predicate for
+                    // statics nested under a GenericEffect.
+                    StaticMode::IgnoreLandwalkForBlocking { qualifier: Some(q) } => {
+                        let kw = format!("{}walk", q.to_ascii_lowercase());
+                        effective_lower.contains(&format!("creatures with {kw}"))
+                            && effective_lower.contains("as though they didn't have")
+                            && effective_lower.contains(&kw)
+                    }
+                    StaticMode::IgnoreLandwalkForBlocking { qualifier: None } => false,
                     _ => false,
                 })
             } else {

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -159,6 +159,23 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     // CR 702.3b: CanAttackWithDefender — allows creatures with defender to attack.
     // Runtime enforcement is in combat.rs::validate_attack().
     registry.insert(StaticMode::CanAttackWithDefender, handle_rule_mod);
+    // CR 509.1b + CR 609.4 + CR 702.14c: IgnoreLandwalkForBlocking — global
+    // rule-modification static observed inside is_landwalk_unblockable.
+    // Registered per discriminant shape (the `None` instance plus the five
+    // basic-subtype instances) to mirror the data-carrying static precedent
+    // (e.g., ExtraBlockers { count: None } row).
+    registry.insert(
+        StaticMode::IgnoreLandwalkForBlocking { qualifier: None },
+        handle_rule_mod,
+    );
+    for q in ["Plains", "Island", "Swamp", "Mountain", "Forest"] {
+        registry.insert(
+            StaticMode::IgnoreLandwalkForBlocking {
+                qualifier: Some(q.to_string()),
+            },
+            handle_rule_mod,
+        );
+    }
     // CR 602.5a: CanActivateAbilitiesAsThoughHaste — bypasses the summoning-sickness
     // gate on a creature's {T}/{Q} activated abilities (Tyvar, Jubilant Brawler).
     // Runtime enforcement is in restrictions.rs::summoning_sick_for_tap_ability().

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -726,6 +726,14 @@ fn parse_static_line_inner(text: &str, inverted: InvertedAsLongAs) -> Option<Sta
         return Some(def);
     }
 
+    // CR 509.1b + CR 609.4 + CR 702.14c + CR 702.14d: "Creatures with <X>walk can
+    // be blocked as though they didn't have <X>walk." Global landwalk-restriction
+    // canceller (Ur-Drago class). Must run before the inverted "As long as" rewrite
+    // so the full literal sentence is detected before any structural rewriting.
+    if let Some(def) = try_parse_ignore_landwalk_for_blocking(&tp, &text) {
+        return Some(def);
+    }
+
     // CR 611.3a: An inverted static of the form "As long as <condition>, <effect>"
     // is semantically equivalent to the canonical "<effect> as long as <condition>".
     // Rewrite to canonical form and re-dispatch so the existing conditional-continuous
@@ -3969,6 +3977,43 @@ fn is_creature_you_control_filter(filter: &TargetFilter) -> bool {
         TargetFilter::Or { filters } => filters.iter().all(is_creature_you_control_filter),
         _ => false,
     }
+}
+
+/// CR 509.1b + CR 609.4 + CR 702.14c + CR 702.14d:
+/// "Creatures with <X>walk can be blocked as though they didn't have <X>walk."
+/// Both qualifier tokens MUST agree (printed cards always reference the same
+/// qualifier; cross-qualifier sentences are guarded out per CR 702.14d).
+///
+/// Class: the Portal/Legends "creatures with Xwalk can be blocked as though
+/// they didn't have Xwalk" cycle (Ur-Drago and four siblings — one per basic
+/// land subtype). Produces a `StaticMode::IgnoreLandwalkForBlocking` global
+/// rule-modification static.
+fn try_parse_ignore_landwalk_for_blocking(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<StaticDefinition> {
+    let ((q1, q2), rest) = nom_on_lower(tp.original, tp.lower, |i| {
+        let (i, _) = tag::<_, _, OracleError<'_>>("creatures with ").parse(i)?;
+        let (i, q1) = parse_basic_landwalk_qualifier(i)?;
+        let (i, _) = tag(" can be blocked as though they didn't have ").parse(i)?;
+        let (i, q2) = parse_basic_landwalk_qualifier(i)?;
+        let (i, _) = opt(tag(".")).parse(i)?;
+        Ok((i, (q1, q2)))
+    })?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    // CR 702.14d: qualifiers don't cancel cross-type. Printed cards always
+    // reference the same qualifier on both sides; guard against false matches.
+    if q1 != q2 {
+        return None;
+    }
+    Some(
+        StaticDefinition::new(StaticMode::IgnoreLandwalkForBlocking {
+            qualifier: Some(q1.to_string()),
+        })
+        .description(text.to_string()),
+    )
 }
 
 fn parse_soulbond_paired_static(tp: &TextPair<'_>, description: &str) -> Option<StaticDefinition> {
@@ -8971,6 +9016,26 @@ fn parse_landwalk_keyword(text: &str) -> Option<Keyword> {
     }
 }
 
+/// CR 702.14a: Parse one of the five basic-land landwalk keyword tokens
+/// (`plainswalk`, `islandwalk`, `swampwalk`, `mountainwalk`, `forestwalk`)
+/// and return the canonical capitalized basic subtype string that
+/// `Keyword::Landwalk(String)` carries (e.g. `swampwalk` → `"Swamp"`).
+///
+/// This is a *qualifier extractor* used by static-line parsers that need
+/// to reference the land subtype directly. It does NOT replace
+/// `parse_landwalk_keyword` (which produces a `Keyword`), and the existing
+/// allow-list at `oracle_target.rs` for landwalk tokens is unaffected.
+pub(crate) fn parse_basic_landwalk_qualifier(input: &str) -> OracleResult<'_, &'static str> {
+    alt((
+        value("Plains", tag("plainswalk")),
+        value("Island", tag("islandwalk")),
+        value("Swamp", tag("swampwalk")),
+        value("Mountain", tag("mountainwalk")),
+        value("Forest", tag("forestwalk")),
+    ))
+    .parse(input)
+}
+
 /// Parse CDA power/toughness equality patterns like:
 /// - "~'s power and toughness are each equal to the number of creatures you control."
 /// - "~'s power is equal to the number of card types among cards in all graveyards
@@ -10877,6 +10942,56 @@ mod tests {
         assert!(def
             .modifications
             .contains(&ContinuousModification::AddPower { value: 1 }));
+    }
+
+    /// CR 509.1b + CR 609.4 + CR 702.14c: Ur-Drago's landwalk canceller produces
+    /// `StaticMode::IgnoreLandwalkForBlocking { qualifier: Some("Swamp") }`.
+    #[test]
+    fn ignore_landwalk_for_blocking_parses_ur_drago_swampwalk() {
+        let def = parse_static_line(
+            "Creatures with swampwalk can be blocked as though they didn't have swampwalk.",
+        )
+        .expect("ur-drago line must parse");
+        assert_eq!(
+            def.mode,
+            StaticMode::IgnoreLandwalkForBlocking {
+                qualifier: Some("Swamp".to_string()),
+            }
+        );
+    }
+
+    /// CR 702.14a: All five basic-land qualifiers parse to the canonical
+    /// capitalized form (verified for islandwalk here).
+    #[test]
+    fn ignore_landwalk_for_blocking_parses_islandwalk() {
+        let def = parse_static_line(
+            "Creatures with islandwalk can be blocked as though they didn't have islandwalk.",
+        )
+        .expect("islandwalk line must parse");
+        assert_eq!(
+            def.mode,
+            StaticMode::IgnoreLandwalkForBlocking {
+                qualifier: Some("Island".to_string()),
+            }
+        );
+    }
+
+    /// CR 702.14d: cross-qualifier sentences are not landwalk cancellations
+    /// (different landwalks don't cancel each other). The parser must reject.
+    #[test]
+    fn ignore_landwalk_for_blocking_rejects_cross_qualifier() {
+        let result = parse_static_line(
+            "Creatures with swampwalk can be blocked as though they didn't have islandwalk.",
+        );
+        // Must not produce IgnoreLandwalkForBlocking. Other parsers may produce
+        // something else, but the qualifier-mismatch path must not match.
+        if let Some(def) = result {
+            assert!(
+                !matches!(def.mode, StaticMode::IgnoreLandwalkForBlocking { .. }),
+                "cross-qualifier text must not produce IgnoreLandwalkForBlocking, got {:?}",
+                def.mode
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -793,6 +793,25 @@ pub enum StaticMode {
     /// CR 702.3b: Allows creatures with defender to attack despite having the keyword.
     /// "can attack as though it didn't have defender" overrides the defender restriction.
     CanAttackWithDefender,
+    /// CR 509.1b + CR 609.4 + CR 702.14c: Globally cancel the landwalk blocking
+    /// restriction for the named qualifier. The attacker still has the keyword
+    /// (CR 609.4: "as though" is scoped to the stated effect); only its
+    /// blocking-restriction consequence is suppressed. Per CR 702.14d, qualifiers
+    /// cancel independently: a swampwalk canceller leaves a co-present islandwalk
+    /// intact.
+    ///
+    /// INVARIANT: `qualifier` MUST match `Keyword::Landwalk`'s canonical capitalized
+    /// form (e.g. "Swamp", "Island", "Plains", "Mountain", "Forest"). `None` reserved
+    /// for a hypothetical "all landwalk" global canceller; no printed card currently
+    /// requires this, but the option preserves room for that class.
+    ///
+    /// Class: the Portal/Legends "creatures with Xwalk can be blocked as though
+    /// they didn't have Xwalk" cycle (Ur-Drago and four siblings — one per basic
+    /// land subtype). Global rule modification (`affected: None`); enforced inside
+    /// `is_landwalk_unblockable` rather than as a layer-6 ability removal.
+    IgnoreLandwalkForBlocking {
+        qualifier: Option<String>,
+    },
     /// CR 602.5a: Bypasses the summoning-sickness gate on a creature's `{T}`/`{Q}`
     /// activated abilities — "You may activate abilities of creatures you control as
     /// though those creatures had haste." This is NOT `AddKeyword(Haste)`: only the
@@ -856,6 +875,7 @@ impl Hash for StaticMode {
                 filter.hash(state);
                 action.hash(state);
             }
+            StaticMode::IgnoreLandwalkForBlocking { qualifier } => qualifier.hash(state),
             StaticMode::Other(s) => s.hash(state),
             StaticMode::GraveyardCastPermission {
                 frequency,
@@ -1075,6 +1095,12 @@ impl fmt::Display for StaticMode {
                 write!(f, "StepEndUnspentMana({filter:?},{action})")
             }
             StaticMode::CanAttackWithDefender => write!(f, "CanAttackWithDefender"),
+            // CR 509.1b + CR 609.4 + CR 702.14c: Display follows the existing
+            // parenthesized-payload pattern. `None` = all-landwalk canceller.
+            StaticMode::IgnoreLandwalkForBlocking { qualifier } => match qualifier {
+                None => write!(f, "IgnoreLandwalkForBlocking"),
+                Some(q) => write!(f, "IgnoreLandwalkForBlocking({q})"),
+            },
             StaticMode::CanActivateAbilitiesAsThoughHaste => {
                 write!(f, "CanActivateAbilitiesAsThoughHaste")
             }
@@ -1309,6 +1335,10 @@ impl FromStr for StaticMode {
             "CantWinTheGame" => StaticMode::CantWinTheGame,
             "CantLoseTheGame" => StaticMode::CantLoseTheGame,
             "CanAttackWithDefender" => StaticMode::CanAttackWithDefender,
+            // CR 509.1b + CR 609.4 + CR 702.14c: bare form = all-landwalk canceller.
+            "IgnoreLandwalkForBlocking" => {
+                StaticMode::IgnoreLandwalkForBlocking { qualifier: None }
+            }
             "CanActivateAbilitiesAsThoughHaste" => StaticMode::CanActivateAbilitiesAsThoughHaste,
             s if s.starts_with("StepEndUnspentMana(") => StaticMode::Other(s.to_string()),
             "UntapsDuringEachOtherPlayersUntapStep" => {
@@ -1436,6 +1466,15 @@ impl FromStr for StaticMode {
                 {
                     let keyword = Keyword::from_str(inner).unwrap();
                     StaticMode::CastWithKeyword { keyword }
+                } else if let Some(inner) = other
+                    .strip_prefix("IgnoreLandwalkForBlocking(")
+                    .and_then(|s| s.strip_suffix(')'))
+                {
+                    // CR 509.1b + CR 609.4 + CR 702.14c: parameterized form carries
+                    // the canonical capitalized land subtype (e.g. "Swamp").
+                    StaticMode::IgnoreLandwalkForBlocking {
+                        qualifier: Some(inner.to_string()),
+                    }
                 } else if let Some(inner) = other
                     .strip_prefix("SkipStep(")
                     .and_then(|s| s.strip_suffix(')'))
@@ -1764,6 +1803,35 @@ mod tests {
                 exemption: ActivationExemption::None,
             }
         );
+    }
+
+    #[test]
+    fn ignore_landwalk_for_blocking_display_fromstr_roundtrip() {
+        // CR 509.1b + CR 609.4 + CR 702.14c: round-trip the `None` (all-landwalk)
+        // form and each of the five basic-land qualifier forms.
+        let cases = [
+            StaticMode::IgnoreLandwalkForBlocking { qualifier: None },
+            StaticMode::IgnoreLandwalkForBlocking {
+                qualifier: Some("Plains".to_string()),
+            },
+            StaticMode::IgnoreLandwalkForBlocking {
+                qualifier: Some("Island".to_string()),
+            },
+            StaticMode::IgnoreLandwalkForBlocking {
+                qualifier: Some("Swamp".to_string()),
+            },
+            StaticMode::IgnoreLandwalkForBlocking {
+                qualifier: Some("Mountain".to_string()),
+            },
+            StaticMode::IgnoreLandwalkForBlocking {
+                qualifier: Some("Forest".to_string()),
+            },
+        ];
+        for case in cases {
+            let s = case.to_string();
+            let parsed = StaticMode::from_str(&s).unwrap();
+            assert_eq!(parsed, case, "round-trip failed for {s}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds engine support for **Ur-Drago**.

## Files changed
- crates/engine/src/types/statics.rs
- crates/engine/src/parser/oracle_static.rs
- crates/engine/src/game/combat.rs
- crates/engine/src/game/static_abilities.rs
- crates/engine/src/game/coverage.rs

## CR references
- CR 509.1b — declare-blockers restrictions
- CR 609.4 — "as though" effects are scoped to the stated effect (authorizing rule for rejecting RemoveKeyword)
- CR 702.14a — landwalk qualifier syntax
- CR 702.14c — landwalk grants conditional unblockability
- CR 702.14d — landwalk qualifiers don't cancel one another

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p engine` — 8626 pass / 0 fail (one unrelated pre-existing failure in `anaphoric_scope_allowlist_guard` outside this branch's scope)
- `oracle-gen --filter "ur-drago"` — emits `"mode":{"IgnoreLandwalkForBlocking":{"qualifier":"Swamp"}}`, zero Unimplemented entries
- `./scripts/gen-card-data.sh` — couldn't run locally (host bash 3.2 lacks `mapfile`); CI will regenerate `client/public/card-data.json`
- `cargo coverage` / `cargo semantic-audit` — deferred to CI for the same reason

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

Tier: Frontier