### PR TITLE
fix(engine): Sakashima legend-rule exemption (#925)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -6481,6 +6481,10 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                     || effective_lower.contains("can't lose the game")
             }
             StaticMode::CantWinTheGame => effective_lower.contains("can't win the game"),
+            // CR 704.5j: Mirror Gallery / Sakashima class — legend-rule exemption.
+            StaticMode::LegendRuleDoesntApply => {
+                effective_lower.contains("legend rule") && effective_lower.contains("doesn't apply")
+            }
             StaticMode::NoMaximumHandSize => effective_lower.contains("no maximum hand size"),
             StaticMode::MaximumHandSize { .. } => effective_lower.contains("maximum hand size is"),
             StaticMode::CantUntap => {

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -584,6 +584,26 @@ fn check_lethal_damage(
     }
 }
 
+/// CR 704.5j: A legendary permanent is exempt from the legend rule while an
+/// active `LegendRuleDoesntApply` static has an `affected` filter that matches
+/// it (Mirror Gallery's global exemption, Sakashima of a Thousand Faces /
+/// Mirror Box's "permanents you control", Cadric / Sliver Gravemother's
+/// type-scoped variants). The candidate is passed as the target object so
+/// type-scoped exemptions are evaluated per-permanent, not per-player.
+fn legend_rule_exempt(
+    state: &GameState,
+    permanent_id: crate::types::identifiers::ObjectId,
+) -> bool {
+    super::static_abilities::check_static_ability(
+        state,
+        StaticMode::LegendRuleDoesntApply,
+        &super::static_abilities::StaticCheckContext {
+            target_id: Some(permanent_id),
+            ..Default::default()
+        },
+    )
+}
+
 /// CR 704.5j: If a player controls two or more legendary permanents with the same name,
 /// that player chooses one and the rest are put into their owners' graveyards.
 /// This is NOT destruction — indestructible does not prevent it.
@@ -609,6 +629,9 @@ fn check_legend_rule(
                             && obj.card_types.supertypes.contains(&Supertype::Legendary)
                     })
                     .unwrap_or(false)
+                    // CR 704.5j: a permanent exempted by a "legend rule doesn't
+                    // apply" static is excluded from the same-name grouping.
+                    && !legend_rule_exempt(state, *id)
             })
             .collect();
 
@@ -2348,6 +2371,156 @@ mod tests {
             WaitingFor::ChooseLegend { .. }
         ));
         assert!(state.battlefield.contains(&id));
