### PR TITLE
Fix #563: AI infinite loop casting Whitemane Lion (non-targeted bounce ETB)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -3720,13 +3720,14 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityCost, AbilityKind, AggregateFunction, CardTypeSetSource, CastManaObjectScope,
-        CastManaSpentMetric, Comparator, ContinuousModification, CountScope, CounterTransferMode,
-        Duration, Effect, FilterProp, GameRestriction, LibraryPosition, ModalChoice,
-        ModalSelectionConstraint, MultiTargetSpec, ObjectProperty, ObjectScope, ProhibitedActivity,
-        PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, RestrictionExpiry,
-        RestrictionPlayerScope, SearchSelectionConstraint, SharedQuality, SharedQualityRelation,
-        StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter, UnlessPayModifier,
+        AbilityCost, AbilityKind, AggregateFunction, BounceSelection, CardTypeSetSource,
+        CastManaObjectScope, CastManaSpentMetric, Comparator, ContinuousModification, CountScope,
+        CounterTransferMode, Duration, Effect, FilterProp, GameRestriction, LibraryPosition,
+        ModalChoice, ModalSelectionConstraint, MultiTargetSpec, ObjectProperty, ObjectScope,
+        ProhibitedActivity, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
+        RestrictionExpiry, RestrictionPlayerScope, SearchSelectionConstraint, SharedQuality,
+        SharedQualityRelation, StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+        UnlessPayModifier,
     };
     use crate::types::card_type::CoreType;
     use crate::types::game_state::{
@@ -3900,7 +3901,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
         )];
 

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -3900,6 +3900,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
         )];
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1791,6 +1791,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         Effect::Bounce {
             target,
             destination,
+            ..
         } => {
             d.push(("target".into(), fmt_target(target)));
             if let Some(dest) = destination {

--- a/crates/engine/src/game/effects/bounce.rs
+++ b/crates/engine/src/game/effects/bounce.rs
@@ -108,10 +108,11 @@ pub fn resolve(
     // Arc Blade, etc.) target the source object rather than inheriting the
     // parent's chosen targets via the chain target-propagation in
     // `effects::mod.rs`.
-    let (target_filter, destination) = match &ability.effect {
+    let (target_filter, destination, non_targeting) = match &ability.effect {
         Effect::Bounce {
             target,
             destination,
+            non_targeting,
         } => (
             target,
             // CR 608.2c: Default to owner's hand — mirrors `BounceAll`'s
@@ -121,8 +122,9 @@ pub fn resolve(
             // parser branches that route through `Bounce` with non-`Hand`
             // destinations don't need a separate resolver.
             destination.unwrap_or(Zone::Hand),
+            *non_targeting,
         ),
-        _ => (&TargetFilter::None, Zone::Hand),
+        _ => (&TargetFilter::None, Zone::Hand, false),
     };
 
     let effective_targets = crate::game::targeting::resolved_targets(ability, target_filter, state);
@@ -136,6 +138,76 @@ pub fn resolve(
             }
         })
         .collect();
+
+    // CR 115.1 + Whitemane Lion ruling (issue #563): Non-targeted
+    // controller-scoped *battlefield* bounce. Oracle text like "return a
+    // creature you control to its owner's hand" parses to a
+    // `Bounce { non_targeting: true, target: Typed{Creature, controller:You}, .. }`.
+    // The targeting pipeline does NOT create target slots for non-targeted
+    // effects (`extract_target_filter_from_effect` returns `None`), so
+    // `targets` is empty here. Enumerate the eligible permanents on the
+    // battlefield matching the filter and either fizzle (0), auto-move (1),
+    // or surface an `EffectZoneChoice` scoped to the ability controller so
+    // they pick which permanent returns (multiple). Mirrors the
+    // non-targeted graveyard branch below and the non-targeted
+    // `Effect::Sacrifice` resolver path.
+    //
+    // The graveyard-scope guard below this block excludes graveyard-scoped
+    // filters from this branch — they continue to flow into the existing
+    // chosen-player graveyard branch which has different selecting-player
+    // semantics (Skullwinder-class).
+    if non_targeting && targets.is_empty() && !filter_targets_zone(target_filter, Zone::Graveyard) {
+        let ctx = crate::game::filter::FilterContext::from_ability(ability);
+        let eligible: Vec<_> = state
+            .battlefield
+            .iter()
+            .copied()
+            .filter(|id| {
+                crate::game::filter::matches_target_filter(state, *id, target_filter, &ctx)
+            })
+            .collect();
+
+        match eligible.len() {
+            0 => {
+                // CR 608.2d: empty pool — the effect does nothing.
+            }
+            1 => {
+                zones::move_to_zone(state, eligible[0], destination, events);
+            }
+            _ => {
+                // CR 608.2c + CR 608.2d: surface card selection scoped to the
+                // ability controller. `EffectKind::ChangeZone` routes through
+                // the existing `EffectZoneChoice` intake
+                // (`engine_resolution_choices.rs`) which honors `destination`
+                // for the battlefield → hand move.
+                state.waiting_for = WaitingFor::EffectZoneChoice {
+                    player: ability.controller,
+                    cards: eligible,
+                    count: 1,
+                    min_count: 1,
+                    up_to: false,
+                    source_id: ability.source_id,
+                    effect_kind: EffectKind::ChangeZone,
+                    zone: Zone::Battlefield,
+                    destination: Some(destination),
+                    enter_tapped: false,
+                    enter_transformed: false,
+                    enters_under_player: None,
+                    enters_attacking: false,
+                    owner_library: false,
+                    track_exiled_by_source: false,
+                    count_param: 0,
+                };
+                return Ok(());
+            }
+        }
+
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
 
     // CR 608.2c + CR 608.2d + CR 109.4 (issue #534): Non-targeted
     // graveyard-return branch. Skullwinder-class effects ("That player
@@ -404,6 +476,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -443,6 +516,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::StackSpell,
                 destination: None,
+                non_targeting: false,
             },
             vec![TargetRef::Object(spell_id)],
             ObjectId(100),
@@ -492,6 +566,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::StackSpell,
                 destination: None,
+                non_targeting: false,
             },
             vec![TargetRef::Object(spell_id)],
             ObjectId(100),
@@ -560,6 +635,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::StackAbility { controller: None },
                 destination: None,
+                non_targeting: false,
             },
             vec![TargetRef::Object(stack_id)],
             ObjectId(100),
@@ -590,6 +666,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::None,
                 destination: None,
+                non_targeting: false,
             },
             vec![],
             obj_id,
@@ -618,6 +695,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -657,6 +735,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: Some(Zone::Library),
+                non_targeting: false,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -693,6 +772,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -725,6 +805,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::ParentTarget,
                 destination: None,
+                non_targeting: false,
             },
             vec![],
             obj_id,
@@ -753,6 +834,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
+                non_targeting: false,
             },
             vec![],
             obj_id,
@@ -796,6 +878,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::ParentTarget,
                 destination: None,
+                non_targeting: false,
             },
         )));
         state
@@ -1050,5 +1133,179 @@ mod tests {
             }
             ref other => panic!("expected BounceAll EffectZoneChoice, got {other:?}"),
         }
+    }
+
+    /// CR 115.1 + Whitemane Lion ruling (issue #563): Non-targeted
+    /// controller-scoped bounce with a single eligible permanent auto-moves
+    /// without prompting. Mirrors the graveyard branch's single-match path.
+    #[test]
+    fn test_bounce_non_targeting_controller_scope_single_eligible_auto_moves() {
+        use crate::types::ability::TypeFilter;
+        use crate::types::card_type::CoreType;
+
+        let mut state = GameState::new_two_player(42);
+        // P0 controls one creature; P1 controls a creature too but the filter
+        // is `controller: You` so only P0's creature is eligible.
+        let own_bear = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        let opp_bear = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opponent Bear".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [own_bear, opp_bear] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            let card_type = crate::types::card_type::CardType {
+                core_types: vec![CoreType::Creature],
+                ..Default::default()
+            };
+            obj.card_types = card_type.clone();
+            obj.base_card_types = card_type;
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::Bounce {
+                target: TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Creature).controller(ControllerRef::You),
+                ),
+                destination: None,
+                non_targeting: true,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // P0's creature moved to hand; P1's creature stayed on battlefield.
+        assert!(state.players[0].hand.contains(&own_bear));
+        assert!(!state.battlefield.contains(&own_bear));
+        assert!(state.battlefield.contains(&opp_bear));
+        // No prompt — single-eligible auto-move path.
+        assert!(matches!(
+            state.waiting_for,
+            crate::types::game_state::WaitingFor::Priority { .. }
+        ));
+    }
+
+    /// CR 115.1 + Whitemane Lion ruling (issue #563): Non-targeted
+    /// controller-scoped bounce with multiple eligible permanents surfaces an
+    /// `EffectZoneChoice` so the controller picks. Mirrors the graveyard
+    /// branch's multi-match path.
+    #[test]
+    fn test_bounce_non_targeting_controller_scope_multiple_eligible_prompts_choice() {
+        use crate::types::ability::TypeFilter;
+        use crate::types::card_type::CoreType;
+
+        let mut state = GameState::new_two_player(42);
+        let own_bear = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        let own_dragon = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Dragon".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [own_bear, own_dragon] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            let card_type = crate::types::card_type::CardType {
+                core_types: vec![CoreType::Creature],
+                ..Default::default()
+            };
+            obj.card_types = card_type.clone();
+            obj.base_card_types = card_type;
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::Bounce {
+                target: TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Creature).controller(ControllerRef::You),
+                ),
+                destination: None,
+                non_targeting: true,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // Both creatures still on battlefield; controller prompted to choose
+        // one via EffectZoneChoice.
+        assert!(state.battlefield.contains(&own_bear));
+        assert!(state.battlefield.contains(&own_dragon));
+        match &state.waiting_for {
+            WaitingFor::EffectZoneChoice {
+                player,
+                cards,
+                count,
+                min_count,
+                effect_kind: EffectKind::ChangeZone,
+                zone: Zone::Battlefield,
+                destination: Some(Zone::Hand),
+                ..
+            } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(*count, 1);
+                assert_eq!(*min_count, 1);
+                assert!(cards.contains(&own_bear));
+                assert!(cards.contains(&own_dragon));
+            }
+            other => panic!("expected EffectZoneChoice for non-targeted bounce, got {other:?}"),
+        }
+    }
+
+    /// CR 115.1 + Whitemane Lion ruling (issue #563): When no eligible
+    /// permanent matches the filter (empty pool), the effect fizzles —
+    /// emits `EffectResolved` without crashing or prompting. Models the
+    /// Whitemane Lion case where the controller has no other creatures.
+    #[test]
+    fn test_bounce_non_targeting_controller_scope_empty_eligible_fizzles() {
+        use crate::types::ability::TypeFilter;
+
+        let mut state = GameState::new_two_player(42);
+        // No creatures on the battlefield — the filter yields an empty pool.
+
+        let ability = ResolvedAbility::new(
+            Effect::Bounce {
+                target: TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Creature).controller(ControllerRef::You),
+                ),
+                destination: None,
+                non_targeting: true,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // No prompt; EffectResolved event emitted.
+        assert!(matches!(
+            state.waiting_for,
+            crate::types::game_state::WaitingFor::Priority { .. }
+        ));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, GameEvent::EffectResolved { .. })));
     }
 }

--- a/crates/engine/src/game/effects/bounce.rs
+++ b/crates/engine/src/game/effects/bounce.rs
@@ -1,7 +1,7 @@
 use crate::game::zones;
 use crate::types::ability::{
-    ControllerRef, Effect, EffectError, EffectKind, FilterProp, ResolvedAbility, TargetFilter,
-    TargetRef, TypedFilter,
+    BounceSelection, ControllerRef, Effect, EffectError, EffectKind, FilterProp, ResolvedAbility,
+    TargetFilter, TargetRef, TypedFilter,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{CastingVariant, GameState, StackEntryKind, WaitingFor};
@@ -112,7 +112,7 @@ pub fn resolve(
         Effect::Bounce {
             target,
             destination,
-            non_targeting,
+            selection,
         } => (
             target,
             // CR 608.2c: Default to owner's hand — mirrors `BounceAll`'s
@@ -122,7 +122,7 @@ pub fn resolve(
             // parser branches that route through `Bounce` with non-`Hand`
             // destinations don't need a separate resolver.
             destination.unwrap_or(Zone::Hand),
-            *non_targeting,
+            matches!(selection, BounceSelection::AtResolution),
         ),
         _ => (&TargetFilter::None, Zone::Hand, false),
     };
@@ -142,7 +142,7 @@ pub fn resolve(
     // CR 115.1 + Whitemane Lion ruling (issue #563): Non-targeted
     // controller-scoped *battlefield* bounce. Oracle text like "return a
     // creature you control to its owner's hand" parses to a
-    // `Bounce { non_targeting: true, target: Typed{Creature, controller:You}, .. }`.
+    // `Bounce { selection: AtResolution, target: Typed{Creature, controller:You}, .. }`.
     // The targeting pipeline does NOT create target slots for non-targeted
     // effects (`extract_target_filter_from_effect` returns `None`), so
     // `targets` is empty here. Enumerate the eligible permanents on the
@@ -476,7 +476,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -516,7 +516,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::StackSpell,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![TargetRef::Object(spell_id)],
             ObjectId(100),
@@ -566,7 +566,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::StackSpell,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![TargetRef::Object(spell_id)],
             ObjectId(100),
@@ -635,7 +635,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::StackAbility { controller: None },
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![TargetRef::Object(stack_id)],
             ObjectId(100),
@@ -666,7 +666,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::None,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![],
             obj_id,
@@ -695,7 +695,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -735,7 +735,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: Some(Zone::Library),
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -772,7 +772,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -805,7 +805,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::ParentTarget,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![],
             obj_id,
@@ -834,7 +834,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![],
             obj_id,
@@ -878,7 +878,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::ParentTarget,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
         )));
         state
