### PR TITLE
fix: address 7-day commit-review findings (cEDH AI, draft auth, phasing, imports, CR)

### DIFF
--- a/client/src-tauri/src/commands.rs
+++ b/client/src-tauri/src/commands.rs
@@ -190,14 +190,7 @@ pub fn get_ai_action(
     let guard = state.game.lock().map_err(|e| e.to_string())?;
     let game = guard.as_ref().ok_or("Game not initialized")?;
 
-    let ai_difficulty = match difficulty.as_str() {
-        "VeryEasy" => AiDifficulty::VeryEasy,
-        "Easy" => AiDifficulty::Easy,
-        "Medium" => AiDifficulty::Medium,
-        "Hard" => AiDifficulty::Hard,
-        "VeryHard" => AiDifficulty::VeryHard,
-        _ => AiDifficulty::Medium,
-    };
+    let ai_difficulty = AiDifficulty::from_label(&difficulty);
 
     let config =
         create_config_for_players(ai_difficulty, Platform::Native, game.players.len() as u8);

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1096,18 +1096,12 @@ pub fn resume_multiplayer_host_state(json_str: &str) -> Result<(), JsValue> {
 }
 
 /// Get the AI's chosen action for the current game state.
-/// `difficulty` is one of: "VeryEasy", "Easy", "Medium", "Hard", "VeryHard".
+/// `difficulty` is one of: "VeryEasy", "Easy", "Medium", "Hard", "VeryHard",
+/// "CEDH" (case-insensitive; see `AiDifficulty::from_label`).
 /// `player_id` is the seat index of the AI player (0-based).
 #[wasm_bindgen]
 pub fn get_ai_action(difficulty: &str, player_id: u8) -> Result<JsValue, JsValue> {
-    let ai_difficulty = match difficulty {
-        "VeryEasy" => AiDifficulty::VeryEasy,
-        "Easy" => AiDifficulty::Easy,
-        "Medium" => AiDifficulty::Medium,
-        "Hard" => AiDifficulty::Hard,
-        "VeryHard" => AiDifficulty::VeryHard,
-        _ => AiDifficulty::Medium,
-    };
+    let ai_difficulty = AiDifficulty::from_label(difficulty);
 
     with_state(|state| {
         let config =
@@ -1134,14 +1128,7 @@ pub fn get_ai_scored_candidates(
     player_id: u8,
     rng_seed: u64,
 ) -> Result<JsValue, JsValue> {
-    let ai_difficulty = match difficulty {
-        "VeryEasy" => AiDifficulty::VeryEasy,
-        "Easy" => AiDifficulty::Easy,
-        "Medium" => AiDifficulty::Medium,
-        "Hard" => AiDifficulty::Hard,
-        "VeryHard" => AiDifficulty::VeryHard,
-        _ => AiDifficulty::Medium,
-    };
+    let ai_difficulty = AiDifficulty::from_label(difficulty);
 
     with_state_mut(|state| {
         // Re-seed the state RNG so each parallel worker explores different
@@ -1167,14 +1154,7 @@ pub fn select_action_from_scores(
     difficulty: &str,
     rng_seed: u64,
 ) -> Result<JsValue, JsValue> {
-    let ai_difficulty = match difficulty {
-        "VeryEasy" => AiDifficulty::VeryEasy,
-        "Easy" => AiDifficulty::Easy,
-        "Medium" => AiDifficulty::Medium,
-        "Hard" => AiDifficulty::Hard,
-        "VeryHard" => AiDifficulty::VeryHard,
-        _ => AiDifficulty::Medium,
-    };
+    let ai_difficulty = AiDifficulty::from_label(difficulty);
     let config = phase_ai::config::create_config(ai_difficulty, Platform::Wasm);
     let scored: Vec<(GameAction, f64)> = serde_json::from_str(scores_json)
         .map_err(|e| JsValue::from_str(&format!("Failed to deserialize scores: {e}")))?;
@@ -1280,14 +1260,7 @@ pub fn resolve_all(
                 GameAction::PassPriority
             } else if let Some(seat) = ai_seats.iter().find(|s| PlayerId(s.player_id) == acting) {
                 // AI player — ask the AI what to do
-                let ai_difficulty = match seat.difficulty.as_str() {
-                    "VeryEasy" => AiDifficulty::VeryEasy,
-                    "Easy" => AiDifficulty::Easy,
-                    "Medium" => AiDifficulty::Medium,
-                    "Hard" => AiDifficulty::Hard,
-                    "VeryHard" => AiDifficulty::VeryHard,
-                    _ => AiDifficulty::Medium,
-                };
+                let ai_difficulty = AiDifficulty::from_label(&seat.difficulty);
                 let config = create_config_for_players(
                     ai_difficulty,
                     Platform::Wasm,

--- a/crates/engine/src/game/effects/cast_copy_of_card.rs
+++ b/crates/engine/src/game/effects/cast_copy_of_card.rs
@@ -179,6 +179,11 @@ fn cast_one_copy(
             ability: resolved,
             casting_variant: CastingVariant::Normal,
             // CR 118.9 + CR 601.2f: "Without paying its mana cost" is an alternative cost.
+            // DEFERRED: the parsed `Effect::CastCopyOfCard.cost` is intentionally
+            // ignored here. Every card in this class today is a free recast, so
+            // the parser only ever emits `ManaCost::zero()`; the copy is cast for
+            // free (`actual_mana_spent: 0`). A future "cast a copy and pay {cost}"
+            // card must thread that alt-cost into this stack entry at this site.
             actual_mana_spent: 0,
         },
     });

--- a/crates/engine/src/game/effects/exchange_life.rs
+++ b/crates/engine/src/game/effects/exchange_life.rs
@@ -7,19 +7,20 @@ use crate::types::ability::{
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 
-/// CR 701.12a: Exchange a player's life total with the source permanent's power
+/// CR 701.12g: Exchange a player's life total with the source permanent's power
 /// or toughness (Tree of Perdition, Tree of Redemption, Evra, Halcyon Witness).
 ///
-/// CR 701.12a requires both previous values to be read before either changes
-/// and makes the exchange all-or-nothing: if the life change is forbidden
-/// (CR 119.7 can't-gain when raising, CR 119.8 can't-lose when lowering), no
-/// part of the exchange occurs. Both writes use the captured previous values,
-/// so their order is irrelevant.
+/// CR 701.12g: each value becomes equal to the previous value of the other, so
+/// both previous values must be read before either changes. When a life total
+/// is involved the player gains or loses the amount of life necessary to reach
+/// the other value (it is a gain/loss, not a set), and the exchange is
+/// all-or-nothing: if the life change is forbidden (CR 119.7 can't-gain when
+/// raising, CR 119.8 can't-lose when lowering), no part of the exchange occurs.
 ///
 /// The stat side becomes an indefinite layer-7b continuous "set" effect
 /// (CR 613.4b) on the source: its base power/toughness is set to the player's
-/// previous life total, so counters (layer 7d) and +N/+N modifiers (layer 7c)
-/// still apply on top per the card's rulings.
+/// previous life total, so counters and +N/+N modifiers (both CR 613.4c) still
+/// apply on top per the card's rulings.
 pub fn resolve(
     state: &mut GameState,
     ability: &ResolvedAbility,
@@ -74,9 +75,9 @@ pub fn resolve(
         .ok_or(EffectError::PlayerNotFound)?
         .life;
 
-    // CR 701.12a + CR 119.7 / CR 119.8: All-or-nothing. The player's life total
-    // would be set to `stat_value` (CR 119.5). If that change is forbidden, no
-    // part of the exchange occurs.
+    // CR 701.12g + CR 119.7 / CR 119.8: All-or-nothing. The player would gain or
+    // lose life to reach `stat_value`. If that change is forbidden (can't-gain
+    // when raising, can't-lose when lowering), no part of the exchange occurs.
     let life_blocked = match stat_value.cmp(&old_life) {
         std::cmp::Ordering::Greater => player_has_cant_gain_life(state, player_id),
         std::cmp::Ordering::Less => player_has_cant_lose_life(state, player_id),
@@ -107,9 +108,9 @@ pub fn resolve(
         None,
     );
 
-    // CR 119.5: Set the player's life total to the stat's previous value by
-    // gaining or losing the difference. The helpers re-check CR 119.7/119.8 and
-    // route through the replacement pipeline.
+    // CR 701.12g: the player gains or loses the difference to reach the stat's
+    // previous value (a gain/loss, not a set). The helpers re-check CR
+    // 119.7/119.8 and route through the replacement pipeline.
     let diff = stat_value - old_life;
     let deferred = match diff.signum() {
         1 => apply_life_gain(state, player_id, diff as u32, events).err(),

--- a/crates/engine/src/game/effects/prepare.rs
+++ b/crates/engine/src/game/effects/prepare.rs
@@ -198,6 +198,13 @@ fn synthesize_prepared_copy_object(
 ) -> Result<(ObjectId, crate::types::identifiers::CardId), String> {
     // CR 722.3c: As the player casts the prepared copy, synthesize a distinct
     // copy object of the prepare face in exile to feed through normal casting.
+    //
+    // DEFERRED (CR 722.3c): strictly, the copy is created in exile when the card
+    // becomes prepared, not at cast time. Materializing it here means exile-zone
+    // replacements/triggers (Containment Priest, Rest in Peace, Leyline of the
+    // Void) cannot observe the prepared copy before it is cast. No current card
+    // depends on that interaction; wiring prepare-time materialization is the
+    // remaining work to make this fully rules-correct.
     let (src_clone, card_id) = {
         let Some(src_obj) = state.objects.get(&source_id) else {
             return Err(format!("source {source_id:?} not found"));

--- a/crates/engine/src/game/phasing.rs
+++ b/crates/engine/src/game/phasing.rs
@@ -439,6 +439,45 @@ mod tests {
     }
 
     #[test]
+    fn phased_out_permanent_is_excluded_from_trigger_candidates() {
+        // CR 702.26b: a phased-out permanent is treated as though it doesn't
+        // exist and must not be offered as a trigger candidate. The index does
+        // not track phase status, so `candidates_for_event` filters it; this
+        // test would fail before that filter was added.
+        use crate::game::trigger_index::candidates_for_event;
+
+        let mut state = GameState::new_two_player(42);
+        let phased = setup_creature(&mut state, "Breezekeeper", PlayerId(0));
+        let live = setup_creature(&mut state, "Bear", PlayerId(0));
+        // Register both as catch-all trigger sources (consulted on every event).
+        state.trigger_index.unclassified.push(phased);
+        state.trigger_index.unclassified.push(live);
+
+        let event = GameEvent::PermanentPhasedOut {
+            object_id: live,
+            indirect: false,
+        };
+
+        // Positive control: both are candidates while phased in.
+        let before = candidates_for_event(&state, &event);
+        assert!(before.contains(&phased));
+        assert!(before.contains(&live));
+
+        let mut events = Vec::new();
+        phase_out_object(&mut state, phased, PhaseOutCause::Directly, &mut events);
+
+        let after = candidates_for_event(&state, &event);
+        assert!(
+            !after.contains(&phased),
+            "phased-out permanent must not be a trigger candidate (CR 702.26b)"
+        );
+        assert!(
+            after.contains(&live),
+            "phased-in permanent must remain a trigger candidate"
+        );
+    }
+
+    #[test]
     fn untap_step_phasing_toggles_phasing_keyword_permanents() {
         let mut state = GameState::new_two_player(42);
         state.active_player = PlayerId(0);

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -893,6 +893,13 @@ pub fn candidates_for_event(state: &GameState, event: &GameEvent) -> SmallVec<[O
             out.extend(bucket.iter().copied());
         }
     }
+    // CR 702.26b: a phased-out permanent is treated as though it doesn't exist,
+    // so it never triggers. The legacy battlefield scan dropped these via
+    // `battlefield_phased_in_ids`; the index does not track phase status
+    // (phasing is not a zone change and does not touch the trigger index), so
+    // the filter must be reapplied here. Unknown ids are kept defensively and
+    // handled by the caller's per-candidate lookup.
+    out.retain(|id| state.objects.get(id).is_none_or(|obj| !obj.is_phased_out()));
     out.sort_unstable_by_key(|id| id.0);
     out.dedup();
     out

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1447,7 +1447,7 @@ pub(super) fn match_taps(
             if !valid_card_matches(trigger, state, *object_id, source_id) {
                 return false;
             }
-            // CR 701.21: "you tap an untapped creature an opponent controls" requires
+            // CR 701.26: "you tap an untapped creature an opponent controls" requires
             // an external cause. Only apply caused_by gating when the trigger explicitly
             // filters for opponent-controlled objects.
             let requires_opponent = matches!(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -2043,15 +2043,17 @@ fn try_parse_create_token_choice(
     }))
 }
 
-/// CR 115.1 + CR 608.2d + CR 701.26a-b: "tap or untap target <object>"
-/// declares a single target as the trigger/spell is put on the stack, then the
-/// controller chooses the tap or untap instruction while resolving.
+/// CR 115.1 + CR 608.2d + CR 701.26a-b: "tap or untap target <object>" (and the
+/// "untap or tap" ordering) declares a single target as the trigger/spell is put
+/// on the stack, then the controller chooses the tap or untap instruction while
+/// resolving. The choice is order-independent, so both verb orderings map to the
+/// same `ChooseOneOf`.
 fn try_parse_tap_or_untap_choice(
     tp: TextPair<'_>,
     ctx: &mut ParseContext,
 ) -> Option<ParsedEffectClause> {
     let ((), rest) = nom_on_lower(tp.original, tp.lower, |i| {
-        value((), tag("tap or untap ")).parse(i)
+        value((), alt((tag("tap or untap "), tag("untap or tap ")))).parse(i)
     })?;
     let (target_text, multi_target) = strip_optional_target_prefix(rest.trim_start());
     let (target, _rem) = parse_target_with_ctx(target_text, ctx);
@@ -2132,8 +2134,8 @@ fn try_parse_put_counter_choice(
     let right_text = format!("put {right_choice} on {target_text}");
 
     let diagnostics_snapshot = ctx.diagnostics.len();
-    let left_clause = parse_effect_clause(&left_text, ctx);
-    let right_clause = parse_effect_clause(&right_text, ctx);
+    let mut left_clause = parse_effect_clause(&left_text, ctx);
+    let mut right_clause = parse_effect_clause(&right_text, ctx);
 
     if !matches!(left_clause.effect, Effect::PutCounter { .. })
         || !matches!(right_clause.effect, Effect::PutCounter { .. })
@@ -2146,15 +2148,56 @@ fn try_parse_put_counter_choice(
         return None;
     }
 
-    let mut left_def = ability_definition_from_clause(AbilityKind::Spell, left_clause);
-    left_def.description = Some(left_text);
-    let mut right_def = ability_definition_from_clause(AbilityKind::Spell, right_clause);
-    right_def.description = Some(right_text);
+    // CR 601.2c: the trailing "on <target>" is a single shared cast-time target
+    // for the whole choice — the player chooses one artifact, then chooses which
+    // counter(s) to put on it. Both branches parsed it identically; lift it to a
+    // parent `TargetOnly` clause (mirrors `try_parse_tap_or_untap_choice`) and
+    // retarget each branch to `ParentTarget`. This surfaces one shared target
+    // slot at cast time, instead of two per-branch targets that
+    // `collect_target_slot_specs` never descends into from inside `ChooseOneOf`.
+    let Effect::PutCounter {
+        target: shared_target,
+        ..
+    } = &left_clause.effect
+    else {
+        ctx.diagnostics.truncate(diagnostics_snapshot);
+        return None;
+    };
+    let shared_target = shared_target.clone();
+    let shared_multi_target = left_clause.multi_target.take();
+    right_clause.multi_target = None;
+    retarget_put_counter_to_parent(&mut left_clause.effect);
+    retarget_put_counter_to_parent(&mut right_clause.effect);
 
-    Some(parsed_clause(Effect::ChooseOneOf {
-        chooser: PlayerFilter::Controller,
-        branches: vec![left_def, right_def],
-    }))
+    let mut left_def = ability_definition_from_clause(AbilityKind::Spell, left_clause);
+    left_def.description = Some(format!("put {left_choice}"));
+    let mut right_def = ability_definition_from_clause(AbilityKind::Spell, right_clause);
+    right_def.description = Some(format!("put {right_choice}"));
+
+    let mut choice = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChooseOneOf {
+            chooser: PlayerFilter::Controller,
+            branches: vec![left_def, right_def],
+        },
+    );
+    choice.description = Some("put your choice of counter".to_string());
+
+    let mut clause = parsed_clause(Effect::TargetOnly {
+        target: shared_target,
+    });
+    clause.multi_target = shared_multi_target;
+    clause.sub_ability = Some(Box::new(choice));
+    Some(clause)
+}
+
+/// Rewrite a `PutCounter` effect to act on the parent clause's target
+/// (`TargetFilter::ParentTarget`), preserving `counter_type` and `count`.
+/// Used when a shared cast-time target is lifted out of a `ChooseOneOf`.
+fn retarget_put_counter_to_parent(effect: &mut Effect) {
+    if let Effect::PutCounter { target, .. } = effect {
+        *target = TargetFilter::ParentTarget;
+    }
 }
 
 /// CR 700.2 + CR 608.2d: Detect inline binary-choice imperatives of the form
@@ -24264,6 +24307,26 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn shared_target_untap_or_tap_reversed_ordering_parses() {
+        // The reversed verb ordering maps to the same shared-target choice; the
+        // generic "A or B" splitter must not swallow the second instruction.
+        let def = parse_effect_chain("Untap or tap target permanent", AbilityKind::Spell);
+        assert!(
+            matches!(&*def.effect, Effect::TargetOnly { .. }),
+            "expected TargetOnly head, got {:?}",
+            def.effect
+        );
+        let choice = def
+            .sub_ability
+            .as_deref()
+            .expect("untap-or-tap must chain a resolution choice");
+        let Effect::ChooseOneOf { branches, .. } = &*choice.effect else {
+            panic!("expected ChooseOneOf sub-ability, got {:?}", choice.effect);
+        };
+        assert_eq!(branches.len(), 2);
+    }
+
     /// Issue #501 FOLLOW-UP — ROOT CAUSE A building-block test. A "gains
     /// suspend" continuous keyword grant carries `Duration::Permanent` (CR
     /// 702.62b + CR 611.2a): the suspend mechanic owns the card's lifetime, so
@@ -36355,8 +36418,26 @@ mod tests {
             AbilityKind::Spell,
         );
 
-        let Effect::ChooseOneOf { chooser, branches } = &*ability.effect else {
-            panic!("expected ChooseOneOf, got {:?}", ability.effect);
+        // The shared "on up to one other target artifact" is a single cast-time
+        // target lifted to a `TargetOnly` head; the up-to-one cap lives on the
+        // head, and the counter choice is the chained sub-ability whose branches
+        // act on `ParentTarget`.
+        assert!(
+            matches!(&*ability.effect, Effect::TargetOnly { .. }),
+            "expected TargetOnly head, got {:?}",
+            ability.effect
+        );
+        assert!(
+            ability.multi_target.is_some(),
+            "shared target should preserve the up-to-one cap on the head"
+        );
+
+        let choice = ability
+            .sub_ability
+            .as_deref()
+            .expect("counter choice must be chained as a sub-ability");
+        let Effect::ChooseOneOf { chooser, branches } = &*choice.effect else {
+            panic!("expected ChooseOneOf sub-ability, got {:?}", choice.effect);
         };
         assert_eq!(*chooser, PlayerFilter::Controller);
         assert_eq!(branches.len(), 2);
@@ -36365,33 +36446,27 @@ mod tests {
             Effect::PutCounter {
                 counter_type,
                 count,
-                ..
+                target,
             } => {
                 assert_eq!(*counter_type, CounterType::Plus1Plus1);
                 assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                assert_eq!(*target, TargetFilter::ParentTarget);
             }
             other => panic!("expected first branch PutCounter, got {other:?}"),
         }
-        assert!(
-            branches[0].multi_target.is_some(),
-            "first branch should preserve up-to target cap"
-        );
 
         match &*branches[1].effect {
             Effect::PutCounter {
                 counter_type,
                 count,
-                ..
+                target,
             } => {
                 assert_eq!(*counter_type, CounterType::Generic("charge".to_string()));
                 assert_eq!(*count, QuantityExpr::Fixed { value: 2 });
+                assert_eq!(*target, TargetFilter::ParentTarget);
             }
             other => panic!("expected second branch PutCounter, got {other:?}"),
         }
-        assert!(
-            branches[1].multi_target.is_some(),
-            "second branch should preserve up-to target cap"
-        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -5428,13 +5428,13 @@ fn try_parse_event(
             // CR 120.2: Plural form for batched "are dealt damage" triggers.
             value(SimpleEvent::DealtDamage, tag("are dealt damage")),
             value(SimpleEvent::BecomesTapped, tag("becomes tapped")),
-            // CR 701.21: Plural form for batched "one or more ... become tapped" triggers.
+            // CR 701.26: Plural form for batched "one or more ... become tapped" triggers.
             value(SimpleEvent::BecomesTapped, tag("become tapped")),
             value(SimpleEvent::TappedForMana, tag("is tapped for mana")),
         ))
         .or(alt((
             value(SimpleEvent::BecomesUntapped, tag("becomes untapped")),
-            // CR 701.21: Plural form for batched "one or more ... become untapped" triggers.
+            // CR 701.26: Plural form for batched "one or more ... become untapped" triggers.
             value(SimpleEvent::BecomesUntapped, tag("become untapped")),
             value(SimpleEvent::BecomesUntapped, tag("untaps")),
             value(SimpleEvent::TurnFaceUp, tag("is turned face up")),
@@ -7539,7 +7539,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         return Some((TriggerMode::Drawn, def));
     }
 
-    // CR 701.21: "you tap an untapped creature an opponent controls"
+    // CR 701.26: "you tap an untapped creature an opponent controls"
     for prefix in [
         "whenever you tap an untapped creature an opponent controls",
         "when you tap an untapped creature an opponent controls",
@@ -12997,7 +12997,7 @@ mod tests {
         assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
     }
 
-    /// CR 701.21 + CR 603.2c: Batched plural form "become tapped" for
+    /// CR 701.26 + CR 603.2c: Batched plural form "become tapped" for
     /// "Whenever one or more nontoken Merfolk you control become tapped" —
     /// Deeproot Pilgrimage.
     #[test]

--- a/crates/phase-ai/src/bin/ai_duel.rs
+++ b/crates/phase-ai/src/bin/ai_duel.rs
@@ -320,18 +320,8 @@ fn validate_deck(payload: &PlayerDeckPayload, expected: usize, label: &str) {
 }
 
 fn parse_difficulty(s: &str) -> AiDifficulty {
-    match s.to_lowercase().as_str() {
-        "veryeasy" => AiDifficulty::VeryEasy,
-        "easy" => AiDifficulty::Easy,
-        "medium" => AiDifficulty::Medium,
-        "hard" => AiDifficulty::Hard,
-        "veryhard" => AiDifficulty::VeryHard,
-        "cedh" => AiDifficulty::CEDH,
-        _ => {
-            eprintln!("Unknown difficulty '{s}', using Medium");
-            AiDifficulty::Medium
-        }
-    }
+    // Single authority for the label → enum mapping lives on `AiDifficulty`.
+    AiDifficulty::from_label(s)
 }
 
 fn print_usage() {

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -44,6 +44,28 @@ pub enum AiDifficulty {
     CEDH,
 }
 
+impl AiDifficulty {
+    /// Parse a difficulty label supplied by a transport boundary (WASM bridge,
+    /// Tauri IPC, CLI). Case-insensitive; unknown labels fall back to `Medium`.
+    ///
+    /// This is the single authority for the label → enum mapping. The frontend
+    /// sends one label per AI seat and uses `"CEDH"` for competitive Commander
+    /// games, so this MUST include the `cedh` arm — every transport that maps a
+    /// difficulty string routes through here precisely so a missing arm can't
+    /// silently downgrade a preset (cEDH previously fell through to `Medium`).
+    pub fn from_label(label: &str) -> AiDifficulty {
+        match label.to_lowercase().as_str() {
+            "veryeasy" => AiDifficulty::VeryEasy,
+            "easy" => AiDifficulty::Easy,
+            "medium" => AiDifficulty::Medium,
+            "hard" => AiDifficulty::Hard,
+            "veryhard" => AiDifficulty::VeryHard,
+            "cedh" => AiDifficulty::CEDH,
+            _ => AiDifficulty::Medium,
+        }
+    }
+}
+
 /// Platform the AI runs on (affects budget constraints).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Platform {
@@ -783,6 +805,31 @@ mod tests {
             let parsed: AiDifficulty = serde_json::from_str(&json).unwrap();
             assert_eq!(diff, parsed);
         }
+    }
+
+    #[test]
+    fn from_label_maps_every_difficulty_including_cedh() {
+        // The transport layers (WASM, Tauri, CLI) all route difficulty strings
+        // through this one mapping; a missing arm silently downgrades a preset.
+        assert_eq!(AiDifficulty::from_label("VeryEasy"), AiDifficulty::VeryEasy);
+        assert_eq!(AiDifficulty::from_label("Easy"), AiDifficulty::Easy);
+        assert_eq!(AiDifficulty::from_label("Medium"), AiDifficulty::Medium);
+        assert_eq!(AiDifficulty::from_label("Hard"), AiDifficulty::Hard);
+        assert_eq!(AiDifficulty::from_label("VeryHard"), AiDifficulty::VeryHard);
+        // The cEDH bug: "CEDH" must not fall through to Medium.
+        assert_eq!(AiDifficulty::from_label("CEDH"), AiDifficulty::CEDH);
+        // Case-insensitive (matches the lobby's case-insensitive "cedh" checks).
+        assert_eq!(AiDifficulty::from_label("cedh"), AiDifficulty::CEDH);
+        assert_eq!(AiDifficulty::from_label("cEDH"), AiDifficulty::CEDH);
+        // The CEDH preset actually engages, not the Medium fallback.
+        assert_eq!(
+            create_config(AiDifficulty::from_label("CEDH"), Platform::Native)
+                .search
+                .max_nodes,
+            96
+        );
+        // Unknown labels fall back to Medium.
+        assert_eq!(AiDifficulty::from_label("nonsense"), AiDifficulty::Medium);
     }
 
     #[test]

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -54,7 +54,9 @@ impl AiDifficulty {
     /// difficulty string routes through here precisely so a missing arm can't
     /// silently downgrade a preset (cEDH previously fell through to `Medium`).
     pub fn from_label(label: &str) -> AiDifficulty {
-        match label.to_lowercase().as_str() {
+        // Trim first: transport boundaries (config files, CLI args via ai_duel)
+        // may carry surrounding whitespace.
+        match label.trim().to_lowercase().as_str() {
             "veryeasy" => AiDifficulty::VeryEasy,
             "easy" => AiDifficulty::Easy,
             "medium" => AiDifficulty::Medium,
@@ -821,6 +823,8 @@ mod tests {
         // Case-insensitive (matches the lobby's case-insensitive "cedh" checks).
         assert_eq!(AiDifficulty::from_label("cedh"), AiDifficulty::CEDH);
         assert_eq!(AiDifficulty::from_label("cEDH"), AiDifficulty::CEDH);
+        // Surrounding whitespace from transport/config boundaries is trimmed.
+        assert_eq!(AiDifficulty::from_label("  CEDH  "), AiDifficulty::CEDH);
         // The CEDH preset actually engages, not the Medium fallback.
         assert_eq!(
             create_config(AiDifficulty::from_label("CEDH"), Platform::Native)

--- a/crates/server-core/src/draft_session.rs
+++ b/crates/server-core/src/draft_session.rs
@@ -244,9 +244,18 @@ impl DraftSessionManager {
             .get_mut(draft_code)
             .ok_or_else(|| format!("Draft not found: {}", draft_code))?;
 
-        let _seat = session
+        let seat = session
             .seat_for_token(token)
             .ok_or_else(|| "Invalid player token".to_string())?;
+
+        // The WebSocket wire surface is untrusted: the client supplies the
+        // action's `seat` field, but the only authority for "who is acting" is
+        // the token → seat mapping resolved above. Bind seat-scoped actions to
+        // that seat and gate table-authority actions to the host (seat 0).
+        // `apply_system_action` deliberately bypasses this for trusted
+        // server-internal actions (auto-pick on timer expiry, GameOver
+        // auto-report), so bot/auto picks are unaffected.
+        let action = authorize_client_draft_action(seat, action)?;
 
         let _deltas = draft_core::session::apply(&mut session.session, action, pack_source)
             .map_err(|e| {
@@ -460,6 +469,52 @@ pub fn draft_grace_period(status: &DraftStatus) -> Duration {
         DraftStatus::Paused => Duration::from_secs(600),
         DraftStatus::Pairing => Duration::from_secs(600),
         DraftStatus::Complete | DraftStatus::Abandoned => Duration::from_secs(60),
+    }
+}
+
+/// The draft host occupies seat 0 (`create_draft` assigns the creator seat 0).
+const DRAFT_HOST_SEAT: usize = 0;
+
+/// Authorize a client-originated draft action against the authenticated seat.
+///
+/// The client controls the action's payload `seat`, but a player may only act
+/// for the seat their token maps to, and only the host may drive table-wide
+/// state. This is the single authority for that check; it runs in
+/// `handle_draft_action` (the client path) and is intentionally NOT applied by
+/// `apply_system_action` (trusted server-internal actions). The transport-layer
+/// `client_forbidden_draft_action_reason` in phase-server is a complementary
+/// earlier gate that blocks actions never permitted from any client.
+fn authorize_client_draft_action(seat: usize, action: DraftAction) -> Result<DraftAction, String> {
+    match action {
+        // Seat-scoped: overwrite the client-supplied seat with the authenticated
+        // seat so a player cannot pick from or submit a deck for another seat.
+        DraftAction::Pick {
+            card_instance_id, ..
+        } => Ok(DraftAction::Pick {
+            seat: seat as u8,
+            card_instance_id,
+        }),
+        DraftAction::SubmitDeck { main_deck, .. } => Ok(DraftAction::SubmitDeck {
+            seat: seat as u8,
+            main_deck,
+        }),
+        // Table authority: only the host may start the draft, advance rounds,
+        // generate pairings, report results, or replace a seat with a bot.
+        DraftAction::StartDraft
+        | DraftAction::AdvanceRound
+        | DraftAction::GeneratePairings { .. }
+        | DraftAction::ReportMatchResult { .. }
+        | DraftAction::ReplaceSeatWithBot { .. } => {
+            if seat == DRAFT_HOST_SEAT {
+                Ok(action)
+            } else {
+                Err("Only the draft host can perform this action".to_string())
+            }
+        }
+        // Server-internal only — never accepted from a client wire surface.
+        DraftAction::SetSeatConnected { .. } => {
+            Err("SetSeatConnected is server-internal".to_string())
+        }
     }
 }
 
@@ -732,5 +787,84 @@ mod tests {
             draft_grace_period(&DraftStatus::Complete),
             Duration::from_secs(60)
         );
+    }
+
+    #[test]
+    fn authorize_rebinds_pick_seat_to_authenticated_seat() {
+        // A non-host (seat 2) picks but spoofs seat 0's pack: the seat is
+        // overwritten with the authenticated seat, never the payload's value.
+        let action = authorize_client_draft_action(
+            2,
+            DraftAction::Pick {
+                seat: 0,
+                card_instance_id: "abc".to_string(),
+            },
+        )
+        .expect("seat-scoped action is allowed for any seat");
+        assert_eq!(
+            action,
+            DraftAction::Pick {
+                seat: 2,
+                card_instance_id: "abc".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn authorize_rebinds_submit_deck_seat() {
+        let action = authorize_client_draft_action(
+            3,
+            DraftAction::SubmitDeck {
+                seat: 0,
+                main_deck: vec!["x".to_string()],
+            },
+        )
+        .expect("submit deck is allowed for any seat");
+        assert_eq!(
+            action,
+            DraftAction::SubmitDeck {
+                seat: 3,
+                main_deck: vec!["x".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn authorize_rejects_host_actions_from_non_host() {
+        for action in [
+            DraftAction::StartDraft,
+            DraftAction::AdvanceRound,
+            DraftAction::ReportMatchResult {
+                match_id: "m".to_string(),
+                winner_seat: Some(1),
+            },
+            DraftAction::ReplaceSeatWithBot {
+                seat: 1,
+                name: None,
+            },
+        ] {
+            assert!(
+                authorize_client_draft_action(1, action).is_err(),
+                "non-host (seat 1) must not drive table-authority actions"
+            );
+        }
+    }
+
+    #[test]
+    fn authorize_allows_host_actions_from_host() {
+        assert!(authorize_client_draft_action(DRAFT_HOST_SEAT, DraftAction::StartDraft).is_ok());
+        assert!(authorize_client_draft_action(DRAFT_HOST_SEAT, DraftAction::AdvanceRound).is_ok());
+    }
+
+    #[test]
+    fn authorize_rejects_set_seat_connected_from_client() {
+        assert!(authorize_client_draft_action(
+            DRAFT_HOST_SEAT,
+            DraftAction::SetSeatConnected {
+                seat: 1,
+                connected: false,
+            },
+        )
+        .is_err());
     }
 }

--- a/lobby-worker/src/import-deck.ts
+++ b/lobby-worker/src/import-deck.ts
@@ -144,7 +144,10 @@ function asString(value: unknown): string | undefined {
 
 // ---------------------------------------------------------------------------
 // Moxfield — https://api2.moxfield.com/v2/decks/all/<publicId>
-// Boards are top-level maps of <id> -> { quantity, card: { name, set, cn } }.
+// Each board maps <id> -> { quantity, card: { name, set, cn } }. The v2 payload
+// nests boards under a top-level `boards` map, each board exposing its entries
+// under `.cards`; older/simplified shapes expose the board map at the top level.
+// `moxfieldBoard` reads whichever is present so an import survives either shape.
 // ---------------------------------------------------------------------------
 
 interface MoxfieldCard {
@@ -158,12 +161,29 @@ interface MoxfieldEntry {
   card?: MoxfieldCard;
 }
 
+interface MoxfieldBoard {
+  cards?: Record<string, MoxfieldEntry>;
+}
+
 interface MoxfieldDeck {
   name?: unknown;
+  boards?: Record<string, MoxfieldBoard>;
   mainboard?: Record<string, MoxfieldEntry>;
   sideboard?: Record<string, MoxfieldEntry>;
   commanders?: Record<string, MoxfieldEntry>;
   companions?: Record<string, MoxfieldEntry>;
+}
+
+// Resolve a board's entry map by key, accepting both the nested v2 shape
+// (`boards.<key>.cards`) and the flat top-level shape (`deck.<key>`).
+function moxfieldBoard(
+  deck: MoxfieldDeck,
+  key: "mainboard" | "sideboard" | "commanders" | "companions",
+): Record<string, MoxfieldEntry> | undefined {
+  const nested = deck.boards?.[key]?.cards;
+  if (nested && typeof nested === "object") return nested;
+  const top = deck[key];
+  return top && typeof top === "object" ? top : undefined;
 }
 
 function moxfieldBoardToCards(board: Record<string, MoxfieldEntry> | undefined): ImportCard[] {
@@ -183,14 +203,25 @@ function moxfieldBoardToCards(board: Record<string, MoxfieldEntry> | undefined):
   return cards;
 }
 
+// An import is only "empty" when no board produced any card. Guarding on just
+// main+commander wrongly rejected sideboard-only or companion-only imports.
+function sectionsEmpty(sections: DeckSections): boolean {
+  return (
+    sections.commander.length === 0 &&
+    sections.main.length === 0 &&
+    sections.sideboard.length === 0 &&
+    sections.companion.length === 0
+  );
+}
+
 function projectMoxfield(deck: MoxfieldDeck): { text: string; empty: boolean } {
   const sections: DeckSections = {
-    commander: moxfieldBoardToCards(deck.commanders),
-    main: moxfieldBoardToCards(deck.mainboard),
-    sideboard: moxfieldBoardToCards(deck.sideboard),
-    companion: moxfieldBoardToCards(deck.companions),
+    commander: moxfieldBoardToCards(moxfieldBoard(deck, "commanders")),
+    main: moxfieldBoardToCards(moxfieldBoard(deck, "mainboard")),
+    sideboard: moxfieldBoardToCards(moxfieldBoard(deck, "sideboard")),
+    companion: moxfieldBoardToCards(moxfieldBoard(deck, "companions")),
   };
-  if (sections.main.length === 0 && sections.commander.length === 0) {
+  if (sectionsEmpty(sections)) {
     return { text: "", empty: true };
   }
   return { text: buildDeckText(asString(deck.name), sections), empty: false };
@@ -277,7 +308,7 @@ function projectArchidekt(deck: ArchidektDeck): { text: string; empty: boolean }
     sections[bucket].push(card);
   }
 
-  if (sections.main.length === 0 && sections.commander.length === 0) {
+  if (sectionsEmpty(sections)) {
     return { text: "", empty: true };
   }
   return { text: buildDeckText(asString(deck.name), sections), empty: false };

--- a/lobby-worker/test/import-deck.test.mjs
+++ b/lobby-worker/test/import-deck.test.mjs
@@ -153,6 +153,38 @@ test("Moxfield: emits companion section last so deckParser doesn't misfile", asy
   assert.ok(text.indexOf("[Main]") < text.indexOf("[Companion]"));
 });
 
+test("Moxfield: projects v2 nested boards (boards.<key>.cards)", async () => {
+  // The v2 API nests boards under a top-level `boards` map with entries under
+  // `.cards`. Reading boards only at the top level silently 404s every import.
+  mockUpstream({
+    name: "Nested",
+    boards: {
+      commanders: { cards: { a: { quantity: 1, card: { name: "Krenko, Mob Boss" } } } },
+      mainboard: { cards: { b: { quantity: 1, card: { name: "Sol Ring" } } } },
+      sideboard: { cards: {} },
+      companions: { cards: {} },
+    },
+  });
+  const resp = await call("https://moxfield.com/decks/nested");
+  assert.equal(resp.status, 200);
+  const text = await resp.text();
+  assert.match(text, /\[Commander\]\n1 Krenko, Mob Boss/);
+  assert.match(text, /\[Main\]\n1 Sol Ring/);
+});
+
+test("Moxfield: sideboard-only deck is not rejected as empty", async () => {
+  mockUpstream({
+    name: "SB only",
+    mainboard: {},
+    commanders: {},
+    sideboard: { a: { quantity: 2, card: { name: "Negate" } } },
+  });
+  const resp = await call("https://moxfield.com/decks/sbonly");
+  assert.equal(resp.status, 200);
+  const text = await resp.text();
+  assert.match(text, /\[Sideboard\]\n2 Negate/);
+});
+
 test("Moxfield: empty deck (private/hidden) returns 404 not_found", async () => {
   mockUpstream({ name: "Hidden", mainboard: {}, commanders: {} });
   const resp = await call("https://moxfield.com/decks/zzz");


### PR DESCRIPTION
Resolves issues surfaced by a comprehensive review of the last 7 days of commits.

HIGH
- AI: the "CEDH" difficulty string was never mapped on any transport (WASM x3,
  Tauri) and fell through to Medium, so the cEDH search preset never ran at play
  time even though setup recognized the bracket. Add `AiDifficulty::from_label`
  as the single label->enum authority and route every transport through it;
  ai_duel now delegates to it too. (#816)
- engine: phased-out permanents could fire triggers. The trigger index has no
  phase awareness and phasing is not a zone change, so `candidates_for_event`
  now re-applies the CR 702.26b phased-in filter the legacy battlefield scan
  used. (#1291)
- server: the draft WebSocket surface trusted the client-supplied `seat`.
  `authorize_client_draft_action` rebinds Pick/SubmitDeck to the token's seat
  and gates StartDraft/AdvanceRound/ReportMatchResult/ReplaceSeatWithBot to the
  host (seat 0). Auto-pick uses `apply_system_action`, which bypasses this. (#1254)
- import: Moxfield v2 nests boards under `boards.<key>.cards`; the projector now
  reads both that and the flat top-level shape so imports don't silently 404.
  Sideboard/companion-only decks are no longer rejected as empty. (#1259)

MED
- engine: "put your choice of A or B counter on <target>" (Flagship Vessel)
  lifted the shared target into a TargetOnly head with the counter choice as a
  sub-ability acting on ParentTarget (mirrors tap-or-untap), so the artifact is
  a single shared cast-time target rather than two per-branch targets the slot
  collector never surfaced. (#1274)
- CR annotations: exchange_life 119.5 (set) -> 701.12g (gain/lose to reach the
  value) and sublayer "counters 7d / +N/+N 7c" -> both CR 613.4c; tap/untap
  plural and "tap an untapped creature" 701.21 (Sacrifice) -> 701.26 (Tap and
  Untap).
- cast_copy_of_card: document the deferred always-zero `cost` field at the cast
  site (all current copy-cast cards are free recasts).

LOW
- parser: accept the reversed "untap or tap target" ordering.
- prepare: restore the CR 722.3c prepare-time-materialization deferral note.

Tests: from_label mapping incl. CEDH; draft authorization (seat rebind + host
gate + reject server-internal); phased-out trigger-candidate exclusion; Flagship
Vessel shared-target shape; reversed untap-or-tap; Moxfield nested-boards and
sideboard-only imports.
