### PR TITLE
Partial: Fix prepared copy mana-cost enforcement (#1187)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2435,6 +2435,7 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
             ));
         }
 
+        let mut prepare_castability_sim: Option<GameState> = None;
         for &obj_id in &state.battlefield {
             if let Some(obj) = state.objects.get(&obj_id) {
                 if obj.controller == player {
@@ -2458,14 +2459,18 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
                     // `prepared.is_some()` (single-authority state flag managed
                     // by `game::effects::prepare`). Assign when WotC publishes
                     // SOS CR update.
-                    if obj.prepared.is_some()
-                        && prepare::can_cast_prepared_copy_now(state, player, obj_id)
-                    {
-                        actions.push(candidate(
-                            GameAction::CastPreparedCopy { source: obj_id },
-                            TacticalClass::Spell,
-                            Some(player),
-                        ));
+                    if obj.prepared.is_some() {
+                        let simulated =
+                            prepare_castability_sim.get_or_insert_with(|| state.clone());
+                        if prepare::can_cast_prepared_copy_now_with_simulation(
+                            simulated, player, obj_id,
+                        ) {
+                            actions.push(candidate(
+                                GameAction::CastPreparedCopy { source: obj_id },
+                                TacticalClass::Spell,
+                                Some(player),
+                            ));
+                        }
                     }
                 }
             }

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -3915,6 +3915,8 @@ mod tests {
 
         state.waiting_for = WaitingFor::Priority { player: p0 };
         state.priority_player = p0;
+        state.active_player = p0;
+        state.phase = crate::types::Phase::PreCombatMain;
 
         let actions = candidate_actions(&state);
         let has_prepared_cast = actions.iter().any(|c| {

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, HashSet};
 use crate::game::casting;
 use crate::game::combat::AttackTarget;
 use crate::game::deck_loading::DeckEntry;
+use crate::game::effects::prepare;
 use crate::game::game_object::RoomDoor;
 use crate::game::keywords;
 use crate::game::mana_sources;
@@ -2457,7 +2458,9 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
                     // `prepared.is_some()` (single-authority state flag managed
                     // by `game::effects::prepare`). Assign when WotC publishes
                     // SOS CR update.
-                    if obj.prepared.is_some() {
+                    if obj.prepared.is_some()
+                        && prepare::can_cast_prepared_copy_now(state, player, obj_id)
+                    {
                         actions.push(candidate(
                             GameAction::CastPreparedCopy { source: obj_id },
                             TacticalClass::Spell,
@@ -3753,6 +3756,39 @@ mod tests {
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::zones::Zone;
 
+    fn prepare_back_face_with_cost(mana_cost: ManaCost) -> crate::game::game_object::BackFaceData {
+        let mut card_types = crate::types::card_type::CardType::default();
+        card_types.core_types.push(CoreType::Sorcery);
+        crate::game::game_object::BackFaceData {
+            name: "Prepared Spell Face".to_string(),
+            power: None,
+            toughness: None,
+            loyalty: None,
+            defense: None,
+            card_types,
+            mana_cost,
+            keywords: Vec::new(),
+            abilities: vec![AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )],
+            trigger_definitions: crate::types::definitions::Definitions::default(),
+            replacement_definitions: crate::types::definitions::Definitions::default(),
+            static_definitions: crate::types::definitions::Definitions::default(),
+            color: Vec::new(),
+            printed_ref: None,
+            modal: None,
+            additional_cost: None,
+            strive_cost: None,
+            casting_restrictions: Vec::new(),
+            casting_options: Vec::new(),
+            layout_kind: Some(LayoutKind::Prepare),
+        }
+    }
+
     // CR 702.xxx: Prepare (Strixhaven) — the AI candidate enumerator must
     // surface a `CastPreparedCopy` action for every prepared creature under
     // the acting player's control while they hold priority. Without this an
@@ -3853,6 +3889,8 @@ mod tests {
             .core_types
             .push(CoreType::Creature);
         state.objects.get_mut(&prepared_id).unwrap().prepared = Some(PreparedState);
+        state.objects.get_mut(&prepared_id).unwrap().back_face =
+            Some(prepare_back_face_with_cost(ManaCost::NoCost));
 
         // Create an unprepared creature on battlefield (must NOT appear).
         let plain_id = create_object(
@@ -3888,6 +3926,46 @@ mod tests {
         assert!(
             !has_plain_cast,
             "must not offer CastPreparedCopy for unprepared creatures"
+        );
+    }
+
+    #[test]
+    fn priority_actions_skip_cast_prepared_copy_when_cost_unpayable() {
+        use crate::game::game_object::PreparedState;
+
+        let mut state = GameState::new_two_player(42);
+        let p0 = PlayerId(0);
+        let prepared_id = create_object(
+            &mut state,
+            CardId(1),
+            p0,
+            "Prepared Costly".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&prepared_id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        state.objects.get_mut(&prepared_id).unwrap().prepared = Some(PreparedState);
+        state.objects.get_mut(&prepared_id).unwrap().back_face =
+            Some(prepare_back_face_with_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 1,
+            }));
+
+        state.waiting_for = WaitingFor::Priority { player: p0 };
+        state.priority_player = p0;
+
+        let actions = candidate_actions(&state);
+        let has_prepared_cast = actions.iter().any(|c| {
+            matches!(c.action, GameAction::CastPreparedCopy { source } if source == prepared_id)
+        });
+        assert!(
+            !has_prepared_cast,
+            "must not offer CastPreparedCopy when mana cost cannot be paid"
         );
     }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -33,6 +33,7 @@ use super::ability_utils::{
 use super::casting_costs::{self, check_additional_cost_or_pay};
 use super::engine::EngineError;
 use super::functioning_abilities::active_static_definitions;
+use super::game_object::PreparedState;
 use super::mana_payment;
 use super::quantity::resolve_quantity;
 use super::restrictions;
@@ -7908,6 +7909,17 @@ pub fn handle_cancel_cast(
             state.stack.remove(pos);
             state.stack_paid_facts.remove(&pending.object_id);
         }
+    }
+
+    if let Some(source_id) = pending.cancel_restore_prepared_source {
+        // CR 601.2i + CR 722.3c: Prepare-copy cast cancellation must restore
+        // the source's prepared marker and clear the synthetic copy object.
+        if let Some(source) = state.objects.get_mut(&source_id) {
+            if source.zone == Zone::Battlefield {
+                source.prepared = Some(PreparedState);
+            }
+        }
+        state.objects.remove(&pending.object_id);
     }
 }
 

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4784,6 +4784,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
         }
     }
@@ -7561,6 +7562,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
         };
 
@@ -7678,6 +7680,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
         };
 
@@ -7764,6 +7767,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
         };
 
@@ -7839,6 +7843,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
         };
 
@@ -7947,6 +7952,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
         };
 

--- a/crates/engine/src/game/effects/prepare.rs
+++ b/crates/engine/src/game/effects/prepare.rs
@@ -196,6 +196,8 @@ fn synthesize_prepared_copy_object(
     source_id: ObjectId,
     controller: PlayerId,
 ) -> Result<(ObjectId, crate::types::identifiers::CardId), String> {
+    // CR 722.3c: As the player casts the prepared copy, synthesize a distinct
+    // copy object of the prepare face in exile to feed through normal casting.
     let (src_clone, card_id) = {
         let Some(src_obj) = state.objects.get(&source_id) else {
             return Err(format!("source {source_id:?} not found"));
@@ -239,6 +241,21 @@ fn synthesize_prepared_copy_object(
     Ok((copy_id, card_id))
 }
 
+fn can_cast_prepared_copy_now_in_simulated_state(
+    simulated: &mut GameState,
+    controller: PlayerId,
+    source_id: ObjectId,
+) -> bool {
+    let original_next_object_id = simulated.next_object_id;
+    let Ok((copy_id, _)) = synthesize_prepared_copy_object(simulated, source_id, controller) else {
+        return false;
+    };
+    let can_cast = casting::can_cast_object_now(simulated, controller, copy_id);
+    cleanup_failed_prepared_copy_cast(simulated, copy_id);
+    simulated.next_object_id = original_next_object_id;
+    can_cast
+}
+
 /// Fast castability probe for `GameAction::CastPreparedCopy` candidate
 /// generation. Synthesizes the same ephemeral copy object used by the actual
 /// cast path in a temporary game-state clone, then asks the canonical casting
@@ -249,11 +266,46 @@ pub fn can_cast_prepared_copy_now(
     source_id: ObjectId,
 ) -> bool {
     let mut simulated = state.clone();
-    let Ok((copy_id, _)) = synthesize_prepared_copy_object(&mut simulated, source_id, controller)
-    else {
-        return false;
-    };
-    casting::can_cast_object_now(&simulated, controller, copy_id)
+    can_cast_prepared_copy_now_in_simulated_state(&mut simulated, controller, source_id)
+}
+
+/// Shared low-allocation probe for candidate enumeration loops that can reuse
+/// one mutable simulation clone across many prepared permanents.
+pub(crate) fn can_cast_prepared_copy_now_with_simulation(
+    simulated: &mut GameState,
+    controller: PlayerId,
+    source_id: ObjectId,
+) -> bool {
+    can_cast_prepared_copy_now_in_simulated_state(simulated, controller, source_id)
+}
+
+fn mark_prepare_copy_cancel_rollback(
+    state: &mut GameState,
+    waiting: &mut WaitingFor,
+    source_id: ObjectId,
+    copy_id: ObjectId,
+) {
+    if let Some(pending) = waiting.pending_cast_mut() {
+        debug_assert_eq!(
+            pending.object_id, copy_id,
+            "prepare pending_cast must point at synthesized copy"
+        );
+        pending.cancel_restore_prepared_source = Some(source_id);
+        return;
+    }
+
+    if matches!(
+        waiting,
+        WaitingFor::ManaPayment { .. } | WaitingFor::PhyrexianPayment { .. }
+    ) {
+        if let Some(pending) = state.pending_cast.as_mut() {
+            debug_assert_eq!(
+                pending.object_id, copy_id,
+                "prepare pending_cast must point at synthesized copy"
+            );
+            pending.cancel_restore_prepared_source = Some(source_id);
+        }
+    }
 }
 
 /// CR 722.3c + CR 601.2: Build an ephemeral token copy of the prepare-spell
@@ -275,13 +327,18 @@ pub fn cast_prepared_copy(
         return Err("prepared copy is not castable now".to_string());
     }
 
-    let waiting = match casting::handle_cast_spell(state, controller, copy_id, card_id, events) {
+    let mut waiting = match casting::handle_cast_spell(state, controller, copy_id, card_id, events)
+    {
         Ok(waiting) => waiting,
         Err(err) => {
             cleanup_failed_prepared_copy_cast(state, copy_id);
             return Err(format!("{err}"));
         }
     };
+
+    // CR 601.2i + CR 722.3c: If the cast is cancelled before completion,
+    // restore the source's prepared marker and remove the synthetic copy.
+    mark_prepare_copy_cancel_rollback(state, &mut waiting, source_id, copy_id);
 
     // CR 722.3c: "Doing so unprepares it." Unprepare-at-cast, not at resolve —
     // so countered / fizzled copies still leave the source unprepared. Single
@@ -848,6 +905,68 @@ mod tests {
         assert!(
             state.stack.is_empty(),
             "failed cast must not leave stack entries"
+        );
+    }
+
+    #[test]
+    fn cancel_pending_prepare_copy_restores_prepared_source() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = setup_creature(&mut state);
+        state.objects.get_mut(&source_id).unwrap().prepared = Some(PreparedState);
+
+        // Synthetic prepare-copy object announced on stack.
+        let copy_id = create_object(
+            &mut state,
+            CardId(77),
+            PlayerId(0),
+            "Prepared Copy".to_string(),
+            Zone::Exile,
+        );
+        state.objects.get_mut(&copy_id).unwrap().is_token = true;
+        state.stack.push_back(StackEntry {
+            id: copy_id,
+            source_id: copy_id,
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(77),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+
+        // Cast-time unprepare happened before cancellation.
+        state.objects.get_mut(&source_id).unwrap().prepared = None;
+
+        let mut pending = crate::types::game_state::PendingCast::new(
+            copy_id,
+            CardId(77),
+            ResolvedAbility::new(
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+                Vec::new(),
+                copy_id,
+                PlayerId(0),
+            ),
+            ManaCost::NoCost,
+        );
+        pending.cancel_restore_prepared_source = Some(source_id);
+
+        crate::game::casting::handle_cancel_cast(&mut state, &pending, &mut Vec::new());
+
+        assert!(
+            state.objects[&source_id].prepared.is_some(),
+            "cancelled cast must restore source prepared state"
+        );
+        assert!(
+            !state.objects.contains_key(&copy_id),
+            "cancelled cast must clear synthesized copy object"
+        );
+        assert!(
+            state.stack.iter().all(|entry| entry.id != copy_id),
+            "cancelled cast must remove stack placeholder for synthesized copy"
         );
     }
 

--- a/crates/engine/src/game/effects/prepare.rs
+++ b/crates/engine/src/game/effects/prepare.rs
@@ -407,6 +407,7 @@ mod tests {
     fn enters_prepared_replacement_marks_permanent_before_priority_actions() {
         let mut state = GameState::new_two_player(42);
         state.active_player = PlayerId(0);
+        state.phase = crate::types::Phase::PreCombatMain;
         state.priority_player = PlayerId(0);
         state.waiting_for = WaitingFor::Priority {
             player: PlayerId(0),
@@ -469,6 +470,7 @@ mod tests {
     fn effect_zone_move_enters_prepared_replacement_marks_permanent() {
         let mut state = GameState::new_two_player(42);
         state.active_player = PlayerId(0);
+        state.phase = crate::types::Phase::PreCombatMain;
         state.priority_player = PlayerId(0);
         state.waiting_for = WaitingFor::Priority {
             player: PlayerId(0),

--- a/crates/engine/src/game/effects/prepare.rs
+++ b/crates/engine/src/game/effects/prepare.rs
@@ -1,33 +1,21 @@
-use std::sync::Arc;
-
 use crate::types::ability::{
-    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
+    CastingPermission, Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
 };
 use crate::types::card::LayoutKind;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{
-    CastingVariant, CopyTargetSlot, GameState, StackEntry, StackEntryKind, WaitingFor,
-};
+use crate::types::game_state::{CopyTargetSlot, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 
-use crate::game::ability_utils::{build_resolved_from_def, build_target_slots};
+use crate::game::ability_utils::build_target_slots;
+use crate::game::casting;
 use crate::game::game_object::PreparedState;
+use crate::game::printed_cards::apply_back_face_to_object;
 
-// KNOWN_LIMITATION: The reminder text for Prepare says a copy of the
-// prepare-spell "appears in exile" while the creature is prepared. This design
-// does NOT materialize that copy as a GameObject. The cast-offer is produced
-// at priority time by scanning battlefield creatures whose `prepared.is_some()`
-// and whose printed `CardLayout::Prepare(_, b)` supplies face `b`. As a result,
-// exile-event triggers and "going-to-exile" replacement effects (Rest in
-// Peace, Leyline of the Void, Containment Priest) will NOT observe the copy.
-// Acceptable for the SOS-era cards — no card in the set interacts with
-// prepare-copies through those hooks — and aligned with CR 722.3c's special
-// exception for prepare-spell copies existing in exile. If a future card
-// requires the copy to be a first-class exile GameObject, materialization can
-// be retrofitted around the existing offer scan without touching the resolver
-// layer.
+// The prepare cast path now materializes a short-lived exile GameObject copy of
+// the prepare-spell face so the copy can reuse the normal casting pipeline
+// (targets/modes/mana payment/cost modifiers).
 
 /// Extract object targets from `ability.targets`, or fall back to `last_created_token_ids`
 /// for `TargetFilter::LastCreated`. Mirrors the pattern used by `suspect::resolve`.
@@ -196,26 +184,18 @@ pub(crate) fn open_copy_target_selection(
     Ok(true)
 }
 
-/// CR 702.xxx + CR 707.10f: Build a token spell-copy on the stack from the
-/// prepare-spell face (face `b`) of `source_id`'s printed card. The resulting
-/// stack entry mirrors the `copy_spell` effect's construction — a fresh
-/// ObjectId, `is_token = true`, `CastingVariant::Normal`, controller = acting
-/// player. The source creature is unprepared at cast time (reminder: "Doing
-/// so unprepares it."), not on resolution — so counter-the-copy leaves the
-/// source permanently unprepared.
-///
-/// If the prepare-face spell requires targets (e.g., Biblioplex's companion
-/// prepare cards), the caller enters `WaitingFor::CopyRetarget` so the
-/// controller can pick legal targets via `open_copy_target_selection`.
-///
-/// Returns Ok(copy_id) on success. Returns Err if the source is not prepared,
-/// lacks a prepare face, or doesn't exist.
-pub fn cast_prepared_copy(
+fn cleanup_failed_prepared_copy_cast(state: &mut GameState, copy_id: ObjectId) {
+    // Defensive cleanup for any failed cast attempt after synthesizing the
+    // ephemeral copy object.
+    state.stack.retain(|entry| entry.id != copy_id);
+    state.objects.remove(&copy_id);
+}
+
+fn synthesize_prepared_copy_object(
     state: &mut GameState,
     source_id: ObjectId,
     controller: PlayerId,
-    events: &mut Vec<GameEvent>,
-) -> Result<ObjectId, String> {
+) -> Result<(ObjectId, crate::types::identifiers::CardId), String> {
     let (src_clone, card_id) = {
         let Some(src_obj) = state.objects.get(&source_id) else {
             return Err(format!("source {source_id:?} not found"));
@@ -231,71 +211,84 @@ pub fn cast_prepared_copy(
     if !matches!(back.layout_kind, Some(LayoutKind::Prepare)) {
         return Err("source back_face is not a Prepare face".to_string());
     }
-    // Select the first ability on face_b as the spell ability. SOS prepare
-    // spells each have a single spell ability (Sorcery-type); more complex
-    // multi-ability prepare faces are out of scope.
-    let ability_def = back
-        .abilities
-        .first()
-        .cloned()
-        .ok_or_else(|| "prepare face has no spell ability".to_string())?;
 
-    // Allocate a new object id for the copy.
     let copy_id = ObjectId(state.next_object_id);
     state.next_object_id += 1;
 
-    // Build a GameObject for the token copy — clone core characteristics from
-    // back_face so zone transitions and filter predicates see the correct
-    // face. Name from face_b, zone = Stack, is_token = true.
     let mut copy_obj = src_clone;
     copy_obj.id = copy_id;
-    copy_obj.name = back.name.clone();
-    copy_obj.power = back.power;
-    copy_obj.toughness = back.toughness;
-    copy_obj.loyalty = back.loyalty;
-    copy_obj.defense = back.defense;
-    copy_obj.card_types = back.card_types.clone();
-    copy_obj.mana_cost = back.mana_cost.clone();
-    copy_obj.keywords = back.keywords.clone();
-    copy_obj.abilities = Arc::new(back.abilities.clone());
-    copy_obj.color = back.color.clone();
-    copy_obj.printed_ref = back.printed_ref.clone();
+    copy_obj.zone = Zone::Exile;
     copy_obj.controller = controller;
     copy_obj.owner = controller;
-    copy_obj.zone = Zone::Stack;
     copy_obj.is_token = true;
-    // CR 722.3c: the copy is a distinct object — clear any per-permanent
-    // state carried over from the source's creature face.
     copy_obj.tapped = false;
     copy_obj.prepared = None;
+    // Do not re-enter alternative-face casting logic for this synthetic copy.
     copy_obj.back_face = None;
+    apply_back_face_to_object(&mut copy_obj, back.clone());
+    copy_obj
+        .casting_permissions
+        .push(CastingPermission::ExileWithAltCost {
+            cost: back.mana_cost.clone(),
+            cast_transformed: false,
+            constraint: None,
+            granted_to: Some(controller),
+        });
     state.objects.insert(copy_id, copy_obj);
 
-    // CR 707.10: Build a ResolvedAbility from face_b's ability definition
-    // preserving sub-ability chains, optional flags, and duration metadata.
-    // `build_resolved_from_def` is the authoritative constructor used by
-    // normal casting (see `ability_utils`).
-    let resolved = build_resolved_from_def(&ability_def, copy_id, controller);
+    Ok((copy_id, card_id))
+}
 
-    state.stack.push_back(StackEntry {
-        id: copy_id,
-        source_id: copy_id,
-        controller,
-        kind: StackEntryKind::Spell {
-            card_id,
-            ability: Some(resolved),
-            casting_variant: CastingVariant::Normal,
-            actual_mana_spent: 0,
-        },
-    });
-    events.push(crate::types::events::GameEvent::StackPushed { object_id: copy_id });
+/// Fast castability probe for `GameAction::CastPreparedCopy` candidate
+/// generation. Synthesizes the same ephemeral copy object used by the actual
+/// cast path in a temporary game-state clone, then asks the canonical casting
+/// predicate whether that copy is castable right now.
+pub fn can_cast_prepared_copy_now(
+    state: &GameState,
+    controller: PlayerId,
+    source_id: ObjectId,
+) -> bool {
+    let mut simulated = state.clone();
+    let Ok((copy_id, _)) = synthesize_prepared_copy_object(&mut simulated, source_id, controller)
+    else {
+        return false;
+    };
+    casting::can_cast_object_now(&simulated, controller, copy_id)
+}
+
+/// CR 722.3c + CR 601.2: Build an ephemeral token copy of the prepare-spell
+/// face (face `b`) in exile, then cast it through the normal spell-casting
+/// pipeline so costs/targets/modes are handled by the same single authority as
+/// every other cast.
+pub fn cast_prepared_copy(
+    state: &mut GameState,
+    source_id: ObjectId,
+    controller: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, String> {
+    let (copy_id, card_id) = synthesize_prepared_copy_object(state, source_id, controller)?;
+
+    // CR 117.1d + CR 601.2g: The copy must be castable with feasible mana
+    // payment options right now; otherwise this special action is illegal.
+    if !casting::can_cast_object_now(state, controller, copy_id) {
+        cleanup_failed_prepared_copy_cast(state, copy_id);
+        return Err("prepared copy is not castable now".to_string());
+    }
+
+    let waiting = match casting::handle_cast_spell(state, controller, copy_id, card_id, events) {
+        Ok(waiting) => waiting,
+        Err(err) => {
+            cleanup_failed_prepared_copy_cast(state, copy_id);
+            return Err(format!("{err}"));
+        }
+    };
 
     // CR 722.3c: "Doing so unprepares it." Unprepare-at-cast, not at resolve —
     // so countered / fizzled copies still leave the source unprepared. Single
     // authority via `unprepare_object`.
     unprepare_object(state, source_id, events);
 
-    Ok(copy_id)
+    Ok(waiting)
 }
 
 #[cfg(test)]
@@ -311,6 +304,7 @@ mod tests {
     use crate::types::card_type::CoreType;
     use crate::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
     use crate::types::identifiers::CardId;
+    use crate::types::mana::{ManaCost, ManaCostShard};
     use crate::types::player::PlayerId;
     use crate::types::replacements::ReplacementEvent;
     use crate::types::zones::Zone;
@@ -827,11 +821,45 @@ mod tests {
         assert_eq!(events.len(), 1);
     }
 
+    #[test]
+    fn cast_prepared_copy_requires_payable_mana_cost() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = setup_creature(&mut state);
+        {
+            let source = state.objects.get_mut(&source_id).unwrap();
+            source.prepared = Some(PreparedState);
+            source.back_face = Some(BackFaceForTest::prepare_with_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 1,
+            }));
+        }
+
+        let mut events = Vec::new();
+        let result = cast_prepared_copy(&mut state, source_id, PlayerId(0), &mut events);
+
+        assert!(
+            result.is_err(),
+            "prepared copy cast must fail when mana cost is not payable"
+        );
+        assert!(
+            state.objects[&source_id].prepared.is_some(),
+            "source remains prepared when cast cannot start"
+        );
+        assert!(
+            state.stack.is_empty(),
+            "failed cast must not leave stack entries"
+        );
+    }
+
     /// Helper to build a minimal back-face with `layout_kind == Prepare` so
     /// the resolver's `has_prepare_face` gate passes in tests.
     struct BackFaceForTest;
     impl BackFaceForTest {
         fn prepare() -> crate::game::game_object::BackFaceData {
+            Self::prepare_with_cost(Default::default())
+        }
+
+        fn prepare_with_cost(mana_cost: ManaCost) -> crate::game::game_object::BackFaceData {
             let mut card_types = crate::types::card_type::CardType::default();
             card_types.core_types.push(CoreType::Sorcery);
             crate::game::game_object::BackFaceData {
@@ -841,7 +869,7 @@ mod tests {
                 loyalty: None,
                 defense: None,
                 card_types,
-                mana_cost: Default::default(),
+                mana_cost,
                 keywords: Vec::new(),
                 abilities: vec![AbilityDefinition::new(
                     AbilityKind::Spell,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -10103,6 +10103,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: crate::types::game_state::CastPaymentMode::Auto,
         }));
         state.waiting_for = WaitingFor::ManaPayment {
@@ -10479,6 +10480,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: crate::types::game_state::CastPaymentMode::Auto,
         }));
         state.waiting_for = WaitingFor::ManaPayment {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3582,10 +3582,10 @@ fn apply_action(
             super::companion::handle_companion_to_hand(state, *player, &mut events)
                 .map_err(EngineError::InvalidAction)?
         }
-        // CR 702.xxx: Prepare (Strixhaven) — priority-time cast of a prepared
-        // creature's face-`b` spell. Produces a token spell-copy on the stack;
-        // the source becomes unprepared at cast time. Assign when WotC
-        // publishes SOS CR update.
+        // CR 722.3c / CR 601.2: Prepare (Strixhaven) — cast a copy of the
+        // prepared face through the normal spell-casting pipeline (costs,
+        // targeting, and mode choices all run through casting.rs single
+        // authority). Assign when WotC publishes SOS CR update.
         (WaitingFor::Priority { player }, GameAction::CastPreparedCopy { source }) => {
             let p = *player;
             // Validate controller.
@@ -3600,18 +3600,8 @@ fn apply_action(
                     "CastPreparedCopy: source not controlled by acting player".to_string(),
                 ));
             }
-            let copy_id = effects::prepare::cast_prepared_copy(state, src, p, &mut events)
-                .map_err(EngineError::InvalidAction)?;
-            // CR 707.10c: If the copy's spell ability has target slots, open
-            // target selection via CopyRetarget. Otherwise return to priority
-            // and let the copy resolve on the stack.
-            if effects::prepare::open_copy_target_selection(state, copy_id, p)
+            effects::prepare::cast_prepared_copy(state, src, p, &mut events)
                 .map_err(EngineError::InvalidAction)?
-            {
-                state.waiting_for.clone()
-            } else {
-                WaitingFor::Priority { player: p }
-            }
         }
         // CR 702.xxx: Paradigm (Strixhaven) — accept the turn-based offer to
         // cast a copy of an exiled paradigm source. Assign when WotC

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -613,6 +613,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
         })
     }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -875,6 +875,11 @@ pub struct PendingCast {
     /// quantities can resolve later.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub convoked_creatures: Vec<ObjectId>,
+    /// CR 601.2i + CR 722.3c: Optional source permanent to re-mark as
+    /// prepared if this cast is cancelled and rolled back. Used by the
+    /// prepared-copy special action to restore pre-cast state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancel_restore_prepared_source: Option<ObjectId>,
     #[serde(default)]
     pub payment_mode: CastPaymentMode,
 }
@@ -909,6 +914,7 @@ impl PendingCast {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
         }
     }
@@ -3098,6 +3104,33 @@ impl WaitingFor {
         }
     }
 
+    /// Mutable variant of `pending_cast_ref()` for call sites that need to
+    /// annotate in-flight cast metadata (for example rollback markers).
+    pub fn pending_cast_mut(&mut self) -> Option<&mut PendingCast> {
+        match self {
+            WaitingFor::ChooseXValue { pending_cast, .. }
+            | WaitingFor::TargetSelection { pending_cast, .. }
+            | WaitingFor::ModeChoice { pending_cast, .. }
+            | WaitingFor::OptionalCostChoice { pending_cast, .. }
+            | WaitingFor::DefilerPayment { pending_cast, .. }
+            | WaitingFor::DiscardForCost { pending_cast, .. }
+            | WaitingFor::SacrificeForCost { pending_cast, .. }
+            | WaitingFor::ReturnToHandForCost { pending_cast, .. }
+            | WaitingFor::ActivationCostOneOfChoice { pending_cast, .. }
+            | WaitingFor::RemoveCounterForCost { pending_cast, .. }
+            | WaitingFor::BlightChoice { pending_cast, .. }
+            | WaitingFor::TapCreaturesForSpellCost { pending_cast, .. }
+            | WaitingFor::BeholdForCost { pending_cast, .. }
+            | WaitingFor::ExileForCost { pending_cast, .. }
+            | WaitingFor::HarmonizeTapChoice { pending_cast, .. } => Some(pending_cast),
+            WaitingFor::CollectEvidenceChoice { resume, .. } => match resume.as_mut() {
+                CollectEvidenceResume::Casting { pending_cast } => Some(pending_cast),
+                CollectEvidenceResume::Effect { .. } => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Whether this state is part of the casting flow and can be backed out of
     /// with `CancelCast` (CR 601.2).
     ///
@@ -5230,6 +5263,7 @@ mod tests {
                 declared_kickers_to_pay: Vec::new(),
                 declined_kickers: Vec::new(),
                 convoked_creatures: Vec::new(),
+                cancel_restore_prepared_source: None,
                 payment_mode: CastPaymentMode::Auto,
             })
         }
@@ -5524,6 +5558,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
         });
         let choose_x = WaitingFor::ChooseXValue {


### PR DESCRIPTION
﻿## Summary
Fixes #1187 by routing CastPreparedCopy through the normal cast pipeline so prepared-copy spells must satisfy standard castability and mana-payment rules.

## Files changed
- crates/engine/src/game/effects/prepare.rs
- crates/engine/src/ai_support/candidates.rs
- crates/engine/src/game/engine.rs

## CR references
- CR 722.3c
- CR 601.2
- CR 117.1d
- CR 601.2g

## Track
Developer

## LLM
Model: codex-5.3
Thinking: medium
Tier: Standard

## Gate A
`	ext
GATE_A_EXIT=0
`

## Anchored on
- crates/engine/src/game/effects/paradigm.rs:83 — existing copy-cast synthesis path for special spell-copy casting.
- crates/engine/src/game/casting.rs:4191 — canonical cast entry point enforcing targets/modes/cost payment.
- crates/engine/src/ai_support/candidates.rs:2407 — candidate gating pattern using can_cast_object_now.

## Verification
- cargo fmt --all — clean
- ./scripts/check-parser-combinators.sh — clean (GATE_A_EXIT=0)
- ./scripts/tilt-wait.sh --timeout 3600 clippy test-engine card-data — clean (TILT_WAIT_EXIT=0)
- cargo test -p engine cast_prepared_copy_requires_payable_mana_cost -- --nocapture — clean
- cargo test -p engine priority_actions_skip_cast_prepared_copy_when_cost_unpayable -- --nocapture — clean
- cargo coverage — failed (COVERAGE_EXIT=101; Windows linker unresolved externals while compiling coverage-report)
- cargo semantic-audit — failed (SEMANTIC_AUDIT_EXIT=1; oracle-gen semantic-audit reports missing field 'cost' in client/public/card-data.json)

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
- cargo coverage fails locally on Windows in coverage-report link step with unresolved externals (LNK2001/LNK2019/LNK1120).
- cargo semantic-audit fails locally because 	arget/tool/oracle-gen.exe semantic-audit cannot deserialize client/public/card-data.json (missing field 'cost' at line 1 column 72544).