@@ -1176,7 +1176,7 @@ mod tests {
                     TypedFilter::new(TypeFilter::Creature).controller(ControllerRef::You),
                 ),
                 destination: None,
-                non_targeting: true,
+                selection: BounceSelection::AtResolution,
             },
             vec![],
             ObjectId(100),
@@ -1237,7 +1237,7 @@ mod tests {
                     TypedFilter::new(TypeFilter::Creature).controller(ControllerRef::You),
                 ),
                 destination: None,
-                non_targeting: true,
+                selection: BounceSelection::AtResolution,
             },
             vec![],
             ObjectId(100),
@@ -1289,7 +1289,7 @@ mod tests {
                     TypedFilter::new(TypeFilter::Creature).controller(ControllerRef::You),
                 ),
                 destination: None,
-                non_targeting: true,
+                selection: BounceSelection::AtResolution,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/effects/create_emblem.rs
+++ b/crates/engine/src/game/effects/create_emblem.rs
@@ -54,7 +54,8 @@ pub fn resolve(
 mod tests {
     use super::*;
     use crate::types::ability::{
-        ContinuousModification, ControllerRef, StaticDefinition, TargetFilter, TypedFilter,
+        BounceSelection, ContinuousModification, ControllerRef, StaticDefinition, TargetFilter,
+        TypedFilter,
     };
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
@@ -207,7 +208,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![crate::types::ability::TargetRef::Object(emblem_id)],
             ObjectId(200),

--- a/crates/engine/src/game/effects/create_emblem.rs
+++ b/crates/engine/src/game/effects/create_emblem.rs
@@ -207,6 +207,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             vec![crate::types::ability::TargetRef::Object(emblem_id)],
             ObjectId(200),

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -434,8 +434,8 @@ mod tests {
     use super::*;
     use crate::game::game_object::GameObject;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, DamageKindFilter, DelayedTriggerCondition, Effect,
-        ManaProduction, ObjectScope, PtValue, QuantityExpr, QuantityRef, TriggerDefinition,
+        AbilityDefinition, AbilityKind, BounceSelection, DamageKindFilter, DelayedTriggerCondition,
+        Effect, ManaProduction, ObjectScope, PtValue, QuantityExpr, QuantityRef, TriggerDefinition,
     };
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::mana::ManaCost;
@@ -829,7 +829,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::ParentTarget,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
         );
         let ability = ResolvedAbility::new(

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -829,6 +829,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::ParentTarget,
                 destination: None,
+                non_targeting: false,
             },
         );
         let ability = ResolvedAbility::new(

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4452,11 +4452,12 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityCondition, AbilityDefinition, AbilityKind, AggregateFunction, CastingPermission,
-        Comparator, ContinuousModification, ControllerRef, DelayedTriggerCondition, Duration,
-        FilterProp, GainLifePlayer, ManaSpendPermission, ObjectProperty, PermissionGrantee,
-        PlayerFilter, PlayerScope, PtValue, QuantityExpr, QuantityRef, SpellContext,
-        StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter, UntilCondition,
+        AbilityCondition, AbilityDefinition, AbilityKind, AggregateFunction, BounceSelection,
+        CastingPermission, Comparator, ContinuousModification, ControllerRef,
+        DelayedTriggerCondition, Duration, FilterProp, GainLifePlayer, ManaSpendPermission,
+        ObjectProperty, PermissionGrantee, PlayerFilter, PlayerScope, PtValue, QuantityExpr,
+        QuantityRef, SpellContext, StaticDefinition, TargetFilter, TargetRef, TypeFilter,
+        TypedFilter, UntilCondition,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -6097,7 +6098,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![TargetRef::Object(permanent)],
             ObjectId(100),
@@ -6230,7 +6231,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -6097,6 +6097,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             vec![TargetRef::Object(permanent)],
             ObjectId(100),
@@ -6229,6 +6230,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
+                non_targeting: false,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/effects/overload.rs
+++ b/crates/engine/src/game/effects/overload.rs
@@ -143,8 +143,8 @@ fn transform_effect_in_place(effect: &mut Effect) {
 mod tests {
     use super::*;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, Effect, PtValue, QuantityExpr, TargetFilter, TypeFilter,
-        TypedFilter,
+        AbilityDefinition, AbilityKind, BounceSelection, Effect, PtValue, QuantityExpr,
+        TargetFilter, TypeFilter, TypedFilter,
     };
     use crate::types::Zone;
 
@@ -215,7 +215,7 @@ mod tests {
         let mut def = leaf(Effect::Bounce {
             target: creature_filter(),
             destination: None,
-            non_targeting: false,
+            selection: BounceSelection::Targeted,
         });
         transform_ability_def(&mut def);
         match *def.effect {
@@ -235,7 +235,7 @@ mod tests {
         let mut def_lib = leaf(Effect::Bounce {
             target: creature_filter(),
             destination: Some(Zone::Library),
-            non_targeting: false,
+            selection: BounceSelection::Targeted,
         });
         transform_ability_def(&mut def_lib);
         match *def_lib.effect {

--- a/crates/engine/src/game/effects/overload.rs
+++ b/crates/engine/src/game/effects/overload.rs
@@ -96,6 +96,7 @@ fn transform_effect_in_place(effect: &mut Effect) {
         Effect::Bounce {
             target,
             destination,
+            ..
         } => Effect::BounceAll {
             target,
             destination,
@@ -214,6 +215,7 @@ mod tests {
         let mut def = leaf(Effect::Bounce {
             target: creature_filter(),
             destination: None,
+            non_targeting: false,
         });
         transform_ability_def(&mut def);
         match *def.effect {
@@ -233,6 +235,7 @@ mod tests {
         let mut def_lib = leaf(Effect::Bounce {
             target: creature_filter(),
             destination: Some(Zone::Library),
+            non_targeting: false,
         });
         transform_ability_def(&mut def_lib);
         match *def_lib.effect {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3654,6 +3654,23 @@ pub(crate) fn extract_target_filter_from_effect(effect: &Effect) -> Option<&Targ
     if matches!(effect, Effect::Sacrifice { .. }) {
         return None;
     }
+    // CR 115.1 + Whitemane Lion ruling: A `Bounce` whose Oracle text omitted
+    // the word "target" ("return a creature you control to its owner's hand")
+    // is NOT a targeted effect — the controller chooses an eligible permanent
+    // at resolution time via `EffectZoneChoice`. Returning a filter here would
+    // route resolution through the targeted path, which (a) creates spurious
+    // target selection slots at stack-push time and (b) leaves the resolver's
+    // targets vector empty, causing the effect to silently no-op. Mirrors the
+    // Sacrifice carve-out above.
+    if matches!(
+        effect,
+        Effect::Bounce {
+            non_targeting: true,
+            ..
+        }
+    ) {
+        return None;
+    }
     // CR 702.95a + CR 115.10a + CR 608.2d: Soulbond pair choices are not
     // targets. PairWith computes its legal partner while resolving.
     if matches!(effect, Effect::PairWith { .. }) {
@@ -6590,6 +6607,7 @@ pub mod tests {
                             .controller(ControllerRef::You),
                     ),
                     destination: None,
+                    non_targeting: false,
                 },
             );
             execute.optional_targeting = true;
@@ -8697,6 +8715,38 @@ pub mod tests {
         assert!(
             extract_target_filter_from_effect(&effect).is_none(),
             "Sacrifice should not extract a target filter (resolution-time selection)"
+        );
+    }
+
+    /// CR 115.1 + Whitemane Lion ruling (issue #563): A non-targeted Bounce
+    /// (Oracle text without the word "target", e.g. "return a creature you
+    /// control to its owner's hand") must not extract a target filter —
+    /// resolution-time `EffectZoneChoice` handles the controller-scoped pick.
+    #[test]
+    fn extract_target_skips_non_targeting_bounce() {
+        let effect = Effect::Bounce {
+            target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            destination: None,
+            non_targeting: true,
+        };
+        assert!(
+            extract_target_filter_from_effect(&effect).is_none(),
+            "non_targeting Bounce should not extract a target filter (resolution-time selection)"
+        );
+    }
+
+    /// CR 115.1 boundary: A targeted Bounce (`non_targeting: false`) still uses
+    /// the targeting pipeline. Mirrors `extract_target_keeps_change_zone_from_battlefield`.
+    #[test]
+    fn extract_target_keeps_targeting_bounce() {
+        let effect = Effect::Bounce {
+            target: TargetFilter::Typed(TypedFilter::creature()),
+            destination: None,
+            non_targeting: false,
+        };
+        assert!(
+            extract_target_filter_from_effect(&effect).is_some(),
+            "targeted Bounce (non_targeting=false) must extract a target filter"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -1,10 +1,10 @@
 use std::collections::HashSet;
 
 use crate::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, ChosenAttribute, CommanderOwnership,
-    ControllerRef, CopyRetargetPermission, DelayedTriggerCondition, Effect, ModalChoice,
-    PlayerFilter, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef, TributeOutcome,
-    TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, ChosenAttribute,
+    CommanderOwnership, ControllerRef, CopyRetargetPermission, DelayedTriggerCondition, Effect,
+    ModalChoice, PlayerFilter, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef,
+    TributeOutcome, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::events::{GameEvent, ManaTapState};
@@ -3665,7 +3665,7 @@ pub(crate) fn extract_target_filter_from_effect(effect: &Effect) -> Option<&Targ
     if matches!(
         effect,
         Effect::Bounce {
-            non_targeting: true,
+            selection: BounceSelection::AtResolution,
             ..
         }
     ) {
@@ -6663,7 +6663,7 @@ pub mod tests {
                             .controller(ControllerRef::You),
                     ),
                     destination: None,
-                    non_targeting: false,
+                    selection: BounceSelection::Targeted,
                 },
             );
             execute.optional_targeting = true;
@@ -8783,26 +8783,26 @@ pub mod tests {
         let effect = Effect::Bounce {
             target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
             destination: None,
-            non_targeting: true,
+            selection: BounceSelection::AtResolution,
         };
         assert!(
             extract_target_filter_from_effect(&effect).is_none(),
-            "non_targeting Bounce should not extract a target filter (resolution-time selection)"
+            "AtResolution Bounce should not extract a target filter (resolution-time selection)"
         );
     }
 
-    /// CR 115.1 boundary: A targeted Bounce (`non_targeting: false`) still uses
+    /// CR 115.1 boundary: A targeted Bounce (`selection: Targeted`) still uses
     /// the targeting pipeline. Mirrors `extract_target_keeps_change_zone_from_battlefield`.
     #[test]
     fn extract_target_keeps_targeting_bounce() {
         let effect = Effect::Bounce {
             target: TargetFilter::Typed(TypedFilter::creature()),
             destination: None,
-            non_targeting: false,
+            selection: BounceSelection::Targeted,
         };
         assert!(
             extract_target_filter_from_effect(&effect).is_some(),
-            "targeted Bounce (non_targeting=false) must extract a target filter"
+            "targeted Bounce (Targeted) must extract a target filter"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -58,6 +58,23 @@ pub(super) fn default_earthbend_target() -> TargetFilter {
     TargetFilter::Typed(TypedFilter::land().controller(ControllerRef::You))
 }
 
+/// CR 115.1 + Whitemane Lion ruling: True iff the filter constrains by a
+/// controller scope (`controller: Some(...)`) at the top level (or inside an
+/// `And`/`Or`/`Not` composition). This is the precondition for treating a
+/// non-targeted bounce as a controller-choice EffectZoneChoice instead of a
+/// no-op — without a controller scope, the resolver has no eligible-set to
+/// enumerate. Mirrors the shape of `filter_targets_zone` in `effects/bounce.rs`.
+pub(super) fn filter_has_controller_scope(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(tf) => tf.controller.is_some(),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_has_controller_scope)
+        }
+        TargetFilter::Not { filter } => filter_has_controller_scope(filter),
+        _ => false,
+    }
+}
+
 fn parse_dig_library_owner(rest_lower: &str) -> TargetFilter {
     if preceded(
         take_until::<_, _, OracleError<'_>>("target player's library"),
@@ -1242,12 +1259,21 @@ pub(super) fn parse_targeted_action_ast(
             }
         });
         let count = counted_return.as_ref().map(|(_, count)| count.clone());
+        // CR 115.1 + Whitemane Lion ruling: Reset the saw_target_keyword flag
+        // before parsing the target phrase so the post-parse value reflects
+        // only this call (not residue from an earlier clause's parse).
+        ctx.saw_target_keyword = false;
         let (target, _count_for_shape) = counted_return.unwrap_or_else(|| {
             let (target, _rem) = parse_target_with_ctx(target_text, ctx);
             #[cfg(debug_assertions)]
             assert_no_compound_remainder(_rem, text);
             (target, QuantityExpr::Fixed { value: 0 })
         });
+        // CR 115.1: A bounce is "non-targeted" iff the Oracle text omitted the
+        // word "target" AND the filter has a controller scope to enumerate
+        // against (Whitemane Lion's "a creature you control" — the controller
+        // picks at resolution time via EffectZoneChoice).
+        let non_targeting = !ctx.saw_target_keyword && filter_has_controller_scope(&target);
         let is_mass = is_mass || count.is_some();
         let origin = super::infer_origin_zone(rest_lower);
 
@@ -1290,7 +1316,10 @@ pub(super) fn parse_targeted_action_ast(
                         enter_tapped: false,
                     })
                 } else {
-                    Some(TargetedImperativeAst::Return { target })
+                    Some(TargetedImperativeAst::Return {
+                        target,
+                        non_targeting,
+                    })
                 }
             }
             Some(d) => {
@@ -1317,7 +1346,10 @@ pub(super) fn parse_targeted_action_ast(
                 if is_mass {
                     Some(TargetedImperativeAst::ReturnAll { target, count })
                 } else {
-                    Some(TargetedImperativeAst::Return { target })
+                    Some(TargetedImperativeAst::Return {
+                        target,
+                        non_targeting,
+                    })
                 }
             }
         };
@@ -1438,9 +1470,13 @@ pub(super) fn lower_targeted_action_ast(ast: TargetedImperativeAst) -> Effect {
         // implicit (1 per parent-affected ID; the runtime expands ParentTarget
         // into the full set at rebind time).
         TargetedImperativeAst::DiscardCard { target } => Effect::DiscardCard { count: 1, target },
-        TargetedImperativeAst::Return { target } => Effect::Bounce {
+        TargetedImperativeAst::Return {
+            target,
+            non_targeting,
+        } => Effect::Bounce {
             target,
             destination: None,
+            non_targeting,
         },
         // CR 400.7 + CR 611.2c: "Return all/each [filter]" mass-bounce — the
         // resolver iterates every matching permanent. Class filter is preserved

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -24,11 +24,11 @@ use crate::parser::oracle_static::{
 #[cfg(test)]
 use crate::types::ability::TypeFilter;
 use crate::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, CategoryChooserScope, ChoiceType, Chooser,
-    ContinuousModification, ControllerRef, CopyRetargetPermission, Duration, Effect, FilterProp,
-    GainLifePlayer, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool, PaymentCost,
-    PlayerScope, PreventionAmount, PreventionScope, PtValue, QuantityExpr, QuantityRef,
-    SearchSelectionConstraint, StaticDefinition, TargetFilter, TypedFilter, ZoneOwner,
+    AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, CategoryChooserScope, ChoiceType,
+    Chooser, ContinuousModification, ControllerRef, CopyRetargetPermission, Duration, Effect,
+    FilterProp, GainLifePlayer, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool,
+    PaymentCost, PlayerScope, PreventionAmount, PreventionScope, PtValue, QuantityExpr,
+    QuantityRef, SearchSelectionConstraint, StaticDefinition, TargetFilter, TypedFilter, ZoneOwner,
 };
 use crate::types::card_type::CoreType;
 use crate::types::phase::Phase;
@@ -37,7 +37,8 @@ use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
 use super::super::oracle_target::{
-    parse_target, parse_target_with_ctx, parse_type_phrase, resolve_pronoun_target,
+    parse_target, parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase,
+    resolve_pronoun_target, TargetSyntax,
 };
 use super::super::oracle_util::{
     contains_possessive, contains_self_or_object_pronoun, parse_count_expr, parse_mana_symbols,
@@ -1259,21 +1260,29 @@ pub(super) fn parse_targeted_action_ast(
             }
         });
         let count = counted_return.as_ref().map(|(_, count)| count.clone());
-        // CR 115.1 + Whitemane Lion ruling: Reset the saw_target_keyword flag
-        // before parsing the target phrase so the post-parse value reflects
-        // only this call (not residue from an earlier clause's parse).
-        ctx.saw_target_keyword = false;
-        let (target, _count_for_shape) = counted_return.unwrap_or_else(|| {
-            let (target, _rem) = parse_target_with_ctx(target_text, ctx);
-            #[cfg(debug_assertions)]
-            assert_no_compound_remainder(_rem, text);
-            (target, QuantityExpr::Fixed { value: 0 })
-        });
-        // CR 115.1: A bounce is "non-targeted" iff the Oracle text omitted the
-        // word "target" AND the filter has a controller scope to enumerate
+        // CR 115.1 + Whitemane Lion ruling: Use `parse_target_with_syntax` so
+        // the "target"-keyword vs descriptor discriminator flows back from
+        // this parse alone, with no cross-clause residue to clear.
+        let (target, target_syntax, _count_for_shape) = match counted_return {
+            Some((target, c)) => (target, TargetSyntax::TargetKeyword, c),
+            None => {
+                let (target, _rem, syntax) = parse_target_with_syntax(target_text, ctx);
+                #[cfg(debug_assertions)]
+                assert_no_compound_remainder(_rem, text);
+                (target, syntax, QuantityExpr::Fixed { value: 0 })
+            }
+        };
+        // CR 115.1: A bounce resolves at-resolution iff the Oracle text omitted
+        // the word "target" AND the filter has a controller scope to enumerate
         // against (Whitemane Lion's "a creature you control" — the controller
         // picks at resolution time via EffectZoneChoice).
-        let non_targeting = !ctx.saw_target_keyword && filter_has_controller_scope(&target);
+        let selection = if matches!(target_syntax, TargetSyntax::Descriptor)
+            && filter_has_controller_scope(&target)
+        {
+            BounceSelection::AtResolution
+        } else {
+            BounceSelection::Targeted
+        };
         let is_mass = is_mass || count.is_some();
         let origin = super::infer_origin_zone(rest_lower);
 
@@ -1316,10 +1325,7 @@ pub(super) fn parse_targeted_action_ast(
                         enter_tapped: false,
                     })
                 } else {
-                    Some(TargetedImperativeAst::Return {
-                        target,
-                        non_targeting,
-                    })
+                    Some(TargetedImperativeAst::Return { target, selection })
                 }
             }
             Some(d) => {
@@ -1346,10 +1352,7 @@ pub(super) fn parse_targeted_action_ast(
                 if is_mass {
                     Some(TargetedImperativeAst::ReturnAll { target, count })
                 } else {
-                    Some(TargetedImperativeAst::Return {
-                        target,
-                        non_targeting,
-                    })
+                    Some(TargetedImperativeAst::Return { target, selection })
                 }
             }
         };
@@ -1470,13 +1473,10 @@ pub(super) fn lower_targeted_action_ast(ast: TargetedImperativeAst) -> Effect {
         // implicit (1 per parent-affected ID; the runtime expands ParentTarget
         // into the full set at rebind time).
         TargetedImperativeAst::DiscardCard { target } => Effect::DiscardCard { count: 1, target },
-        TargetedImperativeAst::Return {
-            target,
-            non_targeting,
-        } => Effect::Bounce {
+        TargetedImperativeAst::Return { target, selection } => Effect::Bounce {
             target,
             destination: None,
-            non_targeting,
+            selection,
         },
         // CR 400.7 + CR 611.2c: "Return all/each [filter]" mass-bounce — the
         // resolver iterates every matching permanent. Class filter is preserved

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6532,12 +6532,22 @@ fn try_parse_verb_and_target<'a>(
         } else {
             (false, target_text)
         };
+        // CR 115.1 + Whitemane Lion ruling: Reset the saw_target_keyword flag
+        // before parsing the target phrase so the post-parse value reflects
+        // only this call (not residue from an earlier clause's parse).
+        ctx.saw_target_keyword = false;
         let (target, mut rem) = parse_target_with_ctx(target_text, ctx);
         if rem.is_empty() {
             rem = dest_remainder;
         }
         let origin = infer_origin_zone(rest_lower);
         let target = add_inferred_origin_constraints_to_target(target, origin, rest_lower);
+        // CR 115.1: A bounce is "non-targeted" iff the Oracle text omitted the
+        // word "target" AND the filter has a controller scope to enumerate
+        // against. Computed here so both Hand-destined and default-None
+        // branches below can stamp it onto the AST.
+        let non_targeting =
+            !ctx.saw_target_keyword && imperative::filter_has_controller_scope(&target);
         return match dest {
             Some(d) if d.zone == Zone::Battlefield => {
                 if is_mass && d.enter_with_counters.is_empty() {
@@ -6576,7 +6586,13 @@ fn try_parse_verb_and_target<'a>(
                         rem,
                     ))
                 } else {
-                    Some((TargetedImperativeAst::Return { target }, rem))
+                    Some((
+                        TargetedImperativeAst::Return {
+                            target,
+                            non_targeting,
+                        },
+                        rem,
+                    ))
                 }
             }
             Some(d) => {
@@ -6601,7 +6617,13 @@ fn try_parse_verb_and_target<'a>(
                     ))
                 }
             }
-            None => Some((TargetedImperativeAst::Return { target }, rem)),
+            None => Some((
+                TargetedImperativeAst::Return {
+                    target,
+                    non_targeting,
+                },
+                rem,
+            )),
         };
     }
 
@@ -21870,6 +21892,52 @@ mod tests {
             matches!(e, Effect::Bounce { .. }),
             "single-target return must stay Bounce, got {e:?}"
         );
+    }
+
+    /// CR 115.1 + Whitemane Lion ruling (issue #563): "Return a creature you
+    /// control to its owner's hand" does NOT contain the word "target" — per
+    /// the Whitemane Lion ruling, the controller chooses at resolution time
+    /// and the effect bypasses the targeting pipeline. The parser must produce
+    /// `Effect::Bounce { non_targeting: true, .. }` so the resolver and
+    /// targeting pipeline pick the non-targeted branch.
+    #[test]
+    fn effect_bounce_non_targeting_when_target_keyword_absent() {
+        let e = parse_effect("Return a creature you control to its owner's hand");
+        match e {
+            Effect::Bounce {
+                non_targeting,
+                target,
+                ..
+            } => {
+                assert!(
+                    non_targeting,
+                    "no 'target' keyword + controller-scoped filter must produce non_targeting=true; got target={target:?}"
+                );
+            }
+            other => panic!("expected Effect::Bounce, got {other:?}"),
+        }
+    }
+
+    /// CR 115.1 (issue #563 boundary): "Return target creature you control to
+    /// its owner's hand" DOES contain the word "target" — the spell follows
+    /// standard target selection and must produce `non_targeting: false`. Pins
+    /// the keyword-presence axis against the non-targeting carve-out.
+    #[test]
+    fn effect_bounce_targeting_when_target_keyword_present() {
+        let e = parse_effect("Return target creature you control to its owner's hand");
+        match e {
+            Effect::Bounce {
+                non_targeting,
+                target,
+                ..
+            } => {
+                assert!(
+                    !non_targeting,
+                    "explicit 'target' keyword must produce non_targeting=false; got target={target:?}"
+                );
+            }
+            other => panic!("expected Effect::Bounce, got {other:?}"),
+        }
     }
 
     /// CR 400.7: "Return all <filter> to the battlefield" (Open the Vaults,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -32,8 +32,8 @@ use super::oracle_quantity::{
     parse_for_each_object_filter_clause,
 };
 use super::oracle_target::{
-    parse_event_context_ref, parse_target, parse_target_with_ctx, parse_that_clause_suffix,
-    parse_type_phrase,
+    parse_event_context_ref, parse_target, parse_target_with_ctx, parse_target_with_syntax,
+    parse_that_clause_suffix, parse_type_phrase, TargetSyntax,
 };
 use super::oracle_util::{
     contains_possessive, has_unconsumed_conditional, parse_mana_symbols, parse_number,
@@ -43,14 +43,14 @@ use crate::database::mtgjson::parse_mtgjson_mana_cost;
 use crate::parser::oracle_effect::subject::parse_subject_application;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
-    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, CardPlayMode,
-    CastPermissionConstraint, CastingPermission, ChoiceType, ChooseFromZoneConstraint,
-    CombatDamageScope, Comparator, ConjureCard, ContinuousModification, ControllerRef,
-    DamageModification, DamageSource, DelayedTriggerCondition, DoubleTarget, Duration, Effect,
-    FilterProp, GainLifePlayer, GameRestriction, ManaProduction, ManaSpendPermission,
-    MultiTargetSpec, ObjectProperty, ObjectScope, PaymentCost, PlayerFilter, PlayerScope,
-    PreventionAmount, PreventionScope, ProhibitedActivity, PtValue, QuantityExpr, QuantityRef,
-    ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RoundingMode,
+    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction,
+    BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
+    ChooseFromZoneConstraint, CombatDamageScope, Comparator, ConjureCard, ContinuousModification,
+    ControllerRef, DamageModification, DamageSource, DelayedTriggerCondition, DoubleTarget,
+    Duration, Effect, FilterProp, GainLifePlayer, GameRestriction, ManaProduction,
+    ManaSpendPermission, MultiTargetSpec, ObjectProperty, ObjectScope, PaymentCost, PlayerFilter,
+    PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PtValue, QuantityExpr,
+    QuantityRef, ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RoundingMode,
     StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink, TargetChoiceTiming,
     TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition, TypeFilter,
     TypedFilter, UnlessPayModifier, UntilCondition,
@@ -6532,22 +6532,26 @@ fn try_parse_verb_and_target<'a>(
         } else {
             (false, target_text)
         };
