### PR TITLE
fix(parser): recognize contracted "it's not" in token-copy except clauses

### DIFF
--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -1325,6 +1325,86 @@ mod tests {
         );
     }
 
+    /// CR 704.5j + CR 707.9b: Issue #685 regression. When token-copy strips
+    /// the Legendary supertype via `additional_modifications`, the legend
+    /// rule SBA must NOT prompt the controller to choose which copy to
+    /// sacrifice — the token is no longer Legendary, so there is exactly one
+    /// Legendary permanent with the shared name (the original). Both
+    /// permanents must remain on the battlefield. This is the SBA-side
+    /// counterpart to the parser-side fix for the contracted "it's not
+    /// legendary" form (Delina, Wild Mage; Ratadrabik of Urborg; etc.).
+    #[test]
+    fn legend_rule_does_not_fire_when_copy_token_drops_legendary() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bahamut".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let s = state.objects.get_mut(&source_id).unwrap();
+            s.base_power = Some(7);
+            s.base_toughness = Some(7);
+            s.power = Some(7);
+            s.toughness = Some(7);
+            s.base_card_types = CardType {
+                supertypes: vec![Supertype::Legendary],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec!["Dragon".to_string()],
+            };
+            s.card_types = s.base_card_types.clone();
+        }
+
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::Any,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![ContinuousModification::RemoveSupertype {
+                    supertype: Supertype::Legendary,
+                }],
+            },
+            vec![TargetRef::Object(source_id)],
+            source_id,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let token_id = ObjectId(state.next_object_id - 1);
+
+        // Run state-based actions; the legend rule SBA must NOT fire because
+        // the token is not Legendary.
+        let mut sba_events = Vec::new();
+        crate::game::sba::check_state_based_actions(&mut state, &mut sba_events);
+
+        assert!(
+            !matches!(
+                state.waiting_for,
+                crate::types::game_state::WaitingFor::ChooseLegend { .. }
+            ),
+            "legend rule must not present a choice when token is not legendary; \
+             got waiting_for={:?}",
+            state.waiting_for
+        );
+        assert_eq!(
+            state.objects[&source_id].zone,
+            Zone::Battlefield,
+            "original legendary creature must remain on battlefield"
+        );
+        assert_eq!(
+            state.objects[&token_id].zone,
+            Zone::Battlefield,
+            "non-legendary token-copy must remain on battlefield"
+        );
+    }
+
     /// CR 122.1 + CR 614.1c: AddCounterOnEnter with matching `if_type` places
     /// the counter on the synthesized token. Spark Double's planeswalker copy
     /// branch is exercised at the BecomeCopy resolver site; this test pins

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -1377,7 +1377,7 @@ mod tests {
         );
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        let token_id = ObjectId(state.next_object_id - 1);
+        let token_id = state.last_created_token_ids[0];
 
         // Run state-based actions; the legend rule SBA must NOT fire because
         // the token is not Legendary.

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -412,28 +412,39 @@ fn split_single_quoted_ability(input: &str) -> Option<(&str, &str)> {
 }
 
 /// CR 205.4 + CR 707.9b: Match `"the token isn't <supertype>"` /
-/// `"it isn't <supertype>"` (and apostrophe-free / "is not" variants).
+/// `"it isn't <supertype>"` (and apostrophe-free, "is not", and contracted
+/// `"it's not"` variants).
 /// Emits [`ContinuousModification::RemoveSupertype`].
 ///
 /// Miirym, Sentinel Wyrm: `"create a token that's a copy of it, except the
 /// token isn't legendary"` is the canonical case. The arm is permissive about
 /// subject phrasing because both forms appear across token-copy and
 /// replacement-copy texts (Spark Double's `"and it isn't legendary"` is the
