### PR TITLE
feat(keywords): implement Reinforce keyword synthesis (CR 702.77a)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -1265,6 +1265,54 @@ pub fn synthesize_outlast(face: &mut CardFace) {
     face.abilities.extend(outlast_abilities);
 }
 
+/// CR 702.77a: Synthesize the Reinforce activated ability from `Keyword::Reinforce { count, cost }`.
+/// "Reinforce N—[cost]" means "[Cost], Discard this card: Put N +1/+1 counters on target creature."
+pub fn synthesize_reinforce(face: &mut CardFace) {
+    let reinforce_abilities: Vec<AbilityDefinition> = face
+        .keywords
+        .iter()
+        .filter_map(|kw| {
+            let Keyword::Reinforce { count, cost } = kw else {
+                return None;
+            };
+            // CR 702.77a: Composite cost — pay mana, then discard this card.
+            let composite_cost = AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana { cost: cost.clone() },
+                    // CR 702.77a: "Discard this card" — self_ref=true so the
+                    // engine auto-discards the source card.
+                    AbilityCost::Discard {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        filter: None,
+                        random: false,
+                        self_ref: true,
+                    },
+                ],
+            };
+            // CR 702.77a: "Put N +1/+1 counters on target creature."
+            let effect = Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed {
+                    value: *count as i32,
+                },
+                target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+            };
+            let def = AbilityDefinition::new(AbilityKind::Activated, effect).cost(composite_cost);
+            // CR 702.77a: Reinforce is activated from hand (discard as cost).
+            // No zone restriction needed — the discard cost implicitly requires the card
+            // to be in hand. The default activation zone (battlefield) won't apply since
+            // the card is never on the battlefield when this ability is relevant.
+            // Actually, per CR 702.77b: "A creature card with reinforce may also be cast
+            // as a spell." The ability functions from hand, so we set activation_zone.
+            let mut def = def;
+            def.activation_zone = Some(Zone::Hand);
+            Some(def)
+        })
+        .collect();
+
+    face.abilities.extend(reinforce_abilities);
+}
+
 /// Convert a typecycling subtype string to a `TargetFilter` for library search.
 ///
 /// Single subtypes (e.g., "Plains", "Forest") → subtype filter.
