### PR TITLE
Fix High Alert defender subject parsing

### DIFF
--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -5752,6 +5752,7 @@ fn parse_creature_subject_filter(subject: &str) -> Option<TargetFilter> {
         prefix.trim()
     } else if !descriptor_text.contains(' ') && descriptor_text.to_lowercase().ends_with('s') {
         if descriptor_text.eq_ignore_ascii_case("creatures") {
+            // CR 205.2a: "creatures" names the creature card type, not a creature subtype.
             let mut typed = TypedFilter::creature();
             if let Some(controller) = controller {
                 typed = typed.controller(controller);
@@ -5778,6 +5779,7 @@ fn parse_creature_subject_filter(subject: &str) -> Option<TargetFilter> {
     };
 
     if descriptor.eq_ignore_ascii_case("creature") {
+        // CR 205.2a: "creature" names the creature card type, not a creature subtype.
         let mut typed = TypedFilter::creature();
         if let Some(controller) = controller {
             typed = typed.controller(controller);

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -5751,6 +5751,16 @@ fn parse_creature_subject_filter(subject: &str) -> Option<TargetFilter> {
     let descriptor = if let Some(prefix) = descriptor_text.strip_suffix(" creatures") {
         prefix.trim()
     } else if !descriptor_text.contains(' ') && descriptor_text.to_lowercase().ends_with('s') {
+        if descriptor_text.eq_ignore_ascii_case("creatures") {
+            let mut typed = TypedFilter::creature();
+            if let Some(controller) = controller {
+                typed = typed.controller(controller);
+            }
+            if has_other {
+                typed = typed.properties(vec![FilterProp::Another]);
+            }
+            return Some(TargetFilter::Typed(typed));
+        }
         // CR 205.3m: Use parse_subtype for irregular plurals (Elves→Elf, Dwarves→Dwarf)
         if let Some((canonical, _)) = parse_subtype(descriptor_text) {
             let mut typed = TypedFilter::creature().subtype(canonical);
@@ -5766,6 +5776,17 @@ fn parse_creature_subject_filter(subject: &str) -> Option<TargetFilter> {
     } else {
         return None;
     };
+
+    if descriptor.eq_ignore_ascii_case("creature") {
+        let mut typed = TypedFilter::creature();
+        if let Some(controller) = controller {
+            typed = typed.controller(controller);
+        }
+        if has_other {
+            typed = typed.properties(vec![FilterProp::Another]);
+        }
+        return Some(TargetFilter::Typed(typed));
+    }
 
     if descriptor.is_empty() {
         return None;
@@ -12728,7 +12749,20 @@ mod tests {
         )
         .unwrap();
         assert_eq!(def.mode, StaticMode::CanAttackWithDefender);
-        assert!(matches!(def.affected, Some(TargetFilter::Typed(_))));
+        let Some(TargetFilter::Typed(tf)) = def.affected else {
+            panic!("expected typed affected filter, got {:?}", def.affected);
+        };
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(
+            tf.type_filters.contains(&TypeFilter::Creature),
+            "expected Creature type filter, got {:?}",
+            tf.type_filters
+        );
+        assert!(
+            tf.get_subtype().is_none(),
+            "generic creatures must not become a Creature subtype filter: {:?}",
+            tf
+        );
     }
 
     #[test]
@@ -15131,7 +15165,26 @@ mod tests {
     }
 
     #[test]
-    fn parse_creature_subject_filter_irregular_plurals() {
+    fn parse_creature_subject_filter_generic_and_irregular_plurals() {
+        let filter = super::parse_creature_subject_filter("Creatures you control").unwrap();
+        if let TargetFilter::Typed(tf) = &filter {
+            assert!(tf.type_filters.contains(&TypeFilter::Creature));
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert_eq!(tf.get_subtype(), None);
+        } else {
+            panic!("Expected generic Creature filter, got {:?}", filter);
+        }
+
+        let filter = super::parse_creature_subject_filter("Other creatures you control").unwrap();
+        if let TargetFilter::Typed(tf) = &filter {
+            assert!(tf.type_filters.contains(&TypeFilter::Creature));
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert_eq!(tf.get_subtype(), None);
+            assert!(tf.properties.contains(&FilterProp::Another));
+        } else {
+            panic!("Expected generic other Creature filter, got {:?}", filter);
+        }
+
         // Single-word plural subtypes should resolve via parse_subtype
         let filter = super::parse_creature_subject_filter("Elves").unwrap();
         if let TargetFilter::Typed(tf) = &filter {


### PR DESCRIPTION
Fixes #858.

## Summary
- Fix generic creature subject parsing so `Creatures you control` maps to a `Creature` type filter, not `Subtype("Creature")`.
- Preserve existing controller and `Other` handling for subject filters.
- High Alert now exports `CanAttackWithDefender` for controlled creatures so its static ability can actually match ordinary creatures with defender.

## Files Changed
- `crates/engine/src/parser/oracle_static.rs`

## CR References
- Added verified CR 205.2a annotations for the generic `creature` / `creatures` parser branches.
- Touched behavior remains covered by existing parser/test references for CR 702.3b and CR 205.3m.

## AI Contribution
- Track: Developer
- Model: codex-5
- Thinking: high
- Tier: Standard

## Gate A
- `./scripts/check-parser-combinators.sh` - clean (exit 0, no output)

## Anchored On
- `crates/engine/src/parser/oracle_static.rs:5731` - existing subject controller suffix handling (`you control` / `your opponents control`).
- `crates/engine/src/parser/oracle_static.rs:5743` - existing `Other` preservation path.
- `crates/engine/src/parser/oracle_static.rs:5764` - existing irregular plural subtype path that the generic guard now precedes.

## Verification
- `cargo fmt --all -- --check` - clean
- `./scripts/check-parser-combinators.sh` - clean
- `cargo test -p engine static_can_attack_despite_defender_creatures_you_control_they` - passed
- `cargo test -p engine parse_creature_subject_filter_generic_and_irregular_plurals` - passed
- `./scripts/gen-card-data.sh` - clean; High Alert `CanAttackWithDefender` exports `Creature` + `controller: You`, with no `Subtype("Creature")`
- `cargo clippy --all-targets -- -D warnings` - clean
- `cargo test -p engine` - passed (`8699 passed; 0 failed; 1 ignored` unit, `462 passed; 0 failed` integration, doctests `0 failed; 7 ignored`)

## Scope Expansion
- None.

## Validation Failures
- None.

## CI Failures
- None.