-/// replacement-form variant).
+/// replacement-form variant). The contracted negated-copula form `"it's not
+/// legendary"` (Delina, Wild Mage; Ember Island Production; Ratadrabik of
+/// Urborg; etc.) is also accepted with both ASCII and curly apostrophes.
 fn parse_isnt_supertype(input: &str) -> Option<(&str, ContinuousModification)> {
     let (rest, _) = alt((
         tag::<_, _, OracleError<'_>>("the token isn't "),
         tag("the token isnt "),
         tag("the token is not "),
+        tag("the token's not "),
+        tag("the token\u{2019}s not "),
         tag("it isn't "),
         tag("it isnt "),
         tag("it is not "),
+        tag("it's not "),
+        tag("it\u{2019}s not "),
         tag("he isn't "),
         tag("he isnt "),
         tag("he is not "),
+        tag("he's not "),
+        tag("he\u{2019}s not "),
         tag("she isn't "),
         tag("she isnt "),
         tag("she is not "),
+        tag("she's not "),
+        tag("she\u{2019}s not "),
     ))
     .parse(input)
     .ok()?;
@@ -1022,6 +1033,128 @@ mod tests {
             vec![ContinuousModification::RemoveSupertype {
                 supertype: Supertype::Legendary,
             }]
+        );
+    }
+
+    /// CR 205.4 + CR 707.9b: contracted negated-copula form "it's not
+    /// legendary" (Delina, Wild Mage; Ratadrabik of Urborg; Jace, Mirror Mage;
+    /// etc.). Issue #685: previously fell through, leaving the token Legendary
+    /// and triggering the legend rule (CR 704.5j) against the original.
+    #[test]
+    fn it_is_not_legendary_contracted_emits_remove_supertype() {
+        let (_, mods) = parse_except_clause(
+            ", except it's not legendary",
+            "Card",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            mods,
+            vec![ContinuousModification::RemoveSupertype {
+                supertype: Supertype::Legendary,
+            }]
+        );
+    }
+
+    /// CR 205.4 + CR 707.9b: curly-apostrophe variant of the contracted
+    /// negated-copula form. Mirrors the apostrophe-pair parity used by
+    /// `parse_subject_pt_and_types` and `parse_is_supertype_in_addition`.
+    #[test]
+    fn its_not_legendary_curly_apostrophe_emits_remove_supertype() {
+        let (_, mods) = parse_except_clause(
+            ", except it\u{2019}s not legendary",
+            "Card",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            mods,
+            vec![ContinuousModification::RemoveSupertype {
+                supertype: Supertype::Legendary,
+            }]
+        );
+    }
+
+    /// CR 707.9a + CR 707.9b: Delina, Wild Mage's full token-copy except clause
+    /// chains the contracted "it's not legendary" with a quoted triggered
+    /// ability. Both modifications must flow through together; previously the
+    /// contracted form was dropped, leaving the token Legendary. The granted
+    /// ability variant (GrantTrigger vs GrantAbility) depends on whether the
+    /// quoted body's trigger condition is recognised — either is acceptable
+    /// here; the assertion is that *some* granted-ability modification
+    /// accompanies the RemoveSupertype, not that the contracted form blocks
+    /// the trailing " and " conjunction.
+    #[test]
+    fn token_compound_clause_strips_legendary_and_grants_ability() {
+        let (_, mods) = parse_except_clause(
+            ", except it's not legendary and it has \"when ~ enters, draw a card.\"",
+            "Card",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            mods.len(),
+            2,
+            "expected RemoveSupertype + a granted ability; got {mods:?}"
+        );
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::RemoveSupertype {
+                    supertype: Supertype::Legendary
+                }
+            )),
+            "missing RemoveSupertype(Legendary); got {mods:?}"
+        );
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::GrantTrigger { .. }
+                    | ContinuousModification::GrantAbility { .. }
+            )),
+            "missing granted ability (GrantTrigger or GrantAbility); got {mods:?}"
+        );
+    }
+
+    /// CR 707.9b: Ember Island Production's first-mode body chains the
+    /// contracted "it's not legendary" with a P/T+subtype override. Both
+    /// halves are characteristic modifications (RemoveSupertype + SetPower +
+    /// SetToughness + AddSubtype), so 707.9b covers the full clause. Confirms
+    /// the contracted negated-copula does not block the
+    /// `parse_subject_pt_and_types` arm that follows the " and " conjunction.
+    #[test]
+    fn token_compound_clause_strips_legendary_and_sets_pt_subtype() {
+        let (_, mods) = parse_except_clause(
+            ", except it's not legendary and it's a 4/4 hero in addition to its other types",
+            "Card",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::RemoveSupertype {
+                    supertype: Supertype::Legendary
+                }
+            )),
+            "missing RemoveSupertype(Legendary); got {mods:?}"
+        );
+        assert!(
+            mods.iter()
+                .any(|m| matches!(m, ContinuousModification::SetPower { value: 4 })),
+            "missing SetPower(4); got {mods:?}"
+        );
+        assert!(
+            mods.iter()
+                .any(|m| matches!(m, ContinuousModification::SetToughness { value: 4 })),
+            "missing SetToughness(4); got {mods:?}"
+        );
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddSubtype { subtype } if subtype == "Hero"
+            )),
+            "missing AddSubtype(Hero); got {mods:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes #685 — non-legendary copy tokens triggering the legend rule.

