### PR TITLE
Fix Mizzix's Mastery copy casting

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1530,6 +1530,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::UnattachAll { target, .. }
         | Effect::Fight { target, .. }
         | Effect::CopySpell { target, .. }
+        | Effect::CastCopyOfCard { target, .. }
         | Effect::BecomeCopy { target, .. }
         | Effect::Suspect { target }
         | Effect::Connive { target, .. }
@@ -6634,6 +6635,9 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                     // (including "enter tapped as a copy of")
                     // Parsed as CopySpell without a description string.
                     effective_lower.contains("as a copy of")
+                }
+                Effect::CastCopyOfCard { .. } => {
+                    effective_lower.contains("copy") && effective_lower.contains("cast the copy")
                 }
                 Effect::Untap { .. } => {
                     // "Untap this creature during each other player's untap step" and similar

--- a/crates/engine/src/game/effects/cast_copy_of_card.rs
+++ b/crates/engine/src/game/effects/cast_copy_of_card.rs
@@ -2,13 +2,12 @@ use crate::game::ability_utils::build_resolved_from_def;
 use crate::game::effects::prepare::open_copy_target_selection;
 use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::types::ability::{
-    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
+    AbilityDefinition, AbilityKind, Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter,
+    TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{
-    CastingVariant, GameState, PendingContinuation, StackEntry, StackEntryKind, WaitingFor,
-};
-use crate::types::identifiers::ObjectId;
+use crate::types::game_state::{CastingVariant, GameState, StackEntry, StackEntryKind, WaitingFor};
+use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::zones::Zone;
 
 /// CR 707.12: Cast a copy of a card/object. The copy is created from the
@@ -34,9 +33,13 @@ pub fn resolve(
 
     if source_ids.is_empty() && references_tracked_set(target_filter) {
         let ctx = FilterContext::from_ability(ability);
+        // CR 608.2c: Resolve the tracked-set sentinel from the resolving effect's
+        // last known context before collecting the affected objects.
         let effective_filter =
             crate::game::targeting::resolve_tracked_set_sentinel(state, target_filter.clone());
-        source_ids = crate::game::targeting::latest_tracked_set_id(state)
+        let tracked_set_id = tracked_set_id_from_filter(&effective_filter)
+            .or_else(|| crate::game::targeting::latest_tracked_set_id(state));
+        source_ids = tracked_set_id
             .and_then(|id| state.tracked_object_sets.get(&id).cloned())
             .unwrap_or_default()
             .into_iter()
@@ -51,7 +54,7 @@ pub fn resolve(
                 cost: cost.clone(),
             };
             resume.sub_ability = None;
-            state.pending_continuation = Some(PendingContinuation::new(Box::new(resume)));
+            super::append_to_pending_continuation(state, Some(Box::new(resume)));
             state.waiting_for = WaitingFor::ChooseFromZoneChoice {
                 player: ability.controller,
                 cards: source_ids,
@@ -117,6 +120,17 @@ fn references_tracked_set(filter: &TargetFilter) -> bool {
     }
 }
 
+fn tracked_set_id_from_filter(filter: &TargetFilter) -> Option<TrackedSetId> {
+    match filter {
+        TargetFilter::TrackedSet { id } | TargetFilter::TrackedSetFiltered { id, .. } => Some(*id),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().find_map(tracked_set_id_from_filter)
+        }
+        TargetFilter::Not { filter } => tracked_set_id_from_filter(filter),
+        _ => None,
+    }
+}
+
 fn cast_one_copy(
     state: &mut GameState,
     source_id: ObjectId,
@@ -133,15 +147,17 @@ fn cast_one_copy(
     let copy_id = ObjectId(state.next_object_id);
     state.next_object_id += 1;
 
-    let ability_def = source.abilities.first().cloned();
+    let ability_def = spell_ability_definition(&source.abilities);
     let mut copy = source;
     copy.id = copy_id;
     copy.controller = ability.controller;
     copy.owner = ability.controller;
+    // CR 707.12 + CR 601.2a: The copy is created and cast as a spell on the stack.
     copy.zone = Zone::Stack;
-    copy.is_token = true;
+    copy.is_token = false;
     copy.tapped = false;
     copy.prepared = None;
+    // CR 707.12: The copy is created in the same zone as the source object before casting.
     copy.cast_from_zone = Some(origin_zone);
     copy.cost_x_paid = None;
     copy.kickers_paid.clear();
@@ -162,6 +178,7 @@ fn cast_one_copy(
             card_id,
             ability: resolved,
             casting_variant: CastingVariant::Normal,
+            // CR 118.9 + CR 601.2f: "Without paying its mana cost" is an alternative cost.
             actual_mana_spent: 0,
         },
     });
@@ -182,6 +199,14 @@ fn cast_one_copy(
     }
 
     Ok(copy_id)
+}
+
+fn spell_ability_definition(abilities: &[AbilityDefinition]) -> Option<AbilityDefinition> {
+    abilities
+        .iter()
+        .find(|ability| ability.kind == AbilityKind::Spell)
+        .or_else(|| abilities.first())
+        .cloned()
 }
 
 #[cfg(test)]
@@ -247,7 +272,7 @@ mod tests {
         let copy_id = state.stack.back().expect("copy on stack").id;
         let copy = state.objects.get(&copy_id).expect("copy object exists");
         assert_eq!(copy.zone, Zone::Stack);
-        assert!(copy.is_token);
+        assert!(!copy.is_token);
         assert_eq!(copy.owner, PlayerId(0));
         assert_eq!(copy.controller, PlayerId(0));
         assert!(matches!(
@@ -299,5 +324,90 @@ mod tests {
         }
         assert!(state.pending_continuation.is_some());
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn tracked_set_choice_uses_resolved_filter_id_not_latest_set() {
+        let mut state = GameState::new_two_player(7);
+        let first = add_exiled_spell_card(&mut state, "Opt");
+        let latest = add_exiled_spell_card(&mut state, "Consider");
+        state
+            .tracked_object_sets
+            .insert(TrackedSetId(1), vec![first]);
+        state
+            .tracked_object_sets
+            .insert(TrackedSetId(2), vec![latest]);
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CastCopyOfCard {
+                target: TargetFilter::TrackedSet {
+                    id: TrackedSetId(1),
+                },
+                cost: ManaCost::zero(),
+            },
+            Vec::new(),
+            ObjectId(99),
+            PlayerId(0),
+        );
+
+        resolve(&mut state, &ability, &mut events).expect("choice opens");
+
+        match &state.waiting_for {
+            WaitingFor::ChooseFromZoneChoice { cards, .. } => {
+                assert_eq!(cards, &vec![first]);
+            }
+            other => panic!("expected ChooseFromZoneChoice, got {other:?}"),
+        }
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn cast_copy_uses_spell_ability_when_non_spell_ability_is_first() {
+        let mut state = GameState::new_two_player(7);
+        let source_id = add_exiled_spell_card(&mut state, "Lightning Bolt");
+        let source = state
+            .objects
+            .get_mut(&source_id)
+            .expect("source object exists");
+        source.abilities = Arc::new(vec![
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "activated ability".to_string(),
+                    description: None,
+                },
+            ),
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Unimplemented {
+                    name: "spell ability".to_string(),
+                    description: None,
+                },
+            ),
+        ]);
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CastCopyOfCard {
+                target: TargetFilter::None,
+                cost: ManaCost::zero(),
+            },
+            vec![TargetRef::Object(source_id)],
+            ObjectId(99),
+            PlayerId(0),
+        );
+
+        resolve(&mut state, &ability, &mut events).expect("cast copy resolves");
+
+        let entry = state.stack.back().expect("copy on stack");
+        match &entry.kind {
+            StackEntryKind::Spell {
+                ability: Some(resolved),
+                ..
+            } => assert!(matches!(
+                resolved.effect,
+                Effect::Unimplemented { ref name, .. } if name == "spell ability"
+            )),
+            other => panic!("expected spell with resolved ability, got {other:?}"),
+        }
     }
 }

