### PR TITLE
feat(engine): exchange a player's life total with a creature's power/toughness

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1738,6 +1738,16 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         Effect::LoseLife { amount, .. } => {
             d.push(("amount".into(), fmt_quantity(amount)));
         }
+        Effect::ExchangeLifeWithStat { player, stat } => {
+            d.push(("player".into(), fmt_target(player)));
+            d.push((
+                "stat".into(),
+                match stat {
+                    PtStat::Power => "power".into(),
+                    PtStat::Toughness => "toughness".into(),
+                },
+            ));
+        }
         Effect::ChangeZone {
             origin,
             destination,

--- a/crates/engine/src/game/effects/exchange_life.rs
+++ b/crates/engine/src/game/effects/exchange_life.rs
@@ -1,0 +1,284 @@
+use crate::game::effects::life::{apply_damage_life_loss, apply_life_gain};
+use crate::game::static_abilities::{player_has_cant_gain_life, player_has_cant_lose_life};
+use crate::types::ability::{
+    ContinuousModification, Duration, Effect, EffectError, EffectKind, PtStat, ResolvedAbility,
+    TargetFilter, TargetRef,
+};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+
+/// CR 701.12a: Exchange a player's life total with the source permanent's power
+/// or toughness (Tree of Perdition, Tree of Redemption, Evra, Halcyon Witness).
+///
+/// CR 701.12a requires both previous values to be read before either changes
+/// and makes the exchange all-or-nothing: if the life change is forbidden
+/// (CR 119.7 can't-gain when raising, CR 119.8 can't-lose when lowering), no
+/// part of the exchange occurs. Both writes use the captured previous values,
+/// so their order is irrelevant.
+///
+/// The stat side becomes an indefinite layer-7b continuous "set" effect
+/// (CR 613.4b) on the source: its base power/toughness is set to the player's
+/// previous life total, so counters (layer 7d) and +N/+N modifiers (layer 7c)
+/// still apply on top per the card's rulings.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let stat = match &ability.effect {
+        Effect::ExchangeLifeWithStat { stat, .. } => *stat,
+        // Dispatcher in effects/mod.rs only routes ExchangeLifeWithStat here.
+        _ => return Ok(()),
+    };
+
+    let resolved_kind = EffectKind::from(&ability.effect);
+
+    // "your life total" forms declare no player target and fall back to the
+    // ability's controller; "target opponent's life total" supplies a player.
+    let player_id = ability
+        .targets
+        .iter()
+        .find_map(|t| match t {
+            TargetRef::Player(pid) => Some(*pid),
+            TargetRef::Object(_) => None,
+        })
+        .unwrap_or(ability.controller);
+
+    // CR 701.12a: capture both previous values before any mutation.
+    let Some(source) = state.objects.get(&ability.source_id) else {
+        // Source left the battlefield before resolution — the stat side can't
+        // be completed, so per CR 701.12a nothing happens.
+        events.push(GameEvent::EffectResolved {
+            kind: resolved_kind,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    };
+    let stat_value = match stat {
+        PtStat::Power => source.power,
+        PtStat::Toughness => source.toughness,
+    };
+    let Some(stat_value) = stat_value else {
+        // Source has no power/toughness (not a creature) — can't complete.
+        events.push(GameEvent::EffectResolved {
+            kind: resolved_kind,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    };
+
+    let old_life = state
+        .players
+        .iter()
+        .find(|p| p.id == player_id)
+        .ok_or(EffectError::PlayerNotFound)?
+        .life;
+
+    // CR 701.12a + CR 119.7 / CR 119.8: All-or-nothing. The player's life total
+    // would be set to `stat_value` (CR 119.5). If that change is forbidden, no
+    // part of the exchange occurs.
+    let life_blocked = match stat_value.cmp(&old_life) {
+        std::cmp::Ordering::Greater => player_has_cant_gain_life(state, player_id),
+        std::cmp::Ordering::Less => player_has_cant_lose_life(state, player_id),
+        std::cmp::Ordering::Equal => false,
+    };
+    if life_blocked {
+        events.push(GameEvent::EffectResolved {
+            kind: resolved_kind,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
+    // CR 613.4b: Set the source's exchanged stat to the player's previous life
+    // total via an indefinite (Duration::Permanent) layer-7b continuous effect.
+    let modification = match stat {
+        PtStat::Power => ContinuousModification::SetPower { value: old_life },
+        PtStat::Toughness => ContinuousModification::SetToughness { value: old_life },
+    };
+    state.add_transient_continuous_effect(
+        ability.source_id,
+        ability.controller,
+        Duration::Permanent,
+        TargetFilter::SpecificObject {
+            id: ability.source_id,
+        },
+        vec![modification],
+        None,
+    );
+
+    // CR 119.5: Set the player's life total to the stat's previous value by
+    // gaining or losing the difference. The helpers re-check CR 119.7/119.8 and
+    // route through the replacement pipeline.
+    let diff = stat_value - old_life;
+    let deferred = match diff.signum() {
+        1 => apply_life_gain(state, player_id, diff as u32, events).err(),
+        -1 => apply_damage_life_loss(state, player_id, (-diff) as u32, events).err(),
+        _ => None,
+    };
+    if deferred.is_some() {
+        // CR 614.7: a competing replacement required a player choice; the helper
+        // installed the WaitingFor and the resume path completes resolution.
+        return Ok(());
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: resolved_kind,
+        source_id: ability.source_id,
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::layers::evaluate_layers;
+    use crate::game::zones::create_object;
+    use crate::types::ability::{ContinuousModification, ControllerRef, TypedFilter};
+    use crate::types::card_type::{CardType, CoreType};
+    use crate::types::identifiers::CardId;
+    use crate::types::player::PlayerId;
+    use crate::types::zones::Zone;
+
+    /// Builds a creature on the battlefield with the given base power/toughness
+    /// and recomputes layers so `power`/`toughness` are populated.
+    fn create_creature(
+        state: &mut GameState,
+        owner: PlayerId,
+        power: i32,
+        toughness: i32,
+    ) -> crate::types::identifiers::ObjectId {
+        let id = create_object(
+            state,
+            CardId(700),
+            owner,
+            "Tree".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.base_power = Some(power);
+        obj.base_toughness = Some(toughness);
+        obj.base_card_types = CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec![],
+        };
+        evaluate_layers(state);
+        id
+    }
+
+    /// CR 701.12a + CR 119.5 + CR 613.4b: Tree of Perdition exchanges the
+    /// opponent's life total with the source's toughness. The opponent's life
+    /// becomes the toughness; the toughness is set (layer 7b) to the opponent's
+    /// previous life.
+    #[test]
+    fn exchange_sets_opponent_life_and_source_toughness() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_creature(&mut state, PlayerId(0), 0, 13);
+        state.players[1].life = 25;
+
+        let ability = ResolvedAbility::new(
+            Effect::ExchangeLifeWithStat {
+                player: TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent),
+                ),
+                stat: PtStat::Toughness,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // CR 119.5: opponent's life becomes the source's previous toughness.
+        assert_eq!(state.players[1].life, 13);
+        // CR 613.4b: a layer-7b set effect locks the source's toughness to the
+        // opponent's previous life total.
+        assert!(state.transient_continuous_effects.iter().any(|e| {
+            e.source_id == source
+                && e.modifications
+                    .contains(&ContinuousModification::SetToughness { value: 25 })
+        }));
+        evaluate_layers(&mut state);
+        assert_eq!(state.objects.get(&source).unwrap().toughness, Some(25));
+    }
+
+    /// CR 701.12a: "your life total" form exchanges the controller's life with
+    /// the source's toughness, with no player target supplied.
+    #[test]
+    fn exchange_uses_controller_when_no_target() {
+        let mut state = GameState::new_two_player(7);
+        let source = create_creature(&mut state, PlayerId(0), 0, 13);
+        state.players[0].life = 4;
+
+        let ability = ResolvedAbility::new(
+            Effect::ExchangeLifeWithStat {
+                player: TargetFilter::Controller,
+                stat: PtStat::Toughness,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.players[0].life, 13);
+        evaluate_layers(&mut state);
+        assert_eq!(state.objects.get(&source).unwrap().toughness, Some(4));
+    }
+
+    /// CR 701.12a + CR 119.7: All-or-nothing. If the player can't gain life and
+    /// the exchange would raise their life, no part of the exchange occurs — the
+    /// toughness is not set either.
+    #[test]
+    fn exchange_blocked_when_cant_gain_life_does_nothing() {
+        use crate::types::ability::{StaticDefinition, TargetFilter as TF};
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new_two_player(99);
+        let source = create_creature(&mut state, PlayerId(0), 0, 13);
+        state.players[0].life = 5;
+        // Player 0 can't gain life.
+        let lock = create_object(
+            &mut state,
+            CardId(901),
+            PlayerId(0),
+            "Lock".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&lock)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::CantGainLife).affected(TF::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+            );
+
+        let ability = ResolvedAbility::new(
+            Effect::ExchangeLifeWithStat {
+                player: TargetFilter::Controller,
+                stat: PtStat::Toughness,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // CR 701.12a: life unchanged (would have risen 5 → 13) ...
+        assert_eq!(state.players[0].life, 5);
+        // ... and the toughness was not set.
+        assert!(!state.transient_continuous_effects.iter().any(|e| {
+            matches!(
+                e.modifications.first(),
+                Some(ContinuousModification::SetToughness { .. })
+            )
+        }));
+    }
+}

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -66,6 +66,7 @@ pub mod effect;
 pub mod endure;
 pub mod energy;
 pub mod exchange_control;
+pub mod exchange_life;
 pub mod exile_from_top_until;
 pub mod exile_top;
 pub mod exploit;
@@ -1497,6 +1498,7 @@ pub fn resolve_effect(
         }
         Effect::CollectEvidence { .. } => collect_evidence::resolve(state, ability, events),
         Effect::SetLifeTotal { .. } => life::resolve_set_life_total(state, ability, events),
+        Effect::ExchangeLifeWithStat { .. } => exchange_life::resolve(state, ability, events),
         Effect::SetDayNight { to } => {
             crate::game::day_night::resolve_set_day_night(state, *to, events);
             Ok(())

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -617,6 +617,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::CounterAll { .. }
         | Effect::GainLife { .. }
         | Effect::LoseLife { .. }
+        | Effect::ExchangeLifeWithStat { .. }
         | Effect::Tap { .. }
         | Effect::Untap { .. }
         | Effect::TapAll { .. }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -27,7 +27,7 @@ use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, CategoryChooserScope, ChoiceType,
     Chooser, ContinuousModification, ControllerRef, CopyRetargetPermission, Duration, Effect,
     FilterProp, GainLifePlayer, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool,
-    PaymentCost, PlayerScope, PreventionAmount, PreventionScope, PtValue, QuantityExpr,
+    PaymentCost, PlayerScope, PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr,
     QuantityRef, SearchSelectionConstraint, StaticDefinition, TargetFilter, TypedFilter, ZoneOwner,
 };
 use crate::types::card_type::CoreType;
@@ -5389,6 +5389,12 @@ pub(super) fn parse_imperative_family_ast(
         // Both shapes lower to ExchangeControl { target_a, target_b }; in the
         // quantified case both filters are identical.
         "exchange" => {
+            // CR 701.12a: "exchange <player>'s life total with ~'s power/toughness"
+            // (Tree of Perdition, Tree of Redemption, Evra) — checked before
+            // "exchange control of" since the two shapes share only the verb.
+            if let Some((player, stat)) = try_parse_exchange_life_with_stat(lower) {
+                return Some(ImperativeFamilyAst::ExchangeLifeWithStat { player, stat });
+            }
             let (rest, _) = tag::<_, _, OracleError<'_>>("exchange control of ")
                 .parse(lower)
                 .ok()?;
@@ -5578,6 +5584,66 @@ pub(super) fn parse_imperative_family_ast(
             None
         }
     }
+}
+
+/// CR 701.12a: Parse "exchange <player>'s life total with ~'s power/toughness"
+/// (Tree of Perdition, Tree of Redemption, Evra, Halcyon Witness) into the
+/// exchanged player filter and the source stat. Returns `None` for any other
+/// "exchange" shape so the caller falls through to "exchange control of".
+///
+/// The whole clause must be consumed (only a trailing terminator may remain) so
+/// unrelated "exchange" phrasings don't match partially.
+fn try_parse_exchange_life_with_stat(lower: &str) -> Option<(TargetFilter, PtStat)> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("exchange ")
+        .parse(lower)
+        .ok()?;
+    let (rest, player) = parse_exchange_life_player(rest)?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("life total with ")
+        .parse(rest)
+        .ok()?;
+    // Source possessive: "~'s " (self-reference normalization) or the literal
+    // "this creature's " form, both naming the ability's source permanent.
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("~'s "),
+        tag("this creature's "),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (rest, stat) = alt((
+        value(PtStat::Toughness, tag::<_, _, OracleError<'_>>("toughness")),
+        value(PtStat::Power, tag("power")),
+    ))
+    .parse(rest)
+    .ok()?;
+    if !rest
+        .trim_start()
+        .trim_end_matches(['.', ';'])
+        .trim()
+        .is_empty()
+    {
+        return None;
+    }
+    Some((player, stat))
+}
+
+/// CR 119: Parse the player whose life total is exchanged. "your" binds to the
+/// ability's controller (no target); "target opponent's" / "target player's"
+/// declare a player target. Returns the filter and the remaining text after the
+/// possessive.
+fn parse_exchange_life_player(input: &str) -> Option<(&str, TargetFilter)> {
+    alt((
+        value(
+            TargetFilter::Controller,
+            tag::<_, _, OracleError<'_>>("your "),
+        ),
+        value(
+            TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+            tag("target opponent's "),
+        ),
+        value(TargetFilter::Player, tag("target player's ")),
+    ))
+    .parse(input)
+    .ok()
 }
 
 /// CR 701.12a: Extract the two per-slot target filters from the "<...>" body of
@@ -6092,6 +6158,9 @@ fn lower_imperative_family_effect(ast: ImperativeFamilyAst) -> Effect {
         // objects.
         ImperativeFamilyAst::ExchangeControl { target_a, target_b } => {
             Effect::ExchangeControl { target_a, target_b }
+        }
+        ImperativeFamilyAst::ExchangeLifeWithStat { player, stat } => {
+            Effect::ExchangeLifeWithStat { player, stat }
         }
         // CR 509.1c: Must be blocked — grant transient MustBeBlocked static via GenericEffect.
         // Uses AddStaticMode so the mode propagates through the layer system to

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -35688,6 +35688,57 @@ mod tests {
         assert!(matches!(&*effect.effect, Effect::Draw { .. }));
     }
 
+    /// CR 701.12a: Tree of Perdition / Tree of Redemption / Evra — "exchange
+    /// <player>'s life total with ~'s power/toughness" parses to
+    /// `ExchangeLifeWithStat` with the right player filter and stat, not the
+    /// previous `Unimplemented { name: "exchange" }` (which surfaced no target
+    /// slot, so the player could never be chosen).
+    #[test]
+    fn exchange_life_with_stat_parses_tree_and_evra() {
+        use crate::types::ability::{ControllerRef, PtStat, TypedFilter};
+
+        // Tree of Perdition: target opponent's life ↔ source toughness.
+        let perdition = parse_effect_chain(
+            "Exchange target opponent's life total with ~'s toughness.",
+            AbilityKind::Activated,
+        );
+        assert_eq!(
+            *perdition.effect,
+            Effect::ExchangeLifeWithStat {
+                player: TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent)
+                ),
+                stat: PtStat::Toughness,
+            }
+        );
+
+        // Tree of Redemption: your life ↔ source toughness (no target).
+        let redemption = parse_effect_chain(
+            "Exchange your life total with ~'s toughness.",
+            AbilityKind::Activated,
+        );
+        assert_eq!(
+            *redemption.effect,
+            Effect::ExchangeLifeWithStat {
+                player: TargetFilter::Controller,
+                stat: PtStat::Toughness,
+            }
+        );
+
+        // Evra, Halcyon Witness: your life ↔ source power.
+        let evra = parse_effect_chain(
+            "Exchange your life total with ~'s power.",
+            AbilityKind::Activated,
+        );
+        assert_eq!(
+            *evra.effect,
+            Effect::ExchangeLifeWithStat {
+                player: TargetFilter::Controller,
+                stat: PtStat::Power,
+            }
+        );
+    }
+
     #[test]
     fn kindred_dominance_excludes_chosen_creature_type() {
         use crate::types::ability::{ChoiceType, TypedFilter};

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2589,6 +2589,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::BlightEffect { .. }
         | Effect::Seek { .. }
         | Effect::SetLifeTotal { .. }
+        | Effect::ExchangeLifeWithStat { .. }
         | Effect::SetDayNight { .. }
         | Effect::GiveControl { .. }
         | Effect::RemoveFromCombat { .. }

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -5,7 +5,7 @@ use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ActivationRestriction, BounceSelection, CastingPermission,
     ControllerRef, CounterSourceRider, Duration, Effect, LibraryPosition, ManaProduction,
     ManaSpendRestriction, ModalSelectionConstraint, OutsideGameSourcePool, PaymentCost,
-    PlayerFilter, PtValue, QuantityExpr, SearchDestinationSplit, SearchSelectionConstraint,
+    PlayerFilter, PtStat, PtValue, QuantityExpr, SearchDestinationSplit, SearchSelectionConstraint,
     StaticDefinition, TargetFilter,
 };
 use crate::types::counter::CounterType;
@@ -347,6 +347,14 @@ pub(crate) enum ImperativeFamilyAst {
     ExchangeControl {
         target_a: TargetFilter,
         target_b: TargetFilter,
+    },
+    /// CR 701.12a: Exchange a player's life total with the source's power or
+    /// toughness (Tree of Perdition, Tree of Redemption, Evra). `player` is the
+    /// player whose life is exchanged (`Controller` for "your", an opponent
+    /// filter for "target opponent's"); `stat` selects which source stat.
+    ExchangeLifeWithStat {
+        player: TargetFilter,
+        stat: PtStat,
     },
     /// CR 509.1c: Must be blocked this turn if able.
     MustBeBlocked,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6654,6 +6654,21 @@ pub enum Effect {
         target: TargetFilter,
         amount: QuantityExpr,
     },
+    /// CR 701.12a: Exchange a player's life total with the source permanent's
+    /// power or toughness. The player's life total becomes the stat's current
+    /// value (CR 119.5 gain/lose-to-reach), and the source gains an indefinite
+    /// layer-7b continuous effect setting that stat to the player's previous
+    /// life total (CR 613.4b). All-or-nothing per CR 701.12a: if the life change
+    /// is forbidden (CR 119.7/119.8 can't-gain/can't-lose), no part occurs.
+    /// `player` selects the player (Controller for "your", Opponent for "target
+    /// opponent"); `stat` selects which of the source's stats is exchanged.
+    /// Tree of Redemption (your life ↔ toughness), Tree of Perdition (target
+    /// opponent's life ↔ toughness), Evra, Halcyon Witness (your life ↔ power).
+    ExchangeLifeWithStat {
+        #[serde(default = "default_target_filter_any")]
+        player: TargetFilter,
+        stat: PtStat,
+    },
     /// CR 730.1: Set the game's day/night designation.
     /// Triggers daybound/nightbound transformations on all relevant permanents.
     SetDayNight {
@@ -7346,6 +7361,7 @@ impl Effect {
 
             Effect::Dig { player, .. }
             | Effect::ExileTop { player, .. }
+            | Effect::ExchangeLifeWithStat { player, .. }
             | Effect::ExileFromTopUntil { player, .. } => Some(player),
 
             // CR 115.1a + CR 601.2c: "Create a [Role/Aura] token attached to
@@ -7661,6 +7677,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::BlightEffect { .. } => "BlightEffect",
         Effect::Seek { .. } => "Seek",
         Effect::SetLifeTotal { .. } => "SetLifeTotal",
+        Effect::ExchangeLifeWithStat { .. } => "ExchangeLifeWithStat",
         Effect::SetDayNight { .. } => "SetDayNight",
         Effect::GiveControl { .. } => "GiveControl",
         Effect::RemoveFromCombat { .. } => "RemoveFromCombat",
@@ -7836,6 +7853,7 @@ pub enum EffectKind {
     BlightEffect,
     Seek,
     SetLifeTotal,
+    ExchangeLifeWithStat,
     SetDayNight,
     GiveControl,
     RemoveFromCombat,
@@ -8018,6 +8036,7 @@ impl From<&Effect> for EffectKind {
             Effect::BlightEffect { .. } => EffectKind::BlightEffect,
             Effect::Seek { .. } => EffectKind::Seek,
             Effect::SetLifeTotal { .. } => EffectKind::SetLifeTotal,
+            Effect::ExchangeLifeWithStat { .. } => EffectKind::ExchangeLifeWithStat,
             Effect::SetDayNight { .. } => EffectKind::SetDayNight,
             Effect::GiveControl { .. } => EffectKind::GiveControl,
             Effect::RemoveFromCombat { .. } => EffectKind::RemoveFromCombat,

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -494,6 +494,10 @@ fn redundancy_delta(
         // attach pick. Its redundancy is the new Aura's grants vs. the
         // existing static layer — out of scope for this policy.
         | Effect::ReturnAsAura { .. }
+        // CR 701.12a: ExchangeLifeWithStat's value depends on the live gap
+        // between a player's life and the source's stat — no static redundancy
+        // signal (it never "does nothing" the way a duplicate keyword grant does).
+        | Effect::ExchangeLifeWithStat { .. }
         | Effect::ProcessRadCounters => None,
     }
 }


### PR DESCRIPTION
## Summary

Implements `Effect::ExchangeLifeWithStat`, the "exchange life total with a creature's power/toughness" mechanic. Previously these cards parsed to `Unimplemented { name: "exchange" }`, so the activated ability exposed **no target slot** — the player could never choose the target opponent (reported in-game on Tree of Perdition).

Cards unlocked (engine coverage report confirms 3 newly supported):
- **Tree of Perdition** — exchange *target opponent's* life total with its toughness
- **Tree of Redemption** — exchange *your* life total with its toughness
- **Evra, Halcyon Witness** — exchange *your* life total with its power

## Rules correctness (CR)

- **CR 701.12a** — the exchange is all-or-nothing: both previous values are read before either changes, and if the life change is forbidden (**CR 119.7** can't-gain when raising / **CR 119.8** can't-lose when lowering) no part of it occurs (toughness is not set either).
- **CR 119.5** — the player's life total is set to the stat's previous value by gaining/losing the difference, routed through the existing life helpers (replacement pipeline + can't-gain/lose short-circuits).
- **CR 613.4b** — the source's stat is set to the player's previous life via an **indefinite (layer-7b) continuous effect**, so `+1/+1` counters (7d) and other modifiers (7c) still apply on top, per the cards' rulings.

## Implementation

- New `Effect::ExchangeLifeWithStat { player: TargetFilter, stat: PtStat }` (reuses the existing `PtStat` Power/Toughness selector — no new selector enum).
- Resolver `game/effects/exchange_life.rs`.
- Parser branch in the `exchange` imperative dispatch: `exchange <your|target opponent's> life total with ~'s power/toughness`.
- Targeting is automatic: `target_filter()` surfaces the `player` slot; `Controller` ("your") is a context-ref so it creates no slot, and "target opponent" resolves as a player via `find_legal_targets`.

## Test plan

- [x] `cargo test -p engine` (8883 pass) incl. new resolver tests (set opponent life + lock source toughness; controller fallback; CR 701.12a all-or-nothing block under can't-gain-life) and parser test for all three cards
- [x] `cargo clippy --all-targets -- -D warnings` clean across workspace (engine, phase-ai, wasm)
- [x] Coverage report: Tree of Perdition / Tree of Redemption / Evra move from Unimplemented → supported

🤖 Generated with [Claude Code](https://claude.com/claude-code)