### PR TITLE
feat(engine): for-each-counter-kind interactive choice (Bribe Taker)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1728,7 +1728,8 @@ fn quantity_ref_references_target_creature(qty: &QuantityRef) -> bool {
         | QuantityRef::ZoneChangeCountThisTurn { filter, .. }
         | QuantityRef::CounterAddedThisTurn { target: filter, .. }
         | QuantityRef::TokensCreatedThisTurn { filter, .. }
-        | QuantityRef::DistinctColorsAmongPermanents { filter } => {
+        | QuantityRef::DistinctColorsAmongPermanents { filter }
+        | QuantityRef::DistinctCounterKindsAmong { filter } => {
             filter_references_target_creature_quantity(filter)
         }
         QuantityRef::SpellsCastThisTurn { filter, .. }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1003,6 +1003,9 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         QuantityRef::DistinctColorsAmongPermanents { filter } => {
             format!("# of colors among {}", fmt_target(filter))
         }
+        QuantityRef::DistinctCounterKindsAmong { filter } => {
+            format!("# of counter kinds among {}", fmt_target(filter))
+        }
         QuantityRef::PreviousEffectAmount => "amount from preceding effect".into(),
         QuantityRef::TrackedSetSize => "cards moved".into(),
         QuantityRef::ExiledFromHandThisResolution => "cards exiled from hand this way".into(),
@@ -5180,6 +5183,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::DistinctColorsAmongPermanents { .. } => {
             ("DistinctColorsAmongPermanents", Handled)
         }
+        QuantityRef::DistinctCounterKindsAmong { .. } => ("DistinctCounterKindsAmong", Handled),
         QuantityRef::PreviousEffectAmount => ("PreviousEffectAmount", Handled),
         QuantityRef::TrackedSetSize => ("TrackedSetSize", Handled),
         QuantityRef::ExiledFromHandThisResolution => ("ExiledFromHandThisResolution", Handled),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -503,6 +503,7 @@ fn drain_pending_repeat_iteration(state: &mut GameState, events: &mut Vec<GameEv
         let crate::types::game_state::PendingRepeatIteration {
             ability,
             tracked_members,
+            iterated_counter_kinds,
             next_iteration,
             total_iterations,
         } = pending;
@@ -512,14 +513,23 @@ fn drain_pending_repeat_iteration(state: &mut GameState, events: &mut Vec<GameEv
         let mut paused = false;
         while iteration < total_iterations {
             let mut iter_ability;
-            let iter_effective: &ResolvedAbility =
-                if let Some(member) = tracked_members.get(iteration) {
-                    iter_ability = (*ability).clone();
-                    rebind_first_object_target(&mut iter_ability.targets, *member);
-                    &iter_ability
-                } else {
-                    &ability
-                };
+            // CR 109.5 / CR 122.1 + CR 608.2c: clone when EITHER a tracked
+            // member rebind (parent-target loop) OR a counter-kind rebind
+            // (DistinctCounterKindsAmong loop) applies to this iteration.
+            let member = tracked_members.get(iteration).copied();
+            let kind = iterated_counter_kinds.get(iteration).cloned();
+            let iter_effective: &ResolvedAbility = if member.is_some() || kind.is_some() {
+                iter_ability = (*ability).clone();
+                if let Some(member) = member {
+                    rebind_first_object_target(&mut iter_ability.targets, member);
+                }
+                if let Some(kind) = kind {
+                    rebind_iterated_counter_kind(&mut iter_ability, kind);
+                }
+                &iter_ability
+            } else {
+                &ability
+            };
             // CR 609.3 + CR 109.5: Drive the FULL chain (parent effect +
             // sub_ability + line-1660 continuation wiring) for each resumed
             // iteration, mirroring iteration 0's path. Calling `resolve_effect`
@@ -553,6 +563,7 @@ fn drain_pending_repeat_iteration(state: &mut GameState, events: &mut Vec<GameEv
                         Some(crate::types::game_state::PendingRepeatIteration {
                             ability: ability.clone(),
                             tracked_members: tracked_members.clone(),
+                            iterated_counter_kinds: iterated_counter_kinds.clone(),
                             next_iteration: next,
                             total_iterations,
                         });
@@ -2029,6 +2040,46 @@ fn rebind_first_object_target(
     }
 }
 
+/// CR 122.1 + CR 608.2c: Rebind a counter-kind-driven `ChooseOneOf` to the
+/// current iteration's counter kind. For each branch tagged
+/// `iteration_kind_binding == Some(RebindToIteratedKind)`, rewrites that
+/// branch's `Effect::PutCounter` counter type to `kind`. The fixed branch
+/// (binding `None`, e.g. "+1/+1") is left untouched. Used by the
+/// `repeat_for: DistinctCounterKindsAmong` loop so each iteration's dynamic
+/// branch puts "a counter of that kind" (CR 608.2d resolution choice).
+/// CR 608.2c + CR 608.2d: True when this ability's `repeat_for` is a
+/// `DistinctCounterKindsAmong` loop — the per-counter-kind iteration source
+/// (Bribe Taker). The "you may" on such an ability applies INDEPENDENTLY to
+/// each iterated kind (the controller may decline kind A and accept kind B —
+/// see the card's official ruling), so the up-front single-gate at the top of
+/// `resolve_chain_body` is suppressed for this shape and optionality is fired
+/// per-iteration inside the `repeat_for` loop instead.
+fn has_kind_driven_repeat(ability: &ResolvedAbility) -> bool {
+    matches!(
+        ability.repeat_for,
+        Some(QuantityExpr::Ref {
+            qty: QuantityRef::DistinctCounterKindsAmong { .. },
+        })
+    )
+}
+
+fn rebind_iterated_counter_kind(
+    ability: &mut ResolvedAbility,
+    kind: crate::types::counter::CounterType,
+) {
+    if let Effect::ChooseOneOf { branches, .. } = &mut ability.effect {
+        for branch in branches.iter_mut() {
+            if branch.iteration_kind_binding
+                == Some(crate::types::ability::IterationKindBinding::RebindToIteratedKind)
+            {
+                if let Effect::PutCounter { counter_type, .. } = branch.effect.as_mut() {
+                    *counter_type = kind.clone();
+                }
+            }
+        }
+    }
+}
+
 pub(crate) fn resolved_object_filter(
     ability: &ResolvedAbility,
     target_filter: &TargetFilter,
@@ -3037,7 +3088,14 @@ fn resolve_chain_body(
     // execution. For subject-anchored optional effects ("its controller may
     // search their library" — Assassin's Trophy), the acting player is the
     // resolved subject (the target permanent's controller), NOT the caster.
-    if ability.optional {
+    //
+    // CR 608.2c + CR 608.2d: EXCEPTION — a `DistinctCounterKindsAmong` loop
+    // (Bribe Taker) makes its "you may" apply PER ITERATED KIND, not once up
+    // front. The card's ruling confirms the controller may decline one kind and
+    // accept another. Suppress the single up-front gate here; the `repeat_for`
+    // loop below fires its own per-iteration `OptionalEffectChoice` for each
+    // counter kind (see the `kind_driven` optional path in the loop).
+    if ability.optional && !has_kind_driven_repeat(ability) {
         let description = ability.description.clone();
         let prompt_player = optional_prompt_player(state, ability);
         let may_trigger_key = ability
@@ -3340,6 +3398,27 @@ fn resolve_chain_body(
                     _ => Vec::new(),
                 };
 
+            // CR 122.1 + CR 608.2c: A `repeat_for: DistinctCounterKindsAmong`
+            // loop iterates once per distinct counter kind on filter-matched
+            // permanents. Unlike `ObjectCount`, the branches reference `SelfRef`
+            // (not `ParentTarget`), so `effect_iterates_over_parent_target` is
+            // false and a separate snapshot arm is required. The kinds are
+            // resolved here (sorted deterministically by `as_str`) so count and
+            // per-iteration binding share one snapshot; each iteration's tagged
+            // `ChooseOneOf` branch is rebound to `iterated_counter_kinds[i]`.
+            let mut kind_driven = false;
+            let iterated_counter_kinds: Vec<crate::types::counter::CounterType> =
+                match &ability.repeat_for {
+                    Some(QuantityExpr::Ref {
+                        qty: QuantityRef::DistinctCounterKindsAmong { filter },
+                    }) => {
+                        kind_driven = true;
+                        let ctx = filter::FilterContext::from_ability(effective);
+                        crate::game::quantity::distinct_counter_kinds_among(state, filter, &ctx)
+                    }
+                    _ => Vec::new(),
+                };
+
             // CR 609.3 + CR 608.2: Execute the effect N times when repeat_for is
             // set. A `member_driven` ObjectCount loop takes its count from the
             // snapshotted members (resolved against `effective`), keeping count and
@@ -3350,6 +3429,11 @@ fn resolve_chain_body(
             // resolve to 0 and the loop to never execute (Torment of Hailfire bug).
             let base_iterations = if member_driven {
                 iter_tracked_members.len()
+            } else if kind_driven {
+                // CR 122.1: count and per-iteration kind binding come from one
+                // snapshot, so an empty controlled-counter set ⇒ 0 iterations ⇒
+                // no prompt.
+                iterated_counter_kinds.len()
             } else if let Some(ref qty) = ability.repeat_for {
                 crate::game::quantity::resolve_quantity_with_targets(state, qty, ability).max(0)
                     as usize
@@ -3404,10 +3488,30 @@ fn resolve_chain_body(
                 let is_replacement_added_copy =
                     replacement_added_copy_start.is_some_and(|start| iteration >= start);
                 let iter_effective: &ResolvedAbility =
-                    if member.is_some() || is_replacement_added_copy {
+                    if member.is_some() || is_replacement_added_copy || kind_driven {
                         iter_ability = effective.clone();
                         if let Some(member) = member {
                             rebind_first_object_target(&mut iter_ability.targets, member);
+                        }
+                        // CR 122.1 + CR 608.2c: rebind this iteration's dynamic
+                        // ChooseOneOf branch to the current counter kind.
+                        if kind_driven {
+                            rebind_iterated_counter_kind(
+                                &mut iter_ability,
+                                iterated_counter_kinds[iteration].clone(),
+                            );
+                            // CR 608.2c + CR 608.2d: when the per-kind action is
+                            // optional (Bribe Taker's "you may"), this iteration
+                            // must route through `resolve_ability_chain` so the
+                            // up-front optional gate fires its OWN
+                            // `OptionalEffectChoice` for THIS kind (decline →
+                            // place nothing for this kind and advance; accept →
+                            // the `ChooseOneOf` branch prompt). The loop owns
+                            // iteration, so clear `repeat_for` on the clone to
+                            // prevent re-entering this loop (the up-front gate at
+                            // the top of `resolve_chain_body` is suppressed for
+                            // kind-driven loops via `has_kind_driven_repeat`).
+                            iter_ability.repeat_for = None;
                         }
                         if let (true, Effect::CopySpell { retarget, .. }) =
                             (is_replacement_added_copy, &mut iter_ability.effect)
@@ -3418,7 +3522,21 @@ fn resolve_chain_body(
                     } else {
                         effective
                     };
-                let _ = resolve_effect(state, iter_effective, events);
+                // CR 608.2d: A kind-driven iteration whose action is optional
+                // fires its per-kind "you may" gate (and any accepted
+                // `ChooseOneOf` branch prompt) through the full chain. All other
+                // iterations resolve the effect directly — `resolve_effect` does
+                // not check `optional`, which is correct because non-kind loops
+                // apply their `optional` once up front in `resolve_chain_body`.
+                if kind_driven && iter_effective.optional {
+                    // CR 608.2c: pass a non-zero depth so the depth==0 prelude
+                    // (chain-local state clearing, resolution counter) does not
+                    // re-run mid-loop — this iteration continues the current
+                    // resolution, mirroring the drain-path resume at depth 1.
+                    let _ = resolve_ability_chain(state, iter_effective, events, depth.max(1));
+                } else {
+                    let _ = resolve_effect(state, iter_effective, events);
+                }
                 // CR 609.3 + CR 109.5: When the inner effect enters an
                 // interactive WaitingFor (e.g. SearchChoice), stash the
                 // remaining iterations so `drain_pending_continuation` can
@@ -3458,6 +3576,10 @@ fn resolve_chain_body(
                             Some(crate::types::game_state::PendingRepeatIteration {
                                 ability: Box::new(resume_ability),
                                 tracked_members: iter_tracked_members.clone(),
+                                // CR 122.1 + CR 608.2c: carry the per-iteration
+                                // counter kinds so each resumed iteration rebinds
+                                // its dynamic branch (empty for non-kind loops).
+                                iterated_counter_kinds: iterated_counter_kinds.clone(),
                                 next_iteration,
                                 total_iterations: iterations,
                             });
@@ -8638,6 +8760,7 @@ mod tests {
         state.pending_repeat_iteration = Some(PendingRepeatIteration {
             ability: Box::new(iter_ability),
             tracked_members: vec![],
+            iterated_counter_kinds: vec![],
             next_iteration: 1,
             total_iterations: 3,
         });
@@ -12077,6 +12200,373 @@ mod tests {
         assert!(
             !evaluate_condition(&condition, &state_no_win, &ability_no_win),
             "NO-WIN scenario: devotion=2, library=50 must NOT satisfy GE",
+        );
+    }
+
+    /// CR 122.1: Non-interactive proof that
+    /// `repeat_for: DistinctCounterKindsAmong` drives the iteration count. A
+    /// plain `PutCounter` (no ChooseOneOf, no "you may") runs once per distinct
+    /// counter kind among controlled permanents.
+    #[test]
+    fn distinct_counter_kinds_among_drives_repeat_for_count() {
+        use crate::types::ability::{TypeFilter, TypedFilter};
+        use crate::types::counter::CounterType;
+
+        let mut state = GameState::new_two_player(42);
+
+        // Source permanent (Bribe-Taker-like) — counters land here.
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        // Two distinct counter kinds among controlled permanents: P1P1 + Lore.
+        let perm_a = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "A".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&perm_a).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.counters.insert(CounterType::Plus1Plus1, 1);
+        }
+        let perm_b = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "B".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&perm_b).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.counters.insert(CounterType::Lore, 1);
+        }
+
+        let filter = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Permanent],
+            controller: Some(ControllerRef::You),
+            properties: vec![],
+        });
+
+        let mut ability = ResolvedAbility::new(
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::SelfRef,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        ability.repeat_for = Some(QuantityExpr::Ref {
+            qty: QuantityRef::DistinctCounterKindsAmong { filter },
+        });
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        // 2 distinct kinds → loop ran twice → source has 2 +1/+1 counters
+        // (the source's own counters do not change the controlled-permanent set
+        // mid-loop because P1P1 is already present on perm_a — the kind set is
+        // snapshotted at loop entry regardless).
+        assert_eq!(
+            state
+                .objects
+                .get(&source)
+                .unwrap()
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0),
+            2,
+            "loop must run once per distinct counter kind (2)"
+        );
+    }
+
+    /// CR 122.1 + CR 608.2c + CR 608.2d + CR 109.4 (T1): Drive Bribe Taker's
+    /// interactive for-each-kind choice end-to-end, PROVING per-kind
+    /// optionality. The controller DECLINES the first kind's "you may" (no
+    /// counter for that kind) and the loop must still ADVANCE to a prompt for
+    /// the second kind, which is ACCEPTED. This is discriminating: under the old
+    /// single up-front gate, declining would have skipped ALL kinds and accepting
+    /// would have forced a counter on EVERY kind — neither matches the card's
+    /// ruling that each kind is independently optional.
+    ///
+    /// Also the H1 discriminator — without the `drain_pending_continuation` call
+    /// in the ChooseBranch handler, only the first prompted kind would advance.
+    #[test]
+    fn bribe_taker_for_each_kind_interactive_choice_runtime() {
+        use crate::game::engine::apply;
+        use crate::types::ability::{IterationKindBinding, TypeFilter, TypedFilter};
+        use crate::types::actions::GameAction;
+        use crate::types::counter::CounterType;
+
+        let mut state = GameState::new_two_player(42);
+
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bribe Taker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        // Controller perm A: +1/+1 counter. Perm B: Lore counter.
+        let perm_a = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "A".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&perm_a).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.counters.insert(CounterType::Plus1Plus1, 1);
+        }
+        let perm_b = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "B".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&perm_b).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.counters.insert(CounterType::Lore, 1);
+        }
+        // OPPONENT perm with Stun counter — MUST be excluded (CR 109.4): if it
+        // leaked in, there would be 3 prompts, not 2.
+        let opp = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(1),
+            "Opp".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&opp).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.counters.insert(CounterType::Stun, 1);
+        }
+
+        let filter = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Permanent],
+            controller: Some(ControllerRef::You),
+            properties: vec![],
+        });
+
+        // Build the Bribe Taker ability: optional ChooseOneOf, fixed (+1/+1) +
+        // dynamic (RebindToIteratedKind) branches, driven by
+        // repeat_for: DistinctCounterKindsAmong.
+        let fixed_branch = AbilityDefinition {
+            ..AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::SelfRef,
+                },
+            )
+        };
+        let dynamic_branch = AbilityDefinition {
+            iteration_kind_binding: Some(IterationKindBinding::RebindToIteratedKind),
+            ..AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::SelfRef,
+                },
+            )
+        };
+        let mut ability = ResolvedAbility::new(
+            Effect::ChooseOneOf {
+                chooser: crate::types::ability::PlayerFilter::Controller,
+                branches: vec![fixed_branch, dynamic_branch],
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        ability.optional = true;
+        ability.repeat_for = Some(QuantityExpr::Ref {
+            qty: QuantityRef::DistinctCounterKindsAmong { filter },
+        });
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        // (d) — non-empty set: the FIRST kind's per-iteration "you may" gate must
+        // fire. The deterministic sorted order is [P1P1, Lore]; iteration 0 is the
+        // P1P1 kind. Under per-kind optionality this is an OptionalEffectChoice
+        // (the decline path is only reachable when the gate is per-iteration).
+        assert!(
+            matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }),
+            "iteration 0 must fire its own per-kind 'you may' gate (got {:?})",
+            state.waiting_for
+        );
+
+        // Iteration 0 (P1P1 kind): DECLINE the "you may". No counter is placed
+        // for this kind, and the loop must ADVANCE to the next kind's gate — this
+        // is the discriminating step: a single up-front gate would have skipped
+        // ALL kinds here.
+        let r = apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::DecideOptionalEffect { accept: false },
+        )
+        .unwrap();
+        events.extend(r.events);
+
+        // (a) Per-kind decline + H1: after declining iteration 0, the loop must
+        // ADVANCE to iteration 1's (Lore) own "you may" gate — not return to
+        // Priority and not skip the remaining kind.
+        assert!(
+            matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }),
+            "after declining kind 0, kind 1 (Lore) must fire its own 'you may' gate \
+             (got {:?})",
+            state.waiting_for
+        );
+
+        // Iteration 1 (Lore kind): ACCEPT the "you may", then choose the DYNAMIC
+        // branch (index 1). (b) This must place a LORE counter, proving the
+        // rebind binds the iterated kind.
+        let r = apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::DecideOptionalEffect { accept: true },
+        )
+        .unwrap();
+        events.extend(r.events);
+        assert!(
+            matches!(state.waiting_for, WaitingFor::ChooseOneOfBranch { .. }),
+            "accepting kind 1 must surface the ChooseOneOf branch prompt, got {:?}",
+            state.waiting_for
+        );
+        let r = apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::ChooseBranch { index: 1 },
+        )
+        .unwrap();
+        events.extend(r.events);
+
+        // Loop complete: back to Priority.
+        assert!(
+            matches!(state.waiting_for, WaitingFor::Priority { .. }),
+            "loop must complete after the last kind, got {:?}",
+            state.waiting_for
+        );
+
+        let src = state.objects.get(&source).unwrap();
+        // Iteration 0 was DECLINED: NO +1/+1 counter was placed for that kind.
+        assert_eq!(
+            src.counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0),
+            0,
+            "declining the P1P1 kind must place NO +1/+1 counter (per-kind 'may')"
+        );
+        // (b) Iteration 1 was ACCEPTED, dynamic branch on the Lore iteration: 1
+        // LORE counter, proving rebind binds the iterated kind.
+        assert_eq!(
+            src.counters.get(&CounterType::Lore).copied().unwrap_or(0),
+            1,
+            "accepting the Lore kind's dynamic branch must place a LORE counter (rebind)"
+        );
+    }
+
+    /// CR 122.1 (T1d): empty controlled-counter set → 0 iterations → no prompt.
+    #[test]
+    fn bribe_taker_empty_counter_set_no_prompt() {
+        use crate::types::ability::{IterationKindBinding, TypeFilter, TypedFilter};
+        use crate::types::counter::CounterType;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bribe Taker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        // No counters anywhere the controller controls.
+        let filter = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Permanent],
+            controller: Some(ControllerRef::You),
+            properties: vec![],
+        });
+        let dynamic_branch = AbilityDefinition {
+            iteration_kind_binding: Some(IterationKindBinding::RebindToIteratedKind),
+            ..AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::SelfRef,
+                },
+            )
+        };
+        let mut ability = ResolvedAbility::new(
+            Effect::ChooseOneOf {
+                chooser: crate::types::ability::PlayerFilter::Controller,
+                branches: vec![dynamic_branch],
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        // CR 608.2c + CR 608.2d: `optional = true` mirrors the real card. With
+        // per-kind optionality, the "you may" gate fires INSIDE the `repeat_for`
+        // loop per iterated kind — so an empty controlled-counter set yields 0
+        // iterations, 0 gates, and no prompt. The up-front single gate in
+        // `resolve_chain_body` is suppressed for `DistinctCounterKindsAmong`
+        // loops (see `has_kind_driven_repeat`), so it cannot leak a stray prompt
+        // on the empty set.
+        ability.optional = true;
+        ability.repeat_for = Some(QuantityExpr::Ref {
+            qty: QuantityRef::DistinctCounterKindsAmong { filter },
+        });
+
+        let initial_waiting = state.waiting_for.clone();
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        // Zero iterations → no prompt installed → waiting_for unchanged.
+        assert_eq!(
+            state.waiting_for, initial_waiting,
+            "empty counter set must not prompt"
         );
     }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1497,6 +1497,16 @@ pub(super) fn handle_resolution_choice(
                 let delayed = super::triggers::check_delayed_triggers(state, &deferred);
                 events.extend(delayed);
             }
+            // CR 608.2c + CR 122.1: advance any paused resolution chain after the
+            // branch resolves. This is the standard post-resolution step every
+            // sibling choice handler runs. It no-ops when no `pending_continuation`
+            // / `pending_repeat_iteration` exists (each drain block is guarded by
+            // `if let Some(..) = ..take()`), so it is safe for existing `ChooseOneOf`
+            // consumers and for the deferred-entry replay above (mutually exclusive
+            // slots). Required so a `repeat_for: DistinctCounterKindsAmong` loop
+            // paused on `ChooseOneOfBranch` advances past the first counter kind to
+            // prompt for each remaining kind (Bribe Taker).
+            effects::drain_pending_continuation(state, events);
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1339,6 +1339,13 @@ fn resolve_ref(
             }
             usize_to_i32_saturating(seen.len())
         }
