### PR TITLE
fix(engine): reject normal hand-cast of no-mana-cost cards (#827)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -4253,11 +4253,19 @@ fn build_oracle_face_inner(
         keywords.retain(|kw| !matches!(kw, Keyword::Hexproof));
     }
 
+    // CR 202.1b: A card with no `manaCost` (lands, and suspend-only cards like
+    // Inevitable Betrayal / Ancestral Vision) has *no* mana cost where its cost
+    // would appear — not a payable {0} cost.
+    // CR 118.6: no mana cost is an unpayable cost. Map an absent manaCost to
+    // `NoCost`; `unwrap_or_default()` previously collapsed it to `Cost{0}`, which
+    // made such cards castable for free from hand (issue #827). Real `{0}` cards
+    // (Ornithopter, Mox) carry an explicit `"{0}"` manaCost and stay
+    // `Cost{ generic: 0 }` via `parse_mtgjson_mana_cost`.
     let mana_cost = mtgjson
         .mana_cost
         .as_deref()
         .map(parse_mtgjson_mana_cost)
-        .unwrap_or_default();
+        .unwrap_or(ManaCost::NoCost);
 
     let mana_derived_colors = derive_colors_from_mana_cost(&mana_cost);
     let mtgjson_colors: Vec<ManaColor> = mtgjson

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4245,7 +4245,26 @@ pub fn handle_cast_spell_with_payment_mode(
     // any keyword-choice prompts (Adventure, Warp, Evoke, Overload) that
     // would fire for hand-only objects.
     match obj.zone {
-        Zone::Hand => {} // Always castable from hand
+        Zone::Hand => {
+            // CR 202.1b: A card with no mana cost (Inevitable Betrayal and other
+            // suspend-only cards) has an unpayable cost.
+            // CR 118.6: it can't be cast from hand by paying that cost; its legal
+            // plays are via an effect/keyword (e.g. Suspend's exile activation),
+            // which are separate actions/zones.
+            // CR 118.6a: an effect that lets you cast it WITHOUT paying its mana
+            // cost may still cast it — the `Unlimited` `CastFromHandFree`
+            // permission (Omniscience) takes this normal path, so don't block it.
+            // Defense-in-depth — the candidate generator already excludes the
+            // no-permission case via `can_cast_object_now`.
+            if matches!(obj.mana_cost, ManaCost::NoCost)
+                && !hand_cast_free_permission_source(state, player, obj)
+                    .is_some_and(|(_, frequency)| frequency == CastFrequency::Unlimited)
+            {
+                return Err(EngineError::InvalidAction(format!(
+                    "Cannot cast {object_id:?} from hand — it has no mana cost (CR 118.6)",
+                )));
+            }
+        }
         Zone::Command if state.format_config.command_zone && obj.is_commander => {}
         Zone::Exile | Zone::Graveyard | Zone::Library => {
             // These zones are allowed only with permission — defer the
@@ -5267,6 +5286,26 @@ fn can_cast_prepared_now(
     let Some(obj) = state.objects.get(&prepared.object_id) else {
         return false;
     };
+
+    // CR 202.1b: A card with no mana cost (suspend-only cards like Inevitable
+    // Betrayal) has an unpayable cost.
+    // CR 118.6: it therefore can't be cast from hand by paying that cost. Its
+    // only legal plays are via an effect/keyword — Suspend's exile activation,
+    // the free-cast from exile, or an effect-granted `CastSpellForFree` — none
+    // of which take this normal-hand-cast path.
+    // CR 118.6a: the exception is an effect that lets you cast it WITHOUT paying
+    // its mana cost. The only such effect routed through this normal-CastSpell
+    // path is an `Unlimited` `CastFromHandFree` permission (Omniscience / Tamiyo
+    // emblem), which `prepare_spell_cast` recognizes via the same predicate and
+    // zeroes the cost. `OncePerTurn` sources (Zaffai) opt in via the dedicated
+    // `CastSpellForFree` action instead. Block the normal hand cast otherwise.
+    if obj.zone == Zone::Hand
+        && matches!(obj.mana_cost, ManaCost::NoCost)
+        && !hand_cast_free_permission_source(state, player, obj)
+            .is_some_and(|(_, frequency)| frequency == CastFrequency::Unlimited)
+    {
+        return false;
+    }
 
     // CR 601.3d: A cast authorized only by a target-dependent flash option is
     // illegal unless a condition-satisfying target exists. Pre-target FEASIBILITY
@@ -13545,7 +13584,10 @@ mod tests {
         {
             let obj = state.objects.get_mut(&spell).unwrap();
             obj.card_types.core_types.push(CoreType::Sorcery);
-            obj.mana_cost = ManaCost::NoCost;
+            // Real {0} mana cost (payable), not NoCost: this fixture exercises the
+            // "pay X life" additional cost, so it must be a castable spell. CR
+            // 118.6 makes a true no-mana-cost (NoCost) card uncastable from hand.
+            obj.mana_cost = ManaCost::zero();
             obj.additional_cost = Some(AdditionalCost::Required(AbilityCost::PayLife {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::Variable {

--- a/crates/engine/tests/integration/inevitable_betrayal_no_mana_cost.rs
+++ b/crates/engine/tests/integration/inevitable_betrayal_no_mana_cost.rs
@@ -1,0 +1,144 @@
+//! Regression for issue #827: Inevitable Betrayal (Suspend 3—{1}{U}{U}, no mana
+//! cost) could be cast "normally" for free from hand.
+//!
+//! CR 202.1b: a card with no mana symbols where its mana cost would appear has
+//! no mana cost. CR 118.6: no mana cost is an unpayable cost, so the card can't
+//! be cast from hand by paying it — its only outlet is the Suspend activation.
+//! CR 118.6a: an effect that lets you cast it *without paying its mana cost*
+//! (e.g. Omniscience) is the exception and may still cast it.
+//!
+//! Two coupled defects produced the original bug:
+//!   - the card-data pipeline emitted `Cost{0}` instead of `ManaCost::NoCost`
+//!     for an absent MTGJSON `manaCost` (synthesis `.unwrap_or_default()`), and
+//!   - the hand-cast gate (`can_cast_object_now` / `handle_cast_spell`) never
+//!     rejected no-mana-cost cards.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use engine::ai_support::legal_actions;
+use engine::database::card_db::CardDatabase;
+use engine::game::casting::can_cast_object_now;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::actions::GameAction;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+fn load_db() -> Option<&'static CardDatabase> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../client/public/card-data.json");
+    if !path.exists() {
+        return None;
+    }
+    static DB: OnceLock<CardDatabase> = OnceLock::new();
+    Some(DB.get_or_init(|| CardDatabase::from_export(&path).expect("export should load")))
+}
+
+/// Core regression: a no-mana-cost card can't be cast normally from hand, a real
+/// {0} card still can, and the no-mana-cost card is NOT bricked — its Suspend
+/// activation remains available.
+#[test]
+fn inevitable_betrayal_no_mana_cost_blocks_normal_cast_but_keeps_suspend() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let betrayal = scenario.add_real_card(P0, "Inevitable Betrayal", Zone::Hand, db);
+    // Control: a real {0} card (explicit "{0}" manaCost) must stay castable —
+    // this is what distinguishes NoCost from a payable Cost{generic:0}.
+    let ornithopter = scenario.add_real_card(P0, "Ornithopter", Zone::Hand, db);
+
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    // {1}{U}{U} so the Suspend activation (its cost) is affordable and offerable.
+    {
+        let pool = &mut runner.state_mut().players[0].mana_pool;
+        pool.add(ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]));
+        pool.add(ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]));
+        pool.add(ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+    }
+
+    // Pipeline fix: no printed mana cost -> NoCost, not a payable {0} cost.
+    assert!(
+        matches!(
+            runner.state().objects[&betrayal].mana_cost,
+            ManaCost::NoCost
+        ),
+        "Inevitable Betrayal must parse with ManaCost::NoCost, got {:?}",
+        runner.state().objects[&betrayal].mana_cost
+    );
+
+    // CR 202.1b + 118.6: an unpayable (no-mana) cost can't be cast normally.
+    // (no mana cost => unpayable => not castable by paying it)
+    assert!(
+        !can_cast_object_now(runner.state(), P0, betrayal),
+        "Inevitable Betrayal (no mana cost) must NOT be castable normally from hand (CR 118.6)"
+    );
+
+    // Control: the real {0} artifact stays castable — the NoCost gate must not
+    // bleed into payable {0} costs.
+    assert!(
+        can_cast_object_now(runner.state(), P0, ornithopter),
+        "A real {{0}} card (Ornithopter) must remain castable from hand"
+    );
+
+    // Not bricked: the card is still playable via its Suspend activation
+    // (a separate ActivateAbility from hand). A future over-broadening of the
+    // NoCost gate that also suppressed this would be caught here.
+    let actions = legal_actions(runner.state());
+    assert!(
+        actions.iter().any(|a| matches!(
+            a,
+            GameAction::ActivateAbility { source_id, .. } if *source_id == betrayal
+        )),
+        "Inevitable Betrayal must still offer its Suspend activation from hand"
+    );
+
+    // Defense-in-depth: a direct CastSpell action is rejected even if it
+    // bypasses the candidate generator (stale action / hand-crafted payload).
+    let card_id = runner.state().objects[&betrayal].card_id;
+    let res = runner.act(GameAction::CastSpell {
+        object_id: betrayal,
+        card_id,
+        targets: vec![],
+    });
+    assert!(
+        res.is_err(),
+        "casting a no-mana-cost card from hand must be InvalidAction, got {res:?}"
+    );
+}
+
+/// CR 118.6a: an effect that lets you cast a card *without paying its mana cost*
+/// (Omniscience — `CastFromHandFree` with `Unlimited` frequency) overrides the
+/// unpayable-cost block, so even a no-mana-cost card becomes castable from hand.
+/// Guards against the gate over-blocking the Omniscience class.
+#[test]
+fn no_mana_cost_card_is_castable_from_hand_under_omniscience() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let betrayal = scenario.add_real_card(P0, "Inevitable Betrayal", Zone::Hand, db);
+    scenario.add_real_card(P0, "Omniscience", Zone::Battlefield, db);
+
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    assert!(
+        can_cast_object_now(runner.state(), P0, betrayal),
+        "With Omniscience (Unlimited CastFromHandFree) in play, a no-mana-cost card \
+         must be castable from hand without paying its mana cost (CR 118.6a)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -49,6 +49,7 @@ mod greater_good_activation;
 mod green_suns_zenith_regression;
 mod harrow_regression;
 mod hunters_insight_combat_draw;
+mod inevitable_betrayal_no_mana_cost;
 mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;


### PR DESCRIPTION
## Summary

Suspend-only cards with no printed mana cost — Inevitable Betrayal, Ancestral Vision, Lotus Bloom and friends — could be cast straight from hand for free, as though they had a `{0}` cost. Their only legal play from hand should be the Suspend activation (or an effect like Omniscience). Closes #827.

## Root cause

Two bugs lined up:

1. **Card-data pipeline.** `build_oracle_face_inner` mapped a missing MTGJSON `manaCost` with `unwrap_or_default()`, and `ManaCost::default()` is `Cost { generic: 0 }` — a *payable* zero cost. A card that prints no mana cost at all became indistinguishable from a real `{0}` card like Ornithopter.
2. **Hand-cast gate.** Even with the cost modelled correctly, nothing in the  cast path rejected a no-mana-cost card from hand, so the empty cost was treated as free.

## Fix

- `database/synthesis.rs`: an absent `manaCost` now maps to `ManaCost::NoCost` (not `Cost{0}`). Real `{0}` cards carry an explicit `"{0}"` and stay `Cost { generic: 0 }`.
- `game/casting.rs`: both the candidate generator (`can_cast_prepared_now`) and the action handler(`handle_cast_spell_with_payment_mode`) reject a `NoCost` card in hand — **unless** an `Unlimited` `CastFromHandFree` permission (Omniscience) is in effect.

## Rules

- **CR 202.1b** — a card with no mana symbols where its mana cost would appear has *no mana cost*.
- **CR 118.6** — no mana cost is an *unpayable* cost; you can't cast the card by paying it.
- **CR 118.6a** — the exception: an effect that lets you cast it *without paying its mana cost* (Omniscience) still works, and is preserved.

## Testing

New `inevitable_betrayal_no_mana_cost.rs` integration test:

- Inevitable Betrayal parses to `ManaCost::NoCost` and is **not** castable normally from hand.
- Its Suspend activation is **still** offered (not bricked).
- A hand-crafted `CastSpell` action is rejected (`InvalidAction`) — defense in depth past the candidate generator.
- A real `{0}` card (Ornithopter) **stays** castable — the gate doesn't bleed into payable zero costs.
- Under Omniscience, the no-mana-cost card **becomes** castable (CR 118.6a).

Engine lib suite green (9045 passing). Full pre-push CI — fmt, clippy,
card-data validate, parser gate, engine + AI tests, oracle-gen — passes locally.
<img width="910" height="735" alt="issue827-after" src="https://github.com/user-attachments/assets/06ec0be2-fad4-4eeb-95a0-9a4cfaaf7398" />

<img width="942" height="713" alt="issue827-after-board" src="https://github.com/user-attachments/assets/52c74f72-ebcc-4774-be58-41d740c5213c" />

<img width="576" height="142" alt="issue827-after-hand" src="https://github.com/user-attachments/assets/6d3eb820-af2e-4747-843c-44c18c47c252" />

<img width="910" height="735" alt="issue827-after-viewer" src="https://github.com/user-attachments/assets/9cc8f00d-bad3-404b-ac31-0d7919502d58" />