### PR TITLE
Fix trigger stack visibility: push triggers before prompting for choices

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3642,7 +3642,16 @@ fn resolve_chain_body(
                         .description
                         .clone()
                         .or_else(|| ability.description.clone());
-                    state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+                    // CR 601.2c + CR 603.3d: Reflexive triggered ability whose
+                    // target choice is still outstanding. Push the entry to the
+                    // stack FIRST (in mid-construction state — `ability.targets`
+                    // empty), then enter `TriggerTargetSelection`. The on-stack
+                    // entry is identified by `state.pending_trigger_entry` and
+                    // mutated by `engine_stack::finalize_trigger_target_selection`
+                    // when the selection completes. The resolver refuses to
+                    // fire entries identified by `pending_trigger_entry` (see
+                    // `stack::resolve_top`).
+                    let pending = crate::game::triggers::PendingTrigger {
                         source_id: ability.source_id,
                         controller: ability.controller,
                         condition: None,
@@ -3656,7 +3665,19 @@ fn resolve_chain_body(
                         description: trigger_description.clone(),
                         may_trigger_origin: None,
                         subject_match_count: None,
-                    });
+                    };
+                    let trigger_events =
+                        crate::game::triggers::take_pending_trigger_event_batch(state, &pending);
+                    let pending_for_state = pending.clone();
+                    let entry_id =
+                        crate::game::triggers::push_pending_trigger_to_stack_with_event_batch(
+                            state,
+                            pending,
+                            trigger_events,
+                            events,
+                        );
+                    state.pending_trigger = Some(pending_for_state);
+                    state.pending_trigger_entry = Some(entry_id);
                     state.waiting_for = WaitingFor::TriggerTargetSelection {
                         player: ability.controller,
                         target_slots,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3920,15 +3920,38 @@ fn apply_action(
             } else if let Some(mut pending_trigger) = state.pending_trigger.take() {
                 // CR 601.2d + CR 603.3d: Triggered abilities divide effects
                 // while being put on the stack. The chosen per-target amounts
-                // are resolution data on the resolved ability.
+                // are resolution data on the resolved ability. The entry is
+                // already on the stack (pushed at distribute-among pause time);
+                // mutate its ability with the distribution and clear
+                // `pending_trigger_entry` so the resolver may now fire it.
+                //
+                // Invariants (panic on violation — no recovery path):
+                // * `pending_trigger_entry` is `Some(_)` (push-first contract).
+                // * Entry id references a `TriggeredAbility` `StackEntry`.
                 pending_trigger.ability.distribution =
                     Some(distribution.iter().map(|(t, a)| (t.clone(), *a)).collect());
-                triggers::push_pending_trigger_to_stack(state, pending_trigger, &mut events);
+                let entry_id = state.pending_trigger_entry.take().expect(
+                    "DistributeAmong completion: pending_trigger_entry must be set under the push-first contract",
+                );
+                let entry = state
+                    .stack
+                    .iter_mut()
+                    .rev()
+                    .find(|entry| entry.id == entry_id)
+                    .expect("DistributeAmong completion: pending_trigger_entry must reference a stack entry");
+                let ability = entry.ability_mut().expect(
+                    "DistributeAmong completion: pending_trigger_entry must reference a TriggeredAbility stack entry",
+                );
+                *ability = pending_trigger.ability.clone();
                 state.priority_passes.clear();
                 state.priority_pass_count = 0;
                 // CR 113.2c + CR 603.2 + CR 603.3b: Drain siblings deferred
                 // behind this distribute-among trigger so each independent
                 // instance reaches the stack (issue #416).
+                debug_assert!(
+                    !triggers::is_pending_trigger_construction_active(state),
+                    "deferred-trigger drain entered with construction still active",
+                );
                 if let Some(waiting_for) =
                     triggers::drain_deferred_trigger_queue(state, &mut events)
                 {
@@ -4167,10 +4190,22 @@ pub(super) fn begin_pending_trigger_target_selection(
             );
             super::triggers::restore_trigger_event_context(state, context_snapshot);
 
-            // CR 700.2b: All modes unavailable (previously chosen OR no legal
-            // targets) — ability cannot be put on the stack. Clear pending
-            // trigger and skip.
+            // CR 700.2b + CR 603.3c: All modes unavailable (previously chosen
+            // OR no legal targets) — ability cannot remain on the stack.
+            // Under the "push first, choose second" contract, the entry may
+            // already have been pushed by `dispatch_pending_trigger_context`;
+            // remove it before clearing the cursor. The new flow filters this
+            // case BEFORE pushing in the modal branch, so this is normally a
+            // dead branch — kept as a defensive cleanup for any
+            // delayed-revalidation paths.
             if unavailable_modes.len() >= modal.mode_count {
+                if let Some(entry_id) = state.pending_trigger_entry.take() {
+                    if state.stack.back().map(|e| e.id) == Some(entry_id) {
+                        state.stack.pop_back();
+                        state.stack_paid_facts.remove(&entry_id);
+                        state.stack_trigger_event_batches.remove(&entry_id);
+                    }
+                }
                 state.pending_trigger = None;
                 return Ok(None);
             }
@@ -4215,6 +4250,24 @@ pub(super) fn begin_pending_trigger_target_selection(
     });
     super::triggers::restore_trigger_event_context(state, context_snapshot);
     let Some((target_slots, selection)) = selection_result? else {
+        // CR 603.3d: No target prompt is required (empty target slots, or
+        // `build_target_slots`/`begin_target_selection_for_ability` reported
+        // no legal completion). Symmetric to the modal `all-modes-unavailable`
+        // branch above: if the "push first" dispatcher already pushed an
+        // in-construction entry for this trigger, pop it before clearing the
+        // cursor. The new flow filters this case BEFORE pushing in the
+        // non-modal branches (Err(_) drops the trigger; Ok(Some(targets))
+        // auto-pushes a complete entry), so this is normally a dead branch —
+        // kept for symmetry with the modal cleanup and for any
+        // delayed-revalidation paths.
+        if let Some(entry_id) = state.pending_trigger_entry.take() {
+            if state.stack.back().map(|e| e.id) == Some(entry_id) {
+                state.stack.pop_back();
+                state.stack_paid_facts.remove(&entry_id);
+                state.stack_trigger_event_batches.remove(&entry_id);
+            }
+        }
+        state.pending_trigger = None;
         return Ok(None);
     };
     Ok(Some(WaitingFor::TriggerTargetSelection {
@@ -11957,7 +12010,10 @@ mod trigger_target_tests {
         )
         .duration(crate::types::ability::Duration::UntilHostLeavesPlay);
 
-        state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+        // CR 603.3c + CR 603.3d "Push first": match what production does —
+        // push the trigger entry to the stack and stash both the pending
+        // trigger and the cursor BEFORE entering target selection.
+        let pending = crate::game::triggers::PendingTrigger {
             source_id: trigger_creature,
             controller: PlayerId(0),
             condition: None,
@@ -11971,7 +12027,16 @@ mod trigger_target_tests {
             description: None,
             may_trigger_origin: None,
             subject_match_count: None,
-        });
+        };
+        let pending_for_state = pending.clone();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
 
         let legal_targets = vec![TargetRef::Object(target1), TargetRef::Object(target2)];
 
@@ -12033,7 +12098,8 @@ mod trigger_target_tests {
         let legal_target = ObjectId(10);
         let illegal_target = ObjectId(99);
 
-        state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+        // CR 603.3c + CR 603.3d "Push first" contract migration.
+        let pending = crate::game::triggers::PendingTrigger {
             source_id: ObjectId(1),
             controller: PlayerId(0),
             condition: None,
@@ -12063,7 +12129,16 @@ mod trigger_target_tests {
             description: None,
             may_trigger_origin: None,
             subject_match_count: None,
-        });
+        };
+        let pending_for_state = pending.clone();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
 
         state.waiting_for = WaitingFor::TriggerTargetSelection {
             player: PlayerId(0),
@@ -12093,7 +12168,8 @@ mod trigger_target_tests {
         let mut state = GameState::new_two_player(42);
         state.active_player = PlayerId(0);
         state.priority_player = PlayerId(0);
-        state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+        // CR 603.3c + CR 603.3d "Push first" contract migration.
+        let pending = crate::game::triggers::PendingTrigger {
             source_id: ObjectId(20),
             controller: PlayerId(0),
             condition: None,
@@ -12134,7 +12210,16 @@ mod trigger_target_tests {
             description: Some("Choose two target players".to_string()),
             may_trigger_origin: None,
             subject_match_count: None,
-        });
+        };
+        let pending_for_state = pending.clone();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
         state.waiting_for = WaitingFor::AbilityModeChoice {
             player: PlayerId(0),
             modal: ModalChoice {
@@ -12183,8 +12268,12 @@ mod trigger_target_tests {
             }
             other => panic!("Expected TriggerTargetSelection, got {other:?}"),
         }
-        assert_eq!(state.stack.len(), 0);
+        // CR 603.3c + CR 603.3d "Push first": after mode chosen, the trigger
+        // entry remains on the stack in mid-construction (target prompt
+        // pending). `pending_trigger_entry` still identifies it.
+        assert_eq!(state.stack.len(), 1);
         assert!(state.pending_trigger.is_some());
+        assert!(state.pending_trigger_entry.is_some());
     }
 
     #[test]
@@ -12194,7 +12283,8 @@ mod trigger_target_tests {
         state.priority_player = PlayerId(0);
 
         let source_id = ObjectId(21);
-        state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+        // CR 603.3c + CR 603.3d "Push first" contract migration.
+        let pending = crate::game::triggers::PendingTrigger {
             source_id,
             controller: PlayerId(0),
             condition: None,
@@ -12242,7 +12332,16 @@ mod trigger_target_tests {
             description: Some("Whenever you cast your second spell each turn".to_string()),
             may_trigger_origin: None,
             subject_match_count: None,
-        });
+        };
+        let pending_for_state = pending.clone();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
         state.waiting_for = WaitingFor::AbilityModeChoice {
             player: PlayerId(0),
             modal: ModalChoice {
@@ -12304,7 +12403,8 @@ mod trigger_target_tests {
     fn triggered_commander_modal_cap_uses_controller_board_state() {
         let mut state = GameState::new_two_player(42);
         let source_id = ObjectId(22);
-        state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+        // CR 603.3c + CR 603.3d "Push first" contract migration.
+        let pending = crate::game::triggers::PendingTrigger {
             source_id,
             controller: PlayerId(0),
             condition: None,
@@ -12359,7 +12459,16 @@ mod trigger_target_tests {
             description: Some("Choose one or both with commander".to_string()),
             may_trigger_origin: None,
             subject_match_count: None,
-        });
+        };
+        let pending_for_state = pending.clone();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
 
         let waiting = begin_pending_trigger_target_selection(&mut state)
             .unwrap()
@@ -12396,7 +12505,8 @@ mod trigger_target_tests {
         state.active_player = PlayerId(0);
         state.priority_player = PlayerId(0);
 
-        state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+        // CR 603.3c + CR 603.3d "Push first" contract migration.
+        let pending = crate::game::triggers::PendingTrigger {
             source_id: ObjectId(30),
             controller: PlayerId(0),
             condition: None,
@@ -12429,7 +12539,16 @@ mod trigger_target_tests {
             description: None,
             may_trigger_origin: None,
             subject_match_count: None,
-        });
+        };
+        let pending_for_state = pending.clone();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
         state.waiting_for = WaitingFor::TriggerTargetSelection {
             player: PlayerId(0),
             target_slots: vec![
@@ -12515,7 +12634,8 @@ mod trigger_target_tests {
             },
         ];
         let target_constraints = vec![TargetSelectionConstraint::DifferentTargetPlayers];
-        state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+        // CR 603.3c + CR 603.3d "Push first" contract migration.
+        let pending = crate::game::triggers::PendingTrigger {
             source_id: ObjectId(31),
             controller: PlayerId(0),
             condition: None,
@@ -12548,7 +12668,16 @@ mod trigger_target_tests {
             description: None,
             may_trigger_origin: None,
             subject_match_count: None,
-        });
+        };
+        let pending_for_state = pending.clone();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
         state.waiting_for = WaitingFor::TriggerTargetSelection {
             player: PlayerId(0),
             target_slots: target_slots.clone(),
@@ -12598,7 +12727,8 @@ mod trigger_target_tests {
         let mut state = GameState::new_two_player(42);
         state.active_player = PlayerId(0);
         state.priority_player = PlayerId(0);
-        state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+        // CR 603.3c + CR 603.3d "Push first" contract migration.
+        let pending = crate::game::triggers::PendingTrigger {
             source_id: ObjectId(40),
             controller: PlayerId(0),
             condition: None,
@@ -12641,7 +12771,16 @@ mod trigger_target_tests {
             description: Some("Choose different target players".to_string()),
             may_trigger_origin: None,
             subject_match_count: None,
-        });
+        };
+        let pending_for_state = pending.clone();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
         state.waiting_for = WaitingFor::AbilityModeChoice {
             player: PlayerId(0),
             modal: ModalChoice {
@@ -12705,8 +12844,8 @@ mod trigger_target_tests {
         state.modal_modes_chosen_this_turn.insert((source_id, 0));
         state.modal_modes_chosen_this_turn.insert((source_id, 1));
 
-        // Set a pending trigger with this modal.
-        state.pending_trigger = Some(crate::game::triggers::PendingTrigger {
+        // CR 603.3c + CR 603.3d "Push first" contract migration.
+        let pending = crate::game::triggers::PendingTrigger {
             source_id,
             controller: PlayerId(0),
             condition: None,
@@ -12743,15 +12882,32 @@ mod trigger_target_tests {
             description: None,
             may_trigger_origin: None,
             subject_match_count: None,
-        });
+        };
+        let pending_for_state = pending.clone();
+        let stack_before = state.stack.len();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
 
         // Call the private function via the engine path.
         let result = begin_pending_trigger_target_selection(&mut state).unwrap();
 
-        // CR 700.2b: All modes exhausted — no AbilityModeChoice produced.
+        // CR 700.2b + CR 603.3c: All modes exhausted — no AbilityModeChoice
+        // produced, defensive cleanup pops the in-construction entry and
+        // clears both `pending_trigger` and `pending_trigger_entry`.
         assert!(result.is_none());
-        // Pending trigger should be cleared.
         assert!(state.pending_trigger.is_none());
+        assert!(state.pending_trigger_entry.is_none());
+        assert_eq!(
+            state.stack.len(),
+            stack_before,
+            "defensive cleanup must pop the in-construction entry",
+        );
     }
 
     #[test]
@@ -16782,6 +16938,12 @@ mod phase_trigger_regression_tests {
         state.priority_player = PlayerId(0);
         state.stack.clear();
         state.pending_trigger = None;
+        // CR 603.3c + CR 603.3d: clear the in-construction cursor too —
+        // symmetric with `pending_trigger`. Without this, a trigger pushed
+        // earlier in the test could leave `pending_trigger_entry` pointing
+        // to a now-cleared `state.stack`, tripping the push-first invariants
+        // on the next trigger.
+        state.pending_trigger_entry = None;
         state.waiting_for = WaitingFor::Priority {
             player: PlayerId(0),
         };

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -284,6 +284,12 @@ fn handle_triggered_mode_choice(
                 state, trigger, resolved, events,
             ));
         } else {
+            // CR 601.2c + CR 603.3d: Mode chosen but target choice still
+            // outstanding. The entry is already on the stack (pushed at modal
+            // pause-time); mutate its ability with the resolved mode so the
+            // target prompt operates on the chosen mode. `pending_trigger_entry`
+            // stays set — construction continues through target selection.
+            mutate_pending_trigger_entry_ability(state, &trigger.ability);
             let description = trigger.description.clone();
             state.pending_trigger = Some(trigger);
             let pending_trigger = state
@@ -306,16 +312,79 @@ fn handle_triggered_mode_choice(
             });
         }
     } else {
-        triggers::push_pending_trigger_to_stack(state, trigger, events);
+        // CR 603.3c: Mode chosen and no further input needed. Entry is already
+        // on the stack (pushed at modal pause-time); mutate its ability with
+        // the resolved mode and clear `pending_trigger_entry` so the resolver
+        // may fire this entry.
+        finalize_pending_trigger_entry_ability(state, &trigger.ability);
         state.priority_passes.clear();
         state.priority_pass_count = 0;
         // CR 113.2c + CR 603.2 + CR 603.3b: Drain siblings deferred behind this
         // modal trigger so each independent instance reaches the stack
         // (issue #416).
+        debug_assert!(
+            !triggers::is_pending_trigger_construction_active(state),
+            "deferred-trigger drain entered with construction still active",
+        );
         if let Some(waiting_for) = triggers::drain_deferred_trigger_queue(state, events) {
             return Ok(waiting_for);
         }
     }
 
     Ok(WaitingFor::Priority { player })
+}
+
+/// CR 603.3c: Mutate the in-construction stack entry's resolved ability
+/// without clearing `pending_trigger_entry`. Used when the controller has
+/// chosen a mode but target selection is still outstanding.
+///
+/// Invariants (panic in debug; see `finalize_pending_trigger_entry_ability`):
+/// * `state.pending_trigger_entry` is `Some(_)`.
+/// * Entry id references a `TriggeredAbility` `StackEntry` in `state.stack`.
+fn mutate_pending_trigger_entry_ability(
+    state: &mut GameState,
+    source_ability: &crate::types::ability::ResolvedAbility,
+) {
+    let entry_id = state
+        .pending_trigger_entry
+        .expect("mutate_pending_trigger_entry_ability: pending_trigger_entry must be set");
+    let entry = state
+        .stack
+        .iter_mut()
+        .rev()
+        .find(|entry| entry.id == entry_id)
+        .expect("mutate_pending_trigger_entry_ability: pending_trigger_entry must reference a stack entry");
+    let ability = entry
+        .ability_mut()
+        .expect("mutate_pending_trigger_entry_ability: pending_trigger_entry must reference a TriggeredAbility");
+    *ability = source_ability.clone();
+}
+
+/// CR 603.3c: Mutate the in-construction stack entry's resolved ability AND
+/// clear `pending_trigger_entry` — construction is complete, the resolver is
+/// now free to fire this entry.
+///
+/// Invariants (no recovery path; violations panic in debug, otherwise leave
+/// the engine in an internally inconsistent state):
+/// * `state.pending_trigger_entry` is `Some(_)` (every caller pushed under the
+///   "push first" contract).
+/// * Entry id references a `TriggeredAbility` `StackEntry` in `state.stack`.
+fn finalize_pending_trigger_entry_ability(
+    state: &mut GameState,
+    source_ability: &crate::types::ability::ResolvedAbility,
+) {
+    let entry_id = state
+        .pending_trigger_entry
+        .take()
+        .expect("finalize_pending_trigger_entry_ability: pending_trigger_entry must be set under the push-first contract");
+    let entry = state
+        .stack
+        .iter_mut()
+        .rev()
+        .find(|entry| entry.id == entry_id)
+        .expect("finalize_pending_trigger_entry_ability: pending_trigger_entry must reference a stack entry");
+    let ability = entry
+        .ability_mut()
+        .expect("finalize_pending_trigger_entry_ability: pending_trigger_entry must reference a TriggeredAbility stack entry");
+    *ability = source_ability.clone();
 }

--- a/crates/engine/src/game/engine_stack.rs
+++ b/crates/engine/src/game/engine_stack.rs
@@ -43,6 +43,11 @@ pub(super) fn finalize_trigger_target_selection(
             if assigned_targets.len() == 1 {
                 trigger.ability.distribution = Some(vec![(assigned_targets[0].clone(), total)]);
             } else {
+                // CR 601.2d: Distribution still outstanding. Entry is already
+                // on the stack with empty `distribution`; mutate the on-stack
+                // ability's targets (so they match what was just chosen) and
+                // keep `pending_trigger_entry` set until division completes.
+                mutate_pending_trigger_entry(state, &trigger.ability);
                 state.pending_trigger = Some(trigger);
                 state.priority_passes.clear();
                 state.priority_pass_count = 0;
@@ -56,7 +61,12 @@ pub(super) fn finalize_trigger_target_selection(
         }
     }
 
-    triggers::push_pending_trigger_to_stack(state, trigger, events);
+    // CR 603.3c + CR 603.3d: Construction complete. The entry is already on
+    // the stack (pushed by the pause-path that started selection); mutate its
+    // ability with the resolved targets/distribution and clear
+    // `pending_trigger_entry` so the resolver may now fire this entry.
+    finalize_pending_trigger_entry_on_stack(state, &trigger.ability);
+
     state.priority_passes.clear();
     state.priority_pass_count = 0;
     // CR 113.2c + CR 603.2 + CR 603.3b: After the active trigger is on the
@@ -64,10 +74,68 @@ pub(super) fn finalize_trigger_target_selection(
     // input (e.g., the second Boggart Prankster's "you attack" trigger waiting
     // behind the first). If a deferred trigger itself needs input, hand back
     // its WaitingFor; otherwise continue to Priority.
+    debug_assert!(
+        !triggers::is_pending_trigger_construction_active(state),
+        "deferred-trigger drain entered with construction still active",
+    );
     if let Some(waiting_for) = triggers::drain_deferred_trigger_queue(state, events) {
         return waiting_for;
     }
     WaitingFor::Priority { player: controller }
+}
+
+/// CR 603.3c + CR 603.3d: Mutate the in-construction stack entry's resolved
+/// ability without clearing `pending_trigger_entry` — the entry is still
+/// awaiting further input (division-among after target selection).
+///
+/// Invariants (panic in debug; see `finalize_pending_trigger_entry_on_stack`):
+/// * `state.pending_trigger_entry` is `Some(_)`.
+/// * Entry id references a `TriggeredAbility` `StackEntry` in `state.stack`.
+fn mutate_pending_trigger_entry(state: &mut GameState, source_ability: &ResolvedAbility) {
+    let entry_id = state
+        .pending_trigger_entry
+        .expect("mutate_pending_trigger_entry: pending_trigger_entry must be set");
+    let entry = state
+        .stack
+        .iter_mut()
+        .rev()
+        .find(|entry| entry.id == entry_id)
+        .expect("mutate_pending_trigger_entry: pending_trigger_entry must reference a stack entry");
+    let ability = entry.ability_mut().expect(
+        "mutate_pending_trigger_entry: pending_trigger_entry must reference a TriggeredAbility",
+    );
+    *ability = source_ability.clone();
+}
+
+/// CR 603.3c + CR 603.3d: Mutate the in-construction stack entry's resolved
+/// ability AND clear `pending_trigger_entry` — construction is complete, the
+/// resolver is now free to fire this entry.
+///
+/// Invariants (no recovery path; violations panic in debug, otherwise leave
+/// the engine in an internally inconsistent state):
+/// * `state.pending_trigger_entry` is `Some(_)` (the "push first" contract
+///   means every code path that reaches this function pushed the entry
+///   already).
+/// * That entry id refers to a `TriggeredAbility` `StackEntry` somewhere in
+///   `state.stack` (the entry has not been popped between push and finalize).
+fn finalize_pending_trigger_entry_on_stack(
+    state: &mut GameState,
+    source_ability: &ResolvedAbility,
+) {
+    let entry_id = state
+        .pending_trigger_entry
+        .take()
+        .expect("finalize_pending_trigger_entry_on_stack: pending_trigger_entry must be set under the push-first contract");
+    let entry = state
+        .stack
+        .iter_mut()
+        .rev()
+        .find(|entry| entry.id == entry_id)
+        .expect("finalize_pending_trigger_entry_on_stack: pending_trigger_entry must reference a stack entry");
+    let ability = entry
+        .ability_mut()
+        .expect("finalize_pending_trigger_entry_on_stack: pending_trigger_entry must reference a TriggeredAbility stack entry");
+    *ability = source_ability.clone();
 }
 
 pub(super) fn handle_trigger_target_selection_select_targets(

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -73,6 +73,19 @@ fn move_prevented_permanent_spell_to_graveyard_if_still_on_stack(
 
 /// CR 608.2: Resolve the top object on the stack.
 pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    // CR 603.3c + CR 603.3d: The top of the stack may be a trigger entry that
+    // is still being constructed (mode / target / division pending). Such an
+    // entry MUST NOT resolve — it is mid-flight while the controller is
+    // gathering inputs via the active `WaitingFor`. The
+    // `pending_trigger_entry` cursor is cleared when construction completes
+    // (target chosen, distribution assigned, etc.); only then is resolution
+    // permitted.
+    if let Some(pending_id) = state.pending_trigger_entry {
+        if state.stack.back().map(|e| e.id) == Some(pending_id) {
+            return;
+        }
+    }
+
     // CR 707.10: A fresh resolution invalidates any previously stashed
     // resolving entry. `resolving_stack_entry` is set below and must persist
     // across an optional-choice round-trip (the Chain cycle's "you may copy

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -2052,17 +2052,20 @@ pub(crate) fn collect_triggers_into_deferred(state: &mut GameState, events: &[Ga
     state.deferred_triggers.extend(pending);
 }
 
-/// CR 603.3: Put triggered ability on the stack.
+/// CR 603.3: Put triggered ability on the stack. Returns the `ObjectId` of the
+/// newly created `StackEntry` so callers that need to track the entry for
+/// in-construction mutation (mode / target / division still being chosen) can
+/// stash it in `state.pending_trigger_entry`.
 pub fn push_pending_trigger_to_stack(
     state: &mut GameState,
     trigger: PendingTrigger,
     events: &mut Vec<GameEvent>,
-) {
+) -> ObjectId {
     let trigger_events = take_pending_trigger_event_batch(state, &trigger);
-    push_pending_trigger_to_stack_with_event_batch(state, trigger, trigger_events, events);
+    push_pending_trigger_to_stack_with_event_batch(state, trigger, trigger_events, events)
 }
 
-fn take_pending_trigger_event_batch(
+pub(crate) fn take_pending_trigger_event_batch(
     state: &mut GameState,
     trigger: &PendingTrigger,
 ) -> Vec<GameEvent> {
@@ -2078,12 +2081,17 @@ fn take_pending_trigger_event_batch(
     }
 }
 
-fn push_pending_trigger_to_stack_with_event_batch(
+/// CR 603.3 + CR 603.3c + CR 603.3d: Push a pending trigger to the stack with
+/// its event batch keyed by entry id. Returns the new entry's `ObjectId` so
+/// callers can stash it in `state.pending_trigger_entry` when the entry is
+/// being constructed in pieces across multiple `WaitingFor` cycles (mode
+/// choice, target selection, distribute-among).
+pub(crate) fn push_pending_trigger_to_stack_with_event_batch(
     state: &mut GameState,
     trigger: PendingTrigger,
     trigger_events: Vec<GameEvent>,
     events: &mut Vec<GameEvent>,
-) {
+) -> ObjectId {
     let PendingTrigger {
         source_id,
         controller,
@@ -2132,6 +2140,17 @@ fn push_pending_trigger_to_stack_with_event_batch(
         },
     };
     stack::push_to_stack(state, entry, events);
+    entry_id
+}
+
+/// CR 603.3c + CR 603.3d: True iff the top of `state.stack` is the trigger
+/// entry currently being constructed (mode / target / division still being
+/// chosen). Callers MUST guard `drain_deferred_trigger_queue` invocations with
+/// this — the deferred-trigger drain pipeline would otherwise push siblings
+/// onto a stack whose top is mid-construction and the resolver would either
+/// fire the in-flight entry or fire siblings out of order.
+pub(crate) fn is_pending_trigger_construction_active(state: &GameState) -> bool {
+    state.pending_trigger_entry.is_some()
 }
 
 /// CR 603.2 + CR 603.3b + CR 309.4c: Dispatch a synthetic
@@ -2171,13 +2190,64 @@ fn dispatch_pending_trigger_context(
         trigger_events,
     } = trigger_context;
 
-    // CR 700.2b: Modal triggered ability — stash for mode selection before
-    // pushing to stack. The engine's mode-choice handler reads
-    // `state.pending_trigger` and prompts the controller.
-    if trigger.modal.is_some() && !trigger.mode_abilities.is_empty() {
-        state.pending_trigger_event_batch = trigger_events;
-        state.pending_trigger = Some(trigger);
-        return true;
+    // CR 603.3c: Modal triggered ability — push the entry to the stack FIRST
+    // (in mid-construction state; the on-stack `ResolvedAbility` does not yet
+    // know which mode is selected), then prompt for mode. Mode/target/division
+    // data lives in `state.pending_trigger` until `handle_triggered_mode_choice`
+    // mutates the on-stack entry's `ability` with the resolved choice. The
+    // resolver refuses to fire entries identified by `pending_trigger_entry`
+    // (see `stack::resolve_top`), so the in-flight entry is safe at the top of
+    // the stack until construction completes.
+    //
+    // Exception: when no legal mode can be chosen (CR 603.3c "If no mode can
+    // be chosen, the ability is removed from the stack"), the trigger is
+    // dropped before any `StackPushed` event is emitted — the entry never
+    // exists on the stack.
+    if let Some(modal_ref) = trigger.modal.as_ref() {
+        if !trigger.mode_abilities.is_empty() {
+            let modal_for_player = super::ability_utils::modal_choice_for_player(
+                state,
+                trigger.controller,
+                trigger.source_id,
+                modal_ref,
+                &crate::types::ability::SpellContext::default(),
+            );
+            let mut unavailable_modes = super::ability_utils::compute_unavailable_modes(
+                state,
+                trigger.source_id,
+                &modal_for_player,
+            );
+            let context_snapshot = push_trigger_event_context(
+                state,
+                trigger.trigger_event.as_ref(),
+                &trigger_events,
+                trigger.subject_match_count,
+            );
+            super::ability_utils::filter_modes_by_target_legality(
+                state,
+                trigger.source_id,
+                trigger.controller,
+                &trigger.mode_abilities,
+                &modal_for_player,
+                &mut unavailable_modes,
+            );
+            restore_trigger_event_context(state, context_snapshot);
+            if unavailable_modes.len() >= modal_for_player.mode_count {
+                // CR 603.3c: No legal mode; drop the trigger entirely.
+                return false;
+            }
+            let pending_for_state = trigger.clone();
+            let entry_id = push_pending_trigger_to_stack_with_event_batch(
+                state,
+                trigger,
+                trigger_events.clone(),
+                events_out,
+            );
+            state.pending_trigger_event_batch = trigger_events;
+            state.pending_trigger = Some(pending_for_state);
+            state.pending_trigger_entry = Some(entry_id);
+            return true;
+        }
     }
 
     let trigger_event = trigger.trigger_event.clone();
@@ -2267,9 +2337,24 @@ fn dispatch_pending_trigger_context(
                         trigger.ability.distribution =
                             Some(vec![(assigned_targets[0].clone(), total)]);
                     } else {
+                        // CR 601.2d + CR 603.3d: Distribute-among with targets
+                        // already chosen but division still pending. Push the
+                        // entry to the stack FIRST (ability has `targets`
+                        // populated, `distribution` still empty), then prompt
+                        // for division. `engine_stack::finalize_trigger_target_selection`
+                        // mutates the on-stack entry's `ability.distribution`
+                        // when the division choice completes.
                         let player = trigger.controller;
+                        let pending_for_state = trigger.clone();
+                        let entry_id = push_pending_trigger_to_stack_with_event_batch(
+                            state,
+                            trigger,
+                            trigger_events.clone(),
+                            events_out,
+                        );
                         state.pending_trigger_event_batch = trigger_events;
-                        state.pending_trigger = Some(trigger);
+                        state.pending_trigger = Some(pending_for_state);
+                        state.pending_trigger_entry = Some(entry_id);
                         state.waiting_for = crate::types::game_state::WaitingFor::DistributeAmong {
                             player,
                             total,
@@ -2291,8 +2376,21 @@ fn dispatch_pending_trigger_context(
             false
         }
         Ok(None) => {
+            // CR 601.2c + CR 603.3d: Manual target selection pending. Push the
+            // entry to the stack FIRST (ability has empty `targets`), then
+            // prompt for target. `engine_stack::finalize_trigger_target_selection`
+            // mutates the on-stack entry's `ability.targets` when each target
+            // is chosen.
+            let pending_for_state = trigger.clone();
+            let entry_id = push_pending_trigger_to_stack_with_event_batch(
+                state,
+                trigger,
+                trigger_events.clone(),
+                events_out,
+            );
             state.pending_trigger_event_batch = trigger_events;
-            state.pending_trigger = Some(trigger);
+            state.pending_trigger = Some(pending_for_state);
+            state.pending_trigger_entry = Some(entry_id);
             restore_trigger_event_context(state, context_snapshot);
             true
         }
@@ -6221,12 +6319,28 @@ pub mod tests {
 
         process_triggers(&mut state, &events);
 
-        // Multiple legal targets -> should set pending_trigger, NOT push to stack
+        // CR 603.3c + CR 603.3d "Push first, choose second": multiple legal
+        // targets -> entry IS on the stack (mid-construction); pending_trigger
+        // and pending_trigger_entry are both set; the resolver refuses to fire
+        // until target selection completes.
         assert!(
             state.pending_trigger.is_some(),
             "Should have pending trigger"
         );
-        assert_eq!(state.stack.len(), 0, "Should NOT be on stack yet");
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "trigger entry pushed at pause time per push-first contract",
+        );
+        assert!(
+            state.pending_trigger_entry.is_some(),
+            "pending_trigger_entry tracks the in-construction stack entry",
+        );
+        assert_eq!(
+            state.stack.back().map(|e| e.id),
+            state.pending_trigger_entry,
+            "top of stack is the in-construction entry",
+        );
         let pending = state.pending_trigger.as_ref().unwrap();
         assert_eq!(pending.source_id, trigger_creature);
         assert_eq!(pending.controller, PlayerId(0));
@@ -6302,8 +6416,16 @@ pub mod tests {
             }
             other => panic!("expected DistributeAmong, got {other:?}"),
         }
+        // CR 603.3c + CR 603.3d: After target selection, the trigger entry is
+        // on the stack in mid-construction (distribution still pending);
+        // pending_trigger_entry tracks it and the resolver refuses to fire it.
         assert!(state.pending_trigger.is_some());
-        assert_eq!(state.stack.len(), 0);
+        assert_eq!(state.stack.len(), 1);
+        assert!(state.pending_trigger_entry.is_some());
+        assert_eq!(
+            state.stack.back().map(|e| e.id),
+            state.pending_trigger_entry
+        );
 
         crate::game::engine::apply(
             &mut state,
@@ -6318,6 +6440,10 @@ pub mod tests {
         .expect("distribution should put trigger on stack");
 
         assert!(state.pending_trigger.is_none());
+        assert!(
+            state.pending_trigger_entry.is_none(),
+            "distribution chosen -> construction complete",
+        );
         assert_eq!(state.stack.len(), 1);
         match &state.stack[0].kind {
             StackEntryKind::TriggeredAbility { ability, .. } => {
@@ -12061,11 +12187,20 @@ pub mod tests {
         );
         assert!(state.pending_trigger.is_some());
         assert_eq!(state.deferred_triggers.len(), 0);
-        // The first trigger should already be on the stack.
+        // CR 603.3c + CR 603.3d: Under "push first, choose second", both
+        // Prankster triggers are on the stack now — the first is fully
+        // constructed at the bottom, the second is mid-construction at the top
+        // (target prompt outstanding). `pending_trigger_entry` identifies the
+        // mid-construction entry; the resolver refuses to fire it.
         assert_eq!(
             state.stack.len(),
-            1,
-            "first Prankster trigger pushed before second prompted"
+            2,
+            "first Prankster trigger pushed (complete) before second pushed (in-construction)"
+        );
+        assert!(state.pending_trigger_entry.is_some());
+        assert_eq!(
+            state.stack.back().map(|e| e.id),
+            state.pending_trigger_entry
         );
 
         // Player chooses the first Prankster as target for the second trigger.
@@ -12077,13 +12212,14 @@ pub mod tests {
         )
         .expect("second prankster choose target");
 
-        // Both triggers are now on the stack.
+        // Both triggers are now on the stack (both fully constructed).
         assert_eq!(
             state.stack.len(),
             2,
             "both Prankster attack triggers must reach the stack"
         );
         assert!(state.pending_trigger.is_none());
+        assert!(state.pending_trigger_entry.is_none());
         assert!(state.deferred_triggers.is_empty());
 
         // Resolve both triggers by passing priority.
@@ -15508,6 +15644,472 @@ mod devour_runtime_tests {
             p1p1(&state, devour),
             2,
             "Devour 2 + one creature sacrificed → 2 +1/+1 counters (N per sacrifice)"
+        );
+    }
+}
+
+// ===================================================================
+// CR 603.3c + CR 603.3d "Push first, choose second" contract tests
+// ===================================================================
+//
+// These tests verify the invariant established by the trigger-stack-push
+// refactor: a triggered ability that requires player input (mode choice,
+// target selection, or division-among) is pushed to `state.stack` BEFORE
+// the prompt is opened, in a mid-construction state. `pending_trigger_entry`
+// identifies the in-construction entry; the resolver (`stack::resolve_top`)
+// refuses to fire entries identified by this cursor. This is the behaviour
+// fix for Lulu, Stern Guardian and the broader class of triggers whose UI
+// prompt previously appeared with no stack entry for context.
+#[cfg(test)]
+mod push_first_contract_tests {
+    use super::process_triggers;
+    use crate::game::effects::resolve_ability_chain;
+    use crate::game::zones::create_object;
+    use crate::types::ability::{
+        AbilityCondition, AbilityDefinition, AbilityKind, ControllerRef, Effect, PaymentCost,
+        QuantityExpr, ResolvedAbility, TargetFilter, TargetRef, TriggerDefinition, TypedFilter,
+    };
+    use crate::types::actions::GameAction;
+    use crate::types::card_type::CoreType;
+    use crate::types::counter::CounterType;
+    use crate::types::events::GameEvent;
+    use crate::types::game_state::{GameState, StackEntryKind, WaitingFor, ZoneChangeRecord};
+    use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::player::PlayerId;
+    use crate::types::triggers::TriggerMode;
+    use crate::types::zones::Zone;
+
+    fn setup() -> GameState {
+        GameState::new_two_player(42)
+    }
+
+    fn make_creature(state: &mut GameState, player: PlayerId, name: &str) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(state.next_object_id),
+            player,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.base_power = Some(2);
+        obj.base_toughness = Some(2);
+        obj.power = Some(2);
+        obj.toughness = Some(2);
+        id
+    }
+
+    fn zone_changed_event(object_id: ObjectId, from: Zone, to: Zone) -> GameEvent {
+        GameEvent::ZoneChanged {
+            object_id,
+            from: Some(from),
+            to,
+            record: Box::new(ZoneChangeRecord {
+                name: "Test Source".to_string(),
+                core_types: vec![CoreType::Enchantment],
+                subtypes: vec![],
+                ..ZoneChangeRecord::test_minimal(object_id, Some(from), to)
+            }),
+        }
+    }
+
+    fn build_exile_target_opponent_creature_trigger() -> TriggerDefinition {
+        TriggerDefinition::new(TriggerMode::ChangesZone)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::ChangeZone {
+                    origin: Some(Zone::Battlefield),
+                    destination: Zone::Exile,
+                    target: TargetFilter::Typed(
+                        TypedFilter::creature().controller(ControllerRef::Opponent),
+                    ),
+                    owner_library: false,
+                    enter_transformed: false,
+                    enters_under: None,
+                    enter_tapped: false,
+                    enters_attacking: false,
+                    up_to: false,
+                    enter_with_counters: vec![],
+                },
+            ))
+            .valid_card(TargetFilter::SelfRef)
+            .destination(Zone::Battlefield)
+    }
+
+    fn make_source_with_trigger(state: &mut GameState) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(state.next_object_id),
+            PlayerId(0),
+            "Test Source".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.entered_battlefield_turn = Some(1);
+        obj.trigger_definitions
+            .push(build_exile_target_opponent_creature_trigger());
+        id
+    }
+
+    /// Test #1 (Lulu / blocker-validating): a target-requiring trigger pushes
+    /// to the stack BEFORE prompting the controller. This test must FAIL on
+    /// the pre-refactor codebase and PASS on the post-refactor codebase.
+    #[test]
+    fn push_first_target_trigger_appears_on_stack_during_prompt() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        // Two legal opponent creatures so target choice cannot auto-resolve.
+        let target1 = make_creature(&mut state, PlayerId(1), "Opp 1");
+        let _target2 = make_creature(&mut state, PlayerId(1), "Opp 2");
+        let source = make_source_with_trigger(&mut state);
+
+        process_triggers(
+            &mut state,
+            &[zone_changed_event(source, Zone::Hand, Zone::Battlefield)],
+        );
+
+        // CR 603.3c + CR 603.3d "Push first": the trigger entry MUST be on the
+        // stack already, identified by `pending_trigger_entry`. This is the
+        // structural change that fails on the pre-refactor codebase, where
+        // `process_triggers` would set `pending_trigger` without pushing.
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "trigger entry must be on the stack while target prompt is pending",
+        );
+        let entry_id = state
+            .pending_trigger_entry
+            .expect("pending_trigger_entry must mark the in-construction entry");
+        assert_eq!(state.stack.back().map(|e| e.id), Some(entry_id));
+        let entry = state.stack.back().unwrap();
+        assert_eq!(entry.source_id, source);
+        assert!(matches!(
+            entry.kind,
+            StackEntryKind::TriggeredAbility { .. }
+        ));
+        assert!(state.pending_trigger.is_some());
+
+        // Drive the engine pipeline forward — `begin_pending_trigger_target_selection`
+        // translates the pending state into `WaitingFor::TriggerTargetSelection`,
+        // matching what the action dispatcher does in production.
+        let wf = crate::game::engine::begin_pending_trigger_target_selection(&mut state)
+            .expect("begin target selection")
+            .expect("target prompt required (two legal targets)");
+        state.waiting_for = wf;
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ));
+
+        // Complete the choice: entry stays on the stack, fully constructed,
+        // with targets populated. Cursor cleared.
+        crate::game::engine::apply_as_current(
+            &mut state,
+            GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(target1)),
+            },
+        )
+        .expect("choose target succeeds");
+        assert_eq!(state.stack.len(), 1, "entry remains on stack post-choice");
+        assert!(
+            state.pending_trigger_entry.is_none(),
+            "construction complete -> cursor cleared",
+        );
+        let entry = state.stack.back().unwrap();
+        if let StackEntryKind::TriggeredAbility { ability, .. } = &entry.kind {
+            assert_eq!(ability.targets, vec![TargetRef::Object(target1)]);
+        } else {
+            panic!("expected TriggeredAbility on stack");
+        }
+    }
+
+    /// Test #5 (resolver-refusal): `stack::resolve_top` must NOT fire the top
+    /// entry while `pending_trigger_entry` identifies it. This is the
+    /// invariant gate that prevents the in-construction entry from resolving.
+    #[test]
+    fn push_first_resolver_refuses_in_construction_entry() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        // Set up a pending-target trigger via the production pipeline (so the
+        // entry is genuinely in-construction, not synthesized by hand).
+        let _t1 = make_creature(&mut state, PlayerId(1), "Opp 1");
+        let _t2 = make_creature(&mut state, PlayerId(1), "Opp 2");
+        let source = make_source_with_trigger(&mut state);
+        process_triggers(
+            &mut state,
+            &[zone_changed_event(source, Zone::Hand, Zone::Battlefield)],
+        );
+
+        // Confirm pre-conditions: top is the in-construction entry.
+        let in_construction_id = state.pending_trigger_entry.expect("entry set");
+        let stack_len_before = state.stack.len();
+        assert_eq!(state.stack.back().map(|e| e.id), Some(in_construction_id));
+
+        // Call resolve_top directly: it must refuse to act on the entry.
+        let mut events = Vec::new();
+        crate::game::stack::resolve_top(&mut state, &mut events);
+
+        assert_eq!(
+            state.stack.len(),
+            stack_len_before,
+            "resolve_top must not pop the in-construction entry",
+        );
+        assert_eq!(
+            state.stack.back().map(|e| e.id),
+            Some(in_construction_id),
+            "in-construction entry stays on top",
+        );
+        assert!(
+            events.is_empty(),
+            "no StackResolved event for refused resolution, got {events:?}",
+        );
+        assert_eq!(
+            state.pending_trigger_entry,
+            Some(in_construction_id),
+            "cursor preserved on refusal",
+        );
+    }
+
+    /// Test #7 (CR 603.3d → CR 601.2c no-legal-targets removal): a
+    /// target-requiring trigger with zero legal targets is dropped without
+    /// pushing to the stack or leaving a cursor.
+    #[test]
+    fn push_first_no_legal_targets_drops_trigger_silently() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        // Opponent controls NO creatures; the trigger requires a target
+        // opponent creature.
+        let source = make_source_with_trigger(&mut state);
+        let stack_before = state.stack.len();
+        process_triggers(
+            &mut state,
+            &[zone_changed_event(source, Zone::Hand, Zone::Battlefield)],
+        );
+
+        assert_eq!(
+            state.stack.len(),
+            stack_before,
+            "no-legal-target trigger must not be pushed to the stack",
+        );
+        assert!(
+            state.pending_trigger_entry.is_none(),
+            "no-legal-target trigger must not leave a cursor",
+        );
+        assert!(state.pending_trigger.is_none());
+    }
+
+    /// Test #10 (reflexive WhenYouDo trigger): the push-first contract holds
+    /// at the OTHER pause-path site, `effects/mod.rs::resolve_chain_body`
+    /// (line ~3654). A reflexive `WhenYouDo` sub-ability with empty `targets`
+    /// and a non-empty target-slot set must push the entry to the stack
+    /// BEFORE entering `WaitingFor::TriggerTargetSelection`. Structurally
+    /// identical to the main dispatch path but lives in a different function;
+    /// a regression here would not fail the other discriminating tests.
+    #[test]
+    fn push_first_reflexive_when_you_do_pushes_to_stack_during_prompt() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        // Cost-payment must succeed so the WhenYouDo gate fires (CR 603.12 +
+        // issue #418): controller has exactly enough energy.
+        state.players[0].energy = 3;
+
+        // Two legal target candidates (own creatures) so the reflexive's
+        // PutCounter target slot has multiple legal choices, forcing the
+        // player-choice path through `begin_target_selection_for_ability`.
+        let candidate1 = make_creature(&mut state, PlayerId(0), "Candidate 1");
+        let _candidate2 = make_creature(&mut state, PlayerId(0), "Candidate 2");
+
+        // Reflexive sub-ability: PutCounter on a chosen creature you control.
+        // `targets` is empty so `effects/mod.rs:3585-3667` enters the
+        // push-first path; `TargetFilter::Typed` resolves to a target slot
+        // when `build_target_slots` runs.
+        let source_id = ObjectId(state.next_object_id);
+        let sub = ResolvedAbility::new(
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        )
+        .condition(AbilityCondition::WhenYouDo);
+
+        // Parent: pay {E}{E}{E}. On success the reflexive `WhenYouDo` fires.
+        let parent = ResolvedAbility::new(
+            Effect::PayCost {
+                cost: PaymentCost::Energy {
+                    amount: QuantityExpr::Fixed { value: 3 },
+                },
+                payer: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        )
+        .sub_ability(sub);
+
+        let stack_before = state.stack.len();
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &parent, &mut events, 0).expect("resolve parent chain");
+
+        // CR 603.3c + CR 603.3d: The reflexive trigger entry MUST be on the
+        // stack now (push-first contract holds at the reflexive site too).
+        assert_eq!(
+            state.stack.len(),
+            stack_before + 1,
+            "reflexive WhenYouDo trigger must be on the stack while its target prompt is open",
+        );
+        let entry_id = state
+            .pending_trigger_entry
+            .expect("pending_trigger_entry must mark the in-construction entry");
+        assert_eq!(state.stack.back().map(|e| e.id), Some(entry_id));
+        let entry = state.stack.back().unwrap();
+        assert!(matches!(
+            entry.kind,
+            StackEntryKind::TriggeredAbility { .. }
+        ));
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ));
+
+        // Complete the target choice: entry stays on stack, fully constructed.
+        crate::game::engine::apply_as_current(
+            &mut state,
+            GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(candidate1)),
+            },
+        )
+        .expect("choose target succeeds");
+        assert!(
+            state.pending_trigger_entry.is_none(),
+            "reflexive construction complete -> cursor cleared",
+        );
+    }
+
+    /// Test #6 (CR 603.3c no-legal-modes modal early-drop): a modal trigger
+    /// where every mode's target is illegal must be dropped at the modal
+    /// pre-filter (`triggers.rs::dispatch_pending_trigger_context` line ~2235)
+    /// BEFORE any `StackPushed` event is emitted. Exercises the new pre-push
+    /// logic (`compute_unavailable_modes` + `filter_modes_by_target_legality`)
+    /// that is otherwise structurally unverified by the non-modal Err-branch
+    /// tests.
+    #[test]
+    fn push_first_no_legal_modes_modal_trigger_dropped_silently() {
+        use crate::types::ability::{ModalChoice, PlayerFilter};
+
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        // No opponent creatures exist. Both modes target an opponent
+        // creature, so every mode pre-filters as illegal at modal-pause time.
+        let source_id = ObjectId(state.next_object_id);
+        let opponent_creature_target =
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent));
+        let mode_a = AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::Destroy {
+                target: opponent_creature_target.clone(),
+                cant_regenerate: false,
+            },
+        );
+        let mode_b = AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::Destroy {
+                target: opponent_creature_target.clone(),
+                cant_regenerate: false,
+            },
+        );
+        let modal = ModalChoice {
+            min_choices: 1,
+            max_choices: 1,
+            mode_count: 2,
+            mode_descriptions: vec!["A".to_string(), "B".to_string()],
+            allow_repeat_modes: false,
+            constraints: vec![],
+            mode_costs: vec![],
+            entwine_cost: None,
+            chooser: PlayerFilter::Controller,
+        };
+        let modal_ability = AbilityDefinition::new(
+            AbilityKind::Database,
+            // Inner effect is not actually executed (a mode replaces it); pick
+            // a placeholder that resolves cleanly if it were ever to fire.
+            Effect::Destroy {
+                target: TargetFilter::None,
+                cant_regenerate: false,
+            },
+        )
+        .with_modal(modal, vec![mode_a, mode_b]);
+
+        // Construct a PendingTrigger directly and dispatch it through the
+        // public pipeline. Modal trigger context with no legal mode reaches
+        // the early-drop branch at `triggers.rs::dispatch_pending_trigger_context`.
+        let trigger = super::PendingTrigger {
+            source_id,
+            controller: PlayerId(0),
+            condition: None,
+            ability: super::super::ability_utils::build_resolved_from_def(
+                &modal_ability,
+                source_id,
+                PlayerId(0),
+            ),
+            timestamp: state.turn_number,
+            target_constraints: Vec::new(),
+            distribute: None,
+            trigger_event: None,
+            modal: modal_ability.modal.clone(),
+            mode_abilities: modal_ability.mode_abilities.clone(),
+            description: None,
+            may_trigger_origin: None,
+            subject_match_count: None,
+        };
+
+        let stack_before = state.stack.len();
+        let mut events = Vec::new();
+        let paused = super::dispatch_pending_trigger_context(
+            &mut state,
+            super::PendingTriggerContext::single(trigger),
+            &mut events,
+        );
+
+        // CR 603.3c "If no mode can be chosen, the ability is removed from
+        // the stack": dispatcher reports no pause; nothing pushed; no cursor.
+        assert!(
+            !paused,
+            "modal trigger with no legal mode must not pause on player input",
+        );
+        assert_eq!(
+            state.stack.len(),
+            stack_before,
+            "no-legal-mode modal trigger must NOT be pushed to the stack",
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, GameEvent::StackPushed { .. })),
+            "no StackPushed event must be emitted for a dropped no-legal-mode modal trigger",
+        );
+        assert!(
+            state.pending_trigger_entry.is_none(),
+            "no-legal-mode modal trigger must not leave a cursor",
+        );
+        assert!(
+            state.pending_trigger.is_none(),
+            "no-legal-mode modal trigger must not leave a stashed pending_trigger",
         );
     }
 }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3738,6 +3738,16 @@ pub struct GameState {
     /// trigger context, consumed when the pending trigger is put on the stack.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pending_trigger_event_batch: Vec<GameEvent>,
+    /// CR 603.3c + CR 603.3d: ObjectId of the stack entry currently being
+    /// constructed (mode / target / division still being chosen by the
+    /// controller). `Some` only while a pause-path `WaitingFor` is outstanding.
+    ///
+    /// "Push first, choose second" invariant: when this is `Some(id)`, the top
+    /// of `state.stack` is the trigger entry with that id, and its
+    /// `ResolvedAbility` has unfilled slots that the active `WaitingFor` is
+    /// gathering. `stack::resolve_top` refuses to fire on this id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_trigger_entry: Option<ObjectId>,
     /// CR 113.2c + CR 603.2 + CR 603.3b: Queue of triggers that fired in the
     /// same pass but were deferred because an earlier trigger needed player
     /// input (modal choice, target selection, or division). Each instance of a
@@ -4664,6 +4674,7 @@ impl GameState {
             spells_cast_last_turn: None,
             pending_trigger: None,
             pending_trigger_event_batch: Vec::new(),
+            pending_trigger_entry: None,
             deferred_triggers: Vec::new(),
             pending_trigger_order: None,
             exile_links: Vec::new(),
@@ -4942,6 +4953,7 @@ impl PartialEq for GameState {
             && self.spells_cast_this_turn == other.spells_cast_this_turn
             && self.spells_cast_last_turn == other.spells_cast_last_turn
             && self.pending_trigger == other.pending_trigger
+            && self.pending_trigger_entry == other.pending_trigger_entry
             && self.deferred_triggers == other.deferred_triggers
             && self.pending_trigger_order == other.pending_trigger_order
             && self.exile_links == other.exile_links


### PR DESCRIPTION
Triggered abilities that require a choice (target selection, mode choice,
or distribute-among) did not appear in state.stack until *after* the
controller completed the choice. Symptom: Lulu, Stern Guardian prompts for
a target, but her card does not show on the stack as the source trigger
until the target is selected, so the player has no idea what they are
choosing a target for.

Adopt "push first, choose second": convert the PendingTrigger to a
StackEntry and push it to the stack BEFORE entering the corresponding
WaitingFor, then mutate the on-stack entry's ability in place as choices
arrive. A new `pending_trigger_entry: Option<ObjectId>` cursor on
GameState identifies the mid-construction entry; stack::resolve_top
refuses to resolve the top entry while its id matches the cursor, so a
half-built trigger can never resolve early.

- game_state.rs: add `pending_trigger_entry` cursor (serde/Clone/PartialEq)
- triggers.rs: push_pending_trigger_to_stack[_with_event_batch] return the
  pushed ObjectId; add is_pending_trigger_construction_active; flip the
  modal / target / division pause paths to push-first; CR 603.3c no-legal-mode
  branch drops before any StackPushed event
- effects/mod.rs: reflexive WhenYouDo pause path pushes first
- engine.rs / engine_modes.rs / engine_stack.rs: completion handlers mutate
  the on-stack entry's ability via mutate_*/finalize_* (mutate keeps the
  cursor for intermediate steps, finalize clears it); remove the legacy
  pre-refactor fallback; migrate test constructors to push-first
- stack.rs: resolver-refusal guard as the first statement of resolve_top

CR 603.3c (modal triggers), CR 603.3d -> 601.2c (targets) / 601.2d
(division), CR 608.2b (post-resolution legality re-check).

5 push-first contract tests cover the target, reflexive, resolver-refusal,
no-legal-targets, and no-legal-modes paths.

Follow-up: consolidate the dual trigger-construction patterns
(dispatch_pending_trigger_context vs the reflexive site in effects/mod.rs)
via a shared push_trigger_and_prompt_for_targets helper in a separate PR.
