### PR TITLE
fix(engine): surface OrderTriggers prompt for multiple beginning-of-step triggers

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -13240,6 +13240,213 @@ pub mod tests {
         );
     }
 
+    /// RUNTIME REGRESSION — multiple suspended cards (Jhoira of the Ghitu).
+    /// CR 603.3b + CR 702.62a: When 2+ cards are suspended (each granted Suspend
+    /// while in exile), the controller's upkeep fires one "remove a time counter"
+    /// trigger per card. Two-or-more simultaneous same-controller triggers require
+    /// the controller to ORDER them (CR 603.3b) before any player gets priority.
+    ///
+    /// This drives the scenario through the real `apply` pipeline (turn-roll →
+    /// `auto_advance` → upkeep). The bug: the Upkeep arm of `auto_advance` called
+    /// `process_phase_triggers` (which set `waiting_for = OrderTriggers` and
+    /// populated `pending_trigger_order`) and then unconditionally returned
+    /// `WaitingFor::Priority`. `apply` wrote that returned `Priority` back over
+    /// `state.waiting_for`, discarding the prompt and stranding all queued triggers
+    /// in `pending_trigger_order` forever — so NONE of the cards (including the
+    /// first) ticked. A single suspended card took the `NoChoiceNeeded` path (no
+    /// prompt to clobber), which is exactly why one card worked but several didn't.
+    ///
+    /// Discriminator: without the fix, the upkeep is reached with
+    /// `waiting_for == Priority`, the `OrderTriggers` submission below fails, both
+    /// counters stay at 3, and `pending_trigger_order` is left orphaned.
+    #[test]
+    fn multiple_suspended_cards_all_tick_on_upkeep() {
+        use crate::types::counter::CounterType;
+
+        let mut state = setup();
+        state.turn_number = 2;
+        state.phase = Phase::DeclareAttackers;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: vec![],
+            valid_attack_targets: vec![],
+        };
+
+        // CR 104.3c: stock both libraries so neither player decks out while the
+        // turn loop drives real turn progression to P0's next upkeep.
+        for player in [PlayerId(0), PlayerId(1)] {
+            for i in 0..12u64 {
+                create_object(
+                    &mut state,
+                    CardId(8100 + u64::from(player.0) * 100 + i),
+                    player,
+                    format!("Filler {}-{i}", player.0),
+                    Zone::Library,
+                );
+            }
+        }
+
+        // Jhoira of the Ghitu — the grant source on the battlefield. Each exiled
+        // card is granted Suspend via a permanent continuous effect affecting it
+        // specifically (mirrors the real `AddKeyword{Suspend}` transient effect
+        // Jhoira's activated ability installs per CR 604.1 + CR 702.62a).
+        let jhoira = make_creature(&mut state, PlayerId(0), "Jhoira of the Ghitu", 1, 3);
+
+        // Two suspended cards in exile, each with 3 time counters and empty
+        // base_keywords (so the off-zone synthesis path treats Suspend as
+        // *granted* and installs the companion upkeep triggers).
+        let mut suspended = Vec::new();
+        for (i, name) in ["Nezahal, Primal Tide", "Omniscience"].iter().enumerate() {
+            let card = create_object(
+                &mut state,
+                CardId(8200 + i as u64),
+                PlayerId(0),
+                (*name).to_string(),
+                Zone::Exile,
+            );
+            state
+                .objects
+                .get_mut(&card)
+                .unwrap()
+                .counters
+                .insert(CounterType::Time, 3);
+            // Grant Suspend to this specific exiled card via a permanent
+            // continuous effect sourced from Jhoira — exactly the
+            // `AddKeyword{Suspend}` transient effect Jhoira's activated ability
+            // installs in real play (CR 604.1 + CR 702.62a).
+            state.transient_continuous_effects.push_back(
+                crate::types::game_state::TransientContinuousEffect {
+                    id: 100 + i as u64,
+                    source_id: jhoira,
+                    controller: PlayerId(0),
+                    timestamp: 1 + i as u64,
+                    duration: Duration::Permanent,
+                    affected: TargetFilter::SpecificObject { id: card },
+                    modifications: vec![ContinuousModification::AddKeyword {
+                        keyword: Keyword::Suspend {
+                            count: 0,
+                            cost: ManaCost::Cost {
+                                generic: 0,
+                                shards: vec![],
+                            },
+                        },
+                    }],
+                    condition: None,
+                    source_name: "Jhoira of the Ghitu".to_string(),
+                },
+            );
+            suspended.push(card);
+        }
+        state.layers_dirty = true;
+
+        // Sanity: both cards must carry granted Suspend off-zone before we drive
+        // the turn — otherwise the upkeep triggers never synthesize.
+        for &card in &suspended {
+            assert!(
+                crate::game::off_zone_characteristics::effective_off_zone_keywords(&state, card)
+                    .iter()
+                    .any(|k| k.kind() == KeywordKind::Suspend),
+                "exiled card {card:?} must have granted Suspend before the upkeep"
+            );
+        }
+
+        // Drive real turn progression (through `apply`, the clobber site) to
+        // PlayerId(0)'s NEXT upkeep.
+        let start_turn = state.turn_number;
+        let mut guard = 0;
+        loop {
+            guard += 1;
+            assert!(guard < 300, "turn progression stalled before P0's upkeep");
+            if state.phase == Phase::Upkeep
+                && state.active_player == PlayerId(0)
+                && state.turn_number > start_turn
+            {
+                break;
+            }
+            if !state.stack.is_empty() && matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                crate::game::engine::apply_as_current(&mut state, GameAction::PassPriority)
+                    .expect("priority pass to resolve stack");
+                continue;
+            }
+            match &state.waiting_for {
+                WaitingFor::Priority { .. } => {
+                    crate::game::engine::apply_as_current(&mut state, GameAction::PassPriority)
+                        .expect("priority pass to advance the turn");
+                }
+                WaitingFor::DeclareAttackers { .. } => {
+                    crate::game::engine::apply_as_current(
+                        &mut state,
+                        GameAction::DeclareAttackers { attacks: vec![] },
+                    )
+                    .expect("declare no attackers");
+                }
+                WaitingFor::DeclareBlockers { .. } => {
+                    crate::game::engine::apply_as_current(
+                        &mut state,
+                        GameAction::DeclareBlockers {
+                            assignments: vec![],
+                        },
+                    )
+                    .expect("declare no blockers");
+                }
+                other => panic!("unexpected waiting state during turn progression: {other:?}"),
+            }
+        }
+
+        // CR 603.3b: at P0's upkeep the engine MUST surface the ordering prompt
+        // for the two suspend triggers — not a bare Priority. This is the
+        // assertion that fails without the `auto_advance` fix.
+        match &state.waiting_for {
+            WaitingFor::OrderTriggers { player, triggers } => {
+                assert_eq!(*player, PlayerId(0), "controller orders own triggers");
+                assert_eq!(
+                    triggers.len(),
+                    2,
+                    "both suspend upkeep triggers must be in the ordering prompt"
+                );
+            }
+            other => panic!(
+                "expected OrderTriggers prompt for the two suspend triggers, got {other:?} \
+                 (pending_trigger_order = {:?})",
+                state.pending_trigger_order.is_some()
+            ),
+        }
+
+        // Submit an order, then drain the two triggers off the stack.
+        crate::game::engine::apply_as_current(
+            &mut state,
+            GameAction::OrderTriggers { order: vec![0, 1] },
+        )
+        .expect("submit suspend trigger order");
+        let mut guard = 0;
+        while !state.stack.is_empty() {
+            guard += 1;
+            assert!(guard < 20, "suspend upkeep-trigger stack failed to drain");
+            crate::game::engine::apply_as_current(&mut state, GameAction::PassPriority)
+                .expect("resolve a suspend upkeep trigger");
+        }
+
+        // CR 702.62a: BOTH cards must have ticked 3 → 2, and the ordering queue
+        // must be fully consumed (no orphan).
+        for &card in &suspended {
+            assert_eq!(
+                state.objects[&card]
+                    .counters
+                    .get(&CounterType::Time)
+                    .copied()
+                    .unwrap_or(0),
+                2,
+                "suspended card {card:?} must tick 3 → 2 on P0's upkeep"
+            );
+        }
+        assert!(
+            state.pending_trigger_order.is_none(),
+            "pending_trigger_order must be cleared after the ordered triggers resolve"
+        );
+    }
+
     /// RUNTIME TEST — issue #411. Drives Syr Konrad's `{1}{B}: Each player mills
     /// a card.` activated ability through the real `apply` pipeline four times.
     /// Both libraries are stacked deterministically: the controller's library

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1266,12 +1266,37 @@ fn add_lore_counters_to_sagas(state: &mut GameState, events: &mut Vec<GameEvent>
 
 /// CR 503.1 / CR 504.2 / CR 507.1 / CR 513.1: Process phase triggers for the current step.
 /// Fabricates a PhaseChanged event for `state.phase` and runs trigger matching.
-/// Returns `true` if any triggers were placed on the stack or are pending target selection.
-fn process_phase_triggers(state: &mut GameState) -> bool {
+///
+/// Returns `(fired, ordering_prompt)`:
+/// * `fired` is `true` if any triggers were placed on the stack, are pending
+///   target selection, or are awaiting CR 603.3b ordering. The combat arms
+///   (BeginCombat / EndCombat) use this to decide whether to set up / tear down
+///   combat and grant a priority window.
+/// * `ordering_prompt` is `Some(WaitingFor::OrderTriggers { .. })` when 2+
+///   simultaneous triggers controlled by the same player fired and that player
+///   must order them (CR 603.3b) before anyone receives priority. The caller
+///   MUST surface this prompt instead of granting priority — `process_triggers`
+///   populated `state.pending_trigger_order` and set `state.waiting_for` to the
+///   prompt, but the phase arm's return value is what `apply` writes back to
+///   `state.waiting_for`. Returning `Priority` here would overwrite the prompt
+///   and strand the queued triggers in `pending_trigger_order` forever (they
+///   never reach the stack). Single-trigger steps take the `NoChoiceNeeded`
+///   path with no prompt and fall through to the normal priority grant.
+fn process_phase_triggers(state: &mut GameState) -> (bool, Option<WaitingFor>) {
     let phase_event = [GameEvent::PhaseChanged { phase: state.phase }];
     let stack_before = state.stack.len();
     super::triggers::process_triggers(state, &phase_event);
-    state.stack.len() > stack_before || state.pending_trigger.is_some()
+    // CR 603.3b: an unresolved ordering pass keeps its triggers in
+    // `pending_trigger_order` (not on the stack, not in `pending_trigger`), so
+    // it must count toward `fired` and surface its prompt.
+    let ordering_prompt = state
+        .pending_trigger_order
+        .is_some()
+        .then(|| state.waiting_for.clone());
+    let fired = state.stack.len() > stack_before
+        || state.pending_trigger.is_some()
+        || ordering_prompt.is_some();
+    (fired, ordering_prompt)
 }
 
 pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> WaitingFor {
@@ -1319,7 +1344,12 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                     continue;
                 }
                 // CR 503.1a: "At the beginning of [your] upkeep" triggers fire here.
-                process_phase_triggers(state);
+                // CR 603.3b: 2+ same-controller upkeep triggers (multiple suspended
+                // cards, two Howling Mines) require an ordering choice that must be
+                // surfaced before priority — see `process_phase_triggers`.
+                if let (_, Some(prompt)) = process_phase_triggers(state) {
+                    return prompt;
+                }
                 // CR 503.2 + CR 117.1c: The active player ALWAYS receives priority
                 // during the upkeep step, regardless of whether triggers fired.
                 // Whether to auto-pass through this priority window (or honor the
@@ -1348,7 +1378,10 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                     return wf;
                 }
                 // CR 504.2: "At the beginning of [your] draw step" triggers fire here.
-                process_phase_triggers(state);
+                // CR 603.3b: surface a same-controller ordering prompt before priority.
+                if let (_, Some(prompt)) = process_phase_triggers(state) {
+                    return prompt;
+                }
                 // CR 504.3 + CR 117.1c: The active player ALWAYS receives priority
                 // during the draw step (after the turn-based draw and any triggers).
                 // See the Upkeep arm above for the rationale — same pattern.
@@ -1375,10 +1408,9 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 }
                 // CR 603.2b + CR 603.3: beginning-of-main-phase triggers are
                 // put on the stack before the active player receives priority.
