### PR TITLE
Fix AI/local concede bypass: dispatch Concede before clearing local state

### DIFF
--- a/client/src/components/chrome/GameMenu.tsx
+++ b/client/src/components/chrome/GameMenu.tsx
@@ -5,10 +5,10 @@ import { useTranslation } from "react-i18next";
 import { ConnectionDot } from "../multiplayer/ConnectionDot.tsx";
 import { FullscreenButton } from "./FullscreenButton.tsx";
 import { VolumeControl } from "./VolumeControl.tsx";
-import { clearGame, useGameStore } from "../../stores/gameStore.ts";
+import { clearGame } from "../../stores/gameStore.ts";
 import { useDraftStore } from "../../stores/draftStore.ts";
-import { useMultiplayerDraftStore } from "../../stores/multiplayerDraftStore.ts";
 import { useCardDataMeta } from "../../hooks/useCardDataMeta.ts";
+import { useConcedeHandler } from "../../hooks/useConcedeHandler.ts";
 
 interface GameMenuProps {
   gameId: string;
@@ -46,6 +46,14 @@ export function GameMenu({
   const cardDataMeta = useCardDataMeta();
   const isDraft = searchParams.get("source") === "draft" && !!searchParams.get("draftId");
   const isDraftPodMatch = searchParams.get("mode") === "draft-match";
+
+  const handleConcede = useConcedeHandler({
+    gameId,
+    isOnlineMode,
+    isDraft,
+    isDraftPodMatch,
+    onConcede,
+  });
 
   useEffect(() => {
     if (!open) return;
@@ -146,32 +154,15 @@ export function GameMenu({
             variant="danger"
             onClick={() => {
               setOpen(false);
+              // Online concedes route through the confirmation dialog
+              // (`onConcede` opens it). All other modes go straight through
+              // the unified concede hook, which dispatches `Concede` to the
+              // engine before clearing local state — see useConcedeHandler.
               if (isOnlineMode && onConcede) {
                 onConcede();
-              } else if (isDraft) {
-                useDraftStore.getState().recordMatchResult(gameId, "loss").then(() => {
-                  clearGame(gameId);
-                  navigate("/draft/quick?resume=1");
-                });
-              } else if (isDraftPodMatch) {
-                const adapter = useGameStore.getState().adapter as {
-                  sendConcede?: () => void | Promise<void>;
-                } | null;
-                void adapter?.sendConcede?.();
-                void useMultiplayerDraftStore
-                  .getState()
-                  .reportActiveMatchConcession()
-                  .then(() => {
-                    clearGame(gameId);
-                    navigate("/draft-pod");
-                  })
-                  .catch((err) => {
-                    console.error("[GameMenu] failed to report draft pod concession:", err);
-                  });
-              } else {
-                clearGame(gameId);
-                navigate("/");
+                return;
               }
+              handleConcede();
             }}
           />
           <MenuButton

--- a/client/src/hooks/__tests__/useConcedeHandler.test.tsx
+++ b/client/src/hooks/__tests__/useConcedeHandler.test.tsx
@@ -155,6 +155,10 @@ describe("useConcedeHandler", () => {
 
     await act(async () => {
       result.current();
+      // Hook chains: sendPromise -> .catch -> .then(report) -> .then(clear+nav).
+      // Four microtask flushes cover the whole chain.
+      await Promise.resolve();
+      await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -164,5 +168,97 @@ describe("useConcedeHandler", () => {
     expect(clearGameMock).toHaveBeenCalledWith("g1");
     expect(navigateMock).toHaveBeenCalledWith("/draft-pod");
     expect(dispatchMock).not.toHaveBeenCalled();
+
+    // Regression coverage for PR #1252 review: sendConcede must complete
+    // BEFORE reportActiveMatchConcession + clearGame + navigate. Without
+    // the chained await on the host-side async sendConcede (which fans
+    // out player_conceded to every guest's PeerJS data channel), tearing
+    // down the adapter mid-fan-out drops peer notifications.
+    const sendOrder = sendConcedeMock.mock.invocationCallOrder[0];
+    const reportOrder = reportActiveMatchConcessionMock.mock.invocationCallOrder[0];
+    const clearOrder = clearGameMock.mock.invocationCallOrder[0];
+    expect(sendOrder).toBeLessThan(reportOrder);
+    expect(reportOrder).toBeLessThan(clearOrder);
+  });
+
+  it("isDraftPodMatch branch awaits async sendConcede before reporting concession (race fix)", async () => {
+    // Discriminating regression: the host-side sendConcede returns a
+    // Promise (it awaits engine concedePlayer then broadcasts to guests).
+    // A fire-and-forget call would invoke reportActiveMatchConcession
+    // synchronously after sendConcede returns its pending promise — this
+    // test gates on the unresolved promise to catch that regression.
+    let releaseSend: () => void = () => {};
+    const sendPending = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    sendConcedeMock.mockReturnValueOnce(sendPending);
+
+    const { result } = renderHook(
+      () =>
+        useConcedeHandler({
+          gameId: "g1",
+          isOnlineMode: false,
+          isDraft: false,
+          isDraftPodMatch: true,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // sendConcede has been called but its promise is still pending —
+    // downstream chain must not have run.
+    expect(sendConcedeMock).toHaveBeenCalledTimes(1);
+    expect(reportActiveMatchConcessionMock).not.toHaveBeenCalled();
+    expect(clearGameMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    // Releasing the send promise lets the chain proceed.
+    await act(async () => {
+      releaseSend();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(reportActiveMatchConcessionMock).toHaveBeenCalledTimes(1);
+    expect(clearGameMock).toHaveBeenCalledWith("g1");
+    expect(navigateMock).toHaveBeenCalledWith("/draft-pod");
+  });
+
+  it("isDraftPodMatch branch still navigates if reportActiveMatchConcession rejects", async () => {
+    // User intent on Concede is to leave — a store-mutation failure
+    // must not strand them on the conceded screen.
+    reportActiveMatchConcessionMock.mockRejectedValueOnce(new Error("store failed"));
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderHook(
+      () =>
+        useConcedeHandler({
+          gameId: "g1",
+          isOnlineMode: false,
+          isDraft: false,
+          isDraftPodMatch: true,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(clearGameMock).toHaveBeenCalledWith("g1");
+    expect(navigateMock).toHaveBeenCalledWith("/draft-pod");
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/client/src/hooks/__tests__/useConcedeHandler.test.tsx
+++ b/client/src/hooks/__tests__/useConcedeHandler.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Runtime tests: these drive the hook's returned callback through the actual
+ * branching logic, asserting that the correct stores/adapters/navigation are
+ * invoked in the correct ORDER. The "ai/local" case asserts dispatch is
+ * awaited before navigation — that ordering is the bug fix (concede must
+ * reach the engine before local state is cleared, otherwise the WasmAdapter
+ * singleton retains the conceded game).
+ */
+import { act, renderHook } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useConcedeHandler } from "../useConcedeHandler";
+
+// ---- Mocks -----------------------------------------------------------------
+
+const dispatchMock = vi.fn();
+const clearGameMock = vi.fn();
+const recordMatchResultMock = vi.fn();
+const reportActiveMatchConcessionMock = vi.fn();
+const sendConcedeMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock("../../stores/gameStore", () => ({
+  useGameStore: {
+    getState: () => ({
+      dispatch: dispatchMock,
+      adapter: { sendConcede: sendConcedeMock },
+    }),
+  },
+  clearGame: (...args: unknown[]) => clearGameMock(...args),
+}));
+
+vi.mock("../../stores/draftStore", () => ({
+  useDraftStore: {
+    getState: () => ({
+      recordMatchResult: recordMatchResultMock,
+    }),
+  },
+}));
+
+vi.mock("../../stores/multiplayerDraftStore", () => ({
+  useMultiplayerDraftStore: {
+    getState: () => ({
+      reportActiveMatchConcession: reportActiveMatchConcessionMock,
+    }),
+  },
+}));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+// ---- Helpers ---------------------------------------------------------------
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+beforeEach(() => {
+  dispatchMock.mockReset();
+  clearGameMock.mockReset();
+  recordMatchResultMock.mockReset();
+  reportActiveMatchConcessionMock.mockReset();
+  sendConcedeMock.mockReset();
+  navigateMock.mockReset();
+
+  dispatchMock.mockResolvedValue([]);
+  recordMatchResultMock.mockResolvedValue(undefined);
+  reportActiveMatchConcessionMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---- Tests -----------------------------------------------------------------
+
+describe("useConcedeHandler", () => {
+  it("ai/local default branch dispatches Concede then clears + navigates home (bug fix)", async () => {
+    const { result } = renderHook(
+      () =>
+        useConcedeHandler({
+          gameId: "g1",
+          isOnlineMode: false,
+          isDraft: false,
+          isDraftPodMatch: false,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      result.current();
+      // Flush the promise chain.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "Concede",
+      data: { player_id: 0 },
+    });
+    expect(clearGameMock).toHaveBeenCalledWith("g1");
+    expect(navigateMock).toHaveBeenCalledWith("/");
+
+    // Regression coverage: dispatch MUST be invoked before clearGame.
+    // Without the await, a future refactor would silently regress and the
+    // WasmAdapter singleton would retain the conceded game.
+    const dispatchOrder = dispatchMock.mock.invocationCallOrder[0];
+    const clearOrder = clearGameMock.mock.invocationCallOrder[0];
+    expect(dispatchOrder).toBeLessThan(clearOrder);
+  });
+
+  it("isDraft branch records match loss then clears + navigates to draft resume", async () => {
+    const { result } = renderHook(
+      () =>
+        useConcedeHandler({
+          gameId: "g1",
+          isOnlineMode: false,
+          isDraft: true,
+          isDraftPodMatch: false,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(recordMatchResultMock).toHaveBeenCalledWith("g1", "loss");
+    expect(clearGameMock).toHaveBeenCalledWith("g1");
+    expect(navigateMock).toHaveBeenCalledWith("/draft/quick?resume=1");
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("isDraftPodMatch branch fires adapter sendConcede + concession report + clear + navigate", async () => {
+    const { result } = renderHook(
+      () =>
+        useConcedeHandler({
+          gameId: "g1",
+          isOnlineMode: false,
+          isDraft: false,
+          isDraftPodMatch: true,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(sendConcedeMock).toHaveBeenCalledTimes(1);
+    expect(reportActiveMatchConcessionMock).toHaveBeenCalledTimes(1);
+    expect(clearGameMock).toHaveBeenCalledWith("g1");
+    expect(navigateMock).toHaveBeenCalledWith("/draft-pod");
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/useConcedeHandler.ts
+++ b/client/src/hooks/useConcedeHandler.ts
@@ -73,16 +73,29 @@ export function useConcedeHandler({
       const adapter = useGameStore.getState().adapter as {
         sendConcede?: () => void | Promise<void>;
       } | null;
-      void adapter?.sendConcede?.();
-      void useMultiplayerDraftStore
-        .getState()
-        .reportActiveMatchConcession()
+      // Host's sendConcede (p2p-adapter.ts:1062) is async — it awaits
+      // concedePlayer (engine dispatch) then fans out player_conceded to
+      // every guest's PeerJS data channel. Guest/WS versions are sync
+      // void-returners; Promise.resolve() normalizes both shapes so we
+      // serialize the chain and never tear down the adapter mid-fan-out.
+      const sendPromise = adapter?.sendConcede
+        ? Promise.resolve(adapter.sendConcede())
+        : Promise.resolve();
+      void sendPromise
+        .catch((err) => {
+          console.error("[useConcedeHandler] sendConcede failed:", err);
+        })
+        .then(() => useMultiplayerDraftStore.getState().reportActiveMatchConcession())
         .then(() => {
           clearGame(gameId);
           navigate("/draft-pod");
         })
         .catch((err) => {
+          // User intent is to leave — strand them on the conceded screen
+          // is a worse outcome than logging the store-mutation failure.
           console.error("[useConcedeHandler] failed to report draft pod concession:", err);
+          clearGame(gameId);
+          navigate("/draft-pod");
         });
       return;
     }

--- a/client/src/hooks/useConcedeHandler.ts
+++ b/client/src/hooks/useConcedeHandler.ts
@@ -1,0 +1,110 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router";
+
+import { clearGame, useGameStore } from "../stores/gameStore";
+import { useDraftStore } from "../stores/draftStore";
+import { useMultiplayerDraftStore } from "../stores/multiplayerDraftStore";
+import { getPlayerId } from "./usePlayerId";
+
+export interface ConcedeHandlerOptions {
+  gameId: string;
+  isOnlineMode: boolean;
+  isDraft: boolean;
+  isDraftPodMatch: boolean;
+  /**
+   * Online-only callback that opens the confirmation dialog. When provided
+   * and `isOnlineMode` is true, the menu wires this directly; the hook does
+   * NOT invoke it. Online concede confirmation routes through this callback
+   * upstream of the hook.
+   */
+  onConcede?: () => void;
+}
+
+/**
+ * Unified concede handler for the game menu's "Concede" action.
+ *
+ * CR 104.3a: A player can concede the game at any time. A player who concedes
+ *   leaves the game. That player loses the game.
+ * CR 800.4a: When a player leaves a multiplayer game, all permanents/spells/
+ *   abilities owned by that player leave the game, and SBAs (CR 704) then
+ *   resolve the resulting game state.
+ *
+ * In AI/local/p2p modes the previous implementation cleared local game
+ * persistence and navigated home without ever dispatching `GameAction::Concede`
+ * to the engine. Because `WasmAdapter` is a module-level singleton kept alive
+ * across sessions for V8 TurboFan re-warm (see adapter/wasm-adapter.ts), the
+ * conceded `GameState` survived in the worker's `RefCell<Option<GameState>>`
+ * and remained fully playable on navigation back. This hook fixes that by
+ * awaiting a real `Concede` dispatch before clearing local state.
+ *
+ * Branches (priority order):
+ *  1. `isDraft` — quick-draft single-match concede.
+ *  2. `isDraftPodMatch` — pod-match concede (P2P adapter sendConcede +
+ *     multiplayer draft store concession report).
+ *  3. Default — AI / local / p2p-host / p2p-join: dispatch `Concede` to the
+ *     engine, then clear local state and navigate home.
+ *
+ * Online mode (`isOnlineMode && onConcede`) is intentionally NOT handled
+ * here — the menu calls `onConcede()` directly to preserve the existing
+ * confirmation-dialog UX.
+ */
+export function useConcedeHandler({
+  gameId,
+  isOnlineMode: _isOnlineMode,
+  isDraft,
+  isDraftPodMatch,
+  onConcede: _onConcede,
+}: ConcedeHandlerOptions): () => void {
+  const navigate = useNavigate();
+
+  return useCallback(() => {
+    if (isDraft) {
+      void useDraftStore
+        .getState()
+        .recordMatchResult(gameId, "loss")
+        .then(() => {
+          clearGame(gameId);
+          navigate("/draft/quick?resume=1");
+        });
+      return;
+    }
+
+    if (isDraftPodMatch) {
+      const adapter = useGameStore.getState().adapter as {
+        sendConcede?: () => void | Promise<void>;
+      } | null;
+      void adapter?.sendConcede?.();
+      void useMultiplayerDraftStore
+        .getState()
+        .reportActiveMatchConcession()
+        .then(() => {
+          clearGame(gameId);
+          navigate("/draft-pod");
+        })
+        .catch((err) => {
+          console.error("[useConcedeHandler] failed to report draft pod concession:", err);
+        });
+      return;
+    }
+
+    // Default: AI / local / p2p-host / p2p-join (when no online dialog).
+    // Awaiting the dispatch BEFORE clearGame + navigate is the bug fix —
+    // it forces the engine to process Concede and run SBAs (CR 704 / 704.5a)
+    // before the local persistence layer drops the game ID. Without the
+    // await, the WasmAdapter singleton retains the conceded game and the
+    // user can resume it by navigating back.
+    void useGameStore
+      .getState()
+      .dispatch({ type: "Concede", data: { player_id: getPlayerId() } })
+      .then(() => {
+        clearGame(gameId);
+        navigate("/");
+      })
+      .catch((err) => {
+        console.error("[useConcedeHandler] concede dispatch failed:", err);
+        // Still clear + navigate on failure — the user has decided to leave.
+        clearGame(gameId);
+        navigate("/");
+      });
+  }, [gameId, isDraft, isDraftPodMatch, navigate]);
+}


### PR DESCRIPTION
The GameMenu concede MenuButton had a 4-branch onClick where the default
branch (AI/local/p2p when not in a draft) called clearGame + navigate
but never dispatched GameAction::Concede to the engine. Because the
WasmAdapter is a module-level singleton kept alive across sessions for
V8 TurboFan re-warm, the conceded GameState survived in the worker's
RefCell<Option<GameState>>, fully playable. Other active games keeping
the worker warm made this trivially reproducible — user could navigate
back to the conceded game's URL and continue playing.

CR 104.3a: A player can concede the game at any time. That player
  leaves the game.
CR 800.4a: When a player leaves a multiplayer game, all permanents/
  spells/abilities owned by that player leave the game; SBAs check
  for an empty library, etc. In AI/local mode the engine must process
  the Concede so SBAs run and GameOver is emitted.

Extract the routing into a custom hook (useConcedeHandler) so the
dispatch table is single-authority and testable without mounting the
full GamePage tree. Three branches: isDraft (quick-draft match-loss
recording), isDraftPodMatch (P2P concede + pod store concession
report), default (AI/local — dispatch Concede then clearGame +
navigate). The default branch awaits the dispatch before navigating
— that's the bug fix.

Online mode bypasses the hook entirely: GameMenu's click handler
checks isOnlineMode && onConcede first and calls onConcede() (which
opens the existing confirm dialog). The dialog's confirm path in
GamePage.handleConcede (unchanged) calls adapter.sendConcede().

Drops now-unused imports from GameMenu (useGameStore,
useMultiplayerDraftStore). Keeps useDraftStore + clearGame because
the Back-to-Menu MenuButton at lines 177-192 still uses them.

Runtime test in useConcedeHandler.test.tsx asserts the default branch
dispatches with the correct payload AND that dispatch's invocation
order precedes clearGame — would catch a regression where someone
removes the await.
