### PR TITLE
chore: add CODEOWNERS to require owner review on main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS — required reviewers for protected branches.
+#
+# Every file in the repo requires review from @matthewevans before a PR
+# can merge to main. Admin bypass is intentionally left on
+# (enforce_admins=false) so the owner can merge their own PRs without
+# self-review, which GitHub does not allow.
+#
+# Self-ownership on this file prevents anyone from adding themselves
+# as an owner via PR without @matthewevans approving.
+
+*                       @matthewevans
+/.github/CODEOWNERS     @matthewevans


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` making @matthewevans the required reviewer for every file in the repo
- Self-ownership on the CODEOWNERS file itself prevents anyone else from PRing changes to the ownership list without owner approval

## Why
Pairs with a follow-on branch-protection change to enable `require_code_owner_reviews` on `main`. Once that's flipped, every PR (including from external contributors) will need owner approval before the merge queue lands it. Owner's own PRs continue to merge via `bypass_pull_request_allowances` (added in the protection change, not this PR).

## Test plan
- [x] No code changes, just config
- [x] CI runs on PR (workflow `pull_request:` trigger has no path filter)
- [ ] Merge via queue to validate end-to-end
- [ ] Follow-up: enable `require_code_owner_reviews` + `bypass_pull_request_allowances` on `main`