+        // CR 122.1: Count distinct counter kinds among permanents matching the
+        // filter (controller-relative, CR 109.4). Counter-side dual of
+        // `DistinctColorsAmongPermanents`. Each `CounterType` present on at
+        // least one matching permanent contributes once.
+        QuantityRef::DistinctCounterKindsAmong { filter } => {
+            usize_to_i32_saturating(distinct_counter_kinds_among(state, filter, &filter_ctx).len())
+        }
         // CR 305.6: Count distinct basic land types among lands controlled by
         // the referenced player. Domain counts distinct land subtypes, not
         // lands, so multiple Forests still contribute one.
@@ -2099,6 +2106,40 @@ fn object_id_for_scope(
         // referents read through `ability` slots, not `state.objects`.
         ObjectScope::CostPaidObject | ObjectScope::Anaphoric => None,
     }
+}
+
+/// CR 122.1: Distinct counter kinds present on permanents matching `filter`
+/// (controller-relative, CR 109.4). Mirrors `DistinctColorsAmongPermanents`'s
+/// resolver (zone from `filter.extract_in_zone()`, `zone_object_ids`,
+/// `matches_target_filter`), enumerating `obj.counters.keys()` the same way
+/// proliferate does. Returns a `Vec<CounterType>` SORTED by `CounterType::as_str`
+/// for determinism — `CounterType` has no `Ord` (and must not gain one), so the
+/// underlying `HashSet` iteration order is nondeterministic and would cause
+/// replay desync if returned directly. Used both as the `len()` source for
+/// `QuantityRef::DistinctCounterKindsAmong` resolution and as the per-iteration
+/// kind sequence for `repeat_for` counter-kind loops.
+pub(crate) fn distinct_counter_kinds_among(
+    state: &GameState,
+    filter: &TargetFilter,
+    filter_ctx: &FilterContext<'_>,
+) -> Vec<CounterType> {
+    let zone = filter
+        .extract_in_zone()
+        .unwrap_or(crate::types::zones::Zone::Battlefield);
+    let mut seen: HashSet<CounterType> = HashSet::new();
+    for &id in crate::game::targeting::zone_object_ids(state, zone).iter() {
+        if !matches_target_filter(state, id, filter, filter_ctx) {
+            continue;
+        }
+        if let Some(obj) = state.objects.get(&id) {
+            for ct in obj.counters.keys() {
+                seen.insert(ct.clone());
+            }
+        }
+    }
+    let mut kinds: Vec<CounterType> = seen.into_iter().collect();
+    kinds.sort_by(|a, b| a.as_str().cmp(&b.as_str()));
+    kinds
 }
 
 pub(crate) fn counter_count_from_map(
@@ -3173,6 +3214,89 @@ mod tests {
             obj.colors_spent_to_cast = crate::types::mana::ColoredManaCount::default();
         }
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), spell), 0);
+    }
+
+    /// CR 122.1 + CR 109.4: count distinct counter kinds among permanents the
+    /// resolving player controls. An opponent's counter kind must be EXCLUDED,
+    /// and the same kind on two controlled permanents counts once. Order is
+    /// deterministic (sorted by `as_str`).
+    #[test]
+    fn resolve_distinct_counter_kinds_among_controlled_permanents() {
+        let mut state = GameState::new_two_player(42);
+
+        // Controller's permanent A: +1/+1 counter.
+        let perm_a = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Perm A".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&perm_a).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.counters.insert(CounterType::Plus1Plus1, 1);
+        }
+        // Controller's permanent B: Lore counter (distinct kind).
+        let perm_b = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Perm B".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&perm_b).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.counters.insert(CounterType::Lore, 1);
+        }
+        // Controller's permanent C: another +1/+1 (same kind as A — counts once).
+        let perm_c = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Perm C".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&perm_c).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.counters.insert(CounterType::Plus1Plus1, 3);
+        }
+        // OPPONENT's permanent: Stun counter — MUST be excluded (CR 109.4).
+        let opp_perm = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(1),
+            "Opp Perm".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&opp_perm).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.counters.insert(CounterType::Stun, 1);
+        }
+
+        let filter = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Permanent],
+            controller: Some(ControllerRef::You),
+            properties: vec![],
+        });
+
+        // Direct helper: distinct kinds among controlled permanents = {P1P1, Lore},
+        // sorted by as_str ("P1P1" < "lore" by byte order; uppercase 'P' = 0x50,
+        // lowercase 'l' = 0x6C).
+        let ctx = FilterContext::from_source_with_controller(perm_a, PlayerId(0));
+        let kinds = distinct_counter_kinds_among(&state, &filter, &ctx);
+        assert_eq!(kinds, vec![CounterType::Plus1Plus1, CounterType::Lore]);
+
+        // QuantityRef resolution returns the count (2).
+        let qty = QuantityExpr::Ref {
+            qty: QuantityRef::DistinctCounterKindsAmong {
+                filter: filter.clone(),
+            },
+        };
+        assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), perm_a), 2);
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -47,13 +47,13 @@ use crate::types::ability::{
     BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
     ChooseFromZoneConstraint, CombatDamageScope, Comparator, ConjureCard, ContinuousModification,
     ControllerRef, DamageModification, DamageSource, DelayedTriggerCondition, DoubleTarget,
-    Duration, Effect, FilterProp, GainLifePlayer, GameRestriction, ManaProduction,
-    ManaSpendPermission, MultiTargetSpec, ObjectProperty, ObjectScope, PaymentCost, PlayerFilter,
-    PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PtValue, QuantityExpr,
-    QuantityRef, ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RoundingMode,
-    StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink, TargetChoiceTiming,
-    TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition, TypeFilter,
-    TypedFilter, UnlessPayModifier, UntilCondition,
+    Duration, Effect, FilterProp, GainLifePlayer, GameRestriction, IterationKindBinding,
+    ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty, ObjectScope, PaymentCost,
+    PlayerFilter, PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PtValue,
+    QuantityExpr, QuantityRef, ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope,
+    RoundingMode, StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink,
+    TargetChoiceTiming, TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition,
+    TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterType;
@@ -2780,6 +2780,90 @@ fn all_core_type_categories() -> Vec<CoreType> {
     ]
 }
 
