### PR TITLE
fix: solve Giggling Skitterspike damage triggers for attack block and spell targeting

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1689,11 +1689,9 @@ pub(super) fn match_becomes_target(
     // CR 115.1a + CR 115.1b: Trigger text like "of a spell" and "of an Aura spell"
     // constrains the targeting source to matching stack spell characteristics.
     if let Some(source_filter) = &trigger.valid_source {
-        let Some(targeting_entry) = state
-            .stack
-            .iter()
-            .find(|entry| entry.id == *targeting_spell_id)
-        else {
+        let Some(targeting_entry) = state.stack.iter().find(|entry| {
+            entry.id == *targeting_spell_id || entry.source_id == *targeting_spell_id
+        }) else {
             return false;
         };
         let trigger_controller = state
@@ -6561,6 +6559,32 @@ mod tests {
             source_id: spell_id,
         };
         // No valid_card, so fallback: event.object_id == source_id param
+        assert!(match_becomes_target(
+            &event,
+            &trigger,
+            trigger_owner,
+            &state
+        ));
+    }
+
+    #[test]
+    fn becomes_target_spell_only_matches_spell_source_object_id() {
+        let (mut state, spell_id) = setup_with_spell_on_stack(false);
+        let stack_entry_id = ObjectId(600);
+        let Some(entry) = state.stack.front_mut() else {
+            panic!("expected spell on stack");
+        };
+        entry.id = stack_entry_id;
+        entry.source_id = spell_id;
+
+        let trigger_owner = ObjectId(5);
+        let mut trigger = make_trigger(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(TargetFilter::StackSpell);
+
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(trigger_owner),
+            source_id: spell_id,
+        };
         assert!(match_becomes_target(
             &event,
             &trigger,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -9648,7 +9648,9 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
         // power. Only `ObjectScope::Anaphoric` is rewritten — an explicit
         // possessive ("the sacrificed creature's power", `CostPaidObject` per
         // CR 608.2k) keeps its parser-fixed referent and is left untouched.
-        Effect::DealDamage { amount, .. } if subject_filter == TargetFilter::SelfRef => {
+        Effect::DealDamage { amount, .. } | Effect::DamageEachPlayer { amount, .. }
+            if subject_filter == TargetFilter::SelfRef =>
+        {
             rewrite_event_source_power_to_object_power(amount, ObjectScope::Source);
         }
         // CR 701.23a: "Its controller may search their library..." — the subject

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -398,8 +398,7 @@ pub(crate) fn parse_trigger_lines_at_index_ir(
         return results;
     }
 
-    // Pattern 2: "whenever ~ [event1] or [event2]" — compound events sharing a subject.
-    // Pattern 2: "whenever ~ [event1], [event2], or [event3]" - serial
+    // Pattern 2: "whenever ~ [event1], [event2], or [event3]" — serial
     // compound events sharing a subject.
     if let Some(halves) = split_serial_event_compound(&cond_lower, &condition) {
         let mut results = Vec::with_capacity(halves.len());
@@ -3647,7 +3646,17 @@ fn normalize_compound_pronouns(text: &str) -> String {
 fn split_serial_event_compound(cond_lower: &str, condition: &str) -> Option<Vec<String>> {
     use super::oracle_nom::primitives::split_once_on;
 
+    // Split the original and lowercase forms in lockstep on the same ASCII
+    // delimiters rather than slicing `condition` with byte offsets taken from
+    // `cond_lower`. `str::to_lowercase()` is not byte-position-preserving for
+    // non-ASCII input (e.g. `İ` grows, `ẞ` shrinks), so a lowercase-derived
+    // offset could land mid-`char` in the original and panic. The delimiters
+    // (`", or "`, `", "`) are pure punctuation and identical in both views, so
+    // parallel splits keep the two aligned without cross-case byte arithmetic.
     let Ok((_, (before_or_lower, after_or_lower))) = split_once_on(cond_lower, ", or ") else {
+        return None;
+    };
+    let Ok((_, (before_or, after_or))) = split_once_on(condition, ", or ") else {
         return None;
     };
     if parse_event_verb_start(after_or_lower.trim_start()).is_err() {
@@ -3657,36 +3666,39 @@ fn split_serial_event_compound(cond_lower: &str, condition: &str) -> Option<Vec<
     let Ok((_, (first_lower, rest_events_lower))) = split_once_on(before_or_lower, ", ") else {
         return None;
     };
+    let Ok((_, (first_original, rest_events_original))) = split_once_on(before_or, ", ") else {
+        return None;
+    };
     let keyword_and_subject = extract_keyword_and_subject(first_lower.trim());
-    let mut results = vec![condition[..first_lower.len()].trim().to_string()];
+    let mut results = vec![first_original.trim().to_string()];
 
-    let rest_events_start = first_lower.len() + ", ".len();
-    let rest_events_original = &condition[rest_events_start..before_or_lower.len()];
     let mut remaining_lower = rest_events_lower;
     let mut remaining_original = rest_events_original;
     loop {
         if let Ok((_, (event_lower, tail_lower))) = split_once_on(remaining_lower, ", ") {
-            let event_original = remaining_original[..event_lower.len()].trim();
+            let Ok((_, (event_original, tail_original))) = split_once_on(remaining_original, ", ")
+            else {
+                return None;
+            };
             if parse_event_verb_start(event_lower.trim()).is_err() {
                 return None;
             }
-            results.push(format!("{keyword_and_subject} {event_original}"));
-            let next_start = event_lower.len() + ", ".len();
+            results.push(format!("{keyword_and_subject} {}", event_original.trim()));
             remaining_lower = tail_lower;
-            remaining_original = &remaining_original[next_start..];
+            remaining_original = tail_original;
         } else {
-            let event_original = remaining_original.trim();
             if parse_event_verb_start(remaining_lower.trim()).is_err() {
                 return None;
             }
-            results.push(format!("{keyword_and_subject} {event_original}"));
+            results.push(format!(
+                "{keyword_and_subject} {}",
+                remaining_original.trim()
+            ));
             break;
         }
     }
 
-    let after_event_start = before_or_lower.len() + ", or ".len();
-    let after_event_original = condition[after_event_start..].trim();
-    results.push(format!("{keyword_and_subject} {after_event_original}"));
+    results.push(format!("{keyword_and_subject} {}", after_or.trim()));
 
     Some(results)
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -398,28 +398,10 @@ pub(crate) fn parse_trigger_lines_at_index_ir(
         return results;
     }
 
-    // Pattern 2: "whenever ~ [event1], [event2], or [event3]" — serial
-    // compound events sharing a subject.
-    if let Some(halves) = split_serial_event_compound(&cond_lower, &condition) {
-        let mut results = Vec::with_capacity(halves.len());
-        for (i, cond) in halves.into_iter().enumerate() {
-            let trigger_text = if effect.is_empty() {
-                cond
-            } else {
-                format!("{cond}, {effect}")
-            };
-            results.push(parse_trigger_line_with_index_ir(
-                &trigger_text,
-                card_name,
-                base_trigger_index.map(|b| b + i),
-                ctx,
-            ));
-        }
-        return results;
-    }
-
-    // Pattern 3: "whenever ~ [event1] or [event2]" - compound events sharing a subject.
-    if let Some(halves) = split_or_event_compound(&cond_lower, &condition) {
+    // Pattern 2: disjunctive shared-subject event list — "whenever ~ A, B, or C"
+    // (N-way serial) or "whenever ~ A or B" (2-way). CR 603.1: each listed event
+    // is its own trigger condition, all sharing the one subject.
+    if let Some(halves) = split_shared_subject_event_list(&cond_lower, &condition) {
         let mut results = Vec::with_capacity(halves.len());
         for (i, cond) in halves.into_iter().enumerate() {
             let trigger_text = if effect.is_empty() {
@@ -3639,7 +3621,23 @@ fn normalize_compound_pronouns(text: &str) -> String {
     result
 }
 
-/// Split serial compound events sharing one subject.
+/// Split a disjunctive shared-subject event trigger into one reconstructed
+/// trigger line per event, with the subject shared across all of them. This is
+/// the single entry point for the whole class: the N-way serial form
+/// ("Whenever ~ A, B, or C") and the 2-way "or" form ("Whenever ~ A or B") are
+/// its two branches. CR 603.1: each listed event is an independent trigger
+/// condition. Dedicated 2-way compound `TriggerMode` variants (AttacksOrBlocks,
+/// EntersOrAttacks) are intentionally left unsplit by `split_or_event_compound`.
+///
+/// Serial is tried first so a comma list ("A, B, or C") is not mis-split by the
+/// 2-way scanner; this preserves the prior dispatch order exactly.
+fn split_shared_subject_event_list(cond_lower: &str, condition: &str) -> Option<Vec<String>> {
+    split_serial_event_compound(cond_lower, condition)
+        .or_else(|| split_or_event_compound(cond_lower, condition))
+}
+
+/// Split serial compound events sharing one subject — the N-way branch of
+/// [`split_shared_subject_event_list`].
 ///
 /// Example: "Whenever ~ attacks, blocks, or becomes the target of a spell"
 /// becomes three trigger conditions, each reusing the same subject.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -399,6 +399,27 @@ pub(crate) fn parse_trigger_lines_at_index_ir(
     }
 
     // Pattern 2: "whenever ~ [event1] or [event2]" — compound events sharing a subject.
+    // Pattern 2: "whenever ~ [event1], [event2], or [event3]" - serial
+    // compound events sharing a subject.
+    if let Some(halves) = split_serial_event_compound(&cond_lower, &condition) {
+        let mut results = Vec::with_capacity(halves.len());
+        for (i, cond) in halves.into_iter().enumerate() {
+            let trigger_text = if effect.is_empty() {
+                cond
+            } else {
+                format!("{cond}, {effect}")
+            };
+            results.push(parse_trigger_line_with_index_ir(
+                &trigger_text,
+                card_name,
+                base_trigger_index.map(|b| b + i),
+                ctx,
+            ));
+        }
+        return results;
+    }
+
+    // Pattern 3: "whenever ~ [event1] or [event2]" - compound events sharing a subject.
     if let Some(halves) = split_or_event_compound(&cond_lower, &condition) {
         let mut results = Vec::with_capacity(halves.len());
         for (i, cond) in halves.into_iter().enumerate() {
@@ -3619,6 +3640,57 @@ fn normalize_compound_pronouns(text: &str) -> String {
     result
 }
 
+/// Split serial compound events sharing one subject.
+///
+/// Example: "Whenever ~ attacks, blocks, or becomes the target of a spell"
+/// becomes three trigger conditions, each reusing the same subject.
+fn split_serial_event_compound(cond_lower: &str, condition: &str) -> Option<Vec<String>> {
+    use super::oracle_nom::primitives::split_once_on;
+
+    let Ok((_, (before_or_lower, after_or_lower))) = split_once_on(cond_lower, ", or ") else {
+        return None;
+    };
+    if parse_event_verb_start(after_or_lower.trim_start()).is_err() {
+        return None;
+    }
+
+    let Ok((_, (first_lower, rest_events_lower))) = split_once_on(before_or_lower, ", ") else {
+        return None;
+    };
+    let keyword_and_subject = extract_keyword_and_subject(first_lower.trim());
+    let mut results = vec![condition[..first_lower.len()].trim().to_string()];
+
+    let rest_events_start = first_lower.len() + ", ".len();
+    let rest_events_original = &condition[rest_events_start..before_or_lower.len()];
+    let mut remaining_lower = rest_events_lower;
+    let mut remaining_original = rest_events_original;
+    loop {
+        if let Ok((_, (event_lower, tail_lower))) = split_once_on(remaining_lower, ", ") {
+            let event_original = remaining_original[..event_lower.len()].trim();
+            if parse_event_verb_start(event_lower.trim()).is_err() {
+                return None;
+            }
+            results.push(format!("{keyword_and_subject} {event_original}"));
+            let next_start = event_lower.len() + ", ".len();
+            remaining_lower = tail_lower;
+            remaining_original = &remaining_original[next_start..];
+        } else {
+            let event_original = remaining_original.trim();
+            if parse_event_verb_start(remaining_lower.trim()).is_err() {
+                return None;
+            }
+            results.push(format!("{keyword_and_subject} {event_original}"));
+            break;
+        }
+    }
+
+    let after_event_start = before_or_lower.len() + ", or ".len();
+    let after_event_original = condition[after_event_start..].trim();
+    results.push(format!("{keyword_and_subject} {after_event_original}"));
+
+    Some(results)
+}
+
 /// Split compound conditions where "or" joins two event verbs sharing the same subject.
 /// Returns `Some(vec![first_trigger, second_trigger])` with reconstructed trigger lines,
 /// or `None` if no compound event "or" is found.
@@ -3767,6 +3839,10 @@ fn parse_event_verb_start(input: &str) -> OracleResult<'_, ()> {
         parse_event_word("exploits"),
         parse_event_word("mutates"),
         parse_event_word("transforms"),
+        parse_event_phrase("becomes the target of a spell or ability"),
+        parse_event_phrase("become the target of a spell or ability"),
+        parse_event_phrase("becomes the target of an aura spell"),
+        parse_event_phrase("becomes the target of a spell"),
     ));
     let player_actions = alt((
         passive_player_actions,
@@ -3912,6 +3988,7 @@ fn find_effect_boundary(lower: &str) -> Option<usize> {
         let comma_pos = search_start + before.len();
         if !continues_player_action_list(after)
             && !continues_disjunctive_zone_change_condition(after)
+            && !continues_serial_event_condition(after)
         {
             return Some(comma_pos);
         }
@@ -3939,6 +4016,21 @@ fn continues_disjunctive_zone_change_condition(after_comma: &str) -> bool {
     let mut ctx = ParseContext::default();
     let (subject, verb) = parse_trigger_subject(clause.trim(), &mut ctx);
     parse_zone_change_clause(&subject, verb).is_some()
+}
+
+fn continues_serial_event_condition(after_comma: &str) -> bool {
+    use super::oracle_nom::primitives::split_once_on;
+
+    let trimmed = after_comma.trim_start();
+    if let Ok((after_or, ())) = value((), tag::<_, _, OracleError<'_>>("or ")).parse(trimmed) {
+        return parse_event_verb_start(after_or.trim_start()).is_ok();
+    }
+
+    let Ok((_, (first_event, after_or))) = split_once_on(trimmed, ", or ") else {
+        return false;
+    };
+    parse_event_verb_start(first_event.trim()).is_ok()
+        && parse_event_verb_start(after_or.trim_start()).is_ok()
 }
 
 fn continues_player_action_list(after_comma: &str) -> bool {
@@ -10106,6 +10198,74 @@ mod tests {
     // so it only fires when the ETB-tapped replacement did NOT apply. For a
     // SelfRef trigger the entering object IS the source, so the evaluator's
     // `source_id` fallback resolves to the same permanent.
+    #[test]
+    fn parse_serial_attack_block_target_compound() {
+        let defs = parse_trigger_lines(
+            "Whenever this creature attacks, blocks, or becomes the target of a spell, \
+             it deals damage equal to its power to each opponent.",
+            "Giggling Skitterspike",
+        );
+
+        assert_eq!(defs.len(), 3, "expected three trigger branches: {defs:?}");
+        assert_eq!(defs[0].mode, TriggerMode::Attacks);
+        assert_eq!(defs[0].valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(defs[1].mode, TriggerMode::Blocks);
+        assert_eq!(defs[1].valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(defs[2].mode, TriggerMode::BecomesTarget);
+        assert_eq!(defs[2].valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(defs[2].valid_source, Some(TargetFilter::StackSpell));
+
+        fn has_damage_each_player(ability: &AbilityDefinition) -> bool {
+            matches!(*ability.effect, Effect::DamageEachPlayer { .. })
+                || ability
+                    .sub_ability
+                    .as_ref()
+                    .is_some_and(|s| has_damage_each_player(s))
+        }
+        fn has_unimplemented(ability: &AbilityDefinition) -> bool {
+            matches!(*ability.effect, Effect::Unimplemented { .. })
+                || ability
+                    .sub_ability
+                    .as_ref()
+                    .is_some_and(|s| has_unimplemented(s))
+        }
+        fn damage_each_player_amount(ability: &AbilityDefinition) -> Option<&QuantityExpr> {
+            match ability.effect.as_ref() {
+                Effect::DamageEachPlayer { amount, .. } => Some(amount),
+                _ => ability
+                    .sub_ability
+                    .as_ref()
+                    .and_then(|s| damage_each_player_amount(s)),
+            }
+        }
+
+        for def in &defs {
+            let execute = def.execute.as_ref().expect("execute ability");
+            assert!(
+                has_damage_each_player(execute),
+                "expected DamageEachPlayer effect, got {:?}",
+                execute.effect
+            );
+            assert!(
+                !has_unimplemented(execute),
+                "effect chain leaked Unimplemented: {:?}",
+                execute
+            );
+            assert!(
+                matches!(
+                    damage_each_player_amount(execute),
+                    Some(QuantityExpr::Ref {
+                        qty: QuantityRef::Power {
+                            scope: crate::types::ability::ObjectScope::Source
+                        }
+                    })
+                ),
+                "expected damage amount to use source power, got {:?}",
+                damage_each_player_amount(execute)
+            );
+        }
+    }
+
     #[test]
     fn trigger_etb_self_enters_untapped_attaches_condition() {
         let def = parse_trigger_line(

--- a/crates/engine/tests/integration/giggling_skitterspike_issue_890.rs
+++ b/crates/engine/tests/integration/giggling_skitterspike_issue_890.rs
@@ -1,0 +1,133 @@
+//! Regression coverage for issue #890.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+use super::rules::AttackTarget;
+
+const SKITTERSPIKE_ORACLE: &str = "Indestructible\n\
+Whenever this creature attacks, blocks, or becomes the target of a spell, it \
+deals damage equal to its power to each opponent.\n\
+{5}: Monstrosity 5.";
+
+fn p1_life(runner: &engine::game::scenario::GameRunner) -> i32 {
+    runner.life(P1)
+}
+
+#[test]
+fn issue_890_attack_trigger_deals_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::DeclareAttackers);
+    let skitterspike = scenario
+        .add_creature_from_oracle(P0, "Giggling Skitterspike", 1, 1, SKITTERSPIKE_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    {
+        let state = runner.state_mut();
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: P0,
+            valid_attacker_ids: vec![skitterspike],
+            valid_attack_targets: vec![AttackTarget::Player(P1)],
+        };
+    }
+
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(skitterspike, AttackTarget::Player(P1))],
+        })
+        .expect("declaring Giggling Skitterspike as attacker should succeed");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(p1_life(&runner), 19);
+}
+
+#[test]
+fn issue_890_block_trigger_deals_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::DeclareAttackers);
+    let skitterspike = scenario
+        .add_creature_from_oracle(P0, "Giggling Skitterspike", 1, 1, SKITTERSPIKE_ORACLE)
+        .id();
+    let attacker = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    let mut runner = scenario.build();
+
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.phase = Phase::DeclareAttackers;
+        state.turn_number = 2;
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: P1,
+            valid_attacker_ids: vec![attacker],
+            valid_attack_targets: vec![AttackTarget::Player(P0)],
+        };
+    }
+
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P0))],
+        })
+        .expect("declaring P1 attacker should succeed");
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareBlockers {
+            assignments: vec![(skitterspike, attacker)],
+        })
+        .expect("blocking with Giggling Skitterspike should succeed");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(p1_life(&runner), 19);
+}
+
+#[test]
+fn issue_890_targeted_by_spell_trigger_deals_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let skitterspike = scenario
+        .add_creature_from_oracle(P0, "Giggling Skitterspike", 1, 1, SKITTERSPIKE_ORACLE)
+        .id();
+    let bolt = scenario.add_bolt_to_hand(P1);
+    scenario.with_mana_pool(
+        P1,
+        vec![ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![])],
+    );
+    let mut runner = scenario.build();
+
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+
+    let card_id = runner.state().objects[&bolt].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: bolt,
+            card_id,
+            targets: vec![],
+        })
+        .expect("casting Lightning Bolt should succeed");
+
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::TargetSelection { .. }
+    ) {
+        runner
+            .act(GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(skitterspike)),
+            })
+            .expect("targeting Giggling Skitterspike should succeed");
+    }
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(p1_life(&runner), 19);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -42,6 +42,7 @@ mod frostcliff_siege_anchor_word_modes;
 mod gatta_and_luzzu_regression;
 mod gemstone_caverns_begin_game;
 mod giada_angel_counters;
+mod giggling_skitterspike_issue_890;
 mod gimbal_gremlin_prodigy;
 mod gluntch_choose_player_chain;
 mod gran_gran_integration;


### PR DESCRIPTION
## Summary

Fixes Giggling Skitterspike so its triggered ability deals damage when it attacks blocks or becomes the target of a spell

Close: #890 

## Changes

- Split serial trigger conditions such as attacks blocks or becomes the target of a spell into separate trigger definitions
- Ensure damage equal to its power uses the source creatures power for each opponent damage effects
- Allow spell target triggers to match the spell source object id as well as the stack entry id
- Added regression tests for attack block and spell targeting behavior

## Before
<img width="1700" height="840" alt="issue-890-before" src="https://github.com/user-attachments/assets/d95c048d-ddff-48c7-89e9-5d76b5faaa70" />

## After
<img width="1700" height="420" alt="issue-890-after" src="https://github.com/user-attachments/assets/9a403eb8-7a4f-4cf2-8e7a-bc0a0a333772" />


## Testing

- `cargo test -p engine parse_serial_attack_block_target_compound --lib -- --nocapture`
- `cargo test -p engine becomes_target_spell_only_matches_spell_source_object_id --lib -- --nocapture`
- `cargo test -p engine issue_890 --test integration -- --nocapture`
