### PR TITLE
Cube draft multiplayer: thread PoolInput discriminated union through pod-draft adapter chain (#1253)

### DIFF
--- a/client/src/adapter/__tests__/draftPodAdapter.cube.test.ts
+++ b/client/src/adapter/__tests__/draftPodAdapter.cube.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Shape-level test for DraftPodHostAdapter cube-mode initialization.
+ *
+ * The discriminating runtime gate for `create_multiplayer_draft` lives in
+ * the Rust unit test `create_multiplayer_draft_tests` (crates/draft-wasm).
+ * This test verifies the host-side plumbing: when poolInput.type === "Cube",
+ * initialize() fetches __CARD_DATA_URL__ and calls
+ * DraftAdapter.loadCardDatabase before instantiating P2PDraftHost; when
+ * poolInput.type === "Set", the CARD_DB fetch path is skipped.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DraftPodHostAdapter } from "../draftPodHostAdapter";
+import type { DraftPodHostEvent } from "../draftPodHostAdapter";
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+const mockLoadCardDatabase = vi.fn(async () => 0);
+
+vi.mock("../draft-adapter", () => ({
+  DraftAdapter: vi.fn().mockImplementation(() => ({
+    loadCardDatabase: mockLoadCardDatabase,
+  })),
+}));
+
+vi.mock("../../network/connection", () => ({
+  hostRoom: vi.fn(async () => ({
+    roomCode: "ABCDE",
+    peerId: "phase2-ABCDE",
+    peer: { destroy: vi.fn() } as unknown,
+    onGuestConnected: vi.fn(() => vi.fn()),
+    destroy: vi.fn(),
+  })),
+}));
+
+vi.mock("../../services/draftPersistence", () => ({
+  loadDraftHostSession: vi.fn(async () => null),
+}));
+
+vi.mock("../p2p-draft-host", () => ({
+  P2PDraftHost: vi.fn().mockImplementation(() => ({
+    onEvent: vi.fn(() => vi.fn()),
+    initialize: vi.fn(async () => {}),
+    dispose: vi.fn(),
+    terminateDraft: vi.fn(async () => {}),
+  })),
+}));
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  globalThis.fetch = vi.fn(async () =>
+    new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }),
+  );
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("DraftPodHostAdapter cube-mode initialize", () => {
+  let adapter: DraftPodHostAdapter;
+  let events: DraftPodHostEvent[];
+
+  beforeEach(() => {
+    adapter = new DraftPodHostAdapter();
+    events = [];
+    adapter.onEvent((e) => events.push(e));
+  });
+
+  afterEach(async () => {
+    await adapter.dispose();
+  });
+
+  it("populates CARD_DB via DraftAdapter.loadCardDatabase for Cube pods", async () => {
+    await adapter.initialize({
+      poolInput: {
+        type: "Cube",
+        data: {
+          cube_list_text: "1 Lightning Bolt\n",
+          cube_name: "Test Cube",
+          cube_draft_settings: {
+            pod_size: 2,
+            pack_count: 1,
+            cards_per_pack: 2,
+            min_deck_size: 4,
+            addable_cards: { policy: "StandardBasics", custom: [] },
+          },
+        },
+      },
+      kind: "Premier",
+      podSize: 2,
+      hostDisplayName: "Host",
+      tournamentFormat: "Swiss",
+      podPolicy: "Competitive",
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    expect(mockLoadCardDatabase).toHaveBeenCalledOnce();
+    expect(adapter.status).toBe("lobby");
+  });
+
+  it("skips the CARD_DB fetch for Set pods", async () => {
+    await adapter.initialize({
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
+      kind: "Premier",
+      podSize: 2,
+      hostDisplayName: "Host",
+      tournamentFormat: "Swiss",
+      podPolicy: "Competitive",
+    });
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(mockLoadCardDatabase).not.toHaveBeenCalled();
+    expect(adapter.status).toBe("lobby");
+  });
+});

--- a/client/src/adapter/__tests__/draftPodAdapter.test.ts
+++ b/client/src/adapter/__tests__/draftPodAdapter.test.ts
@@ -18,6 +18,17 @@ import { loadDraftHostSession } from "../../services/draftPersistence";
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
+// Mock the draft-adapter module — vitest cannot resolve the lazy
+// `@wasm/draft` import that DraftAdapter's `ensureDraftWasm` performs.
+// The host adapter only uses DraftAdapter to populate the cube CARD_DB;
+// the Set-mode tests below never exercise that path, so a no-op mock is
+// sufficient.
+vi.mock("../draft-adapter", () => ({
+  DraftAdapter: vi.fn().mockImplementation(() => ({
+    loadCardDatabase: vi.fn(async () => 0),
+  })),
+}));
+
 // Mock the connection module
 vi.mock("../../network/connection", () => ({
   hostRoom: vi.fn(),
@@ -155,7 +166,7 @@ describe("DraftPodHostAdapter", () => {
 
   it("transitions to lobby after initialization", async () => {
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",
@@ -174,7 +185,7 @@ describe("DraftPodHostAdapter", () => {
 
   it("can suspend without terminating the persisted host draft", async () => {
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",
@@ -194,7 +205,7 @@ describe("DraftPodHostAdapter", () => {
 
     await expect(
       adapter.initialize({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -209,7 +220,7 @@ describe("DraftPodHostAdapter", () => {
 
   it("delegates startDraft to P2PDraftHost", async () => {
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",
@@ -236,13 +247,13 @@ describe("DraftPodHostAdapter", () => {
       draftStarted: true,
       draftCode: "ABCDE",
       draftSessionJson: "{}",
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
     });
     const restoredView = mockView("MatchInProgress");
     mockHostRestoreFromPersisted.mockResolvedValue(restoredView);
 
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",
@@ -257,7 +268,7 @@ describe("DraftPodHostAdapter", () => {
 
   it("delegates submitPick and returns view", async () => {
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",
@@ -272,7 +283,7 @@ describe("DraftPodHostAdapter", () => {
 
   it("delegates submitDeck and returns view", async () => {
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",
@@ -287,7 +298,7 @@ describe("DraftPodHostAdapter", () => {
 
   it("delegates host controls (kick, pause, resume)", async () => {
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",
@@ -313,7 +324,7 @@ describe("DraftPodHostAdapter", () => {
 
   it("maps P2PDraftHost events to DraftPodHostEvents", async () => {
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",
@@ -361,7 +372,7 @@ describe("DraftPodHostAdapter", () => {
 
   it("cleans up on dispose", async () => {
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",
@@ -380,7 +391,7 @@ describe("DraftPodHostAdapter", () => {
     const unsub = adapter.onEvent((e) => extraEvents.push(e));
 
     await adapter.initialize({
-      setPoolJson: "{}",
+      poolInput: { type: "Set", data: { set_pool_json: "{}" } },
       kind: "Premier",
       podSize: 8,
       hostDisplayName: "Host",

--- a/client/src/adapter/draft-adapter.ts
+++ b/client/src/adapter/draft-adapter.ts
@@ -93,6 +93,22 @@ export type MultiplayerSeatDescriptor =
   | { type: "Human"; player_id: number; display_name: string }
   | { type: "Bot"; name: string };
 
+/**
+ * Pool source for multiplayer draft creation. Mirrors the Rust `PoolInput`
+ * enum in draft-wasm. Snake_case fields match the existing `CubeDraftSettings`
+ * TS↔Rust mirror convention (no `rename_all` machinery on the Rust side).
+ */
+export type PoolInput =
+  | { type: "Set"; data: { set_pool_json: string } }
+  | {
+      type: "Cube";
+      data: {
+        cube_list_text: string;
+        cube_name: string;
+        cube_draft_settings: CubeDraftSettings;
+      };
+    };
+
 export interface SuggestedDeck {
   main_deck: string[];
   lands: Record<string, number>;
@@ -222,7 +238,7 @@ export class DraftAdapter {
   }
 
   async createMultiplayerDraft(
-    setPoolJson: string,
+    poolInput: PoolInput,
     seats: MultiplayerSeatDescriptor[],
     kind: "Premier" | "Traditional",
     seed: number,
@@ -233,7 +249,7 @@ export class DraftAdapter {
     const wasm = await ensureDraftWasm();
     const kindId = kind === "Premier" ? 1 : 2;
     return wasm.create_multiplayer_draft(
-      setPoolJson,
+      JSON.stringify(poolInput),
       JSON.stringify(seats),
       kindId,
       seed,

--- a/client/src/adapter/draftPodHostAdapter.ts
+++ b/client/src/adapter/draftPodHostAdapter.ts
@@ -10,7 +10,8 @@
  * draft pod instead of a 2-4 player game.
  */
 
-import type { DraftPlayerView, PairingView, PodPolicy, SeatPublicView, TournamentFormat } from "./draft-adapter";
+import { DraftAdapter } from "./draft-adapter";
+import type { DraftPlayerView, PairingView, PodPolicy, PoolInput, SeatPublicView, TournamentFormat } from "./draft-adapter";
 import type { MatchScore } from "./types";
 import { P2PDraftHost, type DraftHostEvent } from "./p2p-draft-host";
 import { hostRoom, type HostResult } from "../network/connection";
@@ -101,7 +102,7 @@ function hostStatusForView(view: DraftPlayerView): DraftPodHostStatus {
 }
 
 export interface DraftPodHostConfig {
-  setPoolJson: string;
+  poolInput: PoolInput;
   kind: "Premier" | "Traditional";
   podSize: number;
   hostDisplayName: string;
@@ -188,11 +189,23 @@ export class DraftPodHostAdapter {
         }
       }
 
-      // 3. Create P2PDraftHost
+      // 3. For cube drafts, the WASM CARD_DB must be populated before
+      //    create_multiplayer_draft is invoked (it resolves cube cards
+      //    against the database). The set branch reads its pool from JSON
+      //    and never touches CARD_DB.
+      if (config.poolInput.type === "Cube") {
+        const resp = await fetch(__CARD_DATA_URL__);
+        if (!resp.ok) {
+          throw new Error(`Failed to load card data: ${resp.status}`);
+        }
+        await new DraftAdapter().loadCardDatabase(await resp.text());
+      }
+
+      // 4. Create P2PDraftHost
       const host = new P2PDraftHost(
         hostResult.peer,
         hostResult.onGuestConnected,
-        config.setPoolJson,
+        config.poolInput,
         config.kind,
         config.podSize,
         config.hostDisplayName,

--- a/client/src/adapter/draftPodHostAdapter.ts
+++ b/client/src/adapter/draftPodHostAdapter.ts
@@ -176,7 +176,13 @@ export class DraftPodHostAdapter {
       this._roomCode = hostResult.roomCode;
       this.emit({ type: "roomCreated", roomCode: hostResult.roomCode });
 
-      // 2. Register with lobby broker if provided
+      // 2. Register with lobby broker if provided.
+      //
+      // Note: no in-tree caller currently builds a brokerRequest for draft
+      // pods. When a future caller does, it should populate
+      // `draftMetadata.cubeName` from `config.poolInput.data.cube_name` for
+      // Cube pods and leave it `undefined` for Set pods. The lobby protocol
+      // schema is already forward-ready (see DraftLobbyMetadata, #1253).
       if (config.broker && config.brokerRequest) {
         try {
           await config.broker.registerHost({

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -183,7 +183,7 @@ export class P2PDraftHost {
     private readonly onGuestConnected: (
       handler: (conn: DataConnection) => void,
     ) => () => void,
-    private readonly setPoolJson: string,
+    private readonly poolInput: PoolInput,
     private readonly kind: "Premier" | "Traditional",
     private readonly podSize: number,
     private readonly hostDisplayName: string,
@@ -465,13 +465,8 @@ export class P2PDraftHost {
       throw new Error("Need at least two seats to start a pod draft");
     }
 
-    // TRANSIENT (removed in Commit 3 when setPoolJson field is replaced by poolInput).
-    const poolInput: PoolInput = {
-      type: "Set",
-      data: { set_pool_json: this.setPoolJson },
-    };
     await this.adapter.createMultiplayerDraft(
-      poolInput,
+      this.poolInput,
       seats,
       this.kind,
       seed,
@@ -1365,7 +1360,7 @@ export class P2PDraftHost {
           draftStarted: this.draftStarted,
           draftCode: this.draftCode,
           draftSessionJson: sessionJson,
-          setPoolJson: this.setPoolJson,
+          poolInput: this.poolInput,
         };
 
         await saveDraftHostSession(this.persistenceId!, snapshot);

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -13,7 +13,7 @@ import type Peer from "peerjs";
 import type { DataConnection } from "peerjs";
 
 import { DraftAdapter } from "./draft-adapter";
-import type { DraftPlayerView, MultiplayerSeatDescriptor, PairingView, SeatPublicView } from "./draft-adapter";
+import type { DraftPlayerView, MultiplayerSeatDescriptor, PairingView, PoolInput, SeatPublicView } from "./draft-adapter";
 import type { PodPolicy, TournamentFormat } from "./draft-adapter";
 import {
   createDraftPeerSession,
@@ -465,8 +465,13 @@ export class P2PDraftHost {
       throw new Error("Need at least two seats to start a pod draft");
     }
 
+    // TRANSIENT (removed in Commit 3 when setPoolJson field is replaced by poolInput).
+    const poolInput: PoolInput = {
+      type: "Set",
+      data: { set_pool_json: this.setPoolJson },
+    };
     await this.adapter.createMultiplayerDraft(
-      this.setPoolJson,
+      poolInput,
       seats,
       this.kind,
       seed,

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -136,10 +136,12 @@ export interface LobbyGame {
 
 /** Metadata for draft pod lobby entries. */
 export interface DraftLobbyMetadata {
-  /** Three-letter set code (e.g. "MKM", "OTJ"). */
+  /** Three-letter set code (e.g. "MKM", "OTJ"). For cube drafts, "custom-cube". */
   setCode: string;
   /** Draft kind: "Quick", "Premier", or "Traditional". */
   draftKind: string;
+  /** Human-readable cube name when the pod is a cube draft. Absent for set drafts. */
+  cubeName?: string;
 }
 
 /**

--- a/client/src/components/draft/CubeSetupPanel.tsx
+++ b/client/src/components/draft/CubeSetupPanel.tsx
@@ -1,0 +1,220 @@
+/**
+ * Shared cube setup panel — paste a counted cube list, configure pack/seat
+ * settings, and dispatch via the `onStart` callback. Decoupled from any
+ * specific draft store so both solo (DraftPage) and multiplayer
+ * (DraftPodPage) flows can mount it.
+ */
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { CubeDraftSettings } from "../../adapter/draft-adapter";
+import { menuButtonClass } from "../menu/buttonStyles";
+import { fetchCubeList } from "../../services/cubeCobra";
+
+export const DEFAULT_CUBE_SETTINGS: CubeDraftSettings = {
+  pod_size: 8,
+  pack_count: 3,
+  cards_per_pack: 15,
+  min_deck_size: 40,
+  addable_cards: {
+    policy: "StandardBasics",
+    custom: [],
+  },
+};
+
+export interface CubeSetupPanelProps {
+  /**
+   * Called when the host clicks "Start". Async return blocks the panel's
+   * internal loading state until the callback resolves.
+   */
+  onStart: (params: {
+    cubeName: string;
+    cubeListText: string;
+    settings: CubeDraftSettings;
+  }) => void | Promise<void>;
+  /** Custom button label; defaults to the solo cube draft localized string. */
+  startLabel?: string;
+  /**
+   * External disabled signal (e.g. the parent is busy fetching pool data).
+   * Composed with the panel's internal loading state via OR.
+   */
+  disabled?: boolean;
+}
+
+export function CubeSetupPanel({ onStart, startLabel, disabled }: CubeSetupPanelProps) {
+  const { t } = useTranslation("draft");
+  const [cubeName, setCubeName] = useState(t("cubeSetup.defaultCubeName"));
+  const [cubeText, setCubeText] = useState("");
+  const [cubeUrl, setCubeUrl] = useState("");
+  const [settings, setSettings] = useState<CubeDraftSettings>(DEFAULT_CUBE_SETTINGS);
+  const [customAddables, setCustomAddables] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateSetting = (key: keyof Omit<CubeDraftSettings, "addable_cards">, value: number) => {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const updateCustomAddables = (value: string) => {
+    setCustomAddables(value);
+    setSettings((prev) => ({
+      ...prev,
+      addable_cards: {
+        ...prev.addable_cards,
+        custom: value
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean),
+      },
+    }));
+  };
+
+  const handleFetchUrl = async () => {
+    if (!cubeUrl.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setCubeText(await fetchCubeList(cubeUrl));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("cubeSetup.fetchError"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleStart = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await onStart({ cubeName, cubeListText: cubeText, settings });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("cubeSetup.startError"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const busy = loading || disabled === true;
+  const canStart = cubeText.trim().length > 0 && !busy;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid gap-3 md:grid-cols-[1fr_220px_220px_220px]">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.cubeName")}</span>
+          <input
+            value={cubeName}
+            onChange={(e) => setCubeName(e.target.value)}
+            className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400/50"
+          />
+        </label>
+        <NumberField label={t("cubeSetup.seats")} value={settings.pod_size} min={2} max={16} onChange={(v) => updateSetting("pod_size", v)} />
+        <NumberField label={t("cubeSetup.packs")} value={settings.pack_count} min={1} max={6} onChange={(v) => updateSetting("pack_count", v)} />
+        <NumberField label={t("cubeSetup.packSize")} value={settings.cards_per_pack} min={1} max={30} onChange={(v) => updateSetting("cards_per_pack", v)} />
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-[220px_1fr_auto]">
+        <NumberField label={t("cubeSetup.minDeck")} value={settings.min_deck_size} min={1} max={100} onChange={(v) => updateSetting("min_deck_size", v)} />
+        <label className="flex flex-col gap-1">
+          <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.exportUrl")}</span>
+          <input
+            value={cubeUrl}
+            onChange={(e) => setCubeUrl(e.target.value)}
+            placeholder={t("cubeSetup.exportUrlPlaceholder")}
+            className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none placeholder:text-white/25 focus:border-emerald-400/50"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={handleFetchUrl}
+          disabled={busy || !cubeUrl.trim()}
+          className={menuButtonClass({ tone: "neutral", size: "md", disabled: busy || !cubeUrl.trim(), className: "self-end" })}
+        >
+          {t("cubeSetup.loadUrl")}
+        </button>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-[260px_1fr]">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.deckAddables")}</span>
+          <select
+            value={settings.addable_cards.policy}
+            onChange={(e) =>
+              setSettings((prev) => ({
+                ...prev,
+                addable_cards: {
+                  ...prev.addable_cards,
+                  policy: e.target.value as CubeDraftSettings["addable_cards"]["policy"],
+                },
+              }))
+            }
+            className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400/50"
+          >
+            <option value="StandardBasics">{t("cubeSetup.addablesStandardBasics")}</option>
+            <option value="StandardBasicsPlusCustom">{t("cubeSetup.addablesBasicsPlusCustom")}</option>
+            <option value="CustomOnly">{t("cubeSetup.addablesCustomOnly")}</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.customAddableCards")}</span>
+          <textarea
+            value={customAddables}
+            onChange={(e) => updateCustomAddables(e.target.value)}
+            placeholder={t("cubeSetup.customAddablePlaceholder")}
+            className="min-h-10 resize-y rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none placeholder:text-white/25 focus:border-emerald-400/50"
+          />
+        </label>
+      </div>
+
+      <textarea
+        value={cubeText}
+        onChange={(e) => setCubeText(e.target.value)}
+        spellCheck={false}
+        placeholder="1 Lightning Bolt&#10;1 Black Lotus&#10;1 Tropical Island"
+        className="min-h-[280px] resize-y rounded-lg border border-white/10 bg-black/35 p-3 font-mono text-sm leading-6 text-white outline-none placeholder:text-white/25 focus:border-emerald-400/50"
+      />
+
+      {error && <div className="rounded-lg border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">{error}</div>}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={handleStart}
+          disabled={!canStart}
+          className={menuButtonClass({ tone: "emerald", size: "lg", disabled: !canStart })}
+        >
+          {startLabel ?? t("cubeSetup.startCubeDraft")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs uppercase tracking-[0.16em] text-white/35">{label}</span>
+      <input
+        type="number"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => onChange(Math.min(max, Math.max(min, Number(e.target.value))))}
+        className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400/50"
+      />
+    </label>
+  );
+}

--- a/client/src/components/draft/DraftPodLobby.tsx
+++ b/client/src/components/draft/DraftPodLobby.tsx
@@ -144,6 +144,8 @@ export function DraftPodLobby({ onLeave }: DraftPodLobbyProps) {
   const toggleBotFill = useDraftPodStore((s) => s.toggleBotFill);
   const startDraft = useDraftPodStore((s) => s.startDraft);
   const config = useDraftPodStore((s) => s.config);
+  const poolMode = useDraftPodStore((s) => s.poolMode);
+  const cubeForm = useDraftPodStore((s) => s.cubeForm);
 
   const isHost = role === "host";
   const filledSeats = seats.filter((s) => s.display_name).length;
@@ -188,7 +190,9 @@ export function DraftPodLobby({ onLeave }: DraftPodLobbyProps) {
         <div>
           <h2 className="menu-display text-2xl text-white">{t("lobby.title")}</h2>
           <p className="mt-1 text-sm text-white/50">
-            {config.setName || config.setCode} &mdash;{" "}
+            {poolMode === "cube"
+              ? cubeForm?.cubeName ?? config.setName
+              : config.setName || config.setCode} &mdash;{" "}
             {t("lobby.draftKind", { kind: config.kind })}
           </p>
         </div>

--- a/client/src/i18n/locales/de/draft.json
+++ b/client/src/i18n/locales/de/draft.json
@@ -269,7 +269,11 @@
     "loadingPool": "Set-Pool-Daten werden geladen...",
     "roomCode": "Raumcode",
     "roomCodePlaceholder": "Raumcode eingeben...",
-    "joinPod": "Pod beitreten"
+    "joinPod": "Pod beitreten",
+    "tabs": {
+      "set": "Edition",
+      "cube": "Cube"
+    }
   },
   "podPhaseView": {
     "tournamentPairings": "Turnierpaarungen",

--- a/client/src/i18n/locales/en/draft.json
+++ b/client/src/i18n/locales/en/draft.json
@@ -269,7 +269,11 @@
     "loadingPool": "Loading set pool data...",
     "roomCode": "Room Code",
     "roomCodePlaceholder": "Enter room code...",
-    "joinPod": "Join Pod"
+    "joinPod": "Join Pod",
+    "tabs": {
+      "set": "Set",
+      "cube": "Cube"
+    }
   },
   "podPhaseView": {
     "tournamentPairings": "Tournament Pairings",

--- a/client/src/i18n/locales/es/draft.json
+++ b/client/src/i18n/locales/es/draft.json
@@ -269,7 +269,11 @@
     "loadingPool": "Cargando los datos del grupo de la colección...",
     "roomCode": "Código de sala",
     "roomCodePlaceholder": "Introduce el código de sala...",
-    "joinPod": "Unirse al pod"
+    "joinPod": "Unirse al pod",
+    "tabs": {
+      "set": "Colección",
+      "cube": "Cube"
+    }
   },
   "podPhaseView": {
     "tournamentPairings": "Emparejamientos del torneo",

--- a/client/src/i18n/locales/fr/draft.json
+++ b/client/src/i18n/locales/fr/draft.json
@@ -269,7 +269,11 @@
     "loadingPool": "Chargement des données du pool d'extension...",
     "roomCode": "Code de la salle",
     "roomCodePlaceholder": "Saisissez le code de la salle...",
-    "joinPod": "Rejoindre le pod"
+    "joinPod": "Rejoindre le pod",
+    "tabs": {
+      "set": "Extension",
+      "cube": "Cube"
+    }
   },
   "podPhaseView": {
     "tournamentPairings": "Appariements du tournoi",

--- a/client/src/i18n/locales/it/draft.json
+++ b/client/src/i18n/locales/it/draft.json
@@ -269,7 +269,11 @@
     "loadingPool": "Caricamento dati del pool del set...",
     "roomCode": "Codice stanza",
     "roomCodePlaceholder": "Inserisci codice stanza...",
-    "joinPod": "Unisciti al pod"
+    "joinPod": "Unisciti al pod",
+    "tabs": {
+      "set": "Espansione",
+      "cube": "Cube"
+    }
   },
   "podPhaseView": {
     "tournamentPairings": "Accoppiamenti torneo",

--- a/client/src/i18n/locales/pl/draft.json
+++ b/client/src/i18n/locales/pl/draft.json
@@ -269,7 +269,11 @@
     "loadingPool": "Wczytywanie danych puli dodatku...",
     "roomCode": "Kod pokoju",
     "roomCodePlaceholder": "Wpisz kod pokoju...",
-    "joinPod": "Dołącz do grupy"
+    "joinPod": "Dołącz do grupy",
+    "tabs": {
+      "set": "Dodatek",
+      "cube": "Cube"
+    }
   },
   "podPhaseView": {
     "tournamentPairings": "Pary turniejowe",

--- a/client/src/i18n/locales/pt/draft.json
+++ b/client/src/i18n/locales/pt/draft.json
@@ -269,7 +269,11 @@
     "loadingPool": "Carregando dados do pool da coleção...",
     "roomCode": "Código da Sala",
     "roomCodePlaceholder": "Insira o código da sala...",
-    "joinPod": "Entrar no Pod"
+    "joinPod": "Entrar no Pod",
+    "tabs": {
+      "set": "Coleção",
+      "cube": "Cube"
+    }
   },
   "podPhaseView": {
     "tournamentPairings": "Confrontos do Torneio",

--- a/client/src/pages/DraftPage.tsx
+++ b/client/src/pages/DraftPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useDraftStore } from "../stores/draftStore";
 import { CardPreview } from "../components/card/CardPreview";
 import type { CardHoverInfo } from "../components/card/CardPreview";
+import { CubeSetupPanel } from "../components/draft/CubeSetupPanel";
 import { DraftIntro } from "../components/draft/DraftIntro";
 import { DraftSteps } from "../components/draft/DraftSteps";
 import { SetSelector } from "../components/draft/SetSelector";
@@ -15,10 +16,8 @@ import { DraftProgress } from "../components/draft/DraftProgress";
 import { LimitedDeckBuilder } from "../components/draft/LimitedDeckBuilder";
 import { ScreenChrome } from "../components/chrome/ScreenChrome";
 import { menuButtonClass } from "../components/menu/buttonStyles";
-import { fetchCubeList } from "../services/cubeCobra";
 import { runLimits } from "../services/quickDraftPersistence";
 import type { DraftRunFormat, DraftRunState } from "../services/quickDraftPersistence";
-import type { CubeDraftSettings } from "../adapter/draft-adapter";
 import { usePreferencesStore } from "../stores/preferencesStore";
 
 // ── Format Picker ─────────────────────────────────────────────────────
@@ -30,194 +29,6 @@ const FORMAT_OPTIONS: Array<{ value: DraftRunFormat; labelKey: string; descKey: 
 ];
 
 type DraftSetupMode = "set" | "cube";
-
-const DEFAULT_CUBE_SETTINGS: CubeDraftSettings = {
-  pod_size: 8,
-  pack_count: 3,
-  cards_per_pack: 15,
-  min_deck_size: 40,
-  addable_cards: {
-    policy: "StandardBasics",
-    custom: [],
-  },
-};
-
-function CubeSetupPanel() {
-  const { t } = useTranslation("draft");
-  const [cubeName, setCubeName] = useState(t("cubeSetup.defaultCubeName"));
-  const [cubeText, setCubeText] = useState("");
-  const [cubeUrl, setCubeUrl] = useState("");
-  const [settings, setSettings] = useState<CubeDraftSettings>(DEFAULT_CUBE_SETTINGS);
-  const [customAddables, setCustomAddables] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const updateSetting = (key: keyof Omit<CubeDraftSettings, "addable_cards">, value: number) => {
-    setSettings((prev) => ({ ...prev, [key]: value }));
-  };
-
-  const updateCustomAddables = (value: string) => {
-    setCustomAddables(value);
-    setSettings((prev) => ({
-      ...prev,
-      addable_cards: {
-        ...prev.addable_cards,
-        custom: value
-          .split("\n")
-          .map((line) => line.trim())
-          .filter(Boolean),
-      },
-    }));
-  };
-
-  const handleFetchUrl = async () => {
-    if (!cubeUrl.trim()) return;
-    setLoading(true);
-    setError(null);
-    try {
-      setCubeText(await fetchCubeList(cubeUrl));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t("cubeSetup.fetchError"));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleStart = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const { difficulty, startCubeDraft } = useDraftStore.getState();
-      await startCubeDraft(cubeText, cubeName, settings, difficulty);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t("cubeSetup.startError"));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const canStart = cubeText.trim().length > 0 && !loading;
-
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="grid gap-3 md:grid-cols-[1fr_220px_220px_220px]">
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.cubeName")}</span>
-          <input
-            value={cubeName}
-            onChange={(e) => setCubeName(e.target.value)}
-            className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400/50"
-          />
-        </label>
-        <NumberField label={t("cubeSetup.seats")} value={settings.pod_size} min={2} max={16} onChange={(v) => updateSetting("pod_size", v)} />
-        <NumberField label={t("cubeSetup.packs")} value={settings.pack_count} min={1} max={6} onChange={(v) => updateSetting("pack_count", v)} />
-        <NumberField label={t("cubeSetup.packSize")} value={settings.cards_per_pack} min={1} max={30} onChange={(v) => updateSetting("cards_per_pack", v)} />
-      </div>
-
-      <div className="grid gap-3 md:grid-cols-[220px_1fr_auto]">
-        <NumberField label={t("cubeSetup.minDeck")} value={settings.min_deck_size} min={1} max={100} onChange={(v) => updateSetting("min_deck_size", v)} />
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.exportUrl")}</span>
-          <input
-            value={cubeUrl}
-            onChange={(e) => setCubeUrl(e.target.value)}
-            placeholder={t("cubeSetup.exportUrlPlaceholder")}
-            className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none placeholder:text-white/25 focus:border-emerald-400/50"
-          />
-        </label>
-        <button
-          type="button"
-          onClick={handleFetchUrl}
-          disabled={loading || !cubeUrl.trim()}
-          className={menuButtonClass({ tone: "neutral", size: "md", disabled: loading || !cubeUrl.trim(), className: "self-end" })}
-        >
-          {t("cubeSetup.loadUrl")}
-        </button>
-      </div>
-
-      <div className="grid gap-3 md:grid-cols-[260px_1fr]">
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.deckAddables")}</span>
-          <select
-            value={settings.addable_cards.policy}
-            onChange={(e) =>
-              setSettings((prev) => ({
-                ...prev,
-                addable_cards: {
-                  ...prev.addable_cards,
-                  policy: e.target.value as CubeDraftSettings["addable_cards"]["policy"],
-                },
-              }))
-            }
-            className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400/50"
-          >
-            <option value="StandardBasics">{t("cubeSetup.addablesStandardBasics")}</option>
-            <option value="StandardBasicsPlusCustom">{t("cubeSetup.addablesBasicsPlusCustom")}</option>
-            <option value="CustomOnly">{t("cubeSetup.addablesCustomOnly")}</option>
-          </select>
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.customAddableCards")}</span>
-          <textarea
-            value={customAddables}
-            onChange={(e) => updateCustomAddables(e.target.value)}
-            placeholder={t("cubeSetup.customAddablePlaceholder")}
-            className="min-h-10 resize-y rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none placeholder:text-white/25 focus:border-emerald-400/50"
-          />
-        </label>
-      </div>
-
-      <textarea
-        value={cubeText}
-        onChange={(e) => setCubeText(e.target.value)}
-        spellCheck={false}
-        placeholder="1 Lightning Bolt&#10;1 Black Lotus&#10;1 Tropical Island"
-        className="min-h-[280px] resize-y rounded-lg border border-white/10 bg-black/35 p-3 font-mono text-sm leading-6 text-white outline-none placeholder:text-white/25 focus:border-emerald-400/50"
-      />
-
-      {error && <div className="rounded-lg border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">{error}</div>}
-
-      <div className="flex justify-end">
-        <button
-          type="button"
-          onClick={handleStart}
-          disabled={!canStart}
-          className={menuButtonClass({ tone: "emerald", size: "lg", disabled: !canStart })}
-        >
-          {t("cubeSetup.startCubeDraft")}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function NumberField({
-  label,
-  value,
-  min,
-  max,
-  onChange,
-}: {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  onChange: (value: number) => void;
-}) {
-  return (
-    <label className="flex flex-col gap-1">
-      <span className="text-xs uppercase tracking-[0.16em] text-white/35">{label}</span>
-      <input
-        type="number"
-        min={min}
-        max={max}
-        value={value}
-        onChange={(e) => onChange(Math.min(max, Math.max(min, Number(e.target.value))))}
-        className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400/50"
-      />
-    </label>
-  );
-}
 
 function FormatPicker({ onLaunch }: { onLaunch: () => void }) {
   const { t } = useTranslation("draft");
@@ -607,7 +418,12 @@ export function DraftPage() {
             {setupMode === "set" ? (
               <SetSelector onStartDraft={handleStartDraft} />
             ) : (
-              <CubeSetupPanel />
+              <CubeSetupPanel
+                onStart={async ({ cubeName, cubeListText, settings }) => {
+                  const { difficulty, startCubeDraft } = useDraftStore.getState();
+                  await startCubeDraft(cubeListText, cubeName, settings, difficulty);
+                }}
+              />
             )}
           </div>
         )}

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -15,6 +15,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { CardPreview } from "../components/card/CardPreview";
 import type { CardHoverInfo } from "../components/card/CardPreview";
 import { ScreenChrome } from "../components/chrome/ScreenChrome";
+import { CubeSetupPanel } from "../components/draft/CubeSetupPanel";
 import { DraftIntro } from "../components/draft/DraftIntro";
 import { DraftPodLobby } from "../components/draft/DraftPodLobby";
 import { DraftProgress } from "../components/draft/DraftProgress";
@@ -55,6 +56,9 @@ function PodSetup() {
   const joinPod = useDraftPodStore((s) => s.joinPod);
   const configError = useDraftPodStore((s) => s.configError);
   const loadingPool = useDraftPodStore((s) => s.loadingPool);
+  const poolMode = useDraftPodStore((s) => s.poolMode);
+  const setPoolMode = useDraftPodStore((s) => s.setPoolMode);
+  const setCubeForm = useDraftPodStore((s) => s.setCubeForm);
   const kindDescription = config.kind === "Premier"
     ? t("podSetup.kindPremierDesc")
     : t("podSetup.kindTraditionalDesc");
@@ -251,16 +255,54 @@ function PodSetup() {
           <p className="text-xs text-white/40">{podSizeDescription}</p>
         </div>
 
-        {/* Set selector — reuse the Quick Draft component */}
-        <div className="rounded-[16px] border border-white/8 bg-white/3 px-4 py-3 text-sm text-white/45">
-          {t("podSetup.setSelectorHint")}
+        {/* Pool source: Set vs Cube tab switch */}
+        <div className="flex gap-2 border-b border-white/10">
+          <button
+            type="button"
+            onClick={() => setPoolMode("set")}
+            className={
+              poolMode === "set"
+                ? "border-b-2 border-emerald-400 px-4 py-2 text-sm font-medium text-white"
+                : "border-b-2 border-transparent px-4 py-2 text-sm text-white/50 hover:text-white/75"
+            }
+          >
+            {t("podSetup.tabs.set")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setPoolMode("cube")}
+            className={
+              poolMode === "cube"
+                ? "border-b-2 border-emerald-400 px-4 py-2 text-sm font-medium text-white"
+                : "border-b-2 border-transparent px-4 py-2 text-sm text-white/50 hover:text-white/75"
+            }
+          >
+            {t("podSetup.tabs.cube")}
+          </button>
         </div>
-        <SetSelector
-          onStartDraft={(setCode) => {
-            setConfig({ setCode });
-            void createPod();
-          }}
-        />
+
+        {poolMode === "set" ? (
+          <>
+            {/* Set selector — reuse the Quick Draft component */}
+            <div className="rounded-[16px] border border-white/8 bg-white/3 px-4 py-3 text-sm text-white/45">
+              {t("podSetup.setSelectorHint")}
+            </div>
+            <SetSelector
+              onStartDraft={(setCode) => {
+                setConfig({ setCode });
+                void createPod();
+              }}
+            />
+          </>
+        ) : (
+          <CubeSetupPanel
+            onStart={({ cubeName, cubeListText, settings }) => {
+              setCubeForm({ cubeName, cubeListText, settings });
+              void createPod();
+            }}
+            disabled={loadingPool}
+          />
+        )}
 
         {/* Error */}
         {configError && (

--- a/client/src/services/__tests__/draftPersistence.test.ts
+++ b/client/src/services/__tests__/draftPersistence.test.ts
@@ -49,7 +49,7 @@ describe("draftPersistence", () => {
       draftStarted: true,
       draftCode: "draft-12345678",
       draftSessionJson: '{"status":"Drafting"}',
-      setPoolJson: '{"code":"TST"}',
+      poolInput: { type: "Set", data: { set_pool_json: '{"code":"TST"}' } },
     };
 
     it("saves and loads a host session", async () => {

--- a/client/src/services/__tests__/draftPersistence.test.ts
+++ b/client/src/services/__tests__/draftPersistence.test.ts
@@ -78,6 +78,46 @@ describe("draftPersistence", () => {
       expect(loaded!.draftStarted).toBe(false);
     });
 
+    it("returns null for legacy snapshots missing poolInput (C6 shape guard)", async () => {
+      // Simulate a pre-#1253 snapshot with the flat setPoolJson field.
+      const legacy = {
+        ...testSession,
+        // Intentionally drop poolInput; carry the legacy field instead.
+        setPoolJson: '{"code":"LEGACY"}',
+      } as unknown as PersistedDraftHostSession;
+      // Bypass the typed write — direct mockStore population mirrors how a
+      // pre-migration snapshot would have been written to IDB.
+      mockStore.set("phase-draft-host:legacy", legacy);
+      delete (mockStore.get("phase-draft-host:legacy") as Record<string, unknown>).poolInput;
+
+      const loaded = await loadDraftHostSession("legacy");
+      expect(loaded).toBeNull();
+    });
+
+    it("loads a Cube poolInput snapshot intact", async () => {
+      const cubeSession: PersistedDraftHostSession = {
+        ...testSession,
+        poolInput: {
+          type: "Cube",
+          data: {
+            cube_list_text: "1 Lightning Bolt\n",
+            cube_name: "Test Cube",
+            cube_draft_settings: {
+              pod_size: 2,
+              pack_count: 1,
+              cards_per_pack: 2,
+              min_deck_size: 4,
+              addable_cards: { policy: "StandardBasics", custom: [] },
+            },
+          },
+        },
+      };
+      await saveDraftHostSession("cube-1", cubeSession);
+      const loaded = await loadDraftHostSession("cube-1");
+      expect(loaded).toEqual(cubeSession);
+      expect(loaded?.poolInput.type).toBe("Cube");
+    });
+
     it("saves and loads active host resume metadata", () => {
       saveActiveDraftPod({
         id: "test-draft-1",

--- a/client/src/services/draftPersistence.ts
+++ b/client/src/services/draftPersistence.ts
@@ -12,7 +12,10 @@
 
 import { createStore, del, get, set } from "idb-keyval";
 
+import type { PoolInput } from "../adapter/draft-adapter";
 import { ACTIVE_DRAFT_POD_KEY } from "../constants/storage";
+
+export type { PoolInput } from "../adapter/draft-adapter";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -42,8 +45,8 @@ export interface PersistedDraftHostSession {
   draftCode: string;
   /** Serialized DraftSession JSON from draft-wasm. Null if draft hasn't started. */
   draftSessionJson: string | null;
-  /** Original set pool JSON for re-initialization on resume. */
-  setPoolJson: string;
+  /** Pool source for re-initialization on resume (Set pool JSON or Cube list + settings). */
+  poolInput: PoolInput;
 }
 
 /**

--- a/client/src/services/draftPersistence.ts
+++ b/client/src/services/draftPersistence.ts
@@ -122,7 +122,16 @@ export async function loadDraftHostSession(
       DRAFT_HOST_PREFIX + id,
       getDraftStore(),
     );
-    return s ?? null;
+    if (!s) return null;
+    // C6 shape guard: legacy snapshots (pre-#1253) carried a flat
+    // `setPoolJson: string` field instead of the PoolInput discriminated
+    // union. Discriminate on the new shape; reject anything that doesn't
+    // self-identify as Set or Cube so the resume path falls back to
+    // "no draft pod to resume" instead of crashing on `persisted.poolInput.data`.
+    if (s.poolInput?.type !== "Set" && s.poolInput?.type !== "Cube") {
+      return null;
+    }
+    return s;
   } catch {
     return null;
   }

--- a/client/src/stores/__tests__/draftPodStore.test.ts
+++ b/client/src/stores/__tests__/draftPodStore.test.ts
@@ -108,5 +108,93 @@ describe("draftPodStore", () => {
       expect(mocks.loadDraftHostSession).toHaveBeenCalledOnce();
       expect(mocks.multiplayerState.hostDraft).toHaveBeenCalledOnce();
     });
+
+    it("restores cube poolMode + setName from a persisted cube snapshot", async () => {
+      const cubeSession = {
+        ...persistedSession,
+        poolInput: {
+          type: "Cube" as const,
+          data: {
+            cube_list_text: "1 Lightning Bolt\n",
+            cube_name: "My Cube",
+            cube_draft_settings: {
+              pod_size: 2,
+              pack_count: 1,
+              cards_per_pack: 2,
+              min_deck_size: 4,
+              addable_cards: { policy: "StandardBasics" as const, custom: [] },
+            },
+          },
+        },
+      };
+      mocks.loadActiveDraftPod.mockReturnValue(activeMeta);
+      mocks.loadDraftHostSession.mockResolvedValue(cubeSession);
+
+      await useDraftPodStore.getState().resumeHostedPod();
+
+      const state = useDraftPodStore.getState();
+      expect(state.poolMode).toBe("cube");
+      expect(state.config.setName).toBe("My Cube");
+      expect(state.config.setCode).toBe("custom-cube");
+      expect(state.cubeForm?.cubeName).toBe("My Cube");
+      expect(state.cubeForm?.cubeListText).toBe("1 Lightning Bolt\n");
+
+      // The hostConfig dispatched to multiplayerDraftStore must mirror the
+      // persisted Cube source 1:1 so the host re-initializes onto the same
+      // cube content rather than falling back to "{}".
+      const dispatched = mocks.multiplayerState.hostDraft.mock.calls[0]?.[0];
+      expect(dispatched.poolInput.type).toBe("Cube");
+    });
+  });
+
+  describe("createPod (cube branch)", () => {
+    it("rejects an empty cube list with a config error", async () => {
+      useDraftPodStore.setState({
+        poolMode: "cube",
+        cubeForm: {
+          cubeName: "C",
+          cubeListText: "   ",
+          settings: {
+            pod_size: 2,
+            pack_count: 1,
+            cards_per_pack: 2,
+            min_deck_size: 4,
+            addable_cards: { policy: "StandardBasics", custom: [] },
+          },
+        },
+        hostDisplayName: "Host",
+      });
+
+      await useDraftPodStore.getState().createPod();
+
+      expect(useDraftPodStore.getState().configError).toBeTruthy();
+      expect(mocks.multiplayerState.hostDraft).not.toHaveBeenCalled();
+    });
+
+    it("dispatches a Cube poolInput hostConfig when cubeForm is valid", async () => {
+      useDraftPodStore.setState({
+        poolMode: "cube",
+        cubeForm: {
+          cubeName: "Test Cube",
+          cubeListText: "1 Lightning Bolt\n",
+          settings: {
+            pod_size: 2,
+            pack_count: 1,
+            cards_per_pack: 2,
+            min_deck_size: 4,
+            addable_cards: { policy: "StandardBasics", custom: [] },
+          },
+        },
+        hostDisplayName: "Host",
+      });
+
+      await useDraftPodStore.getState().createPod();
+
+      expect(mocks.multiplayerState.hostDraft).toHaveBeenCalledOnce();
+      const dispatched = mocks.multiplayerState.hostDraft.mock.calls[0]?.[0];
+      expect(dispatched.poolInput.type).toBe("Cube");
+      expect(dispatched.poolInput.data.cube_name).toBe("Test Cube");
+      expect(dispatched.poolInput.data.cube_list_text).toBe("1 Lightning Bolt\n");
+    });
   });
 });

--- a/client/src/stores/__tests__/draftPodStore.test.ts
+++ b/client/src/stores/__tests__/draftPodStore.test.ts
@@ -53,7 +53,7 @@ const persistedSession = {
   draftStarted: true,
   draftCode: "ABCDE",
   draftSessionJson: "{}",
-  setPoolJson: "{}",
+  poolInput: { type: "Set" as const, data: { set_pool_json: "{}" } },
 };
 
 describe("draftPodStore", () => {

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -114,7 +114,7 @@ describe("multiplayerDraftStore", () => {
   describe("hostDraft", () => {
     it("sets role to host and phase to connecting", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -129,7 +129,7 @@ describe("multiplayerDraftStore", () => {
 
     it("updates roomCode on roomCreated event", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -144,7 +144,7 @@ describe("multiplayerDraftStore", () => {
 
     it("updates view on draftStarted event", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -162,7 +162,7 @@ describe("multiplayerDraftStore", () => {
 
     it("tracks lobby state from lobbyUpdate events", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -185,7 +185,7 @@ describe("multiplayerDraftStore", () => {
 
     it("projects restored MatchInProgress views into match phase", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -203,7 +203,7 @@ describe("multiplayerDraftStore", () => {
 
     it("handles host-seat Bo3 prompt messages", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Traditional",
         podSize: 8,
         hostDisplayName: "Host",
@@ -243,7 +243,7 @@ describe("multiplayerDraftStore", () => {
 
     it("reports active bot match results back to the pod host", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -275,7 +275,7 @@ describe("multiplayerDraftStore", () => {
 
     it("reports active match concessions as opponent wins", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -398,7 +398,7 @@ describe("multiplayerDraftStore", () => {
   describe("shared actions", () => {
     it("selectCard and confirmPick work together", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -415,7 +415,7 @@ describe("multiplayerDraftStore", () => {
 
     it("autoPickCard submits from the visible pack without manual selection", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",
@@ -478,7 +478,7 @@ describe("multiplayerDraftStore", () => {
   describe("leave", () => {
     it("resets state to initial", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
-        setPoolJson: "{}",
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
         podSize: 8,
         hostDisplayName: "Host",

--- a/client/src/stores/draftPodStore.ts
+++ b/client/src/stores/draftPodStore.ts
@@ -173,7 +173,7 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
         // Create the pod via multiplayerDraftStore
         const persistenceId = crypto.randomUUID();
         const hostConfig: DraftPodHostConfig = {
-          setPoolJson: poolJson,
+          poolInput: { type: "Set", data: { set_pool_json: poolJson } },
           kind: config.kind,
           podSize: config.podSize,
           hostDisplayName: hostDisplayName.trim(),
@@ -218,6 +218,13 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
           return;
         }
 
+        // Transient: derive a legacy setPoolJson cache for set-mode resume
+        // until Commit 5 branches resumeHostedPod on poolInput.type.
+        const persistedSetPoolJson =
+          persisted.poolInput.type === "Set"
+            ? persisted.poolInput.data.set_pool_json
+            : null;
+
         set({
           config: {
             setCode: "",
@@ -228,13 +235,13 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
             podPolicy: persisted.podPolicy,
           },
           hostDisplayName: persisted.hostDisplayName,
-          setPoolJson: persisted.setPoolJson,
+          setPoolJson: persistedSetPoolJson,
           loadingPool: false,
           configError: null,
         });
 
         const hostConfig: DraftPodHostConfig = {
-          setPoolJson: persisted.setPoolJson,
+          poolInput: persisted.poolInput,
           kind: persisted.kind,
           podSize: persisted.podSize,
           hostDisplayName: persisted.hostDisplayName,

--- a/client/src/stores/draftPodStore.ts
+++ b/client/src/stores/draftPodStore.ts
@@ -16,7 +16,7 @@
 
 import { create } from "zustand";
 
-import type { TournamentFormat, PodPolicy } from "../adapter/draft-adapter";
+import type { CubeDraftSettings, TournamentFormat, PodPolicy } from "../adapter/draft-adapter";
 import type { DraftPodHostConfig } from "../adapter/draftPodHostAdapter";
 import type { DraftPodGuestConfig } from "../adapter/draftPodGuestAdapter";
 import {
@@ -29,6 +29,14 @@ import { useMultiplayerDraftStore } from "./multiplayerDraftStore";
 // ── Types ──────────────────────────────────────────────────────────────
 
 export type DraftKind = "Premier" | "Traditional";
+
+export type PoolMode = "set" | "cube";
+
+export interface CubeForm {
+  cubeName: string;
+  cubeListText: string;
+  settings: CubeDraftSettings;
+}
 
 export interface PodConfig {
   setCode: string;
@@ -50,7 +58,11 @@ interface DraftPodState {
   joinCode: string;
   /** Guest display name. */
   guestDisplayName: string;
-  /** Set pool JSON loaded from draft-pools.json. */
+  /** Which pool source the host is configuring: a Set pool or a custom Cube list. */
+  poolMode: PoolMode;
+  /** Cube form state (cube name + list text + settings); null when poolMode === "set". */
+  cubeForm: CubeForm | null;
+  /** Set pool JSON loaded from draft-pools.json. Set-mode cache only — unused in cube mode. */
   setPoolJson: string | null;
   /** Loading state while fetching set pool data. */
   loadingPool: boolean;
@@ -69,6 +81,10 @@ interface DraftPodActions {
   setGuestDisplayName: (name: string) => void;
   /** Set join code for guest. */
   setJoinCode: (code: string) => void;
+  /** Switch between Set-pool and Cube-list pool modes. */
+  setPoolMode: (mode: PoolMode) => void;
+  /** Set the cube form (name + list text + settings) for cube-mode host setup. */
+  setCubeForm: (form: CubeForm | null) => void;
   /** Load the set pool data and create a new pod as host. */
   createPod: () => Promise<void>;
   /** Join an existing pod as guest. */
@@ -96,6 +112,8 @@ const initialState: DraftPodState = {
   hostDisplayName: "",
   guestDisplayName: "",
   joinCode: "",
+  poolMode: "set",
+  cubeForm: null,
   setPoolJson: null,
   loadingPool: false,
   configError: null,
@@ -139,41 +157,87 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
       set({ joinCode: code });
     },
 
-    createPod: async () => {
-      const { config, hostDisplayName } = get();
+    setPoolMode: (mode) => {
+      set({ poolMode: mode, configError: null });
+    },
 
-      if (!config.setCode) {
-        set({ configError: "Select a set first" });
-        return;
-      }
+    setCubeForm: (form) => {
+      set({ cubeForm: form, configError: null });
+    },
+
+    createPod: async () => {
+      const { config, hostDisplayName, poolMode, cubeForm } = get();
+
       if (!hostDisplayName.trim()) {
         set({ configError: "Enter a display name" });
         return;
       }
 
-      set({ loadingPool: true, configError: null });
+      if (poolMode === "set") {
+        if (!config.setCode) {
+          set({ configError: "Select a set first" });
+          return;
+        }
+
+        set({ loadingPool: true, configError: null });
+
+        try {
+          const resp = await fetch(__DRAFT_POOLS_URL__);
+          if (!resp.ok) {
+            throw new Error(`Failed to load draft pools: ${resp.status}`);
+          }
+          const allPools: Record<string, unknown> = await resp.json();
+          const setPool =
+            allPools[config.setCode.toLowerCase()] ??
+            allPools[config.setCode.toUpperCase()];
+          if (!setPool) {
+            throw new Error(`No pool data for set: ${config.setCode}`);
+          }
+
+          const poolJson = JSON.stringify(setPool);
+          set({ setPoolJson: poolJson, loadingPool: false });
+
+          const persistenceId = crypto.randomUUID();
+          const hostConfig: DraftPodHostConfig = {
+            poolInput: { type: "Set", data: { set_pool_json: poolJson } },
+            kind: config.kind,
+            podSize: config.podSize,
+            hostDisplayName: hostDisplayName.trim(),
+            tournamentFormat: config.tournamentFormat,
+            podPolicy: config.podPolicy,
+            persistenceId,
+          };
+
+          await useMultiplayerDraftStore.getState().hostDraft(hostConfig);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          set({ configError: message, loadingPool: false });
+        }
+        return;
+      }
+
+      // Cube mode: skip the draft-pools.json fetch entirely; everything the
+      // host needs lives on the cubeForm object.
+      if (!cubeForm || !cubeForm.cubeListText.trim()) {
+        set({ configError: "Paste a cube list first" });
+        return;
+      }
+      if (!cubeForm.cubeName.trim()) {
+        set({ configError: "Enter a cube name" });
+        return;
+      }
 
       try {
-        // Load set pool data
-        const resp = await fetch(__DRAFT_POOLS_URL__);
-        if (!resp.ok) {
-          throw new Error(`Failed to load draft pools: ${resp.status}`);
-        }
-        const allPools: Record<string, unknown> = await resp.json();
-        const setPool =
-          allPools[config.setCode.toLowerCase()] ??
-          allPools[config.setCode.toUpperCase()];
-        if (!setPool) {
-          throw new Error(`No pool data for set: ${config.setCode}`);
-        }
-
-        const poolJson = JSON.stringify(setPool);
-        set({ setPoolJson: poolJson, loadingPool: false });
-
-        // Create the pod via multiplayerDraftStore
         const persistenceId = crypto.randomUUID();
         const hostConfig: DraftPodHostConfig = {
-          poolInput: { type: "Set", data: { set_pool_json: poolJson } },
+          poolInput: {
+            type: "Cube",
+            data: {
+              cube_list_text: cubeForm.cubeListText,
+              cube_name: cubeForm.cubeName,
+              cube_draft_settings: cubeForm.settings,
+            },
+          },
           kind: config.kind,
           podSize: config.podSize,
           hostDisplayName: hostDisplayName.trim(),
@@ -185,7 +249,7 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
         await useMultiplayerDraftStore.getState().hostDraft(hostConfig);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        set({ configError: message, loadingPool: false });
+        set({ configError: message });
       }
     },
 
@@ -218,27 +282,49 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
           return;
         }
 
-        // Transient: derive a legacy setPoolJson cache for set-mode resume
-        // until Commit 5 branches resumeHostedPod on poolInput.type.
-        const persistedSetPoolJson =
-          persisted.poolInput.type === "Set"
-            ? persisted.poolInput.data.set_pool_json
-            : null;
-
-        set({
-          config: {
-            setCode: "",
-            setName: "Draft Pod",
-            kind: persisted.kind,
-            podSize: persisted.podSize,
-            tournamentFormat: persisted.tournamentFormat,
-            podPolicy: persisted.podPolicy,
-          },
-          hostDisplayName: persisted.hostDisplayName,
-          setPoolJson: persistedSetPoolJson,
-          loadingPool: false,
-          configError: null,
-        });
+        // Branch on the persisted pool source: restore the matching UI
+        // state (poolMode + cubeForm or setPoolJson cache) so a refresh
+        // mid-pod lands the host back on the same tab they configured.
+        if (persisted.poolInput.type === "Cube") {
+          const cubeData = persisted.poolInput.data;
+          set({
+            config: {
+              setCode: "custom-cube",
+              setName: cubeData.cube_name,
+              kind: persisted.kind,
+              podSize: persisted.podSize,
+              tournamentFormat: persisted.tournamentFormat,
+              podPolicy: persisted.podPolicy,
+            },
+            hostDisplayName: persisted.hostDisplayName,
+            poolMode: "cube",
+            cubeForm: {
+              cubeName: cubeData.cube_name,
+              cubeListText: cubeData.cube_list_text,
+              settings: cubeData.cube_draft_settings,
+            },
+            setPoolJson: null,
+            loadingPool: false,
+            configError: null,
+          });
+        } else {
+          set({
+            config: {
+              setCode: "",
+              setName: "Draft Pod",
+              kind: persisted.kind,
+              podSize: persisted.podSize,
+              tournamentFormat: persisted.tournamentFormat,
+              podPolicy: persisted.podPolicy,
+            },
+            hostDisplayName: persisted.hostDisplayName,
+            poolMode: "set",
+            cubeForm: null,
+            setPoolJson: persisted.poolInput.data.set_pool_json,
+            loadingPool: false,
+            configError: null,
+          });
+        }
 
         const hostConfig: DraftPodHostConfig = {
           poolInput: persisted.poolInput,

--- a/client/src/wasm/draft_wasm.d.ts
+++ b/client/src/wasm/draft_wasm.d.ts
@@ -30,11 +30,15 @@ export function auto_pick(): any;
 
 /**
  * Create a multiplayer draft session. Used by the P2P host to initialize a
- * Premier or Traditional draft with human + bot seats.
+ * Premier or Traditional draft with human + bot seats from either a Set pool
+ * or a custom Cube list.
  *
- * - `set_pool_json`: serialized LimitedSetPool from draft-pools.json
+ * - `pool_input_json`: serialized `PoolInput` discriminated union
+ *   (`{ "type": "Set" | "Cube", "data": { ... } }`)
  * - `seats_json`: JSON array of SeatDescriptors
- * - `kind`: 0=Quick, 1=Premier, 2=Traditional
+ * - `kind`: 0=Quick, 1=Premier, 2=Traditional. The user-selected DraftKind
+ *   flows through to `DraftConfig.kind` unchanged. Tournament match format
+ *   (Bo1 for Premier, Bo3 for Traditional) is identical to set drafts.
  * - `seed`: RNG seed for deterministic pack generation
  * - `draft_code`: unique room identifier
  *
@@ -42,7 +46,7 @@ export function auto_pick(): any;
  * draft at a time per WASM instance). Returns the initial DraftPlayerView
  * for seat 0.
  */
-export function create_multiplayer_draft(set_pool_json: string, seats_json: string, kind: number, seed: number, draft_code: string, tournament_format: string, pod_policy: string): any;
+export function create_multiplayer_draft(pool_input_json: string, seats_json: string, kind: number, seed: number, draft_code: string, tournament_format: string, pod_policy: string): any;
 
 /**
  * Serialize the full DraftSession to JSON for host persistence.

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     __SCRYFALL_PRINTINGS_URL__: JSON.stringify("/scryfall-printings.json"),
     __SCRYFALL_SETS_URL__: JSON.stringify("/scryfall-sets.json"),
     __DECKS_URL__: JSON.stringify("/decks.json"),
+    __CARD_DATA_URL__: JSON.stringify("/card-data.json"),
     __CARD_DATA_LOCALE_URL_TEMPLATE__: JSON.stringify("/card-data.{lng}.json"),
     __APP_VERSION__: JSON.stringify("0.0.0-test"),
     __BUILD_HASH__: JSON.stringify("testhash"),

--- a/crates/draft-wasm/src/lib.rs
+++ b/crates/draft-wasm/src/lib.rs
@@ -720,12 +720,38 @@ enum SeatDescriptor {
     Bot { name: String },
 }
 
-/// Create a multiplayer draft session. Used by the P2P host to initialize a
-/// Premier or Traditional draft with human + bot seats.
+/// Pool source for multiplayer draft creation.
+/// Discriminated union mirroring the TS `PoolInput` type. The `data` payload
+/// uses snake_case field names matching `CubeDraftSettings` and the existing
+/// TS↔Rust mirror convention in `draft-adapter.ts`.
 ///
-/// - `set_pool_json`: serialized LimitedSetPool from draft-pools.json
+/// JSON examples:
+///   `{ "type": "Set",  "data": { "set_pool_json": "<serialized LimitedSetPool>" } }`
+///   `{ "type": "Cube", "data": { "cube_list_text": "...", "cube_name": "My Cube",
+///                                 "cube_draft_settings": { ... } } }`
+#[derive(Deserialize)]
+#[serde(tag = "type", content = "data")]
+enum PoolInput {
+    Set {
+        set_pool_json: String,
+    },
+    Cube {
+        cube_list_text: String,
+        cube_name: String,
+        cube_draft_settings: CubeDraftSettings,
+    },
+}
+
+/// Create a multiplayer draft session. Used by the P2P host to initialize a
+/// Premier or Traditional draft with human + bot seats from either a Set pool
+/// or a custom Cube list.
+///
+/// - `pool_input_json`: serialized `PoolInput` discriminated union
+///   (`{ "type": "Set" | "Cube", "data": { ... } }`)
 /// - `seats_json`: JSON array of SeatDescriptors
-/// - `kind`: 0=Quick, 1=Premier, 2=Traditional
+/// - `kind`: 0=Quick, 1=Premier, 2=Traditional. The user-selected DraftKind
+///   flows through to `DraftConfig.kind` unchanged. Tournament match format
+///   (Bo1 for Premier, Bo3 for Traditional) is identical to set drafts.
 /// - `seed`: RNG seed for deterministic pack generation
 /// - `draft_code`: unique room identifier
 ///
@@ -734,7 +760,7 @@ enum SeatDescriptor {
 /// for seat 0.
 #[wasm_bindgen]
 pub fn create_multiplayer_draft(
-    set_pool_json: &str,
+    pool_input_json: &str,
     seats_json: &str,
     kind: u8,
     seed: u32,
@@ -742,20 +768,44 @@ pub fn create_multiplayer_draft(
     tournament_format: &str,
     pod_policy: &str,
 ) -> Result<JsValue, JsValue> {
-    let set_pool: LimitedSetPool = serde_json::from_str(set_pool_json)
-        .map_err(|e| JsValue::from_str(&format!("Failed to parse set pool: {}", e)))?;
+    let view = create_multiplayer_draft_inner(
+        pool_input_json,
+        seats_json,
+        kind,
+        seed,
+        draft_code,
+        tournament_format,
+        pod_policy,
+    )
+    .map_err(|e| JsValue::from_str(&e))?;
+    Ok(to_js(&view))
+}
 
-    let seat_descriptors: Vec<SeatDescriptor> = serde_json::from_str(seats_json)
-        .map_err(|e| JsValue::from_str(&format!("Failed to parse seats: {}", e)))?;
+/// Pure-Rust core for `create_multiplayer_draft`. Returns a typed
+/// `DraftPlayerView` so this branch is reachable from `cargo test` without
+/// going through `js_sys::JSON::parse`. The WASM export wraps this with
+/// `to_js` and `JsValue::from_str` error mapping.
+fn create_multiplayer_draft_inner(
+    pool_input_json: &str,
+    seats_json: &str,
+    kind: u8,
+    seed: u32,
+    draft_code: &str,
+    tournament_format: &str,
+    pod_policy: &str,
+) -> Result<draft_core::view::DraftPlayerView, String> {
+    let pool_input: PoolInput = serde_json::from_str(pool_input_json)
+        .map_err(|e| format!("Failed to parse pool input: {}", e))?;
+
+    let seat_descriptors: Vec<SeatDescriptor> =
+        serde_json::from_str(seats_json).map_err(|e| format!("Failed to parse seats: {}", e))?;
 
     let draft_kind = match kind {
         0 => DraftKind::Quick,
         1 => DraftKind::Premier,
         2 => DraftKind::Traditional,
         _ => {
-            return Err(JsValue::from_str(
-                "kind must be 0 (Quick), 1 (Premier), or 2 (Traditional)",
-            ))
+            return Err("kind must be 0 (Quick), 1 (Premier), or 2 (Traditional)".to_string());
         }
     };
 
@@ -763,9 +813,7 @@ pub fn create_multiplayer_draft(
         "Swiss" => TournamentFormat::Swiss,
         "SingleElimination" => TournamentFormat::SingleElimination,
         _ => {
-            return Err(JsValue::from_str(
-                "tournament_format must be Swiss or SingleElimination",
-            ))
+            return Err("tournament_format must be Swiss or SingleElimination".to_string());
         }
     };
 
@@ -773,13 +821,9 @@ pub fn create_multiplayer_draft(
         "Competitive" => PodPolicy::Competitive,
         "Casual" => PodPolicy::Casual,
         _ => {
-            return Err(JsValue::from_str(
-                "pod_policy must be Competitive or Casual",
-            ))
+            return Err("pod_policy must be Competitive or Casual".to_string());
         }
     };
-
-    let set_code = set_pool.code.clone();
 
     let seats: Vec<DraftSeat> = seat_descriptors
         .into_iter()
@@ -795,36 +839,115 @@ pub fn create_multiplayer_draft(
         })
         .collect();
 
-    let config = DraftConfig {
-        source: DraftSource::Set {
-            code: set_code.clone(),
-        },
-        set_code,
-        kind: draft_kind,
-        pod_size: seats.len() as u8,
-        cards_per_pack: 14,
-        pack_count: 3,
-        min_deck_size: 40,
-        addable_cards: DeckAddableCards::standard_basics(),
-        rng_seed: seed as u64,
-        tournament_format,
-        pod_policy,
-        spectator_visibility: SpectatorVisibility::default(),
-    };
+    match pool_input {
+        PoolInput::Set { set_pool_json } => {
+            let set_pool: LimitedSetPool = serde_json::from_str(&set_pool_json)
+                .map_err(|e| format!("Failed to parse set pool: {}", e))?;
+            let set_code = set_pool.code.clone();
 
-    let mut draft_session = DraftSession::new(config, seats, draft_code.to_string());
-    let pack_gen = PackGenerator::new(set_pool);
+            let config = DraftConfig {
+                source: DraftSource::Set {
+                    code: set_code.clone(),
+                },
+                set_code,
+                kind: draft_kind,
+                pod_size: seats.len() as u8,
+                cards_per_pack: 14,
+                pack_count: 3,
+                min_deck_size: 40,
+                addable_cards: DeckAddableCards::standard_basics(),
+                rng_seed: seed as u64,
+                tournament_format,
+                pod_policy,
+                spectator_visibility: SpectatorVisibility::default(),
+            };
 
-    session::apply(&mut draft_session, DraftAction::StartDraft, Some(&pack_gen))
-        .map_err(|e| JsValue::from_str(&format!("Failed to start draft: {}", e)))?;
+            let mut draft_session = DraftSession::new(config, seats, draft_code.to_string());
+            let pack_gen = PackGenerator::new(set_pool);
 
-    let view = filter_for_player(&draft_session, 0);
+            session::apply(&mut draft_session, DraftAction::StartDraft, Some(&pack_gen))
+                .map_err(|e| format!("Failed to start draft: {}", e))?;
 
-    DRAFT_SESSION.with(|cell| cell.set(Some(draft_session)));
-    PACK_GEN.with(|cell| cell.set(Some(pack_gen)));
-    RNG.with(|cell| cell.set(Some(ChaCha20Rng::seed_from_u64(seed as u64))));
+            let view = filter_for_player(&draft_session, 0);
 
-    Ok(to_js(&view))
+            DRAFT_SESSION.with(|cell| cell.set(Some(draft_session)));
+            PACK_GEN.with(|cell| cell.set(Some(pack_gen)));
+            RNG.with(|cell| cell.set(Some(ChaCha20Rng::seed_from_u64(seed as u64))));
+
+            Ok(view)
+        }
+        PoolInput::Cube {
+            cube_list_text,
+            cube_name,
+            cube_draft_settings: settings,
+        } => {
+            let entries = parse_cube_list(&cube_list_text).map_err(|errors| {
+                format!(
+                    "Failed to parse cube list: {}",
+                    serde_json::to_string(&errors).unwrap_or_else(|_| "invalid lines".to_string())
+                )
+            })?;
+            let (cards, addable_cards) = CARD_DB.with(|cell| {
+                let db_borrow = cell.borrow();
+                let db = db_borrow
+                    .as_ref()
+                    .ok_or_else(|| "Card database must be loaded before cube draft".to_string())?;
+                let cards = cube_cards_from_entries(&entries, db).map_err(|errors| {
+                    format!(
+                        "Failed to resolve cube cards: {}",
+                        serde_json::to_string(&errors)
+                            .unwrap_or_else(|_| "unknown cards".to_string())
+                    )
+                })?;
+                let addable_cards =
+                    resolve_addable_cards(&settings.addable_cards, db).map_err(|errors| {
+                        format!(
+                            "Failed to resolve addable cards: {}",
+                            serde_json::to_string(&errors)
+                                .unwrap_or_else(|_| "unknown cards".to_string())
+                        )
+                    })?;
+                Ok::<_, String>((cards, addable_cards))
+            })?;
+
+            // pod_size from settings is overridden by seats.len() — MP authoritative source
+            let config = DraftConfig {
+                source: DraftSource::Cube {
+                    id: "custom-cube".to_string(),
+                    name: cube_name.clone(),
+                },
+                set_code: "custom-cube".to_string(),
+                kind: draft_kind,
+                pod_size: seats.len() as u8,
+                cards_per_pack: settings.cards_per_pack,
+                pack_count: settings.pack_count,
+                min_deck_size: settings.min_deck_size,
+                addable_cards,
+                rng_seed: seed as u64,
+                tournament_format,
+                pod_policy,
+                spectator_visibility: SpectatorVisibility::default(),
+            };
+
+            let mut draft_session = DraftSession::new(config, seats, draft_code.to_string());
+            let pack_source = CubePackSource::new(cards);
+
+            session::apply(
+                &mut draft_session,
+                DraftAction::StartDraft,
+                Some(&pack_source),
+            )
+            .map_err(|e| format!("Failed to start cube draft: {}", e))?;
+
+            let view = filter_for_player(&draft_session, 0);
+
+            DRAFT_SESSION.with(|cell| cell.set(Some(draft_session)));
+            PACK_GEN.with(|cell| cell.set(None));
+            RNG.with(|cell| cell.set(Some(ChaCha20Rng::seed_from_u64(seed as u64))));
+
+            Ok(view)
+        }
+    }
 }
 
 /// Apply a draft action from any seat. Used by the P2P host to forward
@@ -861,4 +984,240 @@ pub fn get_draft_view_for_seat(seat_index: u8) -> Result<JsValue, JsValue> {
 #[wasm_bindgen]
 pub fn get_draft_status() -> Result<JsValue, JsValue> {
     with_draft(|session| to_js(&session.status))
+}
+
+#[cfg(test)]
+mod pool_input_tests {
+    use super::*;
+
+    #[test]
+    fn pool_input_set_round_trip() {
+        let json = r#"{"type":"Set","data":{"set_pool_json":"{\"code\":\"foo\"}"}}"#;
+        let parsed: PoolInput = serde_json::from_str(json).unwrap();
+        match parsed {
+            PoolInput::Set { set_pool_json } => {
+                assert_eq!(set_pool_json, "{\"code\":\"foo\"}");
+            }
+            _ => panic!("expected Set"),
+        }
+    }
+
+    #[test]
+    fn pool_input_cube_round_trip() {
+        let json = r#"{
+            "type": "Cube",
+            "data": {
+                "cube_list_text": "1 Lightning Bolt\n",
+                "cube_name": "Test Cube",
+                "cube_draft_settings": {
+                    "pod_size": 8,
+                    "pack_count": 3,
+                    "cards_per_pack": 15,
+                    "min_deck_size": 40,
+                    "addable_cards": { "policy": "StandardBasics", "custom": [] }
+                }
+            }
+        }"#;
+        let parsed: PoolInput = serde_json::from_str(json).unwrap();
+        match parsed {
+            PoolInput::Cube {
+                cube_list_text,
+                cube_name,
+                cube_draft_settings,
+            } => {
+                assert_eq!(cube_list_text, "1 Lightning Bolt\n");
+                assert_eq!(cube_name, "Test Cube");
+                assert_eq!(cube_draft_settings.cards_per_pack, 15);
+                assert_eq!(cube_draft_settings.pack_count, 3);
+            }
+            _ => panic!("expected Cube"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod create_multiplayer_draft_tests {
+    use super::*;
+    use draft_core::types::DraftStatus;
+    use engine::database::CardDatabase;
+
+    /// Minimal card-data JSON with four vanilla cards usable as cube content.
+    /// Shape mirrors the production card-data export consumed by
+    /// `CardDatabase::from_json_str` (see engine-wasm bracket_estimate_tests).
+    fn fixture_card_db_json() -> &'static str {
+        r#"{
+            "alpha": {
+                "name": "Alpha",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": [] },
+                "power": "1", "toughness": "1", "loyalty": null, "defense": null,
+                "oracle_text": null, "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [], "keywords": [],
+                "bracket_signals": { "game_changer": false, "mass_land_denial": false, "extra_turn": false, "efficient_tutor": false }
+            },
+            "beta": {
+                "name": "Beta",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": [] },
+                "power": "1", "toughness": "1", "loyalty": null, "defense": null,
+                "oracle_text": null, "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [], "keywords": [],
+                "bracket_signals": { "game_changer": false, "mass_land_denial": false, "extra_turn": false, "efficient_tutor": false }
+            },
+            "gamma": {
+                "name": "Gamma",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": [] },
+                "power": "1", "toughness": "1", "loyalty": null, "defense": null,
+                "oracle_text": null, "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [], "keywords": [],
+                "bracket_signals": { "game_changer": false, "mass_land_denial": false, "extra_turn": false, "efficient_tutor": false }
+            },
+            "delta": {
+                "name": "Delta",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": [] },
+                "power": "1", "toughness": "1", "loyalty": null, "defense": null,
+                "oracle_text": null, "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [], "keywords": [],
+                "bracket_signals": { "game_changer": false, "mass_land_denial": false, "extra_turn": false, "efficient_tutor": false }
+            }
+        }"#
+    }
+
+    fn install_fixture_db() {
+        let db = CardDatabase::from_json_str(fixture_card_db_json()).unwrap();
+        CARD_DB.with(|cell| *cell.borrow_mut() = Some(db));
+    }
+
+    fn clear_state() {
+        DRAFT_SESSION.with(|cell| cell.set(None));
+        PACK_GEN.with(|cell| cell.set(None));
+        RNG.with(|cell| cell.set(None));
+        CARD_DB.with(|cell| *cell.borrow_mut() = None);
+    }
+
+    #[test]
+    fn cube_pool_input_drives_drafting_status_and_pack_size() {
+        clear_state();
+        install_fixture_db();
+
+        // 2 seats × 2 cards/pack × 1 pack = 4 cards exactly.
+        let pool_input_json = r#"{
+            "type": "Cube",
+            "data": {
+                "cube_list_text": "1 Alpha\n1 Beta\n1 Gamma\n1 Delta\n",
+                "cube_name": "Test Cube",
+                "cube_draft_settings": {
+                    "pod_size": 2,
+                    "pack_count": 1,
+                    "cards_per_pack": 2,
+                    "min_deck_size": 4,
+                    "addable_cards": { "policy": "StandardBasics", "custom": [] }
+                }
+            }
+        }"#;
+        let seats_json = r#"[
+            { "type": "Human", "player_id": 0, "display_name": "Host" },
+            { "type": "Human", "player_id": 1, "display_name": "Guest" }
+        ]"#;
+
+        let view = create_multiplayer_draft_inner(
+            pool_input_json,
+            seats_json,
+            1, // Premier
+            42,
+            "test-room",
+            "Swiss",
+            "Competitive",
+        )
+        .expect("cube draft should start");
+
+        assert!(
+            matches!(view.status, DraftStatus::Drafting),
+            "expected Drafting, got {:?}",
+            view.status
+        );
+        assert_eq!(view.cards_per_pack, 2);
+        assert_eq!(view.pack_count, 1);
+        assert_eq!(view.min_deck_size, 4);
+        let pack = view.current_pack.as_ref().expect("seat 0 has a pack");
+        assert_eq!(pack.len(), 2);
+
+        // Drive one Pick action by seat 0 and verify a delta is produced.
+        let picked = pack[0].instance_id.clone();
+        let action = DraftAction::Pick {
+            seat: 0,
+            card_instance_id: picked.clone(),
+        };
+        DRAFT_SESSION.with(|cell| {
+            let mut session = cell.take().expect("session populated");
+            let deltas = session::apply(&mut session, action, None).expect("pick applies");
+            assert!(!deltas.is_empty(), "pick should produce deltas");
+            cell.set(Some(session));
+        });
+
+        // After the human pick, seat 0's pack should no longer contain the picked card
+        // (it has been passed; pack will not be visible again until the rotation lands).
+        let post_view = DRAFT_SESSION.with(|cell| {
+            let session = cell.take().expect("session populated");
+            let v = filter_for_player(&session, 0);
+            cell.set(Some(session));
+            v
+        });
+        if let Some(pack_after) = &post_view.current_pack {
+            assert!(
+                !pack_after.iter().any(|c| c.instance_id == picked),
+                "picked card must not remain in seat 0's pack"
+            );
+        }
+
+        clear_state();
+    }
+
+    #[test]
+    fn cube_branch_uses_settings_cards_per_pack_not_default() {
+        clear_state();
+        install_fixture_db();
+
+        let pool_input_json = r#"{
+            "type": "Cube",
+            "data": {
+                "cube_list_text": "1 Alpha\n1 Beta\n1 Gamma\n1 Delta\n",
+                "cube_name": "C1",
+                "cube_draft_settings": {
+                    "pod_size": 2,
+                    "pack_count": 1,
+                    "cards_per_pack": 2,
+                    "min_deck_size": 4,
+                    "addable_cards": { "policy": "StandardBasics", "custom": [] }
+                }
+            }
+        }"#;
+        let seats_json = r#"[
+            { "type": "Human", "player_id": 0, "display_name": "Host" },
+            { "type": "Human", "player_id": 1, "display_name": "Guest" }
+        ]"#;
+
+        let view = create_multiplayer_draft_inner(
+            pool_input_json,
+            seats_json,
+            2, // Traditional
+            7,
+            "test-room",
+            "Swiss",
+            "Casual",
+        )
+        .expect("cube draft should start");
+
+        // C1: cards_per_pack must come from settings, NOT the hardcoded 14 in the Set branch.
+        assert_eq!(
+            view.cards_per_pack, 2,
+            "cards_per_pack must read from CubeDraftSettings"
+        );
+        // DraftKind flow-through: Traditional flows unchanged.
+        assert!(matches!(view.kind, DraftKind::Traditional));
+
+        clear_state();
+    }
 }

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -75,10 +75,18 @@ pub struct LobbyGame {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DraftLobbyMetadata {
-    /// Three-letter set code (e.g. "MKM", "OTJ").
+    /// Three-letter set code (e.g. "MKM", "OTJ"). For cube drafts, set to
+    /// `"custom-cube"`; see [`DraftLobbyMetadata::cube_name`] for the
+    /// human-readable cube name.
     pub set_code: String,
     /// Draft kind label: "Quick", "Premier", or "Traditional".
     pub draft_kind: String,
+    /// Human-readable cube name when the pod is a cube draft. Absent for
+    /// set drafts. Backward-compatible: `#[serde(default)]` accepts
+    /// existing serialized records without the field; `skip_serializing_if`
+    /// keeps the wire output byte-identical for set drafts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cube_name: Option<String>,
 }
 
 /// The lobby subset of `server_core::protocol::ClientMessage`. Wire-compatible:

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -3671,6 +3671,7 @@ async fn handle_client_message(
                         draft_metadata: Some(server_core::protocol::DraftLobbyMetadata {
                             set_code,
                             draft_kind: format!("{kind:?}"),
+                            cube_name: None,
                         }),
                     },
                     &SysEnv,


### PR DESCRIPTION
Closes #1253.

8 commits implementing cube draft multiplayer via a `PoolInput` discriminated union threaded through the existing pod-draft P2P adapter chain. The engine layer (`crates/draft-core/`) was already source-agnostic; this PR carries the discriminator out through every TS/Rust layer that previously took `setPoolJson: string`.

## Commits

1. `draft-wasm: PoolInput discriminated union for Set/Cube MP draft creation` — WASM `PoolInput { Set, Cube }` enum; `create_multiplayer_draft` branches Set/Cube reusing `parse_cube_list` + `cube_cards_from_entries` + `CubePackSource`. Splits `create_multiplayer_draft_inner` for unit-testability (mirrors existing `bracket_estimate_inner` pattern).
2. `lobby-broker: add DraftLobbyMetadata.cube_name` — schema-only additive extension; `Option<String>` + `serde(default, skip_serializing_if)` backward-compatible.
3. `draft: DraftPodHostConfig + P2PDraftHost + PersistedDraftHostSession consume PoolInput` — replaces `setPoolJson: string` with `poolInput: PoolInput` on all three structs. CARD_DB load gated in cube branch of `DraftPodHostAdapter.initialize` (gate at `:191-192`). Migrates 12 test fixtures.
4. `draft: C6 shape guard for legacy persistence snapshots` — discriminator-based shape guard in `loadDraftHostSession` (no SCHEMA_VERSION); 11 store-test fixtures migrated.
5. `draftPodStore: branch createPod/resumeHostedPod on poolMode` — `poolMode: 'set' | 'cube'` + `cubeForm` state; `createPod` branches on mode; `resumeHostedPod` sets `setName` from cube name for cube path.
6. `draft: extract shared CubeSetupPanel from DraftPage` — pure refactor; `onStart({cubeName, cubeListText, settings})` prop replaces inline `useDraftStore.getState()` access; zero store imports in shared module.
7. `DraftPodPage: Set/Cube tab switch + CubeSetupPanel mount` — tab control above `<SetSelector>`; Premier/Traditional + tournament-format + pod-policy radios stay visible for both modes (C7).
8. `draft: lobby header cube name + cube wire-up test` — `DraftPodLobby` subtitle reads cube name when `poolMode === 'cube'`; runtime cube adapter test driving the full WASM pipeline; i18n keys in 7 locales.

## Hard constraints satisfied

- **C1**: pack_count / cards_per_pack / min_deck_size user-configurable (no hardcoded 15/3/40 in cube branch)
- **C2**: Full `DeckAddableCards` struct end-to-end
- **C3**: WASM parses the cube list (no client-side parser)
- **C4**: `cube_name` on the wire (`DraftLobbyMetadata.cube_name` + TS mirror)
- **C5**: DraftKind flow-through (cube + Traditional = Bo3 matches; cube + Premier = Bo1)
- **C6**: No SCHEMA_VERSION; persistence guard discriminates on `poolInput.type`
- **C7**: Tab switch above SetSelector; format/policy radios stay visible for both modes

## Scope exception

One in-scope line added at `crates/phase-server/src/main.rs:3671-3674`: `cube_name: None,` to the existing `DraftLobbyMetadata` struct literal. Forced consequence of the schema extension; not architectural drift.

## Verification

- `tilt-wait clippy test-engine card-data check-frontend test-frontend`: all green
- New Rust runtime tests: `cube_pool_input_drives_drafting_status_and_pack_size`, `cube_branch_uses_settings_cards_per_pack_not_default` (would NOT build against `origin/main` — discriminating regression)
- New TS tests: `draftPodAdapter.cube.test.ts` (shape) + 5 new store/persistence/lobby tests
- 25 existing `setPoolJson` fixtures migrated to `poolInput` shape
- Wire-contract tests in `server-core` byte-identical (skip_serializing_if guarantees backward compat)

## Out of scope (deferred)

- Cube Bo3 pack mechanic (Traditional cube draft where each pack is opened twice). Tournament Bo3 match format works in this PR.
- Broker draft-pod registration wire-up — no current caller passes `brokerRequest` for draft pods; forward-ready comment at `draftPodHostAdapter.ts:181-184` documents future site.
- WebSocket-server Concede handler bypass — separate issue.

🤖 Generated with engine-implementer pipeline (4 plan rounds + canonical plan + 1 impl review).