+    }
+
+    // --- CR 704.5j: Legend-rule exemption tests (Sakashima / Mirror Gallery class) ---
+
+    /// Helper: put a legendary creature with the given name onto the battlefield
+    /// under `owner`'s control.
+    fn add_legendary(
+        state: &mut GameState,
+        card: CardId,
+        owner: PlayerId,
+        name: &str,
+        turn: u32,
+    ) -> ObjectId {
+        let id = create_creature(state, card, owner, name, 2, 1);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.supertypes.push(Supertype::Legendary);
+        obj.entered_battlefield_turn = Some(turn);
+        id
+    }
+
+    /// Helper: add a permanent whose `LegendRuleDoesntApply` static carries the
+    /// given `affected` scope (`None` = global Mirror Gallery; a controller-scoped
+    /// filter = Sakashima/Cadric class).
+    fn add_legend_exemption(
+        state: &mut GameState,
+        owner: PlayerId,
+        affected: Option<TargetFilter>,
+    ) -> ObjectId {
+        use crate::types::ability::StaticDefinition;
+        let id = create_object(
+            state,
+            CardId(200),
+            owner,
+            "Legend Exemption".to_string(),
+            Zone::Battlefield,
+        );
+        let mut def = StaticDefinition::new(StaticMode::LegendRuleDoesntApply);
+        def.affected = affected;
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .static_definitions
+            .push(def);
+        id
+    }
+
+    #[test]
+    fn sba_legend_rule_suppressed_by_global_exemption() {
+        // CR 704.5j: Mirror Gallery — "The legend rule doesn't apply." (global).
+        let mut state = setup();
+        let id1 = add_legendary(&mut state, CardId(1), PlayerId(0), "Thalia", 1);
+        let id2 = add_legendary(&mut state, CardId(2), PlayerId(0), "Thalia", 2);
+        add_legend_exemption(&mut state, PlayerId(0), None);
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::ChooseLegend { .. }),
+            "global legend-rule exemption must suppress the legend-rule choice"
+        );
+        assert!(state.battlefield.contains(&id1));
+        assert!(state.battlefield.contains(&id2));
+    }
+
+    #[test]
+    fn sba_legend_rule_suppressed_for_controller_scope() {
+        // CR 704.5j: Sakashima of a Thousand Faces — "doesn't apply to permanents
+        // you control." The controller keeps both same-name legendaries.
+        let mut state = setup();
+        let id1 = add_legendary(&mut state, CardId(1), PlayerId(0), "Sakashima", 1);
+        let id2 = add_legendary(&mut state, CardId(2), PlayerId(0), "Sakashima", 2);
+        add_legend_exemption(
+            &mut state,
+            PlayerId(0),
+            Some(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::You),
+            )),
+        );
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::ChooseLegend { .. }),
+            "controller-scoped legend-rule exemption must suppress the choice for its controller"
+        );
+        assert!(state.battlefield.contains(&id1));
+        assert!(state.battlefield.contains(&id2));
+    }
+
+    #[test]
+    fn sba_legend_rule_still_applies_to_opponent_without_exemption() {
+        // CR 704.5j: Sakashima's "permanents you control" exemption is controller
+        // scoped — an opponent who controls two same-name legendaries is still
+        // subject to the legend rule.
+        let mut state = setup();
+        // Player 0 controls Sakashima (the exemption source).
+        add_legend_exemption(
+            &mut state,
+            PlayerId(0),
+            Some(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::You),
+            )),
+        );
+        // Player 1 controls two copies of the same legendary, with no exemption.
+        let id1 = add_legendary(&mut state, CardId(1), PlayerId(1), "Atraxa", 1);
+        let id2 = add_legendary(&mut state, CardId(2), PlayerId(1), "Atraxa", 2);
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        match &state.waiting_for {
+            WaitingFor::ChooseLegend {
+                player, candidates, ..
+            } => {
+                assert_eq!(*player, PlayerId(1));
+                assert!(candidates.contains(&id1));
+                assert!(candidates.contains(&id2));
+            }
+            other => panic!("Expected ChooseLegend for opponent, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn sba_legend_rule_type_scoped_exemption_only_exempts_matching() {
+        // CR 704.5j: Sliver Gravemother — "doesn't apply to Slivers you control."
+        // Two same-name NON-Sliver legendaries are still collapsed by the rule.
+        let mut state = setup();
+        add_legendary(&mut state, CardId(1), PlayerId(0), "Sliver Overlord", 1);
+        add_legendary(&mut state, CardId(2), PlayerId(0), "Sliver Overlord", 2);
+        // The exemption only covers Slivers; the legendaries above have no subtype.
+        add_legend_exemption(
+            &mut state,
+            PlayerId(0),
+            Some(TargetFilter::Typed(
+                TypedFilter::default()
+                    .controller(ControllerRef::You)
+                    .subtype("Sliver".to_string()),
+            )),
+        );
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            matches!(state.waiting_for, WaitingFor::ChooseLegend { .. }),
+            "type-scoped exemption must not exempt permanents outside its filter"
+        );
     }
 
     // --- CR 704.5q: Counter cancellation tests ---

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -157,6 +157,9 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     // via player_has_cant_win(). Per CR 104.2a, the last-player-standing case
     // is not blocked by this static and is enforced by elimination::check_game_over.
     registry.insert(StaticMode::CantWinTheGame, handle_rule_mod);
+    // CR 704.5j: LegendRuleDoesntApply — affected permanents are excluded from
+    // the legend-rule SBA. Runtime enforcement is in sba.rs::legend_rule_exempt().
+    registry.insert(StaticMode::LegendRuleDoesntApply, handle_rule_mod);
     // CR 702.179e: Card-specific rule modification allowing speed to exceed 4.
     registry.insert(StaticMode::SpeedCanIncreaseBeyondFour, handle_rule_mod);
     // CR 609.4b: "You may spend mana as though it were mana of any color."

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -197,6 +197,11 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     "can't win the game",
     "can't lose the game",
     "don't lose the game",
