### PR TITLE
Fix #594: ExileCastPermission static for Maralen-class cast-from-exile

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1196,6 +1196,17 @@ fn exile_objects_castable_by_permission(
     state: &GameState,
     player: PlayerId,
 ) -> Vec<(ObjectId, ObjectId, CastFrequency)> {
+    // Hot-path fast exit: this runs once per legal-actions computation (and so
+    // once per AI-search node). When nothing was exiled "with" a source this
+    // turn, no `ExileCastPermission` static can offer a card — short-circuit
+    // before `exile_permission_sources` scans the whole battlefield and
+    // allocates an `active_static_definitions` iterator per controlled
+    // permanent. Equivalent to the empty-pool `else { continue }` below, but
+    // pays a single `HashMap::is_empty()` instead in the ~100% of board states
+    // with no Maralen-class permanent in play.
+    if state.cards_exiled_with_source_this_turn.is_empty() {
+        return Vec::new();
+    }
     let mut results = Vec::new();
     let sources = exile_permission_sources(state, player);
     for source in &sources {
@@ -1272,6 +1283,12 @@ pub(crate) fn exile_cast_permission_source(
 ) -> Option<(ObjectId, CastFrequency, ExileCastCost)> {
     let obj = state.objects.get(&exiled_id)?;
     if obj.zone != Zone::Exile {
+        return None;
+    }
+    // Same empty-pool fast exit as `exile_objects_castable_by_permission`: with
+    // nothing exiled-with-a-source this turn, no static can authorize the cast,
+    // so skip the battlefield scan in `exile_permission_sources`.
+    if state.cards_exiled_with_source_this_turn.is_empty() {
         return None;
     }
     let sources = exile_permission_sources(state, player);

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -406,6 +406,21 @@ pub fn spell_objects_available_to_cast(state: &GameState, player: PlayerId) -> V
         objects.extend(permission_ids);
     }
 
+    // CR 601.2a + CR 113.6b + CR 118.9: Cards in exile castable via a
+    // `StaticMode::ExileCastPermission` static from a battlefield permanent
+    // (Maralen, Fae Ascendant). Restricted to cards exiled "with" the source
+    // *this turn* (per the per-turn rolling list); the static's `affected`
+    // filter further constrains the eligible cards (type, mana value, etc.).
+    // CR 117.1c: per-turn frequency is enforced inside the helper, not by
+    // active-player gating, so the same logic covers the rare case of an
+    // `Unlimited` printing on either player's turn.
+    let exile_permission_ids: HashSet<ObjectId> =
+        exile_objects_castable_by_permission(state, player)
+            .iter()
+            .map(|(obj_id, _source_id, _freq)| *obj_id)
+            .collect();
+    objects.extend(exile_permission_ids);
+
     // CR 401.5 + CR 118.9 + CR 601.2a: Top card of library castable via a
     // `TopOfLibraryCastPermission` static (Realmwalker, Future Sight, Bolas's
     // Citadel, Magus of the Future, etc.). Filter is re-evaluated each call
@@ -804,6 +819,13 @@ fn has_exile_cast_permission(
                 obj.owner == player && turn_number > *turn_foretold
             }
         })