-        // CR 115.1 + Whitemane Lion ruling: Reset the saw_target_keyword flag
-        // before parsing the target phrase so the post-parse value reflects
-        // only this call (not residue from an earlier clause's parse).
-        ctx.saw_target_keyword = false;
-        let (target, mut rem) = parse_target_with_ctx(target_text, ctx);
+        // CR 115.1 + Whitemane Lion ruling: Use `parse_target_with_syntax` so
+        // the "target"-keyword vs descriptor discriminator flows back from
+        // this parse alone, with no cross-clause residue to clear.
+        let (target, mut rem, target_syntax) = parse_target_with_syntax(target_text, ctx);
         if rem.is_empty() {
             rem = dest_remainder;
         }
         let origin = infer_origin_zone(rest_lower);
         let target = add_inferred_origin_constraints_to_target(target, origin, rest_lower);
-        // CR 115.1: A bounce is "non-targeted" iff the Oracle text omitted the
-        // word "target" AND the filter has a controller scope to enumerate
+        // CR 115.1: A bounce resolves at-resolution iff the Oracle text omitted
+        // the word "target" AND the filter has a controller scope to enumerate
         // against. Computed here so both Hand-destined and default-None
         // branches below can stamp it onto the AST.
-        let non_targeting =
-            !ctx.saw_target_keyword && imperative::filter_has_controller_scope(&target);
+        let selection = if matches!(target_syntax, TargetSyntax::Descriptor)
+            && imperative::filter_has_controller_scope(&target)
+        {
+            BounceSelection::AtResolution
+        } else {
+            BounceSelection::Targeted
+        };
         return match dest {
             Some(d) if d.zone == Zone::Battlefield => {
                 if is_mass && d.enter_with_counters.is_empty() {
@@ -6586,13 +6590,7 @@ fn try_parse_verb_and_target<'a>(
                         rem,
                     ))
                 } else {
-                    Some((
-                        TargetedImperativeAst::Return {
-                            target,
-                            non_targeting,
-                        },
-                        rem,
-                    ))
+                    Some((TargetedImperativeAst::Return { target, selection }, rem))
                 }
             }
             Some(d) => {
@@ -6617,13 +6615,7 @@ fn try_parse_verb_and_target<'a>(
                     ))
                 }
             }
