### PR TITLE
fix(parser): per-player "their" + counter-move source resolve to the right object

### DIFF
--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -600,6 +600,11 @@ pub(super) fn try_parse_move_counters<'a>(
 
     Some((
         Effect::MoveCounters {
+            // CR 122.8: when a leaves-the-battlefield trigger puts a departed
+            // object's counters onto another object, the same number/kinds the
+            // object had are placed on the destination — read from the leaving
+            // object's last-known information (CR 400.7), so the source must be
+            // the triggering object, not the ability source.
             source: resolve_it_pronoun(ctx),
             counter_type: None,
             count: None,

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -551,15 +551,25 @@ fn resolve_that_creature_in_trigger<'a>(text: &'a str, ctx: &mut ParseContext) -
 /// case where the source's counters are copied (not strictly moved) to a
 /// second object.
 ///
-/// `"its"` / `"this creature's"` are possessive pronouns referring to the
-/// ability source (live state). `"those"` is an anaphoric reference to the
-/// counters that were on the source — typically used in dies / leaves-
-/// battlefield triggers gated by an `if it had counters on it` condition
-/// (Scolding Administrator class). The runtime resolver in
-/// `effects::counters::resolve_move` already performs LKI fallback on the
-/// source object (CR 400.7), so dies-triggers correctly read counters from
-/// the dying creature's last-known state regardless of pronoun form.
-pub(super) fn try_parse_move_counters<'a>(lower: &str, text: &'a str) -> Option<(Effect, &'a str)> {
+/// `"its"` / `"this creature's"` / `"those"` all refer anaphorically to the
+/// object whose counters the trigger condition (`if it had counters on it`)
+/// established. Which object that is depends on the trigger's subject:
+///
+/// - A **self** dies/leaves trigger ("When ~ dies, put its counters on …" —
+///   Scolding Administrator) → the source object itself (`SelfRef`).
+/// - An **other-object** leaves trigger ("Whenever a creature you control
+///   leaves the battlefield, … put those counters on ~" — The Ozolith) → the
+///   triggering creature (`TriggeringSource`), NOT the ability source.
+///
+/// `resolve_it_pronoun` makes exactly this distinction from `ctx.subject`, so
+/// the counter source binds to the right object. The runtime resolver in
+/// `effects::counters::resolve_move` performs LKI fallback (CR 400.7), so the
+/// counters are read from the leaving object's last-known state either way.
+pub(super) fn try_parse_move_counters<'a>(
+    lower: &str,
+    text: &'a str,
+    ctx: &mut ParseContext,
+) -> Option<(Effect, &'a str)> {
     let ((), after_put) = nom_on_lower(lower, lower, |i| value((), tag("put ")).parse(i))?;
     let after_put = after_put.trim();
     // Detect "its counters" / "this creature's counters" / "those counters"
@@ -590,7 +600,7 @@ pub(super) fn try_parse_move_counters<'a>(lower: &str, text: &'a str) -> Option<
 
     Some((
         Effect::MoveCounters {
-            source: TargetFilter::SelfRef,
+            source: resolve_it_pronoun(ctx),
             counter_type: None,
             count: None,
             mode: CounterTransferMode::Put,
@@ -1473,7 +1483,7 @@ mod tests {
     #[test]
     fn move_counters_those_counters_anaphora() {
         let lower = "put those counters on up to one target creature";
-        let result = try_parse_move_counters(lower, lower);
+        let result = try_parse_move_counters(lower, lower, &mut default_ctx());
         let Some((
             Effect::MoveCounters {
                 source,
@@ -1501,6 +1511,34 @@ mod tests {
             }
             other => panic!("expected typed creature target, got {other:?}"),
         }
+    }
+
+    /// CR 122.8 + CR 400.7 (The Ozolith): "Whenever a creature you control
+    /// leaves the battlefield, ... put those counters on ~." Here the trigger
+    /// subject is a non-self creature filter, so "those counters" refers to the
+    /// triggering creature — the counter SOURCE must be `TriggeringSource`, not
+    /// `SelfRef` (the ability source, which never has the counters and would
+    /// make the move a no-op).
+    #[test]
+    fn move_counters_those_counters_from_other_object_trigger() {
+        use crate::types::ability::TypedFilter;
+        let mut ctx = default_ctx();
+        ctx.subject = Some(TargetFilter::Typed(TypedFilter::creature()));
+        let lower = "put those counters on ~";
+        let result = try_parse_move_counters(lower, lower, &mut ctx);
+        let Some((Effect::MoveCounters { source, target, .. }, _)) = result else {
+            panic!("expected MoveCounters, got {result:?}");
+        };
+        assert_eq!(
+            source,
+            TargetFilter::TriggeringSource,
+            "source must be the triggering (leaving) creature, not the ability source"
+        );
+        assert_eq!(
+            target,
+            TargetFilter::SelfRef,
+            "counters are put onto ~ (the ability source)"
+        );
     }
 
     /// CR 122.1b: Avenging Huntbonder (NCC) attack trigger places a `double

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6214,7 +6214,7 @@ pub(super) fn parse_zone_counter_ast(
                 target,
             },
             _rem,
-        )) = super::counter::try_parse_move_counters(lower, text)
+        )) = super::counter::try_parse_move_counters(lower, text, ctx)
         {
             return Some(ZoneCounterImperativeAst::MoveCounters {
                 source,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -10850,6 +10850,29 @@ fn rewrite_player_scope_refs(def: &mut AbilityDefinition) {
     }
 }
 
+/// CR 608.2 + CR 109.5: Apply `rewrite_player_scope_refs` rooted at every def in
+/// the chain that carries `player_scope` — not only the outermost one. A scoped
+/// clause routinely appears NESTED as a sub-ability: Betor, Kin to All chains
+/// "draw a card", "untap each creature you control", then "each opponent loses
+/// half their life, rounded up", so `player_scope: Opponent` sits on the third
+/// sub-ability while the outermost effect (Draw) has none. Gating the rewrite on
+/// the outermost def's scope left the nested clause's "their life" as
+/// `LifeTotal { Target }`, which resolves to 0 (no player target). Once a scoped
+/// root is found, `rewrite_player_scope_refs` already recurses through its own
+/// sub-chain, so we stop descending here to avoid rewriting it twice.
+fn apply_player_scope_rewrites(def: &mut AbilityDefinition) {
+    if def.player_scope.is_some() {
+        rewrite_player_scope_refs(def);
+        return;
+    }
+    if let Some(sub) = def.sub_ability.as_mut() {
+        apply_player_scope_rewrites(sub);
+    }
+    if let Some(else_branch) = def.else_ability.as_mut() {
+        apply_player_scope_rewrites(else_branch);
+    }
+}
+
 /// CR 107.1a: Back-apply a rounding mode to every `DivideRounded` in an ability
 /// tree. Used by `parse_effect_chain_ir` after stripping a trailing
 /// "Round down each time" / "Round up each time" sentence (Pox Plague), so
@@ -13903,12 +13926,12 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         })
     };
 
-    // CR 608.2 + CR 107.2: If the outermost ability carries `player_scope`,
-    // rewrite target-scoped refs ("their life", "their hand") to their
-    // controller-scoped equivalents so they resolve per-iterating-player.
-    if result.player_scope.is_some() {
-        rewrite_player_scope_refs(&mut result);
-    }
+    // CR 608.2 + CR 107.2: Wherever an ability in the chain carries
+    // `player_scope` (outermost OR a nested sub-ability), rewrite target-scoped
+    // refs ("their life", "their hand") to their per-iterating-player
+    // equivalents. Walks the whole tree so a scoped clause buried under earlier
+    // non-scoped clauses (Betor, Kin to All) is still rewritten.
+    apply_player_scope_rewrites(&mut result);
 
     // CR 107.1a: Apply the chain-level rounding annotation (captured above)
     // to every DivideRounded in the built tree. No-op when the sentence was
@@ -28477,6 +28500,50 @@ mod tests {
             }
             other => panic!("Expected LoseLife, got {other:?}"),
         }
+    }
+
+    /// CR 107.1a + CR 109.5 regression (Betor, Kin to All): an "each opponent
+    /// loses half their life, rounded up" clause NESTED as a sub-ability (not
+    /// the outermost effect) must still pick up the player-scope rewrite, so
+    /// "their life" binds to each iterating opponent (`ScopedPlayer`). Before
+    /// the fix the rewrite only ran when the OUTERMOST def carried
+    /// `player_scope`, so the nested clause kept `LifeTotal { Target }` — which
+    /// resolves to 0 (no player target), making the life loss a no-op.
+    #[test]
+    fn nested_each_opponent_loses_half_life_uses_scoped_player() {
+        use crate::types::ability::{PlayerFilter, RoundingMode};
+        let def = parse_effect_chain(
+            "Draw a card. Then each opponent loses half their life, rounded up.",
+            AbilityKind::Spell,
+        );
+        // Walk the sub_ability chain to the LoseLife clause.
+        let mut node = &def;
+        let lose = loop {
+            if matches!(&*node.effect, Effect::LoseLife { .. }) {
+                break node;
+            }
+            node = node
+                .sub_ability
+                .as_deref()
+                .expect("LoseLife present in chain");
+        };
+        assert_eq!(lose.player_scope, Some(PlayerFilter::Opponent));
+        let Effect::LoseLife { amount, .. } = &*lose.effect else {
+            unreachable!()
+        };
+        assert_eq!(
+            *amount,
+            QuantityExpr::DivideRounded {
+                inner: Box::new(QuantityExpr::Ref {
+                    qty: QuantityRef::LifeTotal {
+                        player: PlayerScope::ScopedPlayer
+                    },
+                }),
+                divisor: 2,
+                rounding: RoundingMode::Up,
+            },
+            "nested each-opponent 'their life' must rebind to ScopedPlayer, got {amount:?}",
+        );
     }
 
     /// CR 107.1a: Cut Your Losses — "Target player mills half their library,


