### PR TITLE
perf(engine): incremental public-state dirty marking (kill O(N²) per-action recompute)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1508,6 +1508,7 @@ export type GameEvent =
   | { type: "CardsRevealed"; data: { player: PlayerId; card_ids?: ObjectId[]; card_names: string[] } }
   | { type: "Regenerated"; data: { object_id: ObjectId } }
   | { type: "CreatureSuspected"; data: { object_id: ObjectId } }
+  | { type: "Detained"; data: { object_id: ObjectId } }
   | { type: "CaseSolved"; data: { object_id: ObjectId } }
   | { type: "ClassLevelGained"; data: { object_id: ObjectId; level: number } }
   | { type: "RingTemptsYou"; data: { player_id: PlayerId } }

--- a/crates/engine/src/game/derived.rs
+++ b/crates/engine/src/game/derived.rs
@@ -8,6 +8,7 @@ use crate::types::ability::StaticCondition;
 use crate::types::card_type::CoreType;
 use crate::types::game_state::GameState;
 use crate::types::statics::StaticMode;
+use crate::types::zones::Zone;
 
 /// Compute display-only derived fields (CR 302.6 summoning sickness, CR 700.5 devotion).
 ///
@@ -27,39 +28,84 @@ pub fn derive_display_state(state: &mut GameState) {
         dirty.dirty_objects.iter().copied().collect()
     };
     for id in object_ids {
-        let (unimplemented, summoning_sickness, mana_idx) = {
+        let (unimplemented, summoning_sickness) = {
             let Some(obj) = state.objects.get(&id) else {
                 continue;
             };
-            let mana_idx = obj
-                .abilities
-                .iter()
-                .enumerate()
-                .find(|(idx, ability)| {
-                    mana_abilities::is_mana_ability(ability)
-                        && mana_abilities::can_activate_mana_ability_now(
-                            state,
-                            obj.controller,
-                            obj.id,
-                            *idx,
-                            ability,
-                        )
-                })
-                .map(|(idx, _)| idx);
             (
                 unimplemented_mechanics(obj),
                 // CR 302.6: Creature must have been under controller's control since turn began to attack or {T}.
                 has_summoning_sickness(obj),
-                mana_idx,
             )
         };
 
         let obj = state.objects.get_mut(&id).expect("object exists");
         obj.unimplemented_mechanics = unimplemented;
         obj.has_summoning_sickness = summoning_sickness;
-        obj.has_mana_ability = mana_idx.is_some();
-        obj.mana_ability_index = mana_idx;
-        obj.available_mana_pips.clear();
+        // Mana availability is only meaningful for battlefield permanents
+        // (mana abilities are activated from the battlefield). For a dirty
+        // object NOT on the battlefield — e.g. a permanent that just left —
+        // reset its mana display fields here so a stale `has_mana_ability`
+        // does not linger; the active battlefield values are (re)computed by
+        // the board-wide mana sweep below. This is the cheap reset half; the
+        // expensive auto-tap simulation runs only in that sweep.
+        if obj.zone != Zone::Battlefield {
+            obj.has_mana_ability = false;
+            obj.mana_ability_index = None;
+            obj.available_mana_pips.clear();
+        }
+    }
+
+    // Mana availability (`has_mana_ability` / `mana_ability_index` /
+    // `available_mana_pips`) is BOARD-GLOBAL derived state, not per-object:
+    // `can_activate_mana_ability_now` runs an auto-tap payability simulation
+    // over the whole controller's pool and every untapped source, so one
+    // permanent's availability can flip when ANOTHER permanent taps, adds mana,
+    // or gains/loses a depletion counter. It must therefore be re-derived as a
+    // single battlefield-wide sweep gated on a mana-specific signal
+    // (`mana_display_dirty`), never per-`dirty_objects` — otherwise a land
+    // marked dirty by a non-mana event (Gemstone Mine depletion `CounterRemoved`,
+    // damage to a creature-land) or a pool/tap change that flips a sibling
+    // land's activatability leaves stale/blank mana display. The mana signal is
+    // mana-specific (not `battlefield_display_dirty`) so spawning a creature
+    // token never triggers this auto-tap sweep over every land.
+    if dirty.mana_display_dirty || dirty.all_objects_dirty {
+        let battlefield_ids: Vec<_> = state.battlefield.iter().copied().collect();
+        let mana_availability: Vec<(crate::types::identifiers::ObjectId, Option<usize>, _)> =
+            battlefield_ids
+                .into_iter()
+                .filter_map(|id| {
+                    let obj = state.objects.get(&id)?;
+                    let mana_idx = obj
+                        .abilities
+                        .iter()
+                        .enumerate()
+                        .find(|(idx, ability)| {
+                            mana_abilities::is_mana_ability(ability)
+                                && mana_abilities::can_activate_mana_ability_now(
+                                    state,
+                                    obj.controller,
+                                    obj.id,
+                                    *idx,
+                                    ability,
+                                )
+                        })
+                        .map(|(idx, _)| idx);
+                    let pips = if obj.card_types.core_types.contains(&CoreType::Land) {
+                        display_land_mana_pips(state, id, obj.controller)
+                    } else {
+                        Vec::new()
+                    };
+                    Some((id, mana_idx, pips))
+                })
+                .collect();
+        for (id, mana_idx, pips) in mana_availability {
+            if let Some(obj) = state.objects.get_mut(&id) {
+                obj.has_mana_ability = mana_idx.is_some();
+                obj.mana_ability_index = mana_idx;
+                obj.available_mana_pips = pips;
+            }
+        }
     }
 
     // Compute per-card devotion for cards with DevotionGE conditions
@@ -125,26 +171,10 @@ pub fn derive_display_state(state: &mut GameState) {
         }
     }
 
