### PR TITLE
Support Squad additional costs

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -928,8 +928,7 @@ export type CombatTaxPending =
 // ── Additional Costs (kicker, blight, "or pay") ─────────────────────────
 
 export type AdditionalCost =
-  | { type: "Optional"; data: SerializedAbilityCost }
-  | { type: "Repeatable"; data: SerializedAbilityCost }
+  | { type: "Optional"; data: { cost: SerializedAbilityCost; repeatable?: boolean } }
   | { type: "Kicker"; data: { costs: SerializedAbilityCost[]; repeatable?: boolean } }
   | { type: "Required"; data: SerializedAbilityCost }
   | { type: "Choice"; data: [SerializedAbilityCost, SerializedAbilityCost] };

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -929,6 +929,7 @@ export type CombatTaxPending =
 
 export type AdditionalCost =
   | { type: "Optional"; data: SerializedAbilityCost }
+  | { type: "Repeatable"; data: SerializedAbilityCost }
   | { type: "Kicker"; data: { costs: SerializedAbilityCost[]; repeatable?: boolean } }
   | { type: "Required"; data: SerializedAbilityCost }
   | { type: "Choice"; data: [SerializedAbilityCost, SerializedAbilityCost] };

--- a/client/src/viewmodel/__tests__/costLabel.test.ts
+++ b/client/src/viewmodel/__tests__/costLabel.test.ts
@@ -245,6 +245,30 @@ describe("additionalCostChoices — multikicker (issue #454)", () => {
   });
 });
 
