### PR TITLE
feat(engine): enters-with-your-choice-of-counter (Denry Klin)

### DIFF
--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -706,25 +706,61 @@ pub(super) fn apply_pending_post_replacement_effect(
     waiting_for
 }
 
-/// CR 614.12a + CR 707.9: If `waiting_for` is `CopyTargetChoice`, clone any
-/// battlefield-entry `ZoneChanged` events for the entering source into
-/// `state.deferred_entry_events`. The original `events` vec is preserved so
-/// the frontend animates the entry as soon as the spell resolves; the deferred
-/// copy is replayed through `process_triggers` / `check_delayed_triggers` once
-/// `BecomeCopy` resolves in `handle_copy_target_choice`.
+/// CR 614.12a: True when every branch of a `ChooseOneOfBranch` is a self-targeted
+/// `PutCounter` — the signature of an "enters with your choice of counter"
+/// replacement (Denry Klin, Editor in Chief). When this holds, the choice is a
+/// pre-entry counter fold and the entering object's `ZoneChanged` event must be
+/// deferred until after the branch is chosen, so ETB observers see the chosen
+/// counter (CR 614.12a). Exhaustive — no wildcard accept.
+fn is_enters_counter_choice(branches: &[AbilityDefinition]) -> bool {
+    branches.len() >= 2
+        && branches.iter().all(|b| {
+            matches!(
+                &*b.effect,
+                Effect::PutCounter {
+                    target: TargetFilter::SelfRef,
+                    ..
+                }
+            )
+        })
+}
+
+/// CR 614.12a + CR 707.9: If `waiting_for` is `CopyTargetChoice`, or a
+/// `ChooseOneOfBranch` that `is_enters_counter_choice` (the enters-with-choice-
+/// of-counter shape), clone any battlefield-entry `ZoneChanged` events for the
+/// entering source into `state.deferred_entry_events`. The original `events` vec
+/// is preserved so the frontend animates the entry as soon as the spell
+/// resolves; the deferred copy is replayed through `process_triggers` /
+/// `check_delayed_triggers` once the choice resolves (in
+/// `handle_copy_target_choice` for copies, in the `ChooseBranch` arm of
+/// `engine_resolution_choices.rs` for enters-counter choices).
 ///