+        // CR 601.2a + CR 113.6b: A `StaticMode::ExileCastPermission` static on a
+        // battlefield permanent controlled by `player` may authorize this exile
+        // card without any object-attached `CastingPermission`. Detected via the
+        // per-turn pool + per-source filter; the helper performs the same checks
+        // (per-turn frequency, pool membership, affected filter) used by
+        // `exile_objects_castable_by_permission`.
+        || exile_cast_permission_source(state, player, obj.id).is_some()
 }
 
 fn cast_permission_constraint_allows_cast(
@@ -1096,6 +1118,182 @@ struct GraveyardPermissionSource<'a> {
     filter: &'a TargetFilter,
     frequency: CastFrequency,
     graveyard_destination_replacement: Option<Zone>,
+}
+
+/// CR 601.2a + CR 113.6b + CR 118.9: An active battlefield permanent carrying
+/// `StaticMode::ExileCastPermission`. Captured during the "which permanents
+/// grant a cast-from-exile permission to `player`?" scan so the caller can
+/// (a) walk the per-turn rolling exile pool keyed on `source_id`, and (b)
+/// stamp the per-source frequency slot at cast finalization.
+#[derive(Clone, Copy)]
+struct ExilePermissionSource<'a> {
+    source_id: ObjectId,
+    filter: &'a TargetFilter,
+    frequency: CastFrequency,
+    /// CR 118.9a: `true` for the Maralen shape — the spell is cast without
+    /// paying its printed mana cost. `casting_costs` reads this flag at cast
+    /// finalization. `false` is the "pay normal cost" shape (no shipping card
+    /// uses it today, but the static keeps the axis available).
+    without_paying_mana_cost: bool,
+}
+
+/// CR 601.2a + CR 113.6b: Enumerate every battlefield permanent controlled by
+/// `player` whose `StaticMode::ExileCastPermission` static is currently
+/// functioning. The returned filter is owned by the static definition (via
+/// `active_static_definitions`) and lives at least as long as the inferred
+/// borrow.
+///
+/// Mirrors `graveyard_permission_sources` for the graveyard family — the
+/// per-source pool then carves out the eligible cards.
+fn exile_permission_sources(state: &GameState, player: PlayerId) -> Vec<ExilePermissionSource<'_>> {
+    state
+        .battlefield
+        .iter()
+        .copied()
+        .filter_map(|source_id| {
+            let obj = state.objects.get(&source_id)?;
+            if obj.controller != player {
+                return None;
+            }
+            active_static_definitions(state, obj).find_map(|definition| match definition.mode {
+                // CR 305.1: All currently shipping cards in this class use
+                // `CardPlayMode::Cast`. `Play` is permitted for symmetry — the
+                // `spell_objects_available_to_cast` path covers cast mode; a
+                // future land-play sibling would extend a Play-mode helper
+                // analogous to `graveyard_lands_playable_by_permission`.
+                StaticMode::ExileCastPermission {
+                    frequency,
+                    play_mode: CardPlayMode::Cast | CardPlayMode::Play,
+                    without_paying_mana_cost,
+                } => definition
+                    .affected
+                    .as_ref()
+                    .map(|filter| ExilePermissionSource {
+                        source_id,
+                        filter,
+                        frequency,
+                        without_paying_mana_cost,
+                    }),
+                _ => None,
+            })
+        })
+        .collect()
+}
+
+/// CR 601.2a + CR 113.6b + CR 118.9: Cards in exile castable via a
+/// `StaticMode::ExileCastPermission` static from a battlefield permanent
+/// (Maralen, Fae Ascendant). Returns `(exiled_object_id, source_permanent_id,
+/// frequency)` so the caller can stamp the per-turn slot at finalize-cast time.
+///
+/// The candidate pool is `state.cards_exiled_with_source_this_turn[source_id]`
+/// — only cards exiled "with" the source during the current turn qualify. The
+/// static's `affected: TargetFilter` then constrains the eligible cards by
+/// type, mana value, etc. Per-source frequency is enforced before filter
+/// evaluation so a consumed `OncePerTurn` slot prunes the source out cheaply.
+fn exile_objects_castable_by_permission(
+    state: &GameState,
+    player: PlayerId,
+) -> Vec<(ObjectId, ObjectId, CastFrequency)> {
+    let mut results = Vec::new();
+    let sources = exile_permission_sources(state, player);
+    for source in &sources {
+        if !exile_cast_frequency_available(state, source.source_id, source.frequency) {
+            continue;
+        }
+        let Some(pool) = state
+            .cards_exiled_with_source_this_turn
+            .get(&source.source_id)
+        else {
+            continue;
+        };
+        let ctx =
+            super::filter::FilterContext::from_source_with_controller(source.source_id, player);
+        for &exiled_id in pool {
+            // CR 400.7: An exiled card may have left exile since being tagged
+            // (e.g. milled into a graveyard by another effect). Re-check zone
+            // before offering it for cast.
+            let Some(obj) = state.objects.get(&exiled_id) else {
+                continue;
+            };
+            if obj.zone != Zone::Exile {
+                continue;
+            }
+            // CR 305.1: Land cards are never offered through the `Cast` path —
+            // they are "played", not "cast" (CR 116.1). The land-play sibling
+            // (analogous to `graveyard_lands_playable_by_permission`) does not
+            // yet exist; once a printing requires it, route through there.
+            if obj
+                .card_types
+                .core_types
+                .contains(&crate::types::card_type::CoreType::Land)
+            {
+                continue;
+            }
+            if super::filter::matches_target_filter(state, exiled_id, source.filter, &ctx) {
+                results.push((exiled_id, source.source_id, source.frequency));
+            }
+        }
+    }
+    results
+}
+
+/// CR 601.2a: Returns true if the `source_id`'s per-turn exile-cast slot is
+/// still available under `frequency`. `Unlimited` is always available;
+/// `OncePerTurn` consults `state.exile_cast_permissions_used`.
+fn exile_cast_frequency_available(
+    state: &GameState,
+    source_id: ObjectId,
+    frequency: CastFrequency,
+) -> bool {
+    match frequency {
+        CastFrequency::Unlimited => true,
+        CastFrequency::OncePerTurn => !state.exile_cast_permissions_used.contains(&source_id),
+        // CR 110.4 is graveyard-permission-only — Maralen-style exile-cast
+        // permissions have no per-permanent-type axis. Treat as a single
+        // OncePerTurn slot if the variant ever appears.
+        CastFrequency::OncePerTurnPerPermanentType => {
+            !state.exile_cast_permissions_used.contains(&source_id)
+        }
+    }
+}
+
+/// CR 601.2a + CR 113.6b: Find the (source, frequency, without_paying_mana_cost)
+/// triple authorizing `player` to cast `exiled_id` via a
+/// `StaticMode::ExileCastPermission`, or `None` when no functioning static
+/// authorizes the cast. Used by `prepare_spell_cast` / `casting_costs` to tag
+/// the `CastingVariant::ExilePermission` context and zero out the mana cost
+/// when the static is the "without paying" shape.
+pub(crate) fn exile_cast_permission_source(
+    state: &GameState,
+    player: PlayerId,
+    exiled_id: ObjectId,
+) -> Option<(ObjectId, CastFrequency, bool)> {
+    let obj = state.objects.get(&exiled_id)?;
+    if obj.zone != Zone::Exile {
+        return None;
+    }
+    let sources = exile_permission_sources(state, player);
+    sources.into_iter().find_map(|source| {
+        if !exile_cast_frequency_available(state, source.source_id, source.frequency) {
+            return None;
+        }
+        let pool = state
+            .cards_exiled_with_source_this_turn
+            .get(&source.source_id)?;
+        if !pool.contains(&exiled_id) {
+            return None;
+        }
+        let ctx =
+            super::filter::FilterContext::from_source_with_controller(source.source_id, player);
+        if !super::filter::matches_target_filter(state, exiled_id, source.filter, &ctx) {
+            return None;
+        }
+        Some((
+            source.source_id,
+            source.frequency,
+            source.without_paying_mana_cost,
+        ))
+    })
 }
 
 fn graveyard_permission_sources(
@@ -1671,6 +1869,17 @@ fn casting_variant_candidates(
         {
             candidates.push(CastingVariant::Foretell);
         }
+        // CR 601.2a + CR 113.6b + CR 118.9a: Cast-from-exile via a
+        // `StaticMode::ExileCastPermission` source (Maralen, Fae Ascendant).
+        // Detection is by per-source pool lookup, not by an on-object permission
+        // — the static issues no `CastingPermission` decoration; eligibility is
+        // re-derived each cast preparation from the per-turn pool plus the
+        // static's `affected` filter.
+        if let Some((source, frequency, _without_paying)) =
+            exile_cast_permission_source(state, player, object_id)
+        {
+            candidates.push(CastingVariant::ExilePermission { source, frequency });
+        }
     }
 
     candidates
@@ -2103,6 +2312,18 @@ fn prepare_spell_cast_with_variant_override_inner(
     // no mana cost — the granting static replaces the mana cost with nothing.
     let is_hand_permission_variant =
         matches!(casting_variant, CastingVariant::HandPermission { .. });
+    // CR 601.2a + CR 118.9a: ExilePermission variant (Maralen, Fae Ascendant).
+    // Pays no mana cost when the granting static carries
+    // `without_paying_mana_cost: true`. Re-derived from `exile_cast_permission_source`
+    // — the variant itself does not carry the flag because that would let the
+    // override side bypass the static's authoritative shape.
+    let is_exile_permission_free_cast =
+        if let CastingVariant::ExilePermission { .. } = casting_variant {
+            exile_cast_permission_source(state, player, object_id)
+                .is_some_and(|(_, _, without_paying_mana_cost)| without_paying_mana_cost)
+        } else {
+            false
+        };
     // CR 702.94a: Miracle alternative cost — pulled from `Keyword::Miracle(cost)`
     // on the hand object. Only honored when the caller explicitly opted into the
     // Miracle variant via the reveal prompt.
@@ -2164,6 +2385,7 @@ fn prepare_spell_cast_with_variant_override_inner(
     let mut mana_cost = if energy_cost_from_exile
         || hand_cast_free
         || is_hand_permission_variant
+        || is_exile_permission_free_cast
         || pure_non_mana_flashback
         || pure_non_mana_evoke
         || casting_variant == CastingVariant::Plot
@@ -27077,5 +27299,143 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #594 (Maralen, Fae Ascendant) — ExileCastPermission end-to-end.
+    //
+    // These tests exercise the new `StaticMode::ExileCastPermission` runtime
+    // path: source detection, per-turn pool membership, affected-filter
+    // gating, per-source OncePerTurn frequency tracking, and turn-cleanup
+    // reset. The parser-side tests live in
+    // `parser::oracle_static::tests::exile_cast_permission_*`.
+    // ---------------------------------------------------------------------
+
+    /// Build a battlefield permanent controlled by `player` carrying a single
+    /// `StaticMode::ExileCastPermission` static definition. Mirrors the shape
+    /// the parser emits for Maralen, Fae Ascendant — `affected: Any` keeps
+    /// the helper test-focused (the filter-gating axis is covered in a
+    /// dedicated test below).
+    fn add_exile_cast_permission_source(
+        state: &mut GameState,
+        player: PlayerId,
+        name: &str,
+        affected: TargetFilter,
+    ) -> ObjectId {
+        use crate::types::ability::StaticDefinition;
+        // Test scaffolding: CardId is opaque — `next_object_id` is monotonic
+        // so reusing it for the card id keeps each call unique without
+        // touching `state.card_db`.
+        let card_id = crate::types::identifiers::CardId(state.next_object_id);
+        let source = create_object(state, card_id, player, name.to_string(), Zone::Battlefield);
+        let def = StaticDefinition::new(StaticMode::ExileCastPermission {
+            frequency: CastFrequency::OncePerTurn,
+            play_mode: CardPlayMode::Cast,
+            without_paying_mana_cost: true,
+        })
+        .affected(affected);
+        let obj = state.objects.get_mut(&source).unwrap();
+        // CR 613.1: `static_definitions` is the runtime (post-layers) view —
+        // the `Definitions` wrapper lets us push the printed definition without
+        // rebuilding the Arc-backed `base_static_definitions`. For the scope of
+        // these tests, only the runtime view is consulted by the cast-permission
+        // helpers (`active_static_definitions(obj)` walks the live set).
+        obj.static_definitions.push(def);
+        source
+    }
+
+    /// Add a vanilla creature card directly into exile owned by `player` —
+    /// no casting permissions, no link metadata. The caller is expected to
+    /// stamp the per-turn `cards_exiled_with_source_this_turn` map.
+    fn add_exiled_card(state: &mut GameState, player: PlayerId, name: &str) -> ObjectId {
+        // Test scaffolding: CardId is opaque — `next_object_id` is monotonic
+        // so reusing it for the card id keeps each call unique without
+        // touching `state.card_db`.
+        let card_id = crate::types::identifiers::CardId(state.next_object_id);
+        let object_id = create_object(state, card_id, player, name.to_string(), Zone::Exile);
+        let obj = state.objects.get_mut(&object_id).unwrap();
+        obj.card_types.core_types = vec![crate::types::card_type::CoreType::Creature];
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![],
+            generic: 1,
+        };
+        object_id
+    }
+
+    /// CR 601.2a + CR 113.6b + CR 118.9: With Maralen on the battlefield, the
+    /// per-turn exile pool, and a card matching the static's affected filter,
+    /// `spell_objects_available_to_cast` must surface the exiled card.
+    #[test]
+    fn exile_cast_permission_surfaces_pool_card() {
+        let mut state = setup_game_at_main_phase();
+        let player = PlayerId(0);
+        let source_id =
+            add_exile_cast_permission_source(&mut state, player, "Maralen", TargetFilter::Any);
+        let exiled = add_exiled_card(&mut state, player, "Exiled Bear");
+        state
+            .cards_exiled_with_source_this_turn
+            .insert(source_id, vec![exiled]);
+
+        let available = spell_objects_available_to_cast(&state, player);
+        assert!(
+            available.contains(&exiled),
+            "exiled card should be castable via Maralen's static"
+        );
+    }
+
+    /// CR 601.2a: The per-source `OncePerTurn` slot must prune the static
+    /// from `spell_objects_available_to_cast` after a single cast through it
+    /// this turn, then come back at turn cleanup.
+    #[test]
+    fn exile_cast_permission_once_per_turn_frequency_gates_offer() {
+        let mut state = setup_game_at_main_phase();
+        let player = PlayerId(0);
+        let source_id =
+            add_exile_cast_permission_source(&mut state, player, "Maralen", TargetFilter::Any);
+        let exiled = add_exiled_card(&mut state, player, "Exiled Bear");
+        state
+            .cards_exiled_with_source_this_turn
+            .insert(source_id, vec![exiled]);
+
+        let before = spell_objects_available_to_cast(&state, player);
+        assert!(before.contains(&exiled), "card available pre-consumption");
+
+        // Consume the OncePerTurn slot.
+        state.exile_cast_permissions_used.insert(source_id);
+        let after_consumed = spell_objects_available_to_cast(&state, player);
+        assert!(
+            !after_consumed.contains(&exiled),
+            "card must be pruned once the slot is consumed"
+        );
+
+        // Turn cleanup resets the slot — same exile pool, available again.
+        state.exile_cast_permissions_used.clear();
+        let after_reset = spell_objects_available_to_cast(&state, player);
+        assert!(
+            after_reset.contains(&exiled),
+            "card returns after slot reset"
+        );
+    }
+
+    /// CR 113.6b: Cards exiled in a previous turn (not present in the
+    /// per-turn map) must not surface. Mirrors Maralen's "this turn"
+    /// scoping — the persistent `exile_links` pool is intentionally NOT
+    /// consulted by this static.
+    #[test]
+    fn exile_cast_permission_rejects_card_outside_per_turn_pool() {
+        let mut state = setup_game_at_main_phase();
+        let player = PlayerId(0);
+        let _source_id =
+            add_exile_cast_permission_source(&mut state, player, "Maralen", TargetFilter::Any);
+        let stale_exile = add_exiled_card(&mut state, player, "Stale Exile");
+        // Intentionally do NOT add `stale_exile` to
+        // `cards_exiled_with_source_this_turn` — simulates a card exiled by
+        // Maralen on a prior turn that survived turn cleanup.
+
+        let available = spell_objects_available_to_cast(&state, player);
+        assert!(
+            !available.contains(&stale_exile),
+            "previous-turn exile card must not be surfaced by the static"
+        );
     }
 }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17,7 +17,8 @@ use crate::types::mana::{
 };
 use crate::types::player::PlayerId;
 use crate::types::statics::{
-    ActivationExemption, CastFrequency, CastingProhibitionCondition, ProhibitionScope, StaticMode,
+    ActivationExemption, CastFrequency, CastingProhibitionCondition, ExileCastCost,
+    ProhibitionScope, StaticMode,
 };
 use crate::types::zones::{ExileCostSourceZone, Zone};
 
@@ -1130,11 +1131,12 @@ struct ExilePermissionSource<'a> {
     source_id: ObjectId,
     filter: &'a TargetFilter,
     frequency: CastFrequency,
-    /// CR 118.9a: `true` for the Maralen shape — the spell is cast without
-    /// paying its printed mana cost. `casting_costs` reads this flag at cast
-    /// finalization. `false` is the "pay normal cost" shape (no shipping card
-    /// uses it today, but the static keeps the axis available).
-    without_paying_mana_cost: bool,
+    /// CR 118.9a: How the spell's mana cost is paid when cast via this
+    /// permission. `WithoutPayingManaCost` is the Maralen shape (the printed
+    /// mana cost is zeroed by `casting_costs`). `PayNormalCost` casts at the
+    /// spell's normal cost — no shipping card uses this shape today, but the
+    /// static keeps the axis available.
+    cost: ExileCastCost,
 }
 
 /// CR 601.2a + CR 113.6b: Enumerate every battlefield permanent controlled by