-            None => Some((
-                TargetedImperativeAst::Return {
-                    target,
-                    non_targeting,
-                },
-                rem,
-            )),
+            None => Some((TargetedImperativeAst::Return { target, selection }, rem)),
         };
     }
 
@@ -18191,13 +18183,13 @@ fn extract_effect_verb(effect: &Effect) -> Option<&'static str> {
 mod tests {
     use super::*;
     use crate::types::ability::{
-        AbilityCondition, AggregateFunction, CardTypeSetSource, CastVariantPaid, ChoiceType,
-        CombatRelation, CombatRelationSubject, Comparator, ContinuousModification, ControllerRef,
-        CopyRetargetPermission, CountScope, DoublePTMode, Duration, FilterProp, GainLifePlayer,
-        LibraryPosition, LinkedExileScope, ManaContribution, ManaProduction, ObjectProperty,
-        ObjectScope, PaymentCost, PermissionGrantee, PtStat, PtValueScope, QuantityExpr,
-        QuantityRef, SearchSelectionConstraint, TargetChoiceTiming, TypeFilter, TypedFilter,
-        ZoneRef,
+        AbilityCondition, AggregateFunction, BounceSelection, CardTypeSetSource, CastVariantPaid,
+        ChoiceType, CombatRelation, CombatRelationSubject, Comparator, ContinuousModification,
+        ControllerRef, CopyRetargetPermission, CountScope, DoublePTMode, Duration, FilterProp,
+        GainLifePlayer, LibraryPosition, LinkedExileScope, ManaContribution, ManaProduction,
+        ObjectProperty, ObjectScope, PaymentCost, PermissionGrantee, PtStat, PtValueScope,
+        QuantityExpr, QuantityRef, SearchSelectionConstraint, TargetChoiceTiming, TypeFilter,
+        TypedFilter, ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::keywords::Keyword;
@@ -21898,20 +21890,18 @@ mod tests {
     /// control to its owner's hand" does NOT contain the word "target" — per
     /// the Whitemane Lion ruling, the controller chooses at resolution time
     /// and the effect bypasses the targeting pipeline. The parser must produce
-    /// `Effect::Bounce { non_targeting: true, .. }` so the resolver and
+    /// `Effect::Bounce { selection: AtResolution, .. }` so the resolver and
     /// targeting pipeline pick the non-targeted branch.
     #[test]
     fn effect_bounce_non_targeting_when_target_keyword_absent() {
         let e = parse_effect("Return a creature you control to its owner's hand");
         match e {
             Effect::Bounce {
-                non_targeting,
-                target,
-                ..
+                selection, target, ..
             } => {
                 assert!(
-                    non_targeting,
-                    "no 'target' keyword + controller-scoped filter must produce non_targeting=true; got target={target:?}"
+                    matches!(selection, BounceSelection::AtResolution),
+                    "no 'target' keyword + controller-scoped filter must produce AtResolution; got target={target:?}"
                 );
             }
             other => panic!("expected Effect::Bounce, got {other:?}"),
@@ -21920,20 +21910,18 @@ mod tests {
 
     /// CR 115.1 (issue #563 boundary): "Return target creature you control to
     /// its owner's hand" DOES contain the word "target" — the spell follows
-    /// standard target selection and must produce `non_targeting: false`. Pins
+    /// standard target selection and must produce `selection: Targeted`. Pins
     /// the keyword-presence axis against the non-targeting carve-out.
     #[test]
     fn effect_bounce_targeting_when_target_keyword_present() {
         let e = parse_effect("Return target creature you control to its owner's hand");
         match e {
             Effect::Bounce {
-                non_targeting,
-                target,
-                ..
+                selection, target, ..
             } => {
                 assert!(
-                    !non_targeting,
-                    "explicit 'target' keyword must produce non_targeting=false; got target={target:?}"
+                    matches!(selection, BounceSelection::Targeted),
+                    "explicit 'target' keyword must produce Targeted; got target={target:?}"
                 );
             }
             other => panic!("expected Effect::Bounce, got {other:?}"),

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -2,11 +2,11 @@ use serde::Serialize;
 
 use crate::types::ability::MultiTargetSpec;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, ActivationRestriction, CastingPermission, ControllerRef,
-    CounterSourceRider, Duration, Effect, LibraryPosition, ManaProduction, ManaSpendRestriction,
-    ModalSelectionConstraint, OutsideGameSourcePool, PaymentCost, PlayerFilter, PtValue,
-    QuantityExpr, SearchDestinationSplit, SearchSelectionConstraint, StaticDefinition,
-    TargetFilter,
+    AbilityCondition, AbilityDefinition, ActivationRestriction, BounceSelection, CastingPermission,
+    ControllerRef, CounterSourceRider, Duration, Effect, LibraryPosition, ManaProduction,
+    ManaSpendRestriction, ModalSelectionConstraint, OutsideGameSourcePool, PaymentCost,
+    PlayerFilter, PtValue, QuantityExpr, SearchDestinationSplit, SearchSelectionConstraint,
+    StaticDefinition, TargetFilter,
 };
 use crate::types::counter::CounterType;
 use crate::types::game_state::DistributionUnit;
@@ -602,13 +602,13 @@ pub(crate) enum TargetedImperativeAst {
     /// CR 701.3: Return to hand (bounce).
     Return {
         target: TargetFilter,
-        /// CR 115.1 + Whitemane Lion ruling: When `true`, the Oracle text did
-        /// NOT use the word "target" (e.g. "return a creature you control to
-        /// its owner's hand"). Captured at parse time from
-        /// `ctx.saw_target_keyword` so the lowering can route to
-        /// `Effect::Bounce { non_targeting: true, .. }` and the resolver picks
-        /// the eligible permanent at resolution time via `EffectZoneChoice`.
-        non_targeting: bool,
+        /// CR 115.1 + Whitemane Lion ruling: Captured at parse time from the
+        /// `TargetSyntax` discriminator. `Descriptor` Oracle text without
+        /// "target" (e.g. "return a creature you control to its owner's hand")
+        /// becomes `BounceSelection::AtResolution`; the resolver picks the
+        /// eligible permanent at resolution via `EffectZoneChoice` rather than
+        /// the targeting pipeline.
+        selection: BounceSelection,
     },
     /// CR 400.7 + CR 611.2c: Mass return-to-hand. Mirrors `TapAll`/`UntapAll`
     /// for "return all/each [filter] to their owners' hands" Oracle text.

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -602,6 +602,13 @@ pub(crate) enum TargetedImperativeAst {
     /// CR 701.3: Return to hand (bounce).
     Return {
         target: TargetFilter,
+        /// CR 115.1 + Whitemane Lion ruling: When `true`, the Oracle text did
+        /// NOT use the word "target" (e.g. "return a creature you control to
+        /// its owner's hand"). Captured at parse time from
+        /// `ctx.saw_target_keyword` so the lowering can route to
+        /// `Effect::Bounce { non_targeting: true, .. }` and the resolver picks
+        /// the eligible permanent at resolution time via `EffectZoneChoice`.
+        non_targeting: bool,
     },
     /// CR 400.7 + CR 611.2c: Mass return-to-hand. Mirrors `TapAll`/`UntapAll`
     /// for "return all/each [filter] to their owners' hands" Oracle text.

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -81,6 +81,18 @@ pub(crate) struct ParseContext {
     /// parsing leaves this false so bare "it" defaults to SelfRef instead of
     /// inventing a parent target.
     pub parent_target_available: bool,
+    /// CR 115.1: Whether the parser consumed the word "target" while extracting
+    /// the current target phrase. Set by `parse_target_with_ctx` at every
+    /// "target"/"target X"/"random target X" leaf consumer and read by
+    /// downstream effect lowering (e.g. `imperative.rs` for `Effect::Bounce`)
+    /// to distinguish *targeted* effects ("return target creature you control")
+    /// from *non-targeted* controller-scoped effects ("return a creature you
+    /// control" — Whitemane Lion / Stonecloaker / Aether Adept's ETB return).
+    /// Per the Whitemane Lion ruling, the latter doesn't target — the
+    /// controller chooses at resolution time, so it bypasses the targeting
+    /// pipeline. Callers must reset to `false` before each independent target
+    /// phrase parse.
+    pub saw_target_keyword: bool,
 }
 
 impl ParseContext {

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -81,18 +81,6 @@ pub(crate) struct ParseContext {
     /// parsing leaves this false so bare "it" defaults to SelfRef instead of
     /// inventing a parent target.
     pub parent_target_available: bool,
-    /// CR 115.1: Whether the parser consumed the word "target" while extracting
-    /// the current target phrase. Set by `parse_target_with_ctx` at every
-    /// "target"/"target X"/"random target X" leaf consumer and read by
-    /// downstream effect lowering (e.g. `imperative.rs` for `Effect::Bounce`)
-    /// to distinguish *targeted* effects ("return target creature you control")
-    /// from *non-targeted* controller-scoped effects ("return a creature you
-    /// control" — Whitemane Lion / Stonecloaker / Aether Adept's ETB return).
-    /// Per the Whitemane Lion ruling, the latter doesn't target — the
-    /// controller chooses at resolution time, so it bypasses the targeting
-    /// pipeline. Callers must reset to `false` before each independent target
-    /// phrase parse.
-    pub saw_target_keyword: bool,
 }
 
 impl ParseContext {

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -33,6 +33,18 @@ use super::oracle_util::{
     SELF_REF_TYPE_PHRASES,
 };
 
+/// CR 115.1: Whether a parsed target phrase used the "target" keyword
+/// (`TargetKeyword`) or a controller-scope descriptor like "a creature you
+/// control" (`Descriptor`). Used to distinguish targeted bounce effects from
+/// the Whitemane Lion class at lowering time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetSyntax {
+    /// The phrase contained the "target" keyword.
+    TargetKeyword,
+    /// The phrase used a descriptor (no "target" keyword).
+    Descriptor,
+}
+
 /// Run a nom combinator on lowercased text, returning the result and
 /// remainder from the original (mixed-case) text.
 ///
@@ -182,7 +194,26 @@ pub fn parse_target(text: &str) -> (TargetFilter, &str) {
 
 /// Context-aware variant of `parse_target`. TargetFallback diagnostics are
 /// accumulated on `ctx.diagnostics` instead of being silently lost.
+///
+/// Discards the `TargetSyntax` discriminator returned by
+/// `parse_target_with_syntax`. Use the latter directly when distinguishing
+/// `target`-keyword vs descriptor phrases matters (e.g. Bounce lowering).
 pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (TargetFilter, &'a str) {
+    let (filter, rest, _syntax) = parse_target_with_syntax(text, ctx);
+    (filter, rest)
+}
+
+/// Context-aware target parser that additionally reports whether the phrase
+/// used the "target" keyword (`TargetKeyword`) or a descriptor scope
+/// (`Descriptor`). CR 115.1 + Whitemane Lion ruling distinguishes these for
+/// `Effect::Bounce` lowering: targeted bounce uses the targeting pipeline,
+/// while descriptor bounce ("return a creature you control") selects at
+/// resolution via `EffectZoneChoice`.
+pub fn parse_target_with_syntax<'a>(
+    text: &'a str,
+    ctx: &mut ParseContext,
+) -> (TargetFilter, &'a str, TargetSyntax) {
+    let mut syntax = TargetSyntax::Descriptor;
     let text = text.trim_start();
     let lower = text.to_lowercase();
 
@@ -207,11 +238,11 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
             // allow-noncombinator: TextPair::strip_suffix is the dual-string structural API for postnominal qualifier stripping (PATTERNS.md §9).
             if let Some(prefix) = trimmed.strip_suffix(suffix) {
                 ctx.target_selection_mode = TargetSelectionMode::Random;
-                let (filter, _) = parse_target_with_ctx(prefix.original, ctx);
+                let (filter, _, _) = parse_target_with_syntax(prefix.original, ctx);
                 let filter = use_owner_for_random_non_battlefield_zone(filter);
                 // Return empty remainder — the entire input has been consumed
                 // (prefix + stripped suffix + any trailing punctuation).
-                return (filter, &text[text.len()..]);
+                return (filter, &text[text.len()..], syntax);
             }
         }
     }
@@ -230,9 +261,9 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
             let before_original = &text[..before_random.len()];
             let after_original = &text[lower.len() - after_random.len()..];
             let rewritten = format!("{before_original} {after_original}");
-            let (filter, _) = parse_target_with_ctx(&rewritten, ctx);
+            let (filter, _, _) = parse_target_with_syntax(&rewritten, ctx);
             let filter = use_owner_for_random_non_battlefield_zone(filter);
-            return (filter, &text[text.len()..]);
+            return (filter, &text[text.len()..], syntax);
         }
     }
 
@@ -264,7 +295,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         .is_ok()
         {
             let original_rest = &text[lower.len() - after_article.len()..];
-            return parse_target_with_ctx(original_rest, ctx);
+            return parse_target_with_syntax(original_rest, ctx);
         }
         // CR 115.1: Bare-trailing "target" with no following type word — the
         // recipient is the multi-target chain's terminal slot ("a third
@@ -275,7 +306,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         {
             if rest_after_target.is_empty() || rest_after_target.starts_with([',', '.']) {
                 let original_rest = &text[lower.len() - after_article.len()..];
-                return parse_target_with_ctx(original_rest, ctx);
+                return parse_target_with_syntax(original_rest, ctx);
             }
         }
     }
@@ -295,7 +326,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
     {
         ctx.target_selection_mode = TargetSelectionMode::Random;
         let original_rest = &text[lower.len() - rest.len()..];
-        return parse_target_with_ctx(original_rest, ctx);
+        return parse_target_with_syntax(original_rest, ctx);
     }
 
     // Quantified target phrases routed here from callers that only need the filter,
@@ -340,7 +371,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                 || (!matches!(*prefix, "one " | "up to one ") && trimmed_rest.starts_with("of "));
             if quantified_target {
                 let original_rest = &text[lower.len() - rest.len()..];
-                return parse_target_with_ctx(original_rest, ctx);
+                return parse_target_with_syntax(original_rest, ctx);
             }
         }
     }
@@ -348,7 +379,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
     for prefix in ["or untap ", "untap ", "or tap ", "tap "] {
         if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(prefix).parse(lower.as_str()) {
             let original_rest = &text[lower.len() - rest.len()..];
-            return parse_target_with_ctx(original_rest, ctx);
+            return parse_target_with_syntax(original_rest, ctx);
         }
     }
 
@@ -359,7 +390,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         "targets",
     ] {
         if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(phrase).parse(lower.as_str()) {
-            return (TargetFilter::Any, &text[lower.len() - rest.len()..]);
+            return (TargetFilter::Any, &text[lower.len() - rest.len()..], syntax);
         }
     }
 
@@ -368,10 +399,10 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
     // dispatches on `ctx.subject` to pick the correct antecedent class — see its
     // doc comment for the typed-subject vs. compound-anaphor split.
     if let Some((_, rest)) = nom_on_lower(text, &lower, |input| parse_word_bounded(input, "it")) {
-        return (resolve_pronoun_target(ctx, "it"), rest);
+        return (resolve_pronoun_target(ctx, "it"), rest, syntax);
     }
     if let Some((_, rest)) = nom_on_lower(text, &lower, |input| parse_word_bounded(input, "them")) {
-        return (resolve_pronoun_target(ctx, "them"), rest);
+        return (resolve_pronoun_target(ctx, "them"), rest, syntax);
     }
     if tag::<_, _, OracleError<'_>>("one of ")
         .parse(lower.as_str())
@@ -382,16 +413,16 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         {
             // "one" is a quantity word, not an object pronoun — preserve the
             // legacy `ParentTarget` binding (multi-target chains).
-            return (TargetFilter::ParentTarget, rest);
+            return (TargetFilter::ParentTarget, rest, syntax);
         }
     }
     // Gendered object pronouns follow the same trigger-subject vs. compound
     // anaphor dispatch as "it"/"them".
     if let Some((_, rest)) = nom_on_lower(text, &lower, |input| parse_word_bounded(input, "him")) {
-        return (resolve_pronoun_target(ctx, "him"), rest);
+        return (resolve_pronoun_target(ctx, "him"), rest, syntax);
     }
     if let Some((_, rest)) = nom_on_lower(text, &lower, |input| parse_word_bounded(input, "her")) {
-        return (resolve_pronoun_target(ctx, "her"), rest);
+        return (resolve_pronoun_target(ctx, "her"), rest, syntax);
     }
     if let Some((filter, rest)) = nom_on_lower(text, &lower, |input| {
         alt((
@@ -418,7 +449,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         ))
         .parse(input)
     }) {
-        return (filter, rest);
+        return (filter, rest, syntax);
     }
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("on ").parse(lower.as_str()) {
         let original_rest = &text[lower.len() - rest.len()..];
@@ -426,7 +457,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
             rest,
             "it" | "them" | "him" | "her" | "enchanted permanent" | "enchanted creature"
         ) {
-            return parse_target_with_ctx(original_rest, ctx);
+            return parse_target_with_syntax(original_rest, ctx);
         }
     }
     // "that [type phrase]" → anaphoric reference to a typed subject
@@ -434,7 +465,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         let original_rest = &text[lower.len() - rest_subject.len()..];
         let (filter, rem) = parse_type_phrase_with_ctx(original_rest, ctx);
         if !matches!(filter, TargetFilter::Any) {
-            return (TargetFilter::ParentTarget, rem);
+            return (TargetFilter::ParentTarget, rem, syntax);
         }
     }
     // "the first [type phrase]" → anaphoric reference to an object identified
