### PR TITLE
Fix The Ring emblem behavior

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1643,6 +1643,7 @@ export interface GameState {
   monarch?: PlayerId | null;
   city_blessing?: PlayerId[];
   ring_level?: Record<string, number>;
+  ring_bearer?: Record<string, ObjectId | null>;
   commander_damage?: CommanderDamageEntry[];
   exile_links?: Array<{ exiled_id: ObjectId; source_id: ObjectId }>;
   match_config?: MatchConfig;

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -107,6 +107,10 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
   const playerId = usePlayerId();
   const gameObjects = useGameStore((s) => s.gameState?.objects);
   const obj = useGameStore((s) => s.gameState?.objects[objectId]);
+  const isRingBearer = useGameStore((s) => {
+    const object = s.gameState?.objects[objectId];
+    return object ? s.gameState?.ring_bearer?.[String(object.controller)] === objectId : false;
+  });
   const battlefieldCardDisplay = usePreferencesStore((s) => s.battlefieldCardDisplay);
   const tapRotation = usePreferencesStore((s) => s.tapRotation);
   const isCompactHeight = useIsCompactHeight();
@@ -529,6 +533,14 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
               className="absolute inset-0 z-20 bg-sky-500/25 mix-blend-screen pointer-events-none rounded-lg"
             />
           )}
+          {isRingBearer && (
+            <div
+              className="absolute bottom-1 left-1 z-20 rounded bg-amber-500/90 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-wide text-amber-950 shadow ring-1 ring-amber-100/70"
+              title={t("permanent.ringBearerTooltip")}
+            >
+              {t("permanent.ringBearer")}
+            </div>
+          )}
         </div>
       ) : (
         <>
@@ -598,6 +610,15 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
             >
               <span aria-hidden>⚔</span>
               {incomingAttackerCount > 1 && <span>×{incomingAttackerCount}</span>}
+            </div>
+          )}
+
+          {isRingBearer && (
+            <div
+              className="absolute bottom-1 left-1 z-20 rounded bg-amber-500/90 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-wide text-amber-950 shadow ring-1 ring-amber-100/70"
+              title={t("permanent.ringBearerTooltip")}
+            >
+              {t("permanent.ringBearer")}
             </div>
           )}
 

--- a/client/src/components/hud/HudBadges.tsx
+++ b/client/src/components/hud/HudBadges.tsx
@@ -125,9 +125,10 @@ type CounterBadgeKind = "poison" | "speed" | "rad" | "energy" | "ring";
 interface CounterBadgeProps {
   kind: CounterBadgeKind;
   value: number;
+  ringBearerName?: string | null;
 }
 