@@ -1164,7 +1166,7 @@ fn exile_permission_sources(state: &GameState, player: PlayerId) -> Vec<ExilePer
                 StaticMode::ExileCastPermission {
                     frequency,
                     play_mode: CardPlayMode::Cast | CardPlayMode::Play,
-                    without_paying_mana_cost,
+                    cost,
                 } => definition
                     .affected
                     .as_ref()
@@ -1172,7 +1174,7 @@ fn exile_permission_sources(state: &GameState, player: PlayerId) -> Vec<ExilePer
                         source_id,
                         filter,
                         frequency,
-                        without_paying_mana_cost,
+                        cost,
                     }),
                 _ => None,
             })
@@ -1257,17 +1259,17 @@ fn exile_cast_frequency_available(
     }
 }
 
-/// CR 601.2a + CR 113.6b: Find the (source, frequency, without_paying_mana_cost)
-/// triple authorizing `player` to cast `exiled_id` via a
+/// CR 601.2a + CR 113.6b: Find the (source, frequency, cost) triple
+/// authorizing `player` to cast `exiled_id` via a
 /// `StaticMode::ExileCastPermission`, or `None` when no functioning static
 /// authorizes the cast. Used by `prepare_spell_cast` / `casting_costs` to tag
 /// the `CastingVariant::ExilePermission` context and zero out the mana cost
-/// when the static is the "without paying" shape.
+/// when the static is the `WithoutPayingManaCost` shape.
 pub(crate) fn exile_cast_permission_source(
     state: &GameState,
     player: PlayerId,
     exiled_id: ObjectId,
-) -> Option<(ObjectId, CastFrequency, bool)> {
+) -> Option<(ObjectId, CastFrequency, ExileCastCost)> {
     let obj = state.objects.get(&exiled_id)?;
     if obj.zone != Zone::Exile {
         return None;
@@ -1288,11 +1290,7 @@ pub(crate) fn exile_cast_permission_source(
         if !super::filter::matches_target_filter(state, exiled_id, source.filter, &ctx) {
             return None;
         }
-        Some((
-            source.source_id,
-            source.frequency,
-            source.without_paying_mana_cost,
-        ))
+        Some((source.source_id, source.frequency, source.cost))
     })
 }
 
@@ -2314,13 +2312,14 @@ fn prepare_spell_cast_with_variant_override_inner(
         matches!(casting_variant, CastingVariant::HandPermission { .. });
     // CR 601.2a + CR 118.9a: ExilePermission variant (Maralen, Fae Ascendant).
     // Pays no mana cost when the granting static carries
-    // `without_paying_mana_cost: true`. Re-derived from `exile_cast_permission_source`
-    // — the variant itself does not carry the flag because that would let the
-    // override side bypass the static's authoritative shape.
+    // `cost: ExileCastCost::WithoutPayingManaCost`. Re-derived from
+    // `exile_cast_permission_source` — the variant itself does not carry the
+    // cost shape because that would let the override side bypass the static's
+    // authoritative shape.
     let is_exile_permission_free_cast =
         if let CastingVariant::ExilePermission { .. } = casting_variant {
             exile_cast_permission_source(state, player, object_id)
-                .is_some_and(|(_, _, without_paying_mana_cost)| without_paying_mana_cost)
+                .is_some_and(|(_, _, cost)| matches!(cost, ExileCastCost::WithoutPayingManaCost))
         } else {
             false
         };
@@ -27331,7 +27330,7 @@ mod tests {
         let def = StaticDefinition::new(StaticMode::ExileCastPermission {
             frequency: CastFrequency::OncePerTurn,
             play_mode: CardPlayMode::Cast,
-            without_paying_mana_cost: true,
+            cost: ExileCastCost::WithoutPayingManaCost,
         })
         .affected(affected);
         let obj = state.objects.get_mut(&source).unwrap();

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3190,6 +3190,19 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
         } => {
             state.hand_cast_free_permissions_used.insert(source);
         }
+        // CR 601.2a + CR 113.6b: Maralen-class exile-cast permission. Stamp
+        // the per-source slot when the static is `OncePerTurn`; `Unlimited`
+        // (no shipping printing yet) skips tracking so the slot never blocks.
+        CastingVariant::ExilePermission {
+            source,
+            frequency: crate::types::statics::CastFrequency::OncePerTurn,
+        }
+        | CastingVariant::ExilePermission {
+            source,
+            frequency: crate::types::statics::CastFrequency::OncePerTurnPerPermanentType,
+        } => {
+            state.exile_cast_permissions_used.insert(source);
+        }
         _ => {}
     }
     if let Some((source, crate::types::statics::CastFrequency::OncePerTurn)) =

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -53,6 +53,11 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             | StaticMode::GraveyardCastPermission { .. }
             | StaticMode::TopOfLibraryCastPermission { .. }
             | StaticMode::CastFromHandFree { .. }
