### PR TITLE
Graduate cube + pod draft out of experimental gating

### DIFF
--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -74,7 +74,6 @@ const SETTINGS_TABS = [
   { id: "audio" },
   { id: "multiplayer" },
   { id: "data" },
-  { id: "experimental" },
 ] as const;
 
 export type SettingsTabId = (typeof SETTINGS_TABS)[number]["id"];
@@ -566,8 +565,6 @@ export function PreferencesModal({
           <DataSection />
         </>
       )}
-
-              {activeTab === "experimental" && <ExperimentalSection />}
             </div>
             <ResetAllFooter resetAllPreferences={resetAllPreferences} />
           </div>
@@ -601,36 +598,6 @@ function ResetAllFooter({
         {t("resetAll.button")}
       </button>
     </div>
-  );
-}
-
-function ExperimentalSection() {
-  const { t } = useTranslation("settings");
-  const experimentalFeatures = usePreferencesStore((s) => s.experimentalFeatures);
-  const setExperimentalFeatures = usePreferencesStore((s) => s.setExperimentalFeatures);
-  return (
-    <SettingsSection title={t("experimental.title")}>
-      <p className="text-xs text-slate-400">
-        {t("experimental.description")}
-      </p>
-
-      <SettingGroup label={t("experimental.draftExperiments")}>
-        <label className="flex min-h-11 items-center gap-3">
-          <input
-            type="checkbox"
-            checked={experimentalFeatures}
-            onChange={(e) => setExperimentalFeatures(e.target.checked)}
-            className="accent-cyan-500"
-          />
-          <div className="flex flex-col">
-            <span className="text-sm text-slate-200">{t("experimental.enableDraftFeatures")}</span>
-            <span className="text-xs text-slate-500">
-              {t("experimental.draftFeaturesDescription")}
-            </span>
-          </div>
-        </label>
-      </SettingGroup>
-    </SettingsSection>
   );
 }
 