-    // Compute dynamic land frame pips from currently available mana options.
-    if dirty.all_objects_dirty || dirty.mana_display_dirty || dirty.battlefield_display_dirty {
-        let mana_pip_cards: Vec<_> = state
-            .battlefield
-            .iter()
-            .filter_map(|&id| {
-                let obj = state.objects.get(&id)?;
-                if !obj.card_types.core_types.contains(&CoreType::Land) {
-                    return None;
-                }
-                let pips = display_land_mana_pips(state, id, obj.controller);
-                Some((id, pips))
-            })
-            .collect();
-        for (id, pips) in mana_pip_cards {
-            if let Some(obj) = state.objects.get_mut(&id) {
-                obj.available_mana_pips = pips;
-            }
-        }
-    }
+    // (Dynamic land frame pips are computed together with `has_mana_ability` in
+    // the single battlefield-wide mana-availability sweep above, gated on
+    // `mana_display_dirty`, so the clear↔repopulate of `available_mana_pips`
+    // is atomic and never split across two differently-gated blocks.)
 
     // CR 903.4: Per-player commander color identity. Derived from
     // `commander_color_identity` (which inspects deck pools and command-zone

--- a/crates/engine/src/game/effects/detain.rs
+++ b/crates/engine/src/game/effects/detain.rs
@@ -27,6 +27,8 @@ pub fn resolve(
 
             // CR 701.35a: Mark the permanent as detained by the controller of this effect.
             obj.detained_by.insert(ability.controller);
+
+            events.push(GameEvent::Detained { object_id: *obj_id });
         }
     }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -38,7 +38,8 @@ use super::mulligan;
 use super::planeswalker;
 use super::priority;
 use super::public_state::{
-    bump_state_revision, finalize_public_state, mark_public_state_all_dirty, sync_waiting_for,
+    bump_state_revision, finalize_public_state, mark_public_state_all_dirty,
+    mark_public_state_from_events, sync_waiting_for,
 };
 use super::sba;
 use super::triggers;
