### PR TITLE
fix(scryfall): match JS toLowerCase for accented card-name image keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,6 +395,7 @@ If you cannot find the rule number in `docs/MagicCompRules.txt`, do NOT write th
 - Frontend uses Tailwind CSS v4, Framer Motion for animations
 - Tests colocated in `__tests__/` directories (frontend) or inline `#[cfg(test)]` modules (Rust)
 - The `release` profile is optimized for WASM size: `opt-level = 'z'`, LTO, single codegen unit, stripped
+- **jq lookup keys consumed by JS must use `js_downcase`, never `ascii_downcase`.** jq's `ascii_downcase` folds only `A–Z`, so an uppercase accented letter (e.g. `É` in Éomer/Éowyn) survives in the key, but the frontend resolves every lookup with JS `.toLowerCase()` which folds `É → é` — the keys silently never match and name-keyed image/data lookups return nothing. The `gen-scryfall-*.sh` scripts share a `js_downcase` jq helper (`scripts/lib/scryfall-fetch.sh`) that matches JS `toLowerCase()` for the Latin-1 accented range. Engine-keyed files (`card-data.json`) are unaffected — Rust `to_lowercase()` is already Unicode-aware. `ascii_downcase` stays correct only for ASCII-only keys (oracle ids, set codes, Scryfall UUIDs). Note: these Scryfall data files are gitignored and served from R2 in prod, so fixing the script requires regenerating and redeploying the data.
 
 ## Releasing
 

--- a/scripts/gen-scryfall-images.sh
+++ b/scripts/gen-scryfall-images.sh
@@ -68,7 +68,7 @@ mkdir -p "$(dirname "$OUTPUT")"
 # Scryfall API calls at runtime.
 NON_PLAYABLE='["token","double_faced_token","emblem","art_series","vanguard","scheme","planar","augment","host"]'
 
-jq -c --argjson exclude "$NON_PLAYABLE" '
+jq -c --argjson exclude "$NON_PLAYABLE" "$SCRYFALL_JQ_PRELUDE"'
   # Playable cards
   ([.[] |
     select(.layout as $l | $exclude | index($l) | not) |
@@ -76,9 +76,9 @@ jq -c --argjson exclude "$NON_PLAYABLE" '
     {
       oracle_id: $card.oracle_id,
       face_names: (if $card.card_faces then
-        [$card.card_faces[] | .name | ascii_downcase]
+        [$card.card_faces[] | .name | js_downcase]
       else
-        [$card.name | ascii_downcase]
+        [$card.name | js_downcase]
       end),
       faces: (if $card.card_faces then
         [$card.card_faces[] | {
@@ -99,9 +99,9 @@ jq -c --argjson exclude "$NON_PLAYABLE" '
     } as $entry |
     (
       [$card.oracle_id | ascii_downcase] +
-      [$card.name | ascii_downcase] +
+      [$card.name | js_downcase] +
       if $card.card_faces and ($card.card_faces[0].name != $card.name)
-      then [$card.card_faces[0].name | ascii_downcase]
+      then [$card.card_faces[0].name | js_downcase]
       else [] end
     ) | unique[] |
     {key: ., value: $entry}
@@ -113,7 +113,7 @@ jq -c --argjson exclude "$NON_PLAYABLE" '
     . as $tok |
     {
       oracle_id: $tok.oracle_id,
-      face_names: [$tok.name | ascii_downcase],
+      face_names: [$tok.name | js_downcase],
       faces: [{normal: $tok.image_uris.normal, art_crop: $tok.image_uris.art_crop}],
       layout: $tok.layout,
       name: $tok.name,
@@ -126,7 +126,7 @@ jq -c --argjson exclude "$NON_PLAYABLE" '
       power: ($tok.power // null),
       toughness: ($tok.toughness // null)
     } as $entry |
-    {key: ("token:" + ($tok.name | ascii_downcase)), value: $entry}
+    {key: ("token:" + ($tok.name | js_downcase)), value: $entry}
   ]) | from_entries
 ' "$ORACLE_FILE" > "$OUTPUT"
 

--- a/scripts/gen-scryfall-token-images.sh
+++ b/scripts/gen-scryfall-token-images.sh
@@ -25,7 +25,7 @@ fi
 echo "Generating $OUTPUT..."
 mkdir -p "$(dirname "$OUTPUT")"
 
-jq -c '
+jq -c "$SCRYFALL_JQ_PRELUDE"'
   [.[] |
     select(.layout == "token" or .layout == "double_faced_token") |
     select(.id != null) |
@@ -34,9 +34,9 @@ jq -c '
       scryfall_id: $card.id,
       oracle_id: $card.oracle_id,
       face_names: (if $card.card_faces then
-        [$card.card_faces[] | .name | ascii_downcase]
+        [$card.card_faces[] | .name | js_downcase]
       else
-        [$card.name | ascii_downcase]
+        [$card.name | js_downcase]
       end),
       faces: (if $card.card_faces then
         [$card.card_faces[] | {

--- a/scripts/lib/scryfall-fetch.sh
+++ b/scripts/lib/scryfall-fetch.sh
@@ -55,6 +55,28 @@ scryfall_download() {
   mv -f "$tmp" "$file"
 }
 
+# jq prelude shared by the gen-scryfall-*.sh transforms. Prepend it to a jq
+# program with shell string adjacency: jq -c "$SCRYFALL_JQ_PRELUDE"'<program>'.
+#
+# js_downcase replicates JavaScript's String.prototype.toLowerCase() for the
+# character set MTG card names use. jq's built-in ascii_downcase only folds A-Z
+# (it leaves every byte >= 0x80 untouched), so an accented capital like É
+# (U+00C9) survives as-is in the generated lookup keys. But the frontend
+# resolves every image by `name.toLowerCase()` / `faceName.toLowerCase()`, and
+# JS folds É -> é (U+00E9). The two byte strings never match, so name-keyed
+# image lookups for Éomer / Éowyn (and any card with an uppercase accented
+# letter) silently miss. js_downcase folds ASCII via ascii_downcase, then the
+# Latin-1 Supplement uppercase block (À..Þ = U+00C0..U+00DE, excluding the
+# × sign at U+00D7) by +0x20 — the complete set of accented capitals in MTG's
+# English card names, verified to match JS toLowerCase byte-for-byte.
+SCRYFALL_JQ_PRELUDE='
+def js_downcase:
+  ascii_downcase
+  | explode
+  | map(if . >= 192 and . <= 222 and . != 215 then . + 32 else . end)
+  | implode;
+'
+
 # scryfall_fetch_bulk TYPE FILE — resolve a bulk-data download_uri by type
 # (e.g. oracle_cards, default_cards) and download it to FILE.
 scryfall_fetch_bulk() {


### PR DESCRIPTION
jq's ascii_downcase folds only A-Z, so an uppercase accented letter
(e.g. É in Éomer/Éowyn) survives in the generated scryfall-data.json
lookup keys. The frontend resolves every image via JS .toLowerCase(),
which folds É → é, so the keys never match and name-keyed image lookups
return no art (battlefield objects with an ASCII oracle_id were immune).

Add a shared js_downcase jq helper (scripts/lib/scryfall-fetch.sh) that
matches JS toLowerCase for the Latin-1 accented range, and use it at
every name/face-name key site in the gen-scryfall-*.sh pipelines.
ASCII-only id keys (oracle ids, set codes, Scryfall UUIDs) keep
ascii_downcase. Engine-keyed card-data.json is unaffected (Rust
to_lowercase is already Unicode-aware).
