### PR TITLE
Fix orphaned dungeon-room triggers after TakeTheInitiative resolves

### DIFF
--- a/crates/engine/src/game/effects/venture.rs
+++ b/crates/engine/src/game/effects/venture.rs
@@ -146,7 +146,7 @@ fn start_dungeon_and_enter(
         room_name: room_name(dungeon, 0).to_string(),
     });
 
-    queue_room_trigger(state, player, dungeon, 0);
+    queue_room_trigger(state, player, dungeon, 0, events);
 }
 
 /// CR 309.7: Complete a dungeon — remove from game, record completion.
@@ -190,7 +190,7 @@ fn advance_to_room(
         });
 
         // CR 309.4c: Queue room trigger.
-        queue_room_trigger(state, player, dungeon, room);
+        queue_room_trigger(state, player, dungeon, room, events);
 
         Ok(())
     } else {
@@ -211,13 +211,20 @@ fn advance_to_room(
     }
 }
 
-/// CR 309.4c: Queue a room's triggered ability onto the pending trigger list.
-/// Room abilities are triggered abilities ("When you move your venture marker
-/// into this room, [effect].") — they go on the stack.
+/// CR 309.4c: Queue and dispatch a room's triggered ability — for no-target
+/// rooms this pushes directly to the stack; for targeted rooms (Forge /
+/// Lost Well / Trap! / Arena) this opens the standard trigger-target-selection
+/// prompt.
 ///
 /// Uses a synthetic ObjectId (dungeon sentinel) so the SBA (CR 704.5t) can
 /// identify pending room abilities when checking dungeon completion.
-fn queue_room_trigger(state: &mut GameState, player: PlayerId, dungeon: DungeonId, room: u8) {
+fn queue_room_trigger(
+    state: &mut GameState,
+    player: PlayerId,
+    dungeon: DungeonId,
+    room: u8,
+    events: &mut Vec<GameEvent>,
+) {
     let source_id = dungeon_sentinel_id(player);
     let name = room_name(dungeon, room);
 
@@ -225,16 +232,7 @@ fn queue_room_trigger(state: &mut GameState, player: PlayerId, dungeon: DungeonI
     let (room_ability, target_constraints) =
         dungeon::room_effects(dungeon, room, source_id, player);
 
-    // Room triggers set pending_trigger. In normal flow, it should already be None
-    // because the engine consumes it before dispatching the next venture action.
-    // If this assertion fires, the call site needs to consume the existing trigger first.
-    debug_assert!(
-        state.pending_trigger.is_none(),
-        "queue_room_trigger: pending_trigger already set — previous trigger not consumed"
-    );
-
-    // Push as a pending trigger so it goes on the stack properly.
-    state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+    let pending = crate::game::triggers::PendingTrigger {
         source_id,
         controller: player,
         condition: None,
@@ -253,7 +251,12 @@ fn queue_room_trigger(state: &mut GameState, player: PlayerId, dungeon: DungeonI
         description: Some(format!("{}: {name}", dungeon::get_definition(dungeon).name)),
         may_trigger_origin: None,
         subject_match_count: None,
-    });
+    };
+
+    // CR 603.2 + CR 309.4c: Dispatch through the standard
+    // trigger pipeline so no-target room triggers land on the stack and
+    // targeted ones open the target-selection prompt.
+    crate::game::triggers::dispatch_synthetic_trigger(state, pending, events);
 }
 
 /// Called by the engine handler when the player chooses a dungeon.
@@ -286,7 +289,7 @@ pub fn handle_choose_room(
     });
 
     // CR 309.4c: Queue room trigger.
-    queue_room_trigger(state, player, dungeon, room_index);
+    queue_room_trigger(state, player, dungeon, room_index, events);
 }
 
 #[cfg(test)]
@@ -348,8 +351,12 @@ mod tests {
             }
         )));
 
-        // Must queue a room trigger (pending_trigger set).
-        assert!(state.pending_trigger.is_some());
+        // Room trigger must reach the stack via the standard dispatch
+        // pipeline (no orphan pending_trigger). Secret Entrance has no
+        // target slots, so it pushes directly to the stack.
+        assert_eq!(state.stack.len(), 1);
+        assert_eq!(state.stack[0].source_id, dungeon_sentinel_id(PlayerId(0)));
+        assert!(state.pending_trigger.is_none());
     }
 
     #[test]