-/// Defense in depth: clears any stale events from a prior `CopyTargetChoice`
-/// that exited abnormally (concede mid-choice, eliminate_player, error return
-/// before drain) so the replay never fires triggers against a phantom object.
+/// Defense in depth: clears any stale events from a prior choice that exited
+/// abnormally (concede mid-choice, eliminate_player, error return before drain)
+/// so the replay never fires triggers against a phantom object.
 fn capture_deferred_entry_events_if_copy_target_choice(
     state: &mut GameState,
     waiting_for: Option<&WaitingFor>,
     events: &[GameEvent],
 ) {
-    let Some(WaitingFor::CopyTargetChoice { source_id, .. }) = waiting_for else {
-        return;
+    let source_id = match waiting_for {
+        Some(WaitingFor::CopyTargetChoice { source_id, .. }) => *source_id,
+        // CR 614.12a: enters-with-your-choice-of-counter defers its entry event
+        // exactly like the copy-target choice does, so the watcher's ETB trigger
+        // observes the chosen counter as the permanent enters.
+        Some(WaitingFor::ChooseOneOfBranch {
+            source_id,
+            branches,
+            ..
+        }) if is_enters_counter_choice(branches) => *source_id,
+        _ => return,
     };
-    let source_id = *source_id;
+    // CR 614.12b boundary (inherited from the CopyTargetChoice path, NOT expanded
+    // here): mass-moving multiple pre-entry-choice permanents in one effect
+    // (`resolve_all` in change_zone.rs does not bail on a post-replacement choice)
+    // could let one object's capture `clear()`/overwrite another's deferred
+    // events. This already affects CopyTargetChoice today, is unreachable in real
+    // cards, and is the CR 614.12b simultaneous-entry boundary.
     state.deferred_entry_events.clear();
     for event in events {
         if matches!(
@@ -1854,6 +1890,273 @@ mod tests {
         assert!(
             trigger_fired,
             "Callidus's granted destroy-same-name trigger must fire from the deferred entry replay"
+        );
+    }
+
+    /// CR 614.12a + CR 608.2d: Drive the full "enters with your choice of
+    /// counter" path (Denry Klin, Editor in Chief line 1) through the production
+    /// pipeline — `replace_event` (Execute) → `move_to_zone` → `apply_etb_counters`
+    /// → `apply_pending_post_replacement_effect` (sets `ChooseOneOfBranch` +
+    /// captures the deferred entry event) → `ChooseBranch`.
+    ///
+    /// Discriminates pre- vs post-entry: a watcher ETB trigger observes "a
+    /// creature entered". The watcher must NOT have fired while paused on the
+    /// choice (the entry is deferred), and after `ChooseBranch` the chosen
+    /// counter must be present AS the watcher's deferred entry replays (proving
+    /// the counter was folded pre-entry per CR 614.12a, not added post-entry).
+    /// `index: 1` (first strike) and `index: 0` (+1/+1) yield different counters,
+    /// proving a real choice.
+    fn drive_denry_choice(branch_index: usize) -> (GameState, ObjectId) {
+        use crate::types::ability::{
+            AbilityDefinition, AbilityKind, Effect, FilterProp, TargetFilter, TriggerDefinition,
+        };
+        use crate::types::triggers::TriggerMode;
+
+        let mut state = GameState::new_two_player(42);
+
+        // Watcher: "When a creature enters, its controller draws a card."
+        // Targetless to keep the assertion focused on the fire-with-counter
+        // ordering rather than target-selection plumbing.
+        let watcher_trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            ))
+            .valid_card(TargetFilter::Typed(
+                crate::types::ability::TypedFilter::new(
+                    crate::types::ability::TypeFilter::Creature,
+                )
+                .properties(vec![FilterProp::Another]),
+            ))
+            .destination(Zone::Battlefield);
+        let watcher = make_creature(&mut state, PlayerId(1), "Soul Warden");
+        state
+            .objects
+            .get_mut(&watcher)
+            .unwrap()
+            .trigger_definitions
+            .push(watcher_trigger);
+
+        // Parse Denry Klin line 1 into the real ReplacementDefinition.
+        let repl = crate::parser::oracle_replacement::parse_replacement_line(
+            "Denry Klin enters with your choice of a +1/+1, first strike, or vigilance counter on it.",
+            "Denry Klin, Editor in Chief",
+        )
+        .expect("Denry Klin line 1 must parse to a replacement");
+        assert_eq!(repl.event, ReplacementEvent::Moved);
+
+        let denry = create_object(
+            &mut state,
+            CardId(200),
+            PlayerId(0),
+            "Denry Klin, Editor in Chief".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&denry).unwrap();
+            obj.base_name = "Denry Klin, Editor in Chief".to_string();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types.core_types.push(CoreType::Creature);
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.replacement_definitions.push(repl);
+        }
+
+        // ── Drive the production Stack→Battlefield pipeline ─────────────────
+        let mut events = Vec::new();
+        let proposed = ProposedEvent::ZoneChange {
+            object_id: denry,
+            from: Zone::Stack,
+            to: Zone::Battlefield,
+            cause: None,
+            enter_tapped: crate::types::proposed_event::EtbTapState::Unspecified,
+            enter_with_counters: Vec::new(),
+            controller_override: None,
+            enter_transformed: false,
+            applied: std::collections::HashSet::new(),
+        };
+        let result = replacement_mod::replace_event(&mut state, proposed, &mut events);
+        let ReplacementResult::Execute(event) = result else {
+            panic!("mandatory enters-with-choice must Execute, got {result:?}");
+        };
+        let crate::types::proposed_event::ProposedEvent::ZoneChange { object_id, to, .. } = event
+        else {
+            panic!("expected ZoneChange execute event");
+        };
+        // Mirror engine.rs's Execute arm: move, then drain the post-replacement
+        // continuation (the ChooseOneOf execute).
+        crate::game::zones::move_to_zone(&mut state, object_id, to, &mut events);
+        assert!(
+            state.post_replacement_continuation.is_some(),
+            "ChooseOneOf execute must stash a post-replacement continuation"
+        );
+        let waiting = apply_pending_post_replacement_effect(
+            &mut state,
+            Some(object_id),
+            None,
+            Some(ReplacementEvent::Moved),
+            &mut events,
+        );
+
+        // ── Paused on the counter choice, entry deferred, watcher NOT fired ──
+        let Some(WaitingFor::ChooseOneOfBranch {
+            source_id,
+            branches,
+            ..
+        }) = waiting.clone()
+        else {
+            panic!("expected ChooseOneOfBranch, got {waiting:?}");
+        };
+        assert_eq!(source_id, denry, "choice source must be the entering Denry");
+        assert_eq!(branches.len(), 3, "three counter branches");
+        assert_eq!(
+            state.deferred_entry_events.len(),
+            1,
+            "Denry's battlefield-entry event must be deferred until the choice is made"
+        );
+        // CR 614.12a: the watcher must NOT have observed the entry yet (no
+        // trigger queued / on stack) — the entry is held back.
+        assert!(
+            state.pending_trigger.is_none()
+                && !state.stack.iter().any(|e| matches!(
+                    e.kind,
+                    crate::types::game_state::StackEntryKind::TriggeredAbility { .. }
+                )),
+            "watcher trigger must not fire before the counter choice (deferred entry)"
+        );
+        assert!(
+            state.objects[&denry].counters.is_empty(),
+            "no counter is present before the choice is made"
+        );
+        state.waiting_for = waiting.unwrap();
+        state.priority_player = PlayerId(0);
+
+        // ── Make the choice ────────────────────────────────────────────────
+        apply_as_current(
+            &mut state,
+            GameAction::ChooseBranch {
+                index: branch_index,
+            },
+        )
+        .expect("choose counter branch");
+
+        (state, denry)
+    }
+
+    #[test]
+    fn denry_klin_enters_with_choice_folds_counter_pre_entry() {
+        use crate::types::counter::CounterType;
+        use crate::types::keywords::KeywordKind;
+
+        // index 1 → first strike: exactly one first strike counter, nothing else.
+        let (state, denry) = drive_denry_choice(1);
+        let counters = &state.objects[&denry].counters;
+        assert_eq!(
+            counters.get(&CounterType::Keyword(KeywordKind::FirstStrike)),
+            Some(&1),
+            "first strike counter must be present"
+        );
+        assert!(
+            !counters.contains_key(&CounterType::Plus1Plus1)
+                && !counters.contains_key(&CounterType::Keyword(KeywordKind::Vigilance)),
+            "no other counter may be present, got {counters:?}"
+        );
+        // CR 614.12a: the deferred entry was replayed, so the watcher observed
+        // Denry WITH the chosen counter (proves pre-entry, not post-entry).
+        assert!(
+            state.deferred_entry_events.is_empty(),
+            "deferred entry must drain on the ChooseBranch replay"
+        );
+        let watcher_fired = state.pending_trigger.is_some()
+            || state.stack.iter().any(|e| {
+                matches!(
+                    e.kind,
+                    crate::types::game_state::StackEntryKind::TriggeredAbility { .. }
+                )
+            });
+        assert!(
+            watcher_fired,
+            "watcher ETB trigger must fire from the deferred entry replay after the choice"
+        );
+
+        // index 0 → +1/+1: different counter, proving a real choice.
+        let (state0, denry0) = drive_denry_choice(0);
+        let counters0 = &state0.objects[&denry0].counters;
+        assert_eq!(
+            counters0.get(&CounterType::Plus1Plus1),
+            Some(&1),
+            "index 0 must place the +1/+1 counter"
+        );
+        assert!(
+            !counters0.contains_key(&CounterType::Keyword(KeywordKind::FirstStrike)),
+            "index 0 must NOT place first strike"
+        );
+    }
+
+    /// Negative guard: a normal (non-entry) `ChooseOneOf` resolved via
+    /// `ChooseBranch` with `state.deferred_entry_events` empty must NOT trigger
+    /// the deferred-entry replay — the disambiguator. This protects against the
+    /// enters-counter replay misrouting an unrelated branch choice.
+    #[test]
+    fn unrelated_choose_branch_does_not_replay_deferred_entry() {
+        use crate::types::ability::{AbilityDefinition, AbilityKind, Effect};
+
+        let mut state = GameState::new_two_player(42);
+        let source = make_creature(&mut state, PlayerId(0), "Source");
+        let p0_life = state.players[0].life;
+
+        // Two unrelated branches (gain 3 / lose 1) — NOT PutCounter/SelfRef, so
+        // the capture never deferred anything for this choice.
+        let branches = vec![
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 3 },
+                    player: crate::types::ability::GainLifePlayer::Controller,
+                },
+            ),
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::LoseLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    target: None,
+                },
+            ),
+        ];
+
+        state.waiting_for = WaitingFor::ChooseOneOfBranch {
+            player: PlayerId(0),
+            controller: PlayerId(0),
+            source_id: source,
+            branches,
+            branch_descriptions: Vec::new(),
+            parent_targets: Vec::new(),
+            context: Default::default(),
+            remaining_players: Vec::new(),
+        };
+        state.priority_player = PlayerId(0);
+        assert!(
+            state.deferred_entry_events.is_empty(),
+            "precondition: no deferred entry for an unrelated choice"
+        );
+
+        apply_as_current(&mut state, GameAction::ChooseBranch { index: 0 })
+            .expect("resolve unrelated ChooseOneOf");
+
+        // Branch 0 (gain 3) applied normally; no replay side effects.
+        assert_eq!(
+            state.players[0].life,
+            p0_life + 3,
+            "gain-life branch applied"
+        );
+        assert!(
+            state.deferred_entry_events.is_empty(),
+            "deferred entry must remain empty for an unrelated choice"
         );
     }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1472,6 +1472,31 @@ pub(super) fn handle_resolution_choice(
                 events,
             )
             .map_err(|err| EngineError::InvalidAction(err.to_string()))?;
