### PR TITLE
fix(engine): protection from each of your opponents (#767)

### DIFF
--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -197,6 +197,20 @@ pub fn source_matches_protection_target(
         // object-intrinsic properties (Cmc, HasColor, PowerLE/GE, etc.) that can
         // be evaluated from the source alone without game state.
         ProtectionTarget::Filter(filter) => source_matches_protection_filter(source, filter),
+        // CR 702.16k: "Protection from [a player]" — the source matches if it is
+        // controlled by the scoped player(s) relative to the protected object's
+        // controller, regardless of the source's characteristics. "Each of your
+        // opponents" (CR 702.16i) is captured by `Opponent`: any controller
+        // other than the protected object's controller is an opponent in 1v1 and
+        // free-for-all multiplayer. Player references with no static context
+        // (target/chosen/etc.) fail closed.
+        ProtectionTarget::FromPlayer(scope) => match scope {
+            crate::types::ability::ControllerRef::Opponent => {
+                source.controller != protected.controller
+            }
+            crate::types::ability::ControllerRef::You => source.controller == protected.controller,
+            _ => false,
+        },
     }
 }
 
@@ -629,6 +643,46 @@ mod tests {
             &ProtectionTarget::ChosenCardType,
             &no_choice,
             &creature_source,
+        ));
+    }
+
+    /// Issue #767 / CR 702.16k: "protection from each of your opponents"
+    /// (Figure of Fable's Avatar form) — a source controlled by an opponent of
+    /// the protected permanent's controller matches; a source the protected
+    /// permanent's own controller controls does not.
+    #[test]
+    fn source_matches_protection_from_opponents() {
+        use crate::types::ability::ControllerRef;
+        use crate::types::player::PlayerId;
+
+        let mut protected = make_obj();
+        protected.controller = PlayerId(0);
+        let mut opponent_source = make_obj();
+        opponent_source.controller = PlayerId(1);
+        let mut own_source = make_obj();
+        own_source.controller = PlayerId(0);
+
+        let from_opponents = ProtectionTarget::FromPlayer(ControllerRef::Opponent);
+        assert!(
+            source_matches_protection_target(&from_opponents, &protected, &opponent_source),
+            "opponent-controlled source must match protection from each of your opponents"
+        );
+        assert!(
+            !source_matches_protection_target(&from_opponents, &protected, &own_source),
+            "own-controlled source must NOT match protection from each of your opponents"
+        );
+
+        // CR 702.16k with `You` scope is the controller-relative inverse.
+        let from_you = ProtectionTarget::FromPlayer(ControllerRef::You);
+        assert!(source_matches_protection_target(
+            &from_you,
+            &protected,
+            &own_source
+        ));
+        assert!(!source_matches_protection_target(
+            &from_you,
+            &protected,
+            &opponent_source
         ));
     }
 

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1609,6 +1609,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_keyword_from_oracle_protection_from_each_of_your_opponents() {
+        use crate::types::ability::ControllerRef;
+        use crate::types::keywords::ProtectionTarget;
+
+        // Issue #767 / CR 702.16k: Figure of Fable's Avatar form. Previously
+        // fell through to ProtectionTarget::CardType("each of your opponents"),
+        // which never matched any source at runtime.
+        let kw = parse_keyword_from_oracle("protection from each of your opponents").unwrap();
+        assert_eq!(
+            kw,
+            Keyword::Protection(ProtectionTarget::FromPlayer(ControllerRef::Opponent))
+        );
+    }
+
+    #[test]
     fn parse_keyword_from_oracle_gift_a_card() {
         use crate::types::keywords::GiftKind;
         let kw = parse_keyword_from_oracle("gift a card").unwrap();

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -349,6 +349,14 @@ pub enum ProtectionTarget {
     /// filter's properties — only `FilterProp` predicates that can be resolved
     /// from the object alone (without game state) are valid here.
     Filter(super::ability::TargetFilter),
+    /// CR 702.16k: "Protection from [a player]" — protection from each object
+    /// controlled by the scoped player(s), relative to the protected object's
+    /// controller, regardless of the source's characteristic values. Covers
+    /// "protection from each of your opponents" (Figure of Fable's Avatar form)
+    /// via `ControllerRef::Opponent`. CR 702.16i makes "each of your opponents"
+    /// behave as protection from every opponent, which the Opponent scope
+    /// captures in one variant.
+    FromPlayer(super::ability::ControllerRef),
 }
 
 /// CR 702.21a: Ward cost — what the targeting player must pay.
@@ -1827,6 +1835,14 @@ fn parse_protection_target(s: &str) -> ProtectionTarget {
         "the chosen card type" | "chosen card type" => ProtectionTarget::ChosenCardType,
         // CR 702.16j: "protection from everything" — typed variant, not stringly-typed
         "everything" => ProtectionTarget::Everything,
+        // CR 702.16k: "protection from each of your opponents" (Figure of
+        // Fable's Avatar form) and its phrasings — protection from every
+        // opponent of the protected permanent's controller.
+        // CR 702.16i: "protection from each ... players" is shorthand for
+        // separate protection from each; the Opponent scope captures all of them.
+        "each of your opponents" | "your opponents" | "an opponent" | "opponents" => {
+            ProtectionTarget::FromPlayer(super::ability::ControllerRef::Opponent)
+        }
         // Lowercase the stored quality — `source_matches_card_type` only matches
         // lowercase, so the canonical stored form must be lowercase.
         _ if lower.starts_with("from ") => ProtectionTarget::Quality(lower),


### PR DESCRIPTION
## Summary
Figure of Fable's Avatar form grants "protection from each of your opponents," but the protection was silently non-functional — the Avatar could still be targeted, blocked, enchanted, and dealt damage by opponents. This adds a player-scoped protection variant (CR 702.16k) and wires it through the parser and the runtime protection gate.

## Root Cause
"Protection from each of your opponents" is a *player* reference, but the parser had no player-scoped `ProtectionTarget`, so `parse_protection_target` fell through to its catch-all and produced `ProtectionTarget::CardType("each of your opponents")`. At runtime, `source_matches_card_type` only recognizes real card types ("creature", "artifact", …), so that string matched **nothing** — the protection never applied to any source.

## Fix
Three coordinated touchpoints (the protection keyword is a single CR 702.16 rule section, so all of "DEBT" flows through one gate):

- **Type** — `crates/engine/src/types/keywords.rs`: new `ProtectionTarget::FromPlayer(ControllerRef)` (CR 702.16k). The player scope is parameterized via the existing `ControllerRef` rather than a bare `FromOpponents`, so future player-scoped protections are parameter values, not new siblings.
- **Parser** — `parse_protection_target`: "protection from each of your opponents" (and the sibling phrasings "your opponents" / "an opponent" / "opponents") now map to `FromPlayer(Opponent)`. Per CR 702.16i, "each of your opponents" behaves as protection from every opponent, which the `Opponent` scope captures in one variant.
- **Runtime** — `crates/engine/src/game/keywords.rs::source_matches_protection_target`: resolves `FromPlayer(scope)` against the **protected permanent's controller** (`Opponent` ⇒ source controlled by a different player; `You` ⇒ same controller). Because every protection check (targeting CR 702.16b, aura attachment 702.16c, blocking, damage prevention 702.16e) routes through this one function, the fix covers them all at once. Player references with no static context fail closed.

New variant cleared the `add-engine-variant` gate: DOES_NOT_EXIST → EXTEND_OK (orthogonal controller-based axis, parameterized via `ControllerRef`) → WITHIN_SECTION (CR 702.16).

## Test Plan
- [x] Parser regression: `parse_keyword_from_oracle("protection from each of your opponents")` → `Protection(FromPlayer(Opponent))` (previously `CardType(...)`)
- [x] Runtime regression: opponent-controlled source matches the protection; own-controlled source does not (+ `You`-scope inverse)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p engine` protection suite — 54 passed, 0 failed
- [x] card-data regenerated → Figure of Fable's Avatar now emits `Protection(FromPlayer(Opponent))`

## Scope
This fixes the protection facet (the leading cause of the reported combat death per the issue thread). The other facets are intentionally out of scope and would be separate PRs: the level-up "resets at end of turn" report appears already resolved (all three level abilities now parse `duration: Permanent`), and Bristlebane Battler's missing "while … -1/-1 counter" intervening-if is a distinct parser gap.

Closes #767