+    // CR 704.5j: Mirror Gallery / Sakashima of a Thousand Faces class —
+    // "the \"legend rule\" doesn't apply [to <scope> you control]". The leading
+    // quote is required: scan_contains only matches at word starts, and "legend"
+    // is glued to its opening quote ("legend) in the Oracle text.
+    "\"legend rule\" doesn't apply",
     "can block an additional",
     "can block any number",
     "play an additional land",

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -2415,6 +2415,13 @@ fn parse_static_line_inner(text: &str, inverted: InvertedAsLongAs) -> Option<Sta
         );
     }
 
+    // --- "the \"legend rule\" doesn't apply [to <scope> you control]" (CR 704.5j) ---
+    // Mirror Gallery (global), Sakashima of a Thousand Faces / Mirror Box
+    // ("permanents you control"), Sliver Gravemother / Spider-Verse (subtype).
+    if let Some(def) = parse_legend_rule_exemption(&tp, &text) {
+        return Some(def);
+    }
+
     // --- "as though it/they had flash" (CR 702.8a) ---
     if nom_primitives::scan_contains(tp.lower, "as though it had flash")
         || nom_primitives::scan_contains(tp.lower, "as though they had flash")
@@ -6441,6 +6448,79 @@ fn lower_rule_static(
                 .description(description.to_string())
         }
     }
+}
+
+/// CR 704.5j: Parse a "the \"legend rule\" doesn't apply [to <scope> you control]"
+/// static-ability line into a `LegendRuleDoesntApply` definition.
+///
+/// - Global form ("the legend rule doesn't apply.") → `affected: None`
+///   (Mirror Gallery).
+/// - Scoped form ("... doesn't apply to <scope> you control.") → a
+///   controller-scoped `affected` filter derived from `<scope>`.
+///
+/// Anchored on the canonical opening, so conditional / compound forms that do
+/// not begin with the exemption clause — "If there are exactly two permanents
+/// named …" (Brothers Yamazaki), "As long as you control …" (Mothers Yamazaki),
+/// "Numot … have vigilance and haste, and the legend rule doesn't apply to
+/// them" (The Herald of Numot) — fall through and remain Unimplemented rather
+/// than being misparsed.
+fn parse_legend_rule_exemption(tp: &TextPair<'_>, text: &str) -> Option<StaticDefinition> {
+    let rest = nom_tag_tp(tp, "the \"legend rule\" doesn't apply")?;
+
+    // Global form: nothing (or just the sentence terminator) follows.
+    if rest.lower.trim().trim_end_matches('.').trim().is_empty() {
+        return Some(
+            StaticDefinition::new(StaticMode::LegendRuleDoesntApply).description(text.to_string()),
+        );
+    }
+
+    // Scoped form: "... to <scope> you control."
+    let scope = nom_tag_tp(&rest, " to ")?;
+    let affected = parse_legend_rule_scope(&scope)?;
+    Some(
+        StaticDefinition::new(StaticMode::LegendRuleDoesntApply)
+            .affected(affected)
+            .description(text.to_string()),
+    )
+}
+
+/// CR 704.5j: Resolve the `<scope>` noun phrase of a legend-rule exemption
+/// ("permanents you control", "Slivers you control", ...) into a
+/// controller-scoped `affected` filter. Returns `None` for scopes this parser
+/// cannot resolve precisely ("tokens", "commanders", "creature tokens", "them"),
+/// so those cards are deferred rather than given a filter that silently matches
+/// nothing.
+/// CR 109.5: "you control" resolves to the source's controller.
+fn parse_legend_rule_scope(scope: &TextPair<'_>) -> Option<TargetFilter> {
+    // Drop the trailing sentence terminator so the combinator suffix split sees
+    // a clean "<descriptor> you control" phrase. allow-noncombinator: punctuation
+    // cleanup on a pre-tokenized chunk, not parsing dispatch.
+    let lower = scope.lower.trim_end().trim_end_matches('.').trim_end();
+    let cleaned = TextPair::new(&scope.original[..lower.len()], lower);
+    let base = parse_subject_suffix(&cleaned, " you control")?;
+
+    // "permanents you control" — every permanent the controller controls
+    // (Sakashima of a Thousand Faces, Mirror Box).
+    if base.lower == "permanents" {
+        return Some(TargetFilter::Typed(
+            TypedFilter::permanent().controller(ControllerRef::You),
+        ));
+    }
+
+    // "<Subtype>s you control" — permanents of a single subtype (Sliver
+    // Gravemother, Spider-Verse). Require the subtype to consume the whole base
+    // so multi-word scopes ("creature tokens") are deferred, not truncated.
+    if let Some((canonical, consumed)) = parse_subtype(base.original) {
+        if consumed == base.original.len() {
+            return Some(TargetFilter::Typed(
+                TypedFilter::permanent()
+                    .subtype(canonical)
+                    .controller(ControllerRef::You),
+            ));
+        }
+    }
+
+    None
 }
 
 /// Determine player scope for "can't [verb]" patterns based on subject phrasing.
