### PR TITLE
Fix tap-or-untap target parsing

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -2043,6 +2043,54 @@ fn try_parse_create_token_choice(
     }))
 }
 
+/// CR 115.1 + CR 608.2d + CR 701.26a-b: "tap or untap target <object>"
+/// declares a single target as the trigger/spell is put on the stack, then the
+/// controller chooses the tap or untap instruction while resolving.
+fn try_parse_tap_or_untap_choice(
+    tp: TextPair<'_>,
+    ctx: &mut ParseContext,
+) -> Option<ParsedEffectClause> {
+    let ((), rest) = nom_on_lower(tp.original, tp.lower, |i| {
+        value((), tag("tap or untap ")).parse(i)
+    })?;
+    let (target_text, multi_target) = strip_optional_target_prefix(rest.trim_start());
+    let (target, _rem) = parse_target_with_ctx(target_text, ctx);
+    if matches!(target, TargetFilter::Any) {
+        return None;
+    }
+    #[cfg(debug_assertions)]
+    assert_no_compound_remainder(_rem, tp.original);
+
+    let mut tap_branch = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Tap {
+            target: TargetFilter::ParentTarget,
+        },
+    );
+    tap_branch.description = Some("tap".to_string());
+    let mut untap_branch = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Untap {
+            target: TargetFilter::ParentTarget,
+        },
+    );
+    untap_branch.description = Some("untap".to_string());
+
+    let mut choice = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChooseOneOf {
+            chooser: PlayerFilter::Controller,
+            branches: vec![tap_branch, untap_branch],
+        },
+    );
+    choice.description = Some("tap or untap".to_string());
+
+    let mut clause = parsed_clause(Effect::TargetOnly { target });
+    clause.multi_target = multi_target;
+    clause.sub_ability = Some(Box::new(choice));
+    Some(clause)
+}
+
 /// CR 700.2 + CR 608.2d: Detect inline binary-choice imperatives of the form
 /// "A or B" where both A and B parse independently as supported effects.
 /// Emits `Effect::ChooseOneOf { branches: [A, B] }` so the second branch is
@@ -3026,6 +3074,13 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // generic inline splitter and token dispatch so "create a Food token or a
     // Treasure token" does not collapse to the first token branch.
     if let Some(clause) = try_parse_create_token_choice(tp, ctx) {
+        return clause;
+    }
+
+    // CR 115.1 + CR 608.2d + CR 701.26a-b: Shared-target tap/untap choice
+    // must run before the generic "A or B" splitter and before simple `tap`
+    // verb dispatch, otherwise the second instruction can be swallowed.
+    if let Some(clause) = try_parse_tap_or_untap_choice(tp, ctx) {
         return clause;
     }
 
@@ -23811,6 +23866,61 @@ mod tests {
                 .modifications
                 .contains(&ContinuousModification::AddKeyword { keyword }));
         }
+    }
+
+    #[test]
+    fn shared_target_tap_or_untap_uses_resolution_choice() {
+        let def = parse_effect_chain("Tap or untap target permanent", AbilityKind::Spell);
+
+        let Effect::TargetOnly {
+            target: TargetFilter::Typed(target),
+        } = &*def.effect
+        else {
+            panic!("expected TargetOnly head, got {:?}", def.effect);
+        };
+        assert!(target
+            .type_filters
+            .iter()
+            .any(|filter| matches!(filter, TypeFilter::Permanent)));
+
+        let choice = def
+            .sub_ability
+            .as_deref()
+            .expect("tap-or-untap must chain a resolution choice");
+        let Effect::ChooseOneOf { chooser, branches } = &*choice.effect else {
+            panic!("expected ChooseOneOf sub-ability, got {:?}", choice.effect);
+        };
+        assert_eq!(*chooser, PlayerFilter::Controller);
+        assert_eq!(branches.len(), 2);
+        assert!(matches!(
+            &*branches[0].effect,
+            Effect::Tap {
+                target: TargetFilter::ParentTarget
+            }
+        ));
+        assert!(matches!(
+            &*branches[1].effect,
+            Effect::Untap {
+                target: TargetFilter::ParentTarget
+            }
+        ));
+    }
+
+    #[test]
+    fn shared_target_tap_or_untap_preserves_up_to_target_count() {
+        let def = parse_effect_chain(
+            "Tap or untap up to one target permanent",
+            AbilityKind::Spell,
+        );
+
+        assert!(matches!(*def.effect, Effect::TargetOnly { .. }));
+        assert_eq!(def.multi_target, Some(MultiTargetSpec::fixed(0, 1)));
+        assert!(matches!(
+            *def.sub_ability
+                .expect("tap-or-untap must chain a resolution choice")
+                .effect,
+            Effect::ChooseOneOf { .. }
+        ));
     }
 
     /// Issue #501 FOLLOW-UP — ROOT CAUSE A building-block test. A "gains


### PR DESCRIPTION
## Summary
Fixes the shared-target Oracle pattern `tap or untap target ...`.

Derevi's two triggers now parse as a stack-time `TargetOnly` target followed by a resolution-time `ChooseOneOf` branch choice between `Tap ParentTarget` and `Untap ParentTarget`.

Fixes #1273.

## Files changed
- `crates/engine/src/parser/oracle_effect/mod.rs`

## CR references
- CR 115.1
- CR 608.2d
- CR 701.26a-b

## Track
Developer

Model: codex-5
Thinking: medium
Tier: Standard

## Anchored on
- `crates/engine/src/parser/oracle_effect/mod.rs:2009` — existing shared-verb `create ... or ...` parser that lowers a single Oracle phrase into `ChooseOneOf` branches.
- `crates/engine/src/parser/oracle_effect/mod.rs:23817` — existing `TargetOnly -> ChooseOneOf` regression test shape for a shared target followed by a resolution-time branch choice.

## Gate A
`./scripts/check-parser-combinators.sh`

Output: no stdout; exit code 0.

## Verification
- `cargo fmt --all -- --check`
- `./scripts/check-parser-combinators.sh`
- `git diff --check`
- `cargo test -p engine shared_target_tap_or_untap`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p engine`
- `./scripts/gen-card-data.sh`

## Notes
- Verified the regenerated Derevi export has both triggers as `TargetOnly -> ChooseOneOf`.