+/// CR 122.1 + CR 608.2d: Parse the body of Bribe Taker's "for each kind of
+/// counter on permanents you control, you may put your choice of a +1/+1 counter
+/// or a counter of that kind on this creature" into a `ChooseOneOf` between a
+/// fixed-counter branch and a dynamic "counter of that kind" branch.
+///
+/// This runs on the body remainder AFTER `strip_for_each_prefix` has lifted the
+/// `DistinctCounterKindsAmong` iteration source onto the parent ability's
+/// `repeat_for` (so the body text here has the "for each … , " prefix already
+/// removed). The leading "you may " is also already peeled by `peel_clause`
+/// (which sets `optional`), but is accepted here as well so direct invocations
+/// (tests, non-peeled paths) parse identically.
+///
+/// The dynamic branch is tagged `IterationKindBinding::RebindToIteratedKind`;
+/// the `repeat_for` loop rewrites its placeholder counter type to each iterated
+/// kind in turn (see `rebind_iterated_counter_kind` in `effects/mod.rs`). The
+/// fixed counter type is parsed via `parse_counter_type_typed`, so the class
+/// covers any fixed counter ("a lore counter or a counter of that kind"), not
+/// just +1/+1. The placeholder counter type on the dynamic branch is a
+/// don't-care — the loop overwrites every tagged branch each iteration.
+fn try_parse_for_each_counter_kind_choice(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
+    type E<'a> = OracleError<'a>;
+
+    let (rest, saw_you_may) = opt(tag::<_, _, E>("you may "))
+        .parse(tp.lower)
+        .map(|(rest, opt_match)| (rest, opt_match.is_some()))
+        .ok()?;
+    let (rest, _) = tag::<_, _, E>("put your choice of ").parse(rest).ok()?;
+    let (rest, _) = nom_primitives::parse_article.parse(rest).ok()?;
+    let (rest, fixed_counter) = nom_primitives::parse_counter_type_typed(rest).ok()?;
+    let (rest, _) = tag::<_, _, E>(" counter or a counter of that kind on ")
+        .parse(rest)
+        .ok()?;
+    // CR 109.4: self target — "this creature" is normalized to `~` upstream.
+    let (rest, _) = tag::<_, _, E>("~").parse(rest).ok()?;
+    if !rest.trim().trim_end_matches('.').is_empty() {
+        return None;
+    }
+
+    // CR 608.2d: the controller chooses between the two branches at resolution.
+    // Fixed branch: put the parsed counter on self.
+    let fixed_branch = AbilityDefinition {
+        description: Some(format!("put a {} counter", fixed_counter.display_phrase())),
+        ..AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounter {
+                counter_type: fixed_counter,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::SelfRef,
+            },
+        )
+    };
+    // Dynamic branch: placeholder counter type is a don't-care — the
+    // `DistinctCounterKindsAmong` loop rewrites it to the current iterated kind
+    // each iteration via `rebind_iterated_counter_kind`.
+    let dynamic_branch = AbilityDefinition {
+        description: Some("put a counter of that kind".to_string()),
+        iteration_kind_binding: Some(IterationKindBinding::RebindToIteratedKind),
+        ..AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::SelfRef,
+            },
+        )
+    };
+
+    Some(ParsedEffectClause {
+        effect: Effect::ChooseOneOf {
+            chooser: PlayerFilter::Controller,
+            branches: vec![fixed_branch, dynamic_branch],
+        },
+        duration: None,
+        sub_ability: None,
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        // CR 608.2: "you may" makes the per-iteration choice optional. When this
+        // body was peeled, `peel_clause` will OR its own optional flag in too.
+        optional: saw_you_may,
+        unless_pay: None,
+    })
+}
+
 fn try_parse_distinct_card_types_from_revealed(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
     type E<'a> = OracleError<'a>;
 
@@ -3478,6 +3562,14 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // matched by the imperative "you may" arm or fall through to
     // `Effect::Unimplemented`.
     if let Some(clause) = try_parse_compound_subject_each(text, ctx) {
+        return clause;
+    }
+
+    // CR 122.1 + CR 608.2d: Bribe Taker — "[you may] put your choice of a
+    // <fixed> counter or a counter of that kind on ~". Runs before the generic
+    // for-each path; the `DistinctCounterKindsAmong` iteration source has already
+    // been lifted onto the parent's `repeat_for` by `strip_for_each_prefix`.
+    if let Some(clause) = try_parse_for_each_counter_kind_choice(tp) {
         return clause;
     }
 
@@ -18820,6 +18912,103 @@ mod tests {
                 properties: vec![FilterProp::Another],
             })),
             ..ParseContext::default()