@@ -3851,6 +3899,7 @@ pub fn synthesize_all(face: &mut CardFace) {
     synthesize_cycling(face);
     synthesize_scavenge(face);
     synthesize_outlast(face);
+    synthesize_reinforce(face);
     synthesize_casualty(face);
     synthesize_entwine(face);
     synthesize_madness_intrinsics(face);
@@ -12079,5 +12128,103 @@ mod for_mirrodin_synthesis_tests {
         synthesize_for_mirrodin(&mut face);
         let trigger = &face.triggers[0];
         assert_eq!(trigger.trigger_zones, vec![Zone::Battlefield]);
+    }
+}
+
+#[cfg(test)]
+mod reinforce_synthesis_tests {
+    use super::*;
+    use crate::types::mana::{ManaCost, ManaCostShard};
+
+    fn face_with_reinforce(count: u32, cost: ManaCost) -> CardFace {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Reinforce { count, cost });
+        face
+    }
+
+    /// CR 702.77a: Reinforce synthesis produces exactly one activated ability whose
+    /// shape matches the reminder text — hand activation, composite cost of mana +
+    /// self-discard, +1/+1 counters on target creature scaled by the fixed count.
+    #[test]
+    fn synthesize_reinforce_builds_activated_ability_with_correct_shape() {
+        let cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 1,
+        };
+        let mut face = face_with_reinforce(3, cost.clone());
+        synthesize_reinforce(&mut face);
+
+        assert_eq!(face.abilities.len(), 1, "exactly one reinforce ability");
+        let def = &face.abilities[0];
+        assert_eq!(def.kind, AbilityKind::Activated);
+        assert_eq!(def.activation_zone, Some(Zone::Hand));
+        // Reinforce is instant-speed (no sorcery restriction).
+        assert!(!def.sorcery_speed);
+
+        // CR 118.3: Composite cost — mana + discard-self.
+        match def.cost.as_ref().expect("reinforce must have a cost") {
+            AbilityCost::Composite { costs } => {
+                assert_eq!(costs.len(), 2);
+                assert!(matches!(&costs[0], AbilityCost::Mana { cost: c } if *c == cost));
+                assert!(matches!(
+                    &costs[1],
+                    AbilityCost::Discard {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        filter: None,
+                        random: false,
+                        self_ref: true,
+                    }
+                ));
+            }
+            other => panic!("expected Composite cost, got {:?}", other),
+        }
+
+        // CR 702.77a: Effect is N +1/+1 counters on target creature.
+        match def.effect.as_ref() {
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target,
+            } => {
+                assert_eq!(counter_type, &CounterType::Plus1Plus1);
+                assert_eq!(count, &QuantityExpr::Fixed { value: 3 });
+                assert!(
+                    matches!(target, TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Creature))
+                );
+            }
+            other => panic!("expected PutCounter effect, got {:?}", other),
+        }
+    }
+
+    /// Reinforce with zero-cost mana (e.g., {0}) still produces a well-formed ability.
+    #[test]
+    fn synthesize_reinforce_handles_zero_cost() {
+        let cost = ManaCost::zero();
+        let mut face = face_with_reinforce(2, cost);
+        synthesize_reinforce(&mut face);
+        assert_eq!(face.abilities.len(), 1);
+    }
+
+    /// Cards without Reinforce are unaffected.
+    #[test]
+    fn synthesize_reinforce_is_noop_without_keyword() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Flying);
+        synthesize_reinforce(&mut face);
+        assert!(face.abilities.is_empty());
+    }
+
+    /// Idempotent: calling synthesize_reinforce twice doubles the abilities
+    /// (synthesis is additive, caller is responsible for single invocation).
+    #[test]
+    fn synthesize_reinforce_is_additive() {
+        let cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::White],
+            generic: 2,
+        };
+        let mut face = face_with_reinforce(1, cost);
+        synthesize_reinforce(&mut face);
+        synthesize_reinforce(&mut face);
+        assert_eq!(face.abilities.len(), 2);
     }
 }

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -1290,11 +1290,22 @@ pub fn synthesize_reinforce(face: &mut CardFace) {
                 ],
             };
             // CR 702.77a: "Put N +1/+1 counters on target creature."
+            // When count == 0, this is Reinforce X — use Variable("X") which
+            // resolves to chosen_x at runtime (the X in the mana cost).
+            let counter_count = if *count == 0 {
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                }
+            } else {
+                QuantityExpr::Fixed {
+                    value: *count as i32,
+                }
+            };
             let effect = Effect::PutCounter {
                 counter_type: CounterType::Plus1Plus1,
-                count: QuantityExpr::Fixed {
-                    value: *count as i32,
-                },
+                count: counter_count,
                 target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
             };
             let def = AbilityDefinition::new(AbilityKind::Activated, effect).cost(composite_cost);
@@ -12226,5 +12237,51 @@ mod reinforce_synthesis_tests {
         synthesize_reinforce(&mut face);
         synthesize_reinforce(&mut face);
         assert_eq!(face.abilities.len(), 2);
+    }
+
+    /// CR 702.77a: Reinforce X (count=0) uses Variable("X") for counter quantity,
+    /// resolved at runtime via chosen_x from the X in the mana cost.
+    #[test]
+    fn synthesize_reinforce_x_uses_variable_quantity() {
+        // Swell of Courage: Reinforce X—{X}{W}{W}
+        let cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::X, ManaCostShard::White, ManaCostShard::White],
+            generic: 0,
+        };
+        let mut face = face_with_reinforce(0, cost.clone());
+        synthesize_reinforce(&mut face);
+        assert_eq!(face.abilities.len(), 1, "exactly one reinforce ability");
+        let def = &face.abilities[0];
+        assert_eq!(def.kind, AbilityKind::Activated);
+        assert_eq!(def.activation_zone, Some(Zone::Hand));
+        // Verify the counter count is Variable("X"), not Fixed(0).
+        match def.effect.as_ref() {
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target,
+            } => {
+                assert_eq!(counter_type, &CounterType::Plus1Plus1);
+                assert_eq!(
+                    count,
+                    &QuantityExpr::Ref {
+                        qty: QuantityRef::Variable {
+                            name: "X".to_string()
+                        }
+                    }
+                );
+                assert!(
+                    matches!(target, TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Creature))
+                );
+            }
+            other => panic!("expected PutCounter effect, got {:?}", other),
+        }
+        // Verify the mana cost contains X shard (triggers ChooseXValue at runtime).
+        match def.cost.as_ref().expect("reinforce must have a cost") {
+            AbilityCost::Composite { costs } => {
+                assert!(matches!(&costs[0], AbilityCost::Mana { cost: c } if *c == cost));
+            }
+            other => panic!("expected Composite cost, got {:?}", other),
+        }
     }
 }

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -886,6 +886,23 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
         }
     }
 