@@ -457,7 +488,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
             let original_rest = &text[lower.len() - rest_subject.len()..];
             let (filter, rem) = parse_type_phrase_with_ctx(original_rest, ctx);
             if !matches!(filter, TargetFilter::Any) {
-                return (TargetFilter::ParentTarget, rem);
+                return (TargetFilter::ParentTarget, rem, syntax);
             }
         }
     }
@@ -467,6 +498,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         return (
             TargetFilter::SelfRef,
             text[lower.len() - rest.len()..].trim_start(),
+            syntax,
         );
     }
 
@@ -477,6 +509,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         return (
             TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Another])),
             rest,
+            syntax,
         );
     }
 
@@ -488,7 +521,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         )
         .parse(input)
     }) {
-        return (TargetFilter::Any, rest);
+        return (TargetFilter::Any, rest, syntax);
     }
 
     // CR 610.3 / CR 406.6: linked exile and counter-marked exile phrases are
@@ -510,18 +543,19 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         return (
             TargetFilter::ExiledBySource,
             &text[lower.len() - rest.len()..],
+            syntax,
         );
     }
 
     // "all " + type phrase
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("all ").parse(lower.as_str()) {
         let (filter, rest) = parse_type_phrase_with_ctx(&text[lower.len() - rest.len()..], ctx);
-        return (filter, rest);
+        return (filter, rest, syntax);
     }
 
     if let Some((_, rest)) = nom_on_lower(text, &lower, |input| parse_word_bounded(input, "player"))
     {
-        return (TargetFilter::Player, rest);
+        return (TargetFilter::Player, rest, syntax);
     }
 
     for zone_word in ["graveyard", "graveyards"] {
@@ -533,6 +567,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                     zone: Zone::Graveyard,
                 }])),
                 rest,
+                syntax,
             );
         }
     }
@@ -543,7 +578,11 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         .chain(SELF_REF_PARSE_ONLY_PHRASES)
     {
         if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(*phrase).parse(lower.as_str()) {
-            return (TargetFilter::SelfRef, &text[lower.len() - rest.len()..]);
+            return (
+                TargetFilter::SelfRef,
+                &text[lower.len() - rest.len()..],
+                syntax,
+            );
         }
     }
 
@@ -554,20 +593,21 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
     // "targets" or the leading word of "target creature".
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("target").parse(lower.as_str()) {
         if rest.is_empty() || rest.starts_with([',', '.']) {
-            // CR 115.1: "target" keyword consumed — flag for downstream lowering
-            // (e.g. Bounce non_targeting detection).
-            ctx.saw_target_keyword = true;
-            return (TargetFilter::Any, &text[lower.len() - rest.len()..]);
+            // CR 115.1: "target" keyword consumed — surfaced via the returned
+            // `TargetSyntax` for downstream lowering (e.g. Bounce selection).
+            syntax = TargetSyntax::TargetKeyword;
+            return (TargetFilter::Any, &text[lower.len() - rest.len()..], syntax);
         }
     }
 
     // "target" group — longest-match-first within
     if let Ok((after_target, _)) = tag::<_, _, OracleError<'_>>("target ").parse(lower.as_str()) {
-        // CR 115.1: "target" keyword consumed — flag for downstream lowering
-        // (e.g. Bounce non_targeting detection). Whitemane Lion's "return a
-        // creature you control" parses through this path's *absence*, so a
-        // false here lets the lowering pipeline pick the non-targeted variant.
-        ctx.saw_target_keyword = true;
+        // CR 115.1: "target" keyword consumed — surfaced via the returned
+        // `TargetSyntax` for downstream lowering (e.g. Bounce selection).
+        // Whitemane Lion's "return a creature you control" parses through
+        // this path's *absence*, so the returned `Descriptor` lets the
+        // lowering pipeline pick the non-targeted variant.
+        syntax = TargetSyntax::TargetKeyword;
         let target_offset = lower.len() - after_target.len();
         // "target player or planeswalker"
         if let Ok((rest, _)) =
@@ -581,6 +621,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                     ],
                 },
                 &text[lower.len() - rest.len()..],
+                syntax,
             );
         }
         // "target opponent"
@@ -588,11 +629,16 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
             return (
                 TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
                 &text[lower.len() - rest.len()..],
+                syntax,
             );
         }
         // "target player"
         if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("player").parse(after_target) {
-            return (TargetFilter::Player, &text[lower.len() - rest.len()..]);
+            return (
+                TargetFilter::Player,
+                &text[lower.len() - rest.len()..],
+                syntax,
+            );
         }
         // "target" + type phrase (generic). CR 903.3 + CR 108.3: "commander[s]"
         // is recognized as a typed-phrase prefix inside `parse_type_phrase_with_ctx`
@@ -603,6 +649,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         return (
             scope_target_spell_phrase(filter, &lower[target_offset..consumed_end]),
             rest,
+            syntax,
         );
     }
 
@@ -641,6 +688,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                     id: TrackedSetId(0),
                 },
                 &text[lower.len() - rest.len()..],
+                syntax,
             );
         }
     }
@@ -649,10 +697,11 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         return (
             TargetFilter::ParentTarget,
             &text[lower.len() - rest.len()..],
+            syntax,
         );
     }
     if let Some((filter, rest)) = parse_definite_parent_reference(lower.as_str()) {
-        return (filter, &text[lower.len() - rest.len()..]);
+        return (filter, &text[lower.len() - rest.len()..], syntax);
     }
 
     // Singular selection from a previously-referenced set.