@@ -14447,6 +14527,81 @@ mod tests {
         let def = parse_static_line("Darksteel Myr must be blocked if able.").unwrap();
         assert_eq!(def.mode, StaticMode::MustBeBlocked);
         assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    }
+
+    #[test]
+    fn static_legend_rule_global_exemption() {
+        // CR 704.5j: Mirror Gallery — "The legend rule doesn't apply." (global).
+        let def = parse_static_line("The \"legend rule\" doesn't apply.").unwrap();
+        assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+        assert_eq!(def.affected, None);
+    }
+
+    #[test]
+    fn static_legend_rule_permanents_you_control() {
+        // CR 704.5j: Sakashima of a Thousand Faces / Mirror Box — controller scope.
+        let def = parse_static_line("The \"legend rule\" doesn't apply to permanents you control.")
+            .unwrap();
+        assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+        assert!(matches!(
+            def.affected,
+            Some(TargetFilter::Typed(TypedFilter {
+                controller: Some(ControllerRef::You),
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn static_legend_rule_subtype_scope() {
+        // CR 704.5j: Sliver Gravemother — "doesn't apply to Slivers you control."
+        let def =
+            parse_static_line("The \"legend rule\" doesn't apply to Slivers you control.").unwrap();
+        assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+        match def.affected {
+            Some(TargetFilter::Typed(ref typed)) => {
+                assert_eq!(typed.controller, Some(ControllerRef::You));
+                assert!(typed.type_filters.iter().any(|t| matches!(
+                    t,
+                    crate::types::ability::TypeFilter::Subtype(s) if s == "Sliver"
+                )));
+            }
+            other => panic!("expected typed subtype filter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn static_legend_rule_routes_through_classifier() {
+        // The classifier must route exemption lines to the static parser.
+        assert!(crate::parser::oracle_classifier::is_static_pattern(
+            "the \"legend rule\" doesn't apply to permanents you control."
+        ));
+        assert!(crate::parser::oracle_classifier::is_static_pattern(
+            "the \"legend rule\" doesn't apply."
+        ));
+    }
+
+    #[test]
+    fn static_legend_rule_defers_unparseable_scopes() {
+        // CR 704.5j: scopes this parser cannot resolve precisely, and conditional
+        // forms, must NOT be emitted as a LegendRuleDoesntApply static — they are
+        // deferred (left Unimplemented), never misparsed into a no-op exemption.
+        for text in [
+            "The \"legend rule\" doesn't apply to tokens you control.", // Cadric
+            "The \"legend rule\" doesn't apply to commanders you control.", // Try-My-Deck Elemental
+            "If there are exactly two permanents named Brothers Yamazaki on the battlefield, the \"legend rule\" doesn't apply to them.",
+        ] {
+            assert!(
+                !matches!(
+                    parse_static_line(text),
+                    Some(StaticDefinition {
+                        mode: StaticMode::LegendRuleDoesntApply,
+                        ..
+                    })
+                ),
+                "scope must be deferred, not misparsed: {text}"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -797,6 +797,15 @@ pub enum StaticMode {
     CantWinTheGame,
     /// CR 104.3b: This player can't lose the game (Platinum Angel effect).
     CantLoseTheGame,
+    /// CR 704.5j: The "legend rule" doesn't apply to the affected permanents, so
+    /// they are excluded from the same-name legendary grouping in the legend-rule
+    /// SBA. Scope rides on `StaticDefinition::affected`: `None` = global (Mirror
+    /// Gallery, "the legend rule doesn't apply"); a controller-scoped filter =
+    /// "doesn't apply to [permanents/tokens/Slivers/commanders] you control"
+    /// (Sakashima of a Thousand Faces, Mirror Box, Cadric, Sliver Gravemother,
+    /// Try-My-Deck Elemental, ...). Enforced per-permanent in `sba.rs` via
+    /// `check_static_ability` with the candidate as the target object.
+    LegendRuleDoesntApply,
     /// Speed may increase beyond 4, and 4+ still counts as max speed for that player.
     SpeedCanIncreaseBeyondFour,
     /// CR 118.12a: Defiler cycle — "As an additional cost to cast [color] permanent
@@ -1145,6 +1154,7 @@ impl fmt::Display for StaticMode {
             }
             StaticMode::CantWinTheGame => write!(f, "CantWinTheGame"),
             StaticMode::CantLoseTheGame => write!(f, "CantLoseTheGame"),
+            StaticMode::LegendRuleDoesntApply => write!(f, "LegendRuleDoesntApply"),
             StaticMode::SpeedCanIncreaseBeyondFour => write!(f, "SpeedCanIncreaseBeyondFour"),
             StaticMode::DefilerCostReduction { color, .. } => {
                 write!(f, "DefilerCostReduction({color:?})")
@@ -1398,6 +1408,7 @@ impl FromStr for StaticMode {
             "MayPlayAdditionalLand" => StaticMode::MayPlayAdditionalLand,
             "CantWinTheGame" => StaticMode::CantWinTheGame,
             "CantLoseTheGame" => StaticMode::CantLoseTheGame,
+            "LegendRuleDoesntApply" => StaticMode::LegendRuleDoesntApply,
             "CanAttackWithDefender" => StaticMode::CanAttackWithDefender,
             // CR 509.1b + CR 609.4 + CR 702.14c: bare form = all-landwalk canceller.
             "IgnoreLandwalkForBlocking" => {


### PR DESCRIPTION
## Summary
- Adds `StaticMode::LegendRuleDoesntApply` (CR 704.5j) and gates the legend-rule state-based action on it, so a permanent that says *"the 'legend rule' doesn't apply…"* stops the rule from collapsing same-name legendaries.
- Fixes the reported card — **Sakashima of a Thousand Faces** — and the rest of the exemption class: **Mirror Gallery**, **Mirror Box**, **Sliver Gravemother**, **Spider-Verse**.

## Root Cause
The clause `The "legend rule" doesn't apply to permanents you control.` parsed to `Effect::Unimplemented`, and the legend-rule SBA (`check_legend_rule` in `crates/engine/src/game/sba.rs`) had no exemption check — so the rule fired against permanents it should ignore.

## Fix
- **Type:** new unit variant `StaticMode::LegendRuleDoesntApply` + `Display`/`FromStr` arms (Hash covered by the existing unit-variant catch-all).
- **SBA:** `check_legend_rule` now excludes any candidate legendary for which `check_static_ability(StaticMode::LegendRuleDoesntApply, { target_id: perm })` holds. Evaluating **per-permanent** (via the existing `static_filter_matches` → `matches_target_filter` path) means global (`affected: None`), controller-scoped (`you control`), and subtype-scoped (`Slivers you control`) sources all resolve correctly — a type-scoped source only exempts the permanents it actually covers.
- **Parser:** anchored branch in `parse_static_line` reusing `parse_subject_suffix` + `parse_subtype`. It returns `None` for scopes it can't resolve precisely ("tokens", "commanders", "creature tokens", "them"), so conditional/compound forms (Brothers Yamazaki, The Herald of Numot) are **deferred rather than misparsed** into a silent no-op exemption.
- **Registry, coverage matcher, and classifier** wired to the new variant.

## Build for the class, not the card
One variant + a per-permanent SBA gate covers every "legend rule doesn't apply" scope. The parser conservatively emits only scopes it can resolve precisely today (global, `permanents you control`, single subtype); the engine already supports the rest, so future scopes are additive parser work — never a misparse.

## Test Plan
- [x] 4 SBA regression tests: global exemption, controller-scope, opponent-not-exempt, type-scope granularity
- [x] 5 parser tests: global, `permanents you control`, subtype scope, classifier routing, deferral of unparseable scopes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p engine` — green (the 3 `db_load_path` tests were a stale pre-built export from the branch base; they pass against the regenerated `card-data.json`)
- [x] Card data regenerated → **Sakashima of a Thousand Faces** now reports **Supported** (coverage 29,887 → 29,900)

Closes #925

Before
<img width="966" height="709" alt="before" src="https://github.com/user-attachments/assets/a24656cd-4755-4d28-b924-a7893c21786c" />

After
<img width="1062" height="770" alt="after" src="https://github.com/user-attachments/assets/bdd823bb-ca9f-48af-80c8-c72148a3988b" />
