### PR TITLE
fix(parser): "all other X with the same name as that X" no longer board-wipes

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -35688,6 +35688,40 @@ mod tests {
         assert!(matches!(&*effect.effect, Effect::Draw { .. }));
     }
 
+    /// CR 201.2: "Destroy target nonland permanent and all other permanents
+    /// with the same name as that permanent" (Maelstrom Pulse, and the Echoing
+    /// cycle, Bile Blight, Homing Lightning, Detention Sphere class). The
+    /// secondary mass effect must filter to permanents whose name matches the
+    /// targeted permanent (`SameNameAsParentTarget`) — without it the effect
+    /// degrades into an unconditional board wipe.
+    #[test]
+    fn maelstrom_pulse_destroys_only_same_named_permanents() {
+        let def = parse_effect_chain(
+            "Destroy target nonland permanent and all other permanents with the same name as that permanent.",
+            AbilityKind::Spell,
+        );
+        assert!(matches!(&*def.effect, Effect::Destroy { .. }));
+        let sub = def.sub_ability.as_ref().expect("DestroyAll continuation");
+        let Effect::DestroyAll { target, .. } = &*sub.effect else {
+            panic!("expected DestroyAll, got {:?}", sub.effect);
+        };
+        let TargetFilter::Typed(typed) = target else {
+            panic!("expected Typed filter, got {target:?}");
+        };
+        assert!(
+            typed
+                .properties
+                .contains(&FilterProp::SameNameAsParentTarget),
+            "DestroyAll must restrict to the parent target's name, got {:?}",
+            typed.properties
+        );
+        assert!(
+            typed.properties.contains(&FilterProp::Another),
+            "DestroyAll must exclude the targeted permanent itself, got {:?}",
+            typed.properties
+        );
+    }
+
     #[test]
     fn kindred_dominance_excludes_chosen_creature_type() {
         use crate::types::ability::{ChoiceType, TypedFilter};

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1736,8 +1736,8 @@ pub fn parse_type_phrase_with_ctx<'a>(
         pos += consumed;
     }
 
-    if let Some(consumed) = parse_same_name_as_source_suffix(&lower[pos..]) {
-        properties.push(FilterProp::SameName);
+    if let Some((prop, consumed)) = parse_same_name_suffix(&lower[pos..]) {
+        properties.push(prop);
         pos += consumed;
     }
 
@@ -3320,22 +3320,51 @@ fn parse_without_keyword_suffix(text: &str) -> Option<(Vec<FilterProp>, usize)> 
     }
 }
 
-fn parse_same_name_as_source_suffix(text: &str) -> Option<usize> {
+/// CR 201.2: Parse a "with the same name as <referent>" filter suffix, mapping
+/// the referent class to the matching name-resolution `FilterProp`:
+///   * "~" / "this <type>" → the *source* object's name (`FilterProp::SameName`).
+///   * "that <type>" → the resolving ability's first object target's name
+///     (`FilterProp::SameNameAsParentTarget`). This is the "destroy/exile/return
+///     target X and all other Xs with the same name as that X" class — Maelstrom
+///     Pulse, the Echoing cycle, Bile Blight, Homing Lightning, Detention Sphere.
+///     Without it the secondary mass effect drops the name constraint and
+///     degrades into an unconditional board wipe.
+fn parse_same_name_suffix(text: &str) -> Option<(FilterProp, usize)> {
     let trimmed = text.trim_start();
     let leading_ws = text.len() - trimmed.len();
-    for suffix in &[
-        "with the same name as ~",
-        "with the same name as this creature",
-        "with the same name as this permanent",
-        "with the same name as this artifact",
-        "with the same name as this enchantment",
-        "with the same name as this land",
-    ] {
-        if tag::<_, _, OracleError<'_>>(*suffix).parse(trimmed).is_ok() {
-            return Some(leading_ws + suffix.len());
-        }
-    }
-    None
+    let (rest, _) = tag::<_, _, OracleError<'_>>("with the same name as ")
+        .parse(trimmed)
+        .ok()?;
+    let (after, prop) = alt((
+        value(FilterProp::SameName, tag("~")),
+        value(
+            FilterProp::SameName,
+            (tag("this "), parse_same_name_referent_noun),
+        ),
+        value(
+            FilterProp::SameNameAsParentTarget,
+            (tag("that "), parse_same_name_referent_noun),
+        ),
+    ))
+    .parse(rest)
+    .ok()?;
+    Some((prop, leading_ws + (trimmed.len() - after.len())))
+}
+
+/// CR 205: The permanent-type noun naming the "same name" referent ("that
+/// permanent", "this creature", etc.). The noun only provides grammatical
+/// agreement with the target — name matching is by name, not type.
+fn parse_same_name_referent_noun(input: &str) -> nom::IResult<&str, &str, OracleError<'_>> {
+    alt((
+        tag("permanent"),
+        tag("creature"),
+        tag("artifact"),
+        tag("enchantment"),
+        tag("planeswalker"),
+        tag("land"),
+        tag("card"),
+    ))
+    .parse(input)
 }
 
 fn parse_ownership_or_controller_suffix(


### PR DESCRIPTION
## Summary

Fixes a destructive parser bug reported in-game: an AI cast **Maelstrom Pulse** and it **destroyed every land** instead of just the same-named permanents.

Oracle text: *"Destroy target nonland permanent **and all other permanents with the same name as that permanent**."* The `with the same name as that permanent` filter suffix was **silently dropped**, so the secondary mass effect parsed as "destroy all *other* permanents" — an unconditional board wipe.

## Root cause

The type-phrase suffix parser (`parse_type_phrase_with_ctx` in `oracle_target.rs`) only recognized the **source-referential** forms — `~` / `this creature` → `FilterProp::SameName`. It had no arm for the **parent-target** form `that <type>`, so the suffix fell through unconsumed and was discarded, leaving just `Another` on the `DestroyAll` filter.

The fix adds `that <permanent|creature|artifact|enchantment|planeswalker|land|card>` → `FilterProp::SameNameAsParentTarget`, which the resolver already inherits from the primary effect's chosen target (the targeted permanent), falling back to LKI after it's destroyed — matching the printed rulings.

The AI never actually targeted a land (the `nonland` filter is correct); the board wipe came entirely from the dropped name constraint.

## Class fixed (building-block, not one-off)

Any `<verb> target X and all other Xs with the same name as that X` whose secondary clause is a chained mass sub-ability:
- **Maelstrom Pulse** (Destroy), **Echoing Ruin** (Destroy artifact), **Echoing Truth** (Bounce) — verified now carry `Another + SameNameAsParentTarget`.
- No regression: `~`/`this creature` cards (Callidus Assassin, Evil Twin) still produce `SameName`.

## Test plan

- [x] New parser test `maelstrom_pulse_destroys_only_same_named_permanents` (asserts the `DestroyAll` sub-ability carries `SameNameAsParentTarget` + `Another`)
- [x] `cargo test -p engine` — oracle_target (318), oracle_effect (1319), same_name (17) all pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] No `SameName` regression on source-referential cards

## Out of scope (separate, noted for follow-up)

The **Pump/damage** members of this wording class (Bile Blight, Echoing Decay/Courage, Homing Lightning) drop the "all other … same name" clause the *opposite* way (hit only the single target). That's a different parse path (compound-subject) and a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)