### PR TITLE
fix(server-core): redact pending_trigger_order for non-controllers (#573)

### DIFF
--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -444,6 +444,20 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         }
     }
 
+    // CR 603.3b + CR 400.2: Per-controller ordering pass — keep the
+    // placement spine visible to everyone (groups, group sizes,
+    // controllers, ordered flags) but strip each group's private
+    // payload from viewers who are not that group's controller.
+    if let Some(order) = filtered.pending_trigger_order.as_mut() {
+        for group in &mut order.groups {
+            if !can_view_private_for_player(group.controller) {
+                for ctx in &mut group.triggers {
+                    redact_pending_trigger_context_for_observer(ctx);
+                }
+            }
+        }
+    }
+
     filtered
 }
 
@@ -476,6 +490,29 @@ fn hide_card(state: &mut GameState, obj_id: ObjectId) {
         obj.source_related_token_ids.clear();
         obj.foretold = false;
     }
+}
+
+/// CR 603.3b + CR 400.2: A pending trigger awaiting its
+/// controller's ordering choice may carry private data —
+/// the firing `GameEvent` can reference hidden-zone objects
+/// (library look/scry/surveil/mill triggers), and the
+/// modal/distribute/mode_abilities/description fields describe
+/// the controller's not-yet-public choices. Strip every payload
+/// an opponent has no rules-permission to see, leaving only
+/// the public spine (source_id, controller, timestamp, ability,
+/// condition, target_constraints, subject_match_count,
+/// may_trigger_origin) needed for the engine to keep running on
+/// the wire and for the opponent's frontend to render an
+/// "opponent is ordering N triggers" indicator.
+fn redact_pending_trigger_context_for_observer(
+    ctx: &mut crate::game::triggers::PendingTriggerContext,
+) {
+    ctx.pending.trigger_event = None;
+    ctx.pending.modal = None;
+    ctx.pending.distribute = None;
+    ctx.pending.mode_abilities.clear();
+    ctx.pending.description = None;
+    ctx.trigger_events.clear();
 }
 
 #[cfg(test)]

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -458,6 +458,27 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         }
     }
 
+    // CR 603.3b + CR 400.2: Same redaction surface applies to the singleton
+    // `pending_trigger` (the currently-targeting trigger) and its sidecar
+    // `pending_trigger_event_batch` (full simultaneous-event set consumed when
+    // it reaches the stack). Gate on the pending trigger's own controller.
+    if let Some(pending) = filtered.pending_trigger.as_mut() {
+        if !can_view_private_for_player(pending.controller) {
+            redact_pending_trigger_for_observer(pending);
+            filtered.pending_trigger_event_batch.clear();
+        }
+    }
+
+    // CR 113.2c + CR 603.2 + CR 603.3b: `deferred_triggers` holds the FIFO
+    // queue of same-pass triggers waiting on the active `pending_trigger` to
+    // resolve. Each entry is a `PendingTriggerContext` with the same private
+    // payload shape — redact per controller.
+    for ctx in &mut filtered.deferred_triggers {
+        if !can_view_private_for_player(ctx.pending.controller) {
+            redact_pending_trigger_context_for_observer(ctx);
+        }
+    }
+
     filtered
 }
 
