### PR TITLE
test(885): Urza's lands conditional mana coverage

### DIFF
--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -3014,6 +3014,11 @@ mod tests {
         );
     }
 
+    /// CR 614.1a positive case: the `Add {C}{C}{C} instead` sub-ability is a
+    /// replacement effect (the word "instead" per CR 614.1a). When its `And`
+    /// condition is satisfied (all three Urza lands controlled), the delta
+    /// replaces the base `Add {C}` production and the pool ends with three
+    /// colorless mana.
     #[test]
     fn resolve_mana_ability_conditional_urza_delta() {
         let mut state = GameState::new_two_player(42);
@@ -3097,6 +3102,96 @@ mod tests {
         assert_eq!(
             state.players[0].mana_pool.count_color(ManaType::Colorless),
             3
+        );
+    }
+
+    /// CR 614.1a negative case: when the sub-ability's "instead" replacement
+    /// (CR 614.1a) cannot fire because its condition is false (here, Urza's
+    /// Power-Plant is missing), only the base `Add {C}` resolves and the
+    /// `And { Mine, Power-Plant }` delta does not apply — the pool ends with
+    /// one colorless, not three. Mirrors
+    /// `resolve_mana_ability_conditional_urza_delta` but omits Power-Plant.
+    #[test]
+    fn resolve_mana_ability_urza_delta_skips_when_companion_land_missing() {
+        let mut state = GameState::new_two_player(42);
+        let tower = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Urza's Tower".to_string(),
+            Zone::Battlefield,
+        );
+        let mine = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Urza's Mine".to_string(),
+            Zone::Battlefield,
+        );
+        // Note: no Urza's Power Plant — the `And` condition cannot be
+        // satisfied, so the sub-ability must not fire.
+        for (id, subtype) in [(tower, "Tower"), (mine, "Mine")] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types.subtypes.push("Urza's".to_string());
+            obj.card_types.subtypes.push(subtype.to_string());
+        }
+
+        let ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::Colorless {
+                    count: QuantityExpr::Fixed { value: 1 },
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Tap)
+        .sub_ability(
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Mana {
+                    produced: ManaProduction::Colorless {
+                        count: QuantityExpr::Fixed { value: 2 },
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .condition(AbilityCondition::And {
+                conditions: vec![
+                    AbilityCondition::ControllerControlsMatching {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::land()
+                                .subtype("Mine".to_string())
+                                .controller(ControllerRef::You),
+                        ),
+                    },
+                    AbilityCondition::ControllerControlsMatching {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::land()
+                                .subtype("Power-Plant".to_string())
+                                .controller(ControllerRef::You),
+                        ),
+                    },
+                ],
+            }),
+        );
+
+        let mut events = Vec::new();
+        resolve_mana_ability(&mut state, tower, PlayerId(0), &ability, &mut events, None).unwrap();
+
+        assert_eq!(
+            state.players[0].mana_pool.count_color(ManaType::Colorless),
+            1,
+            "with Power-Plant absent the And condition is false and only the base \
+             Add {{C}} fires; pool = {:?}",
+            state.players[0].mana_pool.mana,
         );
     }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6419,6 +6419,113 @@ mod tests {
         }
     }
 