-                if process_phase_triggers(state) {
-                    return WaitingFor::Priority {
-                        player: state.active_player,
-                    };
+                // CR 603.3b: surface a same-controller ordering prompt first.
+                if let (_, Some(prompt)) = process_phase_triggers(state) {
+                    return prompt;
                 }
                 // CR 505.6: The active player receives priority during a main phase.
                 return WaitingFor::Priority {
@@ -1390,9 +1422,15 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 // Process triggers regardless of attackers — CR 507.1 says the step
                 // happens unconditionally; trigger conditions (e.g., ControlCount)
                 // are checked by the trigger system, not by skipping the step.
-                let triggers_fired = process_phase_triggers(state);
+                let (triggers_fired, ordering_prompt) = process_phase_triggers(state);
                 if triggers_fired {
                     state.combat = Some(crate::game::combat::CombatState::default());
+                    // CR 603.3b: surface a same-controller ordering prompt before
+                    // priority; combat state is set first so it exists when the
+                    // ordered begin-combat triggers later resolve.
+                    if let Some(prompt) = ordering_prompt {
+                        return prompt;
+                    }
                     return WaitingFor::Priority {
                         player: state.active_player,
                     };
@@ -1480,7 +1518,7 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
             }
             Phase::EndCombat => {
                 // CR 511.1: "At end of combat" triggers fire here.
-                let triggers_fired = process_phase_triggers(state);
+                let (triggers_fired, ordering_prompt) = process_phase_triggers(state);
                 // CR 511.3: At end of combat, all creatures are removed from combat.
                 state.combat = None;
                 super::layers::prune_end_of_combat_effects(state);
@@ -1492,6 +1530,10 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                     .pending_damage_replacements
                     .retain(|r| !matches!(r.expiry, Some(RestrictionExpiry::EndOfCombat)));
                 if triggers_fired {
+                    // CR 603.3b: surface a same-controller ordering prompt before priority.
+                    if let Some(prompt) = ordering_prompt {
+                        return prompt;
+                    }
                     return WaitingFor::Priority {
                         player: state.active_player,
                     };
@@ -1515,7 +1557,10 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 super::layers::prune_until_next_end_step_effects(state, state.active_player);
                 // CR 513.1: End step — active player receives priority.
                 // CR 513.1a: "At the beginning of [your] end step" triggers fire here.
-                process_phase_triggers(state);
+                // CR 603.3b: surface a same-controller ordering prompt before priority.
+                if let (_, Some(prompt)) = process_phase_triggers(state) {
+                    return prompt;
+                }
                 return WaitingFor::Priority {
                     player: state.active_player,
                 };


### PR DESCRIPTION
When 2+ simultaneous same-controller phase triggers fire (e.g. several cards
suspended via Jhoira of the Ghitu, each with an "at the beginning of your
upkeep, remove a time counter" trigger), process_triggers sets
waiting_for = OrderTriggers and populates pending_trigger_order per CR 603.3b
— the controller must order them before any player gets priority.

Every phase arm in auto_advance called process_phase_triggers and then
unconditionally returned WaitingFor::Priority. apply() writes that returned
Priority back over state.waiting_for, discarding the OrderTriggers prompt and
stranding the queued triggers in pending_trigger_order forever — so none of
the cards (including the first) ever ticked. A single trigger took the
NoChoiceNeeded path (no prompt to clobber), which is why one suspended card
worked but several did not.

process_phase_triggers now returns (fired, Option<WaitingFor>); all six
trigger-firing arms (Upkeep, Draw, Main, BeginCombat, EndCombat, End) surface
the ordering prompt before granting priority. Fixes the whole class, not just
suspend (two Howling Mines on draw, multiple cumulative-upkeep permanents,
etc.).

Adds multiple_suspended_cards_all_tick_on_upkeep, which drives two suspended
cards through the real apply pipeline (the clobber site) to the controller's
upkeep, asserts the OrderTriggers prompt is surfaced, and verifies both time
counters tick 3->2 with no orphaned pending_trigger_order.
