### PR TITLE
Address review: consolidate trigger-entry mutation helpers into triggers.rs

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3930,19 +3930,7 @@ fn apply_action(
                 // * Entry id references a `TriggeredAbility` `StackEntry`.
                 pending_trigger.ability.distribution =
                     Some(distribution.iter().map(|(t, a)| (t.clone(), *a)).collect());
-                let entry_id = state.pending_trigger_entry.take().expect(
-                    "DistributeAmong completion: pending_trigger_entry must be set under the push-first contract",
-                );
-                let entry = state
-                    .stack
-                    .iter_mut()
-                    .rev()
-                    .find(|entry| entry.id == entry_id)
-                    .expect("DistributeAmong completion: pending_trigger_entry must reference a stack entry");
-                let ability = entry.ability_mut().expect(
-                    "DistributeAmong completion: pending_trigger_entry must reference a TriggeredAbility stack entry",
-                );
-                *ability = pending_trigger.ability.clone();
+                triggers::finalize_pending_trigger_entry(state, &pending_trigger.ability);
                 state.priority_passes.clear();
                 state.priority_pass_count = 0;
                 // CR 113.2c + CR 603.2 + CR 603.3b: Drain siblings deferred

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -289,7 +289,7 @@ fn handle_triggered_mode_choice(
             // pause-time); mutate its ability with the resolved mode so the
             // target prompt operates on the chosen mode. `pending_trigger_entry`
             // stays set — construction continues through target selection.
-            mutate_pending_trigger_entry_ability(state, &trigger.ability);
+            triggers::mutate_pending_trigger_entry(state, &trigger.ability);
             let description = trigger.description.clone();
             state.pending_trigger = Some(trigger);
             let pending_trigger = state
@@ -316,7 +316,7 @@ fn handle_triggered_mode_choice(
         // on the stack (pushed at modal pause-time); mutate its ability with
         // the resolved mode and clear `pending_trigger_entry` so the resolver
         // may fire this entry.
-        finalize_pending_trigger_entry_ability(state, &trigger.ability);
+        triggers::finalize_pending_trigger_entry(state, &trigger.ability);
         state.priority_passes.clear();
         state.priority_pass_count = 0;
         // CR 113.2c + CR 603.2 + CR 603.3b: Drain siblings deferred behind this
@@ -332,59 +332,4 @@ fn handle_triggered_mode_choice(
     }
 
     Ok(WaitingFor::Priority { player })
-}
-
-/// CR 603.3c: Mutate the in-construction stack entry's resolved ability
-/// without clearing `pending_trigger_entry`. Used when the controller has
-/// chosen a mode but target selection is still outstanding.
-///
-/// Invariants (panic in debug; see `finalize_pending_trigger_entry_ability`):
-/// * `state.pending_trigger_entry` is `Some(_)`.
-/// * Entry id references a `TriggeredAbility` `StackEntry` in `state.stack`.
-fn mutate_pending_trigger_entry_ability(
-    state: &mut GameState,
-    source_ability: &crate::types::ability::ResolvedAbility,
-) {
-    let entry_id = state
-        .pending_trigger_entry
-        .expect("mutate_pending_trigger_entry_ability: pending_trigger_entry must be set");
-    let entry = state
-        .stack
-        .iter_mut()
-        .rev()
-        .find(|entry| entry.id == entry_id)
-        .expect("mutate_pending_trigger_entry_ability: pending_trigger_entry must reference a stack entry");
-    let ability = entry
-        .ability_mut()
-        .expect("mutate_pending_trigger_entry_ability: pending_trigger_entry must reference a TriggeredAbility");
-    *ability = source_ability.clone();
-}
-
-/// CR 603.3c: Mutate the in-construction stack entry's resolved ability AND
-/// clear `pending_trigger_entry` — construction is complete, the resolver is
-/// now free to fire this entry.
-///
-/// Invariants (no recovery path; violations panic in debug, otherwise leave
-/// the engine in an internally inconsistent state):
-/// * `state.pending_trigger_entry` is `Some(_)` (every caller pushed under the
-///   "push first" contract).
-/// * Entry id references a `TriggeredAbility` `StackEntry` in `state.stack`.
-fn finalize_pending_trigger_entry_ability(
-    state: &mut GameState,
-    source_ability: &crate::types::ability::ResolvedAbility,
-) {
-    let entry_id = state
-        .pending_trigger_entry
-        .take()
-        .expect("finalize_pending_trigger_entry_ability: pending_trigger_entry must be set under the push-first contract");
-    let entry = state
-        .stack
-        .iter_mut()
-        .rev()
-        .find(|entry| entry.id == entry_id)
-        .expect("finalize_pending_trigger_entry_ability: pending_trigger_entry must reference a stack entry");
-    let ability = entry
-        .ability_mut()
-        .expect("finalize_pending_trigger_entry_ability: pending_trigger_entry must reference a TriggeredAbility stack entry");
-    *ability = source_ability.clone();
 }

--- a/crates/engine/src/game/engine_stack.rs
+++ b/crates/engine/src/game/engine_stack.rs
@@ -47,7 +47,7 @@ pub(super) fn finalize_trigger_target_selection(
                 // on the stack with empty `distribution`; mutate the on-stack
                 // ability's targets (so they match what was just chosen) and
                 // keep `pending_trigger_entry` set until division completes.
-                mutate_pending_trigger_entry(state, &trigger.ability);
+                triggers::mutate_pending_trigger_entry(state, &trigger.ability);
                 state.pending_trigger = Some(trigger);
                 state.priority_passes.clear();
                 state.priority_pass_count = 0;
@@ -65,7 +65,7 @@ pub(super) fn finalize_trigger_target_selection(
     // the stack (pushed by the pause-path that started selection); mutate its
     // ability with the resolved targets/distribution and clear
     // `pending_trigger_entry` so the resolver may now fire this entry.
-    finalize_pending_trigger_entry_on_stack(state, &trigger.ability);
+    triggers::finalize_pending_trigger_entry(state, &trigger.ability);
 
     state.priority_passes.clear();
     state.priority_pass_count = 0;
@@ -82,60 +82,6 @@ pub(super) fn finalize_trigger_target_selection(
         return waiting_for;
     }
     WaitingFor::Priority { player: controller }
-}
-
-/// CR 603.3c + CR 603.3d: Mutate the in-construction stack entry's resolved
-/// ability without clearing `pending_trigger_entry` — the entry is still
-/// awaiting further input (division-among after target selection).
-///
-/// Invariants (panic in debug; see `finalize_pending_trigger_entry_on_stack`):
-/// * `state.pending_trigger_entry` is `Some(_)`.
-/// * Entry id references a `TriggeredAbility` `StackEntry` in `state.stack`.
-fn mutate_pending_trigger_entry(state: &mut GameState, source_ability: &ResolvedAbility) {
-    let entry_id = state
-        .pending_trigger_entry
-        .expect("mutate_pending_trigger_entry: pending_trigger_entry must be set");
-    let entry = state
-        .stack
-        .iter_mut()
-        .rev()
-        .find(|entry| entry.id == entry_id)
-        .expect("mutate_pending_trigger_entry: pending_trigger_entry must reference a stack entry");
-    let ability = entry.ability_mut().expect(
-        "mutate_pending_trigger_entry: pending_trigger_entry must reference a TriggeredAbility",
-    );
-    *ability = source_ability.clone();
-}
-
-/// CR 603.3c + CR 603.3d: Mutate the in-construction stack entry's resolved
-/// ability AND clear `pending_trigger_entry` — construction is complete, the
-/// resolver is now free to fire this entry.
-///
-/// Invariants (no recovery path; violations panic in debug, otherwise leave
-/// the engine in an internally inconsistent state):
-/// * `state.pending_trigger_entry` is `Some(_)` (the "push first" contract
-///   means every code path that reaches this function pushed the entry
-///   already).
-/// * That entry id refers to a `TriggeredAbility` `StackEntry` somewhere in
-///   `state.stack` (the entry has not been popped between push and finalize).
-fn finalize_pending_trigger_entry_on_stack(
-    state: &mut GameState,
-    source_ability: &ResolvedAbility,
-) {
-    let entry_id = state
-        .pending_trigger_entry
-        .take()
-        .expect("finalize_pending_trigger_entry_on_stack: pending_trigger_entry must be set under the push-first contract");
-    let entry = state
-        .stack
-        .iter_mut()
-        .rev()
-        .find(|entry| entry.id == entry_id)
-        .expect("finalize_pending_trigger_entry_on_stack: pending_trigger_entry must reference a stack entry");
-    let ability = entry
-        .ability_mut()
-        .expect("finalize_pending_trigger_entry_on_stack: pending_trigger_entry must reference a TriggeredAbility stack entry");
-    *ability = source_ability.clone();
 }
 
 pub(super) fn handle_trigger_target_selection_select_targets(

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -2153,6 +2153,63 @@ pub(crate) fn is_pending_trigger_construction_active(state: &GameState) -> bool 
     state.pending_trigger_entry.is_some()
 }
 
+/// CR 603.3c + CR 603.3d: Overwrite the in-construction stack entry's resolved
+/// ability with `source_ability`, leaving `pending_trigger_entry` untouched.
+/// Use for intermediate construction steps (e.g. a mode chosen while target
+/// selection is still outstanding) where the entry must remain non-resolvable.
+///
+/// Invariants (panic on violation — the push-first contract guarantees them):
+/// * `state.pending_trigger_entry` is `Some(_)`.
+/// * That id references a `TriggeredAbility` `StackEntry` in `state.stack`.
+pub(crate) fn mutate_pending_trigger_entry(
+    state: &mut GameState,
+    source_ability: &ResolvedAbility,
+) {
+    let entry_id = state
+        .pending_trigger_entry
+        .expect("mutate_pending_trigger_entry: pending_trigger_entry must be set under the push-first contract");
+    assign_pending_trigger_entry_ability(state, entry_id, source_ability);
+}
+
+/// CR 603.3c + CR 603.3d: Overwrite the in-construction stack entry's resolved
+/// ability with `source_ability` AND clear `pending_trigger_entry` —
+/// construction is complete, so the resolver is now free to fire this entry.
+///
+/// Invariants (panic on violation — no recovery path):
+/// * `state.pending_trigger_entry` is `Some(_)` (every caller pushed under the
+///   push-first contract).
+/// * That id references a `TriggeredAbility` `StackEntry` in `state.stack`.
+pub(crate) fn finalize_pending_trigger_entry(
+    state: &mut GameState,
+    source_ability: &ResolvedAbility,
+) {
+    let entry_id = state
+        .pending_trigger_entry
+        .take()
+        .expect("finalize_pending_trigger_entry: pending_trigger_entry must be set under the push-first contract");
+    assign_pending_trigger_entry_ability(state, entry_id, source_ability);
+}
+
+/// Locate the in-construction `TriggeredAbility` entry identified by `entry_id`
+/// (searching from the top of the stack down) and overwrite its resolved
+/// ability. Shared find-and-assign logic for `mutate`/`finalize` above.
+fn assign_pending_trigger_entry_ability(
+    state: &mut GameState,
+    entry_id: ObjectId,
+    source_ability: &ResolvedAbility,
+) {
+    let entry = state
+        .stack
+        .iter_mut()
+        .rev()
+        .find(|entry| entry.id == entry_id)
+        .expect("pending_trigger_entry must reference a stack entry");
+    let ability = entry
+        .ability_mut()
+        .expect("pending_trigger_entry must reference a TriggeredAbility stack entry");
+    *ability = source_ability.clone();
+}
+
 /// CR 603.2 + CR 603.3b + CR 309.4c: Dispatch a synthetic
 /// single trigger (game-rule trigger queued mid-resolution, e.g. dungeon
 /// room ability from `effects::venture::queue_room_trigger`). Delegates


### PR DESCRIPTION
Gemini review flagged that the mutate/finalize on-stack-entry helpers were
duplicated across engine_stack.rs, engine_modes.rs, and inline in engine.rs.
Consolidate into two pub(crate) helpers in triggers.rs:

- mutate_pending_trigger_entry: overwrite the in-construction entry's ability,
  keep `pending_trigger_entry` set (intermediate construction step)
- finalize_pending_trigger_entry: overwrite + clear the cursor (construction
  complete, resolver unlocked)

Both delegate to a private assign_pending_trigger_entry_ability for the shared
find-by-cursor-and-assign logic. Removes ~90 lines of triplicated code with no
behavior change (9351 engine tests pass unchanged). CR 603.3c + CR 603.3d.