+            // CR 601.2a + CR 113.6b: ExileCastPermission carries frequency,
+            // play_mode, and the `without_paying_mana_cost` flag. Runtime
+            // enforcement is in casting.rs::exile_objects_castable_by_permission
+            // and casting_costs.rs.
+            | StaticMode::ExileCastPermission { .. }
             | StaticMode::CastWithKeyword { .. }
             // CR 702.16: PlayerProtection carries a `ProtectionTarget` (Strings) —
             // open value space, consumed by direct match in `player_protection_from`.
@@ -6429,6 +6434,13 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
             // already enforced by the parser; coverage just needs a phrase
             // that the static description will contain.
             StaticMode::TopOfLibraryCastPermission { .. } => {
+                effective_lower.contains("you may cast") || effective_lower.contains("you may play")
+            }
+            // CR 601.2a + CR 113.6b: Maralen-class exile-cast permission. The
+            // discriminator phrase ("from among cards exiled with") is
+            // already enforced by the parser; coverage just needs a phrase
+            // the static description will contain.
+            StaticMode::ExileCastPermission { .. } => {
                 effective_lower.contains("you may cast") || effective_lower.contains("you may play")
             }
             StaticMode::CantCastDuring { .. } => {

--- a/crates/engine/src/game/exile_links.rs
+++ b/crates/engine/src/game/exile_links.rs
@@ -9,6 +9,14 @@ const LINKED_EXILE_CONSUMER_TAGS: &[&str] = &[
     "CardsExiledBySource",
     "OwnersOfCardsExiledBySource",
     "ChoiceAmongExiledColors",
+    // CR 601.2a + CR 113.6b: A source carrying `StaticMode::ExileCastPermission`
+    // (Maralen, Fae Ascendant) consumes its own linked-exile pool to grant
+    // casting permission. Detection by externally-tagged serde key ensures the
+    // source-level scan (`source_contains_linked_exile_consumer`) marks the
+    // permanent as a tracked-exile consumer even when the consuming reference
+    // is on a static rather than on a target filter — no special-casing of the
+    // static-definition shape required.
+    "ExileCastPermission",
 ];
 
 /// CR 607.1 / CR 607.2a + CR 406.6: A source only needs ordinary
@@ -49,6 +57,32 @@ pub(crate) fn push_tracked_by_source(
         source_id,
         kind: ExileLinkKind::TrackedBySource,
     });
+    push_exiled_with_source_this_turn(state, exiled_id, source_id);
+}
+
+/// CR 601.2a + CR 113.6b: Record an `exiled_id` as exiled "with" `source_id`
+/// during the current turn so the per-turn rolling list
+/// (`GameState::cards_exiled_with_source_this_turn`) stays in lockstep with the
+/// persistent `exile_links` pool. Callers that already populate `exile_links`
+/// via `push_tracked_by_source` get this for free; callers that build typed
+/// exile-link kinds directly (e.g. `UntilSourceLeaves`) and still need their
+/// exiled cards to feed `StaticMode::ExileCastPermission` should call this
+/// helper alongside the link push.
+///
+/// Idempotent: a duplicate `(source_id, exiled_id)` pair is dropped, mirroring
+/// `push_tracked_by_source`.
+pub(crate) fn push_exiled_with_source_this_turn(
+    state: &mut GameState,
+    exiled_id: ObjectId,
+    source_id: ObjectId,
+) {
+    let entry = state
+        .cards_exiled_with_source_this_turn
+        .entry(source_id)
+        .or_default();
+    if !entry.contains(&exiled_id) {
+        entry.push(exiled_id);
+    }
 }
 
 pub(crate) fn ability_contains_linked_exile_consumer(ability: &ResolvedAbility) -> bool {

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -468,6 +468,14 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
     state.hand_cast_free_permissions_used.clear();
     // CR 601.2a: Reset per-turn PlayFromExile source usage (Evelyn-style permissions).
     state.exile_play_permissions_used.clear();
+    // CR 601.2a + CR 113.6b: Reset per-turn ExileCastPermission once-per-turn
+    // tracking (Maralen, Fae Ascendant) and the rolling list of cards exiled
+    // with each tracked source this turn. Both are turn-scoped slices; the
+    // persistent `exile_links` pool is untouched and continues to back the
+    // open-ended "cards exiled with ~" filter for sources without a per-turn
+    // cap.
+    state.exile_cast_permissions_used.clear();
+    state.cards_exiled_with_source_this_turn.clear();
     // CR 702.94a: Reset per-player first-card-drawn-this-turn tracking for miracle.
     state.first_card_drawn_this_turn.clear();
     state.cards_drawn_this_turn.clear();

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -2855,6 +2855,34 @@ mod tests {
         assert!(state.counter_added_this_turn.is_empty());
     }
 
+    /// CR 601.2a + CR 113.6b: Turn cleanup must clear BOTH the per-source
+    /// `ExileCastPermission` once-per-turn slots AND the rolling "cards exiled
+    /// with this source this turn" pool (Maralen, Fae Ascendant). Driven
+    /// through `start_next_turn` rather than a manual `.clear()`, so a
+    /// regression dropping either reset line in `start_next_turn` fails here
+    /// instead of staying green.
+    #[test]
+    fn start_next_turn_resets_exile_cast_permission_tracking() {
+        let mut state = setup();
+        let source = ObjectId(42);
+        state.exile_cast_permissions_used.insert(source);
+        state
+            .cards_exiled_with_source_this_turn
+            .insert(source, vec![ObjectId(7)]);
+
+        let mut events = Vec::new();
+        start_next_turn(&mut state, &mut events);
+
+        assert!(
+            state.exile_cast_permissions_used.is_empty(),
+            "OncePerTurn exile-cast slots must reset at turn start"
+        );
+        assert!(
+            state.cards_exiled_with_source_this_turn.is_empty(),
+            "per-turn exiled-with-source pool must reset at turn start"
+        );
+    }
+
     #[test]
     fn start_next_turn_emits_turn_started_event() {
         let mut state = setup();

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -1020,6 +1020,15 @@ fn parse_static_line_inner(text: &str, inverted: InvertedAsLongAs) -> Option<Sta
         return Some(result);
     }
 
+    // CR 601.2a + CR 113.6b + CR 118.9: "Once each turn, you may cast [filter]
+    // from among cards exiled with ~ this turn [without paying its mana cost]."
+    // Maralen, Fae Ascendant is the type specimen; the handler accepts the
+    // wider class (any frequency, any mana-value comparator) so future
+    // printings slot in without parser changes.
+    if let Some(result) = try_parse_exile_cast_permission(&text, &lower) {
+        return Some(result);
+    }
+
     // CR 601.2b + CR 118.9a + CR 601.2: Omniscience-class restricted free-cast
     // static. Optional " from your hand" zone qualifier — Dracogenesis's
     // "you may cast Dragon spells without paying their mana costs" relies on
@@ -10263,6 +10272,106 @@ fn try_parse_graveyard_cast_permission(text: &str, lower: &str) -> Option<Static
     Some(def)
 }
 
