### PR TITLE
modals: route card hover preview through DialogShell at the dialog-level

### DIFF
--- a/client/src/components/modal/AdventureCastModal.tsx
+++ b/client/src/components/modal/AdventureCastModal.tsx
@@ -40,6 +40,7 @@ function AdventureCastContent({
       eyebrow={t("adventureCast.eyebrow")}
       title={t("adventureCast.title")}
       subtitle={t("adventureCast.subtitle")}
+      previewObjectId={objectId}
     >
       <div className="flex flex-col gap-2 px-3 py-3 lg:px-5 lg:py-5">
         <button

--- a/client/src/components/modal/AlternativeCostModal.tsx
+++ b/client/src/components/modal/AlternativeCostModal.tsx
@@ -158,6 +158,7 @@ function AlternativeCostContent({
       eyebrow={copy.eyebrow}
       title={t("alternativeCost.title")}
       subtitle={copy.subtitle}
+      previewObjectId={objectId}
     >
       {copy.showOracleText && (
         <div className="px-3 pt-3 lg:px-5 lg:pt-4">

--- a/client/src/components/modal/CascadeChoiceModal.tsx
+++ b/client/src/components/modal/CascadeChoiceModal.tsx
@@ -90,6 +90,7 @@ function CascadeChoiceContent({
       }
       title={t("cascadeChoice.title", { name: obj.name })}
       subtitle={subtitle}
+      previewObjectId={hitCardId}
     >
       <div className="flex flex-col gap-2 px-3 py-3 lg:px-5 lg:py-5">
         <button

--- a/client/src/components/modal/CastingVariantModal.tsx
+++ b/client/src/components/modal/CastingVariantModal.tsx
@@ -68,6 +68,7 @@ function CastingVariantContent({
       eyebrow={t("castingVariant.eyebrow")}
       title={t("castingVariant.title")}
       subtitle={obj.name}
+      previewObjectId={data.object_id}
     >
       <div className="flex flex-col gap-2 px-3 py-3 lg:px-5 lg:py-5">
         {data.options.map((option, index) => (

--- a/client/src/components/modal/ChoiceModal.tsx
+++ b/client/src/components/modal/ChoiceModal.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import type { CardType } from "../../adapter/types.ts";
+import type { CardType, ObjectId } from "../../adapter/types.ts";
 import { RichLabel } from "../mana/RichLabel.tsx";
 import { CardTextboxPreview } from "./CardTextboxPreview.tsx";
 import { DialogShell } from "./DialogShell.tsx";
@@ -22,6 +22,9 @@ interface ChoiceModalProps {
   /** Card type info for the preview. The preview uses this to pick the right
    * rules-text band for non-standard frames (saga, planeswalker, battle, etc.). */
   previewCardTypes?: CardType;
+  /** When provided alongside previewCardName, hovering the inline preview fires
+   * inspectObject for the floating full-card view. */
+  previewObjectId?: ObjectId;
   footer?: ReactNode;
 }
 
@@ -33,6 +36,7 @@ export function ChoiceModal({
   onClose,
   previewCardName,
   previewCardTypes,
+  previewObjectId,
   footer,
 }: ChoiceModalProps) {
   return (
@@ -40,6 +44,7 @@ export function ChoiceModal({
       title={<RichLabel text={title} size="md" />}
       subtitle={subtitle ? <RichLabel text={subtitle} size="xs" /> : undefined}
       onClose={onClose}
+      previewObjectId={previewObjectId}
     >
       {previewCardName && (
         <div className="px-3 pt-3 lg:px-5 lg:pt-4">

--- a/client/src/components/modal/CombatTaxModal.tsx
+++ b/client/src/components/modal/CombatTaxModal.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 
 import type { ManaCost, ObjectId, WaitingFor } from "../../adapter/types.ts";
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
+import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { ManaCostSymbols } from "../mana/ManaCostSymbols.tsx";
@@ -109,6 +110,7 @@ function CombatTaxContent({ data }: { data: CombatTaxPayment["data"] }) {
 }
 
 function CreatureCostRow({
+  objectId,
   cost,
   name,
 }: {
@@ -116,8 +118,12 @@ function CreatureCostRow({
   cost: ManaCost;
   name: string;
 }) {
+  const hoverProps = useInspectHoverProps();
   return (
-    <div className="flex items-center justify-between py-1 text-sm">
+    <div
+      {...hoverProps(objectId)}
+      className="flex items-center justify-between py-1 text-sm"
+    >
       <span className="truncate text-slate-200">{name}</span>
       <ManaCostSymbols cost={cost} />
     </div>

--- a/client/src/components/modal/DialogShell.tsx
+++ b/client/src/components/modal/DialogShell.tsx
@@ -2,6 +2,8 @@ import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useEffect, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { ObjectId } from "../../adapter/types.ts";
+import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useOptionalDialogPeek } from "./dialogPeekContext.ts";
 
 interface DialogShellProps {
@@ -14,6 +16,10 @@ interface DialogShellProps {
   children: ReactNode;
   footer?: ReactNode;
   onClose?: () => void;
+  /** When set, hovering anywhere on the dialog card fires inspectObject for
+   * the referenced game object. Use this for dialogs that represent a single
+   * card subject (cast prompts, face choices, miracle reveal, etc.). */
+  previewObjectId?: ObjectId;
 }
 
 const SIZE_CLASS: Record<NonNullable<DialogShellProps["size"]>, string> = {
@@ -32,10 +38,14 @@ export function DialogShell({
   children,
   footer,
   onClose,
+  previewObjectId,
 }: DialogShellProps) {
   const { t } = useTranslation("game");
   const peek = useOptionalDialogPeek();
+  const inspectHoverProps = useInspectHoverProps();
   const resolvedEyebrow = eyebrow ?? t("dialogShell.eyebrow");
+  const cardHoverProps =
+    previewObjectId != null ? inspectHoverProps(previewObjectId) : undefined;
 
   // Esc-to-close: standard modal contract. Only attach when the dialog is
   // dismissable (consumers like ChoiceOverlay that omit `onClose` have a
@@ -85,7 +95,7 @@ export function DialogShell({
           exit={{ scale: 0.95, opacity: 0, y: 10 }}
           transition={{ duration: 0.2, ease: "easeOut" }}
         >
-          <div className={cardClass}>
+          <div {...cardHoverProps} className={cardClass}>
             <DialogHeader
               eyebrow={resolvedEyebrow}
               eyebrowClassName={eyebrowClassName}

--- a/client/src/components/modal/DistributeAmongModal.tsx
+++ b/client/src/components/modal/DistributeAmongModal.tsx
@@ -3,6 +3,7 @@ import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
+import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import type { DistributionUnit, TargetRef, WaitingFor } from "../../adapter/types.ts";
 import { ChoiceOverlay, ConfirmButton } from "./ChoiceOverlay.tsx";
@@ -24,6 +25,7 @@ export function DistributeAmongModal({ data }: { data: DistributeAmong["data"] }
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
   const objects = useGameStore((s) => s.gameState?.objects);
+  const hoverProps = useInspectHoverProps();
 
   // One amount per target index; initialize with 0 each.
   const [amounts, setAmounts] = useState<number[]>(() =>
@@ -63,6 +65,7 @@ export function DistributeAmongModal({ data }: { data: DistributeAmong["data"] }
         {data.targets.map((target, i) => (
           <div
             key={i}
+            {...("Object" in target ? hoverProps(target.Object) : undefined)}
             className="flex items-center justify-between gap-3 rounded-lg bg-gray-800/60 p-3"
           >
             <span className="text-sm font-medium text-gray-200">

--- a/client/src/components/modal/MiracleRevealModal.tsx
+++ b/client/src/components/modal/MiracleRevealModal.tsx
@@ -103,6 +103,7 @@ function MiracleRevealContent({
             ? t("miracleReveal.subtitleCastMadness")
             : t("miracleReveal.subtitleCastMiracle")
       }
+      previewObjectId={objectId}
     >
       <div className="flex flex-col gap-2 px-3 py-3 lg:px-5 lg:py-5">
         <button

--- a/client/src/components/modal/ModalFaceModal.tsx
+++ b/client/src/components/modal/ModalFaceModal.tsx
@@ -63,6 +63,7 @@ function ModalFaceContent({
       eyebrow={t("modalFace.eyebrow")}
       title={t("modalFace.title")}
       subtitle={t("modalFace.subtitle")}
+      previewObjectId={objectId}
     >
       <div className="flex flex-col gap-2 px-3 py-3 lg:px-5 lg:py-5">
         <FaceButton

--- a/client/src/components/modal/ModeChoiceModal.tsx
+++ b/client/src/components/modal/ModeChoiceModal.tsx
@@ -16,6 +16,11 @@ export function ModeChoiceModal() {
   const isModeChoice = waitingFor?.type === "ModeChoice" || waitingFor?.type === "AbilityModeChoice";
   const isAbilityMode = waitingFor?.type === "AbilityModeChoice";
   const modal: ModalChoice | null = isModeChoice ? waitingFor.data.modal : null;
+  const sourceObjectId = !isModeChoice
+    ? undefined
+    : waitingFor.type === "AbilityModeChoice"
+      ? waitingFor.data.source_id
+      : waitingFor.data.pending_cast.object_id;
   const unavailableModes: number[] = useMemo(
     () =>
       isAbilityMode && "unavailable_modes" in waitingFor.data
@@ -116,6 +121,7 @@ export function ModeChoiceModal() {
       size="md"
       scrollable
       footer={footer}
+      previewObjectId={sourceObjectId}
     >
       <div className="px-3 py-3 lg:px-5 lg:py-5">
         <div className="flex flex-col gap-2">

--- a/client/src/components/modal/MoveCountersDistributionModal.tsx
+++ b/client/src/components/modal/MoveCountersDistributionModal.tsx
@@ -9,6 +9,7 @@ import type {
   WaitingFor,
 } from "../../adapter/types.ts";
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
+import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { formatCounterType } from "../../viewmodel/cardProps.ts";
 import { gameButtonClass } from "../ui/buttonStyles.ts";
@@ -39,6 +40,7 @@ export function MoveCountersDistributionModal({
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
   const objects = useGameStore((s) => s.gameState?.objects);
+  const hoverProps = useInspectHoverProps();
   const availableCounters = useMemo(
     () =>
       data.available
@@ -152,6 +154,7 @@ export function MoveCountersDistributionModal({
                 return (
                   <div
                     key={`${key}-${destinationId}`}
+                    {...hoverProps(destinationId)}
                     className="flex items-center justify-between gap-3 rounded-lg bg-gray-800/60 p-3"
                   >
                     <span className="text-sm font-medium text-gray-200">

--- a/client/src/components/modal/OptionalEffectModal.tsx
+++ b/client/src/components/modal/OptionalEffectModal.tsx
@@ -37,6 +37,8 @@ export function OptionalEffectModalContent({
     <ChoiceModal
       title={t("optionalEffect.title", { name: sourceName })}
       subtitle={description}
+      previewCardName={sourceObj?.name}
+      previewObjectId={waitingFor.data.source_id}
       options={[
         { id: "accept", label: t("optionalEffect.yes") },
         { id: "decline", label: t("optionalEffect.no") },

--- a/client/src/components/modal/PermanentTypeSlotModal.tsx
+++ b/client/src/components/modal/PermanentTypeSlotModal.tsx
@@ -48,6 +48,7 @@ function SlotChoiceContent({
       eyebrow={t("permanentTypeSlot.eyebrow")}
       title={t("permanentTypeSlot.title")}
       subtitle={t("permanentTypeSlot.subtitle", { name: cardName })}
+      previewObjectId={objectId}
     >
       <div className="px-3 pt-3 lg:px-5 lg:pt-4">
         <CardTextboxPreview cardName={cardName} />

--- a/client/src/components/modal/ProliferateModal.tsx
+++ b/client/src/components/modal/ProliferateModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
+import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { usePlayerId } from "../../hooks/usePlayerId.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import type { TargetRef, WaitingFor } from "../../adapter/types.ts";
@@ -46,6 +47,7 @@ export function ProliferateModal({
   const dispatch = useGameDispatch();
   const objects = useGameStore((s) => s.gameState?.objects);
   const playerId = usePlayerId();
+  const hoverProps = useInspectHoverProps();
 
   const [selected, setSelected] = useState<TargetRef[]>(data.eligible);
 
@@ -108,6 +110,7 @@ export function ProliferateModal({
               key={key}
               type="button"
               aria-pressed={isSelected}
+              {...("Object" in target ? hoverProps(target.Object) : undefined)}
               onClick={() => handleToggle(target)}
               className={
                 gameButtonClass({

--- a/client/src/components/modal/TopOrBottomChoiceModal.tsx
+++ b/client/src/components/modal/TopOrBottomChoiceModal.tsx
@@ -36,6 +36,7 @@ export function TopOrBottomChoiceModalContent({
     <ChoiceModal
       title={t("topOrBottom.title", { name: cardName })}
       previewCardName={cardName}
+      previewObjectId={objectId}
       options={[
         { id: "top", label: t("topOrBottom.top") },
         { id: "bottom", label: t("topOrBottom.bottom") },

--- a/client/src/components/modal/TributeModal.tsx
+++ b/client/src/components/modal/TributeModal.tsx
@@ -42,6 +42,8 @@ export function TributeModal() {
     <ChoiceModal
       title={t("tribute.title", { name: sourceName })}
       subtitle={t("tribute.subtitle", { count: counters, name: sourceName })}
+      previewCardName={rawSourceName ?? undefined}
+      previewObjectId={data.source_id}
       options={[
         {
           id: "pay",

--- a/client/src/components/modal/TriggerOrderModal.tsx
+++ b/client/src/components/modal/TriggerOrderModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { PendingTriggerSummary } from "../../adapter/types.ts";
+import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { DialogShell } from "./DialogShell.tsx";
 
@@ -20,6 +21,7 @@ export function TriggerOrderModal() {
   const { t } = useTranslation("game");
   const waitingFor = useGameStore((s) => s.waitingFor);
   const dispatch = useGameStore((s) => s.dispatch);
+  const hoverProps = useInspectHoverProps();
 
   const isOrderTriggers = waitingFor?.type === "OrderTriggers";
   const engineTriggers = isOrderTriggers
@@ -79,6 +81,7 @@ export function TriggerOrderModal() {
             return (
               <li
                 key={`${trigger.source_id}-${engineIndex}`}
+                {...hoverProps(trigger.source_id)}
                 className="flex items-start gap-2 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3"
               >
                 <div className="flex-1 text-left">


### PR DESCRIPTION
Adds previewObjectId to DialogShell and wires hover via useInspectHoverProps
on the modal card container, so dialogs that represent a single card subject
declare ownership once instead of spreading hoverProps on every choice button.

Multi-card list modals (CombatTax, TriggerOrder, MoveCountersDistribution,
DistributeAmong, Proliferate) keep per-row hover — each row is a distinct
card identity. ChoiceModal forwards previewObjectId to DialogShell so
TopOrBottom/Tribute/OptionalEffect all inherit hover via the shared chrome.

CardChoiceModal's 24 existing hover sites (Thoughtseize-class flows) are
untouched — each card in revealed strips already has individual hover.