+        }
+    }
+
+    /// CR 122.1 + CR 608.2d: Bribe Taker building-block — "for each kind of
+    /// counter on permanents you control, you may put your choice of a +1/+1
+    /// counter or a counter of that kind on this creature" lifts a
+    /// `DistinctCounterKindsAmong` iteration source onto `repeat_for` and a
+    /// `ChooseOneOf` body with a fixed (+1/+1) branch and a dynamic
+    /// `RebindToIteratedKind` branch, both targeting `SelfRef`.
+    #[test]
+    fn bribe_taker_for_each_counter_kind_choice() {
+        let mut ctx = ParseContext::default();
+        let def = parse_effect_chain_with_context(
+            "for each kind of counter on permanents you control, you may put your choice of a +1/+1 counter or a counter of that kind on ~.",
+            AbilityKind::Spell,
+            &mut ctx,
+        );
+        // CR 122.1: iteration source lifted onto the parent's repeat_for.
+        match &def.repeat_for {
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::DistinctCounterKindsAmong { filter },
+            }) => match filter {
+                TargetFilter::Typed(tf) => {
+                    assert_eq!(tf.type_filters, vec![TypeFilter::Permanent]);
+                    assert_eq!(tf.controller, Some(ControllerRef::You));
+                }
+                other => panic!("expected typed permanent filter, got {other:?}"),
+            },
+            other => panic!("expected DistinctCounterKindsAmong repeat_for, got {other:?}"),
+        }
+        // CR 608.2: "you may" → optional choice.
+        assert!(def.optional, "expected optional ChooseOneOf");
+        match &*def.effect {
+            Effect::ChooseOneOf { chooser, branches } => {
+                assert_eq!(*chooser, PlayerFilter::Controller);
+                assert_eq!(branches.len(), 2);
+                // Fixed branch: +1/+1 on self, no kind binding.
+                assert_eq!(branches[0].iteration_kind_binding, None);
+                match &*branches[0].effect {
+                    Effect::PutCounter {
+                        counter_type,
+                        target,
+                        ..
+                    } => {
+                        assert_eq!(*counter_type, CounterType::Plus1Plus1);
+                        assert_eq!(*target, TargetFilter::SelfRef);
+                    }
+                    other => panic!("expected PutCounter fixed branch, got {other:?}"),
+                }
+                // Dynamic branch: tagged RebindToIteratedKind, on self.
+                assert_eq!(
+                    branches[1].iteration_kind_binding,
+                    Some(IterationKindBinding::RebindToIteratedKind)
+                );
+                match &*branches[1].effect {
+                    Effect::PutCounter { target, .. } => {
+                        assert_eq!(*target, TargetFilter::SelfRef);
+                    }
+                    other => panic!("expected PutCounter dynamic branch, got {other:?}"),
+                }
+            }
+            other => panic!("expected ChooseOneOf, got {other:?}"),
+        }
+    }
+
+    /// Generality check: a non-+1/+1 fixed counter ("a lore counter or a counter
+    /// of that kind") proves the class is not hardcoded to +1/+1.
+    #[test]
+    fn for_each_counter_kind_choice_non_p1p1_fixed() {
+        let mut ctx = ParseContext::default();
+        let def = parse_effect_chain_with_context(
+            "for each kind of counter on permanents you control, put your choice of a lore counter or a counter of that kind on ~.",
+            AbilityKind::Spell,
+            &mut ctx,
+        );
+        assert!(matches!(
+            &def.repeat_for,
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::DistinctCounterKindsAmong { .. }
+            })
+        ));
+        // No "you may" → mandatory.
+        assert!(!def.optional);
+        match &*def.effect {
+            Effect::ChooseOneOf { branches, .. } => {
+                match &*branches[0].effect {
+                    Effect::PutCounter { counter_type, .. } => {
+                        assert_eq!(*counter_type, CounterType::Lore);
+                    }
+                    other => panic!("expected PutCounter, got {other:?}"),
+                }
+                assert_eq!(
+                    branches[1].iteration_kind_binding,
+                    Some(IterationKindBinding::RebindToIteratedKind)
+                );
+            }
+            other => panic!("expected ChooseOneOf, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -588,6 +588,25 @@ fn parse_number_of_distinct_colors_among_permanents_tail(
     Ok(("", QuantityRef::DistinctColorsAmongPermanents { filter }))
 }
 
+/// CR 122.1: Parse the iteration source "kind of counter on/among <filter>" →
+/// `QuantityRef::DistinctCounterKindsAmong { filter }`. Counter-side analogue of
+/// `parse_number_of_distinct_colors_among_permanents_tail`. Used by Bribe
+/// Taker's "for each kind of counter on permanents you control" — the filter is
+/// any controlled-permanent type phrase, so the combinator covers the whole
+/// class, not one card. Both "on" and "among" surface forms are accepted.
+fn parse_for_each_distinct_counter_kinds_among(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("kind of counter ").parse(input)?;
+    let (rest, _) = alt((tag("on "), tag("among "))).parse(rest)?;
+    let (filter, remainder) = parse_type_phrase(rest);
+    if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    Ok(("", QuantityRef::DistinctCounterKindsAmong { filter }))
+}
+
 /// CR 201.2 + CR 603.4: Parse "differently named <type-phrase>" after
 /// "the number of" → `QuantityRef::ObjectCountDistinct { filter, qualities: [Name] }`.
 ///
@@ -1693,6 +1712,10 @@ fn parse_for_each_clause_ref_with_they_controller(
         parse_for_each_battlefield_type,
         parse_for_each_commander_cast_count,
         parse_mana_spent_to_cast_ref,
+        // CR 122.1: "kind of counter on/among <filter>" (Bribe Taker). Placed
+        // before the generic `<type> you control` arm so the leading "kind"
+        // token does not commit to it.
+        parse_for_each_distinct_counter_kinds_among,
         parse_for_each_controlled_type,
     )))
     .parse(input)