+/// CR 601.2a + CR 113.6b + CR 118.9: Parse the Maralen-class exile cast
+/// permission line: "Once each turn, you may cast [filter] from among cards
+/// exiled with ~ this turn [without paying its mana cost]." Mirrors
+/// `try_parse_graveyard_cast_permission` for the exile-pool sibling.
+///
+/// Accepted shapes:
+/// - "once each turn, you may cast a spell with mana value less than or equal
+///   to <quantity_ref> from among cards exiled with ~ this turn without paying
+///   its mana cost." (Maralen, Fae Ascendant)
+/// - The longer "once during each of your turns, you may cast …" synonym.
+/// - Unlimited shape ("you may cast …") is left for a future printing — Maralen
+///   is the only shipping card today so the `Unlimited` branch is not gated on
+///   any anchor; adding it requires an Oracle-confirmed sibling printing first.
+///
+/// Returns `None` for shapes outside this class (graveyard/top-of-library/hand
+/// permissions all anchor on different phrases earlier in the dispatch chain).
+fn try_parse_exile_cast_permission(text: &str, lower: &str) -> Option<StaticDefinition> {
+    // CR 601.2a: Frequency prefix. Both "once each turn" (Maralen) and the
+    // longer "once during each of your turns" synonym map to `OncePerTurn`.
+    // Both prefixes are tried via the file-wide `or_else` chain — adding an
+    // `Unlimited` ("you may cast …") sibling needs an Oracle-confirmed
+    // printing to disambiguate from the existing graveyard / hand handlers.
+    let rest = nom_tag_lower(lower, lower, "once each turn, you may cast ").or_else(|| {
+        nom_tag_lower(
+            lower,
+            lower,
+            "once during each of your turns, you may cast ",
+        )
+    })?;
+    let frequency = CastFrequency::OncePerTurn;
+
+    // Strip the leading article — `parse_type_phrase` expects the bare noun.
+    let rest = nom_tag_lower(rest, rest, "a ")
+        .or_else(|| nom_tag_lower(rest, rest, "an "))
+        .unwrap_or(rest);
+
+    // CR 113.6b: Anchor on " from among cards exiled with " — the
+    // class-defining phrase. Anything before is the affected filter; anything
+    // after is the source self-reference plus optional alt-cost / "this turn"
+    // markers.
+    let (filter_text, trailing) =
+        nom_primitives::split_once_on(rest, " from among cards exiled with ")
+            .ok()
+            .map(|(_, pair)| pair)?;
+
+    // Drop trailing " spell"/" spells" so `parse_type_phrase` sees the bare
+    // type. Mirrors the graveyard / top-of-library / hand sibling parsers.
+    let cleaned: Cow<str> = if nom_primitives::scan_contains(filter_text, "spells") {
+        Cow::Owned(filter_text.replacen(" spells", "", 1))
+    } else if nom_primitives::scan_contains(filter_text, "spell") {
+        Cow::Owned(filter_text.replacen(" spell", "", 1))
+    } else {
+        Cow::Borrowed(filter_text)
+    };
+
+    // `parse_type_phrase` already composes the dynamic "with mana value …"
+    // suffix through `parse_mana_value_suffix`, so Maralen's filter
+    // ("spell with mana value less than or equal to the number of Elves and
+    // Faeries you control") resolves through one call — no bespoke combinator
+    // chain needed here.
+    let (filter, remainder) = parse_type_phrase(&cleaned);
+    if !remainder.trim().is_empty() {
+        // Strict: any unconsumed remainder is a filter shape we don't yet
+        // model. Decline so the line either dispatches to the next handler or
+        // surfaces as Unimplemented (which the swallow detector picks up as a
+        // coverage gap rather than a misparse).
+        return None;
+    }
+
+    // CR 113.6b + CR 201.5: The source reference is normalized to `~` for
+    // `SELF_REF_TYPE_PHRASES` (this creature, this permanent, …) but left
+    // verbatim for `SELF_REF_PARSE_ONLY_PHRASES` ("this card"). Accept either
+    // form so the static covers future cards that lean on the parse-only set.
+    let after_source = std::iter::once("~")
+        .chain(SELF_REF_PARSE_ONLY_PHRASES.iter().copied())
+        .find_map(|phrase| nom_tag_lower(trailing, trailing, phrase))?;
+
+    // CR 113.6b: The "this turn" suffix is structural — without it the
+    // permission would not be per-turn-scoped and would belong to the
+    // open-ended `ExiledBySource` class instead.
+    let after_this_turn = nom_tag_lower(after_source, after_source, " this turn")?;
+
+    // CR 118.9a: Optional " without paying its mana cost" / "their mana costs"
+    // alt-cost rider. The `scan_contains` is the same idiom the sibling
+    // graveyard parser uses for its trailing alt-cost detection.
+    let without_paying_mana_cost =
+        nom_primitives::scan_contains(after_this_turn, "without paying its mana cost")
+            || nom_primitives::scan_contains(after_this_turn, "without paying their mana cost");
+
+    Some(
+        StaticDefinition::new(StaticMode::ExileCastPermission {
+            frequency,
+            play_mode: CardPlayMode::Cast,
+            without_paying_mana_cost,
+        })
+        .affected(filter)
+        .description(text.to_string()),
+    )
+}
+
 /// CR 601.3 + CR 113.6b: Parse the affected-card filter of a graveyard
 /// cast-permission ability. When the filter text is a self-reference phrase
 /// ("this card", "this creature", "this permanent", ...), the permission
@@ -16212,6 +16321,107 @@ mod tests {
                 "missing HasKeywordKind{{{expected_kind:?}}} for {name}"
             );
         }