@@ -467,6 +474,13 @@ mod tests {
         assert!(events
             .iter()
             .any(|e| matches!(e, GameEvent::InitiativeTaken { .. })));
+
+        // Room trigger must reach the stack via the standard dispatch
+        // pipeline (no orphan pending_trigger). Secret Entrance has no
+        // target slots, so it pushes directly to the stack.
+        assert_eq!(state.stack.len(), 1);
+        assert_eq!(state.stack[0].source_id, dungeon_sentinel_id(PlayerId(0)));
+        assert!(state.pending_trigger.is_none());
     }
 
     #[test]
@@ -493,5 +507,9 @@ mod tests {
             }
             other => panic!("Expected ChooseDungeonRoom on retake, got {other:?}"),
         }
+
+        // Branch-point retake never reaches `queue_room_trigger`, so no
+        // pending trigger should be left orphaned (regression guard for #587).
+        assert!(state.pending_trigger.is_none());
     }
 }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -2097,6 +2097,22 @@ fn push_pending_trigger_to_stack_with_event_batch(
     stack::push_to_stack(state, entry, events);
 }
 
+/// CR 603.2 + CR 603.3b + CR 309.4c: Dispatch a synthetic
+/// single trigger (game-rule trigger queued mid-resolution, e.g. dungeon
+/// room ability from `effects::venture::queue_room_trigger`). Delegates
+/// to the same pipeline as `process_triggers` so target slots, modal
+/// choice, distribute-among, and mana abilities are handled identically.
+/// Returns `true` if the dispatch paused on player input (target / mode
+/// / distribute prompt), `false` if the trigger reached the stack or
+/// resolved inline.
+pub(crate) fn dispatch_synthetic_trigger(
+    state: &mut GameState,
+    trigger: PendingTrigger,
+    events_out: &mut Vec<GameEvent>,
+) -> bool {
+    dispatch_pending_trigger_context(state, PendingTriggerContext::single(trigger), events_out)
+}
+
 /// CR 113.2c + CR 603.2 + CR 603.3b: Drive a single collected trigger through
 /// its disposition. Returns `true` when the trigger paused on player input
 /// (modal mode choice, target selection, or division-among) — callers must

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -70,6 +70,7 @@ mod ripples_of_undeath_regression;
 mod rite_of_consumption_damage;
 mod roots_of_wisdom_if_you_cant_draw;
 mod rules;
+mod seasoned_dungeoneer_initiative_room_trigger;
 mod serras_emissary_chosen_card_type_protection;
 mod skullwinder_chosen_opponent;
 mod spellstutter_sprite_counter_with_x;

