### PR TITLE
FIX Prevent lobby host self-join

### DIFF
--- a/crates/lobby-broker/src/broker.rs
+++ b/crates/lobby-broker/src/broker.rs
@@ -419,6 +419,14 @@ impl Broker {
         password: Option<String>,
         reservation_token: Option<String>,
     ) -> Vec<Outbound> {
+        if conn
+            .host_game
+            .as_deref()
+            .is_some_and(|owned| owned == game_code)
+        {
+            return vec![error("You are already hosting this game")];
+        }
+
         let guest_commit = conn
             .client_hello
             .as_ref()
@@ -502,6 +510,14 @@ impl Broker {
         let mut out = Vec::new();
         let mut reservation_token = None;
         let mut reservation_expires_at_ms = None;
+
+        if conn
+            .host_game
+            .as_deref()
+            .is_some_and(|owned| owned == game_code)
+        {
+            return vec![error("You are already hosting this game")];
+        }
 
         // --- build-commit + password gates, then snapshot ---
         let guest_commit = conn
@@ -1049,6 +1065,60 @@ mod tests {
         assert!(matches!(
             out.as_slice(),
             [Outbound::ToSelf(LobbyServerMessage::PeerInfo { .. })]
+        ));
+    }
+
+    #[test]
+    fn host_cannot_join_own_game() {
+        let env = FakeEnv::new();
+        let mut broker = Broker::new();
+        let mut host = ConnState::default();
+        hello(&mut host, &mut broker, &env);
+        let created = create(&mut host, &mut broker, &env);
+        let code = game_code_of(&created);
+
+        let out = broker.handle(
+            &mut host,
+            LobbyClientMessage::JoinGameWithPassword {
+                game_code: code,
+                deck: test_deck(),
+                display_name: "Host".into(),
+                password: None,
+                reservation_token: None,
+            },
+            &env,
+        );
+
+        assert!(matches!(
+            out.as_slice(),
+            [Outbound::ToSelf(LobbyServerMessage::Error { .. })]
+        ));
+    }
+
+    #[test]
+    fn host_cannot_lookup_own_game() {
+        let env = FakeEnv::new();
+        let mut broker = Broker::new();
+        let mut host = ConnState::default();
+        hello(&mut host, &mut broker, &env);
+        let created = create(&mut host, &mut broker, &env);
+        let code = game_code_of(&created);
+
+        let out = broker.handle(
+            &mut host,
+            LobbyClientMessage::LookupJoinTarget {
+                game_code: code,
+                password: None,
+                reserve: false,
+                display_name: Some("Host".into()),
+                release_reservation_token: None,
+            },
+            &env,
+        );
+
+        assert!(matches!(
+            out.as_slice(),
+            [Outbound::ToSelf(LobbyServerMessage::Error { .. })]
         ));
     }
 

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1828,6 +1828,10 @@ fn is_joining_current_game(identity: &SocketIdentity, target_game_code: &str) ->
         .game_code
         .as_deref()
         .is_some_and(|active| active == target_game_code)
+        || identity
+            .lobby_host_game
+            .as_deref()
+            .is_some_and(|hosted| hosted == target_game_code)
 }
 
 async fn reject_joining_current_game(
@@ -4385,6 +4389,11 @@ mod handshake_tests {
 
         assert!(is_joining_current_game(&identity, "GAME01"));
         assert!(!is_joining_current_game(&identity, "GAME02"));
+
+        let mut lobby_identity = empty_identity();
+        lobby_identity.lobby_host_game = Some("GAME01".to_string());
+        assert!(is_joining_current_game(&lobby_identity, "GAME01"));
+        assert!(!is_joining_current_game(&lobby_identity, "GAME02"));
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1823,6 +1823,31 @@ async fn require_host(identity: &SocketIdentity, socket: &mut WebSocket) -> Resu
     Ok(())
 }
 
+fn is_joining_current_game(identity: &SocketIdentity, target_game_code: &str) -> bool {
+    identity
+        .game_code
+        .as_deref()
+        .is_some_and(|active| active == target_game_code)
+}
+
+async fn reject_joining_current_game(
+    identity: &SocketIdentity,
+    target_game_code: &str,
+    socket: &mut WebSocket,
+) -> Result<(), ()> {
+    if !is_joining_current_game(identity, target_game_code) {
+        return Ok(());
+    }
+
+    let msg = ServerMessage::Error {
+        message: "You are already in this game.".to_string(),
+    };
+    if let Ok(json) = serde_json::to_string(&msg) {
+        let _ = socket.send(Message::text(json)).await;
+    }
+    Err(())
+}
+
 async fn draft_pack_generator_for_start(
     draft_state: &SharedDraftState,
     draft_pools: &SharedDraftPools,
@@ -1989,6 +2014,13 @@ async fn handle_client_message(
 
         ClientMessage::JoinGame { game_code, deck } => {
             info!(game = %game_code, deck_size = deck.main_deck.len(), "JoinGame");
+            if reject_joining_current_game(identity, &game_code, socket)
+                .await
+                .is_err()
+            {
+                return;
+            }
+
             let resolved = match resolve_deck(db, &deck) {
                 Ok(entries) => entries,
                 Err(e) => {
@@ -2813,6 +2845,13 @@ async fn handle_client_message(
         } => {
             info!(game = %game_code, "LookupJoinTarget");
 
+            if reject_joining_current_game(identity, &game_code, socket)
+                .await
+                .is_err()
+            {
+                return;
+            }
+
             let mut reservation_token = None;
             let mut reservation_expires_at_ms = None;
 
@@ -3052,6 +3091,13 @@ async fn handle_client_message(
             reservation_token,
         } => {
             info!(game = %game_code, joiner = %display_name, "JoinGameWithPassword");
+
+            if reject_joining_current_game(identity, &game_code, socket)
+                .await
+                .is_err()
+            {
+                return;
+            }
 
             // --- Lobby-only broker path ------------------------------
             //
@@ -4121,6 +4167,25 @@ mod handshake_tests {
     use engine::types::actions::GameAction;
     use server_core::protocol::DeckData;
 
+    fn empty_identity() -> SocketIdentity {
+        SocketIdentity {
+            game_code: None,
+            player_id: None,
+            player_token: None,
+            lobby_subscribed: false,
+            session_span: None,
+            client_hello: None,
+            lobby_host_game: None,
+            seat_reservations: Vec::new(),
+            lobby_reservations: Vec::new(),
+            draft_code: None,
+            draft_seat: None,
+            draft_token: None,
+            spectator_draft_code: None,
+            spectator_visibility: None,
+        }
+    }
+
     fn empty_deck() -> DeckData {
         DeckData {
             main_deck: vec!["Forest".into()],
@@ -4310,6 +4375,22 @@ mod handshake_tests {
                 guest: "def5678".into(),
             }
         );
+    }
+
+    #[test]
+    fn joining_current_game_is_rejected_by_helper() {
+        let mut identity = empty_identity();
+        identity.game_code = Some("GAME01".to_string());
+        identity.player_id = Some(PlayerId(0));
+
+        assert!(is_joining_current_game(&identity, "GAME01"));
+        assert!(!is_joining_current_game(&identity, "GAME02"));
+    }
+
+    #[test]
+    fn joining_without_active_game_is_allowed_by_helper() {
+        let identity = empty_identity();
+        assert!(!is_joining_current_game(&identity, "GAME01"));
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes a lobby regression where the host could join their own game and become their own opponent.

## Files changed
- crates/phase-server/src/main.rs
- crates/lobby-broker/src/broker.rs

## Track
Developer

## LLM
Model: gpt-5.3-codex
Thinking: medium
Tier: Standard

## Gate A
CHECK_PARSER_EXIT=0

## Anchored on
- crates/phase-server/src/main.rs:1813 — existing identity-based host guard (equire_host) and error reply pattern in the same handler module.
- crates/lobby-broker/src/broker.rs:626 — existing broker ownership gate (Only the lobby host can update metadata) using conn.host_game authority checks.

## Verification
- cargo fmt --all — clean
- ./scripts/check-parser-combinators.sh (via ash -lc) — clean (CHECK_PARSER_EXIT=0)
- cargo clippy-strict — clean (CLIPPY_EXIT=0)
- cargo test -p lobby-broker -p phase-server — clean (TEST_EXIT=0)
- ./scripts/gen-card-data.sh (via ash -lc) — long-running compile did not complete in this session before termination
- cargo coverage — long-running compile did not complete in this session before termination
- cargo semantic-audit — not run (blocked on prior long-running verification commands)

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
Local long-running verification could not be completed in this Windows session for:
- ./scripts/gen-card-data.sh
- cargo coverage
- cargo semantic-audit (not run after prior two remained incomplete)