### PR TITLE
Fix opponent HUD collapse after multiplayer elimination

### DIFF
--- a/client/src/components/board/AttackTargetLines.tsx
+++ b/client/src/components/board/AttackTargetLines.tsx
@@ -5,6 +5,7 @@ import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { usePlayerId } from "../../hooks/usePlayerId.ts";
+import { isOneOnOne } from "../../viewmodel/gameStateView.ts";
 import {
   arcPath,
   useAttackerArrowPositions,
@@ -60,16 +61,17 @@ function AttackArrowPath({ arrow, isMinimal }: { arrow: AttackArrowData; isMinim
  *  Player-target arrows only draw in multiplayer (>2 players); in 1v1 the
  *  player attack is implicit and drawing would be visual noise. */
 export function AttackTargetLines() {
-  const combat = useGameStore((s) => s.gameState?.combat ?? null);
-  const objects = useGameStore((s) => s.gameState?.objects);
-  const seatOrder = useGameStore((s) => s.gameState?.seat_order);
-  const eliminatedPlayers = useGameStore((s) => s.gameState?.eliminated_players);
+  const gameState = useGameStore((s) => s.gameState);
+  const combat = gameState?.combat ?? null;
+  const objects = gameState?.objects;
+  const seatOrder = gameState?.seat_order;
+  const eliminatedPlayers = gameState?.eliminated_players;
   const focusedOpponent = useUiStore((s) => s.focusedOpponent) as PlayerId | null;
   const vfxQuality = usePreferencesStore((s) => s.vfxQuality);
   const localPlayerId = usePlayerId();
   const isMinimal = vfxQuality === "minimal";
 
-  const isMultiplayer = (seatOrder?.length ?? 0) > 2;
+  const isMultiplayer = gameState != null && !isOneOnOne(gameState);
   const effectiveFocusedOpponent = useMemo(() => {
     if (focusedOpponent != null) return focusedOpponent;
     const eliminated = new Set(eliminatedPlayers ?? []);

--- a/client/src/components/board/BlockAssignmentLines.tsx
+++ b/client/src/components/board/BlockAssignmentLines.tsx
@@ -7,7 +7,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { usePlayerId } from "../../hooks/usePlayerId.ts";
 import { useRafPositions } from "../../hooks/useRafPositions.ts";
 import { arcPath } from "../../hooks/useAttackerArrowPositions.ts";
-import { getOpponentIds } from "../../viewmodel/gameStateView.ts";
+import { getOpponentIds, isOneOnOne } from "../../viewmodel/gameStateView.ts";
 import type { ObjectId, PlayerId } from "../../adapter/types.ts";
 
 const BLOCK_COLOR = "rgba(56,189,248,0.95)";
@@ -19,13 +19,11 @@ export function BlockAssignmentLines() {
   const focusedOpponent = useUiStore((s) => s.focusedOpponent) as PlayerId | null;
   const combat = useGameStore((s) => s.gameState?.combat ?? null);
   const objects = useGameStore((s) => s.gameState?.objects);
-  const seatOrder = useGameStore((s) => s.gameState?.seat_order);
   const vfxQuality = usePreferencesStore((s) => s.vfxQuality);
   const localPlayerId = usePlayerId();
 
-  const isMultiplayer = (seatOrder?.length ?? 0) > 2;
-
   const gameState = useGameStore((s) => s.gameState);
+  const isMultiplayer = gameState != null && !isOneOnOne(gameState);
   const opponents = useMemo(() => getOpponentIds(gameState, localPlayerId), [gameState, localPlayerId]);
   const effectiveFocusedOpponent = focusedOpponent ?? opponents[0] ?? null;
 

--- a/client/src/components/board/GameBoard.tsx
+++ b/client/src/components/board/GameBoard.tsx
@@ -11,6 +11,7 @@ import {
   buildPlayerBattlefieldView,
   getWaitingForObjectChoiceIds,
   getOpponentIds,
+  isOneOnOne,
 } from "../../viewmodel/gameStateView.ts";
 import { BoardInteractionContext } from "./BoardInteractionContext.tsx";
 import { CombatLine } from "./CombatLine.tsx";
@@ -186,7 +187,11 @@ export function GameBoard({ oppHud, playerHud }: GameBoardProps) {
     );
   }
 
-  const is1v1 = opponents.length === 1;
+  // 1v1 layout is a property of the game's seat count, not of how many
+  // opponents are currently alive — eliminations would otherwise flip a
+  // 3+ player game into the 1v1 inline-pill layout and cram the multi-tab
+  // OpponentHud rail into PlayerArea's small `hud` slot.
+  const is1v1 = isOneOnOne(gameState);
 
   // Undo button for the player's land column
   const undoButton = canUndo ? (
@@ -206,12 +211,20 @@ export function GameBoard({ oppHud, playerHud }: GameBoardProps) {
       <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
         {/* Opponent area */}
         {is1v1 ? (
-          <PlayerArea
-            battlefieldView={focusedBattlefieldView ?? undefined}
-            playerId={opponents[0]}
-            mode="focused"
-            hud={oppHud}
-          />
+          opponents[0] != null ? (
+            <PlayerArea
+              battlefieldView={focusedBattlefieldView ?? undefined}
+              playerId={opponents[0]}
+              mode="focused"
+              hud={oppHud}
+            />
+          ) : (
+            // 1v1 game where the sole opponent has been eliminated. The
+            // GameOver modal mounts on the same state, but renders one
+            // tick later; guard so we don't index `gameState.players`
+            // with `undefined` in the interim.
+            <div className="flex flex-1 items-center justify-center" />
+          )
         ) : (
           <div className="flex min-h-0 flex-1 flex-col">
             {/* Keep opponent controls above overflowing command-zone cards. */}

--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -12,6 +12,7 @@ import { getOpponentDisplayName, useMultiplayerStore } from "../../stores/multip
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { partitionByType } from "../../viewmodel/battlefieldProps.ts";
+import { isOneOnOne } from "../../viewmodel/gameStateView.ts";
 import { LifeTotal } from "../controls/LifeTotal.tsx";
 import { ManaPoolSummary } from "./ManaPoolSummary.tsx";
 import { ScoreBadge } from "../draft/ScoreBadge.tsx";
@@ -61,7 +62,13 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
 
   const eliminated = gameState?.eliminated_players ?? [];
   const liveOpponents = allOpponents.filter((id) => !eliminated.includes(id));
-  const isMultiplayer = allOpponents.length > 1;
+  // Routed through `isOneOnOne` so this can't drift from GameBoard's
+  // layout decision — the bug that motivated the helper was exactly
+  // those two derivations disagreeing after an elimination. The
+  // `gameState != null` guard preserves the original null-state default
+  // (treat as 1v1) so the pre-game placeholder renders the pill, not an
+  // empty rail.
+  const isMultiplayer = gameState != null && !isOneOnOne(gameState);
 
   // The `OpponentTab` row renders with a default-focused opponent even when
   // `focusedOpponent` is null (it falls back to the first live opponent).

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import type { GameState, PlayerId } from "../../adapter/types";
+import {
+  getOpponentIds,
+  getSeatCount,
+  isOneOnOne,
+} from "../gameStateView";
+
+// Test fixtures only populate the fields these helpers actually read.
+// Cast through `unknown` so we don't have to hand-construct the full
+// hundreds-of-fields GameState surface.
+function makeState(seatOrder: PlayerId[], eliminated: PlayerId[] = []): GameState {
+  return {
+    seat_order: seatOrder,
+    eliminated_players: eliminated,
+    players: seatOrder.map((id) => ({ id })),
+  } as unknown as GameState;
+}
+
+describe("getSeatCount", () => {
+  it("returns the seat_order length for a 2-player game", () => {
+    expect(getSeatCount(makeState([0, 1]))).toBe(2);
+  });
+
+  it("returns the seat_order length for a 4-player game", () => {
+    expect(getSeatCount(makeState([0, 1, 2, 3]))).toBe(4);
+  });
+
+  it("stays stable after eliminations (seat_order is not pruned)", () => {
+    expect(getSeatCount(makeState([0, 1, 2, 3], [1, 2]))).toBe(4);
+  });
+
+  it("falls back to players.length when seat_order is absent", () => {
+    const state = { players: [{ id: 0 }, { id: 1 }, { id: 2 }] } as unknown as GameState;
+    expect(getSeatCount(state)).toBe(3);
+  });
+
+  it("returns 0 for a null state", () => {
+    expect(getSeatCount(null)).toBe(0);
+  });
+});
+
+describe("isOneOnOne", () => {
+  // The bug that motivates this helper: GameBoard and OpponentHud derived
+  // "is this 1v1?" from different inputs (live opponents vs. seat count).
+  // In a 4-player Commander game with two eliminations, the derivations
+  // disagreed and the multi-tab rail got crammed into the 1v1 inline-pill
+  // slot. These cases lock the boundary so that can't recur.
+
+  it("is true for a fresh 2-player game", () => {
+    expect(isOneOnOne(makeState([0, 1]))).toBe(true);
+  });
+
+  it("is false for a fresh 4-player game", () => {
+    expect(isOneOnOne(makeState([0, 1, 2, 3]))).toBe(false);
+  });
+
+  it("stays false for a 4-player game with 1 live opponent (regression case)", () => {
+    // Player 0's perspective: opponents 1 and 2 eliminated, only 3 alive.
+    expect(isOneOnOne(makeState([0, 1, 2, 3], [1, 2]))).toBe(false);
+  });
+
+  it("stays false for a 4-player game with all opponents eliminated", () => {
+    expect(isOneOnOne(makeState([0, 1, 2, 3], [1, 2, 3]))).toBe(false);
+  });
+
+  it("stays true for a 2-player game with the opponent eliminated", () => {
+    // GameOver mounts on the same state — the helper just needs to not
+    // flip layouts on the way there.
+    expect(isOneOnOne(makeState([0, 1], [1]))).toBe(true);
+  });
+
+  it("returns false for a null state", () => {
+    expect(isOneOnOne(null)).toBe(false);
+  });
+});
+
+describe("getOpponentIds", () => {
+  it("excludes the perspective player and eliminated players", () => {
+    expect(getOpponentIds(makeState([0, 1, 2, 3], [2]), 0)).toEqual([1, 3]);
+  });
+
+  it("returns an empty array in a 2-player game with the opponent eliminated", () => {
+    // This is the regression edge case the 1v1 branch in GameBoard now
+    // guards against — `opponents[0]` is undefined here, and the layout
+    // must not index `gameState.players[undefined]`.
+    expect(getOpponentIds(makeState([0, 1], [1]), 0)).toEqual([]);
+  });
+});

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -29,6 +29,21 @@ export function getOpponentIds(
   return seatOrder.filter((id) => id !== playerId && !eliminated.has(id));
 }
 
+// The game's seat count, stable across eliminations — the engine never
+// removes from `seat_order`. Single source of truth for layout decisions
+// like "is this 1v1?". Keep all callers (GameBoard, OpponentHud,
+// BlockAssignmentLines, AttackTargetLines) routed through here so they
+// cannot drift apart — the bug this helper exists to prevent is exactly
+// that drift.
+export function getSeatCount(gameState: GameState | null): number {
+  if (!gameState) return 0;
+  return gameState.seat_order?.length ?? gameState.players.length;
+}
+
+export function isOneOnOne(gameState: GameState | null): boolean {
+  return getSeatCount(gameState) === 2;
+}
+
 export function getPlayerZoneIds(
   gameState: GameState | null,
   zone: "graveyard" | "exile",


### PR DESCRIPTION
In a 4-player Commander game, eliminating two AIs flipped
GameBoard's layout to the 1v1 inline-pill variant while
OpponentHud kept rendering the multi-tab rail — the rail got
crammed into PlayerArea's small `hud` slot and visually collapsed.

The two derivations of "is this 1v1?" had drifted: GameBoard
used live opponents (excludes eliminated), OpponentHud used
seat_order (includes eliminated). Extract isOneOnOne / getSeatCount
into gameStateView so the four call sites (GameBoard, OpponentHud,
BlockAssignmentLines, AttackTargetLines) share one definition.

Also guard the 1v1 + sole-opponent-eliminated tick so we don't
index gameState.players[undefined] before GameOver mounts.