`parse_isnt_supertype` in `become_copy_except.rs` only recognised non-contracted
negated copulas ("it isn't", "it is not"), so cards printing the contracted form
("…except it's not legendary") silently dropped the `RemoveSupertype(Legendary)`
modification from the AST. The resulting token retained the Legendary supertype
and CR 704.5j fired against it + the original, forcing the user to sacrifice
one. This change adds the eight contracted-form `tag()` arms (`it's not`,
`he's not`, `she's not`, `the token's not`, in ASCII + curly-apostrophe
variants) and adds a token-copy SBA-interaction test asserting the legend rule
does not fire when the copy drops Legendary.

Cards now correctly producing non-legendary copy tokens: Delina, Wild Mage;
Ember Island Production; Ratadrabik of Urborg; Jace, Mirror Mage; Shaun,
Father of Synths; The Majestic Duo; Vesuvan Duplimancy; Dedicated Dollmaker;
I Am Never Alone; Ran and Shaw.

## Files changed
- crates/engine/src/parser/oracle_effect/become_copy_except.rs
- crates/engine/src/game/effects/token_copy.rs

## CR references
- CR 704.5j — legend rule SBA
- CR 707.9b — copy modifications (token-copy "except" clauses)
- CR 707.9a — copiable values applied at creation
- CR 205.4 — supertypes

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo clippy-strict` — clean (qa-tester)
- `cargo test -p engine` — 9166 pass / 0 fail (qa-tester)
- `./scripts/gen-card-data.sh` — Delina + Ember Island Production emit
  `RemoveSupertype(Legendary)`; no Unimplemented regressions
- Pipeline gates: doc-guardian CLEAN, code-reviewer APPROVE WITH SUGGESTIONS
  (no BUG / RULES BUG), qa-tester READY FOR PR

## Follow-ups (non-blocking)
- `parse_isnt_supertype`'s `alt()` now has 20/21 arms (Cartesian growth across
  subject × verb-form × apostrophe-form). Adding one more apostrophe-form
  variant will hit nom's tuple-alt ceiling. Recommend a follow-up issue to
  refactor by nesting `preceded(alt(<subjects>), alt(<verb-forms>))`.
- Ratadrabik of Urborg also prints "…and it's a 2/2 black Zombie in addition
  to its other colors and types". This PR resolves the legend-rule axis for
  Ratadrabik, but the P/T + color + Zombie half still drops because
  `parse_subject_pt_and_types` only handles "in addition to its/his/her other
  types", not the "colors and types" variant. Recommend a follow-up issue.
- Building-block coverage is Cartesian in code but tests only exercise the
  `it`-subject arms (no live MTG card uses `he's not` / `she's not` /
  `the token's not` today). Deferred — no live regression risk.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.