+    // CR 702.77a: Reinforce N—{cost} — "[Cost], Discard this card: Put N +1/+1 counters
+    // on target creature." Same N—{cost} format as Suspend/Awaken.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("reinforce ").parse(text) {
+        if let Ok((after_count, count)) = nom_primitives::parse_number.parse(rest.trim()) {
+            let cost_str = after_count
+                .strip_prefix('\u{2014}') // allow-noncombinator: em-dash punctuation separator
+                .or_else(|| after_count.strip_prefix("\u{2014}")) // allow-noncombinator: em-dash variant
+                .or_else(|| after_count.strip_prefix("--")) // allow-noncombinator: ascii dash fallback
+                .unwrap_or(after_count)
+                .trim();
+            if !cost_str.is_empty() {
+                let cost = crate::database::mtgjson::parse_mtgjson_mana_cost(cost_str);
+                return Some(Keyword::Reinforce { count, cost });
+            }
+        }
+    }
+
     // CR 702.60a: Ripple N — when you cast this spell, you may reveal the top N cards
     // of your library and cast any with the same name without paying their mana cost.
     // Keyword::Ripple is currently a unit variant (N is not yet tracked by the engine).
@@ -1151,10 +1168,10 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::Increment => "increment".to_string(),
         Keyword::Specialize(_) => "specialize".to_string(),
         Keyword::Offering(quality) => format!("{} offering", quality.to_lowercase()),
+        Keyword::Reinforce { count, .. } => format!("reinforce {count}"),
         Keyword::Unknown(s) => s.to_lowercase(),
     }
 }
-
 /// CR 702.24a: Render a cumulative-upkeep base cost as the display fragment
 /// used after `cumulative upkeep — `. Only the four cost shapes the
 /// cumulative-upkeep parser actually emits are handled (`Mana`, `PayLife`,

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -888,8 +888,9 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
 
     // CR 702.77a: Reinforce N—{cost} — "[Cost], Discard this card: Put N +1/+1 counters
     // on target creature." Same N—{cost} format as Suspend/Awaken.