@@ -3186,6 +3209,33 @@ mod tests {
             },
             other => panic!("expected DistinctColorsAmongPermanents, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_parse_for_each_distinct_counter_kinds_among() {
+        // CR 122.1: "kind of counter on permanents you control" iteration source.
+        let (rest, q) =
+            parse_for_each_clause_ref("kind of counter on permanents you control").unwrap();
+        assert_eq!(rest, "");
+        match q {
+            QuantityRef::DistinctCounterKindsAmong { filter } => match filter {
+                TargetFilter::Typed(tf) => {
+                    assert_eq!(tf.type_filters, vec![TypeFilter::Permanent]);
+                    assert_eq!(tf.controller, Some(ControllerRef::You));
+                }
+                other => panic!("expected typed permanent filter, got {other:?}"),
+            },
+            other => panic!("expected DistinctCounterKindsAmong, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_for_each_distinct_counter_kinds_among_creatures() {
+        // "among" surface form + a non-permanent type phrase.
+        let (rest, q) =
+            parse_for_each_clause_ref("kind of counter among creatures you control").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(q, QuantityRef::DistinctCounterKindsAmong { .. }));
     }
 
     #[test]

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -1145,6 +1145,11 @@ fn detect_dynamic_qty(
         // permanents you control, add one mana of that color" is captured as
         // a dynamic mana-production carrier, not a QuantityExpr count.
         "DistinctColorsAmongPermanents",
+        // CR 122.1: Bribe Taker class — "for each kind of counter on
+        // permanents you control" is captured as a `DistinctCounterKindsAmong`
+        // iteration-source QuantityRef driving `repeat_for`, not a swallowed
+        // count.
+        "DistinctCounterKindsAmong",
         // CR 702.122: Strive — "this spell costs {N} more for each target
         // beyond the first" is captured on the top-level `Card` as
         // `strive_cost: Some(ManaCost)`, not inside an ability tree.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3171,6 +3171,15 @@ pub enum QuantityRef {
     /// mana ability. Composes with `ObjectCount`-style filter predicates and is
     /// the dual to `ManaProduction::DistinctColorsAmongPermanents`.
     DistinctColorsAmongPermanents { filter: TargetFilter },
+    /// CR 122.1: distinct counter kinds among filter-matched permanents
+    /// (controller-relative, CR 109.4). Counter-side dual of
+    /// `DistinctColorsAmongPermanents` — counts each distinct `CounterType`
+    /// appearing on at least one permanent matching `filter` exactly once.
+    /// Used by Bribe Taker's "for each kind of counter on permanents you
+    /// control" iteration source. Kept a separate variant from the color
+    /// dual because counters (CR 122.1) and colors (CR 105/106) are distinct
+    /// rule sections the engine resolves independently.
+    DistinctCounterKindsAmong { filter: TargetFilter },
 }
 
 /// CR 107.1a: Rounding direction for fractional Oracle-text expressions.
@@ -8512,6 +8521,13 @@ pub struct AbilityDefinition {
     /// `lower_effect_chain_ir` from the `ClauseBoundary` PRECEDING this clause.
     #[serde(default, skip_serializing_if = "SubAbilityLink::is_continuation")]
     pub sub_link: SubAbilityLink,
+    /// CR 608.2c + CR 122.1: when this ability is a `ChooseOneOf` branch driven
+    /// by a counter-kind iteration (`repeat_for: DistinctCounterKindsAmong`),
+    /// `Some(RebindToIteratedKind)` marks the branch whose `PutCounter`
+    /// counter type must be rewritten to the current iteration's counter kind
+    /// before resolution. `None` (default) = branch is fixed (e.g. "+1/+1").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iteration_kind_binding: Option<IterationKindBinding>,
 }
 
 /// Private serialization mirror for `AbilityDefinition`. Holds a borrowed view
@@ -8580,6 +8596,8 @@ struct AbilityDefinitionRepr<'a> {
     repeat_until: &'a Option<RepeatContinuation>,
     #[serde(skip_serializing_if = "SubAbilityLink::is_continuation")]
     sub_link: SubAbilityLink,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iteration_kind_binding: &'a Option<IterationKindBinding>,
 }
 
 impl Serialize for AbilityDefinition {
@@ -8621,6 +8639,7 @@ impl Serialize for AbilityDefinition {
             target_selection_mode,
             repeat_until,
             sub_link,
+            iteration_kind_binding,
         } = self;
         let repr = AbilityDefinitionRepr {
             kind,
@@ -8657,6 +8676,7 @@ impl Serialize for AbilityDefinition {
             target_selection_mode: *target_selection_mode,
             repeat_until,
             sub_link: *sub_link,
+            iteration_kind_binding,
         };
         /// Flatten wrapper: the mirror carries the real field set;
         /// `consumes_source` is the computed UI key (#506).
@@ -8723,6 +8743,20 @@ pub enum RepeatContinuation {
     ControllerChoice,
 }
 
+/// CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be
+/// rebound to the current counter-kind iteration before resolving. Used when a
+/// `repeat_for: DistinctCounterKindsAmong` loop drives a "put your choice of a
+/// fixed counter or a counter of that kind" choice — the dynamic branch carries
+/// `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to
+/// the iteration's kind. Typed (not a bool) so future binding modes can extend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum IterationKindBinding {
+    /// Rebind this branch's `PutCounter` counter type to the current iterated
+    /// counter kind.
+    RebindToIteratedKind,
+}
+
 impl fmt::Debug for AbilityDefinition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // JSON serialization instead of field-by-field Debug — avoids stack overflow
@@ -8781,6 +8815,7 @@ impl AbilityDefinition {
             target_selection_mode: TargetSelectionMode::Chosen,
             repeat_until: None,
             sub_link: SubAbilityLink::ContinuationStep,
+            iteration_kind_binding: None,
         }
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -665,6 +665,13 @@ pub struct PendingRepeatIteration {
     pub ability: Box<crate::types::ability::ResolvedAbility>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tracked_members: Vec<ObjectId>,
+    /// CR 122.1 + CR 608.2c: the per-iteration counter kinds snapshotted at
+    /// loop entry for a `repeat_for: DistinctCounterKindsAmong` loop. Indexed
+    /// by iteration number; each resumed iteration rebinds its tagged
+    /// `ChooseOneOf` branch to `iterated_counter_kinds[iteration]`. Empty when
+    /// the loop is not counter-kind-driven.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub iterated_counter_kinds: Vec<crate::types::counter::CounterType>,
     pub next_iteration: usize,
     pub total_iterations: usize,
 }


### PR DESCRIPTION
Support "for each kind of counter on <filter>, [you may] put your choice
of a <fixed> counter or a counter of that kind on <self>" — Bribe Taker:
"for each kind of counter on permanents you control, you may put your
choice of a +1/+1 counter or a counter of that kind on this creature."
For each DISTINCT counter kind K controlled, the player may independently
put their choice of {fixed, a counter of kind K} on self.

- New QuantityRef::DistinctCounterKindsAmong { filter } — counter-side dual
  of DistinctColorsAmongPermanents (separate variant: counters CR 122.1 vs
  colors CR 105/106). Resolved in distinct_counter_kinds_among, sorted by
  CounterType::as_str() for deterministic replay (CounterType has no Ord).
  Drives repeat_for.
- Dynamic "of that kind" anaphor: new typed IterationKindBinding enum tags
  the dynamic ChooseOneOf branch; the repeat_for loop snapshots the iterated
  kinds onto PendingRepeatIteration and rewrites the tagged branch's
  PutCounter.counter_type to the current kind each iteration (mirrors
  rebind_first_object_target). No CounterType sentinel.
- Per-kind "you may": the kind-driven loop applies the ability's optional
  flag PER ITERATION (suppressing the single up-front gate via
  has_kind_driven_repeat; the per-iteration clone clears repeat_for and
  routes through resolve_ability_chain so each kind fires its own
  OptionalEffectChoice). Each kind is independently declinable per the card's
  ruling.
- Fixed: the (ChooseOneOfBranch, ChooseBranch) handler now drains the pending
  continuation, so a repeat_for loop paused on a per-kind choice advances to
  the next kind (previously only the first kind resolved).
- Reuses ChooseOneOfBranch + OptionalEffectChoice (no new WaitingFor/
  GameAction/frontend). Empty kind-set resolves with no prompt.

CR 122.1 (counters), CR 122.1b (keyword counters), CR 608.2c (iteration
order), CR 608.2d (resolution choices / "may"), CR 109.4 (control).