+    /// CR 205.3i + CR 614.1a + CR 605.1a: All three Urza lands share a single
+    /// parsed shape — an activated mana ability (`{T}: Add {C}.` per CR 605.1a)
+    /// plus a conditional `Add {C}{C}{C} instead` sub-ability whose "instead"
+    /// makes it a replacement effect (CR 614.1a) gated on the player
+    /// controlling the OTHER two Urza land subtypes (from the CR 205.3i land
+    /// type list: Mine, Power-Plant, Tower). The
+    /// critical assertion is the cross-naming of the `And` branches: a
+    /// regression that emits `[Mine, Mine]` instead of `[Mine, Power-Plant]`
+    /// would let Urza's Tower count itself as one of the required lands and
+    /// silently change the rules. Each row in the table below pins the exact
+    /// pair of subtypes the parsed condition must reference.
+    #[test]
+    fn urzas_lands_share_delta_shape() {
+        // (card name, oracle text, expected subtypes on the And conditions in
+        // the order the parser emits them)
+        let cases: [(&str, &str, [&str; 2], &[&str]); 3] = [
+            (
+                "Urza's Tower",
+                "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
+                ["Mine", "Power-Plant"],
+                &["Urza's", "Tower"],
+            ),
+            (
+                "Urza's Power Plant",
+                "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C}{C} instead.",
+                ["Mine", "Tower"],
+                &["Urza's", "Power-Plant"],
+            ),
+            (
+                "Urza's Mine",
+                "{T}: Add {C}. If you control an Urza's Power-Plant and an Urza's Tower, add {C}{C}{C} instead.",
+                ["Power-Plant", "Tower"],
+                &["Urza's", "Mine"],
+            ),
+        ];
+
+        for (name, text, expected_subs, subtypes) in cases {
+            let r = parse(text, name, &[], &["Land"], subtypes);
+            assert_eq!(r.abilities.len(), 1, "{name}: expected one ability");
+            let ability = &r.abilities[0];
+
+            match ability.effect.as_ref() {
+                Effect::Mana {
+                    produced: ManaProduction::Colorless { count },
+                    ..
+                } => assert_eq!(
+                    *count,
+                    QuantityExpr::Fixed { value: 1 },
+                    "{name}: base mana must be exactly one colorless"
+                ),
+                other => panic!("{name}: expected base colorless mana, got {other:?}"),
+            }
+
+            let sub = ability
+                .sub_ability
+                .as_ref()
+                .unwrap_or_else(|| panic!("{name}: expected conditional delta sub-ability"));
+
+            match sub.effect.as_ref() {
+                Effect::Mana {
+                    produced: ManaProduction::Colorless { count },
+                    ..
+                } => assert_eq!(
+                    *count,
+                    QuantityExpr::Fixed { value: 2 },
+                    "{name}: delta must be +2 colorless (total 3 minus base 1)"
+                ),
+                other => panic!("{name}: expected colorless mana delta, got {other:?}"),
+            }
+
+            let conditions = match sub
+                .condition
+                .as_ref()
+                .unwrap_or_else(|| panic!("{name}: expected sub-ability condition"))
+            {
+                AbilityCondition::And { conditions } => conditions,
+                other => panic!("{name}: expected And condition, got {other:?}"),
+            };
+            assert_eq!(
+                conditions.len(),
+                2,
+                "{name}: And must have exactly two ControllerControlsMatching branches"
+            );
+
+            let extracted: Vec<&str> = conditions
+                .iter()
+                .map(|c| match c {
+                    AbilityCondition::ControllerControlsMatching {
+                        filter: TargetFilter::Typed(typed),
+                    } => typed
+                        .get_subtype()
+                        .unwrap_or_else(|| panic!("{name}: filter must carry a subtype")),
+                    other => panic!(
+                        "{name}: expected ControllerControlsMatching with Typed filter, got {other:?}"
+                    ),
+                })
+                .collect();
+
+            assert_eq!(
+                extracted,
+                expected_subs.to_vec(),
+                "{name}: And branches must reference the OTHER two Urza land subtypes — \
+                 a regression here lets the land count itself as one of the required pieces"
+            );
+        }
+    }
+
     #[test]
     fn parses_ugin_labyrinth_exiled_card_mana_as_delta() {
         let r = parse(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -91,6 +91,7 @@ mod twice_instead_repeat_for;
 mod tyvar_activate_as_though_haste;
 mod ureni_attack_trigger;
 mod urzas_saga_chapter_two;
+mod urzas_tower_conditional_mana;
 mod virulent_emissary_trigger;
 mod volatile_fault_that_player_search;
 mod wedding_ring_etb_token_copy;

--- a/crates/engine/tests/integration/urzas_tower_conditional_mana.rs
+++ b/crates/engine/tests/integration/urzas_tower_conditional_mana.rs
@@ -36,13 +36,28 @@ use engine::types::mana::ManaType;
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
+const URZA_LAND_KEYS: [&str; 3] = ["urza's tower", "urza's mine", "urza's power plant"];
+
 fn load_db() -> Option<&'static CardDatabase> {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../client/public/card-data.json");
     if !path.exists() {
         return None;
     }
     static DB: OnceLock<CardDatabase> = OnceLock::new();
-    Some(DB.get_or_init(|| CardDatabase::from_export(&path).expect("export should load")))
+    Some(DB.get_or_init(|| {
+        let raw = std::fs::read_to_string(&path).expect("card-data.json should be readable");
+        let export: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&raw).expect("card-data.json should be a JSON object");
+        let mut selected = serde_json::Map::new();
+        for key in URZA_LAND_KEYS {
+            let value = export
+                .get(key)
+                .unwrap_or_else(|| panic!("{key} should be in card-data.json"));
+            selected.insert(key.to_string(), value.clone());
+        }
+        CardDatabase::from_json_str(&serde_json::Value::Object(selected).to_string())
+            .expect("Urza land export records should load")
+    }))
 }
 
 /// With all three Urza lands on the battlefield, tapping Urza's Tower for mana