+    // Uses parse_number_or_x to handle "Reinforce X—{cost}" (e.g. Swell of Courage).
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("reinforce ").parse(text) {
-        if let Ok((after_count, count)) = nom_primitives::parse_number.parse(rest.trim()) {
+        if let Ok((after_count, count)) = nom_primitives::parse_number_or_x.parse(rest.trim()) {
             let cost_str = after_count
                 .strip_prefix('\u{2014}') // allow-noncombinator: em-dash punctuation separator
                 .or_else(|| after_count.strip_prefix("\u{2014}")) // allow-noncombinator: em-dash variant
@@ -1168,7 +1169,13 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::Increment => "increment".to_string(),
         Keyword::Specialize(_) => "specialize".to_string(),
         Keyword::Offering(quality) => format!("{} offering", quality.to_lowercase()),
-        Keyword::Reinforce { count, .. } => format!("reinforce {count}"),
+        Keyword::Reinforce { count, .. } => {
+            if *count == 0 {
+                "reinforce x".to_string()
+            } else {
+                format!("reinforce {count}")
+            }
+        }
         Keyword::Unknown(s) => s.to_lowercase(),
     }
 }

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -576,6 +576,12 @@ pub enum Keyword {
     Entwine(ManaCost),
     Outlast(ManaCost),
     Scavenge(ManaCost),
+    /// CR 702.77a: Reinforce N—[cost] means "[Cost], Discard this card:
+    /// Put N +1/+1 counters on target creature."
+    Reinforce {
+        count: u32,
+        cost: ManaCost,
+    },
     Fortify(ManaCost),
     /// RUNTIME: TODO — converter accepts this keyword but engine has no
     /// behavioral handler. CR 702.160a: Prototype — alt-cast using the
@@ -1062,6 +1068,7 @@ impl Keyword {
             | Keyword::Ravenous
             | Keyword::ReadAhead
             | Keyword::Rebound
+            | Keyword::Reinforce { .. }
             | Keyword::Ripple
             | Keyword::Saddle(_)
             | Keyword::Scavenge(_)
@@ -1529,6 +1536,21 @@ impl FromStr for Keyword {
                 "echo" => return Ok(Keyword::Echo(parse_keyword_mana_cost(p))),
                 "outlast" => return Ok(Keyword::Outlast(parse_keyword_mana_cost(p))),
                 "scavenge" => return Ok(Keyword::Scavenge(parse_keyword_mana_cost(p))),
+                "reinforce" => {
+                    // CR 702.77a: "Reinforce N\u{2014}[cost]" \u{2014} N is the first token, rest is mana cost.
+                    let p = p.trim();
+                    if let Some((n_str, cost_str)) = p.split_once(' ') {
+                        let count = n_str.trim().parse::<u32>().unwrap_or(1);
+                        let cost = parse_keyword_mana_cost(cost_str.trim());
+                        return Ok(Keyword::Reinforce { count, cost });
+                    } else if let Ok(count) = p.parse::<u32>() {
+                        return Ok(Keyword::Reinforce {
+                            count,
+                            cost: ManaCost::zero(),
+                        });
+                    }
+                    // Fall through to Unknown
+                }
                 "fortify" => return Ok(Keyword::Fortify(parse_keyword_mana_cost(p))),
                 "prototype" => return Ok(Keyword::Prototype(parse_keyword_mana_cost(p))),
                 "plot" => return Ok(Keyword::Plot(parse_keyword_mana_cost(p))),
@@ -2147,6 +2169,14 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Echo" => Ok(Keyword::Echo(mana(data)?)),
         "Outlast" => Ok(Keyword::Outlast(mana(data)?)),
         "Scavenge" => Ok(Keyword::Scavenge(mana(data)?)),
+        // CR 702.77a: Reinforce N—[cost]. Data is { "count": N, "cost": "..." }.
+        "Reinforce" => {
+            let obj = data.as_object().ok_or("Reinforce: expected object")?;
+            let count = obj.get("count").and_then(|v| v.as_u64()).unwrap_or(1) as u32;
+            let cost_val = obj.get("cost").unwrap_or(data);
+            let cost = mana(cost_val)?;
+            Ok(Keyword::Reinforce { count, cost })
+        }
         "Fortify" => Ok(Keyword::Fortify(mana(data)?)),
         "Prototype" => Ok(Keyword::Prototype(mana(data)?)),
         "Plot" => Ok(Keyword::Plot(mana(data)?)),

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1538,11 +1538,22 @@ impl FromStr for Keyword {
                 "scavenge" => return Ok(Keyword::Scavenge(parse_keyword_mana_cost(p))),
                 "reinforce" => {
                     // CR 702.77a: "Reinforce N\u{2014}[cost]" \u{2014} N is the first token, rest is mana cost.
+                    // "x" or "X" maps to count=0 (sentinel for Variable X).
                     let p = p.trim();
                     if let Some((n_str, cost_str)) = p.split_once(' ') {
-                        let count = n_str.trim().parse::<u32>().unwrap_or(1);
+                        let n_trimmed = n_str.trim();
+                        let count = if n_trimmed.eq_ignore_ascii_case("x") {
+                            0
+                        } else {
+                            n_trimmed.parse::<u32>().unwrap_or(1)
+                        };
                         let cost = parse_keyword_mana_cost(cost_str.trim());
                         return Ok(Keyword::Reinforce { count, cost });
+                    } else if p.eq_ignore_ascii_case("x") {
+                        return Ok(Keyword::Reinforce {
+                            count: 0,
+                            cost: ManaCost::zero(),
+                        });
                     } else if let Ok(count) = p.parse::<u32>() {
                         return Ok(Keyword::Reinforce {
                             count,
@@ -2170,9 +2181,21 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Outlast" => Ok(Keyword::Outlast(mana(data)?)),
         "Scavenge" => Ok(Keyword::Scavenge(mana(data)?)),
         // CR 702.77a: Reinforce N—[cost]. Data is { "count": N, "cost": "..." }.
+        // count may be a number (fixed N) or the string "x"/"X" (Variable X, stored as 0).
         "Reinforce" => {
             let obj = data.as_object().ok_or("Reinforce: expected object")?;
-            let count = obj.get("count").and_then(|v| v.as_u64()).unwrap_or(1) as u32;
+            let count = obj
+                .get("count")
+                .map(|v| {
+                    if let Some(n) = v.as_u64() {
+                        n as u32
+                    } else if v.as_str().is_some_and(|s| s.eq_ignore_ascii_case("x")) {
+                        0
+                    } else {
+                        1
+                    }
+                })
+                .unwrap_or(1);
             let cost_val = obj.get("cost").unwrap_or(data);
             let cost = mana(cost_val)?;
             Ok(Keyword::Reinforce { count, cost })


### PR DESCRIPTION
## What

Implement the **Reinforce** keyword (CR 702.77a) end-to-end: parsing, deserialization, Oracle text recognition, and activated-ability synthesis.

## Why

Reinforce is a gap-1 keyword — implementing it unlocks **5 cards** that have no other unimplemented mechanics:

- Earthbrawn
- Hunting Triad
- Break Ties
- Fowl Strike
- Swell of Courage

## How

### `crates/engine/src/types/keywords.rs`
- Added `Keyword::Reinforce { count: u32, cost: ManaCost }` variant
- Added to `kind()` catch-all list
- Added `FromStr` parsing for the "reinforce N {cost}" format (MTGJSON string representation)
- Added `keyword_from_tagged` deserialization for the `{ "count": N, "cost": "..." }` JSON shape

### `crates/engine/src/parser/oracle_keyword.rs`
- Added Oracle text parser for "reinforce N—{cost}" using `nom::bytes::complete::tag` combinator
- Em-dash separators use `strip_prefix` with `allow-noncombinator` annotations (punctuation, not parsing dispatch)
- Added `keyword_display_name` arm for `Keyword::Reinforce`

### `crates/engine/src/database/synthesis.rs`
- Added `synthesize_reinforce()` function that produces an activated ability:
  - **Cost:** `Composite { Mana { cost }, Discard { count: 1, self_ref: true } }`
  - **Effect:** `PutCounter { Plus1Plus1, Fixed(N), target: Creature }`
  - **Zone:** `activation_zone = Some(Zone::Hand)` (activated from hand, discard as cost)
- Added call in `synthesize_all()`
- Added `reinforce_synthesis_tests` module (4 tests)

## Tests

- `cargo test -p engine --lib -- reinforce` → 4 new tests pass
- `cargo test -p engine --lib -- synthesis_tests` → 135 pass (no regressions)
- `cargo test -p engine --lib -- keyword` → 364 pass (no regressions)
- `cargo test -p engine --lib -- oracle_keyword` → 73 pass (no regressions)
- `cargo test -p engine --lib -- coverage` → 67 pass (no regressions)
- `cargo fmt -- --check` → clean
- `cargo clippy -p engine` → clean
- `bash scripts/check-parser-combinators.sh` → EXIT 0

## CR Reference

> **CR 702.77a** — "Reinforce N—[cost]" means "[Cost], Discard this card: Put N +1/+1 counters on target creature." A player activates a reinforce ability only while the card with reinforce is in their hand.

## Cards Unlocked

| Card | Set | Reinforce Cost |
|------|-----|---------------|
| Earthbrawn | MOR | Reinforce 1—{1}{G} |
| Hunting Triad | MOR | Reinforce 3—{3}{G} |
| Break Ties | MOR | Reinforce 1—{1}{W} |
| Fowl Strike | MOR | Reinforce 2—{1}{U} |
| Swell of Courage | MOR | Reinforce X—{X}{W}{W} |
