### PR TITLE
Fix #702: dice roll effects (parser dispatch + result modifiers)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -10,9 +10,9 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction,
     AdditionalCost, AggregateFunction, CardTypeSetSource, ChoiceType, Comparator,
     ContinuousModification, ControllerRef, CountScope, CounterSourceRider, DelayedTriggerCondition,
-    DoublePTMode, Duration, Effect, EffectOutcomeSignal, FilterProp, GainLifePlayer,
-    GameRestriction, ManaProduction, ObjectProperty, ObjectScope, PlayerFilter, PlayerScope,
-    PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
+    DieRollModifier, DoublePTMode, Duration, Effect, EffectOutcomeSignal, FilterProp,
+    GainLifePlayer, GameRestriction, ManaProduction, ObjectProperty, ObjectScope, PlayerFilter,
+    PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
     ReplacementDefinition, ReplacementMode, SharedQuality, SharedQualityRelation, SpeedDelta,
     SpellCastingOption, SpellCastingOptionKind, StaticCondition, StaticDefinition, TargetFilter,
     TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
@@ -1939,10 +1939,21 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 d.push(("free cast".into(), "yes".into()));
             }
         }
-        Effect::RollDie { sides, results } => {
+        Effect::RollDie {
+            sides,
+            results,
+            modifier,
+        } => {
             d.push(("sides".into(), sides.to_string()));
             if !results.is_empty() {
                 d.push(("branches".into(), results.len().to_string()));
+            }
+            if let Some(m) = modifier {
+                let label = match m {
+                    DieRollModifier::Add { .. } => "add",
+                    DieRollModifier::Subtract { .. } => "subtract",
+                };
+                d.push(("modifier".into(), label.into()));
             }
         }
         Effect::FlipCoin {

--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -1598,6 +1598,7 @@ mod tests {
             Effect::RollDie {
                 sides: 6,
                 results: vec![],
+                modifier: None,
             },
             vec![],
             creature,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2329,6 +2329,22 @@ fn previous_effect_amount_from_events(
                 _ => None,
             })
             .sum(),
+        // CR 706.2 + CR 608.2c: A die roll's *actual* result (natural + modifier,
+        // clamped at 0) is the numeric value a follow-up `PreviousEffectAmount`
+        // condition reads. Unlike damage/life amounts, the relevant amount is
+        // always defined — even a clamped-to-zero result is a valid
+        // sub-ability gate (Deck of Many Things' "if the result is 0 or less,
+        // discard your hand"). We short-circuit on the first DieRolled event
+        // (the one this RollDie effect emitted; any nested rolls happen inside
+        // a deeper chain that clears `last_effect_amount` on entry, but their
+        // events still appear later in the slice and must be ignored here so
+        // the OUTER RollDie's actual is what the OUTER sub_ability sees).
+        Effect::RollDie { .. } => {
+            return events.iter().find_map(|event| match event {
+                GameEvent::DieRolled { result, .. } => Some(*result as i32),
+                _ => None,
+            });
+        }
         _ => 0,
     };
 

--- a/crates/engine/src/game/effects/roll_die.rs
+++ b/crates/engine/src/game/effects/roll_die.rs
@@ -1,33 +1,64 @@
 use rand::Rng;
 
-use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
+use crate::game::quantity::resolve_quantity;
+use crate::types::ability::{DieRollModifier, Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 
 use super::resolve_ability_chain;
 
 /// CR 706: Roll a die and execute the matching result branch.
+///
+/// CR 706.2: The natural roll is taken from a uniform 1..=sides distribution
+/// using the game's seeded RNG; the (optional) modifier is then applied to
+/// produce the *actual* result, which is what result-table branches consult
+/// and what downstream effects ("where X is the result") snapshot via
+/// `GameEvent::DieRolled.result`.
 pub fn resolve(
     state: &mut GameState,
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (sides, results) = match &ability.effect {
-        Effect::RollDie { sides, results } => (*sides, results),
+    let (sides, results, modifier) = match &ability.effect {
+        Effect::RollDie {
+            sides,
+            results,
+            modifier,
+        } => (*sides, results, modifier.as_ref()),
         _ => return Err(EffectError::MissingParam("RollDie".to_string())),
     };
 
-    // CR 706.2: Roll the die using the game's seeded RNG.
-    let result = state.rng.random_range(1..=sides);
+    // CR 706.2: Roll the die using the game's seeded RNG. This is the
+    // "natural result" before any modifiers.
+    let natural = state.rng.random_range(1..=sides);
+
+    // CR 706.2: Apply the (optional) modifier to produce the actual result.
+    // The result is clamped to a u8-representable non-negative integer so a
+    // large subtract doesn't wrap; branches with `min`/`max` already in u8
+    // simply won't match when the actual result is 0.
+    let actual = if let Some(m) = modifier {
+        let delta = match m {
+            DieRollModifier::Add { value } => {
+                resolve_quantity(state, value, ability.controller, ability.source_id)
+            }
+            DieRollModifier::Subtract { value } => {
+                -resolve_quantity(state, value, ability.controller, ability.source_id)
+            }
+        };
+        let combined = (natural as i32).saturating_add(delta);
+        combined.clamp(0, u8::MAX as i32) as u8
+    } else {
+        natural
+    };
 
     events.push(GameEvent::DieRolled {
         player_id: ability.controller,
         sides,
-        result,
+        result: actual,
     });
 
     // CR 706.2: Find the matching result branch and resolve its effect.
-    if let Some(branch) = results.iter().find(|b| result >= b.min && result <= b.max) {
+    if let Some(branch) = results.iter().find(|b| actual >= b.min && actual <= b.max) {
         let sub = ResolvedAbility::new(
             *branch.effect.effect.clone(),
             ability.targets.clone(),
@@ -70,6 +101,7 @@ mod tests {
             Effect::RollDie {
                 sides: 20,
                 results: vec![branch],
+                modifier: None,
             },
             vec![],
             ObjectId(1),
@@ -115,6 +147,7 @@ mod tests {
             Effect::RollDie {
                 sides: 20,
                 results: vec![branch],
+                modifier: None,
             },
             vec![],
             ObjectId(1),
@@ -136,6 +169,7 @@ mod tests {
             Effect::RollDie {
                 sides: 6,
                 results: vec![],
+                modifier: None,
             },
             vec![],
             ObjectId(1),
@@ -148,5 +182,184 @@ mod tests {
         assert!(events
             .iter()
             .any(|e| matches!(e, GameEvent::DieRolled { sides: 6, .. })));
+    }
+
+    /// CR 706.2: "Roll a d20 and add the number of cards in your hand" — the
+    /// modifier shifts the natural roll upward. We choose a generous branch
+    /// covering 1..=40 so the test is RNG-deterministic regardless of seed.
+    #[test]
+    fn roll_die_add_modifier_shifts_result_upward() {
+        let mut state = GameState::new_two_player(42);
+        // Seed two cards into the controller's hand so the modifier resolves to 2.
+        state.players[0]
+            .hand
+            .push_back(crate::types::identifiers::ObjectId(100));
+        state.players[0]
+            .hand
+            .push_back(crate::types::identifiers::ObjectId(101));
+        let branch = DieResultBranch {
+            min: 1,
+            max: 40,
+            effect: Box::new(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: crate::types::ability::TargetFilter::Controller,
+                },
+            )),
+        };
+        // Add a card to draw.
+        crate::game::zones::create_object(
+            &mut state,
+            crate::types::identifiers::CardId(1),
+            PlayerId(0),
+            "Card A".to_string(),
+            crate::types::zones::Zone::Library,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::RollDie {
+                sides: 20,
+                results: vec![branch],
+                modifier: Some(DieRollModifier::Add {
+                    value: QuantityExpr::Ref {
+                        qty: crate::types::ability::QuantityRef::HandSize {
+                            player: crate::types::ability::PlayerScope::Controller,
+                        },
+                    },
+                }),
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        let result = events
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::DieRolled { result, .. } => Some(*result),
+                _ => None,
+            })
+            .expect("DieRolled event should be present");
+        // Natural roll ∈ 1..=20, modifier = +2 (two cards in hand), so actual ∈ 3..=22.
+        assert!(
+            (3..=22).contains(&result),
+            "actual result {result} should reflect +2 modifier"
+        );
+    }
+
+    /// CR 706.2: "Roll a d20 and subtract the number of cards in your hand" —
+    /// the modifier shifts the natural roll downward. With many cards in
+    /// hand, the actual result can be 0 or below, which clamps to 0.
+    #[test]
+    fn roll_die_subtract_modifier_clamps_at_zero() {
+        let mut state = GameState::new_two_player(42);
+        // Twenty-five cards in hand → modifier resolves to 25; any d20 roll
+        // produces actual ≤ 0, which clamps to 0.
+        for i in 0..25 {
+            state.players[0]
+                .hand
+                .push_back(crate::types::identifiers::ObjectId(200 + i));
+        }
+        let ability = ResolvedAbility::new(
+            Effect::RollDie {
+                sides: 20,
+                results: vec![],
+                modifier: Some(DieRollModifier::Subtract {
+                    value: QuantityExpr::Ref {
+                        qty: crate::types::ability::QuantityRef::HandSize {
+                            player: crate::types::ability::PlayerScope::Controller,
+                        },
+                    },
+                }),
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        let result = events
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::DieRolled { result, .. } => Some(*result),
+                _ => None,
+            })
+            .expect("DieRolled event should be present");
+        assert_eq!(result, 0, "subtract modifier should clamp at 0");
+    }
+
+    /// CR 706.2: With a seeded RNG, rolling the same die twice from two
+    /// identically-seeded states must produce the same natural result.
+    /// This is foundational for replays and AI-search determinism.
+    #[test]
+    fn roll_die_with_seeded_rng_is_deterministic() {
+        let mut state_a = GameState::new_two_player(7);
+        let mut state_b = GameState::new_two_player(7);
+        let ability = |state_seed: PlayerId| {
+            ResolvedAbility::new(
+                Effect::RollDie {
+                    sides: 20,
+                    results: vec![],
+                    modifier: None,
+                },
+                vec![],
+                ObjectId(1),
+                state_seed,
+            )
+        };
+        let mut ev_a = Vec::new();
+        let mut ev_b = Vec::new();
+        resolve(&mut state_a, &ability(PlayerId(0)), &mut ev_a).unwrap();
+        resolve(&mut state_b, &ability(PlayerId(0)), &mut ev_b).unwrap();
+        let r_a = ev_a
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::DieRolled { result, .. } => Some(*result),
+                _ => None,
+            })
+            .unwrap();
+        let r_b = ev_b
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::DieRolled { result, .. } => Some(*result),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(r_a, r_b, "identically-seeded RNG must roll the same result");
+    }
+
+    /// CR 706.1: All sides in the supported set produce results in 1..=sides.
+    /// This sweeps a representative slice of polyhedral dice to ensure the
+    /// RNG range is correct for every die size used in Magic (d4, d6, d8,
+    /// d10, d12, d20, d100).
+    #[test]
+    fn roll_die_produces_value_in_range_for_each_die_size() {
+        for sides in [4_u8, 6, 8, 10, 12, 20, 100] {
+            let mut state = GameState::new_two_player(sides as u64);
+            let ability = ResolvedAbility::new(
+                Effect::RollDie {
+                    sides,
+                    results: vec![],
+                    modifier: None,
+                },
+                vec![],
+                ObjectId(1),
+                PlayerId(0),
+            );
+            // Roll fifty times per size; every roll must be in 1..=sides.
+            for _ in 0..50 {
+                let mut events = Vec::new();
+                resolve(&mut state, &ability, &mut events).unwrap();
+                let r = events
+                    .iter()
+                    .find_map(|e| match e {
+                        GameEvent::DieRolled { result, .. } => Some(*result),
+                        _ => None,
+                    })
+                    .unwrap();
+                assert!((1..=sides).contains(&r), "d{sides} result {r} out of range");
+            }
+        }
     }
 }

--- a/crates/engine/src/game/effects/roll_die.rs
+++ b/crates/engine/src/game/effects/roll_die.rs
@@ -37,15 +37,18 @@ pub fn resolve(
     // large subtract doesn't wrap; branches with `min`/`max` already in u8
     // simply won't match when the actual result is 0.
     let actual = if let Some(m) = modifier {
-        let delta = match m {
-            DieRollModifier::Add { value } => {
-                resolve_quantity(state, value, ability.controller, ability.source_id)
-            }
-            DieRollModifier::Subtract { value } => {
-                -resolve_quantity(state, value, ability.controller, ability.source_id)
-            }
-        };
-        let combined = (natural as i32).saturating_add(delta);
+        // Carry the sign as the saturating operation rather than negating the
+        // resolved delta: `-resolve_quantity(..)` would panic in debug builds
+        // (and wrap in release) when the quantity resolves to `i32::MIN`.
+        let combined =
+            match m {
+                DieRollModifier::Add { value } => (natural as i32).saturating_add(
+                    resolve_quantity(state, value, ability.controller, ability.source_id),
+                ),
+                DieRollModifier::Subtract { value } => (natural as i32).saturating_sub(
+                    resolve_quantity(state, value, ability.controller, ability.source_id),
+                ),
+            };
         combined.clamp(0, u8::MAX as i32) as u8
     } else {
         natural

--- a/crates/engine/src/game/effects/roll_die.rs
+++ b/crates/engine/src/game/effects/roll_die.rs
@@ -362,4 +362,201 @@ mod tests {
             }
         }
     }
+
+    /// CR 706.2 + CR 608.2c: After a RollDie resolves, the actual result is
+    /// stamped into `state.last_effect_amount` so a follow-up sub-ability with
+    /// `AbilityCondition::PreviousEffectAmount` can gate on it. This is the
+    /// channel that powers "If the result is 0 or less, discard your hand"
+    /// (Deck of Many Things) and analogous result-conditional riders.
+    #[test]
+    fn roll_die_stamps_last_effect_amount_for_chain() {
+        use crate::types::ability::{AbilityCondition, Comparator};
+        let mut state = GameState::new_two_player(7);
+        // No modifier: actual result == natural ∈ 1..=20, always > 0.
+        let ability = ResolvedAbility::new(
+            Effect::RollDie {
+                sides: 20,
+                results: vec![],
+                modifier: None,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        let result = events
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::DieRolled { result, .. } => Some(*result as i32),
+                _ => None,
+            })
+            .expect("DieRolled event must be present");
+        assert_eq!(
+            state.last_effect_amount,
+            Some(result),
+            "last_effect_amount must mirror the actual rolled result so PreviousEffectAmount conditions can read it"
+        );
+        // And the AbilityCondition resolver consumes that channel correctly.
+        let cond = AbilityCondition::PreviousEffectAmount {
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 1 },
+        };
+        let dummy = ResolvedAbility::new(
+            Effect::Unimplemented {
+                name: "probe".into(),
+                description: None,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        assert!(
+            crate::game::effects::evaluate_condition(&cond, &state, &dummy),
+            "result {result} ≥ 1, so the PreviousEffectAmount(GE, 1) condition must hold"
+        );
+    }
+
+    /// CR 706.2 (Deck of Many Things, end-to-end): "Roll a d20 and subtract
+    /// the number of cards in your hand. If the result is 0 or less, discard
+    /// your hand." With 25 cards in hand the modifier dominates any d20 →
+    /// actual clamps to 0, so the conditional Discard sub-ability MUST fire.
+    #[test]
+    fn roll_die_conditional_subability_fires_when_result_le_zero() {
+        use crate::types::ability::{
+            AbilityCondition, Comparator, DieRollModifier, PlayerScope, QuantityRef, TargetFilter,
+        };
+        let mut state = GameState::new_two_player(42);
+        // Seed 25 real hand objects so the modifier (-25) overpowers any
+        // d20 natural roll and the Discard has cards to actually move.
+        for i in 0..25 {
+            crate::game::zones::create_object(
+                &mut state,
+                crate::types::identifiers::CardId(2000 + i as u64),
+                PlayerId(0),
+                format!("Card {i}"),
+                crate::types::zones::Zone::Hand,
+            );
+        }
+        let hand_before = state.players[0].hand.len();
+        // Conditional Discard guarded by "result ≤ 0".
+        let discard = ResolvedAbility::new(
+            Effect::Discard {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                target: TargetFilter::Controller,
+                random: false,
+                unless_filter: None,
+                filter: None,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        )
+        .condition(AbilityCondition::PreviousEffectAmount {
+            comparator: Comparator::LE,
+            rhs: QuantityExpr::Fixed { value: 0 },
+        });
+        let ability = ResolvedAbility::new(
+            Effect::RollDie {
+                sides: 20,
+                results: vec![],
+                modifier: Some(DieRollModifier::Subtract {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::HandSize {
+                            player: PlayerScope::Controller,
+                        },
+                    },
+                }),
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        )
+        .sub_ability(discard);
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        // Roll clamped to 0; condition LE 0 holds; controller discards hand.
+        assert_eq!(
+            state.players[0].hand.len(),
+            0,
+            "result ≤ 0 should fire the guarded Discard, emptying the hand from {hand_before}"
+        );
+    }
+
+    /// CR 706.2 (Deck of Many Things, end-to-end): "Roll a d20 and subtract
+    /// the number of cards in your hand. If the result is 0 or less, discard
+    /// your hand." With zero cards in hand the modifier is 0 → natural roll
+    /// (≥ 1) wins → result ≥ 1, so the conditional Discard MUST NOT fire.
+    #[test]
+    fn roll_die_conditional_subability_skipped_when_result_positive() {
+        use crate::types::ability::{
+            AbilityCondition, AggregateFunction, Comparator, DieRollModifier, PlayerScope,
+            QuantityRef, TargetFilter,
+        };
+        let mut state = GameState::new_two_player(7);
+        // Seed two real hand objects; with 0 cards we'd test nothing — we want
+        // visible objects that would have been discarded had the gate broken.
+        for i in 0..2 {
+            crate::game::zones::create_object(
+                &mut state,
+                crate::types::identifiers::CardId(3000 + i as u64),
+                PlayerId(0),
+                format!("Card {i}"),
+                crate::types::zones::Zone::Hand,
+            );
+        }
+        // Modifier reads opponent's hand size (which is 0) so the result
+        // equals the natural d20 ≥ 1.
+        let discard = ResolvedAbility::new(
+            Effect::Discard {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                target: TargetFilter::Controller,
+                random: false,
+                unless_filter: None,
+                filter: None,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        )
+        .condition(AbilityCondition::PreviousEffectAmount {
+            comparator: Comparator::LE,
+            rhs: QuantityExpr::Fixed { value: 0 },
+        });
+        let ability = ResolvedAbility::new(
+            Effect::RollDie {
+                sides: 20,
+                results: vec![],
+                modifier: Some(DieRollModifier::Subtract {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::HandSize {
+                            player: PlayerScope::Opponent {
+                                aggregate: AggregateFunction::Sum,
+                            },
+                        },
+                    },
+                }),
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        )
+        .sub_ability(discard);
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        // Result ≥ 1, so the LE 0 gate fails and the Discard is skipped.
+        assert_eq!(
+            state.players[0].hand.len(),
+            2,
+            "result ≥ 1 must not fire the guarded Discard"
+        );
+    }
 }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1802,6 +1802,7 @@ mod tests {
                 max: 6,
                 effect: Box::new(conjure_ability("roll", Zone::Hand)),
             }],
+            modifier: None,
         };
         walk_effect(&roll, &mut names);
 

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2256,6 +2256,10 @@ pub(super) fn try_nom_condition_as_ability_condition(
         return Some(condition);
     }
 
+    if let Some(condition) = parse_die_result_condition(lower.as_str()) {
+        return Some(condition);
+    }
+
     // CR 702.62a: "it doesn't have [keyword]" / "it does not have [keyword]" — pronoun
     // subject lacks-keyword check (e.g., "If it doesn't have suspend, it gains suspend").
     // Mirrors the "~ doesn't have" / "this creature doesn't have" handler in oracle_condition.rs.
@@ -2871,6 +2875,26 @@ fn parse_previous_effect_excess_damage_condition(lower: &str) -> Option<AbilityC
     Some(AbilityCondition::PreviousEffectAmount {
         comparator: Comparator::GT,
         rhs: QuantityExpr::Fixed { value: 0 },
+    })
+}
+
+/// CR 706.2 + CR 608.2c: "If the result is N or less / N or more / N or
+/// greater / less than N / greater than N / equal to N / N" — a comparator on
+/// the *actual* result of the most recent die roll in this resolution. Maps
+/// to `AbilityCondition::PreviousEffectAmount`, which reads
+/// `state.last_effect_amount` (populated for `Effect::RollDie` by
+/// `previous_effect_amount_from_events`). Covers Deck of Many Things' "If the
+/// result is 0 or less, discard your hand" and the analogous "is N or
+/// less/more" phrasings used by every dice-table rider in the corpus.
+fn parse_die_result_condition(lower: &str) -> Option<AbilityCondition> {
+    let rest = tag::<_, _, OracleError<'_>>("the result is ")
+        .parse(lower)
+        .ok()
+        .map(|(rest, _)| rest)?;
+    let (comparator, value) = parse_comparison_suffix(rest)?;
+    Some(AbilityCondition::PreviousEffectAmount {
+        comparator,
+        rhs: QuantityExpr::Fixed { value },
     })
 }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5238,10 +5238,10 @@ pub(super) fn parse_imperative_family_ast(
             .ok()
             .map(|(_, ast)| ast)
         }
-        // CR 706: "roll a d20"
-        "roll" | "rolls" => {
-            try_parse_roll_die_sides(lower).map(|sides| ImperativeFamilyAst::RollDie { sides })
-        }
+        // CR 706 + CR 706.2: "roll a d20" with an optional "and add/subtract X"
+        // modifier suffix attached as a typed `DieRollModifier`.
+        "roll" | "rolls" => try_parse_roll_die_with_modifier(lower)
+            .map(|(sides, modifier)| ImperativeFamilyAst::RollDie { sides, modifier }),
         // CR 725.1: "become the monarch"
         "become" | "becomes" => {
             if lower == "become the monarch" || lower == "becomes the monarch" {
@@ -5763,19 +5763,30 @@ fn try_parse_flip_n_coins(lower: &str) -> Option<ImperativeFamilyAst> {
     Some(ImperativeFamilyAst::FlipCoins { count: expr })
 }
 
-fn try_parse_roll_die_sides(lower: &str) -> Option<u8> {
+/// CR 706.1a: Returns `(sides, remainder)`. The remainder is the slice immediately after
+/// the consumed die phrase, with whitespace untrimmed. Callers needing to
+/// attach trailing modifiers / clauses can branch on the remainder shape.
+fn try_parse_roll_die_sides_with_rest(lower: &str) -> Option<(u8, &str)> {
     // Strip the "roll a " / "rolls a " prefix.
     let (rest, _) = alt((tag::<_, _, OracleError<'_>>("roll a "), tag("rolls a ")))
         .parse(lower)
         .ok()?;
-    // Numeric form: "d20", "d6", "d4"
-    if let Ok((num_rest, _)) = tag::<_, _, OracleError<'_>>("d").parse(rest) {
-        if let Ok(sides) = num_rest.parse::<u8>() {
-            return Some(sides);
+    // CR 706.1a: Numeric form — consume "d" followed by the longest run of
+    // ASCII digits. This permits trailing text like " and add the number of
+    // cards in your hand" or terminating punctuation.
+    if let Ok((after_d, _)) = tag::<_, _, OracleError<'_>>("d").parse(rest) {
+        let digit_end = after_d
+            .bytes()
+            .position(|b| !b.is_ascii_digit())
+            .unwrap_or(after_d.len());
+        if digit_end > 0 {
+            if let Ok(sides) = after_d[..digit_end].parse::<u8>() {
+                return Some((sides, &after_d[digit_end..]));
+            }
         }
     }
-    // CR 706: Word-form: "six-sided die", "four-sided die", etc.
-    let (_, sides) = alt((
+    // CR 706.1a: Word-form — "six-sided die", "four-sided die", etc.
+    let (after_word, sides) = alt((
         value(
             4_u8,
             alt((tag::<_, _, OracleError<'_>>("four-sided"), tag("4-sided"))),
@@ -5788,24 +5799,83 @@ fn try_parse_roll_die_sides(lower: &str) -> Option<u8> {
     ))
     .parse(rest)
     .ok()?;
-    Some(sides)
+    // Consume the optional " die" suffix so it doesn't leak into the
+    // modifier-detection path. Tolerant of absence ("roll a six-sided").
+    let after_word = alt((
+        value((), tag::<_, _, OracleError<'_>>(" die")),
+        value((), tag("")),
+    ))
+    .parse(after_word)
+    .ok()
+    .map(|(rest, _)| rest)
+    .unwrap_or(after_word);
+    Some((sides, after_word))
 }
 
-/// CR 706.2: Try to parse a d20 result table line like "1—9 | Draw two cards"
-/// or "20 | Search your library for a card". Returns `(min, max, effect_text)`.
+/// CR 706 + CR 706.2: Try to parse a full `"roll a d{N}"` clause, including
+/// an optional trailing `" and (add|subtract) {quantity}"` modifier that the
+/// resolver applies to the natural roll before result-table lookup.
+///
+/// Returns `(sides, modifier)` on success. The modifier is `None` when the
+/// remainder is empty or only contains trailing punctuation; otherwise the
+/// remainder must shape as a recognized add/subtract clause.
+fn try_parse_roll_die_with_modifier(
+    lower: &str,
+) -> Option<(u8, Option<crate::types::ability::DieRollModifier>)> {
+    let (sides, rest) = try_parse_roll_die_sides_with_rest(lower)?;
+    let rest = rest.trim_end_matches(['.', ',', ';']).trim();
+    if rest.is_empty() {
+        return Some((sides, None));
+    }
+    // Modifier shapes: "and add X", "and subtract X". Anything else means the
+    // clause is wider than just a roll — let the dispatch fall through to
+    // higher-level chain parsing (e.g., "roll a d20 for each player").
+    let (after_and, _) = tag::<_, _, OracleError<'_>>("and ").parse(rest).ok()?;
+    let (modifier_text, sign) = alt((
+        value(true, tag::<_, _, OracleError<'_>>("add ")),
+        value(false, tag("subtract ")),
+    ))
+    .parse(after_and)
+    .ok()?;
+    let value = crate::parser::oracle_quantity::parse_quantity_ref(modifier_text)?;
+    let modifier = if sign {
+        crate::types::ability::DieRollModifier::Add {
+            value: crate::types::ability::QuantityExpr::Ref { qty: value },
+        }
+    } else {
+        crate::types::ability::DieRollModifier::Subtract {
+            value: crate::types::ability::QuantityExpr::Ref { qty: value },
+        }
+    };
+    Some((sides, Some(modifier)))
+}
+
+/// CR 706.2: Try to parse a d20 result table line like "1—9 | Draw two cards",
+/// "20 | Search your library for a card", or "15+ | Scry X, then draw X cards".
+/// Returns `(min, max, effect_text)`. Open-ended upper bounds ("15+") set
+/// `max = u8::MAX` so any modifier-boosted roll above the printed lower bound
+/// resolves to this branch — see CR 706.2 on modifier-shifted results
+/// (Diviner's Portent, Gale's Redirection, etc.).
 pub(crate) fn try_parse_die_result_line(text: &str) -> Option<(u8, u8, &str)> {
     let trimmed = text.trim();
 
-    // Find the pipe separator: "N—M | effect" or "N | effect"
+    // Find the pipe separator: "N—M | effect", "N+ | effect", or "N | effect"
     let (_, (range_part, effect_text)) = nom_primitives::split_once_on(trimmed, " | ").ok()?;
     let range_part = range_part.trim();
     let effect_text = effect_text.trim();
 
-    // Parse range: "1—9" (em dash U+2014), "10—19", "20" (single value)
+    // Parse range: "1—9" (em dash U+2014), "10—19", "15+" (open-ended upper),
+    // or "20" (single value).
     let (min, max) = if let Some(dash_idx) = range_part.find('\u{2014}') {
         let min_str = &range_part[..dash_idx];
         let max_str = &range_part[dash_idx + '\u{2014}'.len_utf8()..];
         (min_str.parse::<u8>().ok()?, max_str.parse::<u8>().ok()?)
+    } else if let Some(min_str) = range_part.strip_suffix('+') {
+        // CR 706.2: "N+" — modifier-shifted rolls can exceed the printed die's
+        // face count, so the upper bound is open. allow-noncombinator: nom is
+        // overkill for a single trailing-char check on a pre-split numeric
+        // token; the surrounding range_part is already nom-split off the pipe.
+        (min_str.trim().parse::<u8>().ok()?, u8::MAX)
     } else {
         // Single value like "20"
         let val = range_part.parse::<u8>().ok()?;
@@ -6095,9 +6165,10 @@ fn lower_imperative_family_effect(ast: ImperativeFamilyAst) -> Effect {
         ImperativeFamilyAst::LoseKeyword(effect) => effect,
         ImperativeFamilyAst::LoseTheGame => Effect::LoseTheGame,
         ImperativeFamilyAst::WinTheGame => Effect::WinTheGame,
-        ImperativeFamilyAst::RollDie { sides } => Effect::RollDie {
+        ImperativeFamilyAst::RollDie { sides, modifier } => Effect::RollDie {
             sides,
             results: vec![],
+            modifier,
         },
         ImperativeFamilyAst::FlipCoin => Effect::FlipCoin {
             win_effect: None,
@@ -9748,5 +9819,116 @@ mod tests {
             }
             other => panic!("expected Effect::PutCounter, got {other:?}"),
         }
+    }
+
+    /// CR 706 + CR 706.2: "Roll a d20" with no modifier parses to a bare RollDie.
+    #[test]
+    fn roll_a_d20_no_modifier_parses_to_roll_die() {
+        let def = super::super::parse_effect_chain("Roll a d20.", AbilityKind::Spell);
+        match &*def.effect {
+            Effect::RollDie {
+                sides,
+                modifier,
+                results,
+            } => {
+                assert_eq!(*sides, 20);
+                assert!(modifier.is_none());
+                assert!(results.is_empty());
+            }
+            other => panic!("expected RollDie, got {other:?}"),
+        }
+    }
+
+    /// CR 706.2: "Roll a d20 and add the number of cards in your hand" parses
+    /// to RollDie with an Add modifier referencing controller hand size.
+    #[test]
+    fn roll_a_d20_with_add_modifier_parses_to_roll_die_with_modifier() {
+        let def = super::super::parse_effect_chain(
+            "Roll a d20 and add the number of cards in your hand.",
+            AbilityKind::Spell,
+        );
+        match &*def.effect {
+            Effect::RollDie {
+                sides, modifier, ..
+            } => {
+                assert_eq!(*sides, 20);
+                let m = modifier.as_ref().expect("expected Add modifier");
+                match m {
+                    crate::types::ability::DieRollModifier::Add { value } => match value {
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::HandSize { player },
+                        } => {
+                            assert!(matches!(
+                                player,
+                                crate::types::ability::PlayerScope::Controller
+                            ));
+                        }
+                        other => panic!("expected HandSize ref, got {other:?}"),
+                    },
+                    other => panic!("expected Add modifier, got {other:?}"),
+                }
+            }
+            other => panic!("expected RollDie, got {other:?}"),
+        }
+    }
+
+    /// CR 706.2: "Roll a d20 and subtract the number of cards in your hand"
+    /// parses to RollDie with a Subtract modifier. Mirrors the Add case to
+    /// guarantee the sign path is wired.
+    #[test]
+    fn roll_a_d20_with_subtract_modifier_parses_to_roll_die_with_modifier() {
+        let def = super::super::parse_effect_chain(
+            "Roll a d20 and subtract the number of cards in your hand.",
+            AbilityKind::Activated,
+        );
+        match &*def.effect {
+            Effect::RollDie {
+                sides, modifier, ..
+            } => {
+                assert_eq!(*sides, 20);
+                let m = modifier.as_ref().expect("expected Subtract modifier");
+                assert!(matches!(
+                    m,
+                    crate::types::ability::DieRollModifier::Subtract { .. }
+                ));
+            }
+            other => panic!("expected RollDie, got {other:?}"),
+        }
+    }
+
+    /// CR 706.2: "Roll a six-sided die" is the word-form variant — parses to
+    /// RollDie { sides: 6 } so cards printed in the older "N-sided die"
+    /// phrasing continue to work alongside the modern "dN" shorthand.
+    #[test]
+    fn roll_a_six_sided_die_parses_to_roll_die_six() {
+        let def = super::super::parse_effect_chain("Roll a six-sided die.", AbilityKind::Spell);
+        match &*def.effect {
+            Effect::RollDie {
+                sides, modifier, ..
+            } => {
+                assert_eq!(*sides, 6);
+                assert!(modifier.is_none());
+            }
+            other => panic!("expected RollDie, got {other:?}"),
+        }
+    }
+
+    /// CR 706.2: open-ended upper bound "N+" parses to (min=N, max=u8::MAX) so
+    /// modifier-boosted rolls beyond the printed face count still resolve to
+    /// the intended branch.
+    #[test]
+    fn die_result_line_open_ended_upper_bound() {
+        assert_eq!(
+            super::try_parse_die_result_line("15+ | Draw two cards."),
+            Some((15, u8::MAX, "Draw two cards."))
+        );
+        assert_eq!(
+            super::try_parse_die_result_line("1\u{2014}9 | Draw a card."),
+            Some((1, 9, "Draw a card."))
+        );
+        assert_eq!(
+            super::try_parse_die_result_line("20 | Win the game."),
+            Some((20, 20, "Win the game."))
+        );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5870,11 +5870,8 @@ pub(crate) fn try_parse_die_result_line(text: &str) -> Option<(u8, u8, &str)> {
         let min_str = &range_part[..dash_idx];
         let max_str = &range_part[dash_idx + '\u{2014}'.len_utf8()..];
         (min_str.parse::<u8>().ok()?, max_str.parse::<u8>().ok()?)
+    // allow-noncombinator: CR 706.2 "N+" open-ended upper bound — single-char structural suffix on a pre-tokenized numeric range slice; the surrounding nom split already isolated `range_part` off the pipe delimiter (Pattern 3 in PATTERNS.md).
     } else if let Some(min_str) = range_part.strip_suffix('+') {
-        // CR 706.2: "N+" — modifier-shifted rolls can exceed the printed die's
-        // face count, so the upper bound is open. allow-noncombinator: nom is
-        // overkill for a single trailing-char check on a pre-split numeric
-        // token; the surrounding range_part is already nom-split off the pipe.
         (min_str.trim().parse::<u8>().ok()?, u8::MAX)
     } else {
         // Single value like "20"

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -605,6 +605,19 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                             ))
                             .parse(remainder_trimmed)
                             .is_ok();
+                    // CR 706.2: "roll a d{N} and (add|subtract) {quantity}" —
+                    // the modifier clause is part of the same RollDie effect
+                    // (it shifts the natural result) and must NOT be peeled
+                    // off as a sibling clause. Without this suppression
+                    // "Roll a d20 and add the number of cards in your hand"
+                    // would split into ["Roll a d20", "add ..."] and the
+                    // modifier silently becomes an Unimplemented sub_ability
+                    // — bypassing the typed modifier path on every D&D-set
+                    // d20 card.
+                    let roll_die_modifier_continuation = ends_with_roll_die_phrase(&before_lower)
+                        && alt((tag::<_, _, OracleError<'_>>("add "), tag("subtract ")))
+                            .parse(remainder_trimmed)
+                            .is_ok();
                     let suppress = nom_primitives::scan_contains(&before_lower, "from among")
                         || is_inside_temporal_prefix(&before_lower)
                         || targeted_compound_continuation
@@ -615,7 +628,8 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                         || compound_subject_each
                         || inside_otherwise_body
                         || have_base_pt_continuation
-                        || continuous_modifier_conjunct;
+                        || continuous_modifier_conjunct
+                        || roll_die_modifier_continuation;
                     if !suppress && starts_bare_and_clause(remainder_trimmed) {
                         push_clause_chunk(&mut chunks, before_and, Some(ClauseBoundary::Comma));
                         current.clear();
@@ -860,6 +874,46 @@ pub(super) fn starts_clause_text_or_conjugated(text: &str) -> bool {
     let rest = &lower[first_word.len()..];
     let deconjugated = format!("{base}{rest}");
     starts_clause_text_lower(&deconjugated)
+}
+
+/// CR 706.2: True iff `before_lower` ends with a "roll a d{N}" phrase (with
+/// the standard set of polyhedral side counts) or the word-form variants
+/// "six-sided die", "twenty-sided die", etc. Used by the bare-and splitter to
+/// keep "roll a d20 and add/subtract X" intact so the typed modifier path
+/// fires instead of producing a stray Unimplemented sub_ability.
+fn ends_with_roll_die_phrase(before_lower: &str) -> bool {
+    let trimmed = before_lower.trim_end();
+    // Numeric form: any "roll a d<digits>" tail. allow-noncombinator:
+    // structural rsplit on a runtime ' ' separator (not a literal dispatch
+    // token) followed by a char-class digit scan — no string-method dispatch
+    // against any literal phrase.
+    if let Some(last_word) = trimmed.rsplit(' ').next() {
+        if let Some(digits) = last_word.strip_prefix('d') {
+            if !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()) {
+                return true;
+            }
+        }
+    }
+    // Word-form: "...-sided die". The tail must match one of the polyhedral
+    // phrases. Take the last three space-separated tokens (`<N>-sided die`)
+    // and parse them with nom alternatives.
+    let tail = trimmed.rsplitn(3, ' ').collect::<Vec<_>>();
+    if tail.len() != 3 {
+        return false;
+    }
+    // tail is reversed; reconstruct "<N>-sided die" by re-joining.
+    let candidate = format!("{} {}", tail[1], tail[0]);
+    let parsed: Result<((), ()), nom::Err<OracleError<'_>>> = alt((
+        value((), tag::<_, _, OracleError<'_>>("four-sided die")),
+        value((), tag("six-sided die")),
+        value((), tag("eight-sided die")),
+        value((), tag("ten-sided die")),
+        value((), tag("twelve-sided die")),
+        value((), tag("twenty-sided die")),
+    ))
+    .parse(candidate.as_str())
+    .map(|(_, v)| ((), v));
+    parsed.is_ok()
 }
 
 fn starts_you_control_subject_predicate(s: &str) -> bool {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -888,6 +888,7 @@ fn ends_with_roll_die_phrase(before_lower: &str) -> bool {
     // token) followed by a char-class digit scan — no string-method dispatch
     // against any literal phrase.
     if let Some(last_word) = trimmed.rsplit(' ').next() {
+        // allow-noncombinator: CR 706.1a "d{digits}" structural shape — single-char prefix `d` followed by an ASCII-digit run on a pre-tokenized last-word slice; this is a CR-spec character-class scan, not dispatch against any literal phrase.
         if let Some(digits) = last_word.strip_prefix('d') {
             if !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()) {
                 return true;

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -381,8 +381,12 @@ pub(crate) enum ImperativeFamilyAst {
     /// CR 104.3a: "[you/target player] win(s) the game"
     WinTheGame,
     /// CR 706: Roll a die with N sides.
+    /// CR 706.2: Optional additive/subtractive modifier applied to the natural
+    /// result before result-table lookup ("Roll a d20 and add the number of
+    /// cards in your hand").
     RollDie {
         sides: u8,
+        modifier: Option<crate::types::ability::DieRollModifier>,
     },
     /// CR 705: Flip a coin.
     FlipCoin,

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -247,6 +247,9 @@ fn find_terminal_roll_die(def: &mut AbilityDefinition) -> Option<&mut Effect> {
 }
 
 /// CR 706: Try to parse a die roll table starting at line `i`.
+/// CR 706.2: Also extracts an optional "and add/subtract X" modifier
+/// from the header line so the resolver can shift the natural result before
+/// branch lookup (Deck of Many Things, Diviner's Portent, Gale's Redirection).
 pub(super) fn try_parse_die_roll_table(
     lines: &[&str],
     i: usize,
@@ -254,7 +257,7 @@ pub(super) fn try_parse_die_roll_table(
     kind: AbilityKind,
 ) -> Option<(AbilityDefinition, usize)> {
     let lower = line.to_lowercase();
-    let sides = parse_roll_die_sides(&lower)?;
+    let (sides, modifier) = parse_roll_die_sides_with_modifier(&lower)?;
 
     let mut branches = Vec::new();
     let mut has_branches = false;
@@ -285,25 +288,64 @@ pub(super) fn try_parse_die_roll_table(
         Effect::RollDie {
             sides,
             results: branches,
+            modifier,
         },
     );
     def.description = Some(line.to_string());
     Some((def, if has_branches { j } else { i + 1 }))
 }
 
-/// CR 706: Parse die side count from "roll a dN" and word-form "roll a six-sided die" patterns.
-fn parse_roll_die_sides(lower: &str) -> Option<u8> {
+/// CR 706.1a + CR 706.2: Parse the header line of a die-roll table, returning
+/// `(sides, optional_modifier)`. The modifier captures "and add/subtract X"
+/// suffixes attached to the roll command. Used by `try_parse_die_roll_table`
+/// so the same shape works at every parsing entry point (spell text, trigger
+/// text, activated effect text).
+fn parse_roll_die_sides_with_modifier(
+    lower: &str,
+) -> Option<(u8, Option<crate::types::ability::DieRollModifier>)> {
     let ((), rest) = nom_on_lower(lower, lower, |i| {
         value((), alt((tag("roll a d"), tag("rolls a d")))).parse(i)
     })?;
-    let rest = rest.trim_end_matches('.');
-    // Numeric form: "roll a d20", "roll a d6" — rest is "20", "6", etc.
-    if let Ok(n) = rest.parse::<u8>() {
-        return Some(n);
+    // Numeric form first; word-form below.
+    let digit_end = rest
+        .bytes()
+        .position(|b| !b.is_ascii_digit())
+        .unwrap_or(rest.len());
+    if digit_end > 0 {
+        if let Ok(sides) = rest[..digit_end].parse::<u8>() {
+            let after = &rest[digit_end..];
+            return Some((sides, parse_optional_modifier_suffix(after)));
+        }
     }
-    // Word-form: "roll a six-sided die" — the "roll a d" prefix consumed "d" which
-    // doesn't apply here, so fall back to word-form parsing on the full string.
-    parse_roll_die_sides_word_form(lower)
+    let sides = parse_roll_die_sides_word_form(lower)?;
+    Some((sides, None))
+}
+
+/// CR 706.2: Parse an optional " and (add|subtract) X" suffix attached to a
+/// die roll header. Returns `None` when the suffix is empty / purely
+/// punctuation; returns `None` (suffix dropped) when the suffix is non-empty
+/// but doesn't shape as a recognized modifier — the caller's outer parsing
+/// has already captured `sides`, and any wider trailing clause is handled by
+/// downstream chain parsing.
+fn parse_optional_modifier_suffix(after: &str) -> Option<crate::types::ability::DieRollModifier> {
+    let trimmed = after.trim().trim_end_matches(['.', ',', ';']).trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (after_and, _) = tag::<_, _, OracleError<'_>>("and ").parse(trimmed).ok()?;
+    let (modifier_text, sign) = alt((
+        value(true, tag::<_, _, OracleError<'_>>("add ")),
+        value(false, tag("subtract ")),
+    ))
+    .parse(after_and)
+    .ok()?;
+    let qty = crate::parser::oracle_quantity::parse_quantity_ref(modifier_text)?;
+    let value = crate::types::ability::QuantityExpr::Ref { qty };
+    Some(if sign {
+        crate::types::ability::DieRollModifier::Add { value }
+    } else {
+        crate::types::ability::DieRollModifier::Subtract { value }
+    })
 }
 
 /// CR 706: Parse word-form die patterns like "roll a six-sided die".

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -410,6 +410,19 @@ pub struct DieResultBranch {
     pub effect: Box<AbilityDefinition>,
 }
 
+/// CR 706.2: Modifier applied to a die roll's natural result before the
+/// effect's result table is consulted. "Roll a d20 and add the number of
+/// cards in your hand" → `Add(QuantityExpr::Ref(HandSize { player: Controller }))`.
+/// "Roll a d20 and subtract the number of cards in your hand" → `Subtract(...)`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum DieRollModifier {
+    /// Add the resolved quantity to the natural roll.
+    Add { value: QuantityExpr },
+    /// Subtract the resolved quantity from the natural roll.
+    Subtract { value: QuantityExpr },
+}
+
 impl std::str::FromStr for Parity {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, ()> {
@@ -6156,10 +6169,14 @@ pub enum Effect {
     WinTheGame,
     /// CR 706: Roll a die with the given number of sides.
     /// If `results` is non-empty, execute the matching branch.
+    /// CR 706.2: `modifier` adjusts the natural roll before result-branch lookup.
+    /// `None` means the natural result is used unchanged.
     RollDie {
         sides: u8,
         #[serde(default)]
         results: Vec<DieResultBranch>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        modifier: Option<DieRollModifier>,
     },
     /// CR 705: Flip a coin. Optionally execute different effects on win/lose.
     FlipCoin {


### PR DESCRIPTION
## Summary
Fixes #702 — dice roll effects do not work. The `Effect::RollDie`, `GameEvent::DieRolled`, and `TriggerMode::RolledDie` infrastructure already existed and was correct; the bug was a **parser-dispatch gap**. Any `"roll a d{N} and add/subtract X"` modifier suffix or `"if the result is N or less, [effect]"` conditional result-gate fell through to `Effect::Unimplemented`. This class-level parser fix unlocks The Deck of Many Things, Diviner's Portent, Revivify, and Arden Angel.

Closes #702.

## Files changed
- crates/engine/src/game/coverage.rs
- crates/engine/src/game/effects/effect.rs
- crates/engine/src/game/effects/mod.rs
- crates/engine/src/game/effects/roll_die.rs
- crates/engine/src/game/printed_cards.rs
- crates/engine/src/parser/oracle_effect/conditions.rs
- crates/engine/src/parser/oracle_effect/imperative.rs
- crates/engine/src/parser/oracle_effect/sequence.rs
- crates/engine/src/parser/oracle_ir/ast.rs
- crates/engine/src/parser/oracle_special.rs
- crates/engine/src/types/ability.rs

## CR references (verified against docs/MagicCompRules.txt)
- CR 706 — Rolling a Die (section header)
- CR 706.1a — d{N} notation for sided dice
- CR 706.2 — natural result + additive/subtractive modifiers
- CR 608.2c — later text modifies meaning during resolution (basis for the conditional-on-result sub-ability gate)

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Tier
Tier: Frontier

## Cards unlocked
- **The Deck of Many Things** — d20 minus hand-size rolls, correct result-table dispatch, conditional discard fires only when result ≤ 0
- **Diviner's Portent** — `Add { HandSize }` modifier; open-ended upper bound `"15+"`
- **Revivify** — `Add` modifier; full result table parsed
- **Arden Angel** — `"if the result is 1, return ~"` gated via class-level `PreviousEffectAmount` fix

## Pipeline summary
- **doc-guardian:** CLEAN — every cited CR number verified against docs/MagicCompRules.txt.
- **code-reviewer (round 1):** REQUEST CHANGES on 1 RULES BUG — Deck of Many Things would discard hand unconditionally after the modifier fix unmasked an existing splitter issue.
- **fix-writer:** Applied class-level fix using existing `AbilityCondition::PreviousEffectAmount` + new `parse_die_result_condition` combinator. Arden Angel benefits as a side effect.
- **code-reviewer (round 2):** APPROVE WITH SUGGESTIONS — no remaining BUG or RULES BUG.
- **qa-tester:** READY FOR PR — 9351 engine tests pass (+15 dice tests), fmt + clippy + parser-combinator gate clean.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `./scripts/check-parser-combinators.sh` — exit 0
- `cargo test -p engine` — 9351 passed, 0 failed, 8 ignored
- `./scripts/gen-card-data.sh` — clean
- `cargo coverage` — 86.0% (29887/34771)
- `cargo semantic-audit` — clean on dice cards
- `cargo parser-gaps` — dice-modifier + result-gate patterns no longer flagged
- `jq '.["the deck of many things"]'` confirms `condition: PreviousEffectAmount{LE, Fixed(0)}` on Discard sub-ability

## Scope Expansion
Class-level fix for the conditional-on-result sub-ability gate uses the existing `AbilityCondition::PreviousEffectAmount` channel — no new infrastructure type was needed, but a new `parse_die_result_condition` nom combinator was added. Arden Angel benefits as a class side effect.

## Validation Failures
A pre-existing failure on `origin/main` in `crates/mtgish-import/tests/manifest_coverage.rs` reports `ORDERING_MANIFEST` missing an entry for `(ReplacementCondition, conditions)`. This is **not** caused by this branch and **not** in this diff — it stems from a separate agent's prior `ReplacementCondition::And { conditions: Vec<...> }` addition. Per CLAUDE.md multi-agent safety, left untouched. `docs/AI-CONTRIBUTOR.md §0.5` declares `crates/mtgish-import/` dormant.

## CI Failures
None expected from this branch.

## Scope Cuts (deferred follow-ups)
1. **Krark's Thumb-style replacement effects** — no `ReplacementEvent::DieRoll` yet
2. **Multi-sentence rolls** (Danse Macabre) — needs sub-ability composition
3. **Recursive "if you roll a 20, repeat"** (Sword of D&D, Boots of Speed) — needs conditional-recursion variant
4. **`QuantityRef`-valued comparators** (Captain Rex Nebula, Clowning Around) — needs `parse_comparison_suffix` to accept dynamic rhs
5. **Frontend dice-roll animation/UI** — not added; log pipeline surfaces values
6. **`-resolve_quantity(...)` debug-panic on `i32::MIN`** in `roll_die.rs:38-40` — trivial 1-line fix, deferred

## Reviewer-flagged CONCERN items (for future visibility)
- `GameEvent::DieRolled.result` conflates natural and modified result (CR 706.2 distinguishes them)
- `clamp(0, u8::MAX)` deviates from CR 706.2; benign today
- Imperative parse path drops entire `RollDie` on unparseable modifier; table-header path falls back gracefully — inconsistent