+            // CR 614.12a: For an "enters with your choice of counter" replacement
+            // (Denry Klin), the entering permanent's battlefield-entry ZoneChanged
+            // event was deferred into `state.deferred_entry_events` by the ETB-
+            // replacement capture in `engine_replacement.rs` so observers don't
+            // fire before the choice is made. Now that `resolve_branch` has folded
+            // the chosen counter onto the still-entering permanent, replay the
+            // deferred entry through the trigger pipeline so ETB observers see the
+            // counter as the permanent enters (pre-entry per CR 614.12a, not a
+            // post-entry counter add). For a normal (non-entry) `ChooseOneOf`,
+            // `deferred_entry_events` is empty, so this is a no-op — the
+            // disambiguator. This is safe because `deferred_entry_events` is
+            // populated ONLY by the ETB-replacement capture (sole production
+            // write-site), and `CopyTargetChoice` drains it via its own
+            // `handle_copy_target_choice` handler, so it is never non-empty during
+            // an unrelated `ChooseBranch`.
+            let deferred = std::mem::take(&mut state.deferred_entry_events);
+            let source_still_on_bf = state
+                .objects
+                .get(&source_id)
+                .is_some_and(|o| o.zone == Zone::Battlefield);
+            if !deferred.is_empty() && source_still_on_bf {
+                super::triggers::process_triggers(state, &deferred);
+                let delayed = super::triggers::check_delayed_triggers(state, &deferred);
+                events.extend(delayed);
+            }
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -36,8 +36,8 @@ use super::oracle_target::{
     parse_that_clause_suffix, parse_type_phrase, TargetSyntax,
 };
 use super::oracle_util::{
-    contains_possessive, has_unconsumed_conditional, parse_mana_symbols, parse_number,
-    split_around, starts_with_possessive, strip_after, TextPair,
+    contains_possessive, has_unconsumed_conditional, parse_count_expr, parse_mana_symbols,
+    parse_number, split_around, starts_with_possessive, strip_after, TextPair,
 };
 use crate::database::mtgjson::parse_mtgjson_mana_cost;
 use crate::parser::oracle_effect::subject::parse_subject_application;