--- a/crates/engine/tests/integration/seasoned_dungeoneer_initiative_room_trigger.rs
+++ b/crates/engine/tests/integration/seasoned_dungeoneer_initiative_room_trigger.rs
@@ -1,0 +1,180 @@
+//! GitHub issue #587 — Seasoned Dungeoneer "take the initiative" ETB
+//! leaves the Undercity Secret Entrance room trigger orphaned.
+//!
+//! Oracle (line 1): "When this creature enters, you take the initiative."
+//!
+//! Bug symptom: after `Effect::TakeTheInitiative` resolved,
+//! `effects::venture::queue_room_trigger` set `state.pending_trigger`
+//! directly, bypassing the trigger-dispatch pipeline. No engine call site
+//! consumed a no-target pending trigger, so the Undercity room 0
+//! (Secret Entrance) "Search your library for a basic land" ability
+//! never reached the stack and never fired.
+//!
+//! Fix: `queue_room_trigger` now routes through
+//! `triggers::dispatch_synthetic_trigger`, which delegates to the same
+//! pipeline as `process_triggers`. No-target room abilities push to the
+//! stack; targeted ones (Forge / Lost Well / Trap! / Arena) open the
+//! standard target-selection prompt.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 309.4c: room abilities are triggered abilities that go on the stack.
+//!   - CR 603.2: a triggered ability triggers when its event occurs.
+//!   - CR 701.49: venture into the dungeon (move marker / enter new dungeon).
+//!   - CR 726.2 / CR 726.5: taking the initiative ventures into Undercity;
+//!     re-taking still triggers a venture.
+//!
+//! Test (a) covers the orphan-state regression: cast Seasoned Dungeoneer,
+//! its ETB resolves, the room trigger must either be on the stack or have
+//! opened a follow-on prompt — never orphaned in `pending_trigger`.
+//!
+//! Test (b) covers the re-take path (CR 726.5): with initiative + Undercity
+//! already on P0, casting Seasoned Dungeoneer ventures from room 0 to a
+//! branch point (rooms 1/2). `queue_room_trigger` is not reached in this
+//! flow, so `pending_trigger` must remain `None`.
+
+use engine::game::dungeon::{dungeon_sentinel_id, DungeonId};
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+/// The ETB-only slice of Seasoned Dungeoneer's Oracle text. We intentionally
+/// drop the combat / Explore lines so the cast/resolve path under test stays
+/// scoped to "you take the initiative".
+const SEASONED_ETB: &str = "When this creature enters, you take the initiative.";
+
+fn cast_creature_from_hand(runner: &mut engine::game::scenario::GameRunner, hand_card: ObjectId) {
+    let card_id = runner
+        .state()
+        .objects
+        .get(&hand_card)
+        .expect("hand card exists")
+        .card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: hand_card,
+            card_id,
+            targets: vec![],
+        })
+        .expect("casting a 0-cost creature should succeed");
+    runner.advance_until_stack_empty();
+}
+
+/// (a) Fresh game: P0 has no initiative and no active dungeon. Casting
+/// Seasoned Dungeoneer resolves its ETB, sets initiative, auto-ventures
+/// into Undercity, and the Secret Entrance room trigger MUST reach the
+/// stack (or open a follow-on prompt) — never be orphaned in
+/// `pending_trigger`.
+#[test]
+fn seasoned_dungeoneer_initiative_dispatches_room_trigger() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Stock P0's library with two basics so the Secret Entrance
+    // "Search your library for a basic land" ability has legal choices.
+    scenario.add_card_to_library_top(P0, "Plains");
+    scenario.add_card_to_library_top(P0, "Forest");
+
+    let seasoned = scenario
+        .add_creature_to_hand_from_oracle(P0, "Seasoned Dungeoneer", 3, 4, SEASONED_ETB)
+        .id();
+
+    let mut runner = scenario.build();
+    cast_creature_from_hand(&mut runner, seasoned);
+
+    let state = runner.state();
+
+    // CR 726.3: initiative is set on the controller.
+    assert_eq!(
+        state.initiative,
+        Some(P0),
+        "CR 726.3: P0 must hold the initiative after the ETB resolves"
+    );
+
+    // CR 726.2 + CR 701.49: P0 enters Undercity at room 0.
+    let progress = state
+        .dungeon_progress
+        .get(&P0)
+        .expect("P0 must have dungeon progress after venturing");
+    assert_eq!(progress.current_dungeon, Some(DungeonId::Undercity));
+    assert_eq!(progress.current_room, 0);
+
+    // CR 309.4c regression guard (issue #587): the Secret Entrance room
+    // trigger must have been dispatched through the standard pipeline.
+    // Before the fix, `queue_room_trigger` left the trigger orphaned in
+    // `state.pending_trigger` and no engine path consumed it. After the fix
+    // it goes on the stack (or opens a follow-on prompt) and resolves —
+    // so `pending_trigger` is always cleared by the time the dust settles.
+    assert!(
+        state.pending_trigger.is_none(),
+        "Issue #587: state.pending_trigger must be drained by dispatch_synthetic_trigger; \
+         got {:?}",
+        state.pending_trigger,
+    );
+
+    // Belt-and-braces: at least one game-rule path consumed the room trigger.
+    // Either it's resolving on the stack right now (search has begun and is
+    // waiting on the player), or it has already resolved and been popped.
+    let room_trigger_on_stack = state
+        .stack
+        .iter()
+        .any(|e| e.source_id == dungeon_sentinel_id(P0));
+    let opened_search_prompt = matches!(state.waiting_for, WaitingFor::SearchChoice { .. });
+    let stack_clean = state.stack.is_empty();
+    assert!(
+        room_trigger_on_stack || opened_search_prompt || stack_clean,
+        "Issue #587: Undercity room trigger must have reached the dispatch pipeline; \
+         stack = {:?}, waiting_for = {:?}",
+        state.stack.iter().map(|e| e.source_id).collect::<Vec<_>>(),
+        state.waiting_for,
+    );
+}
+
+/// (b) Re-take path: P0 already holds initiative and is in Undercity at
+/// room 0 (a branch point: {1, 2}). Casting Seasoned Dungeoneer still
+/// ventures (CR 726.5), but lands on the branch-choice prompt before
+/// `queue_room_trigger` runs — so `pending_trigger` must remain `None`.
+#[test]
+fn seasoned_dungeoneer_initiative_retake_lands_on_room_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let seasoned = scenario
+        .add_creature_to_hand_from_oracle(P0, "Seasoned Dungeoneer", 3, 4, SEASONED_ETB)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Pre-seed initiative + Undercity room 0 on P0.
+    {
+        let state = runner.state_mut();
+        state.initiative = Some(P0);
+        let progress = state.dungeon_progress.entry(P0).or_default();
+        progress.current_dungeon = Some(DungeonId::Undercity);
+        progress.current_room = 0;
+    }
+
+    cast_creature_from_hand(&mut runner, seasoned);
+
+    let state = runner.state();
+
+    // CR 726.5: re-taking initiative still ventures. Undercity room 0
+    // branches to rooms 1 and 2, so we land on ChooseDungeonRoom.
+    match &state.waiting_for {
+        WaitingFor::ChooseDungeonRoom {
+            dungeon, options, ..
+        } => {
+            assert_eq!(*dungeon, DungeonId::Undercity);
+            assert_eq!(options.as_slice(), &[1, 2]);
+        }
+        other => panic!("expected ChooseDungeonRoom on re-take, got {other:?}"),
+    }
+
+    // No queue_room_trigger call is made on this path, so no orphan can exist.
+    assert!(
+        state.pending_trigger.is_none(),
+        "Issue #587: branch-point re-take must not leave a pending trigger; got {:?}",
+        state.pending_trigger,
+    );
+}