@@ -686,6 +735,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
             return (
                 TargetFilter::ParentTarget,
                 &text[lower.len() - rest.len()..],
+                syntax,
             );
         }
     }
@@ -706,6 +756,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                     id: TrackedSetId(0),
                 },
                 &text[lower.len() - rest.len()..],
+                syntax,
             );
         }
     }
@@ -755,14 +806,18 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         ))
         .parse(input)
     }) {
-        return (filter, rest);
+        return (filter, rest, syntax);
     }
     // Generic "the [noun]'s controller" — any possessive ending in "'s controller"
     // catches subtypes like "the Wall's controller" and similar.
     if let Ok((after_the, _)) = tag::<_, _, OracleError<'_>>("the ").parse(lower.as_str()) {
         if let Some(pos) = after_the.find("'s controller") {
             let consumed = "the ".len() + pos + "'s controller".len();
-            return (TargetFilter::ParentTargetController, &text[consumed..]);
+            return (
+                TargetFilter::ParentTargetController,
+                &text[consumed..],
+                syntax,
+            );
         }
     }
     // "the [type] card" / "the enchanted [type] card" — definite reference to a
@@ -802,14 +857,18 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                 .map(|(r, _)| r)
                 .unwrap_or(card_start);
             let consumed = lower.len() - rest_after_card.len();
-            return (TargetFilter::ParentTarget, &text[consumed..]);
+            return (TargetFilter::ParentTarget, &text[consumed..], syntax);
         }
     }
     // "himself" / "herself" — archaic self-reference (e.g., "deals damage to himself")
     if let Ok((rest, _)) =
         alt((tag::<_, _, OracleError<'_>>("himself"), tag("herself"))).parse(lower.as_str())
     {
-        return (TargetFilter::SelfRef, &text[lower.len() - rest.len()..]);
+        return (
+            TargetFilter::SelfRef,
+            &text[lower.len() - rest.len()..],
+            syntax,
+        );
     }
 
     // CR 115.1 + CR 102.2: Opponent player references — "each opponent",
@@ -836,7 +895,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         ))
         .parse(input)
     }) {
-        return (filter, rest);
+        return (filter, rest, syntax);
     }
 
     for phrase in ["opponent's graveyard", "an opponent's graveyard"] {
@@ -851,6 +910,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                     },
                 ])),
                 &text[lower.len() - rest.len()..],
+                syntax,
             );
         }
     }
@@ -874,6 +934,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         return (
             TargetFilter::ExiledBySource,
             &text[lower.len() - rest.len()..],
+            syntax,
         );
     }
     if let Ok((rest, _)) =
@@ -884,6 +945,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         return (
             TargetFilter::ExiledBySource,
             &text[text.len() - after_type.len()..],
+            syntax,
         );
     }
 
@@ -900,13 +962,14 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                 id: TrackedSetId(0),
             },
             &text[lower.len() - rest.len()..],
+            syntax,
         );
     }
 
     // "each " + type phrase
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("each ").parse(lower.as_str()) {
         let (filter, rest) = parse_type_phrase_with_ctx(&text[lower.len() - rest.len()..], ctx);
-        return (filter, rest);
+        return (filter, rest, syntax);
     }
 
     // "enchanted [type]" / "equipped creature"
@@ -918,7 +981,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         )
         .parse(input)
     }) {
-        return (filter, rest);
+        return (filter, rest, syntax);
     }
     // "enchanted [type phrase]" → parse the type after "enchanted " and add EnchantedBy
     if let Ok((rest_lower, _)) = tag::<_, _, OracleError<'_>>("enchanted ").parse(lower.as_str()) {
@@ -932,7 +995,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                 }
                 other => other,
             };
-            return (enchanted, rest);
+            return (enchanted, rest, syntax);
         }
     }
     // "equipped creature" → creature with EquippedBy
@@ -943,7 +1006,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         )
         .parse(input)
     }) {
-        return (filter, rest);
+        return (filter, rest, syntax);
     }
 
     // "exiled cards with [counter] counters on them" — linked only by the
@@ -975,6 +1038,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                 },
             ])),
             &text[lower.len() - rest.len()..],
+            syntax,
         );
     }
     if let Ok((rest, _)) =
@@ -984,19 +1048,20 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         return (
             TargetFilter::ExiledBySource,
             &text[text.len() - after_type.len()..],
+            syntax,
         );
     }
 
     // "you" — the controller (not a targeted player), with word boundary
     if let Some((_, rest)) = nom_on_lower(text, &lower, |input| parse_word_bounded(input, "you")) {
-        return (TargetFilter::Controller, rest);
+        return (TargetFilter::Controller, rest, syntax);
     }
 
     // "the top/bottom [N] [type] card[s] of [possessive] library/graveyard"
     // Zone position references that appear as targets of exile/mill/reveal effects.
     // Returns a filter with InZone for the referenced zone and controller.
     if let Some((filter, rest)) = parse_zone_position_ref(text, &lower) {
-        return (filter, rest);
+        return (filter, rest, syntax);
     }
 
     // CR 400.12: Bare possessive zone references ("their graveyard", "your library").
@@ -1040,6 +1105,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                             ..Default::default()
                         }),
                         &text[consumed..],
+                        syntax,
                     );
                 }
             }
@@ -1063,6 +1129,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
                         ..Default::default()
                     }),
                     &text[consumed..],
+                    syntax,
                 );
             }
         }
@@ -1082,6 +1149,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
         (
             scope_target_spell_phrase(filter, &lower[..consumed_end]),
             rest,
+            syntax,
         )
     } else {
         ctx.push_diagnostic(OracleDiagnostic::TargetFallback {
@@ -1089,7 +1157,7 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
             text: text.trim().into(),
             line_index: 0,
         });
-        (TargetFilter::Any, text)
+        (TargetFilter::Any, text, syntax)
     }
 }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -554,12 +554,20 @@ pub fn parse_target_with_ctx<'a>(text: &'a str, ctx: &mut ParseContext) -> (Targ
     // "targets" or the leading word of "target creature".
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("target").parse(lower.as_str()) {
         if rest.is_empty() || rest.starts_with([',', '.']) {
+            // CR 115.1: "target" keyword consumed — flag for downstream lowering
+            // (e.g. Bounce non_targeting detection).
+            ctx.saw_target_keyword = true;
             return (TargetFilter::Any, &text[lower.len() - rest.len()..]);
         }
     }
 
     // "target" group — longest-match-first within
     if let Ok((after_target, _)) = tag::<_, _, OracleError<'_>>("target ").parse(lower.as_str()) {
+        // CR 115.1: "target" keyword consumed — flag for downstream lowering
+        // (e.g. Bounce non_targeting detection). Whitemane Lion's "return a
+        // creature you control" parses through this path's *absence*, so a
+        // false here lets the lowering pipeline pick the non-targeted variant.
+        ctx.saw_target_keyword = true;
         let target_offset = lower.len() - after_target.len();
         // "target player or planeswalker"
         if let Ok((rest, _)) =

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9855,11 +9855,11 @@ mod tests {
     use crate::parser::oracle_ir::context::ParseContext;
     use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
     use crate::types::ability::{
-        AbilityCondition, AbilityCost, AbilityKind, AggregateFunction, CastingPermission,
-        Comparator, ContinuousModification, ControllerRef, CountScope, DamageModification,
-        DelayedTriggerCondition, Duration, Effect, FilterProp, ManaSpendPermission, ObjectScope,
-        PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
-        TargetFilter, TypeFilter, TypedFilter,
+        AbilityCondition, AbilityCost, AbilityKind, AggregateFunction, BounceSelection,
+        CastingPermission, Comparator, ContinuousModification, ControllerRef, CountScope,
+        DamageModification, DelayedTriggerCondition, Duration, Effect, FilterProp,
+        ManaSpendPermission, ObjectScope, PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope,
+        QuantityExpr, QuantityRef, TargetFilter, TypeFilter, TypedFilter,
     };
     use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::replacements::ReplacementEvent;
@@ -16272,7 +16272,7 @@ mod tests {
             Some(Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             })
         ));
     }
@@ -16292,7 +16292,7 @@ mod tests {
             Some(Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             })
         ));
     }
@@ -16316,7 +16316,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             }
         ));
         assert!(matches!(

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -130,6 +130,7 @@ fn self_recursion_trigger_zone(
         crate::types::ability::Effect::Bounce {
             target: TargetFilter::SelfRef,
             destination,
+            ..
         } if destination.is_none_or(|zone| zone == Zone::Hand) => {
             parse_self_return_origin_zone(source_lower)
         }
@@ -16081,6 +16082,7 @@ mod tests {
             Some(Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
+                non_targeting: false,
             })
         ));
     }
@@ -16100,6 +16102,7 @@ mod tests {
             Some(Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
+                non_targeting: false,
             })
         ));
     }
@@ -16123,6 +16126,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::SelfRef,
                 destination: None,
+                non_targeting: false,
             }
         ));
         assert!(matches!(

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4934,6 +4934,26 @@ impl StepSkipTarget {
     }
 }
 
+/// CR 115.1: Whether the `Bounce` effect selects its affected object at
+/// cast/activation time ("target", locked) or at resolution time (controller-
+/// scoped filter like "a creature you control" — Whitemane Lion).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BounceSelection {
+    /// Default — target chosen at cast/activation via the targeting pipeline.
+    #[default]
+    Targeted,
+    /// CR 608.2c: Controller chooses an eligible object at resolution.
+    AtResolution,
+}
+
+impl BounceSelection {
+    /// Helper for `#[serde(skip_serializing_if = ...)]`.
+    pub fn is_targeted(&self) -> bool {
+        matches!(self, Self::Targeted)
+    }
+}
+
 /// The typed effect enum. Each variant corresponds to an effect handler.
 /// Zero HashMap<String, String> fields.
 // clippy::large_enum_variant: `Effect` is the engine's central 100+ variant
@@ -5368,17 +5388,12 @@ pub enum Effect {
         target: TargetFilter,
         #[serde(default)]
         destination: Option<Zone>,
-        /// CR 115.1 + Whitemane Lion ruling: When `true`, the effect does NOT
-        /// use the word "target" in its Oracle text ("return a creature you
-        /// control to its owner's hand"). The controller chooses an eligible
-        /// permanent at resolution time via `WaitingFor::EffectZoneChoice`,
-        /// bypassing the targeting pipeline (`extract_target_filter_from_effect`
-        /// returns `None`). When `false`, the effect uses "target" and follows
-        /// standard target selection. Defaults to `false` so existing
-        /// card-data.json records (which predate this field) continue to
-        /// deserialize as the canonical targeted form.
-        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-        non_targeting: bool,
+        /// CR 115.1 + Whitemane Lion ruling: Controls whether this effect uses
+        /// the targeting pipeline (`Targeted`) or selects at resolution
+        /// (`AtResolution` — Whitemane Lion class). Card-data.json records
+        /// predating this field deserialize as `Targeted` via the default.
+        #[serde(default, skip_serializing_if = "BounceSelection::is_targeted")]
+        selection: BounceSelection,
     },
     /// CR 400.7 + CR 611.2c: Mass-bounce — return every permanent matching
     /// `target` to its owner's hand (default) or `destination` if set. Mirrors

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5368,6 +5368,17 @@ pub enum Effect {
         target: TargetFilter,
         #[serde(default)]
         destination: Option<Zone>,
+        /// CR 115.1 + Whitemane Lion ruling: When `true`, the effect does NOT
+        /// use the word "target" in its Oracle text ("return a creature you
+        /// control to its owner's hand"). The controller chooses an eligible
+        /// permanent at resolution time via `WaitingFor::EffectZoneChoice`,
+        /// bypassing the targeting pipeline (`extract_target_filter_from_effect`
+        /// returns `None`). When `false`, the effect uses "target" and follows
+        /// standard target selection. Defaults to `false` so existing
+        /// card-data.json records (which predate this field) continue to
+        /// deserialize as the canonical targeted form.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        non_targeting: bool,
     },
     /// CR 400.7 + CR 611.2c: Mass-bounce — return every permanent matching
     /// `target` to its owner's hand (default) or `destination` if set. Mirrors