--- a/crates/engine/src/game/effects/cast_copy_of_card.rs
+++ b/crates/engine/src/game/effects/cast_copy_of_card.rs
@@ -1,0 +1,303 @@
+use crate::game::ability_utils::build_resolved_from_def;
+use crate::game::effects::prepare::open_copy_target_selection;
+use crate::game::filter::{matches_target_filter, FilterContext};
+use crate::types::ability::{
+    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
+};
+use crate::types::events::GameEvent;
+use crate::types::game_state::{
+    CastingVariant, GameState, PendingContinuation, StackEntry, StackEntryKind, WaitingFor,
+};
+use crate::types::identifiers::ObjectId;
+use crate::types::zones::Zone;
+
+/// CR 707.12: Cast a copy of a card/object. The copy is created from the
+/// source object's copiable values and put onto the stack as part of casting.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let (target_filter, cost) = match &ability.effect {
+        Effect::CastCopyOfCard { target, cost } => (target, cost),
+        _ => return Err(EffectError::MissingParam("CastCopyOfCard".to_string())),
+    };
+
+    let mut source_ids: Vec<ObjectId> = ability
+        .targets
+        .iter()
+        .filter_map(|target| match target {
+            TargetRef::Object(id) => Some(*id),
+            TargetRef::Player(_) => None,
+        })
+        .collect();
+
+    if source_ids.is_empty() && references_tracked_set(target_filter) {
+        let ctx = FilterContext::from_ability(ability);
+        let effective_filter =
+            crate::game::targeting::resolve_tracked_set_sentinel(state, target_filter.clone());
+        source_ids = crate::game::targeting::latest_tracked_set_id(state)
+            .and_then(|id| state.tracked_object_sets.get(&id).cloned())
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|id| matches_target_filter(state, *id, &effective_filter, &ctx))
+            .collect();
+
+        if !source_ids.is_empty() {
+            let count = source_ids.len();
+            let mut resume = ability.clone();
+            resume.effect = Effect::CastCopyOfCard {
+                target: TargetFilter::None,
+                cost: cost.clone(),
+            };
+            resume.sub_ability = None;
+            state.pending_continuation = Some(PendingContinuation::new(Box::new(resume)));
+            state.waiting_for = WaitingFor::ChooseFromZoneChoice {
+                player: ability.controller,
+                cards: source_ids,
+                count,
+                up_to: true,
+                constraint: None,
+                source_id: ability.source_id,
+            };
+            return Ok(());
+        }
+    }
+
+    if source_ids.is_empty() {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::CastCopyOfCard,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
+    for (index, source_id) in source_ids.iter().copied().enumerate() {
+        let copy_id =
+            cast_one_copy(state, source_id, ability, events).map_err(EffectError::InvalidParam)?;
+
+        if open_copy_target_selection(state, copy_id, ability.controller)
+            .map_err(EffectError::InvalidParam)?
+        {
+            let mut resume = ability.clone();
+            resume.effect = Effect::CastCopyOfCard {
+                target: TargetFilter::None,
+                cost: cost.clone(),
+            };
+            resume.sub_ability = None;
+            if index + 1 < source_ids.len() {
+                resume.targets = source_ids[index + 1..]
+                    .iter()
+                    .copied()
+                    .map(TargetRef::Object)
+                    .collect();
+            } else {
+                resume.targets.clear();
+            }
+            super::append_to_pending_continuation(state, Some(Box::new(resume)));
+            return Ok(());
+        }
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::CastCopyOfCard,
+        source_id: ability.source_id,
+    });
+    Ok(())
+}
+
+fn references_tracked_set(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::TrackedSet { .. } | TargetFilter::TrackedSetFiltered { .. } => true,
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(references_tracked_set)
+        }
+        TargetFilter::Not { filter } => references_tracked_set(filter),
+        _ => false,
+    }
+}
+
+fn cast_one_copy(
+    state: &mut GameState,
+    source_id: ObjectId,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<ObjectId, String> {
+    let (source, card_id, origin_zone) = {
+        let Some(source) = state.objects.get(&source_id) else {
+            return Err(format!("copy source {source_id:?} not found"));
+        };
+        (source.clone(), source.card_id, source.zone)
+    };
+
+    let copy_id = ObjectId(state.next_object_id);
+    state.next_object_id += 1;
+
+    let ability_def = source.abilities.first().cloned();
+    let mut copy = source;
+    copy.id = copy_id;
+    copy.controller = ability.controller;
+    copy.owner = ability.controller;
+    copy.zone = Zone::Stack;
+    copy.is_token = true;
+    copy.tapped = false;
+    copy.prepared = None;
+    copy.cast_from_zone = Some(origin_zone);
+    copy.cost_x_paid = None;
+    copy.kickers_paid.clear();
+    copy.additional_cost_payment_count = 0;
+    state.objects.insert(copy_id, copy);
+
+    let mut resolved =
+        ability_def.map(|def| build_resolved_from_def(&def, copy_id, ability.controller));
+    if let Some(resolved) = resolved.as_mut() {
+        resolved.context.cast_from_zone = Some(origin_zone);
+    }
+
+    state.stack.push_back(StackEntry {
+        id: copy_id,
+        source_id: copy_id,
+        controller: ability.controller,
+        kind: StackEntryKind::Spell {
+            card_id,
+            ability: resolved,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+    events.push(GameEvent::StackPushed { object_id: copy_id });
+    events.push(GameEvent::SpellCast {
+        card_id,
+        controller: ability.controller,
+        object_id: copy_id,
+    });
+    if let Some(obj) = state.objects.get(&copy_id).cloned() {
+        crate::game::restrictions::record_spell_cast_from_zone(
+            state,
+            ability.controller,
+            &obj,
+            origin_zone,
+            CastingVariant::Normal,
+        );
+    }
+
+    Ok(copy_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use crate::game::zones::create_object;
+    use crate::types::ability::{AbilityDefinition, AbilityKind};
+    use crate::types::card_type::CoreType;
+    use crate::types::identifiers::{CardId, TrackedSetId};
+    use crate::types::mana::ManaCost;
+    use crate::types::player::PlayerId;
+
+    fn add_exiled_spell_card(state: &mut GameState, name: &str) -> ObjectId {
+        let owner = PlayerId(0);
+        let id = create_object(
+            state,
+            CardId(state.next_object_id),
+            owner,
+            name.to_string(),
+            Zone::Exile,
+        );
+        let obj = state.objects.get_mut(&id).expect("created object exists");
+        obj.card_types.core_types.push(CoreType::Instant);
+        obj.abilities = Arc::new(vec![AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Unimplemented {
+                name: "test spell".to_string(),
+                description: None,
+            },
+        )]);
+        id
+    }
+
+    #[test]
+    fn explicit_target_casts_a_stack_copy_without_moving_source_card() {
+        let mut state = GameState::new_two_player(7);
+        let source_id = add_exiled_spell_card(&mut state, "Lightning Bolt");
+        let source_card_id = state
+            .objects
+            .get(&source_id)
+            .expect("source exists")
+            .card_id;
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CastCopyOfCard {
+                target: TargetFilter::None,
+                cost: ManaCost::zero(),
+            },
+            vec![TargetRef::Object(source_id)],
+            ObjectId(99),
+            PlayerId(0),
+        );
+
+        resolve(&mut state, &ability, &mut events).expect("cast copy resolves");
+
+        assert_eq!(
+            state.objects.get(&source_id).expect("source exists").zone,
+            Zone::Exile
+        );
+        assert_eq!(state.stack.len(), 1);
+        let copy_id = state.stack.back().expect("copy on stack").id;
+        let copy = state.objects.get(&copy_id).expect("copy object exists");
+        assert_eq!(copy.zone, Zone::Stack);
+        assert!(copy.is_token);
+        assert_eq!(copy.owner, PlayerId(0));
+        assert_eq!(copy.controller, PlayerId(0));
+        assert!(matches!(
+            state.stack.back().expect("copy on stack").kind,
+            StackEntryKind::Spell { card_id, .. } if card_id == source_card_id
+        ));
+        assert!(events.iter().any(|event| {
+            matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == copy_id)
+        }));
+    }
+
+    #[test]
+    fn tracked_set_opens_up_to_choice_for_copies_to_cast() {
+        let mut state = GameState::new_two_player(7);
+        let first = add_exiled_spell_card(&mut state, "Opt");
+        let second = add_exiled_spell_card(&mut state, "Consider");
+        state
+            .tracked_object_sets
+            .insert(TrackedSetId(1), vec![first, second]);
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CastCopyOfCard {
+                target: TargetFilter::TrackedSet {
+                    id: TrackedSetId(0),
+                },
+                cost: ManaCost::zero(),
+            },
+            Vec::new(),
+            ObjectId(99),
+            PlayerId(0),
+        );
+
+        resolve(&mut state, &ability, &mut events).expect("choice opens");
+
+        match &state.waiting_for {
+            WaitingFor::ChooseFromZoneChoice {
+                player,
+                cards,
+                count,
+                up_to,
+                ..
+            } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(*count, 2);
+                assert!(*up_to);
+                assert_eq!(cards, &vec![first, second]);
+            }
+            other => panic!("expected ChooseFromZoneChoice, got {other:?}"),
+        }
+        assert!(state.pending_continuation.is_some());
+        assert!(events.is_empty());
+    }
+}

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -31,6 +31,7 @@ pub mod blight;
 pub mod bolster;
 pub mod bounce;
 pub mod cascade;
