### PR TITLE
Fix Heroes in a Half Shell combat damage trigger

### DIFF
--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -850,10 +850,12 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AbilityDefinition, Comparator, ContinuousModification, ControllerRef, Effect, QuantityExpr,
-        QuantityRef, StaticCondition, StaticDefinition, TriggerDefinition, TypedFilter,
+        QuantityRef, StaticCondition, StaticDefinition, TargetFilter, TriggerDefinition,
+        TypedFilter,
     };
     use crate::types::card_type::CoreType;
-    use crate::types::identifiers::CardId;
+    use crate::types::counter::CounterType;
+    use crate::types::identifiers::{CardId, TrackedSetId};
     use crate::types::player::PlayerId;
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
@@ -1674,6 +1676,102 @@ mod tests {
                     && source_ids.contains(&attacker_b)
             )
         }));
+    }
+
+    #[test]
+    fn one_or_more_combat_damage_trigger_tracks_matching_sources_for_those_creatures() {
+        let mut state = setup();
+        let watcher = create_object(
+            &mut state,
+            CardId(550),
+            PlayerId(0),
+            "Heroes in a Half Shell".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&watcher)
+            .unwrap()
+            .trigger_definitions
+            .push({
+                let valid_source = TargetFilter::Or {
+                    filters: vec![
+                        TargetFilter::Typed(
+                            TypedFilter::default()
+                                .subtype("Mutant".to_string())
+                                .controller(ControllerRef::You),
+                        ),
+                        TargetFilter::Typed(
+                            TypedFilter::default()
+                                .subtype("Ninja".to_string())
+                                .controller(ControllerRef::You),
+                        ),
+                        TargetFilter::Typed(
+                            TypedFilter::default()
+                                .subtype("Turtle".to_string())
+                                .controller(ControllerRef::You),
+                        ),
+                    ],
+                };
+                let mut trigger = TriggerDefinition::new(TriggerMode::DamageDoneOnceByController)
+                    .execute(AbilityDefinition::new(
+                        crate::types::ability::AbilityKind::Spell,
+                        Effect::PutCounterAll {
+                            counter_type: CounterType::Plus1Plus1,
+                            count: QuantityExpr::Fixed { value: 1 },
+                            target: TargetFilter::TrackedSet {
+                                id: TrackedSetId(0),
+                            },
+                        },
+                    ));
+                trigger.valid_source = Some(valid_source);
+                trigger.valid_target = Some(TargetFilter::Player);
+                trigger
+            });
+
+        let mutant = create_creature(&mut state, PlayerId(0), "Mutant", 2, 2);
+        state
+            .objects
+            .get_mut(&mutant)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Mutant".to_string());
+        let human = create_creature(&mut state, PlayerId(0), "Human", 2, 2);
+        state
+            .objects
+            .get_mut(&human)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Human".to_string());
+        state
+            .tracked_object_sets
+            .insert(TrackedSetId(99), vec![human]);
+        setup_combat(&mut state, vec![mutant, human], vec![]);
+
+        let mut events = Vec::new();
+        resolve_combat_damage(&mut state, &mut events);
+        assert_eq!(state.stack.len(), 1);
+
+        crate::game::stack::resolve_top(&mut state, &mut events);
+
+        assert_eq!(
+            state.objects[&mutant]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or_default(),
+            1
+        );
+        assert_eq!(
+            state.objects[&human]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or_default(),
+            0
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -596,20 +596,29 @@ pub fn resolve_add_all(
         _ => return Ok(()),
     };
     // CR 608.2c: Bind the `TrackedSetId(0)` sentinel emitted by the parser for
-    // "put a counter on each [card] this way" continuations to the highest
-    // tracked set id — the set the immediately preceding effect in this chain
-    // published. Empty sets are *not* skipped here (unlike
+    // "put a counter on each [card] this way" continuations to the active
+    // chain tracked set — the set the immediately preceding effect in this
+    // chain published. Empty sets are *not* skipped here (unlike
     // `targeting::resolve_tracked_set_sentinel`): a chained counter effect
-    // refers to the preceding effect's set even when it ended up empty.
+    // refers to the preceding effect's set even when it ended up empty. When
+    // no chain set exists, combat-damage trigger context may provide the
+    // filtered "those creatures" source set; otherwise fall back to the legacy
+    // latest tracked set behavior.
     let target_filter = match crate::game::effects::resolved_object_filter(ability, &target_filter)
     {
         TargetFilter::TrackedSet {
             id: crate::types::identifiers::TrackedSetId(0),
         } => state
-            .tracked_object_sets
-            .iter()
-            .max_by_key(|(id, _)| id.0)
-            .map(|(id, _)| TargetFilter::TrackedSet { id: *id })
+            .chain_tracked_set_id
+            .map(|id| TargetFilter::TrackedSet { id })
+            .or_else(|| crate::game::targeting::current_combat_damage_source_filter(state))
+            .or_else(|| {
+                state
+                    .tracked_object_sets
+                    .iter()
+                    .max_by_key(|(id, _)| id.0)
+                    .map(|(id, _)| TargetFilter::TrackedSet { id: *id })
+            })
             .unwrap_or(TargetFilter::TrackedSet {
                 id: crate::types::identifiers::TrackedSetId(0),
             }),

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -1410,6 +1410,28 @@ pub(crate) fn latest_tracked_set_id(state: &GameState) -> Option<TrackedSetId> {
         .map(|(&id, _)| id)
 }
 
+/// CR 510.2 + CR 608.2c: In a simultaneous combat-damage event, "those
+/// creatures" on the resolving trigger can refer to the filtered source set
+/// carried by `CombatDamageDealtToPlayer`.
+pub(crate) fn current_combat_damage_source_filter(state: &GameState) -> Option<TargetFilter> {
+    let source_ids = match state.current_trigger_event.as_ref()? {
+        GameEvent::CombatDamageDealtToPlayer { source_ids, .. } => source_ids,
+        _ => return None,
+    };
+
+    match source_ids.as_slice() {
+        [] => None,
+        [id] => Some(TargetFilter::SpecificObject { id: *id }),
+        ids => Some(TargetFilter::Or {
+            filters: ids
+                .iter()
+                .copied()
+                .map(|id| TargetFilter::SpecificObject { id })
+                .collect(),
+        }),
+    }
+}
+
 /// CR 608.2c: Bind the `TrackedSetId(0)` sentinel in a `TargetFilter` to the
 /// most recent non-empty tracked set.
 ///
@@ -1417,9 +1439,12 @@ pub(crate) fn latest_tracked_set_id(state: &GameState) -> Option<TrackedSetId> {
 /// exiled card") and its type-filtered intersection `TrackedSetFiltered` ("X
 /// cards revealed this way"). Filters that are not sentinel-backed — already
 /// bound tracked-set filters and every non-tracked-set filter — are returned
-/// unchanged. When no tracked set is available the sentinel is left in place so
-/// downstream resolution still sees a (vacuously matching nothing) filter
-/// rather than a silently mismatched concrete id.
+/// unchanged. The active chain-local set wins first; when no chain set is
+/// available, combat-damage trigger context can supply a filtered source set;
+/// otherwise the latest non-empty tracked set is used for legacy callers. If
+/// none of those exists, the sentinel is left in place so downstream resolution
+/// still sees a (vacuously matching nothing) filter rather than a silently
+/// mismatched concrete id.
 ///
 /// This is the single authority for sentinel binding: `ChangeZone` resolution,
 /// chained-ability resolution, and the delayed-trigger / counter / permission
@@ -1432,22 +1457,33 @@ pub(crate) fn resolve_tracked_set_sentinel(
     match filter {
         TargetFilter::TrackedSet {
             id: TrackedSetId(0),
-        } => match latest_tracked_set_id(state) {
-            Some(id) => TargetFilter::TrackedSet { id },
-            None => TargetFilter::TrackedSet {
+        } => state
+            .chain_tracked_set_id
+            .map(|id| TargetFilter::TrackedSet { id })
+            .or_else(|| current_combat_damage_source_filter(state))
+            .or_else(|| latest_tracked_set_id(state).map(|id| TargetFilter::TrackedSet { id }))
+            .unwrap_or(TargetFilter::TrackedSet {
                 id: TrackedSetId(0),
-            },
-        },
+            }),
         TargetFilter::TrackedSetFiltered {
             id: TrackedSetId(0),
             filter,
-        } => match latest_tracked_set_id(state) {
-            Some(id) => TargetFilter::TrackedSetFiltered { id, filter },
-            None => TargetFilter::TrackedSetFiltered {
-                id: TrackedSetId(0),
-                filter,
-            },
-        },
+        } => {
+            if let Some(id) = state.chain_tracked_set_id {
+                TargetFilter::TrackedSetFiltered { id, filter }
+            } else if let Some(source_filter) = current_combat_damage_source_filter(state) {
+                TargetFilter::And {
+                    filters: vec![source_filter, *filter],
+                }
+            } else if let Some(id) = latest_tracked_set_id(state) {
+                TargetFilter::TrackedSetFiltered { id, filter }
+            } else {
+                TargetFilter::TrackedSetFiltered {
+                    id: TrackedSetId(0),
+                    filter,
+                }
+            }
+        }
         other => other,
     }
 }

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1025,6 +1025,10 @@ pub(super) fn matching_damage_done_once_by_controller_event(
         return None;
     };
 
+    if !valid_player_matches(trigger, state, *player_id, source_id) {
+        return None;
+    }
+
     let matching_sources = if let Some(filter) = &trigger.valid_source {
         source_ids
             .iter()
@@ -5378,6 +5382,51 @@ mod tests {
             trigger_source,
             &state
         ));
+    }
+
+    #[test]
+    fn matching_damage_done_once_event_respects_valid_target() {
+        let mut state = setup();
+        let trigger_source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Combat Damage Watcher".to_string(),
+            Zone::Battlefield,
+        );
+        let source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let mut trigger = make_trigger(TriggerMode::DamageDoneOnceByController);
+        trigger.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+        trigger.valid_target = Some(TargetFilter::Controller);
+
+        let event = GameEvent::CombatDamageDealtToPlayer {
+            player_id: PlayerId(1),
+            source_ids: vec![source],
+        };
+
+        assert!(matching_damage_done_once_by_controller_event(
+            &event,
+            &trigger,
+            trigger_source,
+            &state,
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1007,6 +1007,46 @@ pub(super) fn match_damage_done_once_by_controller(
     source_ids.contains(&source_id)
 }
 
+pub(super) fn matching_damage_done_once_by_controller_event(
+    event: &GameEvent,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+) -> Option<GameEvent> {
+    // CR 603.2c + CR 608.2c: Preserve the single aggregate combat-damage
+    // trigger event while narrowing its source set to the objects that
+    // satisfied this trigger's source filter. Downstream "those creatures"
+    // effects read this filtered event context.
+    let GameEvent::CombatDamageDealtToPlayer {
+        player_id,
+        source_ids,
+    } = event
+    else {
+        return None;
+    };
+
+    let matching_sources = if let Some(filter) = &trigger.valid_source {
+        source_ids
+            .iter()
+            .copied()
+            .filter(|source| target_filter_matches_object(state, *source, filter, source_id))
+            .collect::<Vec<_>>()
+    } else if source_ids.contains(&source_id) {
+        vec![source_id]
+    } else {
+        Vec::new()
+    };
+
+    if matching_sources.is_empty() {
+        None
+    } else {
+        Some(GameEvent::CombatDamageDealtToPlayer {
+            player_id: *player_id,
+            source_ids: matching_sources,
+        })
+    }
+}
+
 /// CR 601.2a vs CR 707.10: whether an event placed a spell on the stack by
 /// *casting* it or by *copying* it. These are distinct game events — a copy
 /// isn't cast — so copy-sensitive and cast-only triggers must be told apart.

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -448,6 +448,13 @@ fn collect_matching_triggers(
                     .into_iter()
                     .map(|trigger_event| vec![trigger_event])
                     .collect()
+            } else if matches!(trig_def.mode, TriggerMode::DamageDoneOnceByController) {
+                super::trigger_matchers::matching_damage_done_once_by_controller_event(
+                    event, trig_def, obj_id, state,
+                )
+                .into_iter()
+                .map(|trigger_event| vec![trigger_event])
+                .collect()
             } else {
                 vec![vec![event.clone()]]
             };

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -449,6 +449,9 @@ fn collect_matching_triggers(
                     .map(|trigger_event| vec![trigger_event])
                     .collect()
             } else if matches!(trig_def.mode, TriggerMode::DamageDoneOnceByController) {
+                // CR 603.2c: One aggregate combat-damage event may satisfy this
+                // trigger once, while CR 608.2c makes the filtered source set
+                // available to later "those creatures" instructions.
                 super::trigger_matchers::matching_damage_done_once_by_controller_event(
                     event, trig_def, obj_id, state,
                 )

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3955,6 +3955,10 @@ fn continues_player_action_list(after_comma: &str) -> bool {
         return true;
     }
 
+    if type_phrase_continues_to_combat_damage_player_event(trimmed) {
+        return true;
+    }
+
     // Recognize type-phrase continuations in comma-separated type lists.
     // E.g. "a creature, planeswalker, or battle enters" — after ", " we see
     // "planeswalker" (a bare type word) or "or battle enters" ("or" + type word).
@@ -3965,12 +3969,16 @@ fn continues_player_action_list(after_comma: &str) -> bool {
     // E.g. "creatures you control get +1/+1" starts with "creatures" (type word) but
     // has "get" (predicate verb) — this is the effect, not a continuation.
     let after_conjunction = alt((
+        value((), tag::<_, _, OracleError<'_>>("and/or ")),
         value((), tag::<_, _, OracleError<'_>>("or ")),
         value((), tag("and ")),
     ))
     .parse(trimmed)
     .map(|(rest, _)| rest)
     .unwrap_or(trimmed);
+    if type_phrase_continues_to_combat_damage_player_event(after_conjunction) {
+        return true;
+    }
     if !starts_with_type_word(after_conjunction) {
         return false;
     }
@@ -3978,6 +3986,23 @@ fn continues_player_action_list(after_comma: &str) -> bool {
     // A continuation has no predicate verb before the trigger event verb;
     // a new sentence has a subject + predicate verb ("creatures you control get").
     !is_new_sentence_not_type_continuation(after_conjunction)
+}
+
+fn type_phrase_continues_to_combat_damage_player_event(text: &str) -> bool {
+    let (filter, rest) = parse_type_phrase(text);
+    if matches!(filter, TargetFilter::Any) || rest.len() >= text.len() {
+        return false;
+    }
+    let rest = rest.trim_start();
+    alt((
+        value(
+            (),
+            tag::<_, _, OracleError<'_>>("deal combat damage to a player"),
+        ),
+        value((), tag("deals combat damage to a player")),
+    ))
+    .parse(rest)
+    .is_ok()
 }
 
 /// Check if the text starting at a type word is a new subject-predicate sentence
@@ -17203,6 +17228,36 @@ mod tests {
         assert!(
             matches!(&def.valid_source, Some(TargetFilter::Or { filters }) if filters.len() == 2)
         );
+    }
+
+    #[test]
+    fn trigger_one_or_more_comma_and_or_subtypes_combat_damage() {
+        let def = parse_trigger_line(
+            "Whenever one or more Mutants, Ninjas, and/or Turtles you control deal combat damage to a player, put a +1/+1 counter on each of those creatures and draw a card.",
+            "Heroes in a Half Shell",
+        );
+
+        assert_eq!(def.mode, TriggerMode::DamageDoneOnceByController);
+        assert_eq!(def.damage_kind, DamageKindFilter::CombatOnly);
+        assert_eq!(def.valid_target, Some(TargetFilter::Player));
+        assert!(matches!(
+            &def.valid_source,
+            Some(TargetFilter::Or { filters }) if filters.len() == 3
+        ));
+
+        let execute = def.execute.as_ref().expect("trigger should have execute");
+        assert!(matches!(
+            *execute.effect,
+            Effect::PutCounterAll {
+                target: TargetFilter::TrackedSet { .. },
+                ..
+            }
+        ));
+        let sub = execute
+            .sub_ability
+            .as_ref()
+            .expect("draw should be chained");
+        assert!(matches!(*sub.effect, Effect::Draw { .. }));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3994,15 +3994,22 @@ fn type_phrase_continues_to_combat_damage_player_event(text: &str) -> bool {
         return false;
     }
     let rest = rest.trim_start();
-    alt((
-        value(
-            (),
-            tag::<_, _, OracleError<'_>>("deal combat damage to a player"),
+    parse_combat_damage_to_player(rest).is_ok()
+}
+
+fn parse_combat_damage_to_player(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        (
+            alt((
+                tag::<_, _, OracleError<'_>>("deal"),
+                tag::<_, _, OracleError<'_>>("deals"),
+            )),
+            tag(" combat damage"),
+            tag(" to a player"),
         ),
-        value((), tag("deals combat damage to a player")),
-    ))
-    .parse(rest)
-    .is_ok()
+    )
+    .parse(input)
 }
 
 /// Check if the text starting at a type word is a new subject-predicate sentence


### PR DESCRIPTION
## Summary
Fixes #1409.

Parses and resolves **Heroes in a Half Shell**'s combat-damage trigger:
- `Mutants, Ninjas, and/or Turtles you control deal combat damage to a player` now parses as one trigger condition instead of splitting at the subtype-list comma.
- The aggregate combat-damage trigger event is narrowed to the matching source creatures for the damaged player.
- `those creatures` now binds to that narrowed combat-damage source context before falling back to older tracked-set behavior.

## Files changed
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/game/trigger_matchers.rs`
- `crates/engine/src/game/triggers.rs`
- `crates/engine/src/game/targeting.rs`
- `crates/engine/src/game/effects/counters.rs`
- `crates/engine/src/game/combat_damage.rs`

## CR references
- CR 510.2
- CR 603.2c
- CR 608.2c

## Track
Developer

## LLM
Model: codex-5
Thinking: high
Tier: Standard

## Anchored on
- `crates/engine/src/parser/oracle_trigger.rs:6916` - existing one-or-more combat-damage trigger parsing family using `DamageDoneOnceByController`.
- `crates/engine/src/game/trigger_matchers.rs:1164` - existing matcher helper that expands/narrows aggregate attack events before trigger resolution.
- `crates/engine/src/game/targeting.rs:1453` - existing tracked-set sentinel binding authority for resolution-time anaphora.

## Gate A
`./scripts/check-parser-combinators.sh` exited 0 with no output.

## Verification
- `cargo fmt --all` - clean
- `cargo fmt --all -- --check` - clean on PR branch
- `./scripts/check-parser-combinators.sh` - clean
- `cargo clippy --all-targets -- -D warnings` - clean
- `cargo test -p engine` - 8868 unit tests passed, 1 ignored; 471 integration tests passed; doc tests ignored as expected
- `./scripts/gen-card-data.sh` - clean; Heroes exports with `DamageDoneOnceByController`, `CombatOnly`, player target, Mutant/Ninja/Turtle source filter, `PutCounterAll` on tracked set, and chained draw
- `cargo test -p engine parser::oracle_trigger::tests::trigger_one_or_more_comma_and_or_subtypes_combat_damage` - clean on PR branch
- `cargo test -p engine game::combat_damage::tests::one_or_more_combat_damage_trigger_tracks_matching_sources_for_those_creatures` - clean on PR branch
- `cargo run -p engine --features cli --bin oracle-gen -- /home/mike/code_projects/phase/data --filter "Heroes in a Half Shell"` - clean targeted export on PR branch using the existing MTGJSON data path
- `git diff --check` - clean

## Scope Expansion
Combat-damage trigger context binding now supports "those creatures" for filtered aggregate `CombatDamageDealtToPlayer` events, reusing existing tracked-set sentinel resolution.

## Validation Failures
None.

## CI Failures
None.