@@ -2174,6 +2174,94 @@ fn recognize_shared_noun_counter_list(input: &str) -> Option<Vec<&str>> {
     .parse(input)
     .ok()?;
     Some(items)
+}
+
+/// CR 122.1 + CR 608.2d: Context-free classifier for a disjunctive
+/// counter-choice list. Given the choices payload (the text BETWEEN
+/// "your choice of " and " on TARGET"), recognize which of the three list
+/// shapes it is and parse each item into a typed `(CounterType, QuantityExpr)`
+/// pair.
+///
+/// Three list shapes (classified in priority order, mirroring
+/// `try_parse_put_counter_choice`):
+///   1. FromAmong  — "a counter from among X, Y, ..., and Z" (bare keywords)
+///   2. SharedNoun — "a X, Y, ..., or Z counter" (one leading article + bare
+///      keyword adjectives + one trailing "counter")
+///   3. Distributed — "a A counter, a B counter, or a C counter" / binary,
+///      each item a full counter noun phrase.
+///
+/// Item parsing:
+///   - Distributed item ("a +1/+1 counter", "two charge counters"):
+///     `parse_count_expr` then `parse_counter_type_typed` on the remainder
+///     (mirrors `counter.rs::try_parse_put_counter`).
+///   - FromAmong / SharedNoun bare-keyword item ("first strike"):
+///     `all_consuming(parse_strict_counter_type)`, count = `Fixed { 1 }`.
+///
+/// Requires at least 2 items and that every item names a real counter type;
+/// a non-counter list returns `None`. Nom-only — no string dispatch.
+///
+/// CR 122.1b: keyword counters (docs/MagicCompRules.txt:1180).
+/// CR 122.1: named counters (docs/MagicCompRules.txt:1176).
+pub(crate) fn classify_and_parse_counter_choice_list(
+    choices_text: &str,
+) -> Option<Vec<(CounterType, QuantityExpr)>> {
+    let (shape, choice_items) =
+        match tag::<_, _, OracleError<'_>>("a counter from among ")(choices_text) {
+            Ok((rest, _)) => (ChoiceListShape::FromAmong, split_choice_list_items(rest)?),
+            // CR 122.1b: keyword counters distribute over a single noun; only
+            // classify as SharedNoun when the shape matches AND every item is a
+            // recognized counter type — otherwise distributed lists and
+            // non-counter lists leak through. Fall through to Distributed when
+            // the strict guard fails.
+            Err(_) => match recognize_shared_noun_counter_list(choices_text) {
+                Some(items)
+                    if items.len() >= 2
+                        && items.iter().all(|item| {
+                            all_consuming(nom_primitives::parse_strict_counter_type)
+                                .parse(item.trim())
+                                .is_ok()
+                        }) =>
+                {
+                    (ChoiceListShape::SharedNoun, items)
+                }
+                _ => (
+                    ChoiceListShape::Distributed,
+                    split_choice_list_items(choices_text)?,
+                ),
+            },
+        };
+
+    if choice_items.len() < 2 {
+        return None;
+    }
+
+    let mut entries: Vec<(CounterType, QuantityExpr)> = Vec::with_capacity(choice_items.len());
+    for item in &choice_items {
+        let item = item.trim();
+        if item.is_empty() {
+            return None;
+        }
+        let entry = match shape {
+            // CR 122.1: full counter noun phrase ("a +1/+1 counter", "two charge
+            // counters"). Parse count then counter type from the remainder.
+            ChoiceListShape::Distributed => {
+                let (count, rest) = parse_count_expr(item)?;
+                let (_after, counter_type) = nom_primitives::parse_counter_type_typed(rest).ok()?;
+                (counter_type, count)
+            }
+            // CR 122.1b: bare keyword name ("first strike"); count is one.
+            ChoiceListShape::FromAmong | ChoiceListShape::SharedNoun => {
+                let (_rest, counter_type) =
+                    all_consuming(nom_primitives::parse_strict_counter_type)
+                        .parse(item)
+                        .ok()?;
+                (counter_type, QuantityExpr::Fixed { value: 1 })
+            }
+        };
+        entries.push(entry);
+    }
+
+    Some(entries)
 }
 
 /// CR 122.1 + CR 608.2d: Parse shared-target counter choices of the form