-export function CounterBadge({ kind, value }: CounterBadgeProps) {
+export function CounterBadge({ kind, value, ringBearerName }: CounterBadgeProps) {
   const { t } = useTranslation("game");
   if (kind === "poison") {
     return (
@@ -172,11 +173,24 @@ export function CounterBadge({ kind, value }: CounterBadgeProps) {
   }
 
   if (kind === "ring") {
+    const ringTitle = [
+      t("badges.ringTooltip", { level: value }),
+      ringBearerName
+        ? t("badges.ringBearerTooltip", { name: ringBearerName })
+        : t("badges.noRingBearerTooltip"),
+      t("badges.ringLevel1"),
+      t("badges.ringLevel2"),
+      t("badges.ringLevel3"),
+      t("badges.ringLevel4"),
+    ].join("\n");
     return (
       <span
         role="img"
-        aria-label={t("badges.ringAriaLabel", { level: value })}
-        title={t("badges.ringTooltip", { level: value })}
+        aria-label={t("badges.ringAriaLabel", {
+          level: value,
+          bearer: ringBearerName ?? t("badges.noRingBearer"),
+        })}
+        title={ringTitle}
         className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center gap-px overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-amber-950 ring-1 bg-yellow-600 ring-yellow-300/70 shadow-[0_0_12px_rgba(202,138,4,0.55)]"
       >
         <span

--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -266,7 +266,13 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
                 <DungeonBadge dungeonName={opponentDesignations.activeDungeon} roomIndex={opponentDesignations.currentRoom} />
               ) : null}
               {isOpponentPhasedOut ? <StatusBadge label={t("player.phasedOut")} tone="neutral" /> : null}
-              {opponentDesignations.ringLevel > 0 ? <CounterBadge kind="ring" value={opponentDesignations.ringLevel} /> : null}
+              {opponentDesignations.ringLevel > 0 ? (
+                <CounterBadge
+                  kind="ring"
+                  value={opponentDesignations.ringLevel}
+                  ringBearerName={opponentDesignations.ringBearerName}
+                />
+              ) : null}
               {opponentDesignations.energy > 0 ? <CounterBadge kind="energy" value={opponentDesignations.energy} /> : null}
               {opponentPoisonCounters > 0 ? <CounterBadge kind="poison" value={opponentPoisonCounters} /> : null}
               {opponentRadCounters > 0 ? <CounterBadge kind="rad" value={opponentRadCounters} /> : null}
@@ -667,7 +673,13 @@ function OpponentTab({ playerId, isFocused, isEliminated, isTeammate: ally, isVa
       {designations.activeDungeon ? (
         <DungeonBadge dungeonName={designations.activeDungeon} roomIndex={designations.currentRoom} />
       ) : null}
-      {designations.ringLevel > 0 ? <CounterBadge kind="ring" value={designations.ringLevel} /> : null}
+      {designations.ringLevel > 0 ? (
+        <CounterBadge
+          kind="ring"
+          value={designations.ringLevel}
+          ringBearerName={designations.ringBearerName}
+        />
+      ) : null}
       {designations.energy > 0 ? <CounterBadge kind="energy" value={designations.energy} /> : null}
       {poisonCounters > 0 ? <CounterBadge kind="poison" value={poisonCounters} /> : null}
       {radCounters > 0 ? <CounterBadge kind="rad" value={radCounters} /> : null}

--- a/client/src/components/hud/PlayerHud.tsx
+++ b/client/src/components/hud/PlayerHud.tsx
@@ -92,7 +92,13 @@ export function PlayerHud() {
               <DungeonBadge dungeonName={designations.activeDungeon} roomIndex={designations.currentRoom} />
             ) : null}
             {isPhasedOut ? <StatusBadge label={t("player.phasedOut")} tone="neutral" /> : null}
-            {designations.ringLevel > 0 ? <CounterBadge kind="ring" value={designations.ringLevel} /> : null}
+            {designations.ringLevel > 0 ? (
+              <CounterBadge
+                kind="ring"
+                value={designations.ringLevel}
+                ringBearerName={designations.ringBearerName}
+              />
+            ) : null}
             {designations.energy > 0 ? <CounterBadge kind="energy" value={designations.energy} /> : null}
             {poisonCounters > 0 ? <CounterBadge kind="poison" value={poisonCounters} /> : null}
             {radCounters > 0 ? <CounterBadge kind="rad" value={radCounters} /> : null}

--- a/client/src/hooks/usePlayerDesignations.ts
+++ b/client/src/hooks/usePlayerDesignations.ts
@@ -1,6 +1,6 @@
 import { useShallow } from "zustand/react/shallow";
 
-import type { DungeonId, PlayerId } from "../adapter/types.ts";
+import type { DungeonId, ObjectId, PlayerId } from "../adapter/types.ts";
 import { useGameStore } from "../stores/gameStore.ts";
 
 export interface PlayerDesignations {
@@ -8,6 +8,8 @@ export interface PlayerDesignations {
   hasInitiative: boolean;
   hasCityBlessing: boolean;
   ringLevel: number;
+  ringBearerId: ObjectId | null;
+  ringBearerName: string | null;
   energy: number;
   /** The active dungeon, or null when the player is not currently venturing.
    *  `dungeon_progress` may carry a stale entry with `current_dungeon: null`
@@ -27,6 +29,8 @@ const EMPTY: PlayerDesignations = {
   hasInitiative: false,
   hasCityBlessing: false,
   ringLevel: 0,
+  ringBearerId: null,
+  ringBearerName: null,
   energy: 0,
   activeDungeon: null,
   currentRoom: 0,
@@ -44,6 +48,8 @@ export function usePlayerDesignations(playerId: PlayerId): PlayerDesignations {
       const hasInitiative = gs.initiative != null && gs.initiative === playerId;
       const hasCityBlessing = gs.city_blessing?.includes(playerId) ?? false;
       const ringLevel = gs.ring_level?.[playerKey(playerId)] ?? 0;
+      const ringBearerId = gs.ring_bearer?.[playerKey(playerId)] ?? null;
+      const ringBearerName = ringBearerId != null ? (gs.objects[String(ringBearerId)]?.name ?? null) : null;
       const energy = gs.players[playerId]?.energy ?? 0;
       const hasAny =
         isMonarch
@@ -57,6 +63,8 @@ export function usePlayerDesignations(playerId: PlayerId): PlayerDesignations {
         hasInitiative,
         hasCityBlessing,
         ringLevel,
+        ringBearerId,
+        ringBearerName,
         energy,
         activeDungeon,
         currentRoom: dungeon?.current_room ?? 0,

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -74,7 +74,9 @@
     "underAttack_other": "Von {{count}} Kreaturen angegriffen",
     "target": "Ziel",
     "copy": "Kopie",
-    "copyTooltip": "Spielstein-Kopie einer echten Karte"
+    "copyTooltip": "Spielstein-Kopie einer echten Karte",
+    "ringBearer": "Ring",
+    "ringBearerTooltip": "Ringträger"
   },
   "player": {
     "opponent": "Geg {{seat}}",
@@ -196,8 +198,15 @@
     "energyAriaLabel_one": "{{count}} Energiemarke",
     "energyAriaLabel_other": "{{count}} Energiemarken",
     "energyTooltip": "Energie: {{count}}",
-    "ringAriaLabel": "Der Eine Ring verlockt dich (Stufe {{level}})",
+    "ringAriaLabel": "Der Eine Ring verlockt dich (Stufe {{level}}), Ringträger: {{bearer}}",
     "ringTooltip": "Der Eine Ring verlockt dich — Stufe {{level}}",
+    "ringBearerTooltip": "Ringträger: {{name}}",
+    "noRingBearer": "keiner",
+    "noRingBearerTooltip": "Kein Ringträger",
+    "ringLevel1": "1. Der Ringträger ist legendär und kann nicht von Kreaturen mit größerer Stärke geblockt werden.",
+    "ringLevel2": "2. Wenn er angreift, ziehst du eine Karte und wirfst dann eine Karte ab.",
+    "ringLevel3": "3. Wenn er von einer Kreatur geblockt wird, opfert deren Beherrscher sie am Ende des Kampfes.",
+    "ringLevel4": "4. Wenn er einem Spieler Kampfschaden zufügt, verliert jeder Gegner 3 Lebenspunkte.",
     "radAriaLabel_one": "{{count}} Strahlungsmarke",
     "radAriaLabel_other": "{{count}} Strahlungsmarken",
     "radTooltip": "Strahlungsmarken: {{count}}",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -74,7 +74,9 @@
     "underAttack_other": "Attacked by {{count}} creatures",
     "target": "Target",
     "copy": "Copy",
-    "copyTooltip": "Token copy of a real card"
+    "copyTooltip": "Token copy of a real card",
+    "ringBearer": "Ring",
+    "ringBearerTooltip": "Ring-bearer"
   },
   "player": {
     "opponent": "Opp {{seat}}",
@@ -196,8 +198,15 @@
     "energyAriaLabel_one": "{{count}} energy counter",
     "energyAriaLabel_other": "{{count}} energy counters",
     "energyTooltip": "Energy: {{count}}",
-    "ringAriaLabel": "The Ring tempts you (level {{level}})",
+    "ringAriaLabel": "The Ring tempts you (level {{level}}), Ring-bearer: {{bearer}}",
     "ringTooltip": "The Ring tempts you — level {{level}}",
+    "ringBearerTooltip": "Ring-bearer: {{name}}",
+    "noRingBearer": "none",
+    "noRingBearerTooltip": "No Ring-bearer",
+    "ringLevel1": "1. Ring-bearer is legendary and can't be blocked by creatures with greater power.",
+    "ringLevel2": "2. When it attacks, draw a card, then discard a card.",
+    "ringLevel3": "3. When it becomes blocked by a creature, that creature's controller sacrifices it at end of combat.",
+    "ringLevel4": "4. When it deals combat damage to a player, each opponent loses 3 life.",
     "radAriaLabel_one": "{{count}} rad counter",
     "radAriaLabel_other": "{{count}} rad counters",
     "radTooltip": "Rad counters: {{count}}",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -74,7 +74,9 @@
     "underAttack_other": "Atacado por {{count}} criaturas",
     "target": "Objetivo",
     "copy": "Copia",
-    "copyTooltip": "Ficha copia de una carta real"
+    "copyTooltip": "Ficha copia de una carta real",
+    "ringBearer": "Anillo",
+    "ringBearerTooltip": "Portador del Anillo"
   },
   "player": {
     "opponent": "Op {{seat}}",
@@ -196,8 +198,15 @@
     "energyAriaLabel_one": "{{count}} contador de energía",
     "energyAriaLabel_other": "{{count}} contadores de energía",
     "energyTooltip": "Energía: {{count}}",
-    "ringAriaLabel": "El Anillo te tienta (nivel {{level}})",
+    "ringAriaLabel": "El Anillo te tienta (nivel {{level}}), portador del Anillo: {{bearer}}",
     "ringTooltip": "El Anillo te tienta — nivel {{level}}",
+    "ringBearerTooltip": "Portador del Anillo: {{name}}",
+    "noRingBearer": "ninguno",
+    "noRingBearerTooltip": "Sin portador del Anillo",
+    "ringLevel1": "1. El portador del Anillo es legendario y no puede ser bloqueado por criaturas con mayor fuerza.",
+    "ringLevel2": "2. Cuando ataca, roba una carta y luego descarta una carta.",
+    "ringLevel3": "3. Cuando sea bloqueado por una criatura, el controlador de esa criatura la sacrifica al final del combate.",
+    "ringLevel4": "4. Cuando haga daño de combate a un jugador, cada oponente pierde 3 vidas.",
     "radAriaLabel_one": "{{count}} contador rad",
     "radAriaLabel_other": "{{count}} contadores rad",
     "radTooltip": "Contadores rad: {{count}}",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -74,7 +74,9 @@
     "underAttack_other": "Attaqué par {{count}} créatures",
     "target": "Cible",
     "copy": "Copie",
-    "copyTooltip": "Jeton-copie d'une vraie carte"
+    "copyTooltip": "Jeton-copie d'une vraie carte",
+    "ringBearer": "Anneau",
+    "ringBearerTooltip": "Porteur de l'Anneau"
   },
   "player": {
     "opponent": "Adv {{seat}}",
@@ -196,8 +198,15 @@
     "energyAriaLabel_one": "{{count}} marqueur énergie",
     "energyAriaLabel_other": "{{count}} marqueurs énergie",
     "energyTooltip": "Énergie : {{count}}",
-    "ringAriaLabel": "L'Anneau vous tente (niveau {{level}})",
+    "ringAriaLabel": "L'Anneau vous tente (niveau {{level}}), porteur de l'Anneau : {{bearer}}",
     "ringTooltip": "L'Anneau vous tente — niveau {{level}}",
+    "ringBearerTooltip": "Porteur de l'Anneau : {{name}}",
+    "noRingBearer": "aucun",
+    "noRingBearerTooltip": "Aucun porteur de l'Anneau",
+    "ringLevel1": "1. Le porteur de l'Anneau est légendaire et ne peut pas être bloqué par des créatures de force supérieure.",
+    "ringLevel2": "2. Quand il attaque, piochez une carte, puis défaussez-vous d'une carte.",
+    "ringLevel3": "3. Quand il devient bloqué par une créature, le contrôleur de cette créature la sacrifie à la fin du combat.",
+    "ringLevel4": "4. Quand il inflige des blessures de combat à un joueur, chaque adversaire perd 3 points de vie.",
     "radAriaLabel_one": "{{count}} marqueur rad",
     "radAriaLabel_other": "{{count}} marqueurs rad",
     "radTooltip": "Marqueurs rad : {{count}}",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -74,7 +74,9 @@
     "underAttack_other": "Attaccato da {{count}} creature",
     "target": "Bersaglio",
     "copy": "Copia",
-    "copyTooltip": "Copia pedina di una carta reale"
+    "copyTooltip": "Copia pedina di una carta reale",
+    "ringBearer": "Anello",
+    "ringBearerTooltip": "Portatore dell'Anello"
   },
   "player": {
     "opponent": "Avv {{seat}}",
@@ -196,8 +198,15 @@
     "energyAriaLabel_one": "{{count}} segnalino energia",
     "energyAriaLabel_other": "{{count}} segnalini energia",
     "energyTooltip": "Energia: {{count}}",
-    "ringAriaLabel": "L'Anello ti tenta (livello {{level}})",
+    "ringAriaLabel": "L'Anello ti tenta (livello {{level}}), portatore dell'Anello: {{bearer}}",
     "ringTooltip": "L'Anello ti tenta — livello {{level}}",
+    "ringBearerTooltip": "Portatore dell'Anello: {{name}}",
+    "noRingBearer": "nessuno",
+    "noRingBearerTooltip": "Nessun portatore dell'Anello",
+    "ringLevel1": "1. Il portatore dell'Anello è leggendario e non può essere bloccato da creature con forza maggiore.",
+    "ringLevel2": "2. Quando attacca, pesca una carta, poi scarta una carta.",
+    "ringLevel3": "3. Quando viene bloccato da una creatura, il controllore di quella creatura la sacrifica alla fine del combattimento.",
+    "ringLevel4": "4. Quando infligge danno da combattimento a un giocatore, ogni avversario perde 3 punti vita.",
     "radAriaLabel_one": "{{count}} segnalino radiazione",
     "radAriaLabel_other": "{{count}} segnalini radiazione",
     "radTooltip": "Segnalini radiazione: {{count}}",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -74,7 +74,9 @@
     "underAttack_other": "Atakowany przez {{count}} stworów",
     "target": "Cel",
     "copy": "Kopia",
-    "copyTooltip": "Kopia tokenowa prawdziwej karty"
+    "copyTooltip": "Kopia tokenowa prawdziwej karty",
+    "ringBearer": "Pierścień",
+    "ringBearerTooltip": "Powiernik Pierścienia"
   },
   "player": {
     "opponent": "Przec {{seat}}",
@@ -196,8 +198,15 @@
     "energyAriaLabel_one": "{{count}} znacznik energii",
     "energyAriaLabel_other": "{{count}} znaczników energii",
     "energyTooltip": "Energia: {{count}}",
-    "ringAriaLabel": "Pierścień cię kusi (poziom {{level}})",
+    "ringAriaLabel": "Pierścień cię kusi (poziom {{level}}), powiernik Pierścienia: {{bearer}}",
     "ringTooltip": "Pierścień cię kusi — poziom {{level}}",
+    "ringBearerTooltip": "Powiernik Pierścienia: {{name}}",
+    "noRingBearer": "brak",
+    "noRingBearerTooltip": "Brak powiernika Pierścienia",
+    "ringLevel1": "1. Powiernik Pierścienia jest legendarny i nie może być blokowany przez stwory o większej sile.",
+    "ringLevel2": "2. Kiedy atakuje, dobierz kartę, a następnie odrzuć kartę.",
+    "ringLevel3": "3. Kiedy zostaje zablokowany przez stwora, kontroler tego stwora poświęca go na końcu walki.",
+    "ringLevel4": "4. Kiedy zada graczowi obrażenia bojowe, każdy przeciwnik traci 3 życia.",
     "radAriaLabel_one": "{{count}} znacznik promieniowania",
     "radAriaLabel_other": "{{count}} znaczników promieniowania",
     "radTooltip": "Znaczniki promieniowania: {{count}}",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -74,7 +74,9 @@
     "underAttack_other": "Atacado por {{count}} criaturas",
     "target": "Alvo",
     "copy": "Cópia",
-    "copyTooltip": "Cópia em ficha de uma carta real"
+    "copyTooltip": "Cópia em ficha de uma carta real",
+    "ringBearer": "Anel",
+    "ringBearerTooltip": "Portador do Anel"
   },
   "player": {
     "opponent": "Op {{seat}}",
@@ -196,8 +198,15 @@
     "energyAriaLabel_one": "{{count}} marcador de energia",
     "energyAriaLabel_other": "{{count}} marcadores de energia",
     "energyTooltip": "Energia: {{count}}",
-    "ringAriaLabel": "O Anel o tenta (nível {{level}})",
+    "ringAriaLabel": "O Anel o tenta (nível {{level}}), portador do Anel: {{bearer}}",
     "ringTooltip": "O Anel o tenta — nível {{level}}",
+    "ringBearerTooltip": "Portador do Anel: {{name}}",
+    "noRingBearer": "nenhum",
+    "noRingBearerTooltip": "Nenhum portador do Anel",
+    "ringLevel1": "1. O portador do Anel é lendário e não pode ser bloqueado por criaturas com poder maior.",
+    "ringLevel2": "2. Quando ele ataca, compre uma carta e depois descarte uma carta.",
+    "ringLevel3": "3. Quando ele for bloqueado por uma criatura, o controlador daquela criatura a sacrifica no final do combate.",
+    "ringLevel4": "4. Quando ele causa dano de combate a um jogador, cada oponente perde 3 pontos de vida.",
     "radAriaLabel_one": "{{count}} marcador de radiação",
     "radAriaLabel_other": "{{count}} marcadores de radiação",
     "radTooltip": "Marcadores de radiação: {{count}}",

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -578,6 +578,13 @@ pub fn validate_blockers_for_player(
             }
         }
 
+        if ring_bearer_unblockable_by_greater_power(state, attacker, blocker) {
+            return Err(format!(
+                "{:?} cannot block {:?} (Ring-bearer can't be blocked by greater power)",
+                blocker_id, attacker_id
+            ));
+        }
+
         // CR 702.16f: Protection — an attacking creature with protection can't
         // be blocked by creatures with the stated quality.
         for kw in &attacker.keywords {
@@ -1896,6 +1903,9 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
             _ => {}
         }
     }
+    if ring_bearer_unblockable_by_greater_power(state, attacker, blocker) {
+        return false;
+    }
     for kw in &attacker.keywords {
         if let Keyword::Protection(target) = kw {
             if crate::game::keywords::source_matches_protection_target(target, attacker, blocker) {
@@ -1944,6 +1954,17 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
         return false;
     }
     true
+}
+
+fn ring_bearer_unblockable_by_greater_power(
+    state: &GameState,
+    attacker: &GameObject,
+    blocker: &GameObject,
+) -> bool {
+    // CR 701.54c: The Ring emblem says "Your Ring-bearer is legendary and
+    // can't be blocked by creatures with greater power."
+    super::effects::ring::is_current_ring_bearer(state, attacker.controller, attacker.id)
+        && blocker.power.unwrap_or(0) > attacker.power.unwrap_or(0)
 }
 
 /// CR 509.1a + CR 509.1b: Compute the maximum number of attackers a creature can block.

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -82,12 +82,15 @@ pub fn resolve(
     // After this call, `delayed_effect` holds no parent context refs.
     snapshot_parent_dependent_quantities(&mut delayed_effect, state, ability);
 
-    let delayed_ability = ResolvedAbility::new(
+    let mut delayed_ability = ResolvedAbility::new(
         delayed_effect,
         snapshot_targets,
         ability.source_id,
         ability.controller,
     );
+    // CR 603.7c: A delayed triggered ability that refers to information from
+    // its creation event keeps that creation-time binding for later resolution.
+    delayed_ability.scoped_player = ability.scoped_player;
 
     // CR 603.7c: Most delayed triggers fire once and are removed.
     // WheneverEvent triggers fire each time and persist until end-of-turn cleanup.

--- a/crates/engine/src/game/effects/ring.rs
+++ b/crates/engine/src/game/effects/ring.rs
@@ -2,6 +2,7 @@ use crate::types::ability::{EffectError, EffectKind, ResolvedAbility};
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::identifiers::ObjectId;
 use crate::types::zones::Zone;
 
 /// CR 701.54: The Ring tempts you.
@@ -60,6 +61,7 @@ pub fn resolve(
     if candidates.len() == 1 {
         // Only one creature — auto-select as ring-bearer.
         state.ring_bearer.insert(controller, Some(candidates[0]));
+        state.layers_dirty = true;
         return Ok(());
     }
 
@@ -72,13 +74,77 @@ pub fn resolve(
     Ok(())
 }
 
+/// CR 701.54e: A player's Ring-bearer designation is valid only while that
+/// creature remains on the battlefield under that player's control.
+pub(crate) fn is_current_ring_bearer(
+    state: &GameState,
+    player: crate::types::player::PlayerId,
+    object_id: ObjectId,
+) -> bool {
+    if state.ring_bearer.get(&player).copied().flatten() != Some(object_id) {
+        return false;
+    }
+    state.objects.get(&object_id).is_some_and(|obj| {
+        obj.zone == Zone::Battlefield
+            && obj.controller == player
+            && obj.card_types.core_types.contains(&CoreType::Creature)
+    })
+}
+
+pub(crate) fn ring_bearer_for(
+    state: &GameState,
+    player: crate::types::player::PlayerId,
+) -> Option<ObjectId> {
+    let object_id = state.ring_bearer.get(&player).copied().flatten()?;
+    is_current_ring_bearer(state, player, object_id).then_some(object_id)
+}
+
+pub(crate) fn clear_ring_bearer_if_object(state: &mut GameState, object_id: ObjectId) {
+    let mut changed = false;
+    state.ring_bearer.retain(|_, bearer| {
+        if matches!(bearer, Some(id) if *id == object_id) {
+            changed = true;
+            false
+        } else {
+            true
+        }
+    });
+    if changed {
+        state.layers_dirty = true;
+    }
+}
+
+pub(crate) fn normalize_ring_bearers(state: &mut GameState) -> bool {
+    let stale: Vec<_> = state
+        .ring_bearer
+        .iter()
+        .filter_map(|(&player, bearer)| {
+            let object_id = bearer.as_ref().copied()?;
+            (!is_current_ring_bearer(state, player, object_id)).then_some(player)
+        })
+        .collect();
+
+    if stale.is_empty() {
+        return false;
+    }
+
+    for player in stale {
+        state.ring_bearer.remove(&player);
+    }
+    state.layers_dirty = true;
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::effects::resolve_ability_chain;
     use crate::game::zones::create_object;
-    use crate::types::ability::{Effect, ResolvedAbility};
-    use crate::types::card_type::{CardType, CoreType};
+    use crate::game::{combat, layers, triggers, zones};
+    use crate::types::ability::{Effect, PlayerFilter, ResolvedAbility, TargetFilter};
+    use crate::types::card_type::{CardType, CoreType, Supertype};
     use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::phase::Phase;
     use crate::types::player::PlayerId;
 
     fn make_creature(state: &mut GameState, card_id: u64, controller: PlayerId) -> ObjectId {
@@ -172,5 +238,154 @@ mod tests {
 
         assert_eq!(state.ring_level[&PlayerId(0)], 1);
         assert_eq!(state.ring_bearer.get(&PlayerId(0)), None);
+    }
+
+    #[test]
+    fn ring_bearer_is_legendary_from_the_ring_emblem() {
+        let mut state = GameState::new_two_player(42);
+        let creature_id = make_creature(&mut state, 1, PlayerId(0));
+        state.ring_level.insert(PlayerId(0), 1);
+        state.ring_bearer.insert(PlayerId(0), Some(creature_id));
+        state.layers_dirty = true;
+
+        layers::evaluate_layers(&mut state);
+
+        assert!(state.objects[&creature_id]
+            .card_types
+            .supertypes
+            .contains(&Supertype::Legendary));
+    }
+
+    #[test]
+    fn ring_bearer_cant_be_blocked_by_greater_power_creature() {
+        let mut state = GameState::new_two_player(42);
+        let attacker = make_creature(&mut state, 1, PlayerId(0));
+        let blocker = make_creature(&mut state, 2, PlayerId(1));
+        state.objects.get_mut(&attacker).unwrap().power = Some(2);
+        state.objects.get_mut(&blocker).unwrap().power = Some(3);
+        state.ring_level.insert(PlayerId(0), 1);
+        state.ring_bearer.insert(PlayerId(0), Some(attacker));
+
+        assert!(!combat::can_block_pair(&state, blocker, attacker));
+
+        state.objects.get_mut(&blocker).unwrap().power = Some(2);
+        assert!(combat::can_block_pair(&state, blocker, attacker));
+    }
+
+    #[test]
+    fn ring_bearer_designation_clears_when_object_leaves_battlefield() {
+        let mut state = GameState::new_two_player(42);
+        let creature_id = make_creature(&mut state, 1, PlayerId(0));
+        state.ring_level.insert(PlayerId(0), 1);
+        state.ring_bearer.insert(PlayerId(0), Some(creature_id));
+        let mut events = Vec::new();
+
+        zones::move_to_zone(&mut state, creature_id, Zone::Graveyard, &mut events);
+
+        assert_eq!(state.ring_bearer.get(&PlayerId(0)), None);
+    }
+
+    #[test]
+    fn ring_level_two_attack_queues_draw_then_discard_trigger() {
+        let mut state = GameState::new_two_player(42);
+        let bearer = make_creature(&mut state, 1, PlayerId(0));
+        state.ring_level.insert(PlayerId(0), 2);
+        state.ring_bearer.insert(PlayerId(0), Some(bearer));
+
+        triggers::process_triggers(
+            &mut state,
+            &[GameEvent::AttackersDeclared {
+                attacker_ids: vec![bearer],
+                defending_player: PlayerId(1),
+                attacks: Vec::new(),
+            }],
+        );
+
+        let ability = state.stack.last().unwrap().ability().unwrap();
+        assert!(matches!(ability.effect, Effect::Draw { .. }));
+        assert!(matches!(
+            ability.sub_ability.as_ref().map(|sub| &sub.effect),
+            Some(Effect::Discard { .. })
+        ));
+    }
+
+    #[test]
+    fn ring_level_three_blocked_queues_delayed_sacrifice_trigger() {
+        let mut state = GameState::new_two_player(42);
+        let bearer = make_creature(&mut state, 1, PlayerId(0));
+        let blocker = make_creature(&mut state, 2, PlayerId(1));
+        state.ring_level.insert(PlayerId(0), 3);
+        state.ring_bearer.insert(PlayerId(0), Some(bearer));
+
+        triggers::process_triggers(
+            &mut state,
+            &[GameEvent::BlockersDeclared {
+                assignments: vec![(blocker, bearer)],
+            }],
+        );
+
+        let ability = state.stack.last().unwrap().ability().unwrap().clone();
+        assert_eq!(ability.controller, PlayerId(0));
+        let Effect::CreateDelayedTrigger { effect, .. } = &ability.effect else {
+            panic!("expected The Ring level 3 to create a delayed trigger");
+        };
+        let Effect::Sacrifice { target, .. } = effect.effect.as_ref() else {
+            panic!("expected delayed trigger to sacrifice the blocker");
+        };
+        let TargetFilter::And { filters } = target else {
+            panic!("expected delayed trigger to scope sacrifice by blocker controller");
+        };
+        assert!(filters
+            .iter()
+            .any(|filter| filter == &TargetFilter::SpecificObject { id: blocker }));
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        assert_eq!(state.delayed_triggers.len(), 1);
+        assert_eq!(state.delayed_triggers[0].controller, PlayerId(0));
+        assert_eq!(state.delayed_triggers[0].ability.controller, PlayerId(0));
+        assert_eq!(
+            state.delayed_triggers[0].ability.scoped_player,
+            Some(PlayerId(1))
+        );
+
+        triggers::check_delayed_triggers(
+            &mut state,
+            &[GameEvent::PhaseChanged {
+                phase: Phase::EndCombat,
+            }],
+        );
+
+        let delayed_ability = state.stack.last().unwrap().ability().unwrap().clone();
+        assert_eq!(delayed_ability.controller, PlayerId(0));
+        assert_eq!(delayed_ability.scoped_player, Some(PlayerId(1)));
+        resolve_ability_chain(&mut state, &delayed_ability, &mut events, 0).unwrap();
+        assert_eq!(state.objects[&blocker].zone, Zone::Graveyard);
+    }
+
+    #[test]
+    fn ring_level_four_combat_damage_queues_each_opponent_loses_life_trigger() {
+        let mut state = GameState::new_two_player(42);
+        let bearer = make_creature(&mut state, 1, PlayerId(0));
+        state.ring_level.insert(PlayerId(0), 4);
+        state.ring_bearer.insert(PlayerId(0), Some(bearer));
+
+        triggers::process_triggers(
+            &mut state,
+            &[GameEvent::CombatDamageDealtToPlayer {
+                player_id: PlayerId(1),
+                source_ids: vec![bearer],
+            }],
+        );
+
+        let ability = state.stack.last().unwrap().ability().unwrap();
+        assert!(matches!(
+            ability.effect,
+            Effect::LoseLife {
+                amount: crate::types::ability::QuantityExpr::Fixed { value: 3 },
+                ..
+            }
+        ));
+        assert_eq!(ability.player_scope, Some(PlayerFilter::Opponent));
     }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2162,6 +2162,7 @@ pub(super) fn handle_resolution_choice(
                 ));
             }
             state.ring_bearer.insert(player, Some(target));
+            state.layers_dirty = true;
             ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
         }
         (WaitingFor::ChooseDungeon { player, options }, GameAction::ChooseDungeon { dungeon }) => {

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -14,7 +14,9 @@ use crate::types::ability::{
     TypedFilter,
 };
 use crate::types::attribution::EffectRef;
-use crate::types::card_type::{is_land_subtype, noncreature_subtype_set, CoreType, SubtypeSet};
+use crate::types::card_type::{
+    is_land_subtype, noncreature_subtype_set, CoreType, SubtypeSet, Supertype,
+};
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::game_state::{DayNight, GameState};
 use crate::types::identifiers::ObjectId;
@@ -513,10 +515,9 @@ fn evaluate_condition_with_context(
             .get(&source_id)
             .is_some_and(|obj| obj.entered_battlefield_turn == Some(state.turn_number)),
         // CR 701.54a: True when this creature is the ring-bearer for its controller.
-        StaticCondition::IsRingBearer => state
-            .ring_bearer
-            .get(&controller)
-            .is_some_and(|bearer| *bearer == Some(source_id)),
+        StaticCondition::IsRingBearer => {
+            super::effects::ring::is_current_ring_bearer(state, controller, source_id)
+        }
         // CR 701.54c: True when the controller's ring level is at least this value.
         StaticCondition::RingLevelAtLeast { level } => {
             state.ring_level.get(&controller).copied().unwrap_or(0) >= *level
@@ -950,6 +951,10 @@ pub fn evaluate_layers(state: &mut GameState) {
     }
 
     super::pairing::cleanup_invalid_pairs(state);
+    if super::effects::ring::normalize_ring_bearers(state) {
+        evaluate_layers(state);
+        return;
+    }
 
     // Step 5: Clear dirty flag
     state.layers_dirty = false;
@@ -988,7 +993,44 @@ pub(crate) fn collect_shared_active_continuous_effects(
         effects.extend(active_continuous_effects_from_static_source(state, obj));
     });
     gather_transient_continuous_effects(state, &mut effects);
+    gather_ring_emblem_continuous_effects(state, &mut effects);
     effects
+}
+
+fn gather_ring_emblem_continuous_effects(
+    state: &GameState,
+    effects: &mut Vec<ActiveContinuousEffect>,
+) {
+    for &player in state.ring_level.keys() {
+        let Some(bearer_id) = super::effects::ring::ring_bearer_for(state, player) else {
+            continue;
+        };
+        let timestamp = state
+            .objects
+            .get(&bearer_id)
+            .map(|obj| obj.timestamp)
+            .unwrap_or_default();
+        let modification = ContinuousModification::AddSupertype {
+            supertype: Supertype::Legendary,
+        };
+        // CR 701.54c: The Ring emblem makes its controller's Ring-bearer
+        // legendary. Model the emblem's type-changing continuous effect in
+        // layer 4 with the bearer as the affected object.
+        effects.push(ActiveContinuousEffect {
+            source_id: bearer_id,
+            controller: player,
+            def_index: None,
+            transient_id: None,
+            mod_index: 0,
+            layer: modification.layer(),
+            timestamp,
+            modification,
+            affected_filter: TargetFilter::SpecificObject { id: bearer_id },
+            condition: None,
+            mode: StaticMode::Continuous,
+            characteristic_defining: false,
+        });
+    }
 }
 
 fn for_each_static_effect_source(

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -1649,6 +1649,8 @@ fn collect_pending_triggers(
         }
     }
 
+    collect_ring_emblem_triggers(state, events, &mut pending);
+
     // CR 603.2d: Trigger doubling — Panharmonicon-style effects.
     // Scan battlefield for objects with StaticMode::Panharmonicon statics,
     // then clone matching pending triggers.
@@ -1670,6 +1672,195 @@ fn collect_pending_triggers(
     pending.reverse();
 
     pending
+}
+
+fn collect_ring_emblem_triggers(
+    state: &GameState,
+    events: &[GameEvent],
+    pending: &mut Vec<PendingTriggerContext>,
+) {
+    for event in events {
+        let players: Vec<_> = state.ring_level.keys().copied().collect();
+        for player in players {
+            let level = state.ring_level.get(&player).copied().unwrap_or(0);
+            let Some(bearer_id) = super::effects::ring::ring_bearer_for(state, player) else {
+                continue;
+            };
+
+            if level >= 2 {
+                // CR 701.54c: Once the Ring has tempted a player two or more
+                // times, it has "Whenever your Ring-bearer attacks, draw a
+                // card, then discard a card."
+                if let GameEvent::AttackersDeclared { attacker_ids, .. } = event {
+                    if attacker_ids.contains(&bearer_id) {
+                        pending.push(ring_pending_trigger(
+                            bearer_id,
+                            player,
+                            player,
+                            event,
+                            ring_level_two_ability(bearer_id, player),
+                            "The Ring level 2",
+                        ));
+                    }
+                }
+            }
+
+            if level >= 3 {
+                // CR 701.54c: Once the Ring has tempted a player three or more
+                // times, it has "Whenever your Ring-bearer becomes blocked by
+                // a creature, the blocking creature's controller sacrifices it
+                // at end of combat."
+                if let GameEvent::BlockersDeclared { assignments } = event {
+                    for (blocker_id, attacker_id) in assignments {
+                        if *attacker_id != bearer_id {
+                            continue;
+                        }
+                        let Some(blocker) = state.objects.get(blocker_id) else {
+                            continue;
+                        };
+                        if !blocker.card_types.core_types.contains(&CoreType::Creature) {
+                            continue;
+                        }
+                        pending.push(ring_pending_trigger(
+                            bearer_id,
+                            player,
+                            player,
+                            event,
+                            ring_level_three_ability(
+                                bearer_id,
+                                blocker.id,
+                                player,
+                                blocker.controller,
+                            ),
+                            "The Ring level 3",
+                        ));
+                    }
+                }
+            }
+
+            if level >= 4 {
+                // CR 701.54c: Once the Ring has tempted a player four or more
+                // times, it has "Whenever your Ring-bearer deals combat damage
+                // to a player, each opponent loses 3 life."
+                if let GameEvent::CombatDamageDealtToPlayer { source_ids, .. } = event {
+                    if source_ids.contains(&bearer_id) {
+                        pending.push(ring_pending_trigger(
+                            bearer_id,
+                            player,
+                            player,
+                            event,
+                            ring_level_four_ability(bearer_id, player),
+                            "The Ring level 4",
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn ring_pending_trigger(
+    source_id: ObjectId,
+    trigger_controller: PlayerId,
+    ability_controller: PlayerId,
+    event: &GameEvent,
+    mut ability: ResolvedAbility,
+    description: &str,
+) -> PendingTriggerContext {
+    ability.controller = ability_controller;
+    PendingTriggerContext::single(PendingTrigger {
+        source_id,
+        controller: trigger_controller,
+        condition: None,
+        ability,
+        timestamp: 0,
+        target_constraints: Vec::new(),
+        distribute: None,
+        trigger_event: Some(event.clone()),
+        modal: None,
+        mode_abilities: vec![],
+        description: Some(description.to_string()),
+        may_trigger_origin: None,
+        subject_match_count: None,
+    })
+}
+
+fn ring_level_two_ability(source_id: ObjectId, controller: PlayerId) -> ResolvedAbility {
+    let discard = ResolvedAbility::new(
+        Effect::Discard {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+            random: false,
+            unless_filter: None,
+            filter: None,
+        },
+        vec![],
+        source_id,
+        controller,
+    );
+    ResolvedAbility::new(
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+        vec![],
+        source_id,
+        controller,
+    )
+    .sub_ability(discard)
+}
+
+fn ring_level_three_ability(
+    source_id: ObjectId,
+    blocker_id: ObjectId,
+    controller: PlayerId,
+    blocker_controller: PlayerId,
+) -> ResolvedAbility {
+    let target = TargetFilter::And {
+        filters: vec![
+            TargetFilter::SpecificObject { id: blocker_id },
+            TargetFilter::Typed(TypedFilter::permanent().controller(ControllerRef::ScopedPlayer)),
+        ],
+    };
+    let sacrifice = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Sacrifice {
+            target,
+            count: QuantityExpr::Fixed { value: 1 },
+            min_count: 0,
+        },
+    );
+    let mut ability = ResolvedAbility::new(
+        Effect::CreateDelayedTrigger {
+            condition: DelayedTriggerCondition::AtNextPhase {
+                phase: Phase::EndCombat,
+            },
+            effect: Box::new(sacrifice),
+            uses_tracked_set: false,
+        },
+        vec![],
+        source_id,
+        controller,
+    );
+    // CR 701.54c + CR 701.21a: The Ring-bearer's controller controls the
+    // triggered and delayed abilities, but the blocking creature's controller
+    // performs the sacrifice.
+    ability.scoped_player = Some(blocker_controller);
+    ability
+}
+
+fn ring_level_four_ability(source_id: ObjectId, controller: PlayerId) -> ResolvedAbility {
+    let mut ability = ResolvedAbility::new(
+        Effect::LoseLife {
+            amount: QuantityExpr::Fixed { value: 3 },
+            target: None,
+        },
+        vec![],
+        source_id,
+        controller,
+    );
+    ability.player_scope = Some(PlayerFilter::Opponent);
+    ability
 }
 
 /// Process events and place triggered abilities on the stack in APNAP order.

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -182,6 +182,12 @@ fn apply_zone_exit_cleanup(state: &mut GameState, object_id: ObjectId, from: Zon
         obj_mut.counters.clear();
     }
 
+    if from == Zone::Battlefield {
+        // CR 701.54e: A player's Ring-bearer designation applies only while
+        // that permanent remains on the battlefield under that player's control.
+        super::effects::ring::clear_ring_bearer_if_object(state, object_id);
+    }
+
     // Prune host-bound transient effects and clean up mana-tap tracking
     // when a permanent leaves the battlefield.
     if from == Zone::Battlefield {


### PR DESCRIPTION
## Summary
Fixes The Ring emblem behavior and display for issue #730.

Fixes #730.

## Files changed
- `crates/engine/src/game/effects/ring.rs`
- `crates/engine/src/game/effects/delayed_trigger.rs`
- `crates/engine/src/game/combat.rs`
- `crates/engine/src/game/layers.rs`
- `crates/engine/src/game/triggers.rs`
- `crates/engine/src/game/engine_resolution_choices.rs`
- `crates/engine/src/game/zones.rs`
- `client/src/adapter/types.ts`
- `client/src/hooks/usePlayerDesignations.ts`
- `client/src/components/hud/HudBadges.tsx`
- `client/src/components/hud/PlayerHud.tsx`
- `client/src/components/hud/OpponentHud.tsx`
- `client/src/components/board/PermanentCard.tsx`
- `client/src/i18n/locales/en/game.json`
- `client/src/i18n/locales/de/game.json`
- `client/src/i18n/locales/es/game.json`
- `client/src/i18n/locales/fr/game.json`
- `client/src/i18n/locales/it/game.json`
- `client/src/i18n/locales/pt/game.json`
- `client/src/i18n/locales/pl/game.json`

## CR references
- CR 701.54a
- CR 701.54b
- CR 701.54c
- CR 701.54e
- CR 701.21a
- CR 603.7c
- CR 603.7e

## Track
Developer

## LLM
Model: codex-5
Thinking: medium
Tier: Standard

## Gate A
Command:

```text
./scripts/check-parser-combinators.sh
```

Output:

```text
(no output; exit code 0)
```

## Anchored on
- `crates/engine/src/game/triggers.rs:730` - existing trigger collection path that gathers pending trigger contexts from engine events.
- `crates/engine/src/game/triggers.rs:991` - existing `CreateDelayedTrigger` with `DelayedTriggerCondition::AtNextPhase` for delayed combat sacrifice behavior.
- `crates/engine/src/game/layers.rs:1292` - existing transient continuous-effect gatherer that emits `ActiveContinuousEffect` records into the layer system.
- `crates/engine/src/game/combat.rs:1852` - existing `can_block_pair` legality predicate used by UI/AI and full blocker validation.

## Verification
- `cargo fmt --all` - clean
- `cargo fmt --all -- --check` - clean
- `./scripts/check-parser-combinators.sh` - clean
- `cargo clippy --all-targets -- -D warnings` - clean
- `cargo test -p engine` - 8,865 unit tests passed; 471 integration tests passed; doc tests ok
- `./scripts/gen-card-data.sh` - schema validation and card-data generation clean
- `pnpm run type-check` - clean
- `pnpm lint` - 0 errors; 1 existing Fast Refresh warning in `client/src/components/draft/CubeSetupPanel.tsx`
- `pnpm test -- --run --coverage` - 125 frontend test files passed; 5 skipped; 1,030 tests passed; 18 todo
- `git diff --check` - clean

## Scope Expansion
None.

## Review Follow-up
- Addressed Gemini review feedback on Ring level 3 trigger control: the Ring-bearer's controller controls the triggered and delayed abilities, while the blocking creature's controller performs the sacrifice.
- Added CR annotations for Ring emblem trigger collection and battlefield-exit cleanup.
- Reworked Ring-bearer normalization so stale designations trigger a fresh layer evaluation before clearing `layers_dirty`.
- Removed the clone of the Ring-bearer map in zone-exit cleanup.

## Validation Failures
None.

## CI Failures
None.
