### PR TITLE
fix(deck-builder): own commander partner-pairing in the engine

### DIFF
--- a/client/src/components/deck-builder/commanderUtils.ts
+++ b/client/src/components/deck-builder/commanderUtils.ts
@@ -4,19 +4,9 @@ import { BASIC_LAND_NAMES, hasUnlimitedCopies } from "../../constants/game";
 
 const WUBRG_COLORS = ["W", "U", "B", "R", "G"] as const;
 
-/** CR 702.124: All partner-family keywords that allow co-commander pairing. */
-const PARTNER_KEYWORDS = new Set([
-  "Partner", "Partner with", "Friends forever",
-  "Choose a Background", "Doctor's companion",
-]);
-
-function hasPartner(card: ScryfallCard): boolean {
-  if (card.keywords) {
-    return card.keywords.some((kw) => PARTNER_KEYWORDS.has(kw));
-  }
-  // Fallback for cards without keywords array
-  return card.oracle_text?.toLowerCase().includes("partner") ?? false;
-}
+// CR 702.124: Partner-pairing legality (including Doctor's Companion / Choose a
+// Background) is owned by the engine (`can_pair_commanders`) and consumed via
+// `commanderPartnerCandidates` in engineRuntime — never re-derived here.
 
 export function getCombinedColorIdentity(
   commanders: string[],
@@ -64,15 +54,4 @@ export function getSingletonViolations(
   return deck
     .filter((e) => e.count > 1 && !BASIC_LAND_NAMES.has(e.name) && !hasUnlimitedCopies(cardDataCache.get(e.name)?.oracle_text))
     .map((e) => e.name);
-}
-
-export function canAddPartner(
-  commanders: string[],
-  card: ScryfallCard,
-  cardDataCache: Map<string, ScryfallCard>,
-): boolean {
-  if (commanders.length === 0) return true;
-  if (commanders.length >= 2) return false;
-  const firstCard = cardDataCache.get(commanders[0]);
-  return (firstCard ? hasPartner(firstCard) : false) && hasPartner(card);
 }

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -29,9 +29,11 @@ import { useBracketEstimate } from "../../hooks/useBracketEstimate";
 import {
   getColorIdentityViolations,
   getSingletonViolations,
-  canAddPartner,
 } from "./commanderUtils";
-import { isCardCommanderEligibleForFormat } from "../../services/engineRuntime";
+import {
+  commanderPartnerCandidates,
+  isCardCommanderEligibleForFormat,
+} from "../../services/engineRuntime";
 
 const PRECON_PREFIX = "[Pre-built] ";
 
@@ -468,37 +470,42 @@ export function useDeckBuilder({
   const handleSetCommander = useCallback(
     (cardName: string) => {
       if (!commanderEligibleNames.has(cardName)) return;
-      setDirty(true);
-      const card = cardDataCache.get(cardName);
+      // CR 702.124: a second pick joins as a co-commander only when the engine
+      // confirms it legally pairs with the existing one; otherwise it swaps. The
+      // pairing decision is queried on demand (authoritative at click time) so a
+      // stale precomputed value can never misclassify an add as a swap.
+      void (async () => {
+        const isPartnerAdd =
+          commanders.length === 1 &&
+          (
+            await commanderPartnerCandidates(commanders[0], [cardName])
+          ).includes(cardName);
+        setDirty(true);
+        const displaced =
+          isPartnerAdd || commanders.length === 0 ? [] : commanders;
+        const nextCommanders = isPartnerAdd
+          ? [...commanders, cardName]
+          : [cardName];
 
-      const isPartnerAdd =
-        card !== undefined &&
-        commanders.length === 1 &&
-        canAddPartner(commanders, card, cardDataCache);
-      const displaced =
-        isPartnerAdd || commanders.length === 0 ? [] : commanders;
-      const nextCommanders = isPartnerAdd
-        ? [...commanders, cardName]
-        : [cardName];
-
-      setCommanders(nextCommanders);
-      setDeck((prev) => {
-        // Remove the new commander from main, then re-introduce any displaced
-        // commanders so they remain in the deck for the user to re-pick.
-        const filtered = prev.main.filter((e) => e.name !== cardName);
-        const restored = displaced.reduce<DeckEntry[]>((acc, name) => {
-          const existing = acc.find((e) => e.name === name);
-          if (existing) {
-            return acc.map((e) =>
-              e.name === name ? { ...e, count: e.count + 1 } : e,
-            );
-          }
-          return [...acc, { count: 1, name }];
-        }, filtered);
-        return { ...prev, main: restored };
-      });
+        setCommanders(nextCommanders);
+        setDeck((prev) => {
+          // Remove the new commander from main, then re-introduce any displaced
+          // commanders so they remain in the deck for the user to re-pick.
+          const filtered = prev.main.filter((e) => e.name !== cardName);
+          const restored = displaced.reduce<DeckEntry[]>((acc, name) => {
+            const existing = acc.find((e) => e.name === name);
+            if (existing) {
+              return acc.map((e) =>
+                e.name === name ? { ...e, count: e.count + 1 } : e,
+              );
+            }
+            return [...acc, { count: 1, name }];
+          }, filtered);
+          return { ...prev, main: restored };
+        });
+      })();
     },
-    [cardDataCache, commanderEligibleNames, commanders],
+    [commanderEligibleNames, commanders],
   );
 
   // Eligibility predicate consulted by each main-deck row. The set is loaded

--- a/client/src/services/engineRuntime.ts
+++ b/client/src/services/engineRuntime.ts
@@ -217,6 +217,21 @@ export async function isCardCommanderEligibleForFormat(
 }
 
 /**
+ * CR 702.124: Of `candidates`, which can legally pair with `firstCommander` as a
+ * co-commander? The engine is the single authority for the partner family
+ * (Partner, Partner with [Name], Friends Forever, Character Select, Doctor's
+ * Companion, Choose a Background) — the frontend never re-derives these rules.
+ */
+export async function commanderPartnerCandidates(
+  firstCommander: string,
+  candidates: string[],
+): Promise<string[]> {
+  await ensureCardDatabase();
+  const engine = await loadEngineModule();
+  return engine.commanderPartnerCandidates(firstCommander, candidates) as string[];
+}
+
+/**
  * CR 100.4a: Per-format sideboard policy as a discriminated union.
  *
  * `Forbidden` and `Unlimited` are unit variants and do not carry a `data`

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -29,6 +29,16 @@ export function classify_deck_js(names_js: any): any;
 export function clear_game_state(): void;
 
 /**
+ * CR 702.124: Of `candidates`, which can legally pair with `first_commander`
+ * as a co-commander? Applies the full partner family (generic Partner, Partner
+ * with [Name], Friends Forever, Character Select, Doctor's Companion, Choose a
+ * Background) via the engine's single-authority `can_pair_commanders`. The
+ * frontend must not re-derive partner-pairing rules — it filters its candidate
+ * list through this. Returns an empty array if the database isn't loaded.
+ */
+export function commanderPartnerCandidates(first_commander: string, candidates: any): any;
+
+/**
  * Create a default 2-player game state.
  */
 export function create_initial_state(): any;
@@ -61,7 +71,8 @@ export function getFormatRegistry(): any;
 
 /**
  * Get the AI's chosen action for the current game state.
- * `difficulty` is one of: "VeryEasy", "Easy", "Medium", "Hard", "VeryHard".
+ * `difficulty` is one of: "VeryEasy", "Easy", "Medium", "Hard", "VeryHard",
+ * "CEDH" (case-insensitive; see `AiDifficulty::from_label`).
  * `player_id` is the seat index of the AI player (0-based).
  */
 export function get_ai_action(difficulty: string, player_id: number): any;
@@ -311,6 +322,7 @@ export interface InitOutput {
     readonly memory: WebAssembly.Memory;
     readonly apply_seat_mutation: (a: number, b: number, c: number, d: number) => [number, number, number];
     readonly classify_deck_js: (a: any) => [number, number, number];
+    readonly commanderPartnerCandidates: (a: number, b: number, c: any) => [number, number, number];
     readonly estimate_bracket_for_deck: (a: any) => [number, number, number];
     readonly evaluate_deck_compatibility_js: (a: any) => [number, number, number];
     readonly export_game_state_json: () => [number, number, number, number];

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -10,11 +10,11 @@ use engine::database::legality::{any_ai_difficulty_is_cedh, validate_cedh_bracke
 use engine::database::{CardDatabase, CardSearchQuery};
 use engine::game::engine::apply;
 use engine::game::{
-    estimate_bracket, evaluate_deck_compatibility, filter_state_for_viewer, finalize_public_state,
-    is_brawl_commander_eligible, is_commander_eligible, is_tiny_leader_eligible,
-    load_and_hydrate_decks, rehydrate_game_from_card_db, resolve_deck_list, start_game,
-    start_game_with_starting_player, validate_name_deck_for_format, BracketEstimate,
-    DeckCompatibilityRequest, DeckList, PlayerDeckList,
+    can_pair_commanders, estimate_bracket, evaluate_deck_compatibility, filter_state_for_viewer,
+    finalize_public_state, is_brawl_commander_eligible, is_commander_eligible,
+    is_tiny_leader_eligible, load_and_hydrate_decks, rehydrate_game_from_card_db,
+    resolve_deck_list, start_game, start_game_with_starting_player, validate_name_deck_for_format,
+    BracketEstimate, DeckCompatibilityRequest, DeckList, PlayerDeckList,
 };
 use engine::types::format::{FormatConfig, GameFormat};
 use engine::types::identifiers::ObjectId;
@@ -307,6 +307,32 @@ pub fn is_card_commander_eligible_for_format(name: &str, format: JsValue) -> boo
             GameFormat::Brawl | GameFormat::HistoricBrawl => is_brawl_commander_eligible(face),
             _ => false,
         }
+    })
+}
+
+/// CR 702.124: Of `candidates`, which can legally pair with `first_commander`
+/// as a co-commander? Applies the full partner family (generic Partner, Partner
+/// with [Name], Friends Forever, Character Select, Doctor's Companion, Choose a
+/// Background) via the engine's single-authority `can_pair_commanders`. The
+/// frontend must not re-derive partner-pairing rules — it filters its candidate
+/// list through this. Returns an empty array if the database isn't loaded.
+#[wasm_bindgen(js_name = commanderPartnerCandidates)]
+pub fn commander_partner_candidates(
+    first_commander: String,
+    candidates: JsValue,
+) -> Result<JsValue, JsValue> {
+    let candidates: Vec<String> = serde_wasm_bindgen::from_value(candidates)
+        .map_err(|e| JsValue::from_str(&format!("Invalid candidate list: {e}")))?;
+    CARD_DB.with(|cell| {
+        let db = cell.borrow();
+        let Some(db) = db.as_ref() else {
+            return Ok(to_js(&Vec::<String>::new()));
+        };
+        let eligible: Vec<String> = candidates
+            .into_iter()
+            .filter(|name| can_pair_commanders(db, &first_commander, name))
+            .collect();
+        Ok(to_js(&eligible))
     })
 }
 

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -1903,6 +1903,20 @@ fn is_pauper_commander_eligible(face: &CardFace) -> bool {
     is_creature_or_vehicle && has_uncommon_printing
 }
 
+/// CR 702.124: Public entry point — can these two named cards form a legal
+/// co-commander pair? Resolves both faces in the database and applies the full
+/// partner-family rules. Returns false if either name is unknown.
+///
+/// This is the single authority for partner-pairing legality. Deck-builder UIs
+/// consume it through the WASM bridge rather than re-implementing the rules, so
+/// the engine and frontend can never disagree about a pairing.
+pub fn can_pair_commanders(db: &CardDatabase, name_a: &str, name_b: &str) -> bool {
+    match (db.get_face_by_name(name_a), db.get_face_by_name(name_b)) {
+        (Some(a), Some(b)) => are_valid_partners(a, b),
+        _ => false,
+    }
+}
+
 /// CR 702.124: Check if two cards form a valid partner pair for co-commanders.
 /// Handles the full partner family: Generic Partner, Partner with [Name],
 /// Friends Forever, Character Select, Doctor's Companion, and Choose a Background.
@@ -3546,6 +3560,41 @@ mod tests {
             vec![],
         );
         assert!(!are_valid_partners(&amy, &random));
+    }
+
+    // CR 702.124: the public `can_pair_commanders` seam (consumed by the WASM
+    // deck-builder bridge) must resolve both names through the database and apply
+    // the asymmetric Doctor's Companion rule in either selection order.
+    #[test]
+    fn can_pair_commanders_resolves_doctor_pairing_through_db() {
+        fn card_json(
+            name: &str,
+            subtypes: &[&str],
+            keywords: serde_json::Value,
+        ) -> serde_json::Value {
+            serde_json::json!({
+                "name": name,
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": ["Legendary"], "core_types": ["Creature"], "subtypes": subtypes },
+                "power": "2", "toughness": "2",
+                "loyalty": null, "defense": null,
+                "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                "keywords": keywords,
+                "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": null, "scryfall_oracle_id": null, "legalities": {}
+            })
+        }
+        let db_json = serde_json::json!({
+            "amy pond": card_json("Amy Pond", &["Human"], serde_json::json!([{ "Partner": { "type": "DoctorsCompanion" } }])),
+            "the eleventh doctor": card_json("The Eleventh Doctor", &["Time Lord", "Doctor"], serde_json::json!([])),
+        })
+        .to_string();
+        let db = CardDatabase::from_json_str(&db_json).unwrap();
+
+        assert!(can_pair_commanders(&db, "Amy Pond", "The Eleventh Doctor"));
+        assert!(can_pair_commanders(&db, "The Eleventh Doctor", "Amy Pond"));
+        // Unknown names resolve to no pairing rather than panicking.
+        assert!(!can_pair_commanders(&db, "Amy Pond", "Nonexistent Card"));
     }
 
     #[test]

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -87,10 +87,10 @@ pub use deck_loading::{
     resolve_deck_list, resolve_player_deck_list, DeckEntry, DeckList, DeckPayload, PlayerDeckList,
 };
 pub use deck_validation::{
-    evaluate_deck_compatibility, is_brawl_commander_eligible, is_commander_eligible,
-    is_tiny_leader_eligible, validate_deck_for_format, validate_name_deck_for_format,
-    CompatibilityCheck, DeckCompatibilityRequest, DeckCompatibilityResult, DeckCoverage,
-    UnsupportedCard,
+    can_pair_commanders, evaluate_deck_compatibility, is_brawl_commander_eligible,
+    is_commander_eligible, is_tiny_leader_eligible, validate_deck_for_format,
+    validate_name_deck_for_format, CompatibilityCheck, DeckCompatibilityRequest,
+    DeckCompatibilityResult, DeckCoverage, UnsupportedCard,
 };
 pub use engine::{
     apply, apply_as_current, new_game, start_game, start_game_skip_mulligan,


### PR DESCRIPTION
The deck builder refused to pair a Doctor's companion (e.g. Amy Pond)
with a Doctor (e.g. The Eleventh Doctor) as co-commanders, and surfaced a
spurious "color identity violations" warning. The client re-implemented
partner legality in TypeScript with a symmetric hasPartner(a) &&
hasPartner(b) gate, which misses the asymmetric partner family (Doctor's
Companion -> Doctor subtype, Choose a Background -> Background subtype)
where only one card declares the keyword.

CR 702.124: make the engine the single authority. Add can_pair_commanders
(wrapping are_valid_partners / subtype_partner_match), expose it via the
WASM commanderPartnerCandidates binding, and query it on demand at
commander-selection time. Delete the divergent TS implementation so the
two paths can no longer disagree.