### PR DESCRIPTION
## Summary

Two related parser fixes, each a case where an anaphoric reference ("their", "those counters") resolved to the wrong object — silently turning an effect into a no-op. Both reported in-game.

### 1. Betor, Kin to All — "each opponent loses half their life, rounded up"
The life loss resolved to **0**. The clause parses with `player_scope: Opponent` and amount `DivideRounded(LifeTotal{...}/2, Up)`, but "their" defaulted to `LifeTotal { Target }`. That's correct for *targeted* clauses ("target opponent loses half their life") but wrong for *each-opponent* clauses, which have no target — so `LifeTotal { Target }` read an absent target and returned 0.

The parser already has a `rewrite_player_scope_refs` pass that rebinds `Target → ScopedPlayer` for exactly this anaphora, but it was gated on the **outermost** def's `player_scope`. Betor's scoped clause is the third sub-ability of a `draw → untap → lose-life` chain, so the outermost effect (Draw) has no scope and the rewrite was skipped. Now applied rooted at **every** def in the chain that carries `player_scope` (`apply_player_scope_rewrites`).

### 2. The Ozolith — counters not accumulating from creatures that leave
"Whenever a creature you control leaves the battlefield … put those counters on The Ozolith" hardcoded the `MoveCounters` **source** to `SelfRef` (The Ozolith), so it moved counters *from Ozolith to Ozolith* — a no-op. The leaving creature's counters were never read.

The source now resolves from the trigger subject via the existing `resolve_it_pronoun(ctx)`:
- other-object leave/dies trigger (subject = creature filter) → `TriggeringSource` (the leaving creature, read via LKI since it's gone — already supported for `mode: Put`)
- self-dies trigger (subject `SelfRef`) → `SelfRef` (unchanged — Scolding Administrator still works)

## Rules
CR 608.2 + CR 109.5 (per-player "their" anaphora) · CR 122.8 + CR 400.7 (counter copy from a leaving object via LKI).

## Test plan
- [x] `cargo test -p engine` (8885 pass) incl. new `nested_each_opponent_loses_half_life_uses_scoped_player` and `move_counters_those_counters_from_other_object_trigger`; existing self-dies (`move_counters_those_counters_anaphora`) and targeted half-life (`blood_tribute_lose_half_their_life_rounded_up`) tests still pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Coverage/oracle-gen: Betor → `LifeTotal{ScopedPlayer}`; The Ozolith LTB → `source: TriggeringSource, target: SelfRef`

🤖 Generated with [Claude Code](https://claude.com/claude-code)