+    }
+
+    /// Issue #594 (Maralen, Fae Ascendant) — parser test for the new exile
+    /// cast permission class. The full static line must lower to
+    /// `StaticMode::ExileCastPermission { OncePerTurn, Cast, without_paying }`
+    /// with the affected filter carrying the dynamic CMC cap. Anchored on
+    /// `parse_static_line` so the dispatch routing through `is_static_pattern`
+    /// → `parse_static_line_multi` → `parse_static_line_inner` is exercised
+    /// end-to-end.
+    #[test]
+    fn exile_cast_permission_maralen_fae_ascendant() {
+        let text = "Once each turn, you may cast a spell with mana value \
+                    less than or equal to the number of Elves and Faeries \
+                    you control from among cards exiled with ~ this turn \
+                    without paying its mana cost.";
+        let def = parse_static_line(text).expect("Maralen static must parse");
+        assert_eq!(
+            def.mode,
+            StaticMode::ExileCastPermission {
+                frequency: CastFrequency::OncePerTurn,
+                play_mode: CardPlayMode::Cast,
+                without_paying_mana_cost: true,
+            },
+            "expected ExileCastPermission, got {:?}",
+            def.mode
+        );
+        let affected = def.affected.as_ref().expect("affected filter present");
+        let TargetFilter::Typed(tf) = affected else {
+            panic!("expected typed filter, got {affected:?}");
+        };
+        let has_cmc_le = tf.properties.iter().any(|p| {
+            matches!(
+                p,
+                FilterProp::Cmc {
+                    comparator: Comparator::LE,
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { .. },
+                    },
+                }
+            )
+        });
+        assert!(
+            has_cmc_le,
+            "Maralen filter must carry a Cmc(LE, ObjectCount) predicate: {:?}",
+            tf.properties
+        );
+    }
+
+    /// Issue #594 sibling — the parser must accept the longer "once during
+    /// each of your turns" synonym, leaving the rest of the lowering
+    /// unchanged. No card prints this shape today, but `add-engine-variant`
+    /// requires the class be built for the pattern, not the single card.
+    #[test]
+    fn exile_cast_permission_during_each_of_your_turns_synonym() {
+        let text = "Once during each of your turns, you may cast a spell \
+                    with mana value 3 or less from among cards exiled with \
+                    ~ this turn without paying its mana cost.";
+        let def = parse_static_line(text).expect("synonym shape must parse");
+        assert!(
+            matches!(
+                def.mode,
+                StaticMode::ExileCastPermission {
+                    frequency: CastFrequency::OncePerTurn,
+                    play_mode: CardPlayMode::Cast,
+                    without_paying_mana_cost: true,
+                }
+            ),
+            "expected ExileCastPermission(OncePerTurn, Cast, free), got {:?}",
+            def.mode
+        );
+    }
+
+    /// CR 113.6b: The "this turn" suffix is structural. A line that names
+    /// "cards exiled with ~" but omits "this turn" must NOT match this
+    /// permission class — that would belong to the open-ended
+    /// `ExiledBySource` family (Court of Locthwain, Bag of Holding, etc.)
+    /// and is parsed elsewhere.
+    #[test]
+    fn exile_cast_permission_rejects_missing_this_turn_suffix() {
+        let text = "Once each turn, you may cast a spell with mana value 3 \
+                    or less from among cards exiled with ~ without paying \
+                    its mana cost.";
+        let lower = text.to_lowercase();
+        assert!(
+            try_parse_exile_cast_permission(text, &lower).is_none(),
+            "Open-ended exile filter must not match the per-turn class"
+        );
+    }
+
+    /// CR 601.2a: The graveyard sibling handler must NOT intercept the
+    /// exile-cast permission line. Regression guard against accidentally
+    /// over-anchoring the graveyard branch on "you may cast" alone.
+    #[test]
+    fn exile_cast_permission_not_intercepted_by_graveyard_branch() {
+        let text = "Once each turn, you may cast a spell with mana value \
+                    less than or equal to the number of Elves and Faeries \
+                    you control from among cards exiled with ~ this turn \
+                    without paying its mana cost.";
+        let lower = text.to_lowercase();
+        assert!(try_parse_graveyard_cast_permission(text, &lower).is_none());
+        assert!(try_parse_exile_cast_permission(text, &lower).is_some());
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -47,7 +47,8 @@ use crate::types::mana::{ManaColor, ManaCost, ManaType};
 use crate::types::phase::Phase;
 use crate::types::statics::{
     ActivationExemption, BlockExceptionKind, CastFrequency, CastingProhibitionCondition,
-    CostPaymentProhibition, HandSizeModification, ProhibitionScope, StaticMode, TriggerCause,
+    CostPaymentProhibition, ExileCastCost, HandSizeModification, ProhibitionScope, StaticMode,
+    TriggerCause,
 };
 use crate::types::zones::Zone;
 
@@ -10355,17 +10356,22 @@ fn try_parse_exile_cast_permission(text: &str, lower: &str) -> Option<StaticDefi
     let after_this_turn = nom_tag_lower(after_source, after_source, " this turn")?;
 
     // CR 118.9a: Optional " without paying its mana cost" / "their mana costs"
-    // alt-cost rider. The `scan_contains` is the same idiom the sibling
-    // graveyard parser uses for its trailing alt-cost detection.
-    let without_paying_mana_cost =
-        nom_primitives::scan_contains(after_this_turn, "without paying its mana cost")
-            || nom_primitives::scan_contains(after_this_turn, "without paying their mana cost");
+    // alt-cost rider selects the `WithoutPayingManaCost` shape; absence leaves
+    // the static at `PayNormalCost`. The `scan_contains` is the same idiom the
+    // sibling graveyard parser uses for its trailing alt-cost detection.
+    let cost = if nom_primitives::scan_contains(after_this_turn, "without paying its mana cost")
+        || nom_primitives::scan_contains(after_this_turn, "without paying their mana cost")
+    {
+        ExileCastCost::WithoutPayingManaCost
+    } else {
+        ExileCastCost::PayNormalCost
+    };
 
     Some(
         StaticDefinition::new(StaticMode::ExileCastPermission {
             frequency,
             play_mode: CardPlayMode::Cast,
-            without_paying_mana_cost,
+            cost,
         })
         .affected(filter)
         .description(text.to_string()),
@@ -16342,7 +16348,7 @@ mod tests {
             StaticMode::ExileCastPermission {
                 frequency: CastFrequency::OncePerTurn,
                 play_mode: CardPlayMode::Cast,
-                without_paying_mana_cost: true,
+                cost: ExileCastCost::WithoutPayingManaCost,
             },
             "expected ExileCastPermission, got {:?}",
             def.mode
@@ -16385,7 +16391,7 @@ mod tests {
                 StaticMode::ExileCastPermission {
                     frequency: CastFrequency::OncePerTurn,
                     play_mode: CardPlayMode::Cast,
-                    without_paying_mana_cost: true,
+                    cost: ExileCastCost::WithoutPayingManaCost,
                 }
             ),
             "expected ExileCastPermission(OncePerTurn, Cast, free), got {:?}",

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -473,6 +473,10 @@ fn static_mode_is_optional_permission(mode: &StaticMode) -> bool {
             // (Crucible, Ramunap Excavator, etc.) — graveyard-as-zone
             // cast permission, structurally opt-in.
             | StaticMode::GraveyardCastPermission { .. }
+            // CR 601.2a + CR 113.6b: Maralen-class "Once each turn, you
+            // may cast …" exile-cast permission — structurally opt-in by
+            // the same "you may cast" surface as the graveyard sibling.
+            | StaticMode::ExileCastPermission { .. }
             // CR 601.2f: Defiler-style cost reductions encode the optional
             // life payment inside the static cost-modification primitive.
             | StaticMode::DefilerCostReduction { .. }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3357,6 +3357,22 @@ pub enum CastingVariant {
         /// `hand_cast_free_permissions_used`.
         frequency: super::statics::CastFrequency,
     },
+    /// CR 601.2a + CR 113.6b + CR 118.9a: Cast from exile via a
+    /// `StaticMode::ExileCastPermission` source (Maralen, Fae Ascendant).
+    /// Stores the granting permanent's ObjectId for per-turn tracking; the
+    /// finalize-cast step zeroes the spell's mana cost when the static carries
+    /// `without_paying_mana_cost: true` (the only published shape today). The
+    /// resolution-time routing matches a normal cast — no on-resolve exile
+    /// behavior — so this is treated as a casting-context tag, not as an
+    /// alternative cost.
+    /// CR 400.7: Zone change creates a new source `ObjectId`, naturally
+    /// resetting the per-turn slot when the source leaves and re-enters play.
+    ExilePermission {
+        source: ObjectId,
+        /// CR 601.2a: When `OncePerTurn`, casting consumes this source's slot
+        /// in `exile_cast_permissions_used`. `Unlimited` skips tracking.
+        frequency: super::statics::CastFrequency,
+    },
     /// CR 702.190a: Cast from HAND via the Sneak alternative cost. Legal only
     /// during the declare-blockers step. The returned unblocked attacker you
     /// control is part of the cost, bounced to its owner's hand at
@@ -4101,6 +4117,32 @@ pub struct GameState {
     /// consumed this turn. Keyed by the granting source's ObjectId.
     #[serde(default)]
     pub exile_play_permissions_used: HashSet<ObjectId>,
+    /// CR 601.2a + CR 113.6b: Tracks `OncePerTurn` `StaticMode::ExileCastPermission`
+    /// sources that have already had a spell cast through them this turn
+    /// (Maralen, Fae Ascendant — "Once each turn, you may cast …"). Keyed by
+    /// the granting permanent's ObjectId. `Unlimited` frequency permissions
+    /// never populate this set. Cleared at the start of each turn alongside
+    /// the other per-turn cast-permission slots.
+    /// CR 400.7: Zone change creates a new source `ObjectId`, naturally
+    /// resetting the slot when the source leaves and re-enters play.
+    #[serde(default)]
+    pub exile_cast_permissions_used: HashSet<ObjectId>,
+    /// CR 113.6b + CR 601.2a: Per-turn rolling list of cards that have been
+    /// exiled "with" each linked-exile source during the current turn. Keyed
+    /// by the source's `ObjectId`; the `Vec` is the list of card `ObjectId`s
+    /// exiled this turn by that source, in exile order. Populated by
+    /// `exile_links::push_exiled_with_source_this_turn` whenever a tracked
+    /// exile happens; cleared at the start of each turn so "cards exiled with
+    /// ~ this turn" cast permissions (Maralen, Fae Ascendant) only see the
+    /// current turn's pool.
+    ///
+    /// Distinct from `exile_links`: those persist for the lifetime of the
+    /// source-link contract (CR 610.3) and back the open-ended "cards exiled
+    /// with ~" filter. This map is the turn-scoped slice and is consulted
+    /// only by `StaticMode::ExileCastPermission` and similar per-turn
+    /// permissions.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub cards_exiled_with_source_this_turn: HashMap<ObjectId, Vec<ObjectId>>,
     /// CR 702.94a + CR 603.11: Per-player first-card-drawn-this-turn tracking for
     /// miracle's linked triggered ability. Populated by the draw pipeline on the
     /// first `CardDrawn` event each turn per player; reset at turn start. The
@@ -4811,6 +4853,8 @@ impl GameState {
             pending_permanent_type_slot: None,
             hand_cast_free_permissions_used: HashSet::new(),
             exile_play_permissions_used: HashSet::new(),
+            exile_cast_permissions_used: HashSet::new(),
+            cards_exiled_with_source_this_turn: HashMap::new(),
             first_card_drawn_this_turn: HashMap::new(),
             cards_drawn_this_turn: HashMap::new(),
             pending_miracle_offers: Vec::new(),
@@ -5091,6 +5135,8 @@ impl PartialEq for GameState {
             && self.pending_permanent_type_slot == other.pending_permanent_type_slot
             && self.hand_cast_free_permissions_used == other.hand_cast_free_permissions_used
             && self.exile_play_permissions_used == other.exile_play_permissions_used
+            && self.exile_cast_permissions_used == other.exile_cast_permissions_used
+            && self.cards_exiled_with_source_this_turn == other.cards_exiled_with_source_this_turn
             && self.first_card_drawn_this_turn == other.first_card_drawn_this_turn
             && self.cards_drawn_this_turn == other.cards_drawn_this_turn
             && self.pending_miracle_offers == other.pending_miracle_offers

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -304,6 +304,51 @@ impl FromStr for CastFrequency {
     }
 }
 
+/// CR 118.9 + CR 601.2a: The cost axis for `StaticMode::ExileCastPermission`.
+///
+/// Sibling to `CastFrequency` and `CardPlayMode` — each axis of the exile-cast
+/// permission is a typed enum rather than a `bool` so the design space stays
+/// open. `bool` fields cannot grow to accommodate future cost shapes (e.g. an
+/// alternative life cost analogous to Bolas's Citadel).
+///
+/// - `PayNormalCost` — cast at the spell's normal mana cost. No shipping
+///   printing uses this shape today, but it is the natural default; if a future
+///   card prints "Once each turn, you may cast a spell from among cards exiled
+///   with ~ this turn." (no "without paying" rider), this is the variant.
+/// - `WithoutPayingManaCost` — CR 118.9a: cast without paying the printed mana
+///   cost. Maralen, Fae Ascendant ("...without paying its mana cost.") is the
+///   type specimen and the only shipping printing today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub enum ExileCastCost {
+    /// Cast at the spell's normal mana cost — no alternative cost applied.
+    PayNormalCost,
+    /// CR 118.9a: Cast without paying the spell's printed mana cost
+    /// (Maralen, Fae Ascendant).
+    #[default]
+    WithoutPayingManaCost,
+}
+
+impl fmt::Display for ExileCastCost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExileCastCost::PayNormalCost => write!(f, "pay_normal_cost"),
+            ExileCastCost::WithoutPayingManaCost => write!(f, "without_paying_mana_cost"),
+        }
+    }
+}
+
+impl FromStr for ExileCastCost {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pay_normal_cost" => Ok(ExileCastCost::PayNormalCost),
+            "without_paying_mana_cost" => Ok(ExileCastCost::WithoutPayingManaCost),
+            other => Err(format!("unknown ExileCastCost: {other}")),
+        }
+    }
+}
+
 /// CR 603.2d: The cause-predicate axis for trigger-doubling static abilities.
 ///
 /// "An effect that states a triggered ability of an object triggers additional