@@ -148,11 +149,15 @@ pub fn apply(
     let mut result = apply_action(state, actor, action)?;
     reconcile_terminal_result(state, &mut result);
     bump_state_revision(state);
-    mark_public_state_all_dirty(state);
     sync_waiting_for(state, &result.waiting_for);
     run_auto_pass_loop(state, &mut result);
     reconcile_terminal_result(state, &mut result);
     remember_public_reveals(state, &result.events);
+    // Targeted public-state dirty marking over the full accumulated event set
+    // (the auto-pass loop appends events). `finalize_public_state` is the only
+    // consumer of `public_state_dirty`, so marking once here over the complete
+    // event stream is correct and cheapest.
+    mark_public_state_from_events(state, &result.events);
     finalize_public_state(state);
     result.log_entries = super::log::resolve_log_entries(&result.events, state);
     Ok(result)

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -147,6 +147,7 @@ fn categorize(event: &GameEvent) -> LogCategory {
         | GameEvent::TurnedFaceUp { .. }
         | GameEvent::Regenerated { .. }
         | GameEvent::CreatureSuspected { .. }
+        | GameEvent::Detained { .. }
         | GameEvent::BecamePrepared { .. }
         | GameEvent::BecameUnprepared { .. }
         | GameEvent::CaseSolved { .. }
@@ -639,6 +640,10 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
 
         GameEvent::CreatureSuspected { object_id } => {
             vec![card_seg(state, *object_id), text(" becomes suspected")]
+        }
+
+        GameEvent::Detained { object_id } => {
+            vec![card_seg(state, *object_id), text(" is detained")]
         }
 
         GameEvent::BecamePrepared { object_id } => {

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -1,6 +1,10 @@
+use crate::types::ability::TargetRef;
+use crate::types::card_type::CoreType;
+use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, PublicStateDirty, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
 
 use super::derived::derive_display_state;
 use super::layers::evaluate_layers;
@@ -57,6 +61,295 @@ pub fn mark_battlefield_display_dirty(state: &mut GameState) {
 
 pub fn mark_mana_display_dirty(state: &mut GameState) {
     state.public_state_dirty.mana_display_dirty = true;
+}
+
+/// Mark `object_id` dirty and, if it is a battlefield permanent whose mana
+/// availability can be displayed (a land, or any permanent with a mana
+/// ability), also raise the mana-display signal.
+///
+/// Mana availability (`has_mana_ability` / `mana_ability_index` /
+/// `available_mana_pips`) is BOARD-GLOBAL: a non-mana event on a mana source
+/// (Gemstone Mine depletion `CounterRemoved`, damage to a creature-land) can
+/// change its displayed mana state, and `derive_display_state` recomputes it
+/// only under the mana gate. Raising the mana signal HERE — and only for
+/// genuine mana sources — keeps a creature-token entry (no mana ability) from
+/// triggering the board-wide auto-tap sweep, preserving the token-storm hot
+/// path while fixing the under-mark for mana lands/dorks.
+fn mark_object_dirty_with_mana(state: &mut GameState, object_id: ObjectId) {
+    mark_public_state_object_dirty(state, object_id);
+    if let Some(obj) = state.objects.get(&object_id) {
+        if obj.zone == Zone::Battlefield
+            && (obj.card_types.core_types.contains(&CoreType::Land)
+                || obj
+                    .abilities
+                    .iter()
+                    .any(super::mana_abilities::is_mana_ability))
+        {
+            mark_mana_display_dirty(state);
+        }
+    }
+}
+
+/// Translate an action's emitted events into the minimal set of public-state
+/// dirty marks needed for `derive_display_state` / `evaluate_layers` to produce
+/// output IDENTICAL to a full all-dirty recompute.
+///
+/// CONSERVATIVE BY CONSTRUCTION: any event that could ripple board-wide via a
+/// continuous/static effect (CR 611.1, CR 613.1) escalates to all-dirty and
+/// returns. Under-marking is a correctness bug (stale displayed P/T, summoning
+/// sickness, mana availability); over-marking only costs time. When in doubt,
+/// all-dirty.
+///
+/// The `match` over `GameEvent` is intentionally wildcard-free: a future event
+/// variant must be classified here or the engine will not compile, preventing
+/// silent under-marking.
+pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]) {
+    // GATE 1 — static/continuous ripple.
+    // CR 611.1 + CR 613.1: A continuous effect can modify any object's
+    // characteristics across the whole board; if layers were re-evaluated this
+    // action (`layers_dirty`), display state for the entire board is potentially
+    // stale, so recompute all of it. This single check covers anthems,
+    // type-changers, keyword-granters, CDAs, control changes, P/T setters, and
+    // every transient continuous effect — they all set `layers_dirty`.
+    if state.layers_dirty {
+        mark_public_state_all_dirty(state);
+        return;
+    }
+
+    // GATE 2 — per-event targeted marking. `layers_dirty` was NOT set, so no
+    // continuous effect changed board-wide; only the objects/players named by
+    // these events can have stale display fields.
+    for event in events {
+        match event {
+            GameEvent::ZoneChanged {
+                object_id, to, from, ..
+            } => {
+                mark_object_dirty_with_mana(state, *object_id);
+                if *to == Zone::Battlefield || *from == Some(Zone::Battlefield) {
+                    mark_battlefield_display_dirty(state);
+                }
+                // A mana source leaving the battlefield changes the pool/tap
+                // simulation for the SIBLING lands that remain, so re-sweep mana
+                // availability. Gated on the leaving object's type (it is now off
+                // the battlefield, so `mark_object_dirty_with_mana`'s zone check
+                // cannot catch it) — a creature leaving never raises this, so the
+                // token-storm + sacrifice path is unaffected.
+                if *from == Some(Zone::Battlefield) {
+                    if let Some(obj) = state.objects.get(object_id) {
+                        if obj.card_types.core_types.contains(&CoreType::Land)
+                            || obj
+                                .abilities
+                                .iter()
+                                .any(super::mana_abilities::is_mana_ability)
+                        {
+                            mark_mana_display_dirty(state);
+                        }
+                    }
+                }
+            }
+            GameEvent::TokenCreated { object_id, .. }
+            | GameEvent::ObjectConjured { object_id, .. } => {
+                // Mana-aware: a creature token (Scute storm) does NOT raise the
+                // mana signal, so the board-wide auto-tap sweep is skipped; a
+                // Treasure/land token does raise it.
+                mark_object_dirty_with_mana(state, *object_id);
+                mark_battlefield_display_dirty(state);
+            }
+            GameEvent::PermanentTapped {
+                object_id,
+                caused_by,
+            } => {
+                mark_public_state_object_dirty(state, *object_id);
+                if let Some(cause) = caused_by {
+                    mark_public_state_object_dirty(state, *cause);
+                }
+                mark_mana_display_dirty(state);
+            }
+            GameEvent::PermanentUntapped { object_id } => {
+                mark_public_state_object_dirty(state, *object_id);
+                mark_mana_display_dirty(state);
+            }
+            GameEvent::ManaAdded { player_id, .. }
+            | GameEvent::ManaPoolEmptied { player_id, .. }
+            | GameEvent::ManaRecolored { player_id, .. } => {
+                mark_public_state_player_dirty(state, *player_id);
+                mark_mana_display_dirty(state);
+            }
+            GameEvent::TappedForMana {
+                player_id,
+                source_id,
+                ..
+            } => {
+                mark_public_state_player_dirty(state, *player_id);
+                mark_public_state_object_dirty(state, *source_id);
+                mark_mana_display_dirty(state);
+            }
+            GameEvent::ManaExpended { player_id, .. } => {
+                mark_public_state_player_dirty(state, *player_id);
+                mark_mana_display_dirty(state);
+            }
+            GameEvent::CounterAdded { object_id, .. }
+            | GameEvent::CounterRemoved { object_id, .. }
+            | GameEvent::Evolved { object_id } => {
+                // +1/+1 counters set `layers_dirty` (counters.rs) → Gate 1 caught
+                // them; this arm fires only for counters that did not touch
+                // layers. A depletion/charge counter on a mana land (Gemstone
+                // Mine) changes its displayed pips, so route through the
+                // mana-aware mark.
+                mark_object_dirty_with_mana(state, *object_id);
+            }
+            GameEvent::DamageDealt { target, .. } | GameEvent::DamagePrevented { target, .. } => {
+                match target {
+                    // A creature-land (Dryad Arbor, animated manland) taking
+                    // damage may change its displayed mana availability.
+                    TargetRef::Object(id) => mark_object_dirty_with_mana(state, *id),
+                    TargetRef::Player(id) => mark_public_state_player_dirty(state, *id),
+                }
+            }
+            GameEvent::DamageCleared { object_id } => {
+                mark_object_dirty_with_mana(state, *object_id);
+            }
+            GameEvent::Detained { object_id } => {
+                // CR 701.35a: Detaining a mana source makes its mana ability
+                // un-activatable (`can_activate_mana_ability_now` checks
+                // `detained_by`), so route through the mana-aware mark to raise
+                // the mana gate and flip the displayed `has_mana_ability`.
+                mark_object_dirty_with_mana(state, *object_id);
+            }
+            GameEvent::LifeChanged { player_id, .. } => {
+                mark_public_state_player_dirty(state, *player_id);
+            }
+            GameEvent::PlayerCounterChanged { player, .. }
+            | GameEvent::EnergyChanged { player, .. }
+            | GameEvent::SpeedChanged { player, .. } => {
+                mark_public_state_player_dirty(state, *player);
+            }
+            GameEvent::CardsDrawn { player_id, .. } => {
+                mark_public_state_player_dirty(state, *player_id);
+            }
+            GameEvent::CardDrawn {
+                player_id,
+                object_id,
+                ..
+            }
+            | GameEvent::Discarded {
+                player_id,
+                object_id,
+            }
+            | GameEvent::Cycled {
+                player_id,
+                object_id,
+            } => {
+                mark_public_state_player_dirty(state, *player_id);
+                mark_public_state_object_dirty(state, *object_id);
+            }
+            GameEvent::PermanentSacrificed {
+                object_id,
+                player_id,
+            } => {
+                // The paired battlefield→graveyard `ZoneChanged` marks the object
+                // + battlefield display; mark the controlling player too.
+                mark_public_state_object_dirty(state, *object_id);
+                mark_public_state_player_dirty(state, *player_id);
+            }
+            GameEvent::CreatureDestroyed { object_id } => {
+                // Paired `ZoneChanged` to graveyard handles battlefield display.
+                mark_public_state_object_dirty(state, *object_id);
+            }
+            GameEvent::MonarchChanged { player_id }
+            | GameEvent::CityBlessingGained { player_id }
+            | GameEvent::InitiativeTaken { player_id }
+            | GameEvent::RingTemptsYou { player_id } => {
+                mark_public_state_player_dirty(state, *player_id);
+            }
+            // CR 702.26: Phasing changes which objects/statics are active and
+            // reshapes the active-static set; conservatively recompute all.
+            GameEvent::PermanentPhasedOut { .. }
+            | GameEvent::PermanentPhasedIn { .. }
+            | GameEvent::PlayerPhasedOut { .. }
+            | GameEvent::PlayerPhasedIn { .. }
+            // Transform changes copiable values (Layer 1) and can flip statics
+            // on/off; conservatively all-dirty.
+            | GameEvent::Transformed { .. }
+            | GameEvent::TurnedFaceUp { .. } => {
+                mark_public_state_all_dirty(state);
+                return;
+            }
+            // CR 302.6: Turn start clears summoning sickness board-wide WITHOUT
+            // setting `layers_dirty` (turns.rs clears `summoning_sick` on all of
+            // the active player's permanents emitting only `TurnStarted`), so
+            // Gate 1 does not catch it. Recompute all display state. See the
+            // existing CR 302.6 annotation at `derived.rs`. MANDATORY all-dirty.
+            GameEvent::TurnStarted { .. } => {
+                mark_public_state_all_dirty(state);
+                return;
+            }
+            // No display-field impact, OR already covered by `layers_dirty`
+            // (Gate 1) / a paired object event above. These events change no
+            // field `derive_display_state` computes. Grouped explicitly (never
+            // `_ => {}`) so a new event variant must be classified to compile.
+            GameEvent::GameStarted
+            | GameEvent::PhaseChanged { .. }
+            | GameEvent::PriorityPassed { .. }
+            | GameEvent::SpellCast { .. }
+            | GameEvent::SpellCopied { .. }
+            | GameEvent::XValueChosen { .. }
+            | GameEvent::AbilityActivated { .. }
+            | GameEvent::PlayerLost { .. }
+            | GameEvent::MulliganStarted
+            | GameEvent::LandPlayed { .. }
+            | GameEvent::StackPushed { .. }
+            | GameEvent::StackResolved { .. }
+            | GameEvent::GameOver { .. }
+            | GameEvent::SpellCountered { .. }
+            | GameEvent::EffectResolved { .. }
+            | GameEvent::Unattached { .. }
+            | GameEvent::AttackersDeclared { .. }
+            | GameEvent::BlockersDeclared { .. }
+            | GameEvent::CombatTaxPaid { .. }
+            | GameEvent::CombatTaxDeclined { .. }
+            | GameEvent::BecomesTarget { .. }
+            | GameEvent::VehicleCrewed { .. }
+            | GameEvent::Stationed { .. }
+            | GameEvent::Saddled { .. }
+            | GameEvent::ReplacementApplied { .. }
+            | GameEvent::DayNightChanged { .. }
+            | GameEvent::CardsRevealed { .. }
+            | GameEvent::CombatDamageDealtToPlayer { .. }
+            | GameEvent::PlayerEliminated { .. }
+            | GameEvent::CrimeCommitted { .. }
+            | GameEvent::PlayerPerformedAction { .. }
+            | GameEvent::Regenerated { .. }
+            | GameEvent::CreatureSuspected { .. }
+            | GameEvent::BecamePrepared { .. }
+            | GameEvent::BecameUnprepared { .. }
+            | GameEvent::CaseSolved { .. }
+            | GameEvent::ClassLevelGained { .. }
+            | GameEvent::DieRolled { .. }
+            | GameEvent::CoinFlipped { .. }
+            | GameEvent::RoomEntered { .. }
+            | GameEvent::RoomDoorUnlocked { .. }
+            | GameEvent::BecomesPlotted { .. }
+            | GameEvent::DungeonCompleted { .. }
+            | GameEvent::Firebend { .. }
+            | GameEvent::Airbend { .. }
+            | GameEvent::Earthbend { .. }
+            | GameEvent::Waterbend { .. }
+            | GameEvent::CompanionRevealed { .. }
+            | GameEvent::CompanionMovedToHand { .. }
+            | GameEvent::NinjutsuActivated { .. }
+            | GameEvent::KeywordAbilityActivated { .. }
+            | GameEvent::CreatureExploited { .. }
+            | GameEvent::Clash { .. }
+            | GameEvent::VoteCast { .. }
+            | GameEvent::VoteResolved { .. }
+            | GameEvent::PowerToughnessChanged { .. }
+            | GameEvent::CascadeMissed { .. }
+            | GameEvent::DebugActionUsed { .. }
+            | GameEvent::DebugPermissionGranted { .. }
+            | GameEvent::DebugPermissionRevoked { .. } => {}
+        }
+    }
 }
 
 pub fn bump_state_revision(state: &mut GameState) {
@@ -116,5 +409,461 @@ mod tests {
         finalize_public_state(&mut state);
 
         assert_eq!(state.priority_player, PlayerId(0));
+    }
+
+    // ── Event-driven dirty-marking (perf fix) ────────────────────────────────
+
+    use crate::game::effects::token_copy;
+    use crate::game::layers::evaluate_layers;
+    use crate::game::zones::create_object;
+    use crate::types::ability::{
+        AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaContribution, ManaProduction,
+        ResolvedAbility, TargetFilter,
+    };
+    use crate::types::card_type::{CardType, CoreType};
+    use crate::types::counter::CounterType;
+    use crate::types::identifiers::CardId;
+    use crate::types::mana::ManaColor;
+    use crate::types::zones::Zone;
+
+    /// Build a Scute-Swarm-like creature (vanilla, no statics) on the
+    /// battlefield, then resolve the REAL copy-token resolver against it.
+    /// Returns (state, copy_source_id, emitted events).
+    fn resolve_real_copy_token(state: &mut GameState) -> (ObjectId, Vec<GameEvent>) {
+        let source_id = create_object(
+            state,
+            CardId(1),
+            PlayerId(0),
+            "Scute Swarm".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let source = state.objects.get_mut(&source_id).unwrap();
+            source.base_power = Some(1);
+            source.base_toughness = Some(1);
+            source.power = Some(1);
+            source.toughness = Some(1);
+            source.base_color = vec![ManaColor::Green];
+            source.color = vec![ManaColor::Green];
+            source.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec!["Insect".to_string()],
+            };
+            source.card_types = source.base_card_types.clone();
+        }
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::SelfRef,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        token_copy::resolve(state, &ability, &mut events).unwrap();
+        (source_id, events)
+    }
+
+    /// PERF-PATH: once layers are stable (no continuous source — Gate 1 false),
+    /// a real copy-token resolution marks only the new token + battlefield
+    /// display, NOT the whole board. Routes through the real `token_copy`
+    /// resolver so a regression that emits the wrong event turns this red.
+    #[test]
+    fn copy_token_resolution_marks_only_new_token_when_layers_stable() {
+        let mut state = GameState::new_two_player(42);
+        let (_source_id, events) = resolve_real_copy_token(&mut state);
+
+        let new_token_id = ObjectId(state.next_object_id - 1);
+
+        // The real resolver sets `layers_dirty` (token_copy.rs entry). The drain
+        // boundary reaches `finalize_public_state` only after an intervening
+        // layer pass has run and cleared the flag, leaving layers stable. Model
+        // that by running the real layer evaluation (which clears `layers_dirty`)
+        // before classifying — exactly the state `apply()` reaches when layers
+        // are not pending.
+        assert!(
+            state.layers_dirty,
+            "real copy resolver must set layers_dirty"
+        );
+        evaluate_layers(&mut state);
+        assert!(!state.layers_dirty, "evaluate_layers clears layers_dirty");
+
+        clear_public_state_dirty(&mut state);
+        mark_public_state_from_events(&mut state, &events);
+
+        let dirty = &state.public_state_dirty;
+        assert!(
+            !dirty.all_objects_dirty,
+            "should not escalate to all-objects when layers are stable"
+        );
+        assert!(
+            dirty.dirty_objects.contains(&new_token_id),
+            "the new copy token must be marked dirty"
+        );
+        assert!(
+            dirty.battlefield_display_dirty,
+            "a battlefield entry must mark battlefield display"
+        );
+        assert!(!dirty.all_players_dirty, "no player-wide change occurred");
+    }
+
+    /// CORRECTNESS-FALLBACK: a real battlefield entry leaves `layers_dirty` set
+    /// (the resolver sets it because a static-bearing object or board static
+    /// could newly apply — Section 4 suppression is not in scope here), so
+    /// Gate 1 escalates to a full all-dirty recompute.
+    #[test]
+    fn battlefield_entry_with_layers_pending_escalates_to_all_dirty() {
+        let mut state = GameState::new_two_player(42);
+        let (_source_id, events) = resolve_real_copy_token(&mut state);
+
+        assert!(
+            state.layers_dirty,
+            "real entry must leave layers pending (Gate 1 input)"
+        );
+
+        clear_public_state_dirty(&mut state);
+        mark_public_state_from_events(&mut state, &events);
+
+        assert!(
+            state.public_state_dirty.all_objects_dirty,
+            "Gate 1 must escalate to all-objects when layers_dirty is set"
+        );
+        assert!(
+            state.public_state_dirty.all_players_dirty,
+            "Gate 1 must escalate to all-players when layers_dirty is set"
+        );
+    }
+
+    /// DIFFERENTIAL: targeted marking + finalize produces per-object/per-player
+    /// display fields IDENTICAL to a forced all-dirty finalize, across both
+    /// Gate-1 branches (layers-stable targeted, layers-pending fallback) and a
+    /// TurnStarted transition. This is the Section-3 invariant guard.
+    #[test]
+    fn targeted_marking_matches_forced_all_dirty() {
+        // Branch 1: layers stable — targeted path collapses to {new_id}.
+        let mut base = GameState::new_two_player(42);
+        let (_src, events) = resolve_real_copy_token(&mut base);
+        evaluate_layers(&mut base);
+        base.layers_dirty = false;
+
+        let mut targeted = base.clone();
+        clear_public_state_dirty(&mut targeted);
+        mark_public_state_from_events(&mut targeted, &events);
+        finalize_public_state(&mut targeted);
+
+        let mut forced = base.clone();
+        mark_public_state_all_dirty(&mut forced);
+        finalize_public_state(&mut forced);
+
+        assert_display_state_eq(&targeted, &forced, "layers-stable copy entry");
+
+        // Branch 2: TurnStarted must escalate to all-dirty on both paths and
+        // produce identical summoning-sickness display.
+        let mut ts_targeted = base.clone();
+        clear_public_state_dirty(&mut ts_targeted);
+        mark_public_state_from_events(
+            &mut ts_targeted,
+            &[GameEvent::TurnStarted {
+                player_id: PlayerId(0),
+                turn_number: 2,
+            }],
+        );
+        assert!(
+            ts_targeted.public_state_dirty.all_objects_dirty,
+            "TurnStarted must escalate to all-dirty"
+        );
+        finalize_public_state(&mut ts_targeted);
+
+        let mut ts_forced = base.clone();
+        mark_public_state_all_dirty(&mut ts_forced);
+        finalize_public_state(&mut ts_forced);
+
+        assert_display_state_eq(&ts_targeted, &ts_forced, "TurnStarted transition");
+    }
+
+    fn assert_display_state_eq(a: &GameState, b: &GameState, label: &str) {
+        for (id, obj_a) in a.objects.iter() {
+            let obj_b = b.objects.get(id).expect("object present in both");
+            assert_eq!(
+                obj_a.has_summoning_sickness, obj_b.has_summoning_sickness,
+                "{label}: summoning sickness mismatch for {id:?}"
+            );
+            assert_eq!(
+                obj_a.unimplemented_mechanics, obj_b.unimplemented_mechanics,
+                "{label}: unimplemented mismatch for {id:?}"
+            );
+            assert_eq!(
+                obj_a.has_mana_ability, obj_b.has_mana_ability,
+                "{label}: mana ability mismatch for {id:?}"
+            );
+            assert_eq!(
+                obj_a.mana_ability_index, obj_b.mana_ability_index,
+                "{label}: mana ability index mismatch for {id:?}"
+            );
+            assert_eq!(
+                obj_a.available_mana_pips, obj_b.available_mana_pips,
+                "{label}: mana pips mismatch for {id:?}"
+            );
+            assert_eq!(
+                obj_a.devotion, obj_b.devotion,
+                "{label}: devotion mismatch for {id:?}"
+            );
+            assert_eq!(
+                obj_a.commander_tax, obj_b.commander_tax,
+                "{label}: commander tax mismatch for {id:?}"
+            );
+        }
+        for (pa, pb) in a.players.iter().zip(b.players.iter()) {
+            assert_eq!(
+                pa.can_look_at_top_of_library, pb.can_look_at_top_of_library,
+                "{label}: peek mismatch for {:?}",
+                pa.id
+            );
+            assert_eq!(
+                pa.commander_color_identity, pb.commander_color_identity,
+                "{label}: commander identity mismatch for {:?}",
+                pa.id
+            );
+        }
+    }
+
+    /// Build a tap-for-mana land on the battlefield. Returns its id.
+    fn make_mana_land(state: &mut GameState) -> ObjectId {
+        let land_id = create_object(
+            state,
+            CardId(2),
+            PlayerId(0),
+            "Gemstone Mine".to_string(),
+            Zone::Battlefield,
+        );
+        let land = state.objects.get_mut(&land_id).unwrap();
+        land.base_card_types = CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Land],
+            subtypes: vec![],
+        };
+        land.card_types = land.base_card_types.clone();
+        let ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::Fixed {
+                    colors: vec![ManaColor::Green],
+                    contribution: ManaContribution::Base,
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Tap);
+        land.abilities = std::sync::Arc::new(vec![ability]);
+        land_id
+    }
+
+    /// DISCRIMINATING (FINDINGS A & B): a battlefield mana land's displayed
+    /// mana availability (`has_mana_ability` / `mana_ability_index` /
+    /// `available_mana_pips`) is BOARD-GLOBAL and must be re-derived when a
+    /// NON-mana event names that land (Gemstone Mine depletion `CounterRemoved`,
+    /// damage to a creature-land). The land's mana state here goes stale (it
+    /// becomes tapped), and only the mana-display gate re-derives it.
+    ///
+    /// Without the fix, `CounterRemoved` does not raise `mana_display_dirty`,
+    /// the board-wide mana sweep is skipped, and the stale `has_mana_ability`
+    /// persists → mismatch with a forced all-dirty finalize (RED). With the fix
+    /// the event raises the mana signal, the sweep runs, and the values match
+    /// (GREEN). Routed through the REAL event path, not a hand-built dirty set.
+    #[test]
+    fn non_mana_event_on_mana_land_refreshes_board_global_mana_state() {
+        let mut base = GameState::new_two_player(42);
+        let land_id = make_mana_land(&mut base);
+        // Derived baseline: untapped land displays a mana ability + pips.
+        mark_public_state_all_dirty(&mut base);
+        finalize_public_state(&mut base);
+        assert!(base.objects[&land_id].has_mana_ability);
+        assert!(!base.objects[&land_id].available_mana_pips.is_empty());
+
+        // Make the displayed mana state STALE: tap the land directly (not via a
+        // mana/tap event) so a fresh derive would show `has_mana_ability=false`
+        // and empty pips, but the cached display still reads the untapped values.
+        let mut targeted = base.clone();
+        targeted.objects.get_mut(&land_id).unwrap().tapped = true;
+
+        // Targeted path: ONLY a non-mana event naming the land.
+        clear_public_state_dirty(&mut targeted);
+        mark_public_state_from_events(
+            &mut targeted,
+            &[GameEvent::CounterRemoved {
+                object_id: land_id,
+                counter_type: CounterType::Generic("depletion".to_string()),
+                count: 1,
+            }],
+        );
+        // Direct observable of the fix: the marking layer raised the mana gate.
+        assert!(
+            targeted.public_state_dirty.mana_display_dirty,
+            "a non-mana event on a mana land must raise the mana-display signal"
+        );
+        finalize_public_state(&mut targeted);
+
+        // Forced all-dirty oracle (same stale starting point).
+        let mut forced = base.clone();
+        forced.objects.get_mut(&land_id).unwrap().tapped = true;
+        mark_public_state_all_dirty(&mut forced);
+        finalize_public_state(&mut forced);
+
+        // Targeted display must equal the forced all-dirty oracle on every
+        // board-global mana field.
+        assert_eq!(
+            targeted.objects[&land_id].has_mana_ability, forced.objects[&land_id].has_mana_ability,
+            "has_mana_ability must match forced all-dirty after a non-mana event"
+        );
+        assert_eq!(
+            targeted.objects[&land_id].mana_ability_index,
+            forced.objects[&land_id].mana_ability_index,
+            "mana_ability_index must match forced all-dirty"
+        );
+        assert_eq!(
+            targeted.objects[&land_id].available_mana_pips,
+            forced.objects[&land_id].available_mana_pips,
+            "available_mana_pips must match forced all-dirty"
+        );
+        // And the stale value was actually corrected: the now-tapped land must
+        // no longer advertise an activatable mana ability (it did before the
+        // event). This is the field that turns RED without the fix.
+        assert!(
+            !targeted.objects[&land_id].has_mana_ability,
+            "tapped mana land must not display an activatable mana ability"
+        );
+    }
+
+    /// Build a mana dork (a creature with a `{T}: Add` ability) on the
+    /// battlefield. Returns its id.
+    fn make_mana_dork(state: &mut GameState) -> ObjectId {
+        let dork_id = create_object(
+            state,
+            CardId(3),
+            PlayerId(0),
+            "Llanowar Elves".to_string(),
+            Zone::Battlefield,
+        );
+        let dork = state.objects.get_mut(&dork_id).unwrap();
+        dork.base_card_types = CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec!["Elf".to_string(), "Druid".to_string()],
+        };
+        dork.card_types = dork.base_card_types.clone();
+        dork.base_power = Some(1);
+        dork.base_toughness = Some(1);
+        dork.power = Some(1);
+        dork.toughness = Some(1);
+        // Enters under control before this turn so it is not summoning-sick and
+        // can tap for mana.
+        dork.entered_battlefield_turn = Some(0);
+        dork.summoning_sick = false;
+        let ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::Fixed {
+                    colors: vec![ManaColor::Green],
+                    contribution: ManaContribution::Base,
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Tap);
+        dork.abilities = std::sync::Arc::new(vec![ability]);
+        dork_id
+    }
+
+    /// DISCRIMINATING (FINDING C): detaining a mana dork (CR 701.35a) makes its
+    /// mana ability un-activatable (`can_activate_mana_ability_now` checks
+    /// `detained_by`), but `detain.rs` emits no mana/tap event — only the new
+    /// `Detained` event. The displayed `has_mana_ability` must flip to false.
+    ///
+    /// Without the `Detained` arm routing through the mana-aware mark, the event
+    /// is inert, the mana gate is not raised, the board-wide sweep is skipped,
+    /// and the stale `has_mana_ability=true` persists → mismatch with a forced
+    /// all-dirty oracle (RED). Drives the REAL `detain::resolve` so detain.rs's
+    /// `Detained` emission is exercised end-to-end, then classifies the emitted
+    /// events through the real path.
+    #[test]
+    fn detain_mana_dork_clears_mana_ability_display() {
+        use crate::game::effects::detain;
+        use crate::types::ability::TargetRef;
+
+        let mut base = GameState::new_two_player(42);
+        let dork_id = make_mana_dork(&mut base);
+        // Derived baseline: untapped, undetained dork displays a mana ability.
+        mark_public_state_all_dirty(&mut base);
+        finalize_public_state(&mut base);
+        assert!(
+            base.objects[&dork_id].has_mana_ability,
+            "baseline: undetained mana dork must display a mana ability"
+        );
+
+        // Targeted path: drive the REAL detain resolver (PlayerId(1) detains the
+        // dork), which emits the `Detained` event and sets `detained_by`.
+        let mut targeted = base.clone();
+        let ability = ResolvedAbility::new(
+            Effect::Detain {
+                target: TargetFilter::Any,
+            },
+            vec![TargetRef::Object(dork_id)],
+            ObjectId(999),
+            PlayerId(1),
+        );
+        let mut events = Vec::new();
+        detain::resolve(&mut targeted, &ability, &mut events).unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, GameEvent::Detained { object_id } if *object_id == dork_id)),
+            "detain resolver must emit Detained"
+        );
+        assert!(targeted.objects[&dork_id]
+            .detained_by
+            .contains(&PlayerId(1)));
+
+        clear_public_state_dirty(&mut targeted);
+        mark_public_state_from_events(&mut targeted, &events);
+        assert!(
+            targeted.public_state_dirty.mana_display_dirty,
+            "Detained on a mana source must raise the mana-display signal"
+        );
+        finalize_public_state(&mut targeted);
+
+        // Forced all-dirty oracle (same detained starting point).
+        let mut forced = base.clone();
+        forced
+            .objects
+            .get_mut(&dork_id)
+            .unwrap()
+            .detained_by
+            .insert(PlayerId(1));
+        mark_public_state_all_dirty(&mut forced);
+        finalize_public_state(&mut forced);
+
+        assert_eq!(
+            targeted.objects[&dork_id].has_mana_ability, forced.objects[&dork_id].has_mana_ability,
+            "has_mana_ability must match forced all-dirty after Detained"
+        );
+        // The detained dork must no longer advertise an activatable mana ability.
+        assert!(
+            !targeted.objects[&dork_id].has_mana_ability,
+            "detained mana dork must not display an activatable mana ability"
+        );
     }
 }

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -758,6 +758,7 @@ pub(crate) fn extract_source_from_event(
         GameEvent::TurnedFaceUp { object_id } => Some(*object_id),
         GameEvent::Cycled { object_id, .. } => Some(*object_id),
         GameEvent::CreatureSuspected { object_id } => Some(*object_id),
+        GameEvent::Detained { object_id } => Some(*object_id),
         GameEvent::CaseSolved { object_id } => Some(*object_id),
         GameEvent::AttackersDeclared { attacker_ids, .. } if attacker_ids.len() == 1 => {
             attacker_ids.first().copied()

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -547,6 +547,7 @@ fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
         GameEvent::PlayerPerformedAction { .. } => push(TriggerEventKey::PlayerActionPerformed),
         GameEvent::Regenerated { .. }
         | GameEvent::CreatureSuspected { .. }
+        | GameEvent::Detained { .. }
         | GameEvent::BecamePrepared { .. }
         | GameEvent::BecameUnprepared { .. } => {}
         GameEvent::CaseSolved { .. } | GameEvent::ClassLevelGained { .. } => {

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -727,6 +727,7 @@ fn count_matching_trigger_event_subjects(
         | GameEvent::PlayerPerformedAction { .. }
         | GameEvent::Regenerated { .. }
         | GameEvent::CreatureSuspected { .. }
+        | GameEvent::Detained { .. }
         | GameEvent::BecamePrepared { .. }
         | GameEvent::BecameUnprepared { .. }
         | GameEvent::CaseSolved { .. }

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -455,6 +455,13 @@ pub enum GameEvent {
     CreatureSuspected {
         object_id: ObjectId,
     },
+    /// CR 701.35a: A permanent was detained — until the detaining player's next
+    /// turn it can't attack or block and its activated abilities can't be
+    /// activated. Display-relevant for mana sources: detaining a mana dork
+    /// makes its mana ability un-activatable.
+    Detained {
+        object_id: ObjectId,
+    },
     /// CR 702.xxx: Prepare (Strixhaven) — a creature became prepared.
     /// Emitted only when the toggle actually flips (idempotent resolvers).
     /// Assign when WotC publishes SOS CR update.


### PR DESCRIPTION
Replace the unconditional full-board `mark_public_state_all_dirty` on every
`apply()` with event-driven targeted dirty marking, eliminating the O(N²)
per-resolution display recompute that made large token-storm boards
(Scute Swarm landfall) unresponsive (~5s/resolution and climbing, 3+ hour
stack drains).

- `mark_public_state_from_events`: single authority translating an action's
  events into the minimal dirty set, with a conservative all-dirty fallback
  (Gate 1, keyed on `layers_dirty`) for any continuous/static ripple
  (CR 611.1/613.1), and mandatory all-dirty on `TurnStarted` (CR 302.6),
  phasing (CR 702.26), and transform. Wildcard-free `match` over `GameEvent`
  so a future variant must be classified or fail to compile.
- Mana availability (`has_mana_ability` / `mana_ability_index` /
  `available_mana_pips`) is board-global derived state (auto-tap payability
  simulation over the whole pool + untapped sources), now re-derived as one
  battlefield-wide sweep gated on a mana-specific signal — never
  per-dirty-object — so a non-mana event naming a mana source (Gemstone Mine
  depletion `CounterRemoved`, damage to a creature-land) and cross-object
  pool/tap changes refresh correctly, without re-introducing board-size
  scaling on the creature-token hot path.
- `GameEvent::Detained` (CR 701.35a): detaining a mana source now refreshes
  its `has_mana_ability` display (mirrors `CreatureSuspected`).

Measured on a 1374→3089-object Scute board: per-action `derive_display_state`
64.4ms→0.38ms (~170x), flat as the board grows. The previously-planned
`layers_dirty` suppression authority (Section 4) was measured unnecessary —
`evaluate_layers` is 0 at the `apply()` boundary because the batch-resolve
seam (#1295) clears `layers_dirty` first — and correctly not shipped.