--- a/client/src/i18n/locales/de/draft.json
+++ b/client/src/i18n/locales/de/draft.json
@@ -112,7 +112,6 @@
   "landing": {
     "title": "Draft",
     "startNew": "Neu starten",
-    "experimental": "Experimentell",
     "quickDraft": {
       "title": "Quick Draft",
       "description": "Drafte 3 Booster mit 7 KI-Draftern, baue ein 40-Karten-Deck und spiele dann eine Bo1-Partie gegen einen von ihnen."

--- a/client/src/i18n/locales/de/menu.json
+++ b/client/src/i18n/locales/de/menu.json
@@ -38,7 +38,7 @@
     },
     "draft": {
       "title": "Draft",
-      "description": "Quick Draft gegen KI sowie experimentelle Cube- und Pod-Draft-Optionen."
+      "description": "Quick Draft gegen KI, Cube-Draft oder hoste einen Pod-Draft."
     },
     "decks": {
       "title": "Decks",

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -9,8 +9,7 @@
     "combat": "Tempo",
     "audio": "Audio",
     "multiplayer": "Mehrspieler",
-    "data": "Daten",
-    "experimental": "Experimentell"
+    "data": "Daten"
   },
   "gameplay": {
     "title": "Spielablauf",
@@ -84,13 +83,6 @@
     "displayName": "Anzeigename",
     "displayNamePlaceholder": "Gib deinen Namen ein",
     "serverSelectionNote": "Die Serverauswahl ist in die Lobby verschoben — öffne den Mehrspielermodus und verwende den Server-Chip (oder „Server wählen“ im P2P-Modus), um Regionen zu wechseln, eine selbst gehostete Instanz zu konfigurieren oder die Verbindung zu testen."
-  },
-  "experimental": {
-    "title": "Experimentell",
-    "description": "Diese Funktionen befinden sich noch in Entwicklung. Sie können unvollständig oder fehlerhaft sein oder sich ohne Vorankündigung ändern. Aktiviere sie, um Dinge frühzeitig auszuprobieren.",
-    "draftExperiments": "Draft-Experimente",
-    "enableDraftFeatures": "Experimentelle Draft-Funktionen aktivieren",
-    "draftFeaturesDescription": "Schaltet Cube Draft und Pod Draft frei. Quick Draft gegen KI ist immer verfügbar."
   },
   "sync": {
     "title": "Cloud-Synchronisierung",

--- a/client/src/i18n/locales/en/draft.json
+++ b/client/src/i18n/locales/en/draft.json
@@ -112,7 +112,6 @@
   "landing": {
     "title": "Draft",
     "startNew": "Start New",
-    "experimental": "Experimental",
     "quickDraft": {
       "title": "Quick Draft",
       "description": "Draft 3 packs with 7 AI drafters, build a 40-card deck, then play a Bo1 match against one of them."

--- a/client/src/i18n/locales/en/menu.json
+++ b/client/src/i18n/locales/en/menu.json
@@ -38,7 +38,7 @@
     },
     "draft": {
       "title": "Draft",
-      "description": "Quick Draft against AI, plus experimental cube and pod draft options."
+      "description": "Quick Draft against AI, cube draft, or host a pod draft."
     },
     "decks": {
       "title": "Decks",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -9,8 +9,7 @@
     "combat": "Pacing",
     "audio": "Audio",
     "multiplayer": "Multiplayer",
-    "data": "Data",
-    "experimental": "Experimental"
+    "data": "Data"
   },
   "gameplay": {
     "title": "Gameplay",
@@ -84,13 +83,6 @@
     "displayName": "Display Name",
     "displayNamePlaceholder": "Enter your name",
     "serverSelectionNote": "Server selection moved to the lobby — open Multiplayer and use the server chip (or \"Pick server\" in P2P mode) to switch regions, configure a self-hosted instance, or test connectivity."
-  },
-  "experimental": {
-    "title": "Experimental",
-    "description": "These features are still in development. They may be incomplete, buggy, or change without notice. Enable them to try things out early.",
-    "draftExperiments": "Draft Experiments",
-    "enableDraftFeatures": "Enable experimental draft features",
-    "draftFeaturesDescription": "Unlocks Cube Draft and Pod Draft. Quick Draft vs AI is always available."
   },
   "sync": {
     "title": "Cloud Sync",

--- a/client/src/i18n/locales/es/draft.json
+++ b/client/src/i18n/locales/es/draft.json
@@ -112,7 +112,6 @@
   "landing": {
     "title": "Draft",
     "startNew": "Empezar nuevo",
-    "experimental": "Experimental",
     "quickDraft": {
       "title": "Quick Draft",
       "description": "Draftea 3 sobres con 7 drafteadores de IA, construye un mazo de 40 cartas y luego juega una partida Bo1 contra uno de ellos."

--- a/client/src/i18n/locales/es/menu.json
+++ b/client/src/i18n/locales/es/menu.json
@@ -38,7 +38,7 @@
     },
     "draft": {
       "title": "Draft",
-      "description": "Quick Draft contra la IA, además de opciones experimentales de cube y pod draft."
+      "description": "Quick Draft contra la IA, draft de cube o aloja un pod draft."
     },
     "decks": {
       "title": "Mazos",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -9,8 +9,7 @@
     "combat": "Ritmo",
     "audio": "Audio",
     "multiplayer": "Multijugador",
-    "data": "Datos",
-    "experimental": "Experimental"
+    "data": "Datos"
   },
   "gameplay": {
     "title": "Jugabilidad",
@@ -84,13 +83,6 @@
     "displayName": "Nombre visible",
     "displayNamePlaceholder": "Introduce tu nombre",
     "serverSelectionNote": "La selección de servidor se trasladó a la sala de espera — abre Multijugador y usa el chip de servidor (o \"Elegir servidor\" en modo P2P) para cambiar de región, configurar una instancia autoalojada o probar la conectividad."
-  },
-  "experimental": {
-    "title": "Experimental",
-    "description": "Estas funciones aún están en desarrollo. Pueden estar incompletas, tener errores o cambiar sin previo aviso. Actívalas para probar cosas pronto.",
-    "draftExperiments": "Experimentos de draft",
-    "enableDraftFeatures": "Activar funciones experimentales de draft",
-    "draftFeaturesDescription": "Desbloquea Cube Draft y Pod Draft. Quick Draft contra la IA siempre está disponible."
   },
   "sync": {
     "title": "Sincronización en la nube",

--- a/client/src/i18n/locales/fr/draft.json
+++ b/client/src/i18n/locales/fr/draft.json
@@ -112,7 +112,6 @@
   "landing": {
     "title": "Draft",
     "startNew": "Démarrer un nouveau",
-    "experimental": "Expérimental",
     "quickDraft": {
       "title": "Quick Draft",
       "description": "Draftez 3 boosters avec 7 drafteurs IA, construisez un deck de 40 cartes, puis jouez un match Bo1 contre l'un d'eux."

--- a/client/src/i18n/locales/fr/menu.json
+++ b/client/src/i18n/locales/fr/menu.json
@@ -38,7 +38,7 @@
     },
     "draft": {
       "title": "Draft",
-      "description": "Quick Draft contre l'IA, plus des options expérimentales de cube et de pod draft."
+      "description": "Quick Draft contre l'IA, draft de cube ou hébergez un pod draft."
     },
     "decks": {
       "title": "Decks",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -9,8 +9,7 @@
     "combat": "Rythme",
     "audio": "Audio",
     "multiplayer": "Multijoueur",
-    "data": "Données",
-    "experimental": "Expérimental"
+    "data": "Données"
   },
   "gameplay": {
     "title": "Jouabilité",
@@ -84,13 +83,6 @@
     "displayName": "Nom affiché",
     "displayNamePlaceholder": "Saisissez votre nom",
     "serverSelectionNote": "La sélection du serveur a été déplacée vers le salon — ouvrez Multijoueur et utilisez la puce du serveur (ou « Choisir un serveur » en mode P2P) pour changer de région, configurer une instance auto-hébergée ou tester la connectivité."
-  },
-  "experimental": {
-    "title": "Expérimental",
-    "description": "Ces fonctionnalités sont encore en développement. Elles peuvent être incomplètes, comporter des bugs ou changer sans préavis. Activez-les pour les essayer en avance.",
-    "draftExperiments": "Expériences de draft",
-    "enableDraftFeatures": "Activer les fonctionnalités de draft expérimentales",
-    "draftFeaturesDescription": "Débloque le Cube Draft et le Pod Draft. Le Quick Draft contre l'IA est toujours disponible."
   },
   "sync": {
     "title": "Synchronisation cloud",

--- a/client/src/i18n/locales/it/draft.json
+++ b/client/src/i18n/locales/it/draft.json
@@ -112,7 +112,6 @@
   "landing": {
     "title": "Draft",
     "startNew": "Inizia nuovo",
-    "experimental": "Sperimentale",
     "quickDraft": {
       "title": "Quick Draft",
       "description": "Drafta 3 buste con 7 draftatori IA, costruisci un mazzo da 40 carte, poi gioca una partita Bo1 contro uno di loro."

--- a/client/src/i18n/locales/it/menu.json
+++ b/client/src/i18n/locales/it/menu.json
@@ -38,7 +38,7 @@
     },
     "draft": {
       "title": "Draft",
-      "description": "Quick Draft contro l'IA, più opzioni sperimentali di draft cube e pod."
+      "description": "Quick Draft contro l'IA, draft cube o ospita un pod draft."
     },
     "decks": {
       "title": "Mazzi",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -9,8 +9,7 @@
     "combat": "Ritmo",
     "audio": "Audio",
     "multiplayer": "Multigiocatore",
-    "data": "Dati",
-    "experimental": "Sperimentale"
+    "data": "Dati"
   },
   "gameplay": {
     "title": "Giocabilità",
@@ -84,13 +83,6 @@
     "displayName": "Nome visualizzato",
     "displayNamePlaceholder": "Inserisci il tuo nome",
     "serverSelectionNote": "La selezione del server è stata spostata nella lobby — apri Multigiocatore e usa il chip del server (o \"Scegli server\" in modalità P2P) per cambiare regione, configurare un'istanza self-hosted o testare la connettività."
-  },
-  "experimental": {
-    "title": "Sperimentale",
-    "description": "Queste funzioni sono ancora in sviluppo. Potrebbero essere incomplete, presentare bug o cambiare senza preavviso. Abilitale per provarle in anticipo.",
-    "draftExperiments": "Esperimenti di draft",
-    "enableDraftFeatures": "Abilita le funzioni sperimentali di draft",
-    "draftFeaturesDescription": "Sblocca Cube Draft e Pod Draft. Quick Draft contro l'IA è sempre disponibile."
   },
   "sync": {
     "title": "Sincronizzazione cloud",

--- a/client/src/i18n/locales/pl/draft.json
+++ b/client/src/i18n/locales/pl/draft.json
@@ -112,7 +112,6 @@
   "landing": {
     "title": "Draft",
     "startNew": "Rozpocznij nowy",
-    "experimental": "Eksperymentalne",
     "quickDraft": {
       "title": "Szybki draft",
       "description": "Zdraftuj 3 boostery z 7 botami, zbuduj talię z 40 kart, a potem rozegraj mecz Bo1 przeciwko jednemu z nich."

--- a/client/src/i18n/locales/pl/menu.json
+++ b/client/src/i18n/locales/pl/menu.json
@@ -38,7 +38,7 @@
     },
     "draft": {
       "title": "Draft",
-      "description": "Szybki draft przeciwko AI oraz eksperymentalne opcje draftu kostkowego i podu."
+      "description": "Szybki draft przeciwko AI, draft kostkowy lub hostuj draft podu."
     },
     "decks": {
       "title": "Talie",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -9,8 +9,7 @@
     "combat": "Tempo",
     "audio": "Dźwięk",
     "multiplayer": "Tryb wieloosobowy",
-    "data": "Dane",
-    "experimental": "Eksperymentalne"
+    "data": "Dane"
   },
   "gameplay": {
     "title": "Rozgrywka",
@@ -84,13 +83,6 @@
     "displayName": "Nazwa wyświetlana",
     "displayNamePlaceholder": "Wprowadź swoją nazwę",
     "serverSelectionNote": "Wybór serwera został przeniesiony do poczekalni — otwórz Tryb wieloosobowy i użyj plakietki serwera (lub „Wybierz serwer” w trybie P2P), aby zmieniać regiony, skonfigurować własną instancję lub przetestować połączenie."
-  },
-  "experimental": {
-    "title": "Eksperymentalne",
-    "description": "Te funkcje są wciąż w fazie rozwoju. Mogą być niekompletne, zawierać błędy lub zmieniać się bez ostrzeżenia. Włącz je, aby wypróbować nowości wcześniej.",
-    "draftExperiments": "Eksperymenty draftowe",
-    "enableDraftFeatures": "Włącz eksperymentalne funkcje draftu",
-    "draftFeaturesDescription": "Odblokowuje Cube Draft i Pod Draft. Szybki draft przeciwko AI jest zawsze dostępny."
   },
   "sync": {
     "title": "Synchronizacja w chmurze",

--- a/client/src/i18n/locales/pt/draft.json
+++ b/client/src/i18n/locales/pt/draft.json
@@ -112,7 +112,6 @@
   "landing": {
     "title": "Draft",
     "startNew": "Começar Novo",
-    "experimental": "Experimental",
     "quickDraft": {
       "title": "Quick Draft",
       "description": "Drafte 3 boosters com 7 draftadores de IA, monte um deck de 40 cartas e jogue uma partida Bo1 contra um deles."

--- a/client/src/i18n/locales/pt/menu.json
+++ b/client/src/i18n/locales/pt/menu.json
@@ -38,7 +38,7 @@
     },
     "draft": {
       "title": "Draft",
-      "description": "Quick Draft contra IA, além de opções experimentais de Cube e Pod Draft."
+      "description": "Quick Draft contra IA, Cube Draft ou hospede um Pod Draft."
     },
     "decks": {
       "title": "Decks",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -9,8 +9,7 @@
     "combat": "Ritmo",
     "audio": "Áudio",
     "multiplayer": "Multijogador",
-    "data": "Dados",
-    "experimental": "Experimental"
+    "data": "Dados"
   },
   "gameplay": {
     "title": "Jogabilidade",
@@ -84,13 +83,6 @@
     "displayName": "Nome de Exibição",
     "displayNamePlaceholder": "Digite seu nome",
     "serverSelectionNote": "A seleção de servidor foi movida para o lobby — abra o Multijogador e use o chip de servidor (ou \"Escolher servidor\" no modo P2P) para trocar de região, configurar uma instância auto-hospedada ou testar a conectividade."
-  },
-  "experimental": {
-    "title": "Experimental",
-    "description": "Esses recursos ainda estão em desenvolvimento. Eles podem estar incompletos, ter bugs ou mudar sem aviso. Ative-os para experimentar as novidades antecipadamente.",
-    "draftExperiments": "Experimentos de Draft",
-    "enableDraftFeatures": "Ativar recursos experimentais de draft",
-    "draftFeaturesDescription": "Desbloqueia o Cube Draft e o Pod Draft. O Quick Draft contra IA está sempre disponível."
   },
   "sync": {
     "title": "Sincronização na nuvem",

--- a/client/src/pages/DraftLandingPage.tsx
+++ b/client/src/pages/DraftLandingPage.tsx
@@ -14,7 +14,6 @@ import {
   type ActiveDraftPodMeta,
 } from "../services/draftPersistence";
 import { loadGame } from "../services/gamePersistence";
-import { usePreferencesStore } from "../stores/preferencesStore";
 
 const SET_LABELS: Record<string, string> = {
   otj: "Outlaws of Thunder Junction",
@@ -60,7 +59,6 @@ export function DraftLandingPage() {
   const navigate = useNavigate();
   const [activeDraft, setActiveDraft] = useState<ActiveQuickDraftMeta | null>(null);
   const [activePod, setActivePod] = useState<ActiveDraftPodMeta | null>(null);
-  const experimentalFeatures = usePreferencesStore((s) => s.experimentalFeatures);
 
   useEffect(() => {
     setActiveDraft(loadActiveQuickDraft());
@@ -91,25 +89,19 @@ export function DraftLandingPage() {
             onClick={() => navigate("/draft/quick")}
           />
 
-          {experimentalFeatures && (
-            <>
-              <DraftModeCard
-                title={t("landing.cubeDraft.title")}
-                description={t("landing.cubeDraft.description")}
-                icon={<CubeIcon />}
-                badge={t("landing.experimental")}
-                onClick={() => navigate("/draft/quick?mode=cube")}
-              />
+          <DraftModeCard
+            title={t("landing.cubeDraft.title")}
+            description={t("landing.cubeDraft.description")}
+            icon={<CubeIcon />}
+            onClick={() => navigate("/draft/quick?mode=cube")}
+          />
 
-              <DraftModeCard
-                title={t("landing.podDraft.title")}
-                description={t("landing.podDraft.description")}
-                icon={<PodIcon />}
-                badge={t("landing.experimental")}
-                onClick={() => navigate("/draft-pod")}
-              />
-            </>
-          )}
+          <DraftModeCard
+            title={t("landing.podDraft.title")}
+            description={t("landing.podDraft.description")}
+            icon={<PodIcon />}
+            onClick={() => navigate("/draft-pod")}
+          />
         </div>
       </div>
     </div>

--- a/client/src/pages/DraftLandingPage.tsx
+++ b/client/src/pages/DraftLandingPage.tsx
@@ -275,13 +275,11 @@ function DraftModeCard({
   title,
   description,
   icon,
-  badge,
   onClick,
 }: {
   title: string;
   description: string;
   icon: ReactNode;
-  badge?: string;
   onClick: () => void;
 }) {
   return (
@@ -296,11 +294,6 @@ function DraftModeCard({
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-2">
           <div className="text-base font-semibold text-white">{title}</div>
-          {badge && (
-            <span className="rounded-full border border-cyan-300/20 bg-cyan-400/10 px-2 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.14em] text-cyan-200">
-              {badge}
-            </span>
-          )}
         </div>
         <p className="mt-1 text-sm text-white/40">{description}</p>
       </div>

--- a/client/src/pages/DraftPage.tsx
+++ b/client/src/pages/DraftPage.tsx
@@ -18,7 +18,6 @@ import { ScreenChrome } from "../components/chrome/ScreenChrome";
 import { menuButtonClass } from "../components/menu/buttonStyles";
 import { runLimits } from "../services/quickDraftPersistence";
 import type { DraftRunFormat, DraftRunState } from "../services/quickDraftPersistence";
-import { usePreferencesStore } from "../stores/preferencesStore";
 
 // ── Format Picker ─────────────────────────────────────────────────────
 
@@ -300,7 +299,6 @@ export function DraftPage() {
   const { t } = useTranslation("draft");
   const phase = useDraftStore((s) => s.phase);
   const reset = useDraftStore((s) => s.reset);
-  const experimentalFeatures = usePreferencesStore((s) => s.experimentalFeatures);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const requestedSetupMode = searchParams.get("mode");
@@ -308,7 +306,7 @@ export function DraftPage() {
   const [introDismissed, setIntroDismissed] = useState(false);
   const [resumeLoading, setResumeLoading] = useState(false);
   const [setupMode, setSetupMode] = useState<DraftSetupMode>(() =>
-    requestedSetupMode === "cube" && experimentalFeatures ? "cube" : "set",
+    requestedSetupMode === "cube" ? "cube" : "set",
   );
 
   useEffect(() => {
@@ -332,13 +330,9 @@ export function DraftPage() {
 
   useEffect(() => {
     if (requestedSetupMode === "cube") {
-      setSetupMode(experimentalFeatures ? "cube" : "set");
+      setSetupMode("cube");
     }
-  }, [requestedSetupMode, experimentalFeatures]);
-
-  useEffect(() => {
-    if (!experimentalFeatures) setSetupMode("set");
-  }, [experimentalFeatures]);
+  }, [requestedSetupMode]);
 
   useEffect(() => {
     return () => {
@@ -397,24 +391,22 @@ export function DraftPage() {
             <h1 className="mb-8 menu-display text-3xl text-white">
               {setupMode === "cube" ? t("page.cubeDraftTitle") : t("page.quickDraftTitle")}
             </h1>
-            {experimentalFeatures && (
-              <div className="mb-5 inline-flex rounded-lg border border-white/10 bg-black/25 p-1">
-                {(["set", "cube"] as const).map((mode) => (
-                  <button
-                    key={mode}
-                    type="button"
-                    onClick={() => setSetupMode(mode)}
-                    className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
-                      setupMode === mode
-                        ? "bg-emerald-400/18 text-emerald-100"
-                        : "text-white/50 hover:bg-white/6 hover:text-white/75"
-                    }`}
-                  >
-                    {mode === "set" ? t("page.setDraftTab") : t("page.cubeTab")}
-                  </button>
-                ))}
-              </div>
-            )}
+            <div className="mb-5 inline-flex rounded-lg border border-white/10 bg-black/25 p-1">
+              {(["set", "cube"] as const).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => setSetupMode(mode)}
+                  className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                    setupMode === mode
+                      ? "bg-emerald-400/18 text-emerald-100"
+                      : "text-white/50 hover:bg-white/6 hover:text-white/75"
+                  }`}
+                >
+                  {mode === "set" ? t("page.setDraftTab") : t("page.cubeTab")}
+                </button>
+              ))}
+            </div>
             {setupMode === "set" ? (
               <SetSelector onStartDraft={handleStartDraft} />
             ) : (

--- a/client/src/pages/DraftPage.tsx
+++ b/client/src/pages/DraftPage.tsx
@@ -329,9 +329,7 @@ export function DraftPage() {
   }, [searchParams]);
 
   useEffect(() => {
-    if (requestedSetupMode === "cube") {
-      setSetupMode("cube");
-    }
+    setSetupMode(requestedSetupMode === "cube" ? "cube" : "set");
   }, [requestedSetupMode]);
 
   useEffect(() => {

--- a/client/src/pages/MultiplayerPage.tsx
+++ b/client/src/pages/MultiplayerPage.tsx
@@ -26,7 +26,6 @@ import type { LiveCheck, MultiplayerView } from "./multiplayerPageState";
 import { classifyCompatResult } from "./multiplayerPageState";
 import { clearWsSession } from "../services/multiplayerSession";
 import { useMultiplayerStore } from "../stores/multiplayerStore";
-import { usePreferencesStore } from "../stores/preferencesStore";
 import {
   useMultiplayerDraftStore,
   type MultiplayerDraftPhase,
@@ -76,7 +75,6 @@ export function MultiplayerPage() {
   const startP2PHostingSession = useMultiplayerStore((s) => s.startP2PHostingSession);
   const showToast = useMultiplayerStore((s) => s.showToast);
 
-  const experimentalFeatures = usePreferencesStore((s) => s.experimentalFeatures);
   const draftPhase = useMultiplayerDraftStore((s) => s.phase);
   const draftRoomCode = useMultiplayerDraftStore((s) => s.roomCode);
   const joinDraft = useMultiplayerDraftStore((s) => s.joinDraft);
@@ -765,7 +763,7 @@ export function MultiplayerPage() {
             key={`${serverAddress}:${lobbyRetryKey}`}
             onHostGame={() => { setConnectionMode("server"); setView("host-setup"); }}
             onHostP2P={() => { setConnectionMode("p2p"); setView("host-setup"); }}
-            onHostDraft={experimentalFeatures ? handleHostDraft : undefined}
+            onHostDraft={handleHostDraft}
             onJoinGame={handleJoinGame}
             connectionMode={connectionMode}
             onServerOffline={() => {

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -137,7 +137,6 @@ function buildDefaultPreferences(): PreferencesState {
     lastFormat: null,
     lastMatchType: "Bo1",
     lastPlayerCount: 2,
-    experimentalFeatures: false,
     dismissedFlowHelpNudge: false,
     dismissedSandboxToolsNudge: false,
     artChain: [] as ArtChainEntry[],
@@ -193,7 +192,6 @@ interface PreferencesState {
   lastFormat: GameFormat | null;
   lastMatchType: MatchType;
   lastPlayerCount: number;
-  experimentalFeatures: boolean;
   dismissedFlowHelpNudge: boolean;
   dismissedSandboxToolsNudge: boolean;
   artChain: ArtChainEntry[];
@@ -246,7 +244,6 @@ interface PreferencesActions {
   setLastFormat: (format: GameFormat) => void;
   setLastMatchType: (matchType: MatchType) => void;
   setLastPlayerCount: (count: number) => void;
-  setExperimentalFeatures: (enabled: boolean) => void;
   setDismissedFlowHelpNudge: (dismissed: boolean) => void;
   setDismissedSandboxToolsNudge: (dismissed: boolean) => void;
   addArtChainEntry: (entry: ArtChainEntry) => void;
@@ -378,7 +375,6 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       setLastFormat: (format) => set({ lastFormat: format }),
       setLastMatchType: (matchType) => set({ lastMatchType: matchType }),
       setLastPlayerCount: (count) => set({ lastPlayerCount: count }),
-      setExperimentalFeatures: (enabled) => set({ experimentalFeatures: enabled }),
       setDismissedFlowHelpNudge: (dismissed) => set({ dismissedFlowHelpNudge: dismissed }),
       setDismissedSandboxToolsNudge: (dismissed) => set({ dismissedSandboxToolsNudge: dismissed }),
       addArtChainEntry: (entry) =>


### PR DESCRIPTION
## Summary

Cube draft and pod draft are no longer gated behind the `experimentalFeatures` preference flag — both are now first-class entry points on the draft landing page and the multiplayer lobby.

## What changed

| Surface | Change |
|---|---|
| `preferencesStore.ts` | Drop `experimentalFeatures` field, type entry, and `setExperimentalFeatures` action |
| `PreferencesModal.tsx` | Drop the **Settings > Experimental** tab and its sole `ExperimentalSection` (the only setting was the draft-features toggle) |
| `DraftPage.tsx` | Set/Cube tab switch is always rendered; remove the cube-disable effect |
| `DraftLandingPage.tsx` | Cube + pod tiles render unconditionally; drop the 'Experimental' badge |
| `MultiplayerPage.tsx` | `onHostDraft` is always passed — Host Draft tile is always available |
| i18n (7 locales) | Drop `tabs.experimental`, the `experimental.*` block, `landing.experimental` badge; rewrite the menu draft tile description (en/es/fr/de/pt/it/pl) |

Net: **47 insertions, 165 deletions** across **26 files**.

## Migration

Removing `experimentalFeatures` from the persisted schema is benign — existing `localStorage` entries holding the field are silently dropped on the next zustand-persist rehydrate. Users who had previously enabled it will see no change (the gate was unconditionally graduated, so the post-rehydrate UI matches the pre-rehydrate UI for everyone).

## Verification

- `check-frontend` (tsc + eslint): ✅ ok (only pre-existing react-refresh warning on `CubeSetupPanel.tsx`, untouched here)
- `test-frontend` (vitest): ✅ ok
- All 21 modified JSON files parse cleanly (`python3 -m json.tool` per file)

No Rust changes — clippy/test-engine/card-data unaffected.

## Why now

Cube draft MP shipped in #1257 (PoolInput discriminated union threaded through the pod-draft adapter chain), and pod draft has been in-tree since PR #1246. Both features now have the full MP infrastructure, persistence, deck-builder, pairing, and reconnect flows working end-to-end. The `experimentalFeatures` shutter was discoverability friction at this point — graduating both surfaces them in the main UI.

## Related

- #1257 (cube draft MP)
- #1246 (pod draft foundation)