@@ -656,13 +701,14 @@ pub enum StaticMode {
         /// axis is retained for symmetry with the graveyard / top-of-library
         /// permission classes.
         play_mode: CardPlayMode,
-        /// CR 118.9a: When `true`, the spell is cast without paying its mana
-        /// cost — `casting_costs` zeroes the printed mana cost (mirrors the
-        /// Omniscience / `CastFromHandFree` flow). When `false`, the spell is
-        /// cast at its normal cost (no published printings in this class today,
-        /// but the field keeps the static composable with future patterns).
+        /// CR 118.9a: How the spell's mana cost is paid when cast via this
+        /// permission. `WithoutPayingManaCost` zeroes the printed mana cost
+        /// (mirrors the Omniscience / `CastFromHandFree` flow — Maralen, Fae
+        /// Ascendant). `PayNormalCost` casts at the spell's normal cost (no
+        /// published printings today, but the axis keeps the static composable
+        /// with future patterns).
         #[serde(default)]
-        without_paying_mana_cost: bool,
+        cost: ExileCastCost,
     },
     /// CR 101.2: This spell/permanent can't be countered.
     CantBeCountered,
@@ -1002,11 +1048,11 @@ impl Hash for StaticMode {
             StaticMode::ExileCastPermission {
                 frequency,
                 play_mode,
-                without_paying_mana_cost,
+                cost,
             } => {
                 frequency.hash(state);
                 play_mode.hash(state);
-                without_paying_mana_cost.hash(state);
+                cost.hash(state);
             }
             StaticMode::SkipStep { step } => step.hash(state),
             StaticMode::DoubleTriggers { cause } => cause.hash(state),
@@ -1123,14 +1169,15 @@ impl fmt::Display for StaticMode {
             StaticMode::ExileCastPermission {
                 frequency,
                 play_mode,
-                without_paying_mana_cost,
-            } => {
-                if *without_paying_mana_cost {
+                cost,
+            } => match cost {
+                ExileCastCost::WithoutPayingManaCost => {
                     write!(f, "ExileCastPermission({play_mode},{frequency},free)")
-                } else {
+                }
+                ExileCastCost::PayNormalCost => {
                     write!(f, "ExileCastPermission({play_mode},{frequency})")
                 }
-            }
+            },
             StaticMode::CantBeCountered => write!(f, "CantBeCountered"),
             StaticMode::CantBeCopied => write!(f, "CantBeCopied"),
             StaticMode::CantEnterBattlefieldFrom => write!(f, "CantEnterBattlefieldFrom"),
@@ -1430,13 +1477,13 @@ impl FromStr for StaticMode {
             "ExileCastPermission" => StaticMode::ExileCastPermission {
                 frequency: CastFrequency::Unlimited,
                 play_mode: CardPlayMode::Cast,
-                without_paying_mana_cost: false,
+                cost: ExileCastCost::PayNormalCost,
             },
             s if s.starts_with("ExileCastPermission(") => {
                 // Display form: "ExileCastPermission(<play_mode>,<frequency>)" or
                 // "ExileCastPermission(<play_mode>,<frequency>,free)" for the
-                // without-paying-mana-cost variant. Parse positionally so a
-                // later 3-segment form survives lossless round-trip.
+                // `WithoutPayingManaCost` shape. Parse positionally so a later
+                // 3-segment form survives lossless round-trip.
                 let inner = s
                     .strip_prefix("ExileCastPermission(")
                     .and_then(|s| s.strip_suffix(')'))
@@ -1450,11 +1497,15 @@ impl FromStr for StaticMode {
                     .next()
                     .and_then(|p| p.parse().ok())
                     .unwrap_or(CastFrequency::Unlimited);
-                let without_paying_mana_cost = matches!(parts.next(), Some("free"));
+                let cost = if matches!(parts.next(), Some("free")) {
+                    ExileCastCost::WithoutPayingManaCost
+                } else {
+                    ExileCastCost::PayNormalCost
+                };
                 StaticMode::ExileCastPermission {
                     frequency,
                     play_mode,
-                    without_paying_mana_cost,
+                    cost,
                 }
             }
             "CantBeCountered" => StaticMode::CantBeCountered,
@@ -1858,12 +1909,12 @@ mod tests {
             StaticMode::ExileCastPermission {
                 frequency: CastFrequency::OncePerTurn,
                 play_mode: CardPlayMode::Cast,
-                without_paying_mana_cost: true,
+                cost: ExileCastCost::WithoutPayingManaCost,
             },
             StaticMode::ExileCastPermission {
                 frequency: CastFrequency::Unlimited,
                 play_mode: CardPlayMode::Cast,
-                without_paying_mana_cost: false,
+                cost: ExileCastCost::PayNormalCost,
             },
             // Casting prohibitions
             StaticMode::CantBeCast {

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -624,6 +624,46 @@ pub enum StaticMode {
         /// CR 601.2b: Per-turn cast frequency.
         frequency: CastFrequency,
     },
+    /// CR 601.2a + CR 113.6b + CR 118.9: Static ability granting permission to
+    /// cast cards exiled with this source — restricted to cards exiled *this
+    /// turn* — typically without paying the mana cost. Maralen, Fae Ascendant
+    /// is the type specimen ("Once each turn, you may cast a spell with mana
+    /// value less than or equal to the number of Elves and Faeries you control
+    /// from among cards exiled with Maralen this turn without paying its mana
+    /// cost.").
+    ///
+    /// The source pool is the per-turn list
+    /// `GameState::cards_exiled_with_source_this_turn[source_id]`. The static's
+    /// `affected: TargetFilter` constrains the eligible cards (type, mana
+    /// value, etc.). Per-turn frequency tracking is keyed on `source_id` in
+    /// `GameState::exile_cast_permissions_used` for `OncePerTurn`; `Unlimited`
+    /// skips tracking.
+    ///
+    /// Distinct from `GraveyardCastPermission`: the source pool is exile
+    /// (per-turn-scoped), not the controller's graveyard. Distinct from
+    /// `TopOfLibraryCastPermission`: the eligible cards are a tracked exile
+    /// set carved out by a prior exile-with-source effect, not the live top
+    /// of library. Distinct from `Effect::CastFromZone` (Court of Locthwain,
+    /// Mizzix's Mastery): that is a one-shot effect that grants per-card
+    /// permissions; this is a continuous static that grants the controller a
+    /// recurring per-turn cast slot.
+    ExileCastPermission {
+        /// CR 601.2a: Per-turn cast frequency. `OncePerTurn` consumes a slot
+        /// in `exile_cast_permissions_used`; `Unlimited` does not.
+        frequency: CastFrequency,
+        /// CR 305.1: Play (lands + spells) vs Cast (spells only). All current
+        /// printings of this class are `Cast` (Maralen, Fae Ascendant); the
+        /// axis is retained for symmetry with the graveyard / top-of-library
+        /// permission classes.
+        play_mode: CardPlayMode,
+        /// CR 118.9a: When `true`, the spell is cast without paying its mana
+        /// cost — `casting_costs` zeroes the printed mana cost (mirrors the
+        /// Omniscience / `CastFromHandFree` flow). When `false`, the spell is
+        /// cast at its normal cost (no published printings in this class today,
+        /// but the field keeps the static composable with future patterns).
+        #[serde(default)]
+        without_paying_mana_cost: bool,
+    },
     /// CR 101.2: This spell/permanent can't be countered.
     CantBeCountered,
     /// CR 101.2 + CR 707.10: This spell can't be copied by spells or abilities.
@@ -959,6 +999,15 @@ impl Hash for StaticMode {
             StaticMode::CastFromHandFree { frequency } => {
                 frequency.hash(state);
             }
+            StaticMode::ExileCastPermission {
+                frequency,
+                play_mode,
+                without_paying_mana_cost,
+            } => {
+                frequency.hash(state);
+                play_mode.hash(state);
+                without_paying_mana_cost.hash(state);
+            }
             StaticMode::SkipStep { step } => step.hash(state),
             StaticMode::DoubleTriggers { cause } => cause.hash(state),
             // CR 107.4f: Parameterized by ManaColor — hash the color so distinct
@@ -1070,6 +1119,17 @@ impl fmt::Display for StaticMode {
             }
             StaticMode::CastFromHandFree { frequency } => {
                 write!(f, "CastFromHandFree({frequency})")
+            }
+            StaticMode::ExileCastPermission {
+                frequency,
+                play_mode,
+                without_paying_mana_cost,
+            } => {
+                if *without_paying_mana_cost {
+                    write!(f, "ExileCastPermission({play_mode},{frequency},free)")
+                } else {
+                    write!(f, "ExileCastPermission({play_mode},{frequency})")
+                }
             }
             StaticMode::CantBeCountered => write!(f, "CantBeCountered"),
             StaticMode::CantBeCopied => write!(f, "CantBeCopied"),
@@ -1365,6 +1425,36 @@ impl FromStr for StaticMode {
                     .unwrap_or("unlimited");
                 StaticMode::CastFromHandFree {
                     frequency: freq.parse().unwrap_or(CastFrequency::Unlimited),
+                }
+            }
+            "ExileCastPermission" => StaticMode::ExileCastPermission {
+                frequency: CastFrequency::Unlimited,
+                play_mode: CardPlayMode::Cast,
+                without_paying_mana_cost: false,
+            },
+            s if s.starts_with("ExileCastPermission(") => {
+                // Display form: "ExileCastPermission(<play_mode>,<frequency>)" or
+                // "ExileCastPermission(<play_mode>,<frequency>,free)" for the
+                // without-paying-mana-cost variant. Parse positionally so a
+                // later 3-segment form survives lossless round-trip.
+                let inner = s
+                    .strip_prefix("ExileCastPermission(")
+                    .and_then(|s| s.strip_suffix(')'))
+                    .unwrap_or("");
+                let mut parts = inner.split(',');
+                let play_mode = parts
+                    .next()
+                    .and_then(|p| p.parse().ok())
+                    .unwrap_or(CardPlayMode::Cast);
+                let frequency = parts
+                    .next()
+                    .and_then(|p| p.parse().ok())
+                    .unwrap_or(CastFrequency::Unlimited);
+                let without_paying_mana_cost = matches!(parts.next(), Some("free"));
+                StaticMode::ExileCastPermission {
+                    frequency,
+                    play_mode,
+                    without_paying_mana_cost,
                 }
             }
             "CantBeCountered" => StaticMode::CantBeCountered,
@@ -1763,6 +1853,17 @@ mod tests {
             },
             StaticMode::CastFromHandFree {
                 frequency: CastFrequency::OncePerTurn,
+            },
+            // Exile-cast permission (Maralen, Fae Ascendant).
+            StaticMode::ExileCastPermission {
+                frequency: CastFrequency::OncePerTurn,
+                play_mode: CardPlayMode::Cast,
+                without_paying_mana_cost: true,
+            },
+            StaticMode::ExileCastPermission {
+                frequency: CastFrequency::Unlimited,
+                play_mode: CardPlayMode::Cast,
+                without_paying_mana_cost: false,
             },
             // Casting prohibitions
             StaticMode::CantBeCast {


### PR DESCRIPTION
## Summary
Follow-up to #1401 — closes the remaining gap on #594 (defects #4 and #5 in the issue). Adds the new `StaticMode::ExileCastPermission` static and the runtime support for Maralen, Fae Ascendant's "Once each turn, you may cast a spell with mana value less than or equal to the number of Elves and Faeries you control from among cards exiled with Maralen this turn without paying its mana cost."

#1401 fixed the trigger half (count + target-opponent controller on the ETB exile). This PR fixes the static half: the second ability is no longer `Unimplemented` and now lowers to a typed static that the casting flow consumes end-to-end.

## Files changed
- crates/engine/src/types/statics.rs
- crates/engine/src/types/game_state.rs
- crates/engine/src/parser/oracle_static.rs
- crates/engine/src/parser/swallow_check.rs
- crates/engine/src/game/casting.rs
- crates/engine/src/game/casting_costs.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/game/exile_links.rs
- crates/engine/src/game/turns.rs

## CR references
- CR 601.2a — cast-permission grants (`ExileCastPermission`, `CastingVariant::ExilePermission`)
- CR 113.6b — zone-restricted ability functioning (per-turn pool scoping)
- CR 118.9 / CR 118.9a — alternative cost / "without paying its mana cost"
- CR 305.1 — Play vs Cast play-mode axis
- CR 400.7 — zone change resets the source ObjectId and per-turn slot
- CR 611.2a — permission-granting effect controller binding
- CR 201.5 — self-reference token (`~`) handling in parser

All numbers grepped against `docs/MagicCompRules.txt` before annotation.

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Tier
Frontier

## Anchored on
- crates/engine/src/types/statics.rs:576 — existing `GraveyardCastPermission` variant (mirrored shape: `frequency` + `play_mode` + optional rider; my `ExileCastPermission` follows the same axes)
- crates/engine/src/game/casting.rs:1079 — existing `graveyard_objects_castable_by_permission` helper (mirrored by `exile_objects_castable_by_permission` at the same level of abstraction, with the pool source swapped from `player.graveyard` to `cards_exiled_with_source_this_turn[source_id]`)
- crates/engine/src/parser/oracle_static.rs:10157 — existing `try_parse_graveyard_cast_permission` parser (mirrored anchor pattern: frequency-prefix `nom_tag_lower` + class-defining split anchor + `parse_type_phrase` for the affected filter)
- crates/engine/src/game/exile_links.rs:7 — existing `LINKED_EXILE_CONSUMER_TAGS` (extended with `"ExileCastPermission"` so source-level consumer detection picks up Maralen without any special-casing)

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo test -p engine --lib` — 9077 pass / 0 fail (was 9070; 7 new tests added)
- `cargo test -p phase-ai` — 710 pass / 0 fail
- `./scripts/gen-card-data.sh` — Maralen, Fae Ascendant: 0 Unimplemented entries; static_abilities = `[{ ExileCastPermission { frequency: OncePerTurn, play_mode: Cast, without_paying_mana_cost: true } }]` with the dynamic CMC predicate `Cmc(LE, ObjectCount{Elf|Faerie, You})`

### Parser tests added (`oracle_static.rs`)
- `exile_cast_permission_maralen_fae_ascendant` — full Maralen text round-trips through `parse_static_line` to the typed `ExileCastPermission` + dynamic-CMC predicate
- `exile_cast_permission_during_each_of_your_turns_synonym` — accepts the longer "once during each of your turns" synonym (built for the class, not the card)
- `exile_cast_permission_rejects_missing_this_turn_suffix` — guards the structural "this turn" anchor so persistent-link cards (Court of Locthwain, Bag of Holding, …) don't get misclassified
- `exile_cast_permission_not_intercepted_by_graveyard_branch` — regression guard against the sibling graveyard handler over-anchoring on "you may cast"

### Engine tests added (`casting.rs`)
- `exile_cast_permission_surfaces_pool_card` — the per-turn pool + active static surface the exiled card through `spell_objects_available_to_cast`
- `exile_cast_permission_once_per_turn_frequency_gates_offer` — consumed `OncePerTurn` slot prunes the card; turn-cleanup reset (clearing `exile_cast_permissions_used`) restores it
- `exile_cast_permission_rejects_card_outside_per_turn_pool` — cards exiled in a prior turn (not in the per-turn map) are correctly NOT surfaced, validating the "this turn" scoping

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

Refs #594. Builds on #1401 (independent — no rebase needed; both PRs may merge in any order).