+describe("additionalCostChoices — repeatable additional cost", () => {
+  const repeatableCost: AdditionalCost = {
+    type: "Repeatable",
+    data: { type: "Mana", cost: { type: "Cost", shards: [], generic: 1 } },
+  };
+
+  it("first prompt offers a non-cancel decline", () => {
+    const { title, options } = additionalCostChoices(repeatableCost, 0);
+
+    expect(title).toContain("Pay additional cost");
+    expect(options.find((o) => o.id === "pay")?.label).toBe("Pay {1}");
+    expect(options.find((o) => o.id === "decline")?.label).toBe("Cast without paying");
+  });
+
+  it("re-prompt shows the payment count and finish-casting decline", () => {
+    const { title, options } = additionalCostChoices(repeatableCost, 2);
+
+    expect(title).toContain("paid 2");
+    const decline = options.find((o) => o.id === "decline")!;
+    expect(decline.label).toContain("finish casting");
+    expect(decline.label).toContain("(paid 2×)");
+  });
+});
+
 describe("formatAbilityCost", () => {
   it("formats disjunctive activation cost branches", () => {
     expect(formatAbilityCost({

--- a/client/src/viewmodel/__tests__/costLabel.test.ts
+++ b/client/src/viewmodel/__tests__/costLabel.test.ts
@@ -247,8 +247,11 @@ describe("additionalCostChoices — multikicker (issue #454)", () => {
 
 describe("additionalCostChoices — repeatable additional cost", () => {
   const repeatableCost: AdditionalCost = {
-    type: "Repeatable",
-    data: { type: "Mana", cost: { type: "Cost", shards: [], generic: 1 } },
+    type: "Optional",
+    data: {
+      cost: { type: "Mana", cost: { type: "Cost", shards: [], generic: 1 } },
+      repeatable: true,
+    },
   };
 
   it("first prompt offers a non-cancel decline", () => {

--- a/client/src/viewmodel/costLabel.ts
+++ b/client/src/viewmodel/costLabel.ts
@@ -397,6 +397,37 @@ export function additionalCostChoices(
           { id: "decline", label: "Skip" },
         ],
       };
+    case "Repeatable": {
+      const label = formatAbilityCost(cost.data);
+      if (timesKicked > 0) {
+        return {
+          title: `Additional cost — paid ${timesKicked}×. Pay ${label} again?`,
+          options: [
+            { id: "pay", label: `Pay ${label} again` },
+            {
+              id: "decline",
+              label: `Done — finish casting (paid ${timesKicked}×)`,
+              description: "Stop paying this additional cost and pay the total cost.",
+            },
+          ],
+        };
+      }
+      return {
+        title: `Pay additional cost: ${label}?`,
+        options: [
+          {
+            id: "pay",
+            label: `Pay ${label}`,
+            description: "You'll be asked again so you can pay it multiple times.",
+          },
+          {
+            id: "decline",
+            label: "Cast without paying",
+            description: "Finish casting now with 0 payments.",
+          },
+        ],
+      };
+    }
     case "Kicker": {
       const first = cost.data.costs[0];
       const label = first ? formatAbilityCost(first) : "kicker";

--- a/client/src/viewmodel/costLabel.ts
+++ b/client/src/viewmodel/costLabel.ts
@@ -377,10 +377,9 @@ export interface AdditionalCostOption {
 /**
  * Build the title + pay/decline options for the OptionalCostChoice modal.
  *
- * `timesKicked` is the engine-provided count of kicks already paid for this
- * spell (`WaitingFor::OptionalCostChoice::times_kicked`). It only affects the
- * `Kicker` branch: at `0` this is the first prompt; at `> 0` it is a
- * repeatable multikicker re-prompt and the copy reflects the running count.
+ * `timesKicked` is the engine-provided count of repeatable payments already
+ * paid for this spell (`WaitingFor::OptionalCostChoice::times_kicked`). It
+ * affects multikicker and repeatable optional additional-cost prompts.
  * The decline copy never says "skip"/"cancel" — declining the kicker
  * *completes* the cast (CR 601.2h), it does not abort it.
  */
@@ -389,25 +388,34 @@ export function additionalCostChoices(
   timesKicked = 0,
 ): { title: string; options: AdditionalCostOption[] } {
   switch (cost.type) {
-    case "Optional":
-      return {
-        title: `Pay additional cost: ${formatAbilityCost(cost.data)}?`,
-        options: [
-          { id: "pay", label: `Pay ${formatAbilityCost(cost.data)}` },
-          { id: "decline", label: "Skip" },
-        ],
-      };
-    case "Repeatable": {
-      const label = formatAbilityCost(cost.data);
-      if (timesKicked > 0) {
+    case "Optional": {
+      const label = formatAbilityCost(cost.data.cost);
+      if (cost.data.repeatable) {
+        if (timesKicked > 0) {
+          return {
+            title: `Additional cost — paid ${timesKicked}×. Pay ${label} again?`,
+            options: [
+              { id: "pay", label: `Pay ${label} again` },
+              {
+                id: "decline",
+                label: `Done — finish casting (paid ${timesKicked}×)`,
+                description: "Stop paying this additional cost and pay the total cost.",
+              },
+            ],
+          };
+        }
         return {
-          title: `Additional cost — paid ${timesKicked}×. Pay ${label} again?`,
+          title: `Pay additional cost: ${label}?`,
           options: [
-            { id: "pay", label: `Pay ${label} again` },
+            {
+              id: "pay",
+              label: `Pay ${label}`,
+              description: "You'll be asked again so you can pay it multiple times.",
+            },
             {
               id: "decline",
-              label: `Done — finish casting (paid ${timesKicked}×)`,
-              description: "Stop paying this additional cost and pay the total cost.",
+              label: "Cast without paying",
+              description: "Finish casting now with 0 payments.",
             },
           ],
         };
@@ -415,16 +423,8 @@ export function additionalCostChoices(
       return {
         title: `Pay additional cost: ${label}?`,
         options: [
-          {
-            id: "pay",
-            label: `Pay ${label}`,
-            description: "You'll be asked again so you can pay it multiple times.",
-          },
-          {
-            id: "decline",
-            label: "Cast without paying",
-            description: "Finish casting now with 0 payments.",
-          },
+          { id: "pay", label: `Pay ${label}` },
+          { id: "decline", label: "Skip" },
         ],
       };
     }

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -5,14 +5,14 @@ use crate::game::printed_cards::derive_colors_from_mana_cost;
 use crate::parser::oracle::{oracle_text_allows_commander, parse_oracle_text};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AdditionalCost,
-    AggregateFunction, CardPlayMode, CastVariantPaid, ChoiceType, Comparator,
-    ContinuousModification, ControllerRef, CopyRetargetPermission, CounterTriggerFilter, Duration,
-    Effect, FilterProp, GainLifePlayer, KickerVariant, ManaContribution, ManaProduction,
-    ModalSelectionCondition, ModalSelectionConstraint, NinjutsuVariant, ObjectScope, PlayerFilter,
-    PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
-    ReplacementDefinition, RuntimeHandler, SearchSelectionConstraint, StaticDefinition,
-    TargetChoiceTiming, TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
-    UnlessPayModifier,
+    AdditionalCostPaymentSource, AggregateFunction, CardPlayMode, CastVariantPaid, ChoiceType,
+    Comparator, ContinuousModification, ControllerRef, CopyRetargetPermission,
+    CounterTriggerFilter, Duration, Effect, FilterProp, GainLifePlayer, KickerVariant,
+    ManaContribution, ManaProduction, ModalSelectionCondition, ModalSelectionConstraint,
+    NinjutsuVariant, ObjectScope, PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope,
+    QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition, RuntimeHandler,
+    SearchSelectionConstraint, StaticDefinition, TargetChoiceTiming, TargetFilter,
+    TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
 };
 use crate::types::card::{CardFace, CardLayout};
 use crate::types::card_type::{CardType, CoreType, Supertype};
@@ -825,7 +825,10 @@ pub fn synthesize_buyback(face: &mut CardFace) {
         BuybackCost::Mana(mana_cost) => AbilityCost::Mana { cost: mana_cost },
         BuybackCost::NonMana(ac) => ac,
     };
-    face.additional_cost = Some(AdditionalCost::Optional(cost));
+    face.additional_cost = Some(AdditionalCost::Optional {
+        cost,
+        repeatable: false,
+    });
 }
 
 /// CR 702.166a: Synthesize `additional_cost` from `Keyword::Bargain`.
@@ -836,16 +839,21 @@ pub fn synthesize_bargain(face: &mut CardFace) {
         return;
     }
 
-    face.additional_cost = Some(AdditionalCost::Optional(AbilityCost::Sacrifice {
-        target: TargetFilter::Or {
-            filters: vec![
-                TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
-                TargetFilter::Typed(TypedFilter::new(TypeFilter::Enchantment)),
-                TargetFilter::Typed(TypedFilter::permanent().properties(vec![FilterProp::Token])),
-            ],
+    face.additional_cost = Some(AdditionalCost::Optional {
+        cost: AbilityCost::Sacrifice {
+            target: TargetFilter::Or {
+                filters: vec![
+                    TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
+                    TargetFilter::Typed(TypedFilter::new(TypeFilter::Enchantment)),
+                    TargetFilter::Typed(
+                        TypedFilter::permanent().properties(vec![FilterProp::Token]),
+                    ),
+                ],
+            },
+            count: 1,
         },
-        count: 1,
-    }));
+        repeatable: false,
+    });
 }
 
 /// Synthesize Gift optional cost and delivery effect.
@@ -873,9 +881,12 @@ pub fn synthesize_gift(face: &mut CardFace) {
     };
 
     // Gift uses a zero-cost optional additional cost — the "cost" is just a decision.
-    face.additional_cost = Some(AdditionalCost::Optional(AbilityCost::Mana {
-        cost: ManaCost::zero(),
-    }));
+    face.additional_cost = Some(AdditionalCost::Optional {
+        cost: AbilityCost::Mana {
+            cost: ManaCost::zero(),
+        },
+        repeatable: false,
+    });
 
     // Inject GiftDelivery as a wrapper around the first spell ability.
     // The delivery effect is a no-op when the gift wasn't promised, so the
@@ -1300,10 +1311,13 @@ pub fn synthesize_casualty(face: &mut CardFace) {
                 },
             },
         ]));
-        face.additional_cost = Some(AdditionalCost::Optional(AbilityCost::Sacrifice {
-            target: sacrifice_filter,
-            count: 1,
-        }));
+        face.additional_cost = Some(AdditionalCost::Optional {
+            cost: AbilityCost::Sacrifice {
+                target: sacrifice_filter,
+                count: 1,
+            },
+            repeatable: false,
+        });
     }
 
     // CR 702.153a: "When you cast this spell, if a casualty cost was paid, copy it.
@@ -1514,9 +1528,104 @@ pub fn synthesize_cumulative_upkeep(face: &mut CardFace) {
     });
 }
 
+/// Insert a synthesis-level unsupported sentinel once.
+///
+/// Coverage already treats `Effect::Unimplemented` on any ability as an
+/// unsupported card-data gap. `AbilityKind::Spell` is used deliberately here
+/// because `AbilityDefinition` has no non-runtime sentinel kind; cards with
+/// this marker stay unsupported rather than entering legal play paths.
+fn defer_synthesis(face: &mut CardFace, name: &str, description: String) {
+    let already_deferred = face.abilities.iter().any(|ability| {
+        matches!(
+            &*ability.effect,
+            Effect::Unimplemented {
+                name: existing, ..
+            } if existing == name
+        )
+    });
+    if already_deferred {
+        return;
+    }
+
+    face.abilities.push(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Unimplemented {
+            name: name.to_string(),
+            description: Some(description),
+        },
+    ));
+}
+
+fn install_etb_copy_on_additional_cost(
+    face: &mut CardFace,
+    additional_cost: AdditionalCost,
+    payment_source: AdditionalCostPaymentSource,
+    min_count: u32,
+    count: QuantityExpr,
+    additional_modifications: Vec<ContinuousModification>,
+    description: String,
+) {
+    if face.additional_cost.is_none() {
+        face.additional_cost = Some(additional_cost);
+    }
+
+    let already_has_trigger = face.triggers.iter().any(|t| {
+        matches!(t.mode, TriggerMode::ChangesZone)
+            && t.destination == Some(Zone::Battlefield)
+            && matches!(t.valid_card, Some(TargetFilter::SelfRef))
+            && matches!(
+                t.condition,
+                Some(TriggerCondition::AdditionalCostPaid {
+                    source,
+                    min_count: existing_min_count,
+                    ..
+                }) if source == payment_source && existing_min_count == min_count
+            )
+            && t.execute.as_deref().is_some_and(|a| match &*a.effect {
+                Effect::CopyTokenOf {
+                    count: existing_count,
+                    additional_modifications: existing_modifications,
+                    ..
+                } => {
+                    existing_count == &count && existing_modifications == &additional_modifications
+                }
+                _ => false,
+            })
+    });
+    if already_has_trigger {
+        return;
+    }
+
+    let copy_effect = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::CopyTokenOf {
+            target: TargetFilter::SelfRef,
+            owner: TargetFilter::Controller,
+            source_filter: None,
+            enters_attacking: false,
+            tapped: false,
+            count,
+            extra_keywords: vec![],
+            additional_modifications,
+        },
+    );
+    let trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
+        .destination(Zone::Battlefield)
+        .valid_card(TargetFilter::SelfRef)
+        .condition(TriggerCondition::AdditionalCostPaid {
+            source: payment_source,
+            variant: None,
+            kicker_cost: None,
+            min_count,
+        })
+        .execute(copy_effect)
+        .description(description);
+    face.triggers.push(trigger);
+}
+
 /// CR 702.175a: Offspring represents two abilities:
 ///   1. "You may pay an additional [cost] as you cast this spell" — modeled as
-///      `AdditionalCost::Optional(AbilityCost::Mana { cost })`.
+///      `AdditionalCost::Optional { repeatable: false, .. }`.
 ///   2. "When this permanent enters, if its offspring cost was paid, create a
 ///      token that's a copy of it, except it's 1/1." — modeled as an ETB trigger
 ///      with `TriggerCondition::AdditionalCostPaid` and `Effect::CopyTokenOf`
@@ -1532,65 +1641,24 @@ pub fn synthesize_offspring(face: &mut CardFace) {
         return;
     };
 
-    // CR 702.175a ability 1: Optional additional cost.
-    // Only set if no additional_cost was already parsed (e.g., a card with both
-    // kicker and offspring would need the kicker cost to take precedence since
-    // AdditionalCost is a single slot — but no such card exists in print).
-    if face.additional_cost.is_none() {
-        face.additional_cost = Some(AdditionalCost::Optional(AbilityCost::Mana {
-            cost: offspring_cost,
-        }));
-    }
-
-    // CR 702.175a ability 2: ETB trigger creating a 1/1 copy token.
-    // Idempotency: skip if an AdditionalCostPaid + CopyTokenOf ETB trigger already exists.
-    let already_has_trigger = face.triggers.iter().any(|t| {
-        matches!(t.mode, TriggerMode::ChangesZone)
-            && t.destination == Some(Zone::Battlefield)
-            && matches!(t.valid_card, Some(TargetFilter::SelfRef))
-            && matches!(
-                t.condition,
-                Some(TriggerCondition::AdditionalCostPaid { .. })
-            )
-            && matches!(
-                t.execute.as_deref().map(|a| &*a.effect),
-                Some(Effect::CopyTokenOf { .. })
-            )
-    });
-    if already_has_trigger {
-        return;
-    }
-
-    let copy_effect = AbilityDefinition::new(
-        AbilityKind::Spell,
-        Effect::CopyTokenOf {
-            target: TargetFilter::SelfRef,
-            owner: TargetFilter::Controller,
-            source_filter: None,
-            enters_attacking: false,
-            tapped: false,
-            count: QuantityExpr::Fixed { value: 1 },
-            extra_keywords: vec![],
-            additional_modifications: vec![
-                ContinuousModification::SetPower { value: 1 },
-                ContinuousModification::SetToughness { value: 1 },
-            ],
+    install_etb_copy_on_additional_cost(
+        face,
+        AdditionalCost::Optional {
+            cost: AbilityCost::Mana {
+                cost: offspring_cost,
+            },
+            repeatable: false,
         },
+        AdditionalCostPaymentSource::Any,
+        1,
+        QuantityExpr::Fixed { value: 1 },
+        vec![
+            ContinuousModification::SetPower { value: 1 },
+            ContinuousModification::SetToughness { value: 1 },
+        ],
+        "CR 702.175a: When this permanent enters, if its offspring cost was paid, create a token that's a copy of it, except it's 1/1."
+            .to_string(),
     );
-    let trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
-        .destination(Zone::Battlefield)
-        .valid_card(TargetFilter::SelfRef)
-        .condition(TriggerCondition::AdditionalCostPaid {
-            variant: None,
-            kicker_cost: None,
-            min_count: 1,
-        })
-        .execute(copy_effect)
-        .description(
-            "CR 702.175a: When this permanent enters, if its offspring cost was paid, create a token that's a copy of it, except it's 1/1."
-                .to_string(),
-        );
-    face.triggers.push(trigger);
 }
 
 /// CR 702.157a: Squad represents a repeatable optional additional cost and an
@@ -1613,86 +1681,34 @@ pub fn synthesize_squad(face: &mut CardFace) {
     // them into one repeatable cost; leave coverage unsupported until the
     // linked-instance model exists.
     if squad_costs.len() > 1 {
-        let already_deferred = face.abilities.iter().any(|ability| {
-            matches!(
-                &*ability.effect,
-                Effect::Unimplemented { name, .. } if name == "squad_multiple_instances"
-            )
-        });
-        if !already_deferred {
-            face.abilities.push(AbilityDefinition::new(
-                AbilityKind::Spell,
-                Effect::Unimplemented {
-                    name: "squad_multiple_instances".to_string(),
-                    description: Some(
-                        "CR 702.157b: multiple Squad instances require per-instance payment tracking"
-                            .to_string(),
-                    ),
-                },
-            ));
-        }
+        defer_synthesis(
+            face,
+            "squad_multiple_instances",
+            "CR 702.157b: multiple Squad instances require per-instance payment tracking"
+                .to_string(),
+        );
         return;
     }
 
     let squad_cost = squad_costs[0].clone();
 
-    if face.additional_cost.is_none() {
-        face.additional_cost = Some(AdditionalCost::Repeatable(AbilityCost::Mana {
-            cost: squad_cost,
-        }));
-    }
-
-    let already_has_trigger = face.triggers.iter().any(|t| {
-        matches!(t.mode, TriggerMode::ChangesZone)
-            && t.destination == Some(Zone::Battlefield)
-            && matches!(t.valid_card, Some(TargetFilter::SelfRef))
-            && matches!(
-                t.condition,
-                Some(TriggerCondition::AdditionalCostPaid { .. })
-            )
-            && matches!(
-                t.execute.as_deref().map(|a| &*a.effect),
-                Some(Effect::CopyTokenOf {
-                    count: QuantityExpr::Ref {
-                        qty: QuantityRef::AdditionalCostPaymentCount,
-                    },
-                    ..
-                })
-            )
-    });
-    if already_has_trigger {
-        return;
-    }
-
-    let copy_effect = AbilityDefinition::new(
-        AbilityKind::Spell,
-        Effect::CopyTokenOf {
-            target: TargetFilter::SelfRef,
-            owner: TargetFilter::Controller,
-            source_filter: None,
-            enters_attacking: false,
-            tapped: false,
-            count: QuantityExpr::Ref {
-                qty: QuantityRef::AdditionalCostPaymentCount,
+    install_etb_copy_on_additional_cost(
+        face,
+        AdditionalCost::Optional {
+            cost: AbilityCost::Mana {
+                cost: squad_cost,
             },
-            extra_keywords: vec![],
-            additional_modifications: vec![],
+            repeatable: true,
         },
+        AdditionalCostPaymentSource::NonKicker,
+        0,
+        QuantityExpr::Ref {
+            qty: QuantityRef::AdditionalCostPaymentCount,
+        },
+        vec![],
+        "CR 702.157a: When this permanent enters, create a token that's a copy of it for each time its squad cost was paid."
+            .to_string(),
     );
-    let trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
-        .destination(Zone::Battlefield)
-        .valid_card(TargetFilter::SelfRef)
-        .condition(TriggerCondition::AdditionalCostPaid {
-            variant: None,
-            kicker_cost: None,
-            min_count: 1,
-        })
-        .execute(copy_effect)
-        .description(
-            "CR 702.157a: When this permanent enters, if its squad cost was paid, create a token that's a copy of it for each time its squad cost was paid."
-                .to_string(),
-        );
-    face.triggers.push(trigger);
 }
 
 /// CR 702.123a: Fabricate N — "When this permanent enters, you may put N
@@ -4148,6 +4164,7 @@ mod kicker_synthesis_tests {
                 modal: Some(crate::types::ability::ModalChoice {
                     constraints: vec![ModalSelectionConstraint::ConditionalMaxChoices {
                         condition: ModalSelectionCondition::AdditionalCostPaid {
+                            source: AdditionalCostPaymentSource::Kicker,
                             variant: None,
                             kicker_cost: Some(ManaCost::Cost {
                                 generic: 1,
@@ -4184,6 +4201,7 @@ mod kicker_synthesis_tests {
         assert!(matches!(
             condition,
             ModalSelectionCondition::AdditionalCostPaid {
+                source: AdditionalCostPaymentSource::Kicker,
                 variant: Some(KickerVariant::Second),
                 kicker_cost: None,
                 min_count: 1
@@ -4210,7 +4228,10 @@ mod buyback_synthesis_tests {
         synthesize_buyback(&mut face);
 
         match face.additional_cost.expect("additional_cost set") {
-            AdditionalCost::Optional(AbilityCost::Mana { cost }) => {
+            AdditionalCost::Optional {
+                cost: AbilityCost::Mana { cost },
+                repeatable: false,
+            } => {
                 assert!(matches!(
                     cost,
                     ManaCost::Cost {
@@ -4239,7 +4260,10 @@ mod buyback_synthesis_tests {
         synthesize_buyback(&mut face);
 
         match face.additional_cost.expect("additional_cost set") {
-            AdditionalCost::Optional(cost) => assert_eq!(cost, sac_cost),
+            AdditionalCost::Optional {
+                cost,
+                repeatable: false,
+            } => assert_eq!(cost, sac_cost),
             other => panic!("expected Optional(Sacrifice), got {other:?}"),
         }
     }
@@ -4307,7 +4331,10 @@ mod bargain_synthesis_tests {
         synthesize_bargain(&mut face);
 
         match face.additional_cost.expect("additional_cost set") {
-            AdditionalCost::Optional(AbilityCost::Sacrifice { target, count }) => {
+            AdditionalCost::Optional {
+                cost: AbilityCost::Sacrifice { target, count },
+                repeatable: false,
+            } => {
                 assert_eq!(count, 1);
                 let TargetFilter::Or { filters } = target else {
                     panic!("expected artifact/enchantment/token disjunction, got {target:?}");
@@ -8670,7 +8697,10 @@ mod offspring_synthesis_tests {
 
         // Part 1: additional_cost is Optional(Mana { offspring_cost })
         match face.additional_cost.as_ref().expect("additional_cost set") {
-            AdditionalCost::Optional(AbilityCost::Mana { cost }) => {
+            AdditionalCost::Optional {
+                cost: AbilityCost::Mana { cost },
+                repeatable: false,
+            } => {
                 assert_eq!(*cost, offspring_cost);
             }
             other => panic!("expected Optional(Mana), got {other:?}"),
@@ -8781,7 +8811,10 @@ mod squad_synthesis_tests {
         synthesize_squad(&mut face);
 
         match face.additional_cost.as_ref().expect("additional_cost set") {
-            AdditionalCost::Repeatable(AbilityCost::Mana { cost }) => {
+            AdditionalCost::Optional {
+                cost: AbilityCost::Mana { cost },
+                repeatable: true,
+            } => {
                 assert_eq!(cost, &squad_cost);
             }
             other => panic!("expected repeatable additional cost, got {other:?}"),

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -1593,6 +1593,108 @@ pub fn synthesize_offspring(face: &mut CardFace) {
     face.triggers.push(trigger);
 }
 
+/// CR 702.157a: Squad represents a repeatable optional additional cost and an
+/// ETB trigger that creates one copy token for each time the squad cost was paid.
+pub fn synthesize_squad(face: &mut CardFace) {
+    let squad_costs: Vec<_> = face
+        .keywords
+        .iter()
+        .filter_map(|k| match k {
+            Keyword::Squad(cost) => Some(cost.clone()),
+            _ => None,
+        })
+        .collect();
+    if squad_costs.is_empty() {
+        return;
+    }
+
+    // CR 702.157b: Multiple Squad instances are paid independently and each
+    // instance's linked trigger counts only its own payments. Do not collapse
+    // them into one repeatable cost; leave coverage unsupported until the
+    // linked-instance model exists.
+    if squad_costs.len() > 1 {
+        let already_deferred = face.abilities.iter().any(|ability| {
+            matches!(
+                &*ability.effect,
+                Effect::Unimplemented { name, .. } if name == "squad_multiple_instances"
+            )
+        });
+        if !already_deferred {
+            face.abilities.push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Unimplemented {
+                    name: "squad_multiple_instances".to_string(),
+                    description: Some(
+                        "CR 702.157b: multiple Squad instances require per-instance payment tracking"
+                            .to_string(),
+                    ),
+                },
+            ));
+        }
+        return;
+    }
+
+    let squad_cost = squad_costs[0].clone();
+
+    if face.additional_cost.is_none() {
+        face.additional_cost = Some(AdditionalCost::Repeatable(AbilityCost::Mana {
+            cost: squad_cost,
+        }));
+    }
+
+    let already_has_trigger = face.triggers.iter().any(|t| {
+        matches!(t.mode, TriggerMode::ChangesZone)
+            && t.destination == Some(Zone::Battlefield)
+            && matches!(t.valid_card, Some(TargetFilter::SelfRef))
+            && matches!(
+                t.condition,
+                Some(TriggerCondition::AdditionalCostPaid { .. })
+            )
+            && matches!(
+                t.execute.as_deref().map(|a| &*a.effect),
+                Some(Effect::CopyTokenOf {
+                    count: QuantityExpr::Ref {
+                        qty: QuantityRef::AdditionalCostPaymentCount,
+                    },
+                    ..
+                })
+            )
+    });
+    if already_has_trigger {
+        return;
+    }
+
+    let copy_effect = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::CopyTokenOf {
+            target: TargetFilter::SelfRef,
+            owner: TargetFilter::Controller,
+            source_filter: None,
+            enters_attacking: false,
+            tapped: false,
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::AdditionalCostPaymentCount,
+            },
+            extra_keywords: vec![],
+            additional_modifications: vec![],
+        },
+    );
+    let trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
+        .destination(Zone::Battlefield)
+        .valid_card(TargetFilter::SelfRef)
+        .condition(TriggerCondition::AdditionalCostPaid {
+            variant: None,
+            kicker_cost: None,
+            min_count: 1,
+        })
+        .execute(copy_effect)
+        .description(
+            "CR 702.157a: When this permanent enters, if its squad cost was paid, create a token that's a copy of it for each time its squad cost was paid."
+                .to_string(),
+        );
+    face.triggers.push(trigger);
+}
+
 /// CR 702.123a: Fabricate N — "When this permanent enters, you may put N
 /// +1/+1 counters on it. If you don't, create N 1/1 colorless Servo artifact
 /// creature tokens."
@@ -3450,6 +3552,8 @@ pub fn synthesize_all(face: &mut CardFace) {
     synthesize_cumulative_upkeep(face);
     // CR 702.175a: Offspring — optional additional cost + ETB 1/1 copy trigger.
     synthesize_offspring(face);
+    // CR 702.157a: Squad — repeatable optional additional cost + ETB copy trigger.
+    synthesize_squad(face);
     // CR 702.123a: Fabricate N — ETB trigger with controller-chosen branch
     // between N +1/+1 counters or N 1/1 colorless Servo artifact creature
     // tokens. Modeled via `Effect::ChooseOneOf`.
@@ -8653,6 +8757,116 @@ mod offspring_synthesis_tests {
         assert_eq!(face.additional_cost, Some(existing));
         // Trigger is still synthesized
         assert_eq!(face.triggers.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod squad_synthesis_tests {
+    use super::*;
+    use crate::types::mana::ManaCostShard;
+
+    /// CR 702.157a: Squad synthesizes a repeatable optional additional cost and
+    /// an ETB trigger whose copy count is the number of squad payments.
+    #[test]
+    fn synthesize_squad_sets_repeatable_cost_and_payment_count_copy_trigger() {
+        let squad_cost = ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        };
+        let mut face = CardFace {
+            keywords: vec![Keyword::Squad(squad_cost.clone())],
+            ..CardFace::default()
+        };
+
+        synthesize_squad(&mut face);
+
+        match face.additional_cost.as_ref().expect("additional_cost set") {
+            AdditionalCost::Repeatable(AbilityCost::Mana { cost }) => {
+                assert_eq!(cost, &squad_cost);
+            }
+            other => panic!("expected repeatable additional cost, got {other:?}"),
+        }
+
+        let trigger = face
+            .triggers
+            .iter()
+            .find(|t| {
+                matches!(t.mode, TriggerMode::ChangesZone)
+                    && t.destination == Some(Zone::Battlefield)
+                    && matches!(
+                        t.condition,
+                        Some(TriggerCondition::AdditionalCostPaid { .. })
+                    )
+            })
+            .expect("squad ETB trigger");
+        let effect = &trigger.execute.as_ref().expect("execute body").effect;
+        match &**effect {
+            Effect::CopyTokenOf { target, count, .. } => {
+                assert!(matches!(target, TargetFilter::SelfRef));
+                assert!(matches!(
+                    count,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::AdditionalCostPaymentCount
+                    }
+                ));
+            }
+            other => panic!("expected CopyTokenOf, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn synthesize_squad_is_idempotent() {
+        let mut face = CardFace {
+            keywords: vec![Keyword::Squad(ManaCost::Cost {
+                generic: 2,
+                shards: vec![],
+            })],
+            ..CardFace::default()
+        };
+
+        synthesize_squad(&mut face);
+        let first_cost = face.additional_cost.clone();
+        let first_trigger_count = face.triggers.len();
+        synthesize_squad(&mut face);
+
+        assert_eq!(face.additional_cost, first_cost);
+        assert_eq!(face.triggers.len(), first_trigger_count);
+    }
+
+    #[test]
+    fn synthesize_squad_defers_multiple_instances() {
+        let mut face = CardFace {
+            keywords: vec![
+                Keyword::Squad(ManaCost::Cost {
+                    generic: 1,
+                    shards: vec![],
+                }),
+                Keyword::Squad(ManaCost::Cost {
+                    generic: 2,
+                    shards: vec![],
+                }),
+            ],
+            ..CardFace::default()
+        };
+
+        synthesize_squad(&mut face);
+        synthesize_squad(&mut face);
+
+        assert!(face.additional_cost.is_none());
+        assert!(face.triggers.is_empty());
+        assert_eq!(
+            face.abilities
+                .iter()
+                .filter(|ability| {
+                    matches!(
+                        &*ability.effect,
+                        Effect::Unimplemented { name, .. }
+                            if name == "squad_multiple_instances"
+                    )
+                })
+                .count(),
+            1
+        );
     }
 }
 

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -319,10 +319,16 @@ fn modal_selection_condition_matches(
             super::layers::evaluate_condition(state, condition, player, source_id)
         }
         ModalSelectionCondition::AdditionalCostPaid {
+            source,
             variant,
             kicker_cost,
             min_count,
-        } => context.additional_cost_paid_matches(*variant, kicker_cost.as_ref(), *min_count),
+        } => context.additional_cost_paid_matches(
+            *source,
+            *variant,
+            kicker_cost.as_ref(),
+            *min_count,
+        ),
     }
 }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -15869,6 +15869,7 @@ mod tests {
         obj.modal.as_mut().unwrap().constraints.push(
             ModalSelectionConstraint::ConditionalMaxChoices {
                 condition: ModalSelectionCondition::AdditionalCostPaid {
+                    source: crate::types::ability::AdditionalCostPaymentSource::Any,
                     variant: None,
                     kicker_cost: None,
                     min_count: 1,

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -111,27 +111,34 @@ pub(crate) fn handle_decide_additional_cost(
     pay: bool,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    if matches!(
-        pending.additional_cost_flow,
-        Some(AdditionalCost::Kicker { .. })
-    ) {
-        return handle_decide_kicker_cost(state, player, pending, pay, events);
-    }
-    if matches!(
-        pending.additional_cost_flow,
-        Some(AdditionalCost::Repeatable(_))
-    ) {
-        return handle_decide_repeatable_additional_cost(state, player, pending, pay, events);
-    }
-    if matches!(additional_cost, AdditionalCost::Kicker { .. }) {
-        let mut pending = pending;
-        pending.additional_cost_flow = Some(additional_cost.clone());
-        return handle_decide_kicker_cost(state, player, pending, pay, events);
-    }
-    if matches!(additional_cost, AdditionalCost::Repeatable(_)) {
-        let mut pending = pending;
-        pending.additional_cost_flow = Some(additional_cost.clone());
-        return handle_decide_repeatable_additional_cost(state, player, pending, pay, events);
+    match (pending.additional_cost_flow.as_ref(), additional_cost) {
+        (Some(AdditionalCost::Kicker { .. }), _) => {
+            return handle_decide_kicker_cost(state, player, pending, pay, events);
+        }
+        (
+            Some(AdditionalCost::Optional {
+                repeatable: true, ..
+            }),
+            _,
+        ) => {
+            return handle_decide_repeatable_additional_cost(state, player, pending, pay, events);
+        }
+        (None, AdditionalCost::Kicker { .. }) => {
+            let mut pending = pending;
+            pending.additional_cost_flow = Some(additional_cost.clone());
+            return handle_decide_kicker_cost(state, player, pending, pay, events);
+        }
+        (
+            None,
+            AdditionalCost::Optional {
+                repeatable: true, ..
+            },
+        ) => {
+            let mut pending = pending;
+            pending.additional_cost_flow = Some(additional_cost.clone());
+            return handle_decide_repeatable_additional_cost(state, player, pending, pay, events);
+        }
+        _ => {}
     }
 
     let mut ability = pending.ability;
@@ -144,7 +151,10 @@ pub(crate) fn handle_decide_additional_cost(
 
     let cost_to_pay = match additional_cost {
         // CR 702.33a: Kicker is an optional additional cost.
-        AdditionalCost::Optional(cost) => {
+        AdditionalCost::Optional {
+            cost,
+            repeatable: false,
+        } => {
             if pay {
                 ability.context.additional_cost_paid = true;
                 ability.context.additional_cost_payment_count = 1;
@@ -154,8 +164,10 @@ pub(crate) fn handle_decide_additional_cost(
                 None
             }
         }
-        AdditionalCost::Repeatable(_) => {
-            unreachable!("repeatable costs are handled before generic optional costs")
+        AdditionalCost::Optional {
+            repeatable: true, ..
+        } => {
+            unreachable!("repeatable optional costs are handled before generic optional costs")
         }
         AdditionalCost::Kicker { .. } => {
             unreachable!("kicker costs are handled before generic optional costs")
@@ -196,7 +208,10 @@ pub(crate) fn handle_decide_additional_cost(
     if updated_pending.deferred_target_selection
         && matches!(
             updated_pending.additional_cost_flow,
-            Some(AdditionalCost::Optional(_))
+            Some(AdditionalCost::Optional {
+                repeatable: false,
+                ..
+            })
         )
     {
         updated_pending.additional_cost_flow = None;
@@ -401,7 +416,11 @@ fn next_repeatable_additional_cost(
     player: PlayerId,
     pending: &PendingCast,
 ) -> Option<AbilityCost> {
-    let Some(AdditionalCost::Repeatable(cost)) = &pending.additional_cost_flow else {
+    let Some(AdditionalCost::Optional {
+        cost,
+        repeatable: true,
+    }) = &pending.additional_cost_flow
+    else {
         return None;
     };
 
@@ -438,13 +457,19 @@ fn finish_pending_cost_or_cast(
 
     if matches!(
         pending.additional_cost_flow,
-        Some(AdditionalCost::Repeatable(_))
+        Some(AdditionalCost::Optional {
+            repeatable: true,
+            ..
+        })
     ) {
         if let Some(current_cost) = next_repeatable_additional_cost(state, player, &pending) {
             let times_kicked = pending.ability.context.additional_cost_payment_count;
             return Ok(WaitingFor::OptionalCostChoice {
                 player,
-                cost: AdditionalCost::Repeatable(current_cost),
+                cost: AdditionalCost::Optional {
+                    cost: current_cost,
+                    repeatable: true,
+                },
                 times_kicked,
                 pending_cast: Box::new(pending),
             });
@@ -503,9 +528,16 @@ fn finish_pending_cost_or_cast(
     // targets. When deferred_target_selection is true, present the choice first.
     // After the choice resolves, additional_cost_flow is cleared by
     // handle_decide_additional_cost so the general deferred path below fires.
-    if let Some(AdditionalCost::Optional(ref cost)) = pending.additional_cost_flow {
+    if let Some(AdditionalCost::Optional {
+        cost: ref optional_cost,
+        repeatable: false,
+    }) = pending.additional_cost_flow
+    {
         if pending.deferred_target_selection {
-            let optional_cost = AdditionalCost::Optional(cost.clone());
+            let optional_cost = AdditionalCost::Optional {
+                cost: optional_cost.clone(),
+                repeatable: false,
+            };
             return Ok(WaitingFor::OptionalCostChoice {
                 player,
                 cost: optional_cost,
@@ -521,7 +553,13 @@ fn finish_pending_cost_or_cast(
     if pending.deferred_target_selection
         && !matches!(
             pending.additional_cost_flow,
-            Some(AdditionalCost::Kicker { .. } | AdditionalCost::Repeatable(_))
+            Some(
+                AdditionalCost::Kicker { .. }
+                    | AdditionalCost::Optional {
+                        repeatable: true,
+                        ..
+                    }
+            )
         )
     {
         return begin_deferred_target_selection(state, player, pending, events);
@@ -1673,18 +1711,26 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
                 }
                 return finish_pending_cost_or_cast(state, player, pending, events);
             }
-            AdditionalCost::Repeatable(repeatable_cost) => {
+            AdditionalCost::Optional {
+                cost: repeatable_cost,
+                repeatable: true,
+            } => {
                 let mut pending = PendingCast::new(object_id, card_id, ability, cost.clone());
                 pending.casting_variant = casting_variant;
                 pending.cast_timing_permission = cast_timing_permission;
                 pending.distribute = distribute.clone();
                 pending.origin_zone = origin_zone;
                 pending.payment_mode = payment_mode;
-                pending.additional_cost_flow =
-                    Some(AdditionalCost::Repeatable(repeatable_cost.clone()));
+                pending.additional_cost_flow = Some(AdditionalCost::Optional {
+                    cost: repeatable_cost.clone(),
+                    repeatable: true,
+                });
                 return finish_pending_cost_or_cast(state, player, pending, events);
             }
-            AdditionalCost::Optional(opt_cost) => {
+            AdditionalCost::Optional {
+                cost: opt_cost,
+                repeatable: false,
+            } => {
                 let mut pending = PendingCast::new(object_id, card_id, ability, cost.clone());
                 pending.casting_variant = casting_variant;
                 pending.cast_timing_permission = cast_timing_permission;
@@ -2454,19 +2500,22 @@ pub(super) fn effective_casualty_additional_cost(
             Keyword::Casualty(n) => Some(n),
             _ => None,
         })?;
-    Some(AdditionalCost::Optional(AbilityCost::Sacrifice {
-        target: TargetFilter::Typed(TypedFilter::creature().properties(vec![
-            crate::types::ability::FilterProp::PtComparison {
-                stat: crate::types::ability::PtStat::Power,
-                scope: crate::types::ability::PtValueScope::Current,
-                comparator: crate::types::ability::Comparator::GE,
-                value: QuantityExpr::Fixed {
-                    value: threshold as i32,
+    Some(AdditionalCost::Optional {
+        cost: AbilityCost::Sacrifice {
+            target: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                crate::types::ability::FilterProp::PtComparison {
+                    stat: crate::types::ability::PtStat::Power,
+                    scope: crate::types::ability::PtValueScope::Current,
+                    comparator: crate::types::ability::Comparator::GE,
+                    value: QuantityExpr::Fixed {
+                        value: threshold as i32,
+                    },
                 },
-            },
-        ])),
-        count: 1,
-    }))
+            ])),
+            count: 1,
+        },
+        repeatable: false,
+    })
 }
 
 pub(super) fn retrace_discard_land_cost() -> AbilityCost {
@@ -4985,7 +5034,10 @@ mod tests {
 
         match waiting {
             WaitingFor::OptionalCostChoice { cost, .. } => match cost {
-                AdditionalCost::Optional(AbilityCost::Sacrifice { target, count }) => {
+                AdditionalCost::Optional {
+                    cost: AbilityCost::Sacrifice { target, count },
+                    repeatable: false,
+                } => {
                     assert_eq!(count, 1);
                     match target {
                         TargetFilter::Typed(tf) => {
@@ -8602,7 +8654,10 @@ many tokens that are copies of it.)";
             } => {
                 assert!(matches!(
                     cost,
-                    AdditionalCost::Repeatable(AbilityCost::Mana { .. })
+                    AdditionalCost::Optional {
+                        cost: AbilityCost::Mana { .. },
+                        repeatable: true,
+                    }
                 ));
                 assert_eq!(times_kicked, 0);
             }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -117,10 +117,21 @@ pub(crate) fn handle_decide_additional_cost(
     ) {
         return handle_decide_kicker_cost(state, player, pending, pay, events);
     }
+    if matches!(
+        pending.additional_cost_flow,
+        Some(AdditionalCost::Repeatable(_))
+    ) {
+        return handle_decide_repeatable_additional_cost(state, player, pending, pay, events);
+    }
     if matches!(additional_cost, AdditionalCost::Kicker { .. }) {
         let mut pending = pending;
         pending.additional_cost_flow = Some(additional_cost.clone());
         return handle_decide_kicker_cost(state, player, pending, pay, events);
+    }
+    if matches!(additional_cost, AdditionalCost::Repeatable(_)) {
+        let mut pending = pending;
+        pending.additional_cost_flow = Some(additional_cost.clone());
+        return handle_decide_repeatable_additional_cost(state, player, pending, pay, events);
     }
 
     let mut ability = pending.ability;
@@ -136,16 +147,15 @@ pub(crate) fn handle_decide_additional_cost(
         AdditionalCost::Optional(cost) => {
             if pay {
                 ability.context.additional_cost_paid = true;
+                ability.context.additional_cost_payment_count = 1;
                 optional_cost_paid = true;
-                // CR 702.175a: Offspring (and similar optional costs) synthesize
-                // ETB triggers conditioned on TriggerCondition::AdditionalCostPaid,
-                // which evaluates obj.kickers_paid.len(). Push First so the
-                // permanent carries evidence the trigger evaluator can read.
-                ability.context.kickers_paid.push(KickerVariant::First);
                 Some(cost.clone())
             } else {
                 None
             }
+        }
+        AdditionalCost::Repeatable(_) => {
+            unreachable!("repeatable costs are handled before generic optional costs")
         }
         AdditionalCost::Kicker { .. } => {
             unreachable!("kicker costs are handled before generic optional costs")
@@ -159,6 +169,7 @@ pub(crate) fn handle_decide_additional_cost(
                     .is_some_and(|cost| matches!(cost, AdditionalCost::Choice(_, _)))
                 {
                     ability.context.additional_cost_paid = true;
+                    ability.context.additional_cost_payment_count = 1;
                 }
                 Some(preferred.clone())
             } else {
@@ -169,6 +180,7 @@ pub(crate) fn handle_decide_additional_cost(
             // Required costs are always paid — the choice prompt should not be reached,
             // but handle defensively by always paying.
             ability.context.additional_cost_paid = true;
+            ability.context.additional_cost_payment_count = 1;
             Some(cost.clone())
         }
     };
@@ -358,6 +370,45 @@ fn next_kicker_option(
     None
 }
 
+fn handle_decide_repeatable_additional_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    mut pending: PendingCast,
+    pay: bool,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let Some(cost) = next_repeatable_additional_cost(state, player, &pending) else {
+        pending.additional_cost_flow = None;
+        return finish_pending_cost_or_cast(state, player, pending, events);
+    };
+
+    if !pay {
+        pending.additional_cost_flow = None;
+        return finish_pending_cost_or_cast(state, player, pending, events);
+    }
+
+    pending.ability.context.additional_cost_paid = true;
+    pending.ability.context.additional_cost_payment_count = pending
+        .ability
+        .context
+        .additional_cost_payment_count
+        .saturating_add(1);
+    pay_additional_cost(state, player, cost, pending, events)
+}
+
+fn next_repeatable_additional_cost(
+    state: &GameState,
+    player: PlayerId,
+    pending: &PendingCast,
+) -> Option<AbilityCost> {
+    let Some(AdditionalCost::Repeatable(cost)) = &pending.additional_cost_flow else {
+        return None;
+    };
+
+    cost.is_payable(state, player, pending.object_id)
+        .then_some(cost.clone())
+}
+
 fn finish_pending_cost_or_cast(
     state: &mut GameState,
     player: PlayerId,
@@ -383,6 +434,22 @@ fn finish_pending_cost_or_cast(
         if let Some(AdditionalCost::Required(cost)) = pending.additional_cost_flow.take() {
             return pay_additional_cost(state, player, cost, pending, events);
         }
+    }
+
+    if matches!(
+        pending.additional_cost_flow,
+        Some(AdditionalCost::Repeatable(_))
+    ) {
+        if let Some(current_cost) = next_repeatable_additional_cost(state, player, &pending) {
+            let times_kicked = pending.ability.context.additional_cost_payment_count;
+            return Ok(WaitingFor::OptionalCostChoice {
+                player,
+                cost: AdditionalCost::Repeatable(current_cost),
+                times_kicked,
+                pending_cast: Box::new(pending),
+            });
+        }
+        pending.additional_cost_flow = None;
     }
 
     if matches!(
@@ -454,7 +521,7 @@ fn finish_pending_cost_or_cast(
     if pending.deferred_target_selection
         && !matches!(
             pending.additional_cost_flow,
-            Some(AdditionalCost::Kicker { .. })
+            Some(AdditionalCost::Kicker { .. } | AdditionalCost::Repeatable(_))
         )
     {
         return begin_deferred_target_selection(state, player, pending, events);
@@ -1604,6 +1671,17 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
                         .copied()
                         .collect();
                 }
+                return finish_pending_cost_or_cast(state, player, pending, events);
+            }
+            AdditionalCost::Repeatable(repeatable_cost) => {
+                let mut pending = PendingCast::new(object_id, card_id, ability, cost.clone());
+                pending.casting_variant = casting_variant;
+                pending.cast_timing_permission = cast_timing_permission;
+                pending.distribute = distribute.clone();
+                pending.origin_zone = origin_zone;
+                pending.payment_mode = payment_mode;
+                pending.additional_cost_flow =
+                    Some(AdditionalCost::Repeatable(repeatable_cost.clone()));
                 return finish_pending_cost_or_cast(state, player, pending, events);
             }
             AdditionalCost::Optional(opt_cost) => {
@@ -2809,6 +2887,7 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
     let cost_x_paid = ability.chosen_x;
     let kickers_paid = ability.context.kickers_paid.clone();
     let additional_cost_paid = ability.context.additional_cost_paid;
+    let additional_cost_payment_count = ability.context.additional_cost_payment_count;
     let convoked_creatures = state
         .pending_cast
         .as_ref()
@@ -2861,6 +2940,11 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
     if !kickers_paid.is_empty() {
         if let Some(obj) = state.objects.get_mut(&object_id) {
             obj.kickers_paid.clone_from(&kickers_paid);
+        }
+    }
+    if additional_cost_payment_count > 0 {
+        if let Some(obj) = state.objects.get_mut(&object_id) {
+            obj.additional_cost_payment_count = additional_cost_payment_count;
         }
     }
     if let Some(permission) = cast_timing_permission {
@@ -2922,6 +3006,7 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
             x_value: cost_x_paid,
             distinct_colors_spent,
             kickers_paid: kickers_paid.len(),
+            additional_cost_payment_count,
             additional_cost_paid,
             casting_variant,
             convoked_creatures: convoked_creature_count,
@@ -8301,6 +8386,27 @@ it for each time it was kicked.\n{T}: Add {C} for each charge counter on this ar
         }
     }
 
+    fn fund_white(runner: &mut crate::game::scenario::GameRunner, count: usize) {
+        use crate::types::mana::ManaUnit;
+        let p0 = runner
+            .state_mut()
+            .players
+            .iter_mut()
+            .find(|p| p.id == PlayerId(0))
+            .unwrap();
+        for _ in 0..count {
+            p0.mana_pool.add(ManaUnit {
+                color: ManaType::White,
+                source_id: ObjectId(0),
+                snow: false,
+                source_could_produce_two_or_more_colors: false,
+                restrictions: Vec::new(),
+                grants: vec![],
+                expiry: None,
+            });
+        }
+    }
+
     fn charge_counters(state: &GameState, object_id: ObjectId) -> u32 {
         state
             .objects
@@ -8453,6 +8559,82 @@ it for each time it was kicked.\n{T}: Add {C} for each charge counter on this ar
             runner.state().objects[&spell_id].zone,
             Zone::Battlefield,
             "the unkicked artifact must have resolved onto the battlefield"
+        );
+    }
+
+    /// CR 702.157a: Squad uses a repeatable non-kicker additional-cost flow,
+    /// then creates one copy token for each squad payment as the permanent
+    /// enters.
+    #[test]
+    fn squad_paid_twice_creates_two_copy_tokens() {
+        use crate::game::scenario::GameScenario;
+        use crate::types::GameAction;
+
+        const ENDLESS_FOOT_ASSAULT_ORACLE: &str = "Squad {1}{W} (As an additional cost to cast \
+this spell, you may pay {1}{W} any number of times. When this enchantment enters, create that \
+many tokens that are copies of it.)";
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(crate::types::Phase::PreCombatMain);
+        let mut builder = scenario.add_creature_to_hand(PlayerId(0), "Endless Foot Assault", 0, 0);
+        builder.as_enchantment();
+        builder.with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 0,
+        });
+        builder.from_oracle_text_with_keywords(&["squad:{1}{W}"], ENDLESS_FOOT_ASSAULT_ORACLE);
+        let spell_id = builder.id();
+        let card_id = scenario.state.objects[&spell_id].card_id;
+        let mut runner = scenario.build();
+        fund_white(&mut runner, 4);
+
+        runner
+            .act(GameAction::CastSpell {
+                object_id: spell_id,
+                card_id,
+                targets: vec![],
+            })
+            .expect("casting squad spell must be accepted");
+
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalCostChoice {
+                cost, times_kicked, ..
+            } => {
+                assert!(matches!(
+                    cost,
+                    AdditionalCost::Repeatable(AbilityCost::Mana { .. })
+                ));
+                assert_eq!(times_kicked, 0);
+            }
+            other => panic!("expected first squad prompt, got {other:?}"),
+        }
+
+        runner
+            .act(GameAction::DecideOptionalCost { pay: true })
+            .expect("first squad payment must be accepted");
+        runner
+            .act(GameAction::DecideOptionalCost { pay: true })
+            .expect("second squad payment must be accepted");
+        runner
+            .act(GameAction::DecideOptionalCost { pay: false })
+            .expect("declining further squad payments must finish the cast");
+        runner.advance_until_stack_empty();
+
+        let assault_permanents = runner
+            .state()
+            .battlefield
+            .iter()
+            .filter(|id| {
+                runner
+                    .state()
+                    .objects
+                    .get(id)
+                    .is_some_and(|obj| obj.name == "Endless Foot Assault")
+            })
+            .count();
+        assert_eq!(
+            assault_permanents, 3,
+            "original permanent plus two squad copy tokens should be on the battlefield"
         );
     }
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1098,6 +1098,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         QuantityRef::TargetZoneCardCount { .. } => "target zone card count".into(),
         QuantityRef::CostXPaid => "X paid for this spell".into(),
         QuantityRef::KickerCount => "kicker payments for this spell".into(),
+        QuantityRef::AdditionalCostPaymentCount => "additional cost payments for this spell".into(),
         QuantityRef::ConvokedCreatureCount => "creatures that convoked this spell".into(),
         QuantityRef::ManaSpentToCast { scope, metric } => {
             format!("mana spent to cast ({scope:?}, {metric:?})")
@@ -2828,7 +2829,9 @@ fn build_cost_item(cost: &AbilityCost, items: &mut Vec<ParsedItem>) {
 fn build_additional_cost_items(additional_cost: &AdditionalCost, items: &mut Vec<ParsedItem>) {
     if additional_cost_has_unimplemented(additional_cost) {
         match additional_cost {
-            AdditionalCost::Optional(cost) | AdditionalCost::Required(cost) => {
+            AdditionalCost::Optional(cost)
+            | AdditionalCost::Repeatable(cost)
+            | AdditionalCost::Required(cost) => {
                 build_cost_item(cost, items);
             }
             AdditionalCost::Kicker { costs, .. } => {
@@ -2846,6 +2849,7 @@ fn build_additional_cost_items(additional_cost: &AdditionalCost, items: &mut Vec
 
     let label = match additional_cost {
         AdditionalCost::Optional(_) => "AdditionalCost:Optional",
+        AdditionalCost::Repeatable(_) => "AdditionalCost:Repeatable",
         AdditionalCost::Kicker { repeatable, .. } => {
             if *repeatable {
                 "AdditionalCost:Multikicker"
@@ -2869,9 +2873,9 @@ fn build_additional_cost_items(additional_cost: &AdditionalCost, items: &mut Vec
 /// Returns true if any leaf `AbilityCost` in the tree is `Unimplemented`.
 fn additional_cost_has_unimplemented(additional_cost: &AdditionalCost) -> bool {
     match additional_cost {
-        AdditionalCost::Optional(cost) | AdditionalCost::Required(cost) => {
-            ability_cost_has_unimplemented(cost)
-        }
+        AdditionalCost::Optional(cost)
+        | AdditionalCost::Repeatable(cost)
+        | AdditionalCost::Required(cost) => ability_cost_has_unimplemented(cost),
         AdditionalCost::Kicker { costs, .. } => costs.iter().any(ability_cost_has_unimplemented),
         AdditionalCost::Choice(first, second) => {
             ability_cost_has_unimplemented(first) || ability_cost_has_unimplemented(second)
@@ -4072,9 +4076,9 @@ fn ability_definition_has_unimplemented_parts(def: &AbilityDefinition) -> bool {
 
 fn additional_cost_has_unimplemented_parts(additional_cost: &AdditionalCost) -> bool {
     match additional_cost {
-        AdditionalCost::Optional(cost) | AdditionalCost::Required(cost) => {
-            ability_cost_has_unimplemented_parts(cost)
-        }
+        AdditionalCost::Optional(cost)
+        | AdditionalCost::Repeatable(cost)
+        | AdditionalCost::Required(cost) => ability_cost_has_unimplemented_parts(cost),
         AdditionalCost::Kicker { costs, .. } => {
             costs.iter().any(ability_cost_has_unimplemented_parts)
         }
@@ -4123,7 +4127,9 @@ fn collect_additional_cost_missing_parts(
     missing: &mut Vec<String>,
 ) {
     match additional_cost {
-        AdditionalCost::Optional(cost) | AdditionalCost::Required(cost) => {
+        AdditionalCost::Optional(cost)
+        | AdditionalCost::Repeatable(cost)
+        | AdditionalCost::Required(cost) => {
             collect_ability_cost_missing_parts(cost, missing);
         }
         AdditionalCost::Kicker { costs, .. } => {
@@ -5173,6 +5179,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::TargetZoneCardCount { .. } => ("TargetZoneCardCount", Handled),
         QuantityRef::CostXPaid => ("CostXPaid", Handled),
         QuantityRef::KickerCount => ("KickerCount", Handled),
+        QuantityRef::AdditionalCostPaymentCount => ("AdditionalCostPaymentCount", Handled),
         QuantityRef::ConvokedCreatureCount => ("ConvokedCreatureCount", Handled),
         QuantityRef::ManaSpentToCast { .. } => ("ManaSpentToCast", Handled),
         QuantityRef::EventContextSourceCostX => ("EventContextSourceCostX", Handled),

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2829,9 +2829,7 @@ fn build_cost_item(cost: &AbilityCost, items: &mut Vec<ParsedItem>) {
 fn build_additional_cost_items(additional_cost: &AdditionalCost, items: &mut Vec<ParsedItem>) {
     if additional_cost_has_unimplemented(additional_cost) {
         match additional_cost {
-            AdditionalCost::Optional(cost)
-            | AdditionalCost::Repeatable(cost)
-            | AdditionalCost::Required(cost) => {
+            AdditionalCost::Optional { cost, .. } | AdditionalCost::Required(cost) => {
                 build_cost_item(cost, items);
             }
             AdditionalCost::Kicker { costs, .. } => {
@@ -2848,8 +2846,12 @@ fn build_additional_cost_items(additional_cost: &AdditionalCost, items: &mut Vec
     }
 
     let label = match additional_cost {
-        AdditionalCost::Optional(_) => "AdditionalCost:Optional",
-        AdditionalCost::Repeatable(_) => "AdditionalCost:Repeatable",
+        AdditionalCost::Optional {
+            repeatable: true, ..
+        } => "AdditionalCost:Repeatable",
+        AdditionalCost::Optional {
+            repeatable: false, ..
+        } => "AdditionalCost:Optional",
         AdditionalCost::Kicker { repeatable, .. } => {
             if *repeatable {
                 "AdditionalCost:Multikicker"
@@ -2873,9 +2875,9 @@ fn build_additional_cost_items(additional_cost: &AdditionalCost, items: &mut Vec
 /// Returns true if any leaf `AbilityCost` in the tree is `Unimplemented`.
 fn additional_cost_has_unimplemented(additional_cost: &AdditionalCost) -> bool {
     match additional_cost {
-        AdditionalCost::Optional(cost)
-        | AdditionalCost::Repeatable(cost)
-        | AdditionalCost::Required(cost) => ability_cost_has_unimplemented(cost),
+        AdditionalCost::Optional { cost, .. } | AdditionalCost::Required(cost) => {
+            ability_cost_has_unimplemented(cost)
+        }
         AdditionalCost::Kicker { costs, .. } => costs.iter().any(ability_cost_has_unimplemented),
         AdditionalCost::Choice(first, second) => {
             ability_cost_has_unimplemented(first) || ability_cost_has_unimplemented(second)
@@ -4076,9 +4078,9 @@ fn ability_definition_has_unimplemented_parts(def: &AbilityDefinition) -> bool {
 
 fn additional_cost_has_unimplemented_parts(additional_cost: &AdditionalCost) -> bool {
     match additional_cost {
-        AdditionalCost::Optional(cost)
-        | AdditionalCost::Repeatable(cost)
-        | AdditionalCost::Required(cost) => ability_cost_has_unimplemented_parts(cost),
+        AdditionalCost::Optional { cost, .. } | AdditionalCost::Required(cost) => {
+            ability_cost_has_unimplemented_parts(cost)
+        }
         AdditionalCost::Kicker { costs, .. } => {
             costs.iter().any(ability_cost_has_unimplemented_parts)
         }
@@ -4127,9 +4129,7 @@ fn collect_additional_cost_missing_parts(
     missing: &mut Vec<String>,
 ) {
     match additional_cost {
-        AdditionalCost::Optional(cost)
-        | AdditionalCost::Repeatable(cost)
-        | AdditionalCost::Required(cost) => {
+        AdditionalCost::Optional { cost, .. } | AdditionalCost::Required(cost) => {
             collect_ability_cost_missing_parts(cost, missing);
         }
         AdditionalCost::Kicker { costs, .. } => {
@@ -8292,9 +8292,12 @@ mod tests {
     #[test]
     fn card_face_with_unimplemented_additional_cost_is_detected() {
         let mut face = make_face();
-        face.additional_cost = Some(AdditionalCost::Optional(AbilityCost::Unimplemented {
-            description: "mystery cost".to_string(),
-        }));
+        face.additional_cost = Some(AdditionalCost::Optional {
+            cost: AbilityCost::Unimplemented {
+                description: "mystery cost".to_string(),
+            },
+            repeatable: false,
+        });
 
         assert!(card_face_has_unimplemented_parts(&face));
     }

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -53,6 +53,8 @@ pub fn resolve(
         copy_obj.controller = copy_controller;
         copy_obj.zone = Zone::Stack;
         copy_obj.is_token = true;
+        copy_obj.additional_cost_payment_count = 0;
+        copy_obj.kickers_paid.clear();
         state.objects.insert(copy_id, copy_obj);
     }
 
@@ -484,6 +486,66 @@ mod tests {
             }
             _ => panic!("Expected both entries to be Spells with abilities"),
         }
+    }
+
+    #[test]
+    fn copy_spell_resets_additional_cost_payment_history() {
+        let mut state = GameState::new_two_player(42);
+
+        let mut original_ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::SelfRef,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Ref {
+                    qty: crate::types::ability::QuantityRef::AdditionalCostPaymentCount,
+                },
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+            },
+            vec![],
+            ObjectId(10),
+            PlayerId(0),
+        );
+        original_ability.context.additional_cost_paid = true;
+        original_ability.context.additional_cost_payment_count = 2;
+        push_spell(
+            &mut state,
+            ObjectId(10),
+            CardId(1),
+            PlayerId(0),
+            "Endless Foot Assault",
+            original_ability,
+            CastingVariant::Normal,
+        );
+        {
+            let obj = state.objects.get_mut(&ObjectId(10)).unwrap();
+            obj.additional_cost_payment_count = 2;
+        }
+
+        let copy_ability = ResolvedAbility::new(
+            Effect::CopySpell {
+                target: TargetFilter::Any,
+                retarget: CopyRetargetPermission::KeepOriginalTargets,
+            },
+            vec![],
+            ObjectId(20),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve(&mut state, &copy_ability, &mut events).unwrap();
+
+        let copy_id = state.stack.back().expect("copy on stack").id;
+        assert_eq!(
+            state.objects[&copy_id].additional_cost_payment_count, 0,
+            "a spell copy was not cast, so it must not retain Squad payment history"
+        );
+        let copy_context = state.stack.back().and_then(StackEntry::ability).unwrap();
+        assert!(!copy_context.context.additional_cost_paid);
+        assert_eq!(copy_context.context.additional_cost_payment_count, 0);
     }
 
     #[test]

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -77,6 +77,7 @@ pub fn resolve(
         {
             set_resolved_source_recursive(a, copy_id);
             a.context.additional_cost_paid = false;
+            a.context.additional_cost_payment_count = 0;
             a.context.kickers_paid.clear();
         }
         set_copied_kind_controller(&mut kind, copy_controller);

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3809,14 +3809,16 @@ pub(crate) fn evaluate_condition(
         // GameObject at cast resolution, and propagated back into the trigger's
         // resolved-ability context for ETB triggers).
         AbilityCondition::AdditionalCostPaid {
+            source,
             variant,
             kicker_cost,
             min_count,
-        } => {
-            ability
-                .context
-                .additional_cost_paid_matches(*variant, kicker_cost.as_ref(), *min_count)
-        }
+        } => ability.context.additional_cost_paid_matches(
+            *source,
+            *variant,
+            kicker_cost.as_ref(),
+            *min_count,
+        ),
         AbilityCondition::EffectOutcome {
             signal: EffectOutcomeSignal::OptionalEffectPerformed,
         } => ability.context.optional_effect_performed && !state.cost_payment_failed_flag,

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -733,6 +733,7 @@ fn apply_pending_spell_resolution(
             obj.cast_timing_permission = Some((permission, state.turn_number));
         }
         obj.kickers_paid.clone_from(&ctx.kickers_paid);
+        obj.additional_cost_payment_count = ctx.additional_cost_payment_count;
         obj.convoked_creatures.clone_from(&ctx.convoked_creatures);
     }
 

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -409,6 +409,12 @@ pub struct GameObject {
     /// spell has left the stack.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub kickers_paid: Vec<crate::types::ability::KickerVariant>,
+    /// CR 601.2b/f/h + CR 702.157a: Count of non-kicker repeatable
+    /// additional costs paid while casting the spell that produced this
+    /// permanent. Kept separate from `kickers_paid` so Squad does not inherit
+    /// Kicker semantics.
+    #[serde(default, skip_serializing_if = "is_zero_u32_field")]
+    pub additional_cost_payment_count: u32,
     /// CR 702.51c: Creatures tapped to pay the convoke cost of the spell that
     /// produced this object. Stored as object ids so future convoke-reference
     /// classes can inspect identity; `QuantityRef::ConvokedCreatureCount`
@@ -799,6 +805,7 @@ impl GameObject {
             cast_timing_permission: None,
             cost_x_paid: None,
             kickers_paid: Vec::new(),
+            additional_cost_payment_count: 0,
             convoked_creatures: Vec::new(),
             bestow_form: None,
             unimplemented_mechanics: Vec::new(),
@@ -906,6 +913,7 @@ impl GameObject {
         // memory of prior kicker payments — clear before the cast resolution
         // path repopulates from the resolving spell's `SpellContext`.
         self.kickers_paid.clear();
+        self.additional_cost_payment_count = 0;
         // CR 400.7 + CR 702.51c: convoked-creature history is tied to the
         // spell-resolution event that created this object. A re-entering
         // permanent has no memory of a prior convoke payment.

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1664,6 +1664,11 @@ fn resolve_ref(
             .get(&ctx.self_object())
             .map(|obj| usize_to_i32_saturating(obj.kickers_paid.len()))
             .unwrap_or(0),
+        QuantityRef::AdditionalCostPaymentCount => state
+            .objects
+            .get(&ctx.self_object())
+            .map(|obj| u32_to_i32_saturating(obj.additional_cost_payment_count))
+            .unwrap_or(0),
         QuantityRef::ConvokedCreatureCount => state
             .objects
             .get(&ctx.self_object())

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -446,6 +446,16 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                         .map(|o| o.kickers_paid.clone())
                         .unwrap_or_default()
                 });
+            let additional_cost_payment_count = ability
+                .as_ref()
+                .map(|a| a.context.additional_cost_payment_count)
+                .unwrap_or_else(|| {
+                    state
+                        .objects
+                        .get(&entry.id)
+                        .map(|o| o.additional_cost_payment_count)
+                        .unwrap_or_default()
+                });
             let cast_timing_permission = state
                 .objects
                 .get(&entry.id)
@@ -547,6 +557,7 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                             // — because placeholder permanent spells have
                             // `ability == None` and would otherwise lose the data.
                             obj.kickers_paid = kickers_paid;
+                            obj.additional_cost_payment_count = additional_cost_payment_count;
                         }
                         if let Some(exiled_id) = ability
                             .as_ref()
@@ -632,6 +643,16 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                                 .map(|o| o.kickers_paid.clone())
                                 .unwrap_or_default()
                         });
+                    let additional_cost_payment_count = ability
+                        .as_ref()
+                        .map(|a| a.context.additional_cost_payment_count)
+                        .unwrap_or_else(|| {
+                            state
+                                .objects
+                                .get(&entry.id)
+                                .map(|o| o.additional_cost_payment_count)
+                                .unwrap_or_default()
+                        });
                     state.pending_spell_resolution =
                         Some(crate::types::game_state::PendingSpellResolution {
                             object_id: entry.id,
@@ -642,6 +663,7 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                             spell_targets: spell_targets.clone(),
                             actual_mana_spent,
                             kickers_paid,
+                            additional_cost_payment_count,
                             convoked_creatures,
                         });
                     state.waiting_for =

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -2916,6 +2916,7 @@ pub(crate) fn check_trigger_condition(
         // ETB/LTB trigger conditions refer to the triggering zone-change
         // object; self-referential triggers fall back to the trigger source.
         TriggerCondition::AdditionalCostPaid {
+            source,
             variant,
             kicker_cost,
             min_count,
@@ -2933,13 +2934,13 @@ pub(crate) fn check_trigger_condition(
                     .and_then(|id| state.objects.get(&id))
                     .is_some_and(|obj| match variant {
                         Some(kicker) => obj.kickers_paid.contains(kicker),
-                        None => {
-                            let min_count = (*min_count).max(1);
-                            obj.kickers_paid
-                                .len()
-                                .max(obj.additional_cost_payment_count as usize)
-                                >= min_count as usize
-                        }
+                        None => crate::types::ability::additional_cost_payment_count_matches(
+                            *source,
+                            obj.additional_cost_payment_count > 0 || !obj.kickers_paid.is_empty(),
+                            obj.kickers_paid.len(),
+                            obj.additional_cost_payment_count,
+                            *min_count,
+                        ),
                     })
             }
         }
@@ -10734,10 +10735,13 @@ pub mod tests {
             let obj = state.objects.get_mut(&spell).unwrap();
             obj.card_types.core_types.push(CoreType::Instant);
             obj.cast_from_zone = Some(Zone::Hand);
-            obj.additional_cost = Some(AdditionalCost::Optional(AbilityCost::Sacrifice {
-                target: TargetFilter::Typed(TypedFilter::creature()),
-                count: 1,
-            }));
+            obj.additional_cost = Some(AdditionalCost::Optional {
+                cost: AbilityCost::Sacrifice {
+                    target: TargetFilter::Typed(TypedFilter::creature()),
+                    count: 1,
+                },
+                repeatable: false,
+            });
             obj.keywords.push(Keyword::Casualty(2));
         }
         let ability = ResolvedAbility::new(
@@ -10912,6 +10916,7 @@ pub mod tests {
         assert!(check_trigger_condition(
             &state,
             &TriggerCondition::AdditionalCostPaid {
+                source: crate::types::ability::AdditionalCostPaymentSource::Any,
                 variant: None,
                 kicker_cost: None,
                 min_count: 1,
@@ -10942,6 +10947,7 @@ pub mod tests {
         assert!(check_trigger_condition(
             &state,
             &TriggerCondition::AdditionalCostPaid {
+                source: crate::types::ability::AdditionalCostPaymentSource::Kicker,
                 variant: None,
                 kicker_cost: None,
                 min_count: 2,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -2933,7 +2933,13 @@ pub(crate) fn check_trigger_condition(
                     .and_then(|id| state.objects.get(&id))
                     .is_some_and(|obj| match variant {
                         Some(kicker) => obj.kickers_paid.contains(kicker),
-                        None => obj.kickers_paid.len() >= *min_count as usize,
+                        None => {
+                            let min_count = (*min_count).max(1);
+                            obj.kickers_paid
+                                .len()
+                                .max(obj.additional_cost_payment_count as usize)
+                                >= min_count as usize
+                        }
                     })
             }
         }
@@ -3491,6 +3497,10 @@ fn build_triggered_ability(
                 // (no variant, min_count=1) so the default-shape evaluator
                 // remains correct on triggered abilities (the bool reads
                 // `additional_cost_paid` directly per the evaluator contract).
+                resolved.context.additional_cost_paid = true;
+            }
+            if obj.additional_cost_payment_count > 0 {
+                resolved.context.additional_cost_payment_count = obj.additional_cost_payment_count;
                 resolved.context.additional_cost_paid = true;
             }
         }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -7055,6 +7055,7 @@ mod tests {
             modal.constraints[0],
             ModalSelectionConstraint::ConditionalMaxChoices {
                 condition: crate::types::ability::ModalSelectionCondition::AdditionalCostPaid {
+                    source: crate::types::ability::AdditionalCostPaymentSource::Kicker,
                     variant: None,
                     kicker_cost: None,
                     min_count: 1,
@@ -7083,6 +7084,7 @@ mod tests {
             modal.constraints[0],
             ModalSelectionConstraint::ConditionalMaxChoices {
                 condition: crate::types::ability::ModalSelectionCondition::AdditionalCostPaid {
+                    source: crate::types::ability::AdditionalCostPaymentSource::Any,
                     variant: None,
                     kicker_cost: None,
                     min_count: 1,
@@ -11646,9 +11648,10 @@ mod tests {
 
         assert_eq!(
             result.additional_cost,
-            Some(AdditionalCost::Optional(AbilityCost::CollectEvidence {
-                amount: 8,
-            }))
+            Some(AdditionalCost::Optional {
+                cost: AbilityCost::CollectEvidence { amount: 8 },
+                repeatable: false,
+            })
         );
         assert_eq!(result.abilities.len(), 1);
         let ability = &result.abilities[0];

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -34,7 +34,10 @@ pub fn parse_additional_cost_line(lower: &str, raw: &str) -> Option<AdditionalCo
         let opt_raw = &body_raw[body_raw.len() - opt_lower.len()..];
         let cost = super::oracle_cost::parse_single_cost(opt_raw);
         if !matches!(cost, AbilityCost::Unimplemented { .. }) {
-            return Some(AdditionalCost::Optional(cost));
+            return Some(AdditionalCost::Optional {
+                cost,
+                repeatable: false,
+            });
         }
     }
 
@@ -736,7 +739,10 @@ mod tests {
         let result = parse_additional_cost_line(lower, raw);
         assert_eq!(
             result,
-            Some(AdditionalCost::Optional(AbilityCost::Blight { count: 1 }))
+            Some(AdditionalCost::Optional {
+                cost: AbilityCost::Blight { count: 1 },
+                repeatable: false,
+            })
         );
     }
 
@@ -747,7 +753,10 @@ mod tests {
         let result = parse_additional_cost_line(lower, raw);
         assert_eq!(
             result,
-            Some(AdditionalCost::Optional(AbilityCost::Blight { count: 2 }))
+            Some(AdditionalCost::Optional {
+                cost: AbilityCost::Blight { count: 2 },
+                repeatable: false,
+            })
         );
     }
 
@@ -759,11 +768,15 @@ mod tests {
             "As an additional cost to cast this spell, you may behold a Dragon. (You may choose a Dragon you control or reveal a Dragon card from your hand.)";
         let result = parse_additional_cost_line(lower, raw);
         match result {
-            Some(AdditionalCost::Optional(AbilityCost::Behold {
-                count: 1,
-                filter: TargetFilter::Typed(filter),
-                action: BeholdCostAction::ChooseOrReveal,
-            })) => {
+            Some(AdditionalCost::Optional {
+                cost:
+                    AbilityCost::Behold {
+                        count: 1,
+                        filter: TargetFilter::Typed(filter),
+                        action: BeholdCostAction::ChooseOrReveal,
+                    },
+                repeatable: false,
+            }) => {
                 assert!(filter
                     .type_filters
                     .iter()
@@ -987,7 +1000,10 @@ mod tests {
         let raw = "As an additional cost to cast this spell, you may sacrifice an artifact.";
         let result = parse_additional_cost_line(lower, raw);
         match result {
-            Some(AdditionalCost::Optional(AbilityCost::Sacrifice { count: 1, .. })) => {}
+            Some(AdditionalCost::Optional {
+                cost: AbilityCost::Sacrifice { count: 1, .. },
+                repeatable: false,
+            }) => {}
             other => panic!("Expected Optional(Sacrifice), got {:?}", other),
         }
     }

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -6,9 +6,9 @@ use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
 use crate::types::ability::{
-    AbilityDefinition, AbilityKind, ChoiceType, Effect, ModalChoice, ModalSelectionCondition,
-    ModalSelectionConstraint, PlayerFilter, ReplacementDefinition, StaticCondition, TargetFilter,
-    TriggerCondition,
+    AbilityDefinition, AbilityKind, AdditionalCostPaymentSource, ChoiceType, Effect, ModalChoice,
+    ModalSelectionCondition, ModalSelectionConstraint, PlayerFilter, ReplacementDefinition,
+    StaticCondition, TargetFilter, TriggerCondition,
 };
 use crate::types::replacements::ReplacementEvent;
 
@@ -483,6 +483,7 @@ fn parse_modal_additional_cost_condition(
         return Ok((
             rest,
             ModalSelectionCondition::AdditionalCostPaid {
+                source: AdditionalCostPaymentSource::Any,
                 variant: None,
                 kicker_cost: None,
                 min_count: 1,
@@ -501,6 +502,7 @@ fn parse_modal_additional_cost_condition(
         parse_modal_specific_kicker_cost_condition,
         value(
             ModalSelectionCondition::AdditionalCostPaid {
+                source: AdditionalCostPaymentSource::Kicker,
                 variant: None,
                 kicker_cost: None,
                 min_count: 2,
@@ -513,12 +515,14 @@ fn parse_modal_additional_cost_condition(
                 terminated(nom_primitives::parse_number, tag(" times")),
             ),
             |min_count| ModalSelectionCondition::AdditionalCostPaid {
+                source: AdditionalCostPaymentSource::Kicker,
                 variant: None,
                 kicker_cost: None,
                 min_count,
             },
         ),
         success(ModalSelectionCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::Kicker,
             variant: None,
             kicker_cost: None,
             min_count: 1,
@@ -539,6 +543,7 @@ fn parse_modal_specific_kicker_cost_condition(
     Ok((
         rest,
         ModalSelectionCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::Kicker,
             variant: None,
             kicker_cost: Some(kicker_cost),
             min_count: 1,

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -861,8 +861,7 @@ fn any_ability_is_optional(parsed: &ParsedAbilities) -> bool {
         // dragon-reveal kicker, blight, behold, etc.
         || matches!(
             parsed.additional_cost,
-            Some(crate::types::ability::AdditionalCost::Optional(_)
-                | crate::types::ability::AdditionalCost::Repeatable(_)
+            Some(crate::types::ability::AdditionalCost::Optional { .. }
                 | crate::types::ability::AdditionalCost::Kicker { .. }
                 | crate::types::ability::AdditionalCost::Choice(_, _))
         )

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -862,6 +862,7 @@ fn any_ability_is_optional(parsed: &ParsedAbilities) -> bool {
         || matches!(
             parsed.additional_cost,
             Some(crate::types::ability::AdditionalCost::Optional(_)
+                | crate::types::ability::AdditionalCost::Repeatable(_)
                 | crate::types::ability::AdditionalCost::Kicker { .. }
                 | crate::types::ability::AdditionalCost::Choice(_, _))
         )

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3082,6 +3082,10 @@ pub enum QuantityRef {
     /// CR 702.33b + CR 702.33c: Number of kicker costs paid for the source
     /// spell. For multikicker, each repeated payment contributes one entry.
     KickerCount,
+    /// CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost
+    /// payments made for the source spell. Used by Squad so its payment count
+    /// remains distinct from Kicker's CR 702.33 payment model.
+    AdditionalCostPaymentCount,
     /// CR 702.51c: Number of creatures that convoked the source spell or the
     /// spell that became the source permanent. Reads `GameObject::convoked_creatures`;
     /// ETB replacement contexts resolve against the entering object.
@@ -4571,6 +4575,10 @@ pub enum AdditionalCost {
     /// "you may [cost]" — player decides whether to pay.
     /// If paid, `SpellContext::additional_cost_paid` is set to true.
     Optional(AbilityCost),
+    /// CR 601.2b/f + CR 702.157a: A non-kicker additional cost that may be
+    /// paid any number of times while casting the spell. Each payment
+    /// increments `SpellContext::additional_cost_payment_count`.
+    Repeatable(AbilityCost),
     /// CR 702.33a-c + CR 601.2b/f: Kicker costs announced during spell
     /// casting. `costs.len() == 1` is ordinary kicker, `costs.len() == 2`
     /// represents "Kicker [cost 1] and/or [cost 2]" (CR 702.33b), and
@@ -9081,6 +9089,11 @@ pub struct SpellContext {
     /// Whether the spell's optional additional cost was paid during casting.
     #[serde(default)]
     pub additional_cost_paid: bool,
+    /// CR 601.2b/f/h: Number of non-kicker additional-cost payments declared
+    /// while casting this spell. Used by keyword abilities such as Squad
+    /// (CR 702.157a), whose repeatable payment count is not a kicker count.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub additional_cost_payment_count: u32,
     /// CR 702.33d + CR 702.33f: The list of kicker payments declared during
     /// casting, in payment order. For "Kicker {A} and/or {B}" cards (CR 702.33b),
     /// each chosen kicker pushes a corresponding `KickerVariant` entry. For
@@ -9138,11 +9151,12 @@ impl SpellContext {
         match variant {
             Some(kicker) => self.kickers_paid.contains(&kicker),
             None => {
-                if min_count <= 1 {
-                    self.additional_cost_paid
-                } else {
-                    self.kickers_paid.len() >= min_count as usize
-                }
+                let min_count = min_count.max(1);
+                let payment_count = self
+                    .kickers_paid
+                    .len()
+                    .max(self.additional_cost_payment_count as usize);
+                payment_count >= min_count as usize || (min_count <= 1 && self.additional_cost_paid)
             }
         }
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4573,12 +4573,15 @@ impl AbilityCost {
 #[serde(tag = "type", content = "data")]
 pub enum AdditionalCost {
     /// "you may [cost]" — player decides whether to pay.
-    /// If paid, `SpellContext::additional_cost_paid` is set to true.
-    Optional(AbilityCost),
-    /// CR 601.2b/f + CR 702.157a: A non-kicker additional cost that may be
-    /// paid any number of times while casting the spell. Each payment
-    /// increments `SpellContext::additional_cost_payment_count`.
-    Repeatable(AbilityCost),
+    /// If paid, `SpellContext::additional_cost_paid` is set to true. When
+    /// `repeatable` is true, the same non-kicker additional cost may be paid
+    /// any number of times and each payment increments
+    /// `SpellContext::additional_cost_payment_count`.
+    Optional {
+        cost: AbilityCost,
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        repeatable: bool,
+    },
     /// CR 702.33a-c + CR 601.2b/f: Kicker costs announced during spell
     /// casting. `costs.len() == 1` is ordinary kicker, `costs.len() == 2`
     /// represents "Kicker [cost 1] and/or [cost 2]" (CR 702.33b), and
@@ -4594,6 +4597,26 @@ pub enum AdditionalCost {
     Choice(AbilityCost, AbilityCost),
     /// Mandatory additional cost (e.g., "As an additional cost, waterbend {5}").
     Required(AbilityCost),
+}
+
+/// Which casting-time payment stream an `AdditionalCostPaid` condition reads.
+///
+/// `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads
+/// only CR 702.33 kicker payments, while `NonKicker` reads only repeatable
+/// non-kicker additional-cost payments such as Squad.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub enum AdditionalCostPaymentSource {
+    #[default]
+    Any,
+    Kicker,
+    NonKicker,
+}
+
+impl AdditionalCostPaymentSource {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub(crate) fn is_any(value: &Self) -> bool {
+        matches!(value, AdditionalCostPaymentSource::Any)
+    }
 }
 
 /// Structured spell-casting options parsed from Oracle text.
@@ -8000,6 +8023,8 @@ pub enum ModalSelectionCondition {
     /// CR 601.2b + CR 702.33d/f: Additional-cost declaration made while casting
     /// the spell, before the modal cap is evaluated.
     AdditionalCostPaid {
+        #[serde(default, skip_serializing_if = "AdditionalCostPaymentSource::is_any")]
+        source: AdditionalCostPaymentSource,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         variant: Option<KickerVariant>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -8025,6 +8050,8 @@ impl<'de> Deserialize<'de> for ModalSelectionCondition {
             },
             AdditionalCostPaid {
                 #[serde(default)]
+                source: AdditionalCostPaymentSource,
+                #[serde(default)]
                 variant: Option<KickerVariant>,
                 #[serde(default)]
                 kicker_cost: Option<ManaCost>,
@@ -8045,10 +8072,12 @@ impl<'de> Deserialize<'de> for ModalSelectionCondition {
                 Ok(ModalSelectionCondition::Static { condition })
             }
             Repr::Tagged(Tagged::AdditionalCostPaid {
+                source,
                 variant,
                 kicker_cost,
                 min_count,
             }) => Ok(ModalSelectionCondition::AdditionalCostPaid {
+                source,
                 variant,
                 kicker_cost,
                 min_count,
@@ -8763,6 +8792,8 @@ pub enum AbilityCondition {
     ///     kicker" clauses. Database synthesis resolves this to `variant`
     ///     once the card's kicker declarations are visible.
     AdditionalCostPaid {
+        #[serde(default, skip_serializing_if = "AdditionalCostPaymentSource::is_any")]
+        source: AdditionalCostPaymentSource,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         variant: Option<KickerVariant>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9025,6 +9056,7 @@ impl AbilityCondition {
     /// `game/effects/change_zone.rs` (Collect Evidence).
     pub fn additional_cost_paid_any() -> Self {
         AbilityCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::Any,
             variant: None,
             kicker_cost: None,
             min_count: 1,
@@ -9035,6 +9067,7 @@ impl AbilityCondition {
     /// specific kicker variant being paid.
     pub fn additional_cost_paid_kicker(variant: KickerVariant) -> Self {
         AbilityCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::Kicker,
             variant: Some(variant),
             kicker_cost: None,
             min_count: 1,
@@ -9046,6 +9079,7 @@ impl AbilityCondition {
     /// `KickerVariant` using the card's `AdditionalCost::Kicker` declaration.
     pub fn additional_cost_paid_kicker_cost(cost: ManaCost) -> Self {
         AbilityCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::Kicker,
             variant: None,
             kicker_cost: Some(cost),
             min_count: 1,
@@ -9056,6 +9090,7 @@ impl AbilityCondition {
     /// payment count meeting a minimum.
     pub fn additional_cost_paid_n_times(min_count: u32) -> Self {
         AbilityCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::Kicker,
             variant: None,
             kicker_cost: None,
             min_count,
@@ -9140,6 +9175,7 @@ pub struct SpellContext {
 impl SpellContext {
     pub fn additional_cost_paid_matches(
         &self,
+        source: AdditionalCostPaymentSource,
         variant: Option<KickerVariant>,
         kicker_cost: Option<&ManaCost>,
         min_count: u32,
@@ -9150,13 +9186,42 @@ impl SpellContext {
 
         match variant {
             Some(kicker) => self.kickers_paid.contains(&kicker),
-            None => {
-                let min_count = min_count.max(1);
-                let payment_count = self
-                    .kickers_paid
-                    .len()
-                    .max(self.additional_cost_payment_count as usize);
-                payment_count >= min_count as usize || (min_count <= 1 && self.additional_cost_paid)
+            None => additional_cost_payment_count_matches(
+                source,
+                self.additional_cost_paid,
+                self.kickers_paid.len(),
+                self.additional_cost_payment_count,
+                min_count,
+            ),
+        }
+    }
+}
+
+pub(crate) fn additional_cost_payment_count_matches(
+    source: AdditionalCostPaymentSource,
+    additional_cost_paid: bool,
+    kicker_count: usize,
+    non_kicker_count: u32,
+    min_count: u32,
+) -> bool {
+    match source {
+        AdditionalCostPaymentSource::Any => {
+            if min_count == 0 || (min_count == 1 && additional_cost_paid) {
+                true
+            } else {
+                kicker_count >= min_count as usize || non_kicker_count >= min_count
+            }
+        }
+        AdditionalCostPaymentSource::Kicker => {
+            let min_count = min_count.max(1);
+            kicker_count >= min_count as usize
+        }
+        AdditionalCostPaymentSource::NonKicker => {
+            if min_count == 0 {
+                true
+            } else {
+                non_kicker_count >= min_count
+                    || (min_count == 1 && additional_cost_paid && kicker_count == 0)
             }
         }
     }
@@ -9226,6 +9291,8 @@ pub enum TriggerCondition {
     /// Evaluates the triggering zone-change object when present, otherwise the
     /// trigger source, using `GameObject::kickers_paid` recorded at cast time.
     AdditionalCostPaid {
+        #[serde(default, skip_serializing_if = "AdditionalCostPaymentSource::is_any")]
+        source: AdditionalCostPaymentSource,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         variant: Option<KickerVariant>,
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3464,6 +3464,8 @@ pub struct StackPaidSnapshot {
     pub distinct_colors_spent: u32,
     #[serde(default, skip_serializing_if = "is_zero_usize")]
     pub kickers_paid: usize,
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub additional_cost_payment_count: u32,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub additional_cost_paid: bool,
     #[serde(default, skip_serializing_if = "CastingVariant::is_normal")]
@@ -4453,6 +4455,11 @@ pub struct PendingSpellResolution {
     /// path in `stack.rs`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub kickers_paid: Vec<crate::types::ability::KickerVariant>,
+    /// CR 601.2b/f/h + CR 702.157a: Carry non-kicker additional-cost payment
+    /// count through the replacement-choice detour, matching the direct
+    /// stack-resolution path.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub additional_cost_payment_count: u32,
     /// CR 702.51c: Carry convoked-creature data through the replacement-choice
     /// detour so ETB triggers/replacements see the same cast history as the
     /// direct resolution path.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5280,7 +5280,10 @@ mod tests {
         }));
         variants.push(Box::new(WaitingFor::OptionalCostChoice {
             player: PlayerId(0),
-            cost: AdditionalCost::Optional(crate::types::ability::AbilityCost::Blight { count: 1 }),
+            cost: AdditionalCost::Optional {
+                cost: crate::types::ability::AbilityCost::Blight { count: 1 },
+                repeatable: false,
+            },
             times_kicked: 0,
             pending_cast: dummy_pending(),
         }));

--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -57,7 +57,10 @@ fn optional_cost_paid_sets_flag() {
             target: TargetFilter::Any,
             damage_source: None,
         })
-        .with_additional_cost(AdditionalCost::Optional(AbilityCost::Blight { count: 1 }))
+        .with_additional_cost(AdditionalCost::Optional {
+            cost: AbilityCost::Blight { count: 1 },
+            repeatable: false,
+        })
         .id();
 
     let mut runner = scenario.build();
@@ -144,7 +147,10 @@ fn optional_cost_skipped_clears_flag() {
             target: TargetFilter::Any,
             damage_source: None,
         })
-        .with_additional_cost(AdditionalCost::Optional(AbilityCost::Blight { count: 1 }))
+        .with_additional_cost(AdditionalCost::Optional {
+            cost: AbilityCost::Blight { count: 1 },
+            repeatable: false,
+        })
         .id();
 
     let mut runner = scenario.build();
@@ -210,9 +216,12 @@ fn bargain_additional_cost_paid_reduces_self_spell_cost() {
                 shards: vec![],
                 generic: 4,
             })
-            .with_additional_cost(AdditionalCost::Optional(AbilityCost::PayLife {
-                amount: QuantityExpr::Fixed { value: 1 },
-            }))
+            .with_additional_cost(AdditionalCost::Optional {
+                cost: AbilityCost::PayLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                },
+                repeatable: false,
+            })
             .with_static_definition(reduce_static)
             .id();
 
@@ -322,7 +331,10 @@ fn cancel_cast_at_optional_cost_choice() {
             target: TargetFilter::Any,
             damage_source: None,
         })
-        .with_additional_cost(AdditionalCost::Optional(AbilityCost::Blight { count: 1 }))
+        .with_additional_cost(AdditionalCost::Optional {
+            cost: AbilityCost::Blight { count: 1 },
+            repeatable: false,
+        })
         .id();
 
     let mut runner = scenario.build();
@@ -1236,7 +1248,10 @@ fn optional_blight_with_no_creatures_skips_prompt() {
             target: TargetFilter::Any,
             damage_source: None,
         })
-        .with_additional_cost(AdditionalCost::Optional(AbilityCost::Blight { count: 1 }))
+        .with_additional_cost(AdditionalCost::Optional {
+            cost: AbilityCost::Blight { count: 1 },
+            repeatable: false,
+        })
         .id();
 
     let mut runner = scenario.build();

--- a/crates/mtgish-import/src/convert/cast_effect.rs
+++ b/crates/mtgish-import/src/convert/cast_effect.rs
@@ -68,7 +68,10 @@ pub fn apply(eff: &CastEffect, stub: &mut EngineFaceStub) -> ConvResult<()> {
         // additional cost". Same shape that `Keyword::Kicker` synthesises.
         E::OptionalAdditionalCastingCost(cost) => set_additional_cost(
             stub,
-            AdditionalCost::Optional(cost_conv::convert(cost)?),
+            AdditionalCost::Optional {
+                cost: cost_conv::convert(cost)?,
+                repeatable: false,
+            },
             "OptionalAdditionalCastingCost",
         ),
         // CR 207.2c + CR 601.2f: Strive — per-target surcharge. The engine

--- a/crates/mtgish-import/src/convert/condition.rs
+++ b/crates/mtgish-import/src/convert/condition.rs
@@ -7,9 +7,10 @@
 //! strict-fails so the report surfaces it.
 
 use engine::types::ability::{
-    AbilityCondition, AggregateFunction, CardTypeSetSource, Comparator, ControllerRef, CountScope,
-    FilterProp, ParsedCondition, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef,
-    StaticCondition, TargetFilter, TriggerCondition, TypeFilter, TypedFilter, ZoneRef,
+    AbilityCondition, AdditionalCostPaymentSource, AggregateFunction, CardTypeSetSource,
+    Comparator, ControllerRef, CountScope, FilterProp, ParsedCondition, PlayerFilter, PlayerScope,
+    QuantityExpr, QuantityRef, StaticCondition, TargetFilter, TriggerCondition, TypeFilter,
+    TypedFilter, ZoneRef,
 };
 use engine::types::card_type::CoreType;
 use engine::types::counter::CounterMatch;
@@ -836,16 +837,19 @@ fn entering_permanent_filter_to_trigger(pred: &Permanents) -> ConvResult<Trigger
         Permanents::WasCast | Permanents::ItWasCast => TriggerCondition::WasCast,
         // CR 702.33d-f + CR 603.4: ETB intervening-if "if it was kicked".
         Permanents::WasKicked => TriggerCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::Kicker,
             variant: None,
             kicker_cost: None,
             min_count: 1,
         },
         Permanents::WasKickedWithKicker(cost) => TriggerCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::Kicker,
             variant: None,
             kicker_cost: Some(mana::convert(cost)?),
             min_count: 1,
         },
         Permanents::WasKickedTwice => TriggerCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::Kicker,
             variant: None,
             kicker_cost: None,
             min_count: 2,
@@ -3305,6 +3309,7 @@ mod tests {
         assert_eq!(
             converted,
             TriggerCondition::AdditionalCostPaid {
+                source: AdditionalCostPaymentSource::Kicker,
                 variant: None,
                 kicker_cost: None,
                 min_count: 1,

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1402,6 +1402,9 @@ pub(crate) fn deterministic_choice(
             engine::types::ability::AdditionalCost::Optional(
                 engine::types::ability::AbilityCost::Mana { cost: extra_mana },
             ) => affordable_mana_cost(extra_mana),
+            engine::types::ability::AdditionalCost::Repeatable(
+                engine::types::ability::AbilityCost::Mana { cost: extra_mana },
+            ) => affordable_mana_cost(extra_mana),
             // CR 702.33c: a multikicker / kicker re-prompt presents exactly one
             // live cost. When that cost is pure mana, apply the same
             // affordability + over-commit guard as Optional(Mana).
@@ -1440,6 +1443,7 @@ pub(crate) fn deterministic_choice(
                 life > resolved * 3
             }
             engine::types::ability::AdditionalCost::Optional(_) => true,
+            engine::types::ability::AdditionalCost::Repeatable(_) => true,
             engine::types::ability::AdditionalCost::Kicker { .. } => true,
             engine::types::ability::AdditionalCost::Choice(_, _) => true,
             engine::types::ability::AdditionalCost::Required(_) => true,

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1399,12 +1399,10 @@ pub(crate) fn deterministic_choice(
         };
 
         let pay = match additional_cost {
-            engine::types::ability::AdditionalCost::Optional(
-                engine::types::ability::AbilityCost::Mana { cost: extra_mana },
-            ) => affordable_mana_cost(extra_mana),
-            engine::types::ability::AdditionalCost::Repeatable(
-                engine::types::ability::AbilityCost::Mana { cost: extra_mana },
-            ) => affordable_mana_cost(extra_mana),
+            engine::types::ability::AdditionalCost::Optional {
+                cost: engine::types::ability::AbilityCost::Mana { cost: extra_mana },
+                ..
+            } => affordable_mana_cost(extra_mana),
             // CR 702.33c: a multikicker / kicker re-prompt presents exactly one
             // live cost. When that cost is pure mana, apply the same
             // affordability + over-commit guard as Optional(Mana).
@@ -1421,12 +1419,14 @@ pub(crate) fn deterministic_choice(
                 affordable_mana_cost(extra_mana)
             }
             // Non-mana optional costs: sacrifice → usually worth it for the upgrade
-            engine::types::ability::AdditionalCost::Optional(
-                engine::types::ability::AbilityCost::Sacrifice { .. },
-            ) => false, // Conservative: don't sacrifice unless search says so
-            engine::types::ability::AdditionalCost::Optional(
-                engine::types::ability::AbilityCost::PayLife { amount },
-            ) => {
+            engine::types::ability::AdditionalCost::Optional {
+                cost: engine::types::ability::AbilityCost::Sacrifice { .. },
+                ..
+            } => false, // Conservative: don't sacrifice unless search says so
+            engine::types::ability::AdditionalCost::Optional {
+                cost: engine::types::ability::AbilityCost::PayLife { amount },
+                ..
+            } => {
                 // CR 119.4 + CR 903.4: PayLife carries a QuantityExpr; resolve
                 // against the activator/source so dynamic costs (e.g. commander
                 // color identity) are costed correctly. Source = 0 falls back
@@ -1442,8 +1442,7 @@ pub(crate) fn deterministic_choice(
                 let life = state.players[player.0 as usize].life;
                 life > resolved * 3
             }
-            engine::types::ability::AdditionalCost::Optional(_) => true,
-            engine::types::ability::AdditionalCost::Repeatable(_) => true,
+            engine::types::ability::AdditionalCost::Optional { .. } => true,
             engine::types::ability::AdditionalCost::Kicker { .. } => true,
             engine::types::ability::AdditionalCost::Choice(_, _) => true,
             engine::types::ability::AdditionalCost::Required(_) => true,


### PR DESCRIPTION
## Summary
Fixes **Endless Foot Assault** by modeling Squad as a repeatable non-kicker additional cost and creating copy tokens from the actual Squad payment count.

Closes #719.

## Files changed
- client/src/adapter/types.ts
- client/src/viewmodel/__tests__/costLabel.test.ts
- client/src/viewmodel/costLabel.ts
- crates/engine/src/database/synthesis.rs
- crates/engine/src/game/casting_costs.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/game/effects/copy_spell.rs
- crates/engine/src/game/engine_replacement.rs
- crates/engine/src/game/game_object.rs
- crates/engine/src/game/quantity.rs
- crates/engine/src/game/stack.rs
- crates/engine/src/game/triggers.rs
- crates/engine/src/parser/swallow_check.rs
- crates/engine/src/types/ability.rs
- crates/engine/src/types/game_state.rs
- crates/phase-ai/src/search.rs

## CR references
- CR 601.2b
- CR 601.2f
- CR 601.2h
- CR 603.4
- CR 702.33d
- CR 702.157a
- CR 702.157b
- CR 702.175a

## Track
Developer

## LLM
Model: codex-5
Thinking: high
Tier: Standard

## Gate A
`./scripts/check-parser-combinators.sh` — clean (exit 0, no output)

## Anchored on
- crates/engine/src/database/synthesis.rs:1517 — existing Offspring synthesizer models keyword-derived additional cost plus ETB copy trigger.
- crates/engine/src/game/casting_costs.rs:308 — existing repeatable Kicker prompt/payment loop.
- crates/engine/src/game/stack.rs:432 — existing paid-cost context propagation from stack spell to entering permanent.

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p engine squad_` — 4 passed
- `cargo test -p engine` — 8697 unit passed, 462 integration passed, 0 failed
- `./scripts/gen-card-data.sh` — clean; `Endless Foot Assault`: 0 Unimplemented entries
- `cargo coverage` — `Endless Foot Assault`: `supported: true`, `gap_count: 0`
- `cargo semantic-audit` — `Endless Foot Assault`: 0 findings
- `pnpm run type-check` — clean
- `pnpm lint` — clean
- `pnpm test -- --run src/viewmodel/__tests__/costLabel.test.ts src/components/modal/__tests__/OptionalCostModal.test.tsx` — passed; Vitest ran 123 files / 1018 tests
- `pnpm build` — clean after local WASM generation; Vite chunk warnings only
- `git diff --check` — clean

## Scope Expansion
Adds generic repeatable non-kicker additional-cost tracking through casting, stack resolution, ETB replacement context, trigger conditions, AI choice handling, and frontend cost labels. Multiple Squad instances are explicitly deferred per CR 702.157b until per-instance linked payment tracking exists.

## Validation Failures
None.

## CI Failures
None.