--- a/crates/engine/tests/integration/roots_of_wisdom_if_you_cant_draw.rs
+++ b/crates/engine/tests/integration/roots_of_wisdom_if_you_cant_draw.rs
@@ -166,8 +166,8 @@ fn roots_of_wisdom_returnable_land_draws_zero() {
 
 use engine::game::zones::create_object;
 use engine::types::ability::{
-    AbilityCondition, ControllerRef, Effect, FilterProp, QuantityExpr, ResolvedAbility,
-    TargetFilter, TypedFilter,
+    AbilityCondition, BounceSelection, ControllerRef, Effect, FilterProp, QuantityExpr,
+    ResolvedAbility, TargetFilter, TypedFilter,
 };
 use engine::types::identifiers::CardId;
 use engine::types::player::PlayerId;
@@ -187,7 +187,7 @@ fn bounce_then_gated_draw(source: ObjectId, controller: PlayerId) -> ResolvedAbi
         Effect::Bounce {
             target: land_in_graveyard,
             destination: Some(Zone::Hand),
-            non_targeting: false,
+            selection: BounceSelection::Targeted,
         },
         vec![],
         source,

--- a/crates/engine/tests/integration/roots_of_wisdom_if_you_cant_draw.rs
+++ b/crates/engine/tests/integration/roots_of_wisdom_if_you_cant_draw.rs
@@ -187,6 +187,7 @@ fn bounce_then_gated_draw(source: ObjectId, controller: PlayerId) -> ResolvedAbi
         Effect::Bounce {
             target: land_in_graveyard,
             destination: Some(Zone::Hand),
+            non_targeting: false,
         },
         vec![],
         source,

--- a/crates/engine/tests/integration/skullwinder_chosen_opponent.rs
+++ b/crates/engine/tests/integration/skullwinder_chosen_opponent.rs
@@ -24,7 +24,8 @@ use engine::game::effects::bounce;
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::zones::create_object;
 use engine::types::ability::{
-    ControllerRef, Effect, FilterProp, ResolvedAbility, TargetFilter, TypeFilter, TypedFilter,
+    BounceSelection, ControllerRef, Effect, FilterProp, ResolvedAbility, TargetFilter, TypeFilter,
+    TypedFilter,
 };
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::CardId;
@@ -97,7 +98,7 @@ fn skullwinder_chosen_opponent_picks_their_own_card() {
         Effect::Bounce {
             target,
             destination: None,
-            non_targeting: false,
+            selection: BounceSelection::Targeted,
         },
         Vec::new(),
         skullwinder,

--- a/crates/engine/tests/integration/skullwinder_chosen_opponent.rs
+++ b/crates/engine/tests/integration/skullwinder_chosen_opponent.rs
@@ -97,6 +97,7 @@ fn skullwinder_chosen_opponent_picks_their_own_card() {
         Effect::Bounce {
             target,
             destination: None,
+            non_targeting: false,
         },
         Vec::new(),
         skullwinder,

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -7,7 +7,7 @@
 //! lands phase by phase.
 
 use engine::types::ability::{
-    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ChoiceType,
+    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, ChoiceType,
     ContinuousModification, ControllerRef, DamageSource, DelayedTriggerCondition, Duration, Effect,
     GainLifePlayer, LibraryPosition, ManaProduction, ManaSpendRestriction,
     ModalSelectionConstraint, MultiTargetSpec, PaymentCost, PlayerFilter, PlayerScope, PtValue,
@@ -2863,7 +2863,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         Action::ReturnAnyNumberOfPermanentsToTheirOwnersHands(filter) => Effect::Bounce {
             target: convert_permanents(filter)?,
             destination: None,
-            non_targeting: false,
+            selection: BounceSelection::Targeted,
         },
         // CR 400.7: Return to owner's hand — mass variant.
         // "Return each <filter> to its owner's hand." Mirrors
@@ -2873,7 +2873,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         Action::PutEachPermanentIntoItsOwnersHand(filter) => Effect::Bounce {
             target: convert_permanents(filter)?,
             destination: None,
-            non_targeting: false,
+            selection: BounceSelection::Targeted,
         },
 
         // CR 701.32: Sacrifice an effect on a permanent (rare; usually via cost).
@@ -2927,7 +2927,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         Action::PutPermanentIntoItsOwnersHand(p) => Effect::Bounce {
             target: convert_permanent(p)?,
             destination: None,
-            non_targeting: false,
+            selection: BounceSelection::Targeted,
         },
 
         // CR 401.1 + CR 608.2c: "Put [target permanent] on top of its owner's
@@ -3312,7 +3312,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         Action::PutAPermanentIntoItsOwnersHand(filter) => Effect::Bounce {
             target: convert_permanents(filter)?,
             destination: None,
-            non_targeting: false,
+            selection: BounceSelection::Targeted,
         },
 
         // CR 701.3a + CR 701.3b: Attach. The mtgish shape is

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -2863,6 +2863,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         Action::ReturnAnyNumberOfPermanentsToTheirOwnersHands(filter) => Effect::Bounce {
             target: convert_permanents(filter)?,
             destination: None,
+            non_targeting: false,
         },
         // CR 400.7: Return to owner's hand — mass variant.
         // "Return each <filter> to its owner's hand." Mirrors
@@ -2872,6 +2873,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         Action::PutEachPermanentIntoItsOwnersHand(filter) => Effect::Bounce {
             target: convert_permanents(filter)?,
             destination: None,
+            non_targeting: false,
         },
 
         // CR 701.32: Sacrifice an effect on a permanent (rare; usually via cost).
@@ -2925,6 +2927,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         Action::PutPermanentIntoItsOwnersHand(p) => Effect::Bounce {
             target: convert_permanent(p)?,
             destination: None,
+            non_targeting: false,
         },
 
         // CR 401.1 + CR 608.2c: "Put [target permanent] on top of its owner's
@@ -3309,6 +3312,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         Action::PutAPermanentIntoItsOwnersHand(filter) => Effect::Bounce {
             target: convert_permanents(filter)?,
             destination: None,
+            non_targeting: false,
         },
 
         // CR 701.3a + CR 701.3b: Attach. The mtgish shape is

--- a/crates/phase-ai/src/cast_facts.rs
+++ b/crates/phase-ai/src/cast_facts.rs
@@ -1,6 +1,7 @@
 use engine::game::game_object::GameObject;
 use engine::types::ability::{
-    AbilityDefinition, AbilityKind, Effect, ReplacementDefinition, TargetFilter, TriggerDefinition,
+    AbilityDefinition, AbilityKind, BounceSelection, Effect, ReplacementDefinition, TargetFilter,
+    TriggerDefinition,
 };
 use engine::types::actions::GameAction;
 use engine::types::card::CardFace;
@@ -344,10 +345,10 @@ fn effect_requires_targets(effect: &Effect) -> bool {
         // the spell does not need a target slot to be cast. Targeted Bounce
         // (with "target") follows the standard target-required predicate.
         Effect::Bounce {
-            target,
-            non_targeting,
-            ..
-        } => !*non_targeting && !matches!(target, TargetFilter::None),
+            target, selection, ..
+        } => {
+            matches!(selection, BounceSelection::Targeted) && !matches!(target, TargetFilter::None)
+        }
         Effect::Destroy { target, .. }
         | Effect::DealDamage { target, .. }
         | Effect::Pump { target, .. }

--- a/crates/phase-ai/src/cast_facts.rs
+++ b/crates/phase-ai/src/cast_facts.rs
@@ -338,13 +338,22 @@ fn is_permanent_spell(object: &GameObject) -> bool {
 
 fn effect_requires_targets(effect: &Effect) -> bool {
     match effect {
+        // CR 115.1 + Whitemane Lion ruling: A non-targeted Bounce ("return a
+        // creature you control") does NOT use the word "target" — the
+        // controller chooses at resolution time via `EffectZoneChoice`, so
+        // the spell does not need a target slot to be cast. Targeted Bounce
+        // (with "target") follows the standard target-required predicate.
+        Effect::Bounce {
+            target,
+            non_targeting,
+            ..
+        } => !*non_targeting && !matches!(target, TargetFilter::None),
         Effect::Destroy { target, .. }
         | Effect::DealDamage { target, .. }
         | Effect::Pump { target, .. }
         | Effect::Counter { target, .. }
         | Effect::Tap { target }
         | Effect::Untap { target }
-        | Effect::Bounce { target, .. }
         | Effect::GainControl { target, .. }
         | Effect::PhaseOut { target }
         | Effect::Fight { target, .. }

--- a/crates/phase-ai/src/features/control.rs
+++ b/crates/phase-ai/src/features/control.rs
@@ -314,7 +314,7 @@ mod tests {
     use super::*;
     use engine::game::DeckEntry;
     use engine::types::ability::{
-        AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter,
+        AbilityDefinition, AbilityKind, BounceSelection, Effect, QuantityExpr, TargetFilter,
     };
     use engine::types::card::CardFace;
     use engine::types::card_type::{CardType, CoreType};
@@ -362,7 +362,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
         )
     }

--- a/crates/phase-ai/src/features/control.rs
+++ b/crates/phase-ai/src/features/control.rs
@@ -362,6 +362,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
         )
     }

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -1726,6 +1726,7 @@ mod tests {
                         .with_type(TypeFilter::Non(Box::new(TypeFilter::Land))),
                 ),
                 destination: None,
+                non_targeting: false,
             },
         )]);
 
@@ -1785,6 +1786,7 @@ mod tests {
                         .controller(engine::types::ability::ControllerRef::You),
                 ),
                 destination: None,
+                non_targeting: false,
             },
         )]);
 

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -784,9 +784,9 @@ mod tests {
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
     use engine::game::zones::create_object;
     use engine::types::ability::{
-        AbilityDefinition, AbilityKind, ContinuousModification, ControllerRef, FilterProp, PtValue,
-        ResolvedAbility, StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter,
-        TypedFilter,
+        AbilityDefinition, AbilityKind, BounceSelection, ContinuousModification, ControllerRef,
+        FilterProp, PtValue, ResolvedAbility, StaticDefinition, TargetFilter, TriggerDefinition,
+        TypeFilter, TypedFilter,
     };
     use engine::types::game_state::{GameState, PendingCast, TargetSelectionSlot, WaitingFor};
     use engine::types::identifiers::{CardId, ObjectId};
@@ -1726,7 +1726,7 @@ mod tests {
                         .with_type(TypeFilter::Non(Box::new(TypeFilter::Land))),
                 ),
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
         )]);
 
@@ -1786,7 +1786,7 @@ mod tests {
                         .controller(engine::types::ability::ControllerRef::You),
                 ),
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
         )]);
 

--- a/crates/phase-ai/src/policies/downside_awareness.rs
+++ b/crates/phase-ai/src/policies/downside_awareness.rs
@@ -197,6 +197,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::Card,
@@ -214,6 +215,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::Card,
@@ -227,6 +229,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::TappedFish,
@@ -247,6 +250,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             None,
         );
@@ -263,6 +267,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::TappedFish,
@@ -278,6 +283,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::TappedFish,

--- a/crates/phase-ai/src/policies/downside_awareness.rs
+++ b/crates/phase-ai/src/policies/downside_awareness.rs
@@ -100,7 +100,7 @@ mod tests {
     use crate::config::AiConfig;
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
     use engine::game::zones::create_object;
-    use engine::types::ability::{AbilityDefinition, AbilityKind, TargetFilter};
+    use engine::types::ability::{AbilityDefinition, AbilityKind, BounceSelection, TargetFilter};
     use engine::types::game_state::{GameState, WaitingFor};
     use engine::types::identifiers::{CardId, ObjectId};
     use engine::types::player::PlayerId;
@@ -197,7 +197,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::Card,
@@ -215,7 +215,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::Card,
@@ -229,7 +229,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::TappedFish,
@@ -250,7 +250,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             None,
         );
@@ -267,7 +267,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::TappedFish,
@@ -283,7 +283,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             Some(Effect::GiftDelivery {
                 kind: GiftKind::TappedFish,

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -300,6 +300,7 @@ fn redundancy_delta(
         Effect::Bounce {
             target,
             destination,
+            ..
         } => match destination {
             None | Some(Zone::Hand) => {
                 bounce_self_undo_redundancy(state, source_id, target, origin)
@@ -1371,6 +1372,7 @@ mod tests {
                     Effect::Bounce {
                         target: bounce_target,
                         destination,
+                        non_targeting: false,
                     },
                 )),
         );
@@ -1475,6 +1477,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
                 destination: None,
+                non_targeting: false,
             },
         );
 

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -862,7 +862,7 @@ mod tests {
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
     use engine::game::zones::create_object;
     use engine::types::ability::{
-        AbilityDefinition, AbilityKind, PtValue, QuantityExpr, TargetFilter,
+        AbilityDefinition, AbilityKind, BounceSelection, PtValue, QuantityExpr, TargetFilter,
     };
     use engine::types::card_type::CoreType;
     use engine::types::game_state::WaitingFor;
@@ -1372,7 +1372,7 @@ mod tests {
                     Effect::Bounce {
                         target: bounce_target,
                         destination,
-                        non_targeting: false,
+                        selection: BounceSelection::Targeted,
                     },
                 )),
         );
@@ -1477,7 +1477,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
         );
 

--- a/crates/phase-ai/src/policies/stack_awareness.rs
+++ b/crates/phase-ai/src/policies/stack_awareness.rs
@@ -528,6 +528,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
+                non_targeting: false,
             },
             vec![TargetRef::Object(creature)],
         );

