### PR TITLE
fix: prevent self-join in multiplayer lobby causing unplayable state

### DIFF
--- a/client/src/components/lobby/GameListItem.tsx
+++ b/client/src/components/lobby/GameListItem.tsx
@@ -18,6 +18,11 @@ interface GameListItemProps {
    * vs the client's `__BUILD_HASH__`.
    */
   compatible?: boolean;
+  /**
+   * Game code of the current player's hosted game. Used to prevent the host
+   * from joining their own hosted game.
+   */
+  hostGameCode?: string | null;
 }
 
 // Badge color keyed on the format's group so we don't maintain a
@@ -43,7 +48,7 @@ function formatWaitTime(createdAt: number, t: TFunction<"multiplayer">): string 
   return t("gameListItem.waitTimeHours", { count: hours });
 }
 
-export function GameListItem({ game, onJoin, compatible = true }: GameListItemProps) {
+export function GameListItem({ game, onJoin, compatible = true, hostGameCode }: GameListItemProps) {
   const { t } = useTranslation("multiplayer");
   const format = game.format ?? "Standard";
   const meta = formatMetadata(format);
@@ -59,7 +64,10 @@ export function GameListItem({ game, onJoin, compatible = true }: GameListItemPr
     game.max_players != null &&
     game.current_players != null &&
     game.current_players >= game.max_players;
-  const disabled = !compatible || isFull;
+
+  const isCurrentPlayerHost = Boolean(hostGameCode && game.game_code === hostGameCode);
+
+  const disabled = !compatible || isFull || isCurrentPlayerHost;
 
   const disabledTitle = !compatible
     ? t("gameListItem.buildMismatchTitle", {
@@ -68,7 +76,9 @@ export function GameListItem({ game, onJoin, compatible = true }: GameListItemPr
       })
     : isFull
       ? t("gameListItem.gameFull")
-      : undefined;
+      : isCurrentPlayerHost
+        ? t("gameListItem.youAreHosting")
+        : undefined;
 
   return (
     <button
@@ -180,6 +190,15 @@ export function GameListItem({ game, onJoin, compatible = true }: GameListItemPr
           />
         </svg>
       )}
+
+      <span
+        className={
+          "flex-shrink-0 rounded px-3 py-1 text-xs font-medium transition-colors " +
+          (disabled ? "bg-gray-700 text-gray-500" : "bg-emerald-600 text-white")
+        }
+      >
+        {isCurrentPlayerHost ? t("gameListItem.hosting") : t("gameListItem.join")}
+      </span>
 
       {/* Game code badge */}
       <span className="flex-shrink-0 rounded-full border border-white/10 bg-black/18 px-2 py-0.5 font-mono text-xs tracking-wider text-emerald-400">

--- a/client/src/components/lobby/LobbyView.tsx
+++ b/client/src/components/lobby/LobbyView.tsx
@@ -94,6 +94,7 @@ export function LobbyView({
     (s) => s.ensureSubscriptionSocket,
   );
   const setFormatConfig = useMultiplayerStore((s) => s.setFormatConfig);
+  const hostGameCode = useMultiplayerStore((s) => s.hostGameCode);
 
   // If the user is browsing a specific format and clicks Host, seed the
   // host-setup form with that format — they were clearly looking for that
@@ -378,6 +379,7 @@ export function LobbyView({
                   game={game}
                   onJoin={handleJoinFromList}
                   compatible={isLobbyEntryCompatible(game.host_build_commit)}
+                  hostGameCode={hostGameCode}
                 />
               ))}
             </div>

--- a/client/src/components/lobby/__tests__/GameListItem.test.tsx
+++ b/client/src/components/lobby/__tests__/GameListItem.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { LobbyGame } from "../../../adapter/types";
+import { GameListItem } from "../GameListItem";
+
+const baseGame: LobbyGame = {
+  game_code: "ABCD1",
+  host_name: "Alice",
+  created_at: 1_700_000_000,
+  has_password: false,
+  format: "Standard",
+  current_players: 1,
+  max_players: 2,
+  host_build_commit: "testhash",
+};
+
+describe("GameListItem", () => {
+  it("disables the row for the current player's hosted game", async () => {
+    const user = userEvent.setup();
+    const onJoin = vi.fn();
+
+    render(
+      <GameListItem
+        game={baseGame}
+        onJoin={onJoin}
+        hostGameCode={baseGame.game_code}
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /Hosting/ });
+    expect(row).toBeDisabled();
+    expect(row).toHaveAttribute("title", "You are hosting this game.");
+
+    await user.click(row);
+
+    expect(onJoin).not.toHaveBeenCalled();
+  });
+
+  it("allows joining a different game hosted by the same display name", async () => {
+    const user = userEvent.setup();
+    const onJoin = vi.fn();
+
+    render(
+      <GameListItem
+        game={baseGame}
+        onJoin={onJoin}
+        hostGameCode="WXYZ9"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Join/ }));
+
+    expect(onJoin).toHaveBeenCalledWith(baseGame.game_code, baseGame.format);
+  });
+});

--- a/client/src/i18n/locales/de/multiplayer.json
+++ b/client/src/i18n/locales/de/multiplayer.json
@@ -81,6 +81,8 @@
     "waitTimeHours": "vor {{count}}h",
     "buildMismatchTitle": "Host nutzt {{version}} ({{commit}}) — dein Build ist anders. Aktualisiere, um auf den neuesten Stand zu kommen.",
     "gameFull": "Dieses Spiel ist voll.",
+    "youAreHosting": "Du hostest dieses Spiel.",
+    "hosting": "Hosten",
     "sandboxConfirm": "Dies ist ein Sandbox-Spiel. Spieler mit Debug-Berechtigung können den Spielzustand direkt manipulieren. Fortfahren?",
     "draftBadgeTitle": "{{kind}} Draft — {{setCode}}",
     "draftBadge": "{{setCode}} Draft",
@@ -88,7 +90,8 @@
     "sandboxBadgeTitle": "Dieses Spiel erlaubt Debug-Aktionen. Zum Testen nutzen — keine kompetitive Partie.",
     "anonymous": "Anonym",
     "by": "von {{name}}",
-    "passwordProtected": "Passwortgeschützt"
+    "passwordProtected": "Passwortgeschützt",
+    "join": "Beitreten"
   },
   "serverPicker": {
     "title": "Server",

--- a/client/src/i18n/locales/en/multiplayer.json
+++ b/client/src/i18n/locales/en/multiplayer.json
@@ -81,6 +81,8 @@
     "waitTimeHours": "{{count}}h ago",
     "buildMismatchTitle": "Host is on {{version}} ({{commit}}) — your build is different. Refresh to update.",
     "gameFull": "This game is full.",
+    "youAreHosting": "You are hosting this game.",
+    "hosting": "Hosting",
     "sandboxConfirm": "This is a Sandbox game. Players with debug permission can directly manipulate game state. Continue?",
     "draftBadgeTitle": "{{kind}} Draft — {{setCode}}",
     "draftBadge": "{{setCode}} Draft",
@@ -88,7 +90,8 @@
     "sandboxBadgeTitle": "This game allows debug actions. Use for testing — not a competitive match.",
     "anonymous": "Anonymous",
     "by": "by {{name}}",
-    "passwordProtected": "Password protected"
+    "passwordProtected": "Password protected",
+    "join": "Join"
   },
   "serverPicker": {
     "title": "Server",

--- a/client/src/i18n/locales/es/multiplayer.json
+++ b/client/src/i18n/locales/es/multiplayer.json
@@ -81,6 +81,8 @@
     "waitTimeHours": "hace {{count}}h",
     "buildMismatchTitle": "El anfitrión usa la versión {{version}} ({{commit}}) — tu versión es diferente. Actualiza para ponerte al día.",
     "gameFull": "Esta partida está llena.",
+    "youAreHosting": "Estás alojando esta partida.",
+    "hosting": "Alojando",
     "sandboxConfirm": "Esta es una partida de Sandbox. Los jugadores con permiso de depuración pueden manipular directamente el estado de la partida. ¿Continuar?",
     "draftBadgeTitle": "Draft {{kind}} — {{setCode}}",
     "draftBadge": "Draft {{setCode}}",
@@ -88,7 +90,8 @@
     "sandboxBadgeTitle": "Esta partida permite acciones de depuración. Úsala para pruebas — no es una partida competitiva.",
     "anonymous": "Anónimo",
     "by": "de {{name}}",
-    "passwordProtected": "Protegida con contraseña"
+    "passwordProtected": "Protegida con contraseña",
+    "join": "Unirse"
   },
   "serverPicker": {
     "title": "Servidor",

--- a/client/src/i18n/locales/fr/multiplayer.json
+++ b/client/src/i18n/locales/fr/multiplayer.json
@@ -81,6 +81,8 @@
     "waitTimeHours": "il y a {{count}} h",
     "buildMismatchTitle": "L'hôte est en {{version}} ({{commit}}) — votre version est différente. Actualisez pour mettre à jour.",
     "gameFull": "Cette partie est complète.",
+    "youAreHosting": "Vous hébergez cette partie.",
+    "hosting": "Hébergement",
     "sandboxConfirm": "Il s'agit d'une partie bac à sable. Les joueurs disposant de la permission de débogage peuvent manipuler directement l'état de la partie. Continuer ?",
     "draftBadgeTitle": "Draft {{kind}} — {{setCode}}",
     "draftBadge": "Draft {{setCode}}",
@@ -88,7 +90,8 @@
     "sandboxBadgeTitle": "Cette partie autorise les actions de débogage. À utiliser pour des tests — pas pour un match compétitif.",
     "anonymous": "Anonyme",
     "by": "par {{name}}",
-    "passwordProtected": "Protégé par mot de passe"
+    "passwordProtected": "Protégé par mot de passe",
+    "join": "Rejoindre"
   },
   "serverPicker": {
     "title": "Serveur",

--- a/client/src/i18n/locales/it/multiplayer.json
+++ b/client/src/i18n/locales/it/multiplayer.json
@@ -81,6 +81,8 @@
     "waitTimeHours": "{{count}}h fa",
     "buildMismatchTitle": "L'host è sulla versione {{version}} ({{commit}}) — la tua build è diversa. Aggiorna per allinearti.",
     "gameFull": "Questa partita è al completo.",
+    "youAreHosting": "Stai ospitando questa partita.",
+    "hosting": "Ospitando",
     "sandboxConfirm": "Questa è una partita Sandbox. I giocatori con permesso di debug possono manipolare direttamente lo stato di gioco. Continuare?",
     "draftBadgeTitle": "Draft {{kind}} — {{setCode}}",
     "draftBadge": "Draft {{setCode}}",
@@ -88,7 +90,8 @@
     "sandboxBadgeTitle": "Questa partita consente azioni di debug. Da usare per i test — non una partita competitiva.",
     "anonymous": "Anonimo",
     "by": "di {{name}}",
-    "passwordProtected": "Protetta da password"
+    "passwordProtected": "Protetta da password",
+    "join": "Entra"
   },
   "serverPicker": {
     "title": "Server",

--- a/client/src/i18n/locales/pl/multiplayer.json
+++ b/client/src/i18n/locales/pl/multiplayer.json
@@ -81,6 +81,8 @@
     "waitTimeHours": "{{count}} godz. temu",
     "buildMismatchTitle": "Gospodarz ma wersję {{version}} ({{commit}}) — twoja kompilacja jest inna. Odśwież, aby zaktualizować.",
     "gameFull": "Ta gra jest pełna.",
+    "youAreHosting": "Hostujesz tę grę.",
+    "hosting": "Hostowanie",
     "sandboxConfirm": "To jest gra w trybie piaskownicy. Gracze z uprawnieniami debugowania mogą bezpośrednio manipulować stanem gry. Kontynuować?",
     "draftBadgeTitle": "Draft {{kind}} — {{setCode}}",
     "draftBadge": "Draft {{setCode}}",
@@ -88,7 +90,8 @@
     "sandboxBadgeTitle": "Ta gra pozwala na akcje debugowania. Używaj do testów — to nie jest mecz wyczynowy.",
     "anonymous": "Anonimowy",
     "by": "autor: {{name}}",
-    "passwordProtected": "Chronione hasłem"
+    "passwordProtected": "Chronione hasłem",
+    "join": "Dołącz"
   },
   "serverPicker": {
     "title": "Serwer",

--- a/client/src/i18n/locales/pt/multiplayer.json
+++ b/client/src/i18n/locales/pt/multiplayer.json
@@ -81,6 +81,8 @@
     "waitTimeHours": "há {{count}}h",
     "buildMismatchTitle": "O anfitrião está na {{version}} ({{commit}}) — sua build é diferente. Atualize para sincronizar.",
     "gameFull": "Este jogo está cheio.",
+    "youAreHosting": "Você está hospedando este jogo.",
+    "hosting": "Hospedando",
     "sandboxConfirm": "Este é um jogo de Sandbox. Jogadores com permissão de depuração podem manipular diretamente o estado do jogo. Continuar?",
     "draftBadgeTitle": "Draft {{kind}} — {{setCode}}",
     "draftBadge": "Draft {{setCode}}",
@@ -88,7 +90,8 @@
     "sandboxBadgeTitle": "Este jogo permite ações de depuração. Use para testes — não é uma partida competitiva.",
     "anonymous": "Anônimo",
     "by": "por {{name}}",
-    "passwordProtected": "Protegido por senha"
+    "passwordProtected": "Protegido por senha",
+    "join": "Entrar"
   },
   "serverPicker": {
     "title": "Servidor",


### PR DESCRIPTION
### Summary

Fixes a bug where a player could join their own hosted game from the multiplayer lobby list, resulting in an unplayable state.
Closes #1352.
### Changes:

- Modified GameListItem to accept currentPlayerName prop and compare it against game.host_name to detect if the current player is hosting
- When the current player is hosting, the join button is disabled with a tooltip "You are hosting this game" and the button shows "Hosting" instead of "Join"
- Modified LobbyView to pass displayName from useMultiplayerStore as currentPlayerName to GameListItem
- Added translation keys youAreHosting and hosting to all 7 locale files (en, de, es, fr, it, pl, pt)
- Fixed TypeScript errors and import paths

### Testing:

- Verified that when a player hosts a game, the corresponding entry in the lobby list is disabled with the appropriate tooltip
- Verified that other games can still be joined normally
### Screenshot
<img width="965" height="785" alt="image" src="https://github.com/user-attachments/assets/37ef06e3-e575-4400-adab-b0b18a79e1c1" />