+pub mod cast_copy_of_card;
 pub mod cast_from_zone;
 pub mod change_targets;
 pub mod change_zone;
@@ -1356,6 +1357,7 @@ pub fn resolve_effect(
         Effect::SeparateIntoPiles { .. } => separate_piles::resolve(state, ability, events),
         Effect::SwitchPT { .. } => switch_pt::resolve(state, ability, events),
         Effect::CopySpell { .. } => copy_spell::resolve(state, ability, events),
+        Effect::CastCopyOfCard { .. } => cast_copy_of_card::resolve(state, ability, events),
         Effect::CopyTokenOf { .. } => token_copy::resolve(state, ability, events),
         Effect::Myriad => myriad::resolve(state, ability, events),
         Effect::BecomeCopy { .. } => become_copy::resolve(state, ability, events),
@@ -1676,6 +1678,9 @@ fn effect_uses_implicit_tracked_set_targets(effect: &Effect) -> bool {
     matches!(
         effect,
         Effect::GrantCastingPermission {
+            target: TargetFilter::TrackedSet { .. },
+            ..
+        } | Effect::CastCopyOfCard {
             target: TargetFilter::TrackedSet { .. },
             ..
         } | Effect::PutAtLibraryPosition {
@@ -2194,6 +2199,7 @@ fn extract_event_context_filter(effect: &Effect) -> Option<&TargetFilter> {
         | Effect::UnattachAll { target, .. }
         | Effect::Transform { target, .. }
         | Effect::CopySpell { target, .. }
+        | Effect::CastCopyOfCard { target, .. }
         | Effect::CopyTokenOf { target, .. }
         | Effect::BecomeCopy { target, .. }
         | Effect::CastFromZone { target, .. }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -653,6 +653,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::Clash
         | Effect::SwitchPT { .. }
         | Effect::CopySpell { .. }
+        | Effect::CastCopyOfCard { .. }
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
         | Effect::BecomeCopy { .. }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -10426,6 +10426,40 @@ fn rewrite_filter_parent_to_tracked_set(filter: &mut TargetFilter) {
     }
 }
 
+fn fold_cast_copy_of_card_defs(defs: &mut Vec<AbilityDefinition>) {
+    let mut index = 0;
+    while index + 1 < defs.len() {
+        let copies_parent_card = matches!(
+            &*defs[index].effect,
+            Effect::CopySpell {
+                target: TargetFilter::ParentTarget,
+                ..
+            }
+        );
+        let casts_the_copy_without_paying = matches!(
+            &*defs[index + 1].effect,
+            Effect::CastFromZone {
+                target: TargetFilter::ParentTarget,
+                without_paying_mana_cost: true,
+                mode: CardPlayMode::Cast,
+                ..
+            }
+        );
+
+        if copies_parent_card && casts_the_copy_without_paying {
+            *defs[index].effect = Effect::CastCopyOfCard {
+                target: tracked_set_filter(),
+                cost: ManaCost::zero(),
+            };
+            defs[index].optional = false;
+            defs[index].repeat_for = None;
+            defs.remove(index + 1);
+        } else {
+            index += 1;
+        }
+    }
+}
+
 fn rewrite_parent_targets_to_tracked_set(effect: &mut Effect) {
     match effect {
         Effect::Tap { target }
@@ -10441,6 +10475,7 @@ fn rewrite_parent_targets_to_tracked_set(effect: &mut Effect) {
         | Effect::Connive { target, .. }
         | Effect::PhaseOut { target }
         | Effect::ForceBlock { target }
+        | Effect::CastCopyOfCard { target, .. }
         | Effect::CopyTokenOf { target, .. }
         | Effect::PutCounter { target, .. }
         | Effect::AddCounter { target, .. }
@@ -13812,6 +13847,12 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
     // `state.last_created_token_ids` (snapshotted at delayed-trigger
     // creation for the Sacrifice case — CR 603.7c).
     resolve_populated_token_anaphors(&mut defs);
+
+    // CR 707.12: "Copy [a card]. You may cast the copy ..." is not a stack
+    // copy (CR 707.10). It creates a card copy in the source zone, then casts
+    // that copy during resolution. Fold the two parsed imperative clauses into
+    // the dedicated engine primitive before generic chain assembly.
+    fold_cast_copy_of_card_defs(&mut defs);
 
     // CR 706 + CR 705: Consolidate die result table lines into their parent RollDie,
     // and coin flip conditional branches into their parent FlipCoin.
@@ -27407,6 +27448,42 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn mizzix_mastery_folds_card_copy_cast_to_cr_707_12_effect() {
+        let def = parse_effect_chain(
+            "Exile target card that's an instant or sorcery from your graveyard. For each card exiled this way, copy it. You may cast the copy without paying its mana cost.",
+            AbilityKind::Spell,
+        );
+        assert!(matches!(
+            def.effect.as_ref(),
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                ..
+            }
+        ));
+
+        let cast_copy = def
+            .sub_ability
+            .as_deref()
+            .expect("card-copy cast sub-ability");
+        let Effect::CastCopyOfCard { target, cost } = cast_copy.effect.as_ref() else {
+            panic!("expected CastCopyOfCard, got {:?}", cast_copy.effect);
+        };
+        assert_eq!(
+            *target,
+            TargetFilter::TrackedSet {
+                id: TrackedSetId(0)
+            }
+        );
+        assert_eq!(cost, &ManaCost::zero());
+        assert!(
+            cast_copy.repeat_for.is_none(),
+            "resolver chooses and casts the tracked-set copies as one CR 707.12 instruction"
+        );
+        assert!(!cast_copy.optional);
+        assert!(cast_copy.sub_ability.is_none());
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2486,6 +2486,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::SeparateIntoPiles { .. }
         | Effect::SwitchPT { .. }
         | Effect::CopySpell { .. }
+        | Effect::CastCopyOfCard { .. }
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
         | Effect::BecomeCopy { .. }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5502,6 +5502,16 @@ pub enum Effect {
         #[serde(default = "default_copy_keep_targets")]
         retarget: CopyRetargetPermission,
     },
+    /// CR 707.12: Create a copy of a card/object in its zone and cast that
+    /// copy while the resolving spell or ability continues resolving.
+    CastCopyOfCard {
+        #[serde(default = "default_target_filter_any")]
+        target: TargetFilter,
+        /// CR 118.9 + CR 601.2f: Alternative mana cost used to cast the copy.
+        /// Mizzix's Mastery and Cipher use `ManaCost::zero()`.
+        #[serde(default)]
+        cost: ManaCost,
+    },
     /// CR 707.2 / CR 707.5: Create a token that's a copy of a permanent.
     /// Copies copiable characteristics (name, mana cost, color, types, P/T, abilities, keywords)
     /// from the chosen copy source to a newly created token on the battlefield.
@@ -7240,6 +7250,7 @@ impl Effect {
             | Effect::Bounce { target, .. }
             | Effect::SwitchPT { target, .. }
             | Effect::CopySpell { target, .. }
+            | Effect::CastCopyOfCard { target, .. }
             | Effect::BecomeCopy { target, .. }
             | Effect::ChooseCard { target, .. }
             | Effect::PutCounter { target, .. }
@@ -7528,6 +7539,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::SeparateIntoPiles { .. } => "SeparateIntoPiles",
         Effect::SwitchPT { .. } => "SwitchPT",
         Effect::CopySpell { .. } => "CopySpell",
+        Effect::CastCopyOfCard { .. } => "CastCopyOfCard",
         Effect::CopyTokenOf { .. } => "CopyTokenOf",
         Effect::Myriad => "Myriad",
         Effect::BecomeCopy { .. } => "BecomeCopy",
@@ -7707,6 +7719,7 @@ pub enum EffectKind {
     SeparateIntoPiles,
     SwitchPT,
     CopySpell,
+    CastCopyOfCard,
     CopyTokenOf,
     Myriad,
     BecomeCopy,
@@ -7885,6 +7898,7 @@ impl From<&Effect> for EffectKind {
             Effect::SeparateIntoPiles { .. } => EffectKind::SeparateIntoPiles,
             Effect::SwitchPT { .. } => EffectKind::SwitchPT,
             Effect::CopySpell { .. } => EffectKind::CopySpell,
+            Effect::CastCopyOfCard { .. } => EffectKind::CastCopyOfCard,
             Effect::CopyTokenOf { .. } => EffectKind::CopyTokenOf,
             Effect::Myriad => EffectKind::Myriad,
             Effect::BecomeCopy { .. } => EffectKind::BecomeCopy,

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -354,6 +354,7 @@ fn redundancy_delta(
         | Effect::SeparateIntoPiles { .. }
         | Effect::SwitchPT { .. }
         | Effect::CopySpell { .. }
+        | Effect::CastCopyOfCard { .. }
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
         | Effect::BecomeCopy { .. }


### PR DESCRIPTION
## Summary
Fixes **Mizzix's Mastery** so exiled card copies can be cast without paying their mana costs.

Resolves #585.

## Files changed
- crates/engine/src/game/coverage.rs
- crates/engine/src/game/effects/cast_copy_of_card.rs
- crates/engine/src/game/effects/mod.rs
- crates/engine/src/game/printed_cards.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/parser/oracle_effect/sequence.rs
- crates/engine/src/types/ability.rs
- crates/phase-ai/src/policies/redundancy_avoidance.rs

## CR references
- CR 707.12
- CR 707.10
- CR 118.9
- CR 601.2f

## Track
Developer

## LLM
Model: codex-5
Thinking: high
Tier: Standard

## Verification
- `cargo fmt --all` - clean
- `./scripts/check-parser-combinators.sh` - clean
- `cargo clippy --all-targets -- -D warnings` - clean
- `cargo test -p engine` - 8862 unit passed / 0 failed, 471 integration passed / 0 failed, doctests ignored
- `./scripts/gen-card-data.sh` - clean; `Mizzix's Mastery`: `supported: true`, `gap_count: 0`
- `cargo coverage` - clean; `Mizzix's Mastery`: `supported: true`, `gap_count: 0`
- `cargo semantic-audit` - clean for `Mizzix's Mastery`; 0 findings for this card

## Gate A
`./scripts/check-parser-combinators.sh` exited 0 with no stdout.

## Anchored on
- crates/engine/src/game/effects/paradigm.rs:117 - existing cast-copy path clones a source object, assigns a fresh object id, and puts the copy on the stack as a spell.
- crates/engine/src/game/effects/prepare.rs:156 - shared copy-cast target-selection helper opens `WaitingFor::CopyRetarget` for fresh spell copies.
- crates/engine/src/game/effects/copy_spell.rs:43 - existing stack-copy resolver allocates a fresh object id and models spell copies as stack objects.

## Scope Expansion
Adds reusable `Effect::CastCopyOfCard` engine support for CR 707.12 card-copy casting, separate from CR 707.10 stack-copy handling.

## Validation Failures
None.

## CI Failures
None.
