### PR TITLE
Fix Kodama of the East Tree swallowed anti-recursion intervening-if

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -128,6 +128,20 @@ pub(crate) fn deliver_replaced_zone_change(
                 obj.tapped = true;
             }
         }
+        // CR 603.6a + CR 400.7: Record which ability placed this permanent so
+        // anti-recursion intervening-ifs ("if it wasn't put onto the battlefield
+        // with this ability") can exclude permanents this very ability placed.
+        // `move_to_zone` already ran `reset_for_battlefield_entry` (clearing the
+        // field to None); set it only for ability-effect-driven entries. This is
+        // synchronous and lands before `process_triggers`, so the field is
+        // visible at ETB trigger fire-time (CR 603.4).
+        if to == Zone::Battlefield {
+            if let Some(src) = source_id {
+                if let Some(obj) = state.objects.get_mut(&object_id) {
+                    obj.entered_via_ability_source = Some(src);
+                }
+            }
+        }
         // CR 110.2a: Apply controller override if the effect specifies
         // "under your control" — set before triggers fire.
         if let Some(new_controller) = ctrl_override {
@@ -1624,6 +1638,63 @@ mod tests {
         assert!(
             !state.battlefield.contains(&source_id),
             "SelfRef source should no longer be on battlefield"
+        );
+    }
+
+    /// CR 603.6a + CR 400.7: An ability-effect-driven battlefield entry through
+    /// `execute_zone_move` stamps `entered_via_ability_source` with the resolving
+    /// ability's source. Building-block coverage for the Kodama anti-recursion
+    /// provenance field — independent of any single card.
+    #[test]
+    fn ability_driven_entry_records_placing_source() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Placer".to_string(),
+            Zone::Battlefield,
+        );
+        let moved = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Placed Card".to_string(),
+            Zone::Hand,
+        );
+        let mut events = Vec::new();
+
+        let result = execute_zone_move(
+            &mut state,
+            moved,
+            Zone::Hand,
+            Zone::Battlefield,
+            source_id,
+            None,
+            false,
+            false,
+            None,
+            &[],
+            false,
+            &mut events,
+        );
+        assert!(matches!(result, ZoneMoveResult::Done));
+
+        let obj = &state.objects[&moved];
+        assert_eq!(obj.zone, Zone::Battlefield);
+        assert_eq!(
+            obj.entered_via_ability_source,
+            Some(source_id),
+            "an ability-effect-driven entry must record the placing ability's source",
+        );
+
+        // CR 400.7: moving the permanent off the battlefield clears the
+        // provenance — a re-entering permanent is a new object.
+        let mut events2 = Vec::new();
+        zones::move_to_zone(&mut state, moved, Zone::Graveyard, &mut events2);
+        assert_eq!(
+            state.objects[&moved].entered_via_ability_source, None,
+            "battlefield exit must clear the ability-placement provenance (CR 400.7)",
         );
     }
 

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -384,6 +384,18 @@ pub struct GameObject {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cast_variant_paid: Option<(CastVariantPaid, u32)>,
 
+    /// CR 603.6a + CR 400.7: When this permanent was put onto the battlefield as
+    /// part of resolving an ability's effect, this is the `ObjectId` of that
+    /// ability's source permanent. Set by `deliver_replaced_zone_change` on
+    /// battlefield entry; `None` for entries that are not ability-effect-driven
+    /// (normal land plays, spell resolution to battlefield, combat, etc.).
+    /// Read by `TriggerCondition::PlacedByAbilitySource` to implement
+    /// anti-recursion intervening-ifs ("if it wasn't put onto the battlefield
+    /// with this ability"). Cleared on battlefield exit/entry per CR 400.7 —
+    /// a re-entering permanent is a new object with no memory of how it arrived.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entered_via_ability_source: Option<ObjectId>,
+
     /// CR 601.3b + CR 702.8a: Which cast-timing permission was used to cast
     /// the spell that became this permanent, and on which turn. Used by trigger
     /// conditions that care whether normal sorcery timing was bypassed.
@@ -809,6 +821,7 @@ impl GameObject {
             summoning_sick: false,
             echo_due: false,
             cast_variant_paid: None,
+            entered_via_ability_source: None,
             cast_timing_permission: None,
             cost_x_paid: None,
             kickers_paid: Vec::new(),
@@ -915,6 +928,10 @@ impl GameObject {
         self.paired_with = None;
         self.chosen_attributes.clear();
         self.cast_variant_paid = None;
+        // CR 400.7 + CR 603.6a: Ability-placement provenance is per-entry. Clear
+        // it here so the set-block in `deliver_replaced_zone_change` repopulates
+        // it only for ability-effect-driven entries (Kodama anti-recursion guard).
+        self.entered_via_ability_source = None;
         self.cast_timing_permission = None;
         // CR 400.7 + CR 702.33d: kicker payments are bound to the casting
         // event that produced this object. A re-entering permanent has no
@@ -971,6 +988,10 @@ impl GameObject {
         // re-checks resolve correctly. A permanent that leaves the battlefield
         // is a new object on any re-entry — clear the stale cast provenance.
         self.cast_from_zone = None;
+        // CR 400.7 + CR 603.6a: Ability-placement provenance is battlefield-entry
+        // scoped — a permanent that leaves the battlefield is a new object on any
+        // re-entry. Clear conservatively on exit, mirroring `cast_from_zone`.
+        self.entered_via_ability_source = None;
         // CR 305.1 + CR 603.4: Land-play provenance is likewise battlefield-
         // entry scoped and must not survive a later zone change.
         self.played_from_zone = None;

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3424,6 +3424,29 @@ pub(crate) fn check_trigger_condition(
                 .and_then(|id| state.objects.get(&id))
                 .is_some_and(|obj| obj.cast_from_zone.is_some())
         }
+        // CR 603.4 + CR 603.6a: "put onto the battlefield with this ability" —
+        // the entering object was placed by THIS trigger's source ability.
+        // Resolve the entering object from the ZoneChanged event (self-referential
+        // triggers fall back to the trigger source); compare its
+        // `entered_via_ability_source` to the trigger source id. The negation
+        // ("wasn't ... with this ability") wraps via `Not`.
+        TriggerCondition::PlacedByAbilitySource => {
+            let checked_id = trigger_event
+                .and_then(|e| match e {
+                    GameEvent::ZoneChanged { object_id, .. } => Some(*object_id),
+                    _ => None,
+                })
+                .or(source_id);
+            matches!(
+                (
+                    checked_id
+                        .and_then(|id| state.objects.get(&id))
+                        .and_then(|o| o.entered_via_ability_source),
+                    source_id,
+                ),
+                (Some(via), Some(src)) if via == src
+            )
+        }
         // CR 305.1 + CR 603.4: "without being played" is encoded as
         // `Not(WasPlayed)` and checks the triggering zone-change object first.
         TriggerCondition::WasPlayed => {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2440,6 +2440,38 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
         );
     }
 
+    // CR 603.4 + CR 603.6a: "if it wasn't put onto the battlefield with this
+    // ability" — anti-recursion intervening-if (Kodama of the East Tree). The
+    // entering permanent must NOT have been placed by this very ability, so a
+    // permanent Kodama itself puts onto the battlefield does not re-trigger it.
+    // Ordered before the positive arm; the two phrases are disjoint ("wasn't put"
+    // does not contain "was put"), mirroring the WasCast/Not(WasCast) disjointness.
+    if let Some((prefix, _)) = scan_split_at_phrase(&lower, |i| {
+        tag::<_, _, OracleError<'_>>("if it wasn't put onto the battlefield with this ability")
+            .parse(i)
+    }) {
+        let pat = "if it wasn't put onto the battlefield with this ability";
+        return (
+            strip_condition_clause(text, prefix.len(), pat.len()),
+            Some(TriggerCondition::Not {
+                condition: Box::new(TriggerCondition::PlacedByAbilitySource),
+            }),
+        );
+    }
+
+    // CR 603.4 + CR 603.6a: positive "if it was put onto the battlefield with
+    // this ability" — the entering permanent was placed by this very ability.
+    if let Some((prefix, _)) = scan_split_at_phrase(&lower, |i| {
+        tag::<_, _, OracleError<'_>>("if it was put onto the battlefield with this ability")
+            .parse(i)
+    }) {
+        let pat = "if it was put onto the battlefield with this ability";
+        return (
+            strip_condition_clause(text, prefix.len(), pat.len()),
+            Some(TriggerCondition::PlacedByAbilitySource),
+        );
+    }
+
     // CR 603.4 + CR 702.138b: "unless it escaped" — the trigger fires unless
     // the source permanent was cast from a graveyard with its escape ability.
     // Phlage, Titan of Fire's Fury: "sacrifice it unless it escaped." The
@@ -11598,6 +11630,47 @@ mod tests {
         assert!(
             cond.is_some(),
             "leading intervening-if must still be hoisted, got {cond:?}",
+        );
+    }
+
+    /// CR 603.4 + CR 603.6a: "if it wasn't put onto the battlefield with this
+    /// ability" — Kodama of the East Tree anti-recursion guard. Must hoist to
+    /// `Not(PlacedByAbilitySource)` and excise the clause so no `Condition_If`
+    /// SwallowedClause warning is emitted.
+    #[test]
+    fn extract_if_condition_wasnt_put_with_this_ability() {
+        let (cleaned, cond) = extract_if_condition(
+            "if it wasn't put onto the battlefield with this ability, you may put a permanent card with equal or lesser mana value from your hand onto the battlefield.",
+        );
+        assert!(
+            matches!(
+                cond,
+                Some(TriggerCondition::Not { ref condition }) if matches!(**condition, TriggerCondition::PlacedByAbilitySource)
+            ),
+            "expected Not(PlacedByAbilitySource), got {cond:?}",
+        );
+        assert!(
+            // allow-noncombinator: test assertion verifying clause excision, not parsing dispatch
+            !cleaned.contains("put onto the battlefield with this ability"),
+            "intervening-if clause must be excised, got: {cleaned}",
+        );
+    }
+
+    /// CR 603.4 + CR 603.6a: positive "if it was put onto the battlefield with
+    /// this ability" → `PlacedByAbilitySource` (no negation wrapper).
+    #[test]
+    fn extract_if_condition_was_put_with_this_ability() {
+        let (cleaned, cond) = extract_if_condition(
+            "if it was put onto the battlefield with this ability, draw a card.",
+        );
+        assert!(
+            matches!(cond, Some(TriggerCondition::PlacedByAbilitySource)),
+            "expected PlacedByAbilitySource, got {cond:?}",
+        );
+        assert!(
+            // allow-noncombinator: test assertion verifying clause excision, not parsing dispatch
+            !cleaned.contains("put onto the battlefield with this ability"),
+            "intervening-if clause must be excised, got: {cleaned}",
         );
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9658,6 +9658,17 @@ pub enum TriggerCondition {
     /// current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.
     ExceptFirstDrawInDrawStep,
 
+    /// CR 603.4 + CR 603.6a + CR 400.7: "if it was put onto the battlefield with
+    /// this ability" — true when the triggering zone-change object's
+    /// `entered_via_ability_source` equals the trigger's own source id (i.e. THIS
+    /// ability placed it). Used by anti-recursion ETB guards (Kodama of the East
+    /// Tree). The negation ("if it wasn't ... with this ability") wraps via
+    /// `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring
+    /// `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the
+    /// `GameEvent::ZoneChanged` event, falling back to the trigger source for
+    /// self-referential cases.
+    PlacedByAbilitySource,
+
     // -- Combinators --
     /// All conditions must be true ("if you gained and lost life this turn")
     And { conditions: Vec<TriggerCondition> },

--- a/crates/engine/tests/integration/kodama_anti_recursion_intervening_if.rs
+++ b/crates/engine/tests/integration/kodama_anti_recursion_intervening_if.rs
@@ -1,0 +1,201 @@
+//! Kodama of the East Tree — anti-recursion intervening-if (CR 603.4).
+//!
+//! Oracle (relevant line):
+//!   "Whenever another permanent you control enters, if it wasn't put onto the
+//!    battlefield with this ability, you may put a permanent card with equal or
+//!    lesser mana value from your hand onto the battlefield."
+//!
+//! The intervening-if `if it wasn't put onto the battlefield with this ability`
+//! is an anti-recursion guard: a permanent that Kodama itself puts onto the
+//! battlefield must NOT re-trigger Kodama (otherwise the player could chain the
+//! entire hand onto the battlefield from one ETB). Previously the clause was
+//! swallowed (`condition == null`), so Kodama-placed permanents re-triggered it.
+//!
+//! Fix (this change):
+//!   - `GameObject.entered_via_ability_source` records the placing ability's
+//!     source on every effect-driven battlefield entry (set in
+//!     `deliver_replaced_zone_change`).
+//!   - `TriggerCondition::PlacedByAbilitySource` reads that field and compares
+//!     it to the trigger's own source id; the parser emits
+//!     `Not(PlacedByAbilitySource)` for the "wasn't" phrasing.
+//!
+//! These tests drive the real cast -> stack -> ETB trigger -> resolution
+//! pipeline through `apply` (not hand-constructed state), proving both:
+//!   (1) a permanent entering by OTHER means DOES trigger Kodama, and
+//!   (2) a permanent Kodama places does NOT re-trigger Kodama (anti-recursion).
+//!
+//! The "with equal or lesser mana value" qualifier is dropped from the fixture
+//! Oracle text: it gates the eligible-card filter on the entering permanent's
+//! mana value, which is orthogonal to the anti-recursion guard under test. The
+//! "you may put a permanent card from your hand onto the battlefield" form is
+//! already proven at runtime by `batched_trigger_subject_count.rs`.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 603.4: intervening-if conditions are checked at trigger time and again
+//!     at resolution.
+//!   - CR 603.6a: each event that puts permanents onto the battlefield checks all
+//!     permanents (including newcomers) for matching ETB triggers.
+//!   - CR 400.7: a permanent that changes zones is a new object with no memory of
+//!     its previous existence (provenance clears on entry/exit).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Kodama's trigger line only — the anti-recursion intervening-if guard plus the
+/// optional put-from-hand effect (mana-value qualifier omitted; see module docs).
+const KODAMA_TRIGGER: &str = "Whenever another permanent you control enters, if it wasn't put \
+     onto the battlefield with this ability, you may put a permanent card from your hand onto \
+     the battlefield.";
+
+/// Cast a 0-cost creature from P0's hand through the real pipeline.
+fn cast_free_creature(runner: &mut engine::game::scenario::GameRunner, id: ObjectId) {
+    let card_id = runner.state().objects[&id].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: id,
+            card_id,
+            targets: vec![],
+        })
+        .expect("casting a 0-cost creature should succeed");
+}
+
+/// Drive the engine forward, passing priority to resolve the stack, until it
+/// reaches the given target `WaitingFor` discriminant or the stack settles.
+/// Returns `true` if an `OptionalEffectChoice` prompt was observed.
+fn advance_to_optional_choice(runner: &mut engine::game::scenario::GameRunner) -> bool {
+    for _ in 0..60 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => return true,
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    return false;
+                }
+                if runner.state().stack.is_empty()
+                    && matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+                {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+/// (1) A permanent entering by other means (a normally cast creature) DOES
+///     trigger Kodama — its `entered_via_ability_source` is `None`, so
+///     `Not(PlacedByAbilitySource)` is true and the trigger fires, raising the
+///     optional "put a permanent from hand" prompt.
+#[test]
+fn permanent_entering_normally_triggers_kodama() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature_from_oracle(P0, "Kodama of the East Tree", 6, 4, KODAMA_TRIGGER)
+        .id();
+    // A 0-cost creature to cast (the non-ability entry that triggers Kodama).
+    let trigger_creature = scenario
+        .add_creature_to_hand(P0, "Plains Walker", 1, 1)
+        .id();
+    // A permanent for Kodama to optionally put from hand.
+    scenario.add_creature_to_hand(P0, "Hand Beast", 2, 2).id();
+
+    let mut runner = scenario.build();
+    cast_free_creature(&mut runner, trigger_creature);
+
+    assert!(
+        advance_to_optional_choice(&mut runner),
+        "CR 603.6a + CR 603.4: a creature cast normally enters with no \
+         ability-placement provenance, so Kodama's `Not(PlacedByAbilitySource)` \
+         guard is true and the trigger must fire (OptionalEffectChoice prompt)"
+    );
+}
+
+/// (2) Anti-recursion: when Kodama itself puts a permanent from hand onto the
+///     battlefield, that placement sets `entered_via_ability_source == Kodama`,
+///     so `Not(PlacedByAbilitySource)` is false → Kodama does NOT re-trigger.
+///     The stack settles after a single resolution; no second prompt appears.
+#[test]
+fn kodama_placed_permanent_does_not_retrigger_kodama() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature_from_oracle(P0, "Kodama of the East Tree", 6, 4, KODAMA_TRIGGER)
+        .id();
+    let trigger_creature = scenario
+        .add_creature_to_hand(P0, "Plains Walker", 1, 1)
+        .id();
+    let hand_beast = scenario.add_creature_to_hand(P0, "Hand Beast", 2, 2).id();
+    // A second eligible permanent so the engine raises an explicit
+    // `EffectZoneChoice` (with a single eligible card it auto-selects — see
+    // `change_zone::resolve`); having two forces the player-choice path.
+    let _alternate = scenario
+        .add_creature_to_hand(P0, "Alternate Beast", 1, 1)
+        .id();
+
+    let mut runner = scenario.build();
+    cast_free_creature(&mut runner, trigger_creature);
+
+    // Kodama's trigger fires for the cast creature.
+    assert!(
+        advance_to_optional_choice(&mut runner),
+        "Kodama must trigger on the normally-cast creature"
+    );
+
+    // Accept the optional sub-ability and choose the hand permanent.
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept Kodama's optional put-from-hand sub-ability");
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::EffectZoneChoice { .. }
+        ),
+        "accepting must prompt a hand-card selection, got {:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![hand_beast],
+        })
+        .expect("select Hand Beast to put onto the battlefield");
+
+    // Resolve everything. If the anti-recursion guard were broken, the placed
+    // Hand Beast would re-trigger Kodama, raising another OptionalEffectChoice
+    // (and potentially looping). The guard holds → the stack settles to Priority.
+    let retriggered = advance_to_optional_choice(&mut runner);
+    assert!(
+        !retriggered,
+        "CR 603.4: the permanent Kodama placed has \
+         `entered_via_ability_source == Kodama`, so `Not(PlacedByAbilitySource)` \
+         is false — Kodama must NOT re-trigger on its own placement"
+    );
+
+    runner.advance_until_stack_empty();
+
+    // Hand Beast reached the battlefield (the optional ability did resolve).
+    assert_eq!(
+        runner.state().objects[&hand_beast].zone,
+        Zone::Battlefield,
+        "the Kodama-placed permanent must be on the battlefield"
+    );
+    // The placed permanent carries the provenance stamp identifying Kodama.
+    assert!(
+        runner.state().objects[&hand_beast]
+            .entered_via_ability_source
+            .is_some(),
+        "the Kodama-placed permanent must record its ability-placement provenance"
+    );
+    // And the stack is empty — no runaway recursion.
+    assert!(
+        runner.state().stack.is_empty(),
+        "the stack must settle empty after a single Kodama resolution"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -54,6 +54,7 @@ mod integration_landfall;
 mod jace_wielder_empty_library_win;
 mod json_smoke_test;
 mod kaito_integration;
+mod kodama_anti_recursion_intervening_if;
 mod krark_clan_ironworks_castability;
 mod leyline_taps_for_mana_repro;
 mod louisoix_sacrifice_counter;


### PR DESCRIPTION
The parser was dropping the "if it wasn't put onto the battlefield with
this ability" clause (card-data condition: null, SwallowedClause warning),
so Kodama re-triggered on permanents it had itself placed — an infinite
loop violating CR 603.4's intervening-if anti-recursion guard.

Add object provenance: GameObject.entered_via_ability_source records the
ability source_id that placed a permanent onto the battlefield (set in
deliver_replaced_zone_change, cleared on entry/exit per CR 400.7). A new
TriggerCondition::PlacedByAbilitySource compares the entering object's
provenance to the triggering ability's source (source-specific per CR
603.4 — a permanent placed by another ability still triggers Kodama).
Parser extracts Not(PlacedByAbilitySource) / PlacedByAbilitySource via
scan_split_at_phrase + tag combinators.

Kodama's condition now parses as Not(PlacedByAbilitySource); a discriminating
runtime test drives cast -> ETB -> put-from-hand and asserts the placed
permanent does not re-trigger, with a positive control proving normal
entries still trigger.