### PR DESCRIPTION
## Summary
Fixes #587. After `Effect::TakeTheInitiative` resolved, the synthetic Undercity room trigger queued by `effects::venture::queue_room_trigger` was orphaned in `state.pending_trigger` and never reached the stack: initiative was gained and `dungeon_progress` advanced, but the Secret Entrance "search for a basic land" trigger silently never fired. The bug affected every dungeon-room trigger (all four `queue_room_trigger` call sites), not just the initiative path. The fix routes synthetic room triggers through the standard dispatch pipeline so they land on the stack (or open the target prompt for targeted rooms like Forge of Heroes / Lost Well / Trap! / Arena) identically to natural triggers.

Closes #587.

## Files changed
- `crates/engine/src/game/triggers.rs` — new `pub(crate) fn dispatch_synthetic_trigger` delegating to `dispatch_pending_trigger_context`
- `crates/engine/src/game/effects/venture.rs` — `queue_room_trigger` takes `events: &mut Vec<GameEvent>` and dispatches via the new helper; obsolete `debug_assert!` removed; 3 call sites + 3 unit tests updated
- `crates/engine/tests/integration/main.rs` — module registration
- `crates/engine/tests/integration/seasoned_dungeoneer_initiative_room_trigger.rs` — 2 regression tests (fresh-game ETB path and re-take branch-point path)

## CR references
- CR 603.2 — trigger event matching
- CR 603.3b — multi-trigger ordering
- CR 309.4c — room ability is a triggered ability (must reach the stack)

## Track
Developer

## LLM
Model: Claude Opus 4.7
Thinking: medium

## Verification
- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p engine` — 9163 pass / 0 fail (includes 2 new regression tests)
- Frontend type-check + lint + vitest — green
- Pipeline: doc-guardian CLEAN; code-reviewer APPROVE (after one fix-loop correcting CR 725 → CR 726 citation drift and dropping a spurious CR 113.2c anchor); qa-tester READY FOR PR.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

## Follow-ups (out of scope for this PR)
- Pre-existing CR 725.x misnumbering for Initiative behavior on `main` at `crates/engine/src/game/effects/venture.rs:42,44,53,62,502` and `crates/engine/src/game/triggers.rs:1408,1422,1485,1505`. Flagged by code-reviewer as a CR-annotation cleanup pass.
- `crates/engine/src/game/effects/mod.rs:3630` (reflexive-trigger path) is a realistic future migration target for `dispatch_synthetic_trigger` — the current path bypasses target-slot reconciliation. Not addressed here to keep the diff surgical.