### PR TITLE
ship/trigger stack perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "rand_chacha",
  "serde",
  "serde_json",
+ "smallvec",
  "strum",
  "tempfile",
  "thiserror",
@@ -2417,6 +2418,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -12,6 +12,7 @@ import { isMultiplayerMode, useGameStore, legalResultState, saveGame, saveCheckp
 import { getOpponentDisplayName } from "../stores/multiplayerStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
 import { useUiStore } from "../stores/uiStore";
+import { stackPressureFromLength } from "../utils/stackPressure";
 import { applySpellPaymentPreference } from "./castPaymentMode";
 
 /**
@@ -582,6 +583,15 @@ export async function restoreGameState(
 }
 
 const BATCH_CHUNK_SIZE = 5;
+// Under "Instant" stack pressure (a multi-hundred/thousand identical-trigger
+// storm, e.g. Scute Swarm) the 5-at-a-time animated countdown is wasted: the
+// dominant cost becomes the per-chunk full-state `getState` (~12MB serialize)
+// + `getLegalActions` + the inter-chunk delay, repeated once per 5 items. We
+// drain in large chunks instead — the engine can resolve unboundedly in one
+// call, but a bounded chunk keeps each WASM call short enough that the main
+// thread yields between chunks (no "page unresponsive" freeze) while still
+// collapsing ~580 round-trips into a handful.
+const BATCH_CHUNK_INSTANT = 200;
 const BATCH_CHUNK_BASE_DELAY_MS = 150;
 let batchResolveInProgress = false;
 
@@ -601,8 +611,14 @@ export async function dispatchResolveAll(
 
   try {
     for (;;) {
+      // Re-evaluate pressure each iteration: a storm shrinks as it drains, so
+      // it eventually drops back to the animated 5-at-a-time path near the end.
+      const stackLen = useGameStore.getState().gameState?.stack.length ?? 0;
+      const instant = stackPressureFromLength(stackLen) === "Instant";
+      const chunkSize = instant ? BATCH_CHUNK_INSTANT : BATCH_CHUNK_SIZE;
+
       const batchResult: BatchResolveResult = await adapter.resolveAll(
-        requester, aiSeats, BATCH_CHUNK_SIZE,
+        requester, aiSeats, chunkSize,
       );
 
       const newState = await adapter.getState();
@@ -620,6 +636,10 @@ export async function dispatchResolveAll(
         batchResult.waitingFor.type === "GameOver" ||
         batchResult.waitingFor.type !== "Priority";
       if (done) break;
+
+      // Skip the inter-chunk pacing delay while draining a storm — the delay
+      // exists for visual countdown pacing, which Instant pressure forgoes.
+      if (instant) continue;
 
       const chunkDelay = Math.round(BATCH_CHUNK_BASE_DELAY_MS * multiplier);
       if (chunkDelay > 0) {

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 web-time = "1"
 im = { version = "15", features = ["serde"] }
+smallvec = { version = "1", features = ["serde", "union"] }
 
 [[bin]]
 name = "coverage-report"

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1,8 +1,8 @@
 use crate::database::legality::LegalityFormat;
 use crate::database::CardDatabase;
 use crate::game::game_object::GameObject;
-use crate::game::static_abilities::{build_static_registry, StaticAbilityHandler};
-use crate::game::triggers::build_trigger_registry;
+use crate::game::static_abilities::{build_static_registry, static_registry, StaticAbilityHandler};
+use crate::game::triggers::{build_trigger_registry, trigger_registry};
 use crate::parser::oracle::is_commander_permission_sentence;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_util::SELF_REF_TYPE_PHRASES;
@@ -3238,7 +3238,9 @@ pub fn unimplemented_mechanics(obj: &GameObject) -> Vec<String> {
 
     // 3. Check trigger modes against trigger registry
     // CR 603.8: StateCondition triggers use the priority pipeline, not the event registry.
-    let trigger_registry = build_trigger_registry();
+    // Cached accessor: this runs per battlefield object on every `apply()` via
+    // display derivation, so the registry must not be rebuilt per call.
+    let trigger_registry = trigger_registry();
     // Classification scan: iterate every printed trigger/static regardless
     // of functioning state — we're computing coverage, not game behavior.
     for trig in obj.trigger_definitions.iter_all() {
@@ -3251,7 +3253,8 @@ pub fn unimplemented_mechanics(obj: &GameObject) -> Vec<String> {
     }
 
     // 4. Check static ability modes against static registry
-    let static_registry = build_static_registry();
+    // Cached accessor (see trigger registry note above) — hot per-object path.
+    let static_registry = static_registry();
     for stat in obj.static_definitions.iter_all() {
         if !static_registry.contains_key(&stat.mode) && !is_data_carrying_static(&stat.mode) {
             missing.push(format!("Static: {}", stat.mode));

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -956,6 +956,14 @@ pub fn evaluate_layers(state: &mut GameState) {
         return;
     }
 
+    // CR 603.6a + CR 611.2e: Layer evaluation just finalized post-layer
+    // trigger sets on every battlefield permanent (granted triggers from
+    // sliver lords, Changeling, Bramble Sovereign, suppress-triggers statics).
+    // Rebuild the TriggerIndex so the next event scan reads the post-layer
+    // trigger set — CR 603.2 requires the post-layer view. Destructive
+    // rebuild replaces both `by_key` and `unclassified` from scratch.
+    crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
+
     // Step 5: Clear dirty flag
     state.layers_dirty = false;
 }

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -67,6 +67,7 @@ pub mod static_abilities;
 pub mod targeting;
 pub mod token_presets;
 pub mod transform;
+pub mod trigger_index;
 pub(crate) mod trigger_matchers;
 pub mod triggers;
 pub mod turn_control;

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::functioning_abilities::{battlefield_active_statics, game_functioning_statics};
@@ -30,6 +31,20 @@ pub struct StaticCheckContext {
     pub target_id: Option<ObjectId>,
     pub player_id: Option<PlayerId>,
     pub card_name: Option<String>,
+}
+
+/// Process-wide cached static-ability registry.
+///
+/// Mirrors [`crate::game::trigger_matchers::trigger_registry`]: the registry
+/// is a pure constant (`StaticMode` → fn-pointer), so it is built once.
+/// `unimplemented_mechanics` consults it per battlefield object per `apply()`;
+/// rebuilding it per call was a display-derivation hot-path cost.
+static STATIC_REGISTRY: LazyLock<HashMap<StaticMode, StaticAbilityHandler>> =
+    LazyLock::new(build_static_registry);
+
+/// Cached accessor for the static-ability registry. Built once on first use.
+pub fn static_registry() -> &'static HashMap<StaticMode, StaticAbilityHandler> {
+    &STATIC_REGISTRY
 }
 
 /// CR 604.1: Static ability registry — maps StaticMode keys to handlers.

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -771,7 +771,14 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::Station
         | EffectKind::Saddle
         | EffectKind::Transform
-        | EffectKind::TurnFaceUp => {}
+        | EffectKind::TurnFaceUp
+        // Added on origin/main after this branch point. No production
+        // EffectResolved-dispatching matcher consumes either: cast-copy fires
+        // on cast events (CastCopyOfCard, Mizzix's Mastery), and life/P-T
+        // exchange emits LifeChanged/PowerToughnessChanged handled by their own
+        // event arms (ExchangeLifeWithStat). No-op here.
+        | EffectKind::CastCopyOfCard
+        | EffectKind::ExchangeLifeWithStat => {}
     }
 }
 

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -1,0 +1,951 @@
+//! CR 603.2 + CR 603.6a + CR 611.2e: `TriggerIndex` — battlefield-scoped
+//! candidate pre-filter for `collect_pending_triggers`. Replaces a full
+//! battlefield scan with an event-keyed lookup so trigger-firing cost scales
+//! with the number of *relevant* triggers, not with `|battlefield|`.
+//!
+//! # Correctness model
+//!
+//! The index maps `TriggerEventKey` → `SmallVec<ObjectId>` ("which permanents
+//! could match an event with this shape"). The consult site unions the
+//! relevant buckets with `unclassified` and asks each candidate's per-trigger
+//! matcher whether it actually matches — the matcher itself is unchanged.
+//!
+//! Two derivers maintain the index:
+//!
+//! - `keys_from_event(event, state)`: the keys an event hits at consult time.
+//! - `keys_from_trigger_def(def)`: the keys a trigger definition registers
+//!   into at maintain time.
+//!
+//! CR 603.2 over-approximation invariant: it is correctness-preserving to
+//! emit more keys than strictly necessary at either site; it is a silent
+//! trigger-drop bug to emit fewer. Both derivers are exhaustive `match`es
+//! with NO `_` wildcard arms — adding a new `TriggerMode`, `GameEvent`, or
+//! `EffectKind` variant is a compile error until the deriver classifies it.
+//!
+//! # Authority
+//!
+//! The authoritative correctness path is the rebuild at the end of
+//! `evaluate_layers` (CR 611.2e): every continuous-effect-driven mutation of
+//! `obj.trigger_definitions` (sliver lords, Changeling, Bramble Sovereign,
+//! suppress-triggers statics) flows through the layer pipeline, and
+//! `collect_pending_triggers` flushes pending layers before reading the index.
+//! The `move_to_zone` incremental hooks are best-effort optimization between
+//! layer flushes — they are NOT the safety net.
+
+use smallvec::SmallVec;
+
+use crate::types::ability::{EffectKind, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter};
+use crate::types::card_type::CoreType;
+use crate::types::events::GameEvent;
+use crate::types::game_state::{GameState, TriggerIndex};
+use crate::types::identifiers::ObjectId;
+use crate::types::keywords::Keyword;
+use crate::types::triggers::{TriggerEventKey, TriggerMode};
+use crate::types::zones::Zone;
+
+use super::game_object::GameObject;
+
+/// Maximum keys a single trigger definition or event can emit. ETB-with-narrow
+/// is 1; `Sacrificed` emits 3 (`Sacrificed` + `LeaveBattlefield` + `Dies`); a
+/// `ZoneChanged` to graveyard with 3 core types emits 1 (broad LBF) + 3
+/// (narrow LBF) + 1 (broad Dies) + 3 (narrow Dies) = 8. Inline `[..; 8]`
+/// covers every observed shape without heap allocation in the hot path.
+type Keys = SmallVec<[TriggerEventKey; 8]>;
+
+/// CR 205: Narrow a trigger's `valid_card` filter to exactly one `CoreType`
+/// when the filter is `Typed { type_filters: [single CoreType-bearing filter] }`.
+/// Any other shape (`Permanent`, `AnyOf`, `Non(_)`, multi-element, missing,
+/// non-`Typed`) yields `None` — the broader `EnterBattlefield(None)` key is
+/// emitted by the trigger AND the event-side broad emission catches it. Stays
+/// conservative.
+fn narrow_core_type(filter: &Option<TargetFilter>) -> Option<CoreType> {
+    let TargetFilter::Typed(TypedFilter { type_filters, .. }) = filter.as_ref()? else {
+        return None;
+    };
+    if type_filters.len() != 1 {
+        return None;
+    }
+    match &type_filters[0] {
+        TypeFilter::Creature => Some(CoreType::Creature),
+        TypeFilter::Artifact => Some(CoreType::Artifact),
+        TypeFilter::Enchantment => Some(CoreType::Enchantment),
+        TypeFilter::Land => Some(CoreType::Land),
+        TypeFilter::Planeswalker => Some(CoreType::Planeswalker),
+        TypeFilter::Battle => Some(CoreType::Battle),
+        // Non-narrow filter shapes — broad emission carries the trigger.
+        TypeFilter::Instant
+        | TypeFilter::Sorcery
+        | TypeFilter::Permanent
+        | TypeFilter::Card
+        | TypeFilter::Any
+        | TypeFilter::Non(_)
+        | TypeFilter::Subtype(_)
+        | TypeFilter::AnyOf(_) => None,
+    }
+}
+
+/// CR 603.2: Derive the `TriggerEventKey`s that the given trigger definition
+/// could match. The deriver is an exhaustive `match` on `TriggerMode` — adding
+/// a new variant becomes a compile error until classified here. Triggers that
+/// are inherently catch-all (`Immediate`, `Always`) or whose match shape is
+/// dynamic emit a single `None` so the caller routes them to `unclassified`.
+/// `StateCondition` and `Unknown(_)` return an EMPTY result *and* the caller
+/// must NOT push such objects to `unclassified` — state triggers run through
+/// the dedicated `check_state_triggers` path, never event-driven dispatch.
+///
+/// Returns `(keys, route_to_unclassified)`:
+/// - non-empty keys → object goes into each bucket
+/// - `route_to_unclassified == true` → object also goes into `unclassified`
+///   (for catch-all modes like `Always`/`Immediate` and for genuinely
+///   unclassified TriggerModes)
+/// - both empty/false → object is NOT registered for this trigger (state
+///   conditions, Unknown).
+fn keys_from_trigger_def(def: &TriggerDefinition) -> (Keys, bool) {
+    let mut keys: Keys = SmallVec::new();
+    let narrow = narrow_core_type(&def.valid_card);
+
+    // Macro to push without manual contains checks. Order doesn't matter for
+    // correctness (dedup is handled at the index level).
+    let mut push = |k: TriggerEventKey| {
+        if !keys.contains(&k) {
+            keys.push(k);
+        }
+    };
+
+    match &def.mode {
+        // --- Zone-change family ---
+        TriggerMode::ChangesZone | TriggerMode::ChangesZoneAll => {
+            // CR 603.6a/c: destination=Battlefield → ETB; origin=Battlefield
+            // → LBF (with Dies subkey for graveyard destination).
+            match (def.origin, def.destination) {
+                (_, Some(Zone::Battlefield)) => push(TriggerEventKey::EnterBattlefield(narrow)),
+                (Some(Zone::Battlefield), Some(Zone::Graveyard)) => {
+                    push(TriggerEventKey::Dies(narrow));
+                    push(TriggerEventKey::LeaveBattlefield(narrow));
+                }
+                (Some(Zone::Battlefield), _) => push(TriggerEventKey::LeaveBattlefield(narrow)),
+                _ => {
+                    // Non-battlefield zone change (e.g. cast-from-graveyard
+                    // observers). Route to unclassified — these are rare and
+                    // not the target of this optimization.
+                    return (keys, true);
+                }
+            }
+        }
+        // CR 702.100a: Evolve — entry-only, narrow filter unused (evolve is
+        // SelfRef-on-source). Route as broad ETB so a controller's incoming
+        // creature is considered.
+        TriggerMode::Evolve => push(TriggerEventKey::EnterBattlefield(Some(CoreType::Creature))),
+        // CR 702.100b: Evolved → matcher consumes the dedicated
+        // `GameEvent::Evolved`. Route to unclassified — Evolved-listening
+        // permanents are rare and the dedicated event keeps the consult cost
+        // bounded.
+        TriggerMode::Evolved => return (keys, true),
+        TriggerMode::ChangesController => push(TriggerEventKey::ChangesController),
+        TriggerMode::LeavesBattlefield => push(TriggerEventKey::LeaveBattlefield(narrow)),
+
+        // --- Damage family ---
+        TriggerMode::DamageDone
+        | TriggerMode::DamageDoneOnce
+        | TriggerMode::DamageAll
+        | TriggerMode::DamageDealtOnce
+        | TriggerMode::DamageDoneOnceByController
+        | TriggerMode::DamageReceived
+        | TriggerMode::ExcessDamage
+        | TriggerMode::ExcessDamageAll => push(TriggerEventKey::DealsDamage),
+        TriggerMode::DamagePreventedOnce => push(TriggerEventKey::DamagePrevented),
+
+        // --- Spells / abilities ---
+        TriggerMode::SpellCast | TriggerMode::SpellCastOrCopy | TriggerMode::SpellCopy => {
+            push(TriggerEventKey::SpellCast(narrow));
+        }
+        TriggerMode::AbilityCast
+        | TriggerMode::AbilityResolves
+        | TriggerMode::AbilityTriggered
+        | TriggerMode::SpellAbilityCast
+        | TriggerMode::SpellAbilityCopy
+        | TriggerMode::AbilityActivated
+        | TriggerMode::NinjutsuActivated
+        | TriggerMode::KeywordAbilityActivated(_) => push(TriggerEventKey::AbilityOrCopyActivated),
+        TriggerMode::Countered => {
+            // CR 701.6: counter-targeting filter is dynamic; rare.
+            return (keys, true);
+        }
+
+        // --- Combat ---
+        TriggerMode::Attacks
+        | TriggerMode::AttackersDeclared
+        | TriggerMode::YouAttack
+        | TriggerMode::AttackersDeclaredOneTarget
+        | TriggerMode::AttackerBlocked
+        | TriggerMode::AttackerBlockedOnce
+        | TriggerMode::AttackerBlockedByCreature
+        | TriggerMode::AttackerUnblocked
+        | TriggerMode::AttackerUnblockedOnce => push(TriggerEventKey::Attacks),
+        TriggerMode::Blocks | TriggerMode::BlockersDeclared | TriggerMode::BecomesBlocked => {
+            push(TriggerEventKey::Blocks);
+        }
+
+        // --- Counters ---
+        TriggerMode::CounterAdded
+        | TriggerMode::CounterAddedOnce
+        | TriggerMode::CounterAddedAll
+        | TriggerMode::CounterPlayerAddedAll
+        | TriggerMode::CounterTypeAddedAll => push(TriggerEventKey::CounterAdded),
+        TriggerMode::CounterRemoved | TriggerMode::CounterRemovedOnce => {
+            push(TriggerEventKey::CounterRemoved);
+        }
+
+        // --- Permanents ---
+        TriggerMode::Sacrificed | TriggerMode::SacrificedOnce => {
+            // CR 701.21 (sacrifice) + CR 603.6c (leaves) + CR 700/404
+            // (graveyard destination): a sacrifice is a leave-to-graveyard.
+            // Per-event dedup at the consult site is safe (LOW 10).
+            push(TriggerEventKey::Sacrificed);
+            push(TriggerEventKey::LeaveBattlefield(narrow));
+            push(TriggerEventKey::Dies(narrow));
+        }
+        TriggerMode::Destroyed => {
+            push(TriggerEventKey::Destroyed);
+            push(TriggerEventKey::LeaveBattlefield(narrow));
+            push(TriggerEventKey::Dies(narrow));
+        }
+        TriggerMode::Taps | TriggerMode::TapAll => push(TriggerEventKey::Taps),
+        TriggerMode::TapsForMana => push(TriggerEventKey::TapsForMana),
+        TriggerMode::Untaps | TriggerMode::UntapAll => push(TriggerEventKey::Untaps),
+
+        // --- Targeting ---
+        TriggerMode::BecomesTarget | TriggerMode::BecomesTargetOnce => {
+            push(TriggerEventKey::BecomesTarget);
+        }
+
+        // --- Cards ---
+        TriggerMode::Drawn => push(TriggerEventKey::CardsDrawn),
+        TriggerMode::Discarded | TriggerMode::DiscardedAll => push(TriggerEventKey::Discarded),
+        TriggerMode::Milled | TriggerMode::MilledOnce | TriggerMode::MilledAll => {
+            push(TriggerEventKey::Milled);
+        }
+        TriggerMode::Exiled => push(TriggerEventKey::Exiled),
+        TriggerMode::Revealed => push(TriggerEventKey::Revealed),
+        // CR 701.24a: Shuffled matcher consumes
+        // `GameEvent::PlayerPerformedAction { ShuffledLibrary }`, not a
+        // dedicated `Shuffled` event. Route via the shared player-action key.
+        TriggerMode::Shuffled => push(TriggerEventKey::PlayerActionPerformed),
+
+        // --- Life ---
+        TriggerMode::LifeGained
+        | TriggerMode::LifeLost
+        | TriggerMode::LifeLostAll
+        | TriggerMode::PayLife => push(TriggerEventKey::LifeChanged),
+        // CR 702.24a (cumulative upkeep) + CR 702.30 (echo): both synthesized
+        // with `def.phase = Some(Upkeep)`, both matchers dispatch on
+        // `PhaseChanged { phase }`.
+        TriggerMode::PayCumulativeUpkeep | TriggerMode::PayEcho => {
+            push(TriggerEventKey::BeginningOfPhase(
+                crate::types::phase::Phase::Upkeep,
+            ));
+        }
+
+        // --- Tokens ---
+        TriggerMode::TokenCreated | TriggerMode::TokenCreatedOnce | TriggerMode::ConjureAll => {
+            push(TriggerEventKey::TokenCreated);
+        }
+
+        // --- Face / transform ---
+        TriggerMode::TurnFaceUp | TriggerMode::Transformed => {
+            push(TriggerEventKey::FaceOrTransform);
+        }
+
+        // --- Phase / turn ---
+        TriggerMode::Phase => match def.phase {
+            Some(phase) => push(TriggerEventKey::BeginningOfPhase(phase)),
+            // Parser can produce `def.phase = None` when phase text is
+            // unrecognized (CR 603.2b fallback). Stay safe via unclassified.
+            None => return (keys, true),
+        },
+        TriggerMode::PhaseIn | TriggerMode::PhaseOut | TriggerMode::PhaseOutAll => {
+            return (keys, true);
+        }
+        TriggerMode::TurnBegin => push(TriggerEventKey::TurnStarted),
+        TriggerMode::NewGame => return (keys, true),
+
+        // --- Monarch / initiative ---
+        TriggerMode::BecomeMonarch | TriggerMode::TakesInitiative => {
+            push(TriggerEventKey::MonarchOrInitiative);
+        }
+
+        // --- Game state ---
+        TriggerMode::LosesGame => push(TriggerEventKey::PlayerLost),
+
+        // --- Mana ---
+        TriggerMode::ManaAdded => push(TriggerEventKey::ManaProduced),
+        TriggerMode::ManaExpend => push(TriggerEventKey::ManaSpent),
+
+        // --- Land ---
+        // CR 305.1: LandPlayed event is global (few battlefield triggers
+        // listen). Route to unclassified — cost is one consult per such card.
+        TriggerMode::LandPlayed => return (keys, true),
+
+        // --- Equipment / aura ---
+        TriggerMode::Attached | TriggerMode::Unattach => push(TriggerEventKey::AttachmentChanged),
+
+        // --- Dungeon / Class / Case ---
+        TriggerMode::DungeonCompleted
+        | TriggerMode::RoomEntered
+        | TriggerMode::ClassLevelGained
+        | TriggerMode::CaseSolved => push(TriggerEventKey::DungeonOrClassOrCase),
+
+        // --- Planar ---
+        TriggerMode::PlanarDice
+        | TriggerMode::PlaneswalkedFrom
+        | TriggerMode::PlaneswalkedTo
+        | TriggerMode::ChaosEnsues => return (keys, true),
+
+        // --- Dice / coin ---
+        TriggerMode::RolledDie | TriggerMode::RolledDieOnce | TriggerMode::FlippedCoin => {
+            push(TriggerEventKey::DieOrCoin);
+        }
+        TriggerMode::Clashed => push(TriggerEventKey::Clashed),
+
+        // --- Day/night ---
+        TriggerMode::DayTimeChanges => push(TriggerEventKey::DayNightChanged),
+
+        // --- Copy ---
+        TriggerMode::Copied => return (keys, true),
+
+        // --- Vote ---
+        TriggerMode::Vote => push(TriggerEventKey::Voted),
+
+        // --- Renown / monstrous ---
+        TriggerMode::BecomeRenowned => push(TriggerEventKey::Renowned),
+        TriggerMode::BecomeMonstrous => push(TriggerEventKey::BecomesMonstrous),
+
+        // --- Player actions ---
+        TriggerMode::Proliferate
+        | TriggerMode::RingTemptsYou
+        | TriggerMode::Surveil
+        | TriggerMode::Scry
+        | TriggerMode::PlayerPerformedAction
+        | TriggerMode::SearchedLibrary
+        | TriggerMode::CollectEvidence
+        | TriggerMode::CommitCrime => push(TriggerEventKey::PlayerActionPerformed),
+
+        // --- Combat events ---
+        TriggerMode::Fight | TriggerMode::FightOnce => push(TriggerEventKey::Fight),
+
+        // --- Set-specific / sparse mechanics: route to unclassified. ---
+        TriggerMode::Abandoned
+        | TriggerMode::ClaimPrize
+        | TriggerMode::CrankContraption
+        | TriggerMode::Devoured
+        | TriggerMode::Discover
+        | TriggerMode::Forage
+        | TriggerMode::FullyUnlock
+        | TriggerMode::GiveGift
+        | TriggerMode::Mentored
+        | TriggerMode::Mutates
+        | TriggerMode::SeekAll
+        | TriggerMode::SetInMotion
+        | TriggerMode::Specializes
+        | TriggerMode::Stationed
+        | TriggerMode::Trains
+        | TriggerMode::UnlockDoor
+        | TriggerMode::VisitAttraction
+        | TriggerMode::BecomesCrewed
+        | TriggerMode::BecomesPlotted
+        | TriggerMode::BecomesSaddled
+        | TriggerMode::Championed
+        | TriggerMode::Exerted
+        | TriggerMode::Crewed
+        | TriggerMode::Crews
+        | TriggerMode::Saddled
+        | TriggerMode::Saddles
+        | TriggerMode::SaddlesOrCrews
+        | TriggerMode::Cycled
+        | TriggerMode::CycledOrDiscarded
+        | TriggerMode::Exploited
+        | TriggerMode::Enlisted
+        | TriggerMode::Foretell
+        | TriggerMode::Investigated
+        | TriggerMode::Adapt => return (keys, true),
+
+        // --- Triggered mechanics with dedicated event keys ---
+        TriggerMode::Explored => push(TriggerEventKey::Explored),
+        TriggerMode::ManifestDread => push(TriggerEventKey::ManifestDreadResolved),
+
+        // --- Catch-all matchers — fires on every event, must always be
+        // considered. Route to unclassified. ---
+        TriggerMode::Immediate | TriggerMode::Always => return (keys, true),
+
+        // --- Compound triggers ---
+        TriggerMode::EntersOrAttacks => {
+            push(TriggerEventKey::EnterBattlefield(narrow));
+            push(TriggerEventKey::Attacks);
+        }
+        TriggerMode::AttacksOrBlocks => {
+            push(TriggerEventKey::Attacks);
+            push(TriggerEventKey::Blocks);
+        }
+
+        // --- Bending (Avatar crossover) ---
+        TriggerMode::Airbend
+        | TriggerMode::Earthbend
+        | TriggerMode::Firebend
+        | TriggerMode::Waterbend
+        | TriggerMode::ElementalBend => push(TriggerEventKey::Bending),
+
+        // CR 603.8: state triggers are processed by the dedicated
+        // `check_state_triggers` path, NOT by event-driven dispatch. The
+        // matcher dispatch returns `None` for them. Skip entirely — neither
+        // a key nor unclassified routing.
+        TriggerMode::StateCondition => return (SmallVec::new(), false),
+        // No matcher registered; never fires through events.
+        TriggerMode::Unknown(_) => return (SmallVec::new(), false),
+    }
+
+    (keys, false)
+}
+
+/// CR 603.2: Derive the `TriggerEventKey`s that the given event hits at
+/// consult time. Exhaustive `match` on `GameEvent` — adding a new variant is
+/// a compile error until classified. The nested `EffectResolved { kind }`
+/// dispatch on `EffectKind` is similarly exhaustive (no `_` arm).
+fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
+    let mut out: Keys = SmallVec::new();
+    let mut push = |k: TriggerEventKey| {
+        if !out.contains(&k) {
+            out.push(k);
+        }
+    };
+
+    match event {
+        GameEvent::GameStarted => {}
+        GameEvent::TurnStarted { .. } => push(TriggerEventKey::TurnStarted),
+        GameEvent::PhaseChanged { phase } => push(TriggerEventKey::BeginningOfPhase(*phase)),
+        GameEvent::PriorityPassed { .. } => {}
+        GameEvent::SpellCast { object_id, .. } => {
+            push(TriggerEventKey::SpellCast(None));
+            if let Some(obj) = state.objects.get(object_id) {
+                for ct in &obj.card_types.core_types {
+                    push(TriggerEventKey::SpellCast(Some(*ct)));
+                }
+            }
+        }
+        GameEvent::SpellCopied {
+            object_id,
+            original_id,
+            ..
+        } => {
+            push(TriggerEventKey::SpellCast(None));
+            // CR 707.10: copy carries the original's characteristics. Read
+            // whichever side is currently live (copies on the stack mirror
+            // their original; if missing, try the original id).
+            let obj = state
+                .objects
+                .get(object_id)
+                .or_else(|| state.objects.get(original_id));
+            if let Some(obj) = obj {
+                for ct in &obj.card_types.core_types {
+                    push(TriggerEventKey::SpellCast(Some(*ct)));
+                }
+            }
+        }
+        GameEvent::XValueChosen { .. } => {}
+        GameEvent::AbilityActivated { .. } => push(TriggerEventKey::AbilityOrCopyActivated),
+        GameEvent::ZoneChanged {
+            from, to, record, ..
+        } => {
+            // CR 603.6a: ETB. Emit broad + per-core-type narrow.
+            if *to == Zone::Battlefield {
+                push(TriggerEventKey::EnterBattlefield(None));
+                for ct in &record.core_types {
+                    push(TriggerEventKey::EnterBattlefield(Some(*ct)));
+                }
+            }
+            // CR 603.6c: leaves battlefield (any destination).
+            if *from == Some(Zone::Battlefield) {
+                push(TriggerEventKey::LeaveBattlefield(None));
+                for ct in &record.core_types {
+                    push(TriggerEventKey::LeaveBattlefield(Some(*ct)));
+                }
+                // CR 700/404: leaves to graveyard is also a Dies event.
+                if *to == Zone::Graveyard {
+                    push(TriggerEventKey::Dies(None));
+                    for ct in &record.core_types {
+                        push(TriggerEventKey::Dies(Some(*ct)));
+                    }
+                }
+            }
+            // CR 701.13: `match_exiled` consumes `ZoneChanged { to: Exile }`
+            // directly — emit the Exiled key whenever any object lands in
+            // exile, regardless of origin.
+            if *to == Zone::Exile {
+                push(TriggerEventKey::Exiled);
+            }
+            // CR 701.17: `match_milled` consumes `ZoneChanged { from: Library,
+            // to: Graveyard }`. Emit Milled key for that exact shape.
+            if *from == Some(Zone::Library) && *to == Zone::Graveyard {
+                push(TriggerEventKey::Milled);
+            }
+        }
+        GameEvent::LifeChanged { .. } => push(TriggerEventKey::LifeChanged),
+        GameEvent::ManaAdded { .. } => push(TriggerEventKey::ManaProduced),
+        GameEvent::TappedForMana { .. } => {
+            push(TriggerEventKey::ManaProduced);
+            push(TriggerEventKey::TapsForMana);
+        }
+        GameEvent::ManaPoolEmptied { .. } | GameEvent::ManaRecolored { .. } => {}
+        GameEvent::PermanentTapped { .. } => push(TriggerEventKey::Taps),
+        GameEvent::PlayerLost { .. } => push(TriggerEventKey::PlayerLost),
+        // CR 800.4: Administrative control transfers on elimination do NOT
+        // flow through ChangesController. PlayerLost only.
+        GameEvent::PlayerEliminated { .. } => push(TriggerEventKey::PlayerLost),
+        GameEvent::MulliganStarted => {}
+        GameEvent::CardsDrawn { .. } | GameEvent::CardDrawn { .. } => {
+            push(TriggerEventKey::CardsDrawn);
+        }
+        GameEvent::PermanentUntapped { .. } => push(TriggerEventKey::Untaps),
+        GameEvent::PermanentPhasedOut { .. }
+        | GameEvent::PermanentPhasedIn { .. }
+        | GameEvent::PlayerPhasedOut { .. }
+        | GameEvent::PlayerPhasedIn { .. } => {}
+        GameEvent::LandPlayed { .. } => {}
+        GameEvent::StackPushed { .. } | GameEvent::StackResolved { .. } => {}
+        GameEvent::Discarded { .. } => push(TriggerEventKey::Discarded),
+        GameEvent::DamageCleared { .. } => {}
+        GameEvent::GameOver { .. } => {}
+        GameEvent::DamageDealt { .. } | GameEvent::CombatDamageDealtToPlayer { .. } => {
+            push(TriggerEventKey::DealsDamage);
+        }
+        GameEvent::DamagePrevented { .. } => push(TriggerEventKey::DamagePrevented),
+        GameEvent::SpellCountered { .. } => {}
+        GameEvent::CounterAdded { .. } => push(TriggerEventKey::CounterAdded),
+        GameEvent::Evolved { .. } => {}
+        GameEvent::CounterRemoved { .. } => push(TriggerEventKey::CounterRemoved),
+        GameEvent::TokenCreated { .. } | GameEvent::ObjectConjured { .. } => {
+            push(TriggerEventKey::TokenCreated);
+        }
+        GameEvent::CreatureDestroyed { .. } => push(TriggerEventKey::Destroyed),
+        GameEvent::PermanentSacrificed { .. } => push(TriggerEventKey::Sacrificed),
+        GameEvent::EffectResolved { kind, .. } => keys_from_effect_kind(*kind, &mut push),
+        GameEvent::Unattached { .. } => push(TriggerEventKey::AttachmentChanged),
+        GameEvent::AttackersDeclared { .. } => push(TriggerEventKey::Attacks),
+        GameEvent::BlockersDeclared { .. } => push(TriggerEventKey::Blocks),
+        GameEvent::CombatTaxPaid { .. } | GameEvent::CombatTaxDeclined { .. } => {}
+        GameEvent::BecomesTarget { .. } => push(TriggerEventKey::BecomesTarget),
+        GameEvent::VehicleCrewed { .. }
+        | GameEvent::Stationed { .. }
+        | GameEvent::Saddled { .. } => {}
+        GameEvent::ReplacementApplied { .. } => {}
+        GameEvent::Transformed { .. } | GameEvent::TurnedFaceUp { .. } => {
+            push(TriggerEventKey::FaceOrTransform);
+        }
+        GameEvent::DayNightChanged { .. } => push(TriggerEventKey::DayNightChanged),
+        GameEvent::CardsRevealed { .. } => push(TriggerEventKey::Revealed),
+        GameEvent::CrimeCommitted { .. } => push(TriggerEventKey::PlayerActionPerformed),
+        GameEvent::Cycled { .. } => {}
+        GameEvent::PlayerPerformedAction { .. } => push(TriggerEventKey::PlayerActionPerformed),
+        GameEvent::Regenerated { .. }
+        | GameEvent::CreatureSuspected { .. }
+        | GameEvent::BecamePrepared { .. }
+        | GameEvent::BecameUnprepared { .. } => {}
+        GameEvent::CaseSolved { .. } | GameEvent::ClassLevelGained { .. } => {
+            push(TriggerEventKey::DungeonOrClassOrCase);
+        }
+        GameEvent::MonarchChanged { .. } => push(TriggerEventKey::MonarchOrInitiative),
+        GameEvent::CityBlessingGained { .. } => {}
+        GameEvent::DieRolled { .. } | GameEvent::CoinFlipped { .. } => {
+            push(TriggerEventKey::DieOrCoin);
+        }
+        GameEvent::RingTemptsYou { .. } => push(TriggerEventKey::PlayerActionPerformed),
+        GameEvent::RoomEntered { .. } | GameEvent::DungeonCompleted { .. } => {
+            push(TriggerEventKey::DungeonOrClassOrCase);
+        }
+        GameEvent::RoomDoorUnlocked { .. } | GameEvent::BecomesPlotted { .. } => {}
+        GameEvent::InitiativeTaken { .. } => push(TriggerEventKey::MonarchOrInitiative),
+        GameEvent::Firebend { .. }
+        | GameEvent::Airbend { .. }
+        | GameEvent::Earthbend { .. }
+        | GameEvent::Waterbend { .. } => push(TriggerEventKey::Bending),
+        GameEvent::CompanionRevealed { .. } | GameEvent::CompanionMovedToHand { .. } => {}
+        GameEvent::NinjutsuActivated { .. } | GameEvent::KeywordAbilityActivated { .. } => {
+            push(TriggerEventKey::AbilityOrCopyActivated);
+        }
+        GameEvent::CreatureExploited { .. } => {}
+        GameEvent::EnergyChanged { .. }
+        | GameEvent::SpeedChanged { .. }
+        | GameEvent::PlayerCounterChanged { .. } => push(TriggerEventKey::PlayerCounterChanged),
+        GameEvent::ManaExpended { .. } => push(TriggerEventKey::ManaSpent),
+        GameEvent::Clash { .. } => push(TriggerEventKey::Clashed),
+        GameEvent::VoteCast { .. } | GameEvent::VoteResolved { .. } => {
+            push(TriggerEventKey::Voted);
+        }
+        GameEvent::PowerToughnessChanged { .. } => {}
+        GameEvent::CascadeMissed { .. }
+        | GameEvent::DebugActionUsed { .. }
+        | GameEvent::DebugPermissionGranted { .. }
+        | GameEvent::DebugPermissionRevoked { .. } => {}
+    }
+
+    out
+}
+
+/// CR 603.2: Map an `EffectKind` carried by `GameEvent::EffectResolved` to
+/// the `TriggerEventKey`(s) the matched matchers consume. Exhaustive `match`
+/// — every variant either dispatches (mapped to a key) or maps explicitly to
+/// no-op. Adding a new `EffectKind` is a compile error until classified.
+///
+/// Only kinds with at least one PRODUCTION `EffectResolved`-dispatching
+/// matcher in `trigger_matchers.rs` emit keys; all others are no-ops.
+fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey)) {
+    match kind {
+        // Production EffectResolved matchers — see `trigger_matchers.rs` lines
+        // 1896, 2072, 2126, 2172, 2198, 2234, 2261, 2313, 2338.
+        EffectKind::Attach | EffectKind::AttachAll | EffectKind::Equip => {
+            push(TriggerEventKey::AttachmentChanged);
+        }
+        EffectKind::Reveal => push(TriggerEventKey::Revealed),
+        EffectKind::GainControl => push(TriggerEventKey::ChangesController),
+        EffectKind::Fight => push(TriggerEventKey::Fight),
+        EffectKind::Explore => push(TriggerEventKey::Explored),
+        EffectKind::Renown => push(TriggerEventKey::Renowned),
+        EffectKind::Monstrosity => push(TriggerEventKey::BecomesMonstrous),
+        EffectKind::ManifestDread => push(TriggerEventKey::ManifestDreadResolved),
+        EffectKind::DayTimeChange => push(TriggerEventKey::DayNightChanged),
+        // All other variants: not dispatched on by any production
+        // EffectResolved matcher (verified against `trigger_matchers.rs` 1-3216).
+        // Explicit `&[]`-equivalent arms — a future contributor who adds a
+        // new EffectResolved-dispatching matcher will force this match to be
+        // re-classified.
+        EffectKind::StartYourEngines
+        | EffectKind::ChangeSpeed
+        | EffectKind::DealDamage
+        | EffectKind::Draw
+        | EffectKind::Pump
+        | EffectKind::PairWith
+        | EffectKind::Destroy
+        | EffectKind::Counter
+        | EffectKind::CounterAll
+        | EffectKind::Token
+        | EffectKind::GainLife
+        | EffectKind::LoseLife
+        | EffectKind::Tap
+        | EffectKind::Untap
+        | EffectKind::AddCounter
+        | EffectKind::RemoveCounter
+        | EffectKind::Sacrifice
+        | EffectKind::DiscardCard
+        | EffectKind::Mill
+        | EffectKind::Scry
+        | EffectKind::PumpAll
+        | EffectKind::DamageAll
+        | EffectKind::DamageEachPlayer
+        | EffectKind::DestroyAll
+        | EffectKind::TapAll
+        | EffectKind::UntapAll
+        | EffectKind::ChangeZone
+        | EffectKind::ChangeZoneAll
+        | EffectKind::Dig
+        | EffectKind::ControlNextTurn
+        | EffectKind::UnattachAll
+        | EffectKind::Surveil
+        | EffectKind::Bounce
+        | EffectKind::BounceAll
+        | EffectKind::ExploreAll
+        | EffectKind::Investigate
+        | EffectKind::Tribute
+        | EffectKind::TimeTravel
+        | EffectKind::BecomeMonarch
+        | EffectKind::Proliferate
+        | EffectKind::Populate
+        | EffectKind::Clash
+        | EffectKind::Vote
+        | EffectKind::SeparateIntoPiles
+        | EffectKind::SwitchPT
+        | EffectKind::CopySpell
+        | EffectKind::CopyTokenOf
+        | EffectKind::Myriad
+        | EffectKind::BecomeCopy
+        | EffectKind::ChooseCard
+        | EffectKind::PutCounter
+        | EffectKind::PutCounterAll
+        | EffectKind::MultiplyCounter
+        | EffectKind::DoublePT
+        | EffectKind::DoublePTAll
+        | EffectKind::MoveCounters
+        | EffectKind::Animate
+        | EffectKind::ReturnAsAura
+        | EffectKind::RegisterBending
+        | EffectKind::GenericEffect
+        | EffectKind::Cleanup
+        | EffectKind::Mana
+        | EffectKind::Discard
+        | EffectKind::Shuffle
+        | EffectKind::SearchLibrary
+        | EffectKind::SearchOutsideGame
+        | EffectKind::ExileTop
+        | EffectKind::TargetOnly
+        | EffectKind::Choose
+        | EffectKind::ChooseDamageSource
+        | EffectKind::Suspect
+        | EffectKind::Connive
+        | EffectKind::PhaseOut
+        | EffectKind::PhaseIn
+        | EffectKind::ForceBlock
+        | EffectKind::SolveCase
+        | EffectKind::BecomePrepared
+        | EffectKind::BecomeUnprepared
+        | EffectKind::SetClassLevel
+        | EffectKind::CreateDelayedTrigger
+        | EffectKind::AddTargetReplacement
+        | EffectKind::AddRestriction
+        | EffectKind::ReduceNextSpellCost
+        | EffectKind::GrantNextSpellAbility
+        | EffectKind::AddPendingETBCounters
+        | EffectKind::CreateEmblem
+        | EffectKind::PayCost
+        | EffectKind::CastFromZone
+        | EffectKind::PreventDamage
+        | EffectKind::CreateDamageReplacement
+        | EffectKind::Regenerate
+        | EffectKind::LoseTheGame
+        | EffectKind::WinTheGame
+        | EffectKind::RollDie
+        | EffectKind::FlipCoin
+        | EffectKind::FlipCoins
+        | EffectKind::FlipCoinUntilLose
+        | EffectKind::RingTemptsYou
+        | EffectKind::VentureIntoDungeon
+        | EffectKind::VentureInto
+        | EffectKind::TakeTheInitiative
+        | EffectKind::ProcessRadCounters
+        | EffectKind::GrantCastingPermission
+        | EffectKind::ChooseFromZone
+        | EffectKind::ChooseObjectsIntoTrackedSet
+        | EffectKind::ChooseAndSacrificeRest
+        | EffectKind::Exploit
+        | EffectKind::GainEnergy
+        | EffectKind::GivePlayerCounter
+        | EffectKind::LoseAllPlayerCounters
+        | EffectKind::ExileFromTopUntil
+        | EffectKind::RevealUntil
+        | EffectKind::Discover
+        | EffectKind::Cascade
+        | EffectKind::MiracleCast
+        | EffectKind::MadnessCast
+        | EffectKind::PutAtLibraryPosition
+        | EffectKind::ChooseDrawnThisTurnPayOrTopdeck
+        | EffectKind::PutOnTopOrBottom
+        | EffectKind::GiftDelivery
+        | EffectKind::Goad
+        | EffectKind::GoadAll
+        | EffectKind::Detain
+        | EffectKind::ExchangeControl
+        | EffectKind::ChangeTargets
+        | EffectKind::Incubate
+        | EffectKind::Amass
+        | EffectKind::Bolster
+        | EffectKind::Adapt
+        | EffectKind::Manifest
+        | EffectKind::ExtraTurn
+        | EffectKind::GrantExtraLoyaltyActivations
+        | EffectKind::SkipNextTurn
+        | EffectKind::SkipNextStep
+        | EffectKind::AdditionalPhase
+        | EffectKind::Double
+        | EffectKind::RuntimeHandled
+        | EffectKind::Learn
+        | EffectKind::Forage
+        | EffectKind::CollectEvidence
+        | EffectKind::Endure
+        | EffectKind::BlightEffect
+        | EffectKind::Seek
+        | EffectKind::SetLifeTotal
+        | EffectKind::SetDayNight
+        | EffectKind::GiveControl
+        | EffectKind::RemoveFromCombat
+        | EffectKind::Conjure
+        | EffectKind::ChooseOneOf
+        | EffectKind::Unimplemented
+        | EffectKind::Crew
+        | EffectKind::Station
+        | EffectKind::Saddle
+        | EffectKind::Transform
+        | EffectKind::TurnFaceUp => {}
+    }
+}
+
+/// CR 702.108 (Prowess), CR 702.156 (Ravenous), CR 702.147 (Decayed),
+/// CR 702.110 (Exploit), CR 702.21 (Ward), Avatar crossover (Firebending):
+/// these keywords synthesize triggered abilities at the consult site of
+/// `collect_pending_triggers` (`game::triggers`) instead of materializing a
+/// `TriggerDefinition` on the object. The index must therefore consider every
+/// battlefield permanent carrying one of these keywords on every event, even
+/// if its printed `trigger_definitions` is empty.
+///
+/// Returns `true` if `obj` carries a keyword whose triggered behavior is
+/// synthesized outside `obj.trigger_definitions`. Such objects are routed to
+/// `unclassified` so the per-candidate loop always visits them.
+pub fn has_synthetic_keyword_trigger_for(obj: &GameObject) -> bool {
+    obj.keywords.iter().any(|k| {
+        matches!(
+            k,
+            Keyword::Prowess
+                | Keyword::Ravenous
+                | Keyword::Decayed
+                | Keyword::Exploit
+                | Keyword::Ward(_)
+                | Keyword::Firebending(_)
+        )
+    })
+}
+
+impl TriggerIndex {
+    /// CR 603.6a: Register a permanent's trigger definitions in the index when
+    /// it enters the battlefield. The caller is responsible for invoking this
+    /// AFTER `reset_for_battlefield_entry` so `obj.trigger_definitions`
+    /// reflects the post-entry initial trigger set.
+    ///
+    /// `synthetic_keyword_trigger` is set when the object carries a keyword
+    /// whose triggered behavior is materialized inside `collect_pending_triggers`
+    /// (Prowess, Ravenous, Decayed, Exploit, Ward, Firebending) — such objects
+    /// are also routed to `unclassified` so the per-candidate loop visits them
+    /// even when their printed trigger set does not register a key.
+    pub fn add(
+        &mut self,
+        object_id: ObjectId,
+        defs: &[TriggerDefinition],
+        synthetic_keyword_trigger: bool,
+    ) {
+        for def in defs {
+            let (keys, route_unclassified) = keys_from_trigger_def(def);
+            for k in keys {
+                let bucket = self.by_key.entry(k).or_default();
+                if !bucket.contains(&object_id) {
+                    bucket.push(object_id);
+                }
+            }
+            if route_unclassified && !self.unclassified.contains(&object_id) {
+                self.unclassified.push(object_id);
+            }
+        }
+        if synthetic_keyword_trigger && !self.unclassified.contains(&object_id) {
+            self.unclassified.push(object_id);
+        }
+    }
+
+    /// CR 603.6c: Remove a permanent from every bucket when it leaves the
+    /// battlefield.
+    pub fn remove(&mut self, object_id: ObjectId) {
+        self.unclassified.retain(|id| *id != object_id);
+        // im::HashMap::iter_mut materializes via copy-on-write per touched
+        // entry; for the typical bucket-count (≤ a few dozen) the bookkeeping
+        // is negligible compared to the previous full battlefield rescan.
+        let mut empty_keys: SmallVec<[TriggerEventKey; 4]> = SmallVec::new();
+        for (k, bucket) in self.by_key.iter_mut() {
+            bucket.retain(|id| *id != object_id);
+            if bucket.is_empty() {
+                empty_keys.push(k.clone());
+            }
+        }
+        for k in empty_keys {
+            self.by_key.remove(&k);
+        }
+    }
+
+    /// CR 603.6a + CR 611.2e: Rebuild from scratch by scanning every phased-in
+    /// battlefield permanent and re-deriving its keys via
+    /// `keys_from_trigger_def`. Called at the end of `evaluate_layers` and
+    /// lazily on first consult after deserialize.
+    pub fn rebuild_from_battlefield(state: &mut GameState) {
+        let mut fresh = TriggerIndex::default();
+        // CR 702.26: phased-out permanents don't trigger.
+        for obj_id in state.battlefield_phased_in_ids() {
+            if let Some(obj) = state.objects.get(&obj_id) {
+                // `as_slice()` exposes the materialized post-layer trigger
+                // set (base + granted) without any CR gate. The per-event
+                // matcher gating in `active_trigger_definitions` runs at
+                // consult time — classification can register on the full set.
+                let synthetic = has_synthetic_keyword_trigger_for(obj);
+                fresh.add(obj_id, obj.trigger_definitions.as_slice(), synthetic);
+            }
+        }
+        state.trigger_index = fresh;
+    }
+}
+
+/// CR 603.2: Public consult helper. Returns the union of buckets the event
+/// keys hit, plus the `unclassified` bucket. Caller dedups against the
+/// per-event `registered_this_event` set as usual.
+pub fn candidates_for_event(state: &GameState, event: &GameEvent) -> SmallVec<[ObjectId; 16]> {
+    let mut out: SmallVec<[ObjectId; 16]> = SmallVec::new();
+    out.extend(state.trigger_index.unclassified.iter().copied());
+    let keys = keys_from_event(event, state);
+    for k in &keys {
+        if let Some(bucket) = state.trigger_index.by_key.get(k) {
+            out.extend(bucket.iter().copied());
+        }
+    }
+    out.sort_unstable_by_key(|id| id.0);
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ability::{TargetFilter, TypedFilter};
+    use crate::types::triggers::TriggerEventKey;
+
+    fn etb_creature_def() -> TriggerDefinition {
+        TriggerDefinition::new(TriggerMode::ChangesZone)
+            .destination(Zone::Battlefield)
+            .valid_card(TargetFilter::Typed(TypedFilter::creature()))
+    }
+
+    #[test]
+    fn etb_creature_emits_narrow_and_broad_keys_via_event() {
+        // A `TriggerMode::ChangesZone` with `destination=Battlefield,
+        // valid_card=Creature` registers under `EnterBattlefield(Creature)`.
+        let def = etb_creature_def();
+        let (keys, route) = keys_from_trigger_def(&def);
+        assert!(keys.contains(&TriggerEventKey::EnterBattlefield(Some(CoreType::Creature))));
+        assert!(!route);
+    }
+
+    #[test]
+    fn sacrificed_emits_three_keys() {
+        // CR 701.21 + CR 603.6c: sacrifice triggers reach via three keys.
+        let def = TriggerDefinition::new(TriggerMode::Sacrificed)
+            .valid_card(TargetFilter::Typed(TypedFilter::creature()));
+        let (keys, _) = keys_from_trigger_def(&def);
+        assert!(keys.contains(&TriggerEventKey::Sacrificed));
+        assert!(keys.contains(&TriggerEventKey::LeaveBattlefield(Some(CoreType::Creature))));
+        assert!(keys.contains(&TriggerEventKey::Dies(Some(CoreType::Creature))));
+    }
+
+    #[test]
+    fn state_condition_emits_no_keys_and_no_unclassified() {
+        let def = TriggerDefinition::new(TriggerMode::StateCondition);
+        let (keys, route) = keys_from_trigger_def(&def);
+        assert!(keys.is_empty());
+        assert!(!route);
+    }
+
+    #[test]
+    fn always_routes_to_unclassified() {
+        let def = TriggerDefinition::new(TriggerMode::Always);
+        let (keys, route) = keys_from_trigger_def(&def);
+        assert!(keys.is_empty());
+        assert!(route);
+    }
+
+    #[test]
+    fn cumulative_upkeep_emits_upkeep_phase_key() {
+        let def = TriggerDefinition::new(TriggerMode::PayCumulativeUpkeep);
+        let (keys, _) = keys_from_trigger_def(&def);
+        assert!(keys.contains(&TriggerEventKey::BeginningOfPhase(
+            crate::types::phase::Phase::Upkeep
+        )));
+    }
+}

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 use crate::types::ability::{
     AbilityTag, CoinFlipResult, ControllerRef, DamageKindFilter, DestinationConstraint, EffectKind,
@@ -179,6 +180,23 @@ pub fn trigger_matcher(mode: TriggerMode) -> Option<TriggerMatcher> {
 // ---------------------------------------------------------------------------
 
 /// Build a registry mapping every TriggerMode to its matcher function.
+/// Process-wide cached trigger-matcher registry.
+///
+/// The registry is a pure constant (`TriggerMode` → fn-pointer) with no
+/// per-call state, so it is built exactly once. `unimplemented_mechanics`
+/// consults it for every battlefield object on every `apply()`; rebuilding
+/// the map per call (619 objects × every action) was the dominant cost in
+/// display derivation. Callers on hot paths must use [`trigger_registry`];
+/// `build_trigger_registry` remains for the `LazyLock` initializer and tests
+/// that need an owned copy.
+static TRIGGER_REGISTRY: LazyLock<HashMap<TriggerMode, TriggerMatcher>> =
+    LazyLock::new(build_trigger_registry);
+
+/// Cached accessor for the trigger-matcher registry. Built once on first use.
+pub fn trigger_registry() -> &'static HashMap<TriggerMode, TriggerMatcher> {
+    &TRIGGER_REGISTRY
+}
+
 pub fn build_trigger_registry() -> HashMap<TriggerMode, TriggerMatcher> {
     let mut r: HashMap<TriggerMode, TriggerMatcher> = HashMap::new();
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -765,8 +765,49 @@ fn collect_pending_triggers(
         if event_is_suppressed_by_static_triggers(state, event) {
             continue;
         }
-        // Scan all permanents on the battlefield for matching triggers
-        for obj_id in trigger_source_ids_for_zone(state, Zone::Battlefield) {
+
+        // CR 603.2 over-approximation differential check (debug-only):
+        // snapshot the dedup sets BEFORE the production loop mutates them so
+        // the shadow scan operates on the same pre-event state the production
+        // loop saw. Without this, batched triggers the production loop would
+        // have found get falsely skipped as "already batched this pass" in
+        // the shadow path.
+        #[cfg(debug_assertions)]
+        let (mut shadow_batched, mut shadow_registered) =
+            (batched_this_pass.clone(), registered_this_event.clone());
+
+        // CR 603.2 + CR 603.6a + CR 611.2e: Consult the maintained TriggerIndex
+        // for candidate battlefield objects. Replaces the legacy full
+        // battlefield scan with an event-keyed bucket union. The
+        // `evaluate_layers` rebuild at the top of `collect_pending_triggers`
+        // guarantees the index reflects post-layer trigger sets.
+        //
+        // Lazy-rebuild sentinel: TriggerIndex is `#[serde(skip)]` and defaults
+        // to empty after deserialize. A genuinely-empty index over a
+        // non-empty battlefield means we need to rebuild before reading; the
+        // common steady-state case (empty index, empty battlefield) is a
+        // harmless no-op.
+        if state.trigger_index.by_key.is_empty()
+            && state.trigger_index.unclassified.is_empty()
+            && !state.battlefield.is_empty()
+        {
+            crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
+        }
+        let candidates = crate::game::trigger_index::candidates_for_event(state, event);
+
+        // CR 603.2 differential test (debug-only): run a SHADOW scan over the
+        // full battlefield with cloned dedup sets and verify every matched
+        // (source_id, trig_idx) pair found by the legacy path is also found
+        // by the index path. Compares matched-context sets — not visited
+        // candidate IDs — so vanilla creatures invisible to the index by
+        // design do not falsely panic.
+        #[cfg(debug_assertions)]
+        let mut shadow_matched: HashSet<(ObjectId, usize)> = HashSet::new();
+        #[cfg(debug_assertions)]
+        let mut production_matched: HashSet<(ObjectId, usize)> = HashSet::new();
+
+        // Scan candidate permanents for matching triggers
+        for obj_id in candidates.iter().copied() {
             let (
                 controller,
                 timestamp,
@@ -829,6 +870,8 @@ fn collect_pending_triggers(
             };
 
             for matched in matched_triggers {
+                #[cfg(debug_assertions)]
+                production_matched.insert((obj_id, matched.trig_idx));
                 record_trigger_fired(state, matched.constraint.as_ref(), obj_id, matched.trig_idx);
                 if matched.batched {
                     batched_this_pass.insert((obj_id, matched.trig_idx));
@@ -1131,6 +1174,45 @@ fn collect_pending_triggers(
                     }
                 }
             }
+        }
+
+        // CR 603.2 over-approximation differential test (debug-only): after the
+        // production loop completes, run a SHADOW battlefield scan with the
+        // pre-event-snapshot dedup sets. Compare matched `(source_id, trig_idx)`
+        // contexts — every match found by the legacy full scan must appear in
+        // the index path's match set. Vanilla creatures visited by the legacy
+        // scan but invisible to the index by design return zero matches and
+        // do not enter the comparison.
+        #[cfg(debug_assertions)]
+        {
+            for obj_id in trigger_source_ids_for_zone(state, Zone::Battlefield) {
+                let Some(obj) = state.objects.get(&obj_id) else {
+                    continue;
+                };
+                let matched = collect_matching_triggers(
+                    state,
+                    event,
+                    events,
+                    obj,
+                    obj.entered_battlefield_turn.unwrap_or(0),
+                    Some(Zone::Battlefield),
+                    &mut shadow_batched,
+                    &mut shadow_registered,
+                );
+                for m in matched {
+                    shadow_matched.insert((obj_id, m.trig_idx));
+                }
+            }
+            let dropped: Vec<(ObjectId, usize)> = shadow_matched
+                .difference(&production_matched)
+                .copied()
+                .collect();
+            debug_assert!(
+                dropped.is_empty(),
+                "TriggerIndex under-approximation (CR 603.2 silent trigger drop): \
+                 event={event:?} dropped_matches={dropped:?} \
+                 candidates_visited={candidates:?}",
+            );
         }
 
         // CR 603.10a: Leaves-the-battlefield abilities look back in time. Objects that
@@ -14361,6 +14443,44 @@ pub mod tests {
             state.players[0].life, 21,
             "the Blood Artist-class dies-observer must resolve from the \
              deferred-trigger flush (issue #423)"
+        );
+    }
+
+    /// CR 603.2 performance benchmark: replay the production Scute Swarm
+    /// snapshot (619 permanents, 2886 batched landfall triggers queued on
+    /// the stack) and report frames/sec. Baseline before the TriggerIndex
+    /// was ~5 frames/sec; target with the index is ≥ 50 frames/sec.
+    ///
+    /// Requires `/tmp/gamestate.json` to be present (the captured snapshot
+    /// is not committed). Skips cleanly when absent.
+    #[test]
+    #[ignore = "perf benchmark; run with `cargo test -p engine scute_swarm_throughput -- --ignored --nocapture`"]
+    fn scute_swarm_throughput() {
+        let path = "/tmp/gamestate.json";
+        let raw = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => {
+                eprintln!("snapshot {path} not present; skipping benchmark");
+                return;
+            }
+        };
+        // Snapshot is wrapped as `{"gameState": {...}}`; unwrap to GameState.
+        let wrapper: serde_json::Value = serde_json::from_str(&raw).expect("snapshot is JSON");
+        let inner = wrapper.get("gameState").cloned().unwrap_or(wrapper);
+        let mut state: GameState =
+            serde_json::from_value(inner).expect("snapshot parses as GameState");
+        let start = std::time::Instant::now();
+        let mut frames = 0u32;
+        while !state.stack.is_empty() && frames < 200 {
+            let actor = state.priority_player;
+            let _ = crate::game::engine::apply(&mut state, actor, GameAction::PassPriority);
+            frames += 1;
+        }
+        let elapsed = start.elapsed();
+        let fps = frames as f64 / elapsed.as_secs_f64().max(f64::EPSILON);
+        eprintln!(
+            "Resolved {} frames in {:?} ({:.1} frames/sec)",
+            frames, elapsed, fps
         );
     }
 }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -31,7 +31,7 @@ use super::speed::{
 use super::stack;
 
 // Re-export so existing paths stay valid.
-pub use super::trigger_matchers::{build_trigger_registry, trigger_matcher};
+pub use super::trigger_matchers::{build_trigger_registry, trigger_matcher, trigger_registry};
 
 /// Function signature for trigger matchers: returns true if event matches the trigger.
 pub type TriggerMatcher = fn(

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -313,6 +313,16 @@ pub fn move_to_zone(
     remove_from_zone(state, object_id, from, owner);
     add_to_zone(state, object_id, to, owner);
 
+    // CR 603.6c: Drop the leaving permanent from the TriggerIndex. The
+    // leaves-battlefield last-known-information scan in
+    // `collect_pending_triggers` reads `state.objects` directly (the object's
+    // zone is no longer Battlefield), unaffected by this removal. The
+    // authoritative correctness path is the `evaluate_layers` rebuild
+    // (CR 611.2e); this hook is incremental optimization between layer flushes.
+    if from == Zone::Battlefield {
+        state.trigger_index.remove(object_id);
+    }
+
     let obj_mut = state.objects.get_mut(&object_id).unwrap();
     obj_mut.zone = to;
 
@@ -373,6 +383,25 @@ pub fn move_to_zone(
             if needs_transform {
                 let _ = super::transform::transform_permanent(state, object_id, events);
             }
+        }
+    }
+
+    // CR 603.6a: Register the post-reset trigger definitions in the index so
+    // `state.clone()` consumers see a coherent battlefield → trigger candidate
+    // map. AUTHORITATIVE PATH: the end-of-`evaluate_layers` rebuild
+    // (CR 611.2e, `layers.rs`) is the safety net; this hook is incremental
+    // optimization between layer flushes. `state.layers_dirty = true` was set
+    // above, guaranteeing a post-layer rebuild on the next
+    // `collect_pending_triggers` consult.
+    if to == Zone::Battlefield {
+        let registration = state.objects.get(&object_id).map(|obj| {
+            let defs: smallvec::SmallVec<[crate::types::ability::TriggerDefinition; 4]> =
+                obj.trigger_definitions.as_slice().iter().cloned().collect();
+            let synthetic = super::trigger_index::has_synthetic_keyword_trigger_for(obj);
+            (defs, synthetic)
+        });
+        if let Some((defs, synthetic)) = registration {
+            state.trigger_index.add(object_id, &defs, synthetic);
         }
     }
 
@@ -483,6 +512,13 @@ pub fn move_to_library_at_index(
     apply_zone_exit_cleanup(state, object_id, from, Zone::Library);
 
     remove_from_zone(state, object_id, from, owner);
+
+    // CR 603.6c: Drop the leaving permanent from the TriggerIndex when this
+    // path is used to move a battlefield permanent into the library
+    // (Conduit-of-Worlds-style "shuffle a permanent into your library").
+    if from == Zone::Battlefield {
+        state.trigger_index.remove(object_id);
+    }
 
     // Place at specified index or push to end (bottom)
     let player = state

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3592,6 +3592,39 @@ pub struct StackPaidSnapshot {
     pub convoked_creatures: usize,
 }
 
+/// CR 603.2: Maintained index from `TriggerEventKey` to the candidate set of
+/// battlefield permanents whose triggers could match an event with that key.
+/// Consulted by `collect_pending_triggers` to skip the full battlefield scan
+/// that previously asked every permanent on every event whether it cared.
+///
+/// CR 603.2 invariant: every battlefield object whose trigger could match
+/// event E must appear in the union of buckets `keys_from_event(E)` looks up
+/// OR in `unclassified`. Over-approximation is correctness-preserving; under-
+/// approximation is a silent trigger drop.
+///
+/// CR 603.6a + CR 611.2e: Granted triggers (sliver lords, Cairn Wanderer,
+/// Bramble Sovereign) are materialized by `evaluate_layers` into
+/// `obj.trigger_definitions`. The index's battlefield-scoped portion is
+/// rebuilt at the end of `evaluate_layers` so it always reflects post-layer
+/// trigger sets. That rebuild is the **authoritative correctness path**; the
+/// `move_to_zone` hooks (`game::zones`) are incremental optimization only.
+///
+/// Backed by `im::HashMap` so `GameState::clone()` (hot path through AI
+/// search, casting affordability simulation, restriction probes) stays O(1)
+/// structural share rather than O(buckets × ObjectIds) deep copy.
+#[derive(Debug, Clone, Default)]
+pub struct TriggerIndex {
+    /// Buckets keyed by event shape. `SmallVec` keeps allocation off the heap
+    /// for the typical bucket size (≤ 4 candidates for most keys on most
+    /// battlefields).
+    pub by_key: im::HashMap<super::triggers::TriggerEventKey, smallvec::SmallVec<[ObjectId; 4]>>,
+    /// Catch-all bucket: any battlefield object whose trigger definitions
+    /// could not be statically classified by `keys_from_trigger_def`.
+    /// Consulted on every event regardless of `keys_from_event` output.
+    /// Empty for the common case where every trigger's mode is known.
+    pub unclassified: smallvec::SmallVec<[ObjectId; 4]>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GameState {
     pub turn_number: u32,
@@ -3715,6 +3748,14 @@ pub struct GameState {
 
     // Layer system
     pub layers_dirty: bool,
+    /// CR 603.2: Candidate pre-filter for `collect_pending_triggers`. Rebuilt
+    /// lazily after deserialize via a sentinel check at the top of the consult
+    /// site; rebuilt eagerly at the end of `evaluate_layers` (CR 611.2e) so the
+    /// post-layer trigger set is reflected. `#[serde(skip)]` because the index
+    /// is derived state — reconstructed from `state.battlefield` + per-object
+    /// `trigger_definitions` whenever needed.
+    #[serde(skip)]
+    pub trigger_index: TriggerIndex,
     pub next_timestamp: u64,
     #[serde(skip, default = "PublicStateDirty::all_dirty")]
     pub public_state_dirty: PublicStateDirty,
@@ -4696,6 +4737,7 @@ impl GameState {
             pending_spell_resolution: None,
             deferred_entry_events: Vec::new(),
             layers_dirty: true,
+            trigger_index: TriggerIndex::default(),
             next_timestamp: 1,
             public_state_dirty: PublicStateDirty::all_dirty(),
             state_revision: 0,

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -58,5 +58,5 @@ pub use player::{Player, PlayerId};
 pub use proposed_event::{ProposedEvent, ReplacementId};
 pub use replacements::ReplacementEvent;
 pub use statics::StaticMode;
-pub use triggers::TriggerMode;
+pub use triggers::{TriggerEventKey, TriggerMode};
 pub use zones::Zone;

--- a/crates/engine/src/types/triggers.rs
+++ b/crates/engine/src/types/triggers.rs
@@ -5,6 +5,155 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use crate::types::ability::AbilityTag;
+use crate::types::card_type::CoreType;
+use crate::types::phase::Phase;
+
+/// CR 603.2: Event-keyed bucket discriminator for the battlefield
+/// `TriggerIndex`. Indexes the small set of structural axes that statically
+/// constrain which event a battlefield trigger could match. A given event maps
+/// to one or more keys; a given trigger definition maps to one or more keys
+/// (or to the `unclassified` bucket via empty derivation).
+///
+/// CR 603.2 over-approximation invariant: it is correctness-preserving to emit
+/// MORE keys for an event or for a trigger definition than are strictly
+/// necessary; it is a silent trigger-drop bug to emit FEWER. The index's
+/// `unclassified` bucket is the safety net for any `TriggerMode` whose match
+/// shape is dynamic (filter depends on game state) or not yet classified here.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TriggerEventKey {
+    /// CR 603.6a: A permanent entered the battlefield. `Some(core_type)` is
+    /// emitted for triggers whose `valid_card` filter narrows to exactly one
+    /// `CoreType`; `None` covers the unrestricted "whenever a permanent enters"
+    /// shape. The event-side deriver emits BOTH the broad `None` key AND one
+    /// `Some(ct)` per element of `ZoneChangeRecord.core_types` so narrow and
+    /// broad listeners both fire.
+    EnterBattlefield(Option<CoreType>),
+    /// CR 603.6c: A permanent moved from battlefield to any other zone
+    /// (death, exile, return-to-hand, library shuffle, library bottom).
+    LeaveBattlefield(Option<CoreType>),
+    /// CR 603.6c + CR 701.8 (Destroy) + CR 404 (graveyard zone): Subset of
+    /// `LeaveBattlefield` where the destination is the graveyard. Emitted on
+    /// the event side as BOTH `LeaveBattlefield` AND `Dies` so dies-triggers
+    /// (Blood Artist) and leaves-triggers (Skyclave Apparition) can coexist.
+    Dies(Option<CoreType>),
+    /// CR 601.2i: A spell was cast OR copied (CR 707.10). `Some(core_type)` is
+    /// emitted for triggers whose `valid_card` filter narrows to exactly one
+    /// `CoreType` (e.g. "whenever a player casts a creature spell").
+    SpellCast(Option<CoreType>),
+    /// CR 603.2 + CR 115.1: An object or player became the target of a spell
+    /// or ability.
+    BecomesTarget,
+    /// CR 508.1: One or more creatures were declared as attackers.
+    Attacks,
+    /// CR 509.1: A creature was declared as a blocker (or a creature became
+    /// blocked).
+    Blocks,
+    /// CR 119.1 + CR 120.1 (damage): Damage was dealt. Coarsely keyed — the
+    /// per-trigger matcher resolves source/target/amount/combat-vs-noncombat at
+    /// match time.
+    DealsDamage,
+    /// CR 615 (prevention): Damage was prevented.
+    DamagePrevented,
+    /// CR 121.1: One or more cards were drawn.
+    CardsDrawn,
+    /// CR 119.3 + CR 118.4 (life gain/loss): A player's life total changed.
+    LifeChanged,
+    /// CR 106 (mana) + CR 605 (mana abilities): Mana was added to a player's
+    /// mana pool, OR a permanent emitted a `TappedForMana` event. Coarse key —
+    /// the matcher distinguishes the two TriggerModes.
+    ManaProduced,
+    /// CR 700.14 (cost-paid context): cumulative mana spent on a spell.
+    ManaSpent,
+    /// CR 122.1 (counter rules): One or more counters were added to a permanent
+    /// or player. The bucket covers all `CounterAdded*` variants (the matcher
+    /// distinguishes per-counter-type at match time).
+    CounterAdded,
+    /// CR 122.1: One or more counters were removed.
+    CounterRemoved,
+    /// CR 603.2b: A phase or step began. Keyed by the specific `Phase` so
+    /// at-the-beginning-of-Upkeep triggers do not consult on every step.
+    BeginningOfPhase(Phase),
+    /// CR 701.26: A permanent became tapped.
+    Taps,
+    /// CR 605 (mana abilities): A permanent became tapped specifically for
+    /// mana.
+    TapsForMana,
+    /// CR 701.26: A permanent became untapped.
+    Untaps,
+    /// CR 701.21: A permanent was sacrificed.
+    Sacrificed,
+    /// CR 701.8: A permanent was destroyed.
+    Destroyed,
+    /// CR 611.3 (continuous-effect rules covering control-changing statics)
+    /// — a permanent's controller changed via a `GainControl` effect.
+    /// NOTE: Administrative control transfers on player elimination
+    /// (CR 800.4) do NOT produce an `EffectResolved { kind: GainControl }`
+    /// event and therefore do NOT flow through this bucket — they are not
+    /// caught by `TriggerMode::ChangesController` either (see
+    /// `match_changes_controller`).
+    ChangesController,
+    /// CR 701.9: A player discarded a card.
+    Discarded,
+    /// CR 701.17: A player put cards into their graveyard from their library.
+    Milled,
+    /// CR 111.1: A token was created (or a card was conjured).
+    TokenCreated,
+    /// CR 701.3 (Attach) + CR 702.6 (Equip): An Aura/Equipment/Fortification
+    /// became attached (or unattached).
+    AttachmentChanged,
+    /// CR 701.40 (Manifest) + CR 712 (face-down spells/permanents): A permanent
+    /// transformed or turned face up.
+    FaceOrTransform,
+    /// CR 122 (counters) + CR 704 / poison: A player counter (poison,
+    /// experience, energy, rad) changed.
+    PlayerCounterChanged,
+    /// CR 705 (flipping a coin) + CR 706 (rolling a die): A die was rolled or
+    /// a coin was flipped.
+    DieOrCoin,
+    /// CR 725 (Monarch) + CR 726 (Initiative): Designation changed hands.
+    MonarchOrInitiative,
+    /// CR 104.3: A player lost the game.
+    PlayerLost,
+    /// CR 701.30: A clash occurred.
+    Clashed,
+    /// CR 701.38: A vote was cast or resolved.
+    Voted,
+    /// CR 731: Day/Night designation flipped.
+    DayNightChanged,
+    /// CR 309 (Dungeon) + CR 716 (Class) + CR 719 (Case): Dungeon/Class/Case
+    /// state change (room entered, class level gained, case solved, dungeon
+    /// completed).
+    DungeonOrClassOrCase,
+    /// CR 701.22 (Scry) / CR 701.25 (Surveil) / CR 701.23 (Search) /
+    /// CR 701.59 (Collect Evidence) / CR 701.34 (Proliferate): generic
+    /// player-action events routed through `PlayerPerformedAction`.
+    PlayerActionPerformed,
+    /// Avatar crossover (no CR — set-specific mechanic): Bending events
+    /// (Firebend, Airbend, Earthbend, Waterbend, ElementalBend).
+    Bending,
+    /// CR 500 (turn structure) + CR 603.2b: `TurnStarted` event. Distinct from
+    /// `BeginningOfPhase` because `TurnBegin` triggers fire on the per-turn
+    /// boundary, not on any specific in-turn phase.
+    TurnStarted,
+    /// CR 701.13: An exile resolution event.
+    Exiled,
+    /// CR 701.20: A card was revealed.
+    Revealed,
+    /// CR 602.1 (activated abilities) + CR 603.1 (triggered abilities):
+    /// keyword-activated, ability-copy, and ninjutsu activation events.
+    AbilityOrCopyActivated,
+    /// CR 702.112: A creature became renowned.
+    Renowned,
+    /// CR 701.37: A creature became monstrous.
+    BecomesMonstrous,
+    /// CR 701.62: A manifest-dread resolution.
+    ManifestDreadResolved,
+    /// CR 701.44: An explore resolution.
+    Explored,
+    /// CR 701.14: A fight resolution (separate from generic deals-damage
+    /// because the matcher dispatches on `EffectResolved { kind: Fight }`).
+    Fight,
+}
 
 /// CR 508.3a: Filter for attack target type in "attacks [a target]" triggers.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
- **perf(triggers): add battlefield TriggerIndex candidate pre-filter**
- **perf(coverage): memoize trigger + static registries via LazyLock**
- **perf(client): drain huge stacks in large chunks, skip per-chunk throttle**