@@ -504,14 +525,22 @@ fn hide_card(state: &mut GameState, obj_id: ObjectId) {
 /// may_trigger_origin) needed for the engine to keep running on
 /// the wire and for the opponent's frontend to render an
 /// "opponent is ordering N triggers" indicator.
+fn redact_pending_trigger_for_observer(pending: &mut crate::game::triggers::PendingTrigger) {
+    pending.trigger_event = None;
+    pending.modal = None;
+    pending.distribute = None;
+    pending.mode_abilities.clear();
+    pending.description = None;
+}
+
+/// CR 603.3b + CR 400.2: Wrapping-context variant of
+/// [`redact_pending_trigger_for_observer`] that also clears the
+/// `trigger_events` sidecar (the full simultaneous-event set for
+/// batched triggers, which can reference hidden-zone objects).
 fn redact_pending_trigger_context_for_observer(
     ctx: &mut crate::game::triggers::PendingTriggerContext,
 ) {
-    ctx.pending.trigger_event = None;
-    ctx.pending.modal = None;
-    ctx.pending.distribute = None;
-    ctx.pending.mode_abilities.clear();
-    ctx.pending.description = None;
+    redact_pending_trigger_for_observer(&mut ctx.pending);
     ctx.trigger_events.clear();
 }
 

--- a/crates/server-core/src/filter.rs
+++ b/crates/server-core/src/filter.rs
@@ -615,6 +615,111 @@ mod tests {
         assert_eq!(p1_own_ctx.trigger_events.len(), 1);
     }
 
+    /// CR 603.3b + CR 400.2: The singleton `pending_trigger` and its sidecar
+    /// `pending_trigger_event_batch` carry the same private payload shape as
+    /// the entries inside `pending_trigger_order`. Opponents must see only
+    /// the public spine; the controller still sees the full payload.
+    #[test]
+    fn pending_trigger_and_event_batch_redact_for_opponent() {
+        use engine::types::events::GameEvent;
+
+        let controller = PlayerId(0);
+        let source_id = ObjectId(303);
+        let ctx = make_pending_ctx_with_private_payload(
+            controller,
+            source_id,
+            "pending trigger private description",
+        );
+
+        let mut state = GameState::new_two_player(42);
+        state.pending_trigger = Some(ctx.pending.clone());
+        state.pending_trigger_event_batch = vec![GameEvent::GameStarted];
+
+        // Controller view: payload intact, batch intact.
+        let owner_view = filter_state_for_player(&state, controller);
+        let owner_pending = owner_view
+            .pending_trigger
+            .as_ref()
+            .expect("controller must still see pending_trigger");
+        assert_eq!(owner_pending.source_id, source_id);
+        assert!(owner_pending.trigger_event.is_some());
+        assert!(owner_pending.modal.is_some());
+        assert_eq!(
+            owner_pending.description.as_deref(),
+            Some("pending trigger private description")
+        );
+        assert_eq!(owner_pending.mode_abilities.len(), 1);
+        assert_eq!(owner_view.pending_trigger_event_batch.len(), 1);
+
+        // Opponent view: spine preserved, payload + sidecar cleared.
+        let opp_view = filter_state_for_player(&state, PlayerId(1));
+        let opp_pending = opp_view
+            .pending_trigger
+            .as_ref()
+            .expect("opponent must still see pending_trigger spine");
+        assert_eq!(opp_pending.source_id, source_id);
+        assert_eq!(opp_pending.controller, controller);
+        assert!(opp_pending.trigger_event.is_none());
+        assert!(opp_pending.modal.is_none());
+        assert!(opp_pending.distribute.is_none());
+        assert!(opp_pending.description.is_none());
+        assert!(opp_pending.mode_abilities.is_empty());
+        assert!(opp_view.pending_trigger_event_batch.is_empty());
+    }
+
+    /// CR 113.2c + CR 603.2 + CR 603.3b: `deferred_triggers` is a FIFO queue
+    /// of `PendingTriggerContext`s waiting on the active `pending_trigger` to
+    /// resolve. Redaction must be per-entry — a viewer who controls one entry
+    /// but not another sees only the controlled one's private payload.
+    #[test]
+    fn deferred_triggers_redact_per_entry_for_opponent() {
+        let ctx0 = make_pending_ctx_with_private_payload(
+            PlayerId(0),
+            ObjectId(401),
+            "p0 deferred description",
+        );
+        let ctx1 = make_pending_ctx_with_private_payload(
+            PlayerId(1),
+            ObjectId(402),
+            "p1 deferred description",
+        );
+
+        let mut state = GameState::new_two_player(42);
+        state.deferred_triggers = vec![ctx0, ctx1];
+
+        let p0_view = filter_state_for_player(&state, PlayerId(0));
+        assert_eq!(p0_view.deferred_triggers.len(), 2);
+        let p0_own = &p0_view.deferred_triggers[0];
+        assert!(p0_own.pending.trigger_event.is_some());
+        assert!(p0_own.pending.modal.is_some());
+        assert_eq!(
+            p0_own.pending.description.as_deref(),
+            Some("p0 deferred description")
+        );
+        let p0_opp = &p0_view.deferred_triggers[1];
+        assert_eq!(p0_opp.pending.source_id, ObjectId(402));
+        assert_eq!(p0_opp.pending.controller, PlayerId(1));
+        assert!(p0_opp.pending.trigger_event.is_none());
+        assert!(p0_opp.pending.modal.is_none());
+        assert!(p0_opp.pending.description.is_none());
+        assert!(p0_opp.pending.mode_abilities.is_empty());
+        assert!(p0_opp.trigger_events.is_empty());
+
+        let p1_view = filter_state_for_player(&state, PlayerId(1));
+        let p1_opp = &p1_view.deferred_triggers[0];
+        assert_eq!(p1_opp.pending.controller, PlayerId(0));
+        assert!(p1_opp.pending.trigger_event.is_none());
+        assert!(p1_opp.pending.modal.is_none());
+        assert!(p1_opp.pending.description.is_none());
+        let p1_own = &p1_view.deferred_triggers[1];
+        assert!(p1_own.pending.trigger_event.is_some());
+        assert!(p1_own.pending.modal.is_some());
+        assert_eq!(
+            p1_own.pending.description.as_deref(),
+            Some("p1 deferred description")
+        );
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig {
             cases: 16,

--- a/crates/server-core/src/filter.rs
+++ b/crates/server-core/src/filter.rs
@@ -340,9 +340,15 @@ mod tests {
     /// CR 603.3b: `WaitingFor::OrderTriggers` carries only public information
     /// (triggers on their way to the shared stack). The variant must survive
     /// `filter_state_for_player` unchanged for both the prompted player and
-    /// the opponent — no hiding, no redaction. `pending_trigger_order` is
-    /// engine-internal scheduling state that references battlefield/stack
-    /// objects only; it must also pass through unchanged.
+    /// the opponent — no hiding, no redaction. The parallel
+    /// `pending_trigger_order` state, by contrast, IS per-controller redacted:
+    /// its placement spine (groups, controllers, ordered flags, group sizes)
+    /// stays visible to everyone, but each group's private trigger payload
+    /// (firing event, modal choice, distribution, mode descriptions) is
+    /// stripped for viewers who don't control that group. That redaction is
+    /// covered by `pending_trigger_order_redacts_private_payload_for_opponent`
+    /// and `pending_trigger_order_redacts_per_group_in_multi_group_order`
+    /// below.
     #[test]
     fn order_triggers_waiting_for_passes_through_to_both_players() {
         use engine::types::game_state::PendingTriggerSummary;
@@ -377,6 +383,236 @@ mod tests {
                 ),
             }
         }
+    }
+
+    /// Build a minimal `PendingTriggerContext` whose private fields are all
+    /// populated, so a viewer-side redaction can be verified by checking that
+    /// each field is cleared/`None`.
+    fn make_pending_ctx_with_private_payload(
+        controller: PlayerId,
+        source_id: ObjectId,
+        description: &str,
+    ) -> engine::game::triggers::PendingTriggerContext {
+        use engine::game::triggers::{PendingTrigger, PendingTriggerContext};
+        use engine::types::ability::{ModalChoice, PlayerFilter, ResolvedAbility};
+        use engine::types::events::GameEvent;
+
+        let event = GameEvent::GameStarted;
+        let ability = ResolvedAbility::new(
+            Effect::Counter {
+                target: TargetFilter::Any,
+                source_rider: None,
+            },
+            Vec::new(),
+            source_id,
+            controller,
+        );
+        let modal = ModalChoice {
+            min_choices: 1,
+            max_choices: 1,
+            mode_count: 2,
+            mode_descriptions: vec!["mode A".into(), "mode B".into()],
+            allow_repeat_modes: false,
+            constraints: Vec::new(),
+            mode_costs: Vec::new(),
+            entwine_cost: None,
+            chooser: PlayerFilter::Controller,
+        };
+        let pending = PendingTrigger {
+            source_id,
+            controller,
+            condition: None,
+            ability,
+            timestamp: 0,
+            target_constraints: Vec::new(),
+            distribute: None,
+            trigger_event: Some(event.clone()),
+            modal: Some(modal),
+            mode_abilities: vec![AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Counter {
+                    target: TargetFilter::Any,
+                    source_rider: None,
+                },
+            )],
+            description: Some(description.to_string()),
+            may_trigger_origin: None,
+            subject_match_count: None,
+        };
+        PendingTriggerContext {
+            pending,
+            trigger_events: vec![event],
+        }
+    }
+
+    /// CR 603.3b + CR 400.2: A single-group `pending_trigger_order` (one
+    /// controller, one trigger with all private fields populated) must show
+    /// the full payload to the group's controller and a redacted payload —
+    /// `trigger_event`/`modal`/`distribute`/`description` cleared to `None`,
+    /// `mode_abilities` and `trigger_events` emptied — to the opponent. The
+    /// public spine (controller, source_id, timestamp, `ordered` flag) is
+    /// preserved for both viewers so the opponent's frontend can still
+    /// render an "opponent is ordering N triggers" indicator.
+    #[test]
+    fn pending_trigger_order_redacts_private_payload_for_opponent() {
+        use engine::types::game_state::{PendingTriggerOrder, TriggerOrderGroup};
+
+        let mut state = GameState::new_two_player(42);
+        let controller = PlayerId(0);
+        let source_id = ObjectId(42);
+        let ctx = make_pending_ctx_with_private_payload(
+            controller,
+            source_id,
+            "private mode description",
+        );
+        state.pending_trigger_order = Some(PendingTriggerOrder {
+            groups: vec![TriggerOrderGroup {
+                controller,
+                triggers: vec![ctx],
+                ordered: false,
+            }],
+            resume_after_ordering: None,
+        });
+
+        // Controller sees the full payload.
+        let owner_view = filter_state_for_player(&state, controller);
+        let owner_order = owner_view
+            .pending_trigger_order
+            .as_ref()
+            .expect("controller must still see pending_trigger_order");
+        assert_eq!(owner_order.groups.len(), 1);
+        let owner_group = &owner_order.groups[0];
+        assert_eq!(owner_group.controller, controller);
+        assert!(!owner_group.ordered);
+        assert_eq!(owner_group.triggers.len(), 1);
+        let owner_ctx = &owner_group.triggers[0];
+        assert_eq!(owner_ctx.pending.source_id, source_id);
+        assert!(owner_ctx.pending.trigger_event.is_some());
+        assert!(owner_ctx.pending.modal.is_some());
+        assert_eq!(
+            owner_ctx.pending.description.as_deref(),
+            Some("private mode description")
+        );
+        assert_eq!(owner_ctx.pending.mode_abilities.len(), 1);
+        assert_eq!(owner_ctx.trigger_events.len(), 1);
+
+        // Opponent sees the spine but no private payload.
+        let opp_view = filter_state_for_player(&state, PlayerId(1));
+        let opp_order = opp_view
+            .pending_trigger_order
+            .as_ref()
+            .expect("opponent must still see pending_trigger_order spine");
+        assert_eq!(opp_order.groups.len(), 1);
+        let opp_group = &opp_order.groups[0];
+        assert_eq!(opp_group.controller, controller);
+        assert!(!opp_group.ordered);
+        assert_eq!(opp_group.triggers.len(), 1);
+        let opp_ctx = &opp_group.triggers[0];
+        // Public spine preserved.
+        assert_eq!(opp_ctx.pending.source_id, source_id);
+        assert_eq!(opp_ctx.pending.controller, controller);
+        assert_eq!(opp_ctx.pending.timestamp, 0);
+        // Private payload redacted.
+        assert!(opp_ctx.pending.trigger_event.is_none());
+        assert!(opp_ctx.pending.modal.is_none());
+        assert!(opp_ctx.pending.distribute.is_none());
+        assert!(opp_ctx.pending.description.is_none());
+        assert!(opp_ctx.pending.mode_abilities.is_empty());
+        assert!(opp_ctx.trigger_events.is_empty());
+    }
+
+    /// CR 603.3b: A two-group `pending_trigger_order` (one group per player)
+    /// must redact each group's private payload independently for the viewer
+    /// who does NOT control that group. Each viewer sees their own group's
+    /// full payload and the other group's spine only.
+    #[test]
+    fn pending_trigger_order_redacts_per_group_in_multi_group_order() {
+        use engine::types::game_state::{PendingTriggerOrder, TriggerOrderGroup};
+
+        let mut state = GameState::new_two_player(42);
+        let ctx0 = make_pending_ctx_with_private_payload(
+            PlayerId(0),
+            ObjectId(101),
+            "p0 private description",
+        );
+        let ctx1 = make_pending_ctx_with_private_payload(
+            PlayerId(1),
+            ObjectId(202),
+            "p1 private description",
+        );
+        state.pending_trigger_order = Some(PendingTriggerOrder {
+            groups: vec![
+                TriggerOrderGroup {
+                    controller: PlayerId(0),
+                    triggers: vec![ctx0],
+                    ordered: false,
+                },
+                TriggerOrderGroup {
+                    controller: PlayerId(1),
+                    triggers: vec![ctx1],
+                    ordered: false,
+                },
+            ],
+            resume_after_ordering: None,
+        });
+
+        // PlayerId(0) view: own group full, opponent group redacted.
+        let p0_view = filter_state_for_player(&state, PlayerId(0));
+        let p0_order = p0_view
+            .pending_trigger_order
+            .as_ref()
+            .expect("pending_trigger_order must still be present");
+        assert_eq!(p0_order.groups.len(), 2);
+        let p0_own = &p0_order.groups[0];
+        assert_eq!(p0_own.controller, PlayerId(0));
+        assert_eq!(p0_own.triggers.len(), 1);
+        let p0_own_ctx = &p0_own.triggers[0];
+        assert!(p0_own_ctx.pending.trigger_event.is_some());
+        assert!(p0_own_ctx.pending.modal.is_some());
+        assert_eq!(
+            p0_own_ctx.pending.description.as_deref(),
+            Some("p0 private description")
+        );
+        assert_eq!(p0_own_ctx.trigger_events.len(), 1);
+
+        let p0_opp = &p0_order.groups[1];
+        assert_eq!(p0_opp.controller, PlayerId(1));
+        assert_eq!(p0_opp.triggers.len(), 1);
+        let p0_opp_ctx = &p0_opp.triggers[0];
+        assert_eq!(p0_opp_ctx.pending.source_id, ObjectId(202));
+        assert!(p0_opp_ctx.pending.trigger_event.is_none());
+        assert!(p0_opp_ctx.pending.modal.is_none());
+        assert!(p0_opp_ctx.pending.description.is_none());
+        assert!(p0_opp_ctx.pending.mode_abilities.is_empty());
+        assert!(p0_opp_ctx.trigger_events.is_empty());
+
+        // PlayerId(1) view: own group full, opponent group redacted.
+        let p1_view = filter_state_for_player(&state, PlayerId(1));
+        let p1_order = p1_view
+            .pending_trigger_order
+            .as_ref()
+            .expect("pending_trigger_order must still be present");
+        assert_eq!(p1_order.groups.len(), 2);
+        let p1_opp = &p1_order.groups[0];
+        assert_eq!(p1_opp.controller, PlayerId(0));
+        let p1_opp_ctx = &p1_opp.triggers[0];
+        assert_eq!(p1_opp_ctx.pending.source_id, ObjectId(101));
+        assert!(p1_opp_ctx.pending.trigger_event.is_none());
+        assert!(p1_opp_ctx.pending.modal.is_none());
+        assert!(p1_opp_ctx.pending.description.is_none());
+        assert!(p1_opp_ctx.pending.mode_abilities.is_empty());
+        assert!(p1_opp_ctx.trigger_events.is_empty());
+
+        let p1_own = &p1_order.groups[1];
+        assert_eq!(p1_own.controller, PlayerId(1));
+        let p1_own_ctx = &p1_own.triggers[0];
+        assert!(p1_own_ctx.pending.trigger_event.is_some());
+        assert!(p1_own_ctx.pending.modal.is_some());
+        assert_eq!(
+            p1_own_ctx.pending.description.as_deref(),
+            Some("p1 private description")
+        );
+        assert_eq!(p1_own_ctx.trigger_events.len(), 1);
     }
 
     proptest! {


### PR DESCRIPTION
## Summary
Fixes a multiplayer state-leak: `GameState.pending_trigger_order`, `pending_trigger`, `pending_trigger_event_batch`, and `deferred_triggers` were passing through `filter_state_for_player` unredacted, exposing each pending trigger's private payload (firing `GameEvent`, modal choice, distribution plan, mode-ability list, description, and the wrapping `trigger_events: Vec<GameEvent>`) to the opposing player. Per CR 603.3b (per-controller trigger ordering) and CR 400.2 (hidden zones must not leak via embedded events), opponents may see the public ordering spine but not the underlying choices.

## Files changed
- `crates/engine/src/game/visibility.rs`
- `crates/server-core/src/filter.rs`

## CR references
- CR 603.3b — per-controller trigger ordering: the order in which simultaneous triggers go on the stack is each controller's private choice
- CR 400.2 — hidden zones must not leak via embedded `GameEvent`s referencing library/hand objects
- CR 113.2c + CR 603.2 — deferred-trigger queue identity (per-entry redaction)

## Track
Developer

## LLM
Model: claude-opus-4-7
Tier: Frontier
Thinking: medium

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (zero warnings)
- `cargo test -p engine` — 9161 passed, 8 ignored
- `cargo test -p server-core` — 132 passed
- Named tests:
  - `pending_trigger_order_redacts_private_payload_for_opponent` — pass
  - `pending_trigger_order_redacts_per_group_in_multi_group_order` — pass
  - `pending_trigger_and_event_batch_redact_for_opponent` — pass (new, fixup)
  - `deferred_triggers_redact_per_entry_for_opponent` — pass (new, fixup)
  - `order_triggers_waiting_for_passes_through_to_both_players` — pass (regression-free)

## Scope expansion
Fixup commit `562a53bf5` extends the redaction to the three sibling fields on `GameState` that carry the same `PendingTrigger` / `PendingTriggerContext` private payload shape:
- `pending_trigger: Option<PendingTrigger>` (in-flight singleton)
- `pending_trigger_event_batch: Vec<GameEvent>` (its simultaneous-event sidecar, cleared in lockstep with the pending it serves)
- `deferred_triggers: Vec<DeferredTrigger>` (FIFO queue, per-entry gate)

Extracts `redact_pending_trigger_for_observer` (operates on the inner struct) so the new singleton redaction path and the existing context-wrapper path share one helper, satisfying the composable-building-blocks pillar. Addresses gemini-code-assist[bot] review feedback (HIGH: sibling coverage gap; MEDIUM: extract reusable helper).

## Follow-up / Known limitations
- Pre-existing CR citation drift at `crates/engine/src/game/visibility.rs:297` and `:425-432` conflates `CR 408` (Command zone) with stack-publicity arguments — the correct rule is `CR 405.4 + CR 400.2`. Not introduced by this PR; flagged for a future doc-only cleanup.

Closes #573