### PR TITLE
feat(parser): support shared-noun counter-choice list (Owen Grady)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5995,6 +5995,96 @@ mod tests {
     }
 
     #[test]
+    fn owen_grady_shared_noun_counter_choice_activated() {
+        use crate::types::counter::CounterType;
+
+        // CR 122.1b shared-noun counter choice on an activate-as-a-sorcery
+        // ability: "{T}: Put your choice of a menace, trample, reach, or haste
+        // counter on target Dinosaur. Activate only as a sorcery."
+        let r = parse(
+            "{T}: Put your choice of a menace, trample, reach, or haste counter on target Dinosaur. Activate only as a sorcery.",
+            "Owen Grady, Raptor Trainer",
+            &[],
+            &["Creature"],
+            &["Human"],
+        );
+
+        assert_eq!(r.abilities.len(), 1);
+        let ability = &r.abilities[0];
+
+        // Tap cost + sorcery-speed activation restriction.
+        assert_eq!(ability.cost, Some(crate::types::ability::AbilityCost::Tap));
+        assert!(ability.sorcery_speed);
+        assert!(ability
+            .activation_restrictions
+            .contains(&crate::types::ability::ActivationRestriction::AsSorcery));
+
+        // The shared "on target Dinosaur" target is lifted to the TargetOnly head.
+        assert!(
+            matches!(&*ability.effect, Effect::TargetOnly { .. }),
+            "expected TargetOnly head, got {:?}",
+            ability.effect
+        );
+        let head_target = ability
+            .effect
+            .target_filter()
+            .expect("TargetOnly head must surface its shared target");
+        assert!(
+            // allow-noncombinator: test assertion on Debug output, not parsing dispatch
+            format!("{head_target:?}").contains("Dinosaur"),
+            "expected shared target to be a Dinosaur filter, got {head_target:?}"
+        );
+
+        // Body is the ChooseOneOf with 4 keyword PutCounter branches on ParentTarget.
+        let choice = ability
+            .sub_ability
+            .as_deref()
+            .expect("counter choice must be chained as a sub-ability");
+        let Effect::ChooseOneOf { chooser, branches } = &*choice.effect else {
+            panic!("expected ChooseOneOf sub-ability, got {:?}", choice.effect);
+        };
+        assert_eq!(*chooser, PlayerFilter::Controller);
+        assert_eq!(branches.len(), 4);
+
+        let expected = [
+            KeywordKind::Menace,
+            KeywordKind::Trample,
+            KeywordKind::Reach,
+            KeywordKind::Haste,
+        ];
+        for (i, kind) in expected.iter().enumerate() {
+            match &*branches[i].effect {
+                Effect::PutCounter {
+                    counter_type,
+                    count,
+                    target,
+                } => {
+                    assert_eq!(
+                        *counter_type,
+                        CounterType::Keyword(*kind),
+                        "branch {i} should be {kind:?}"
+                    );
+                    assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                    assert_eq!(*target, TargetFilter::ParentTarget);
+                }
+                other => panic!("expected branch {i} PutCounter, got {other:?}"),
+            }
+        }
+
+        // No Unimplemented anywhere in the chain.
+        assert!(
+            !matches!(&*ability.effect, Effect::Unimplemented { .. }),
+            "head must not be Unimplemented"
+        );
+        for branch in branches {
+            assert!(
+                !matches!(&*branch.effect, Effect::Unimplemented { .. }),
+                "branch must not be Unimplemented"
+            );
+        }
+    }
+
+    #[test]
     fn spell_cast_restrictions_parse_into_top_level_metadata() {
         let r = parse(
             "Cast this spell only during combat on an opponent's turn.\nReturn X target creature cards from your graveyard to the battlefield. Sacrifice those creatures at the beginning of the next end step.",

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -2126,6 +2126,56 @@ fn split_choice_list_items(input: &str) -> Option<Vec<&str>> {
     Some(items)
 }
 
+/// Shape of a disjunctive counter-choice list. Determines how each list item
+/// is synthesized back into a `put ... on ...` branch clause.
+///
+/// - `Distributed`: each item is a complete counter noun phrase that already
+///   ends in "counter" ("a +1/+1 counter", "two charge counters"). The item is
+///   used verbatim as the choice phrase.
+/// - `FromAmong`: "a counter from among X, Y, ..., and Z" — each item is a bare
+///   keyword name; synthesized as "a <item> counter".
+/// - `SharedNoun`: "a X, Y, ..., or Z counter" — one leading article and one
+///   trailing "counter" shared across a list of bare keyword adjectives;
+///   synthesized as "a <item> counter".
+enum ChoiceListShape {
+    Distributed,
+    FromAmong,
+    SharedNoun,
+}
+
+/// CR 122.1b: keyword counters distribute over a single shared noun. Recognize
+/// the "shared-noun" disjunctive list shape: ONE leading article, a list of
+/// bare keyword adjectives, and ONE trailing "counter" — e.g. "a menace,
+/// trample, reach, or haste counter" yields `["menace", "trample", "reach",
+/// "haste"]`.
+///
+/// The item combinator must stop at BOTH a list separator AND the trailing
+/// " counter" sentinel; otherwise the final item greedily consumes
+/// "haste counter" and the trailing `tag(" counter")` has nothing left to
+/// match, causing `all_consuming` to fail. Excluding the sentinel from the
+/// item leaves " counter" for the terminating tag.
+///
+/// Returns `None` unless the entire input is consumed as `a <list> counter`.
+/// Per-item strict-counter-type validation is the caller's responsibility — a
+/// raw match here does not yet guarantee every item names a real counter type.
+fn recognize_shared_noun_counter_list(input: &str) -> Option<Vec<&str>> {
+    let trailing_counter = || value((), (tag::<_, _, OracleError<'_>>(" counter"), eof));
+    let item = recognize(many1(preceded(
+        not(alt((parse_choice_list_separator, trailing_counter()))),
+        anychar,
+    )));
+    let (_, items) = preceded(
+        tag::<_, _, OracleError<'_>>("a "),
+        all_consuming(terminated(
+            separated_list1(parse_choice_list_separator, item),
+            tag(" counter"),
+        )),
+    )
+    .parse(input)
+    .ok()?;
+    Some(items)
+}
+
 /// CR 122.1 + CR 608.2d: Parse shared-target counter choices of the form
 /// "put your choice of A counter-pattern, B counter-pattern, or C
 /// counter-pattern on TARGET" (N-ary branches).
@@ -2161,20 +2211,42 @@ fn try_parse_put_counter_choice(
     let (choices_tp, target_tp) = after_choice.split_around(" on ")?;
 
     // Split the post-"on" choices into individual items via nom combinators.
-    // Two list shapes (CR 122.1 + CR 608.2d), both handled by one separator
-    // grammar (`parse_choice_list_separator`):
-    //   1. "from among" bare keywords: "a counter from among X, Y, ..., and Z"
-    //   2. distributed / binary nouns: "a A counter, a B counter, or a C
-    //      counter" or "a A counter or a B counter"
-    // CR 122.1b: the "from among" form names bare keywords; strip its prefix so
-    // each branch is later synthesized as "a <keyword> counter".
+    // Three list shapes (CR 122.1 + CR 608.2d), classified in priority order:
+    //   1. FromAmong  — "a counter from among X, Y, ..., and Z" (bare keywords)
+    //   2. SharedNoun — "a X, Y, ..., or Z counter" (one leading article + bare
+    //      keyword adjectives + one trailing "counter")
+    //   3. Distributed — "a A counter, a B counter, or a C counter" / binary
+    //      ("a A counter or a B counter"), each item a full counter noun phrase.
+    // CR 122.1b: both FromAmong and SharedNoun name bare keywords; each branch
+    // is later synthesized as "a <keyword> counter".
     let choices_text = choices_tp.original;
-    let (list_text, from_among) =
-        match tag::<_, _, nom::error::Error<&str>>("a counter from among ")(choices_text) {
-            Ok((rest, _)) => (rest, true),
-            Err(_) => (choices_text, false),
+    let (shape, choice_items) =
+        match tag::<_, _, OracleError<'_>>("a counter from among ")(choices_text) {
+            Ok((rest, _)) => (ChoiceListShape::FromAmong, split_choice_list_items(rest)?),
+            // CR 122.1b: keyword counters distribute over a single noun; CR
+            // 608.2d: choice made at resolution; CR 601.2c: shared target at
+            // cast. Only classify as SharedNoun when the shape matches AND every
+            // item is a recognized counter type — otherwise distributed lists
+            // ("a +1/+1 counter, ...") and non-counter lists ("a red or blue
+            // creature") would leak through. Fall through to Distributed when
+            // the strict guard fails.
+            Err(_) => match recognize_shared_noun_counter_list(choices_text) {
+                Some(items)
+                    if items.len() >= 2
+                        && items.iter().all(|item| {
+                            all_consuming(nom_primitives::parse_strict_counter_type)
+                                .parse(item.trim())
+                                .is_ok()
+                        }) =>
+                {
+                    (ChoiceListShape::SharedNoun, items)
+                }
+                _ => (
+                    ChoiceListShape::Distributed,
+                    split_choice_list_items(choices_text)?,
+                ),
+            },
         };
-    let choice_items = split_choice_list_items(list_text)?;
 
     // Require at least 2 branches.
     if choice_items.len() < 2 {
@@ -2200,12 +2272,13 @@ fn try_parse_put_counter_choice(
     let mut branch_clauses: Vec<(ParsedEffectClause, String)> =
         Vec::with_capacity(choice_items.len());
     for item in &choice_items {
-        // CR 122.1b: the "from among" form names bare keywords, so synthesize
-        // "a <keyword> counter"; distributed/binary items are full noun phrases.
-        let choice_phrase = if from_among {
-            format!("a {} counter", item.trim())
-        } else {
-            item.trim().to_string()
+        // CR 122.1b: FromAmong and SharedNoun name bare keywords, so synthesize
+        // "a <keyword> counter"; Distributed items are already full noun phrases.
+        let choice_phrase = match shape {
+            ChoiceListShape::Distributed => item.trim().to_string(),
+            ChoiceListShape::FromAmong | ChoiceListShape::SharedNoun => {
+                format!("a {} counter", item.trim())
+            }
         };
         let branch_text = format!("put {choice_phrase} on {target_text}");
         let clause = parse_effect_clause(&branch_text, ctx);
@@ -36595,6 +36668,88 @@ mod tests {
                 other => panic!("expected branch {i} PutCounter, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn choose_one_of_detects_shared_noun_counter_choice() {
+        use crate::types::counter::CounterType;
+        use crate::types::keywords::KeywordKind;
+
+        // CR 122.1b shared-noun shape: one leading article + bare keyword
+        // adjectives + one trailing "counter" ("a flying, lifelink, or
+        // deathtouch counter" == choice of {flying, lifelink, deathtouch}).
+        let ability = parse_effect_chain(
+            "Put your choice of a flying, lifelink, or deathtouch counter on target creature.",
+            AbilityKind::Spell,
+        );
+
+        // The shared "on target creature" is a single cast-time target lifted to
+        // a `TargetOnly` head; the counter choice is the chained sub-ability
+        // whose branches act on `ParentTarget`.
+        assert!(
+            matches!(&*ability.effect, Effect::TargetOnly { .. }),
+            "expected TargetOnly head, got {:?}",
+            ability.effect
+        );
+
+        let choice = ability
+            .sub_ability
+            .as_deref()
+            .expect("counter choice must be chained as a sub-ability");
+        let Effect::ChooseOneOf { chooser, branches } = &*choice.effect else {
+            panic!("expected ChooseOneOf sub-ability, got {:?}", choice.effect);
+        };
+        assert_eq!(*chooser, PlayerFilter::Controller);
+        assert_eq!(branches.len(), 3);
+
+        let expected = [
+            KeywordKind::Flying,
+            KeywordKind::Lifelink,
+            KeywordKind::Deathtouch,
+        ];
+        for (i, kind) in expected.iter().enumerate() {
+            match &*branches[i].effect {
+                Effect::PutCounter {
+                    counter_type,
+                    count,
+                    target,
+                } => {
+                    assert_eq!(
+                        *counter_type,
+                        CounterType::Keyword(*kind),
+                        "branch {i} should be {:?}",
+                        kind
+                    );
+                    assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                    assert_eq!(*target, TargetFilter::ParentTarget);
+                }
+                other => panic!("expected branch {i} PutCounter, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn shared_noun_counter_choice_rejects_non_counter_list() {
+        // "a red or blue creature" is a noun-phrase disjunction, not a counter
+        // choice — the per-item strict-counter-type guard must reject it so the
+        // shared-noun arm does not produce a ChooseOneOf-of-PutCounter shape.
+        let ability = parse_effect_chain(
+            "Put your choice of a red or blue creature on target creature.",
+            AbilityKind::Spell,
+        );
+
+        let is_counter_choice = match &*ability.effect {
+            Effect::TargetOnly { .. } => ability.sub_ability.as_deref().is_some_and(|sub| {
+                matches!(&*sub.effect, Effect::ChooseOneOf { branches, .. }
+                    if branches.iter().all(|b| matches!(&*b.effect, Effect::PutCounter { .. })))
+            }),
+            _ => false,
+        };
+        assert!(
+            !is_counter_choice,
+            "non-counter list must not be parsed as a shared-noun counter choice, got {:?}",
+            ability.effect
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/primitives.rs
+++ b/crates/engine/src/parser/oracle_nom/primitives.rs
@@ -298,6 +298,33 @@ pub fn parse_counter_type_typed(input: &str) -> OracleResult<'_, CounterType> {
     .parse(input)
 }
 
+/// Parse a *recognized* counter type, rejecting unknown tokens.
+///
+/// This is `parse_counter_type_typed` MINUS the open-ended `take_till1 →
+/// Generic` fallback arm. Only the three enumerated arms (P/T modifier,
+/// keyword counter, named counter) are tried, so an unrecognized token such as
+/// "red" or "blue creature" fails the parse instead of mapping to
+/// `CounterType::Generic`. Callers use this to validate that a list item names
+/// a real counter type before classifying a disjunctive list as a counter
+/// choice.
+///
+/// CR 122.1b: keyword counters (docs/MagicCompRules.txt:1180).
+/// CR 122.1: named counters (docs/MagicCompRules.txt:1176).
+pub(crate) fn parse_strict_counter_type(input: &str) -> OracleResult<'_, CounterType> {
+    alt((
+        map(parse_pt_modifier, |(power, toughness)| {
+            crate::types::counter::parse_counter_type(&format!("{power:+}/{toughness:+}"))
+        }),
+        map(parse_keyword_counter_name, |raw| {
+            crate::types::counter::parse_counter_type(raw)
+        }),
+        map(parse_named_counter_type, |raw| {
+            crate::types::counter::parse_counter_type(raw)
+        }),
+    ))
+    .parse(input)
+}
+
 /// Parse a keyword counter name: "flying", "first strike", "double strike", etc.
 ///
 /// CR 122.1b: A keyword counter on a permanent causes that object to gain the
@@ -901,6 +928,15 @@ mod tests {
         assert_eq!(parse_number("eighty").unwrap().1, 80);
         assert_eq!(parse_number("ninety").unwrap().1, 90);
         assert_eq!(parse_number("one hundred").unwrap().1, 100);
+    }
+
+    /// `parse_strict_counter_type` accepts recognized counter tokens (keyword
+    /// counters, named counters) and rejects unknown tokens — unlike
+    /// `parse_counter_type_typed`, which maps anything to `CounterType::Generic`.
+    #[test]
+    fn test_parse_strict_counter_type_rejects_unrecognized() {
+        assert!(parse_strict_counter_type("menace").is_ok());
+        assert!(parse_strict_counter_type("red").is_err());
     }
 
     /// "one hundred" must be tried BEFORE "one" so "one hundred cards"


### PR DESCRIPTION
Add the third disjunctive counter-choice list shape to
try_parse_put_counter_choice: the shared-noun form "a {X, Y, ..., or Z}
counter" — one leading article + bare keyword adjectives + one trailing
"counter" distributing over all of them ("a menace, trample, reach, or
haste counter"). Distinct from the distributed and from-among forms.

- New pub(crate) parse_strict_counter_type (oracle_nom/primitives.rs):
  parse_counter_type_typed minus the Generic fallback, validates each
  shared-noun item so non-counter lists reject.
- Replace the from_among bool with a typed ChoiceListShape enum;
  classification order FromAmong -> SharedNoun -> Distributed.
- Shared-noun recognizer is pure nom; the item boundary stops at both the
  separator AND a (" counter", eof) sentinel so the final item does not
  swallow the trailing noun. A load-bearing per-item strict guard
  (all_consuming(parse_strict_counter_type) + len>=2) rejects distributed/
  from-among/non-counter lists.

Owen Grady, Raptor Trainer now parses end-to-end: activated {T} ability,
sorcery-speed, target Dinosaur lifted to a TargetOnly head, body
ChooseOneOf of 4 keyword PutCounter branches on ParentTarget. Pure parser
change — keyword counters and shared-target lifting already resolve.

CR 122.1b, CR 122.1, CR 608.2d, CR 601.2c.
