### PR TITLE
Add Toxic Deluge X-life regression tests

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13286,6 +13286,70 @@ mod tests {
     }
 
     #[test]
+    fn toxic_deluge_style_x_life_additional_cost_still_pays_mana_cost() {
+        let mut state = setup_game_at_main_phase();
+        let spell = create_object(
+            &mut state,
+            CardId(12363),
+            PlayerId(0),
+            "Toxic Deluge Style Spell".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Black],
+                generic: 2,
+            };
+            obj.additional_cost = Some(AdditionalCost::Required(AbilityCost::PayLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+            }));
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::PumpAll {
+                    power: PtValue::Variable("-X".to_string()),
+                    toughness: PtValue::Variable("-X".to_string()),
+                    target: TargetFilter::Typed(TypedFilter::creature()),
+                },
+            ));
+        }
+        add_mana(&mut state, PlayerId(0), ManaType::Black, 1);
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 2);
+
+        let waiting = handle_cast_spell(
+            &mut state,
+            PlayerId(0),
+            spell,
+            CardId(12363),
+            &mut Vec::new(),
+        )
+        .expect("X life additional cost should prompt before mana payment");
+        state.waiting_for = waiting;
+        match state.waiting_for {
+            WaitingFor::ChooseXValue { max, .. } => assert_eq!(max, 20),
+            ref other => panic!("expected ChooseXValue, got {other:?}"),
+        }
+
+        apply_as_current(&mut state, GameAction::ChooseX { value: 5 }).unwrap();
+
+        assert_eq!(state.players[0].life, 15);
+        assert_eq!(state.players[0].mana_pool.total(), 0);
+        assert_eq!(state.stack.len(), 1);
+        match &state.stack[0].kind {
+            StackEntryKind::Spell {
+                ability: Some(ability),
+                ..
+            } => assert_eq!(ability.chosen_x, Some(5)),
+            other => panic!("expected spell on stack, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn cant_pay_cost_sacrifice_filters_forbidden_permanents_only() {
         let mut state = setup_game_at_main_phase();
         let spell = create_object(

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4528,17 +4528,16 @@ mod tests {
             &[],
         );
 
-        match r.additional_cost.expect("additional cost") {
-            AdditionalCost::Required(AbilityCost::PayLife { amount }) => {
-                assert!(matches!(
-                    amount,
-                    QuantityExpr::Ref {
-                        qty: QuantityRef::Variable { ref name }
-                    } if name == "X"
-                ));
-            }
-            other => panic!("expected required X life cost, got {other:?}"),
-        }
+        assert_eq!(
+            r.additional_cost,
+            Some(AdditionalCost::Required(AbilityCost::PayLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+            }))
+        );
         assert_eq!(r.abilities.len(), 1);
         match r.abilities[0].effect.as_ref() {
             Effect::PumpAll {

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4519,6 +4519,42 @@ mod tests {
     }
 
     #[test]
+    fn toxic_deluge_full_oracle_parses_x_life_cost_and_x_pump() {
+        let r = parse(
+            "As an additional cost to cast this spell, pay X life.\nAll creatures get -X/-X until end of turn.",
+            "Toxic Deluge",
+            &[],
+            &["Sorcery"],
+            &[],
+        );
+
+        match r.additional_cost.expect("additional cost") {
+            AdditionalCost::Required(AbilityCost::PayLife { amount }) => {
+                assert!(matches!(
+                    amount,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Variable { ref name }
+                    } if name == "X"
+                ));
+            }
+            other => panic!("expected required X life cost, got {other:?}"),
+        }
+        assert_eq!(r.abilities.len(), 1);
+        match r.abilities[0].effect.as_ref() {
+            Effect::PumpAll {
+                power,
+                toughness,
+                target,
+            } => {
+                assert_eq!(power, &PtValue::Variable("-X".to_string()));
+                assert_eq!(toughness, &PtValue::Variable("-X".to_string()));
+                assert_eq!(target, &TargetFilter::Typed(TypedFilter::creature()));
+            }
+            other => panic!("expected all-creature -X/-X pump, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn llanowar_elves_mana_ability() {
         let r = parse(
             "{T}: Add {G}.",


### PR DESCRIPTION
## Summary
Adds focused regression coverage for **Toxic Deluge** / issue #609, where `pay X life` as a required additional casting cost must prompt for X and feed that same X into `-X/-X`.

Closes #609.

## Files changed
- `crates/engine/src/parser/oracle.rs`
- `crates/engine/src/game/casting.rs`

## CR references
No CR annotations added or changed. The tested behavior exercises existing CR 601.2b/f/h, CR 118.3, and CR 119.4 handling in the casting-cost path.

## Track
Developer

Model: codex-5
Thinking: medium
Tier: Standard

## Anchored on
- `crates/engine/src/parser/oracle.rs:4498` — existing full-Oracle additional-cost regression for Harrow.
- `crates/engine/src/game/casting.rs:13203` — existing runtime X-life additional-cost regression.

## Gate A
Command: `./scripts/check-parser-combinators.sh`

Output: command exited 0 with no output.

## Verification
- `cargo fmt --all -- --check`
- `./scripts/check-parser-combinators.sh`
- `cargo test -p engine toxic_deluge`
- `cargo test -p engine pay_x_life`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check HEAD~1 HEAD`

## Notes
This is test-only because the parser and runtime fix were already present on `origin/main`; issue #609 was still open and needed direct card-facing coverage to make the closure auditable.