--- a/crates/phase-ai/src/policies/stack_awareness.rs
+++ b/crates/phase-ai/src/policies/stack_awareness.rs
@@ -317,7 +317,7 @@ mod tests {
     use crate::config::AiConfig;
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
     use engine::game::zones::create_object;
-    use engine::types::ability::{ResolvedAbility, TargetFilter};
+    use engine::types::ability::{BounceSelection, ResolvedAbility, TargetFilter};
     use engine::types::card_type::CoreType;
     use engine::types::game_state::{
         GameState, PendingCast, StackEntry, StackEntryKind, TargetSelectionSlot, WaitingFor,
@@ -528,7 +528,7 @@ mod tests {
             Effect::Bounce {
                 target: TargetFilter::Any,
                 destination: None,
-                non_targeting: false,
+                selection: BounceSelection::Targeted,
             },
             vec![TargetRef::Object(creature)],
         );

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -56,6 +56,18 @@ fn first_serum_powder_in_hand(
 /// it with structural "source-state-unchanged" detection.
 const MAX_ACTIVATIONS_PER_SOURCE_PER_TURN: u32 = 4;
 
+/// CR 117.1 + Whitemane Lion loop mitigation (issue #563): AI safety cap on
+/// the number of times the same card can be CAST in a single turn by the AI.
+/// Identification is by card name captured in `SpellCastRecord` so different
+/// printings/copies of the same card share the cap. CR 117.1 permits unbounded
+/// casting at priority — this cap is a pure AI-pathology mitigation against
+/// loop-prone cards (ETB self-bounce, Whitemane Lion class) whose
+/// per-occurrence value remains positive even when the net board state is
+/// unchanged. Three is generous enough for legitimate value plays (Snapcaster
+/// flashback + recast, Eternal Witness reanimate chain) while preventing the
+/// thousands-of-iterations pathology observed in #563.
+const MAX_CASTS_OF_SAME_CARD_PER_TURN: usize = 3;
+
 /// Choose the best action for the AI player given the current game state.
 ///
 /// - For 0 or 1 legal actions, returns immediately.
@@ -912,7 +924,37 @@ pub fn score_candidates(
     let gated: Vec<_> = gated
         .into_iter()
         .filter(|g| match &g.candidate.action {
-            GameAction::CastSpell { object_id, .. } => !state.cancelled_casts.contains(object_id),
+            GameAction::CastSpell { object_id, .. } => {
+                if state.cancelled_casts.contains(object_id) {
+                    return false;
+                }
+                // CR 117.1 + #563: Cap repeated casts of the same card by name
+                // within a single turn. The AI player's
+                // `spells_cast_this_turn_by_player` record carries each cast's
+                // captured name (`SpellCastRecord.name`) so the cap survives
+                // the spell having left the stack. Lookups are case-sensitive
+                // matches against the candidate object's current name (set at
+                // creation from the card name).
+                let candidate_name = state
+                    .objects
+                    .get(object_id)
+                    .map(|o| o.name.as_str())
+                    .unwrap_or("");
+                if candidate_name.is_empty() {
+                    return true;
+                }
+                let cast_count = state
+                    .spells_cast_this_turn_by_player
+                    .get(&ai_player)
+                    .map(|history| {
+                        history
+                            .iter()
+                            .filter(|rec| rec.name == candidate_name)
+                            .count()
+                    })
+                    .unwrap_or(0);
+                cast_count < MAX_CASTS_OF_SAME_CARD_PER_TURN
+            }
             GameAction::ActivateAbility {
                 source_id,
                 ability_index,

--- a/crates/phase-ai/src/tactical_gate.rs
+++ b/crates/phase-ai/src/tactical_gate.rs
@@ -607,7 +607,7 @@ mod tests {
     use engine::ai_support::{ActionMetadata, TacticalClass};
     use engine::game::combat::{AttackerInfo, CombatState};
     use engine::game::scenario::{GameScenario, P0, P1};
-    use engine::types::ability::{ResolvedAbility, TargetFilter};
+    use engine::types::ability::{BounceSelection, ResolvedAbility, TargetFilter};
     use engine::types::game_state::{
         PendingCast, StackEntry, StackEntryKind, TargetSelectionProgress, TargetSelectionSlot,
         WaitingFor,
@@ -825,7 +825,7 @@ mod tests {
                     Effect::Bounce {
                         target: TargetFilter::Any,
                         destination: None,
-                        non_targeting: false,
+                        selection: BounceSelection::Targeted,
                     },
                     Vec::new(),
                     unsummon,

--- a/crates/phase-ai/src/tactical_gate.rs
+++ b/crates/phase-ai/src/tactical_gate.rs
@@ -825,6 +825,7 @@ mod tests {
                     Effect::Bounce {
                         target: TargetFilter::Any,
                         destination: None,
+                        non_targeting: false,
                     },
                     Vec::new(),
                     unsummon,

--- a/crates/phase-ai/tests/whitemane_lion_bounded.rs
+++ b/crates/phase-ai/tests/whitemane_lion_bounded.rs
@@ -1,0 +1,134 @@
+//! CR 115.1 + Whitemane Lion ruling (issue #563): regression guard for the
+//! non-targeted self-bounce ETB infinite-loop pathology.
+//!
+//! Pre-fix the AI would cast Whitemane Lion ({1}{W}, 2/2, ETB "return a
+//! creature you control to its owner's hand") and the ETB resolution let it
+//! pick itself as the bounce target. With the source returning to hand each
+//! cast, the AI re-cast it on the next priority window for an unbounded
+//! number of iterations per turn — the canonical symptom was the duel-suite
+//! safety cap of 10,000 actions being hit before any turn could end.
+//!
+//! The PR addresses this in three layered ways:
+//!
+//! 1. Parser routes the non-targeted "return a creature you control" Oracle
+//!    text to `Effect::Bounce { selection: BounceSelection::AtResolution }`
+//!    rather than emitting a target slot the AI fills with the source itself.
+//! 2. The resolver branch in `effects/bounce.rs` enumerates eligible permanents
+//!    at resolution and (when only the source itself is eligible) auto-moves
+//!    without ever asking the AI to "target".
+//! 3. `MAX_CASTS_OF_SAME_CARD_PER_TURN` in `phase-ai/src/search.rs` caps the
+//!    AI at 3 casts of any one card name per turn as a defence-in-depth net
+//!    against pathological positive-EV recasts.
+//!
+//! Together these bound the pathology; this test locks the bound in.
+//!
+//! `#[ignore]` because it loads card-data.json (requires `cargo run --bin
+//! card-data-export` or the setup.sh script), which isn't available in
+//! unit-test CI. Opt in via
+//! `cargo test -p phase-ai --test whitemane_lion_bounded -- --ignored`.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+use engine::database::CardDatabase;
+use engine::game::deck_loading::{
+    load_deck_into_state, resolve_deck_list, DeckList, PlayerDeckList,
+};
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::player::PlayerId;
+use phase_ai::auto_play::run_ai_actions;
+use phase_ai::config::{create_config_for_players, AiDifficulty, Platform};
+
+/// Comfortable headroom for natural-game-completion variance. Pre-fix runs hit
+/// 10,000 every game; post-fix this deck completes naturally well under 4,000.
+const BOUND_ACTIONS: usize = 4000;
+
+fn load_db() -> CardDatabase {
+    let cards_dir = std::env::var("PHASE_CARDS_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("..")
+                .join("client")
+                .join("public")
+        });
+    let export_path = cards_dir.join("card-data.json");
+    CardDatabase::from_export(&export_path)
+        .unwrap_or_else(|e| panic!("load card-data.json from {}: {e}", export_path.display()))
+}
+
+fn repeat(name: &str, n: usize) -> Vec<String> {
+    std::iter::repeat_n(name.to_string(), n).collect()
+}
+
+/// 60-card deck packed with Whitemane Lion. Other creatures give the AI legal
+/// non-source bounce targets so it cannot trivially "pass" because no other
+/// option exists; the test thus discriminates against the loop being broken
+/// for the right reason (cap + resolver fix), not for an accidental absence
+/// of any Whitemane Lion-castable position.
+fn deck_whitemane_lion_stack() -> Vec<String> {
+    let mut d = Vec::with_capacity(60);
+    d.extend(repeat("Plains", 28));
+    d.extend(repeat("Whitemane Lion", 16));
+    d.extend(repeat("Savannah Lions", 8));
+    d.extend(repeat("Elite Vanguard", 8));
+    d
+}
+
+#[test]
+#[ignore = "loads card-data.json + runs a full game; opt in via --ignored"]
+fn whitemane_lion_self_bounce_does_not_infinite_loop() {
+    let db = load_db();
+
+    let list = DeckList {
+        player: PlayerDeckList {
+            main_deck: deck_whitemane_lion_stack(),
+            sideboard: Vec::new(),
+            commander: Vec::new(),
+        },
+        opponent: PlayerDeckList {
+            main_deck: deck_whitemane_lion_stack(),
+            sideboard: Vec::new(),
+            commander: Vec::new(),
+        },
+        ai_decks: Vec::new(),
+    };
+    let payload = resolve_deck_list(&db, &list);
+
+    let mut state = GameState::new_two_player(1);
+    load_deck_into_state(&mut state, &payload);
+    engine::game::engine::start_game(&mut state);
+
+    let ai_players: HashSet<PlayerId> = [PlayerId(0), PlayerId(1)].into_iter().collect();
+    let config = create_config_for_players(AiDifficulty::Easy, Platform::Native, 2);
+    let ai_configs: HashMap<PlayerId, _> =
+        [(PlayerId(0), config.clone()), (PlayerId(1), config.clone())]
+            .into_iter()
+            .collect();
+
+    let mut total_actions: usize = 0;
+    loop {
+        let results = run_ai_actions(&mut state, &ai_players, &ai_configs);
+        if results.is_empty() {
+            break;
+        }
+        total_actions += results.len();
+        if total_actions >= BOUND_ACTIONS {
+            panic!(
+                "whitemane-lion-stack mirror exceeded action bound: {total_actions} >= \
+                 {BOUND_ACTIONS} at turn {}. Likely a regression in non-targeted bounce \
+                 routing (parser/resolver) or `MAX_CASTS_OF_SAME_CARD_PER_TURN`.",
+                state.turn_number,
+            );
+        }
+    }
+
+    assert!(
+        matches!(state.waiting_for, WaitingFor::GameOver { .. }),
+        "game did not reach GameOver (actions = {total_actions}, turn = {}, waiting_for \
+         discriminant = {:?})",
+        state.turn_number,
+        std::mem::discriminant(&state.waiting_for),
+    );
+}


### PR DESCRIPTION
## Summary
Fixes #563. The Whitemane Lion ETB (`return a creature you control to its owner's hand`) is non-targeted per CR 115.1 and the official Whitemane Lion ruling, but the parser was wiring it as a targeted bounce and surfacing a `TriggerTargetSelection` slot. The AI filled that slot with the Lion itself, returning it to hand on resolution and re-casting it forever. Fix is layered across parser (root cause), resolver, and AI (defence-in-depth).

## Files changed
- crates/engine/src/game/ability_utils.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/game/effects/bounce.rs
- crates/engine/src/game/effects/create_emblem.rs
- crates/engine/src/game/effects/delayed_trigger.rs
- crates/engine/src/game/effects/mod.rs
- crates/engine/src/game/effects/overload.rs
- crates/engine/src/game/triggers.rs
- crates/engine/src/parser/oracle_effect/imperative.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/parser/oracle_ir/ast.rs
- crates/engine/src/parser/oracle_ir/context.rs
- crates/engine/src/parser/oracle_target.rs
- crates/engine/src/parser/oracle_trigger.rs
- crates/engine/src/types/ability.rs
- crates/engine/tests/integration/roots_of_wisdom_if_you_cant_draw.rs
- crates/engine/tests/integration/skullwinder_chosen_opponent.rs
- crates/mtgish-import/src/convert/action.rs
- crates/phase-ai/src/cast_facts.rs
- crates/phase-ai/src/features/control.rs
- crates/phase-ai/src/policies/anti_self_harm.rs
- crates/phase-ai/src/policies/downside_awareness.rs
- crates/phase-ai/src/policies/redundancy_avoidance.rs
- crates/phase-ai/src/policies/stack_awareness.rs
- crates/phase-ai/src/search.rs
- crates/phase-ai/src/tactical_gate.rs

## CR references
- CR 115.1 — targets are only chosen when Oracle text uses the word "target"
- CR 608.2c — controller-scoped choice resolution for non-targeted effects
- CR 608.2d — empty-pool handling for non-targeted effects

## Track
Developer

## LLM
Model: Claude Opus 4.7
Thinking level: medium

## Scope Expansion
The fix grew beyond a single-card patch into a class-level architectural change: `Effect::Bounce` gained a `non_targeting: bool` axis, `ParseContext` gained a `saw_target_keyword: bool` flag, and `effects/bounce.rs` gained a non-targeted resolution branch mirroring the `Sacrifice` pattern. This covers the entire class of non-targeted controller-scoped bounce ETBs (Whitemane Lion, Stonecloaker, Aether Channeler, Dream Stalker, Emancipation Angel, Esperzoa, Cache Raiders, Ambrosia Whiteheart, etc.) rather than one card. The AI also picked up a defence-in-depth cap (`MAX_CASTS_OF_SAME_CARD_PER_TURN = 3`) to harden `search.rs` against any remaining loop-prone pathology.