@@ -36726,6 +36814,103 @@ mod tests {
                 other => panic!("expected branch {i} PutCounter, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn classify_counter_choice_list_all_three_shapes() {
+        use crate::types::counter::CounterType;
+        use crate::types::keywords::KeywordKind;
+
+        // SharedNoun: one article + bare keyword adjectives + trailing "counter".
+        let shared =
+            classify_and_parse_counter_choice_list("a +1/+1, first strike, or vigilance counter")
+                .expect("shared-noun counter list should classify");
+        assert_eq!(
+            shared,
+            vec![
+                (CounterType::Plus1Plus1, QuantityExpr::Fixed { value: 1 }),
+                (
+                    CounterType::Keyword(KeywordKind::FirstStrike),
+                    QuantityExpr::Fixed { value: 1 }
+                ),
+                (
+                    CounterType::Keyword(KeywordKind::Vigilance),
+                    QuantityExpr::Fixed { value: 1 }
+                ),
+            ]
+        );
+
+        // Distributed: each item a full counter noun phrase.
+        let distributed = classify_and_parse_counter_choice_list(
+            "a +1/+1 counter, a first strike counter, or a vigilance counter",
+        )
+        .expect("distributed counter list should classify");
+        assert_eq!(
+            distributed,
+            vec![
+                (CounterType::Plus1Plus1, QuantityExpr::Fixed { value: 1 }),
+                (
+                    CounterType::Keyword(KeywordKind::FirstStrike),
+                    QuantityExpr::Fixed { value: 1 }
+                ),
+                (
+                    CounterType::Keyword(KeywordKind::Vigilance),
+                    QuantityExpr::Fixed { value: 1 }
+                ),
+            ]
+        );
+
+        // FromAmong: "a counter from among X, Y, and Z" (bare keywords).
+        let from_among = classify_and_parse_counter_choice_list(
+            "a counter from among first strike, vigilance, and lifelink",
+        )
+        .expect("from-among counter list should classify");
+        assert_eq!(
+            from_among,
+            vec![
+                (
+                    CounterType::Keyword(KeywordKind::FirstStrike),
+                    QuantityExpr::Fixed { value: 1 }
+                ),
+                (
+                    CounterType::Keyword(KeywordKind::Vigilance),
+                    QuantityExpr::Fixed { value: 1 }
+                ),
+                (
+                    CounterType::Keyword(KeywordKind::Lifelink),
+                    QuantityExpr::Fixed { value: 1 }
+                ),
+            ]
+        );
+
+        // Distributed with a non-unit count ("two charge counters").
+        let with_count =
+            classify_and_parse_counter_choice_list("a +1/+1 counter or two charge counters")
+                .expect("distributed counter list with count should classify");
+        assert_eq!(
+            with_count,
+            vec![
+                (CounterType::Plus1Plus1, QuantityExpr::Fixed { value: 1 }),
+                (
+                    CounterType::Generic("charge".to_string()),
+                    QuantityExpr::Fixed { value: 2 }
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn classify_counter_choice_list_rejects_non_counter_and_singletons() {
+        // Non-counter disjunction must not classify as a counter choice.
+        assert!(
+            classify_and_parse_counter_choice_list("a red or blue creature").is_none(),
+            "non-counter list must return None"
+        );
+        // A single item is not a choice (requires >= 2).
+        assert!(
+            classify_and_parse_counter_choice_list("a +1/+1 counter").is_none(),
+            "single-item list must return None"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -28,8 +28,8 @@ use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, CastVariantPaid, ChoiceType, CombatDamageScope,
     Comparator, ContinuousModification, ControllerRef, CopyManaValueLimit, DamageModification,
     DamageRedirectTarget, DamageTargetFilter, DamageTargetPlayerScope, Duration, Effect,
-    FilterProp, ManaModification, ManaReplacementScope, PreventionAmount, QuantityExpr,
-    QuantityRef, ReplacementCondition, ReplacementDefinition, ReplacementMode,
+    FilterProp, ManaModification, ManaReplacementScope, PlayerFilter, PreventionAmount,
+    QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition, ReplacementMode,
     ReplacementPlayerScope, StaticCondition, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::counter::{CounterMatch, CounterType};
@@ -1693,6 +1693,91 @@ fn parse_enters_with_counters(
     .parse(after_with)
     .map_or(after_with, |(rest, _)| rest);
 
+    // CR 614.12a + CR 608.2d: "~ enters with your choice of <counter-choice-list>
+    // on it" — the controller chooses WHICH counter as the permanent enters, and
+    // that choice is made before the permanent enters (CR 614.12a). Detect the
+    // "your choice of " marker, split off the trailing self-referential target
+    // ("on it" / "on ~"), classify the disjunctive list into typed counter
+    // entries, and build a `ChooseOneOf` of `PutCounter { target: SelfRef }`
+    // branches directly (no parent-target lift — the entering permanent is
+    // always the recipient). Runtime folds the chosen counter pre-entry via the
+    // deferred-entry-events capture in `engine_replacement.rs` /
+    // `engine_resolution_choices.rs`.
+    if let Some((choices, _on)) = strip_enters_with_choice_target(after_additional) {
+        if let Some(entries) =
+            crate::parser::oracle_effect::classify_and_parse_counter_choice_list(choices)
+        {
+            // `classify_and_parse_counter_choice_list` already requires len >= 2.
+            let branches: Vec<AbilityDefinition> = entries
+                .into_iter()
+                .map(|(counter_type, count)| {
+                    let mut def = AbilityDefinition::new(
+                        AbilityKind::Spell,
+                        Effect::PutCounter {
+                            counter_type: counter_type.clone(),
+                            count,
+                            // CR 614.12a: the entering permanent is the recipient.
+                            target: TargetFilter::SelfRef,
+                        },
+                    );
+                    def.description = Some(format!("a {} counter", counter_type.display_phrase()));
+                    def
+                })
+                .collect();
+
+            let choice = AbilityDefinition::new(
+                AbilityKind::Spell,
+                // CR 608.2d: resolution choice — controller picks the branch.
+                Effect::ChooseOneOf {
+                    chooser: PlayerFilter::Controller,
+                    branches,
+                },
+            );
+            let mut choice = choice;
+            choice.description = Some("your choice of counter".to_string());
+
+            // Compose with "enters tapped" if present (mirrors the single-counter
+            // tail below).
+            let execute = if has_enters_tapped_phrase(work_text) {
+                AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::Tap {
+                        target: TargetFilter::SelfRef,
+                    },
+                )
+                .sub_ability(choice)
+            } else {
+                choice
+            };
+
+            // CR 614.1c: "enters with" is a replacement effect on the Moved event.
+            let mut def = ReplacementDefinition::new(ReplacementEvent::Moved)
+                .execute(execute)
+                .valid_card(TargetFilter::SelfRef)
+                .description(original_text.to_string());
+
+            // Reuse the existing condition tail (escape / kicker / cast-from-zone
+            // / raid / web-slinging / generic only-if).
+            if is_escape {
+                def = def.condition(ReplacementCondition::CastViaEscape);
+            } else if let Some(cond) = kicker_condition {
+                def = def.condition(cond);
+            } else if let Some(zone) = extract_cast_from_zone_suffix(work_text) {
+                def = def.condition(ReplacementCondition::CastFromZone { zone });
+            } else if extract_you_attacked_this_turn_suffix(work_text) {
+                def = def.condition(ReplacementCondition::YouAttackedThisTurn);
+            } else if extract_cast_using_web_slinging_suffix(work_text) {
+                def = def.condition(ReplacementCondition::CastVariantPaid {
+                    variant: CastVariantPaid::WebSlinging,
+                });
+            } else if let Some(condition) = extract_enters_with_only_if_suffix(work_text) {
+                def = def.condition(condition);
+            }
+
+            return Some(def);
+        }
+    }
+
     let counter_entries = parse_enters_counter_entries(after_additional);
     // Detect dynamic count: "a number of [type] counters ... equal to [qty]"
     let after_prefix = tag::<_, _, OracleError<'_>>("a number of ")
@@ -2008,6 +2093,36 @@ fn parse_enters_counter_separator(input: &str) -> Option<&str> {
         .ok()?;
 
     Some(after_sep)
+}
+
+/// CR 614.12a: For "your choice of <list> on it", split off the trailing
+/// self-referential target. Given the text AFTER "your choice of " (e.g.
+/// "a +1/+1, first strike, or vigilance counter on it."), return
+/// `Some((choices, target))` where `choices` is the disjunctive counter list
+/// ("a +1/+1, first strike, or vigilance counter") and `target` is the
+/// self-reference ("it"). Returns `None` when the target is NOT a self-reference
+/// (so external-recipient phrasings fall through to other parsers).
+///
+/// Nom-only: `take_until(" on ")` splits the list from the trailing " on
+/// <target>", then the target (with trailing punctuation stripped) is validated
+/// against the self/object pronoun set (`it` / `~`).
+fn strip_enters_with_choice_target(after_choice: &str) -> Option<(&str, &str)> {
+    // Detect the "your choice of " marker via nom (no string dispatch).
+    let (after_marker, _) = tag::<_, _, OracleError<'_>>("your choice of ")
+        .parse(after_choice)
+        .ok()?;
+    // Split list from trailing " on <target>".
+    let (after_on, choices) = take_until::<_, _, OracleError<'_>>(" on ")
+        .parse(after_marker)
+        .ok()?;
+    let (target, _) = tag::<_, _, OracleError<'_>>(" on ").parse(after_on).ok()?;
+    let target_clean = target.trim().trim_end_matches('.').trim();
+    // CR 614.12a: the recipient must be the entering permanent itself.
+    if super::oracle_util::SELF_AND_OBJECT_PRONOUNS.contains(&target_clean) {
+        Some((choices, target_clean))
+    } else {
+        None
+    }
 }
 
 fn build_enters_counter_ability(entries: Vec<(CounterType, QuantityExpr)>) -> AbilityDefinition {
@@ -6935,6 +7050,77 @@ mod tests {
             }
             other => panic!("Expected PutCounter, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn enters_with_your_choice_of_counter_builds_selfref_choose_one_of() {
+        use crate::types::keywords::KeywordKind;
+
+        // CR 614.12a + CR 608.2d: "~ enters with your choice of <list> on it"
+        // should parse to a Moved replacement whose execute is a ChooseOneOf of
+        // self-targeted PutCounter branches — NOT a single Generic counter, and
+        // NO ParentTarget/TargetOnly lift (the entering permanent is always the
+        // recipient).
+        let assert_choice = |text: &str, expected: &[CounterType]| {
+            let def = parse_replacement_line(text, "Denry Klin, Editor in Chief")
+                .unwrap_or_else(|| panic!("should parse: {text}"));
+            assert_eq!(def.event, ReplacementEvent::Moved, "text: {text}");
+            assert_eq!(
+                def.valid_card,
+                Some(TargetFilter::SelfRef),
+                "valid_card should be SelfRef: {text}"
+            );
+            let Effect::ChooseOneOf { chooser, branches } = &*def.execute.as_ref().unwrap().effect
+            else {
+                panic!("expected ChooseOneOf execute, got {:?}", def.execute);
+            };
+            assert_eq!(*chooser, PlayerFilter::Controller);
+            assert_eq!(branches.len(), expected.len(), "branch count: {text}");
+            for (i, ct) in expected.iter().enumerate() {
+                match &*branches[i].effect {
+                    Effect::PutCounter {
+                        counter_type,
+                        target,
+                        ..
+                    } => {
+                        assert_eq!(counter_type, ct, "branch {i} counter_type: {text}");
+                        // CR 614.12a: every branch targets the entering permanent.
+                        assert_eq!(
+                            *target,
+                            TargetFilter::SelfRef,
+                            "branch {i} must be SelfRef (not ParentTarget/TargetOnly): {text}"
+                        );
+                    }
+                    other => panic!("branch {i} expected PutCounter, got {other:?}"),
+                }
+            }
+        };
+
+        let expected = [
+            CounterType::Plus1Plus1,
+            CounterType::Keyword(KeywordKind::FirstStrike),
+            CounterType::Keyword(KeywordKind::Vigilance),
+        ];
+
+        // SharedNoun shape (Denry Klin line 1).
+        assert_choice(
+            "Denry Klin enters with your choice of a +1/+1, first strike, or vigilance counter on it.",
+            &expected,
+        );
+        // Distributed shape.
+        assert_choice(
+            "Denry Klin enters with your choice of a +1/+1 counter, a first strike counter, or a vigilance counter on it.",
+            &expected,
+        );
+        // FromAmong shape (bare keywords).
+        assert_choice(
+            "Denry Klin enters with your choice of a counter from among first strike, vigilance, and lifelink on it.",
+            &[
+                CounterType::Keyword(KeywordKind::FirstStrike),
+                CounterType::Keyword(KeywordKind::Vigilance),
+                CounterType::Keyword(KeywordKind::Lifelink),
+            ],
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/counter.rs
+++ b/crates/engine/src/types/counter.rs
@@ -92,6 +92,21 @@ impl CounterType {
         }
     }
 
+    /// Player-facing counter name for prompts and choice descriptions, e.g.
+    /// "+1/+1", "-1/-1", "first strike", "vigilance". Unlike [`as_str`], which
+    /// produces serialization keys ("P1P1"/"M1M1"), this renders the P/T-shaped
+    /// variants in MTG `+N/+M` display form. Non-P/T variants reuse `as_str`.
+    pub fn display_phrase(&self) -> Cow<'_, str> {
+        match self {
+            CounterType::Plus1Plus1 => Cow::Owned(format_power_toughness_counter(1, 1)),
+            CounterType::Minus1Minus1 => Cow::Owned(format_power_toughness_counter(-1, -1)),
+            CounterType::PowerToughness { power, toughness } => {
+                Cow::Owned(format_power_toughness_counter(*power, *toughness))
+            }
+            _ => self.as_str(),
+        }
+    }
+
     pub fn power_toughness_delta(&self) -> Option<(i32, i32)> {
         match self {
             CounterType::Plus1Plus1 => Some((1, 1)),


### PR DESCRIPTION
Support "~ enters with your choice of <counter-choice-list> on it" for all
three counter-choice list shapes. The controller chooses which counter as
the permanent enters; the chosen counter is folded in BEFORE entry triggers
fire (CR 614.12a), so ETB observers see the permanent with its counter.

Previously Denry Klin, Editor in Chief line 1 misparsed the whole phrase
into a single CounterType::Generic("your choice of a +1/+1, first strike,
or vigilance") and applied it unconditionally — a silent rules bug. Now it
produces a ChooseOneOf of three PutCounter{target:SelfRef} branches.

- Parser: extract context-free classify_and_parse_counter_choice_list
  (3-shape classification + per-item (CounterType, count)) shared with the
  effect-path splitter; detect "your choice of" in parse_enters_with_counters
  and build SelfRef PutCounter branches directly (mirrors
  build_enters_counter_ability — no "on it" reparse, no parent-target lift).
- Engine: mirror the CopyTargetChoice deferred-entry pattern. Generalize the
  battlefield-entry capture to also fire for an enters-counter
  ChooseOneOfBranch (is_enters_counter_choice: every branch is
  PutCounter{SelfRef}); on ChooseBranch, after the chosen branch applies the
  counter, replay state.deferred_entry_events so ETB triggers observe the
  realized object. The empty/non-empty deferred_entry_events vector is the
  disambiguator — unrelated ChooseOneOf resolutions never populate it, so the
  replay is a no-op for them. Zero new WaitingFor/GameAction/state fields.
- Branch descriptions use a new CounterType::display_phrase() ("a +1/+1
  counter", "a first strike counter") rather than Debug format.

Denry line 2 ("put the same number of each kind of counter on that
creature") remains Unimplemented — separate copy-counter-kinds gap, out of
scope. Known boundary inherited from CopyTargetChoice: mass-entering
multiple pre-entry-choice permanents in one effect (CR 614.12b) is
unreachable in real cards.

CR 614.12a (choice before entry), CR 614.1c (enters-with replacement),
CR 614.12b (simultaneous entries), CR 608.2d (resolution choice),
CR 122.1b (keyword counters), CR 122.1 (named counters).