--- a/crates/engine/tests/integration/urzas_tower_conditional_mana.rs
+++ b/crates/engine/tests/integration/urzas_tower_conditional_mana.rs
@@ -1,0 +1,87 @@
+//! Integration coverage for issue #885 — Urza's Tower / Mine / Power-Plant.
+//!
+//! Oracle (activated mana ability on each):
+//!   `{T}: Add {C}. If you control an Urza's <other> and an Urza's <other>,`
+//!   `add {C}{C}{C} instead.`
+//!
+//! A unit test in `mana_abilities.rs` already proves the resolver produces
+//! three colorless mana from a handcrafted `Effect::Mana` + `sub_ability` AST,
+//! but nothing exercises the full pipeline (parser emit → real card load →
+//! runtime `ActivateAbility` → mana production). This test closes that gap
+//! using the parsed `client/public/card-data.json` so any drift in the
+//! parser shape that the resolver depends on shows up here as a runtime
+//! divergence, not just a unit-test failure.
+//!
+//! CR 605.3b: An activated mana ability doesn't go on the stack — it
+//! resolves immediately after it is activated, so the assertion looks at
+//! the active player's mana pool directly after the `ActivateAbility` call.
+//! CR 614.1a: "Add {C}. If you control … add {C}{C}{C} instead." — the
+//! word "instead" makes the sub-ability a replacement effect; its condition
+//! is evaluated as the ability resolves (CR 608), and with all three Urza
+//! lands controlled the `And` condition is satisfied and the delta
+//! (+2 colorless) replaces the base production net (1 + 2 = 3 C).
+//! CR 205.3i: "Mine," "Power-Plant," and "Tower" are distinct land subtypes
+//! from the enumerated land type list; the cross-naming of the parsed
+//! `ControllerControlsMatching` filters is what makes the three lands
+//! reference each other rather than themselves.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use engine::database::card_db::CardDatabase;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::actions::GameAction;
+use engine::types::mana::ManaType;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+fn load_db() -> Option<&'static CardDatabase> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../client/public/card-data.json");
+    if !path.exists() {
+        return None;
+    }
+    static DB: OnceLock<CardDatabase> = OnceLock::new();
+    Some(DB.get_or_init(|| CardDatabase::from_export(&path).expect("export should load")))
+}
+
+/// With all three Urza lands on the battlefield, tapping Urza's Tower for mana
+/// must produce three colorless (the `Add {C}` base plus the +2 delta granted
+/// by the satisfied `If you control an Urza's Mine and an Urza's Power-Plant`
+/// sub-ability). This is the load-bearing end-to-end check for issue #885.
+#[test]
+fn urzas_tower_with_mine_and_power_plant_produces_three_colorless() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let tower_id = scenario.add_real_card(P0, "Urza's Tower", Zone::Battlefield, db);
+    let _mine_id = scenario.add_real_card(P0, "Urza's Mine", Zone::Battlefield, db);
+    let _plant_id = scenario.add_real_card(P0, "Urza's Power Plant", Zone::Battlefield, db);
+
+    let mut runner = scenario.build();
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: tower_id,
+            ability_index: 0,
+        })
+        .expect("activating Urza's Tower mana ability must succeed");
+
+    let pool = &runner.state().players[P0.0 as usize].mana_pool;
+    assert_eq!(
+        pool.count_color(ManaType::Colorless),
+        3,
+        "Urza's Tower with Urza's Mine + Urza's Power Plant must produce 3 colorless \
+         (1 base + 2 delta from satisfied sub-ability); pool = {:?}",
+        pool.mana,
+    );
+    assert_eq!(
+        pool.total(),
+        3,
+        "no other mana types must be produced; pool = {:?}",
+        pool.mana,
+    );
+}


### PR DESCRIPTION
## Summary
Closes the coverage gap identified during investigation of #885 (Urza's Tower / Mine / Power-Plant conditional `{C}{C}{C}` mana). The engine is correct end-to-end — the existing resolver unit test `resolve_mana_ability_conditional_urza_delta` proves the parsed AST produces 3 colorless, and the new integration test added here confirms the full pipeline (parser → real card load → runtime `ActivateAbility`) also produces 3 colorless with all three Urza lands on the battlefield. The reported behavior is most consistent with only one of the two required companion lands being on the battlefield — Tower's Oracle text requires BOTH Mine AND Power-Plant, and the `And` condition correctly short-circuits otherwise.

Three new tests close the coverage gap:
1. Integration test exercises parser → real card load → runtime `ActivateAbility` end-to-end with all three Urza lands present.
2. Negative unit test pins the one-land-missing branch (likely the scenario the reporter actually hit) to the base `{C}` output.
3. Parser shape test (table-driven across all three Urza lands) pins the shared `Effect::Mana + sub_ability + AbilityCondition::And { ControllerControlsMatching, ControllerControlsMatching }` shape with correct cross-naming of the OTHER two land subtypes.

## Files changed
- crates/engine/src/game/mana_abilities.rs
- crates/engine/src/parser/oracle.rs
- crates/engine/tests/integration/main.rs
- crates/engine/tests/integration/urzas_tower_conditional_mana.rs

## CR references
- CR 605.3b — mana abilities resolve immediately, not on the stack
- CR 614.1a — "instead" replacement effects
- CR 605.1a — activated mana ability criteria
- CR 205.3i — land subtypes (Mine / Power-Plant / Tower / Urza's)
- CR 608 — resolving spells and abilities

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking level: medium

Closes #885