### PR TITLE
feat(client): purple playable affordance in graveyard/exile zone viewer

### DIFF
--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -12,9 +12,8 @@ import { useUiStore } from "../../stores/uiStore.ts";
 import { useCanActForWaitingState, usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
 import { getPlayerZoneIds, getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
-import { CASTABLE_AFFORDANCE_ACTIVE, CASTABLE_AFFORDANCE_IDLE } from "../../viewmodel/castableAffordance.ts";
-import { playOrCastActionsForObject } from "../../viewmodel/cardActionChoice.ts";
-import { abilityChoiceLabel } from "../../viewmodel/costLabel.ts";
+import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.ts";
+import { playOrCastActionsForObject, resolveSingleActionDispatch } from "../../viewmodel/cardActionChoice.ts";
 
 interface ZoneViewerProps {
   zone: "graveyard" | "exile";
@@ -39,6 +38,8 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
   const waitingFor = useGameStore((s) => s.waitingFor);
   const dispatch = useGameStore((s) => s.dispatch);
   const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
+  const inspectObject = useUiStore((s) => s.inspectObject);
+  const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
   const dispatchAction = useGameDispatch();
   const currentPlayerId = usePerspectivePlayerId();
   const canActForWaitingState = useCanActForWaitingState();
@@ -63,6 +64,28 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
     }
     return targets;
   }, [canActForWaitingState, waitingFor]);
+
+  // Click-to-cast mirrors ZoneHand: a lone non-confirming action dispatches
+  // immediately, otherwise the shared ability-choice modal opens. Closing the
+  // viewer surfaces that modal (DialogHost z-40) which would otherwise sit
+  // behind the ZoneViewer panel (z-50), and matches Arena dismissing the zone
+  // view once a cast begins. resolveSingleActionDispatch is the single
+  // auto-vs-confirm authority — never re-decided inline here.
+  const handleCast = useCallback(
+    (target: GameObject, actions: GameAction[]) => {
+      inspectObject(null);
+      const auto = resolveSingleActionDispatch(actions, target);
+      if (auto) {
+        dispatch(auto);
+      } else {
+        setPendingAbilityChoice({ objectId: target.id, actions });
+      }
+      onClose();
+    },
+    [dispatch, inspectObject, setPendingAbilityChoice, onClose],
+  );
+
+  const zoneLabel = t(ZONE_TITLE_KEYS[zone]);
 
   return (
     <ModalPanelShell
@@ -96,9 +119,10 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
                   key={obj.id}
                   obj={obj}
                   isValidTarget={isValidTarget}
-                  castActions={castActions}
+                  canCast={castActions.length > 0}
+                  castTitle={t("zone.castFromZone", { zone: zoneLabel, name: obj.name })}
                   onTarget={() => dispatchAction({ type: "ChooseTarget", data: { target: { Object: obj.id } } })}
-                  onCast={(action) => dispatch(action)}
+                  onCast={() => handleCast(obj, castActions)}
                 />
               );
             })}
@@ -112,15 +136,17 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
 function ZoneCard({
   obj,
   isValidTarget,
-  castActions,
+  canCast,
+  castTitle,
   onTarget,
   onCast,
 }: {
   obj: GameObject;
   isValidTarget: boolean;
-  castActions: GameAction[];
+  canCast: boolean;
+  castTitle: string;
   onTarget: () => void;
-  onCast: (action: GameAction) => void;
+  onCast: () => void;
 }) {
   const inspectObject = useUiStore((s) => s.inspectObject);
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
@@ -139,40 +165,35 @@ function ZoneCard({
       useUiStore.getState().openDebugContextMenu({ objectId: obj.id, x: e.clientX, y: e.clientY });
       return;
     }
-    if (isValidTarget) onTarget();
-  }, [obj.id, isValidTarget, onTarget, longPressFired]);
+    if (isValidTarget) { onTarget(); return; }
+    if (canCast) onCast();
+  }, [obj.id, isValidTarget, canCast, onTarget, onCast, longPressFired]);
 
-  const canCast = castActions.length > 0;
   return (
     <div
-      className={`shrink-0 cursor-pointer rounded transition-colors ${
+      className={`group relative inline-flex shrink-0 cursor-pointer rounded-lg transition-transform ${
         isValidTarget
           ? CASTABLE_AFFORDANCE_ACTIVE
           : canCast
-            ? CASTABLE_AFFORDANCE_IDLE
+            ? "hover:scale-[1.03]"
             : "hover:ring-1 hover:ring-white/20"
       }`}
       data-card-hover
+      title={canCast && !isValidTarget ? castTitle : undefined}
       {...hoverProps(obj.id)}
       onClick={handleClick}
       {...longPressHandlers}
     >
       <CardImage cardName={obj.name} size="normal" />
       {canCast && !isValidTarget && (
-        <div className="mt-1 flex flex-col gap-1">
-          {castActions.map((action, i) => {
-            const { label } = abilityChoiceLabel(action, obj);
-            return (
-              <button
-                key={i}
-                onClick={() => onCast(action)}
-                className="w-full rounded-md bg-amber-600/80 px-2 py-1 text-xs font-semibold text-white transition hover:bg-amber-500"
-              >
-                {label}
-              </button>
-            );
-          })}
-        </div>
+        <>
+          {/* Arena-style purple "playable" affordance — same treatment as the
+              ZoneHand castable stack, replacing the per-card "Cast/Play" button
+              so castable cards keep their natural size. pointer-events-none lets
+              clicks fall through to the card's own onClick (handleCast). */}
+          <div className="pointer-events-none absolute inset-0 rounded-lg bg-purple-600/30 transition-colors group-hover:bg-purple-600/10" />
+          <div className="pointer-events-none absolute inset-0 rounded-lg ring-2 ring-purple-400/70 shadow-[0_0_12px_3px_rgba(147,51,234,0.5)]" />
+        </>
       )}
     </div>
   );

--- a/client/src/components/zone/__tests__/ZoneViewer.test.tsx
+++ b/client/src/components/zone/__tests__/ZoneViewer.test.tsx
@@ -135,7 +135,10 @@ describe("ZoneViewer", () => {
   it("dispatches an engine-provided graveyard CastSpell action", () => {
     render(<ZoneViewer zone="graveyard" playerId={0} onClose={vi.fn()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /cast flame jab/i }));
+    // The castable card carries the purple "playable" affordance instead of a
+    // labeled button; clicking the card itself routes through handleCast and
+    // auto-dispatches the lone CastSpell action.
+    fireEvent.click(screen.getByTestId("card-image"));
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith(


### PR DESCRIPTION
Replace the per-card "Cast/Play <name>" amber button column in the
graveyard/exile zone modal with the Arena-style purple translucent
overlay + glow used by the ZoneHand castable stack, and make the whole
card click-to-cast.

- Castable cards now render the purple overlay + ring instead of growing
  taller with a button column, keeping every card the same size.
- Clicking a castable card routes through handleCast, delegating the
  auto-dispatch-vs-choice-modal decision to resolveSingleActionDispatch
  (single source of truth) — multi-mode cards still open the shared
  AbilityChoiceModal.
- Close the viewer on cast so the choice/targeting modal (DialogHost
  z-40) is visible above the former ZoneViewer panel (z-50), matching
  Arena dismissing the zone view once a cast begins.
- Castability remains pure engine authority (legalActionsByObject); the
  card's title tooltip reuses the existing zone.castFromZone i18n key.
