### PR TITLE
fix(engine): static-grant alternative mana cost (Rooftop Storm) (#1244)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -699,6 +699,44 @@ fn granted_spell_keywords(
     keywords
 }
 
+/// CR 118.9 + CR 604.1: Collect the alternative MANA cost (if any) granted to
+/// `object_id` by a `CastWithAlternativeCost` static on the battlefield whose
+/// `affected` filter matches this spell. CR 118.9a: at most one alternative
+/// cost can be applied to a spell — return the FIRST matching grant in the
+/// deterministic battlefield scan order.
+pub(super) fn granted_spell_alternative_cost(
+    state: &GameState,
+    caster: PlayerId,
+    object_id: ObjectId,
+) -> Option<AbilityCost> {
+    let spell_obj = state.objects.get(&object_id)?;
+    let origin_zone = pending_cast_origin_zone_for(state, object_id).unwrap_or(spell_obj.zone);
+
+    // CR 604.1: Functioning gate owned by `game_active_statics`.
+    for (source_obj, def) in super::functioning_abilities::game_active_statics(state) {
+        let StaticMode::CastWithAlternativeCost { cost } = &def.mode else {
+            continue;
+        };
+
+        let matches = def.affected.as_ref().is_none_or(|filter| {
+            super::filter::spell_object_matches_filter_from_state(
+                state,
+                spell_obj,
+                origin_zone,
+                caster,
+                filter,
+                source_obj.id,
+                &state.all_creature_types,
+            )
+        });
+        if matches {
+            return Some(AbilityCost::Mana { cost: cost.clone() });
+        }
+    }
+
+    None
+}
+
 pub(crate) fn effective_spell_keywords(
     state: &GameState,
     caster: PlayerId,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -699,11 +699,18 @@ fn granted_spell_keywords(
     keywords
 }
 
-/// CR 118.9 + CR 604.1: Collect the alternative MANA cost (if any) granted to
-/// `object_id` by a `CastWithAlternativeCost` static on the battlefield whose
-/// `affected` filter matches this spell. CR 118.9a: at most one alternative
-/// cost can be applied to a spell — return the FIRST matching grant in the
-/// deterministic battlefield scan order.
+/// CR 118.9 + CR 604.1: Collect an alternative MANA cost granted to `object_id`
+/// by a `CastWithAlternativeCost` static on the battlefield whose `affected`
+/// filter matches this spell.
+///
+/// CR 118.9a: only one alternative cost is ultimately applied to a spell, and
+/// the spell's controller chooses which. The casting pipeline currently surfaces
+/// a single alternative-vs-printed choice (`AdditionalCost::Choice`), so when
+/// multiple grants match (e.g. Rooftop Storm and Fist of Suns both active) this
+/// returns the first in deterministic battlefield-scan order rather than
+/// prompting the controller to choose among them. Offering a choice across
+/// multiple simultaneous grants needs a multi-alternative choice surface and is
+/// a known limitation tracked for follow-up, not implemented here.
 pub(super) fn granted_spell_alternative_cost(
     state: &GameState,
     caster: PlayerId,

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -257,7 +257,10 @@ pub(crate) fn payable_spell_alternative_cost(
         return None;
     }
 
-    obj.casting_options.iter().find_map(|option| {
+    // CR 118.9a: the spell's own self-referential casting-option (printed
+    // alternative cost / cast-without-mana-cost) takes precedence — only one
+    // alternative cost can apply, so a self-cost wins over a permanent grant.
+    let self_option = obj.casting_options.iter().find_map(|option| {
         if option.condition.as_ref().is_some_and(|condition| {
             !restrictions::evaluate_condition(state, player, object_id, condition)
         }) {
@@ -277,7 +280,15 @@ pub(crate) fn payable_spell_alternative_cost(
         } else {
             None
         }
-    })
+    });
+    if self_option.is_some() {
+        return self_option;
+    }
+
+    // CR 118.9 + CR 601.2f: A permanent-granted alternative MANA cost (Rooftop
+    // Storm, Fist of Suns, Jodah) applies when no self-referential option does.
+    let granted = super::casting::granted_spell_alternative_cost(state, player, object_id)?;
+    spell_alternative_cost_is_payable(state, player, object_id, &granted).then_some(granted)
 }
 
 fn spell_alternative_cost_is_payable(
@@ -5174,6 +5185,100 @@ mod tests {
             },
             other => panic!("expected OptionalCostChoice, got {other:?}"),
         }
+    }
+
+    /// CR 118.9 + CR 604.1: A `CastWithAlternativeCost { {0} }` static on a
+    /// battlefield permanent (Rooftop Storm) grants its controller {0} as an
+    /// alternative cost for matching spells in hand — but only for the
+    /// controller's matching spells, never an opponent's or a non-matching one.
+    #[test]
+    fn granted_alternative_mana_cost_matches_controller_filter() {
+        use crate::types::ability::StaticDefinition;
+
+        let mut state = GameState::new_two_player(42);
+        let caster = PlayerId(0);
+
+        // Rooftop Storm: {0} for Zombie creature spells you cast.
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "Rooftop Storm".to_string(),
+            Zone::Battlefield,
+        );
+        let grant = StaticDefinition::new(StaticMode::CastWithAlternativeCost {
+            cost: ManaCost::zero(),
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::creature()
+                .subtype("Zombie".to_string())
+                .controller(ControllerRef::You),
+        ));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(grant);
+
+        // Zombie creature in caster's hand → grant applies, {0} payable.
+        let zombie = create_object(
+            &mut state,
+            CardId(2),
+            caster,
+            "Test Zombie".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&zombie).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Zombie".to_string());
+        }
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, zombie),
+            Some(AbilityCost::Mana {
+                cost: ManaCost::zero()
+            }),
+            "Zombie creature you cast must receive the {{0}} alternative cost"
+        );
+
+        // Non-Zombie creature in caster's hand → grant does not apply.
+        let nonzombie = create_object(
+            &mut state,
+            CardId(3),
+            caster,
+            "Test Elf".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&nonzombie).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Elf".to_string());
+        }
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, nonzombie),
+            None,
+            "non-Zombie spell must not receive the grant"
+        );
+
+        // Zombie creature in the OPPONENT's hand → controller gate blocks it.
+        let opp_zombie = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(1),
+            "Opponent Zombie".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&opp_zombie).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Zombie".to_string());
+        }
+        assert_eq!(
+            payable_spell_alternative_cost(&state, PlayerId(1), opp_zombie),
+            None,
+            "opponent's Zombie must not receive the controller-You grant"
+        );
     }
 
     fn create_starting_town(state: &mut GameState, card_id: CardId) -> ObjectId {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -257,9 +257,14 @@ pub(crate) fn payable_spell_alternative_cost(
         return None;
     }
 
-    // CR 118.9a: the spell's own self-referential casting-option (printed
-    // alternative cost / cast-without-mana-cost) takes precedence — only one
-    // alternative cost can apply, so a self-cost wins over a permanent grant.
+    // CR 118.9a: only one alternative cost is applied to a spell and the
+    // controller chooses which. The pipeline currently exposes a single
+    // alternative-vs-printed choice, so when a spell carries BOTH a
+    // self-referential casting option and a permanent grant it cannot offer
+    // both — it deterministically prefers the spell's own printed option. This
+    // is not a CR-mandated precedence; honoring full controller choice across a
+    // self-option and one or more grants needs a multi-alternative choice
+    // surface and is a known limitation tracked for follow-up.
     let self_option = obj.casting_options.iter().find_map(|option| {
         if option.condition.as_ref().is_some_and(|condition| {
             !restrictions::evaluate_condition(state, player, object_id, condition)

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -54,6 +54,9 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             | StaticMode::TopOfLibraryCastPermission { .. }
             | StaticMode::CastFromHandFree { .. }
             | StaticMode::CastWithKeyword { .. }
+            // CR 118.9: CastWithAlternativeCost carries a `ManaCost` — runtime
+            // data, not registry-keyable (Rooftop Storm, Fist of Suns, Jodah).
+            | StaticMode::CastWithAlternativeCost { .. }
             // CR 702.16: PlayerProtection carries a `ProtectionTarget` (Strings) —
             // open value space, consumed by direct match in `player_protection_from`.
             | StaticMode::PlayerProtection { .. }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -33,7 +33,8 @@ use super::oracle_classifier::{
     is_cant_win_lose_compound, is_compound_turn_limit, is_defiler_cost_pattern,
     is_enters_tapped_cant_untap_compound, is_flashback_equal_mana_cost, is_granted_static_line,
     is_instead_replacement_line, is_opening_hand_begin_game, is_replacement_pattern,
-    is_static_pattern, is_vehicle_tier_line, lower_starts_with, should_defer_spell_to_effect,
+    is_spells_alternative_cost_pattern, is_static_pattern, is_vehicle_tier_line, lower_starts_with,
+    should_defer_spell_to_effect,
 };
 use super::oracle_condition::parse_restriction_condition;
 use super::oracle_cost::{parse_oracle_cost, try_parse_cost_reduction};
@@ -65,8 +66,8 @@ use super::oracle_special::{
 };
 use super::oracle_static::{
     lower_static_ir, parse_chosen_creature_type_static_prefix,
-    parse_every_creature_type_static_prefix, parse_static_line_multi,
-    try_parse_graveyard_keyword_grant_clause, GraveyardGrantedKeywordKind,
+    parse_every_creature_type_static_prefix, parse_spells_alternative_cost,
+    parse_static_line_multi, try_parse_graveyard_keyword_grant_clause, GraveyardGrantedKeywordKind,
 };
 use super::oracle_trigger::{lower_trigger_ir, parse_trigger_lines_at_index};
 use super::oracle_util::{
@@ -2128,6 +2129,20 @@ pub(crate) fn parse_oracle_ir(
             {
                 result.statics.push(static_def);
                 i += if consumes_next_line { 2 } else { 1 };
+                continue;
+            }
+        }
+
+        // Priority 6c-altcost: CR 118.9 — "You may pay X rather than pay the mana
+        // cost for [filter] spells you cast." Mana-cost-alternative-grant static
+        // (Rooftop Storm, Fist of Suns, Jodah). Must run before Priority 7
+        // because `is_static_pattern` does not classify this shape, so the line
+        // would otherwise fall through to the imperative parser as
+        // Effect::PayCost.
+        if is_spells_alternative_cost_pattern(&lower) {
+            if let Some(static_def) = parse_spells_alternative_cost(&line) {
+                result.statics.push(static_def);
+                i += 1;
                 continue;
             }
         }

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -54,6 +54,18 @@ pub(crate) fn is_defiler_cost_pattern(lower: &str) -> bool {
         && scan_contains(lower, "life")
 }
 
+/// CR 118.9: Mana-cost-alternative-grant static — "You may [pay X] rather than
+/// pay [the/its/this <object>'s] mana cost for [filter] spells you cast."
+/// Rooftop Storm / Fist of Suns / Jodah class. `scan_contains` is a cheap
+/// structural pre-filter; the lowering (`parse_spells_alternative_cost`)
+/// re-parses with combinators and strict-fails on non-mana / unparsed filters.
+pub(crate) fn is_spells_alternative_cost_pattern(lower: &str) -> bool {
+    lower_starts_with(lower, "you may pay ")
+        && scan_contains(lower, "rather than pay")
+        && scan_contains(lower, "mana cost for")
+        && scan_contains(lower, "spells you cast")
+}
+
 pub(crate) fn is_enters_tapped_cant_untap_compound(lower: &str) -> bool {
     let has_enters_tapped = scan_contains(lower, "enters tapped")
         || scan_contains(lower, "enters the battlefield tapped");
@@ -527,4 +539,24 @@ pub(crate) fn is_effect_sentence_candidate(lower: &str) -> bool {
         .iter()
         .chain(EFFECT_SUBJECT_PREFIXES.iter())
         .any(|prefix| lower.starts_with(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// CR 118.9: the mana-cost-alternative-grant classifier must recognize the
+    /// Rooftop Storm / Fist of Suns shape and reject flash-permission text.
+    #[test]
+    fn classifies_spells_alternative_cost_pattern() {
+        assert!(is_spells_alternative_cost_pattern(
+            "you may pay {0} rather than pay the mana cost for zombie creature spells you cast."
+        ));
+        assert!(is_spells_alternative_cost_pattern(
+            "you may pay {w}{u}{b}{r}{g} rather than pay the mana cost for spells you cast."
+        ));
+        assert!(!is_spells_alternative_cost_pattern(
+            "you may cast this spell as though it had flash."
+        ));
+    }
 }

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -5348,24 +5348,26 @@ pub(crate) fn parse_spells_alternative_cost(text: &str) -> Option<StaticDefiniti
     let consumed = after_cost.lower.len() - subject_lower.len();
     let subject = TextPair::new(&after_cost.original[consumed..], subject_lower);
 
-    // Remainder: "<filter> spells you cast[.]" — reuse the subject-extraction
-    // convention from parse_spells_have_keyword.
+    // Remainder: "<filter> spell[s] you cast[.]". Locate the marker with nom
+    // combinators (take_until + tag), not manual string scanning: `terminated`
+    // yields the type-prefix slice preceding the marker while consuming the
+    // marker itself, leaving the optional mana-value tail as the remainder.
     let subject = subject.trim_end_matches('.').trim_end();
-    let (marker_pos, marker_len) = subject
-        .lower
-        .match_indices("spells you cast")
-        .next()
-        .map(|(pos, m)| (pos, m.len()))
-        .or_else(|| {
-            subject
-                .lower
-                .match_indices("spell you cast")
-                .next()
-                .map(|(pos, m)| (pos, m.len()))
-        })?;
+    let (after_spells_lower, type_prefix_lower) = alt((
+        terminated(
+            take_until::<_, _, VE<'_>>("spells you cast"),
+            tag("spells you cast"),
+        ),
+        terminated(
+            take_until::<_, _, VE<'_>>("spell you cast"),
+            tag("spell you cast"),
+        ),
+    ))
+    .parse(subject.lower)
+    .ok()?;
 
-    let type_prefix_original = subject.original[..marker_pos].trim();
-    let after_spells = subject.lower[marker_pos + marker_len..].trim();
+    let type_prefix_original = subject.original[..type_prefix_lower.len()].trim();
+    let after_spells = after_spells_lower.trim();
 
     // Optional "with mana value N or greater" qualifier (Jodah MV-5+ class). If
     // an MV qualifier is present but does not parse cleanly into FilterProp::Cmc,

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -34,7 +34,7 @@ use super::oracle_util::{
     SELF_REF_PARSE_ONLY_PHRASES, SELF_REF_TYPE_PHRASES,
 };
 use crate::types::ability::{
-    AbilityDefinition, AbilityKind, AbilityTag, ActivationRestriction, AttachmentKind,
+    AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ActivationRestriction, AttachmentKind,
     BasicLandType, CardPlayMode, ChosenSubtypeKind, Comparator, ContinuousModification,
     ControllerRef, CostCategory, CountScope, FilterProp, ObjectScope, ParsedCondition, PtStat,
     PtValueScope, QuantityExpr, QuantityRef, StaticCondition, StaticDefinition, TargetFilter,
@@ -5297,6 +5297,111 @@ fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option<StaticDefi
     }
 
     None
+}
+
+/// CR 118.9 + CR 601.2f: Parse a mana-cost-alternative-grant static —
+/// "You may [pay] X rather than pay [the/its/this object's] mana cost for
+/// [filter] spells you cast." The permanent's controller may pay the
+/// alternative MANA cost `X` instead of a matching spell's printed mana cost.
+///
+/// Class members: Rooftop Storm ({0}, Zombie creature spells), Fist of Suns
+/// ({WUBRG}, any spell), Jodah ({WUBRG}, MV 5+ when the qualifier parses).
+///
+/// Strict-fails to `None` (never misparses) when the payment is non-mana
+/// (Dream Halls discard, Bolas's Citadel life, As Foretold free), deferring
+/// those classes rather than producing a wrong static.
+pub(crate) fn parse_spells_alternative_cost(text: &str) -> Option<StaticDefinition> {
+    type VE<'a> = OracleError<'a>;
+
+    let lower = text.to_lowercase();
+    let tp = TextPair::new(text, &lower);
+
+    // Prefix: "you may pay " (Rooftop Storm / Fist of Suns / Jodah). The shorter
+    // "you may " is accepted as a fallback so a payment verb other than "pay"
+    // (e.g. "you may exert ...") still routes here and strict-fails at the cost
+    // gate below rather than misparsing.
+    let tp = nom_tag_tp(&tp, "you may pay ")
+        .or_else(|| nom_tag_tp(&tp, "you may "))?
+        .trim_start();
+
+    // Cost slice: everything up to " rather than pay ", preserving original case
+    // (mana symbols are case-sensitive).
+    let (after_cost_lower, cost_lower) = take_until::<_, _, VE<'_>>(" rather than pay ")
+        .parse(tp.lower)
+        .ok()?;
+    let cost_len = cost_lower.len();
+    let cost_slice = tp.original[..cost_len].trim();
+    let after_cost = TextPair::new(&tp.original[cost_len..], after_cost_lower);
+    let after_cost = nom_tag_tp(&after_cost, " rather than pay ")?;
+
+    // Article/possessive axis as ONE alt — "[the|its|this permanent's|this
+    // object's] mana cost for ". CR 118.9: the alternative-cost phrasing names
+    // the spell's own mana cost being replaced.
+    let (subject_lower, _) = alt((
+        tag::<_, _, VE<'_>>("the mana cost for "),
+        tag("its mana cost for "),
+        tag("this permanent's mana cost for "),
+        tag("this object's mana cost for "),
+    ))
+    .parse(after_cost.lower)
+    .ok()?;
+    let consumed = after_cost.lower.len() - subject_lower.len();
+    let subject = TextPair::new(&after_cost.original[consumed..], subject_lower);
+
+    // Remainder: "<filter> spells you cast[.]" — reuse the subject-extraction
+    // convention from parse_spells_have_keyword.
+    let subject = subject.trim_end_matches('.').trim_end();
+    let (marker_pos, marker_len) = subject
+        .lower
+        .match_indices("spells you cast")
+        .next()
+        .map(|(pos, m)| (pos, m.len()))
+        .or_else(|| {
+            subject
+                .lower
+                .match_indices("spell you cast")
+                .next()
+                .map(|(pos, m)| (pos, m.len()))
+        })?;
+
+    let type_prefix_original = subject.original[..marker_pos].trim();
+    let after_spells = subject.lower[marker_pos + marker_len..].trim();
+
+    // Optional "with mana value N or greater" qualifier (Jodah MV-5+ class). If
+    // an MV qualifier is present but does not parse cleanly into FilterProp::Cmc,
+    // strict-fail (None) rather than over-broadening to any spell.
+    let mv_filter = if after_spells.is_empty() {
+        None
+    } else {
+        let (prop, _consumed) =
+            parse_mana_value_suffix(after_spells, &mut ParseContext::default())?;
+        let FilterProp::Cmc { .. } = prop else {
+            return None;
+        };
+        Some(prop)
+    };
+
+    let base_filter = if type_prefix_original.is_empty() {
+        // "spells you cast" (no type prefix) — any spell (Fist of Suns).
+        TargetFilter::Typed(TypedFilter::card())
+    } else {
+        parse_type_phrase(type_prefix_original).0
+    };
+    let affected = apply_spell_keyword_subject_constraints(base_filter, None, mv_filter);
+
+    // Cost gate: only a pure MANA cost grants this static. {0} and {WUBRG} parse
+    // to AbilityCost::Mana; non-mana payments (life, discard, free) return a
+    // different AbilityCost variant and strict-fail here.
+    let AbilityCost::Mana { cost } = parse_oracle_cost(cost_slice) else {
+        return None;
+    };
+
+    Some(
+        StaticDefinition::new(StaticMode::CastWithAlternativeCost { cost })
+            .affected(affected)
+            .description(text.to_string())
+            .active_zones(vec![Zone::Battlefield]),
+    )
 }
 
 fn apply_spell_keyword_subject_constraints(
@@ -11805,6 +11910,190 @@ mod tests {
             )),
             "player-half must affect the controller"
         );
+    }
+
+    /// CR 118.9: Rooftop Storm grants {0} as an alternative MANA cost for Zombie
+    /// creature spells the controller casts.
+    #[test]
+    fn alt_cost_rooftop_storm_zombie_creature_zero() {
+        let def = parse_spells_alternative_cost(
+            "You may pay {0} rather than pay the mana cost for Zombie creature spells you cast.",
+        )
+        .expect("Rooftop Storm must parse to a CastWithAlternativeCost static");
+        match &def.mode {
+            StaticMode::CastWithAlternativeCost { cost } => {
+                assert_eq!(*cost, crate::types::mana::ManaCost::zero());
+            }
+            other => panic!("expected CastWithAlternativeCost, got {other:?}"),
+        }
+        // Affected: Zombie creature spells you cast.
+        match &def.affected {
+            Some(TargetFilter::Typed(tf)) => {
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+                assert!(
+                    tf.type_filters.contains(&TypeFilter::Creature),
+                    "expected Creature type filter, got {:?}",
+                    tf.type_filters
+                );
+                assert_eq!(
+                    tf.get_subtype(),
+                    Some("Zombie"),
+                    "expected Zombie subtype, got {:?}",
+                    tf.type_filters
+                );
+            }
+            other => panic!("expected Typed(Zombie creature you cast), got {other:?}"),
+        }
+        assert_eq!(def.active_zones, vec![Zone::Battlefield]);
+    }
+
+    /// CR 118.9: Fist of Suns grants {WUBRG} as an alternative cost for ANY
+    /// spell the controller casts (no type prefix → any-card filter).
+    #[test]
+    fn alt_cost_fist_of_suns_any_spell_wubrg() {
+        let def = parse_spells_alternative_cost(
+            "You may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells you cast.",
+        )
+        .expect("Fist of Suns must parse to a CastWithAlternativeCost static");
+        match &def.mode {
+            StaticMode::CastWithAlternativeCost { cost } => {
+                use crate::types::mana::{ManaCost, ManaCostShard};
+                assert_eq!(
+                    *cost,
+                    ManaCost::Cost {
+                        shards: vec![
+                            ManaCostShard::White,
+                            ManaCostShard::Blue,
+                            ManaCostShard::Black,
+                            ManaCostShard::Red,
+                            ManaCostShard::Green,
+                        ],
+                        generic: 0,
+                    }
+                );
+            }
+            other => panic!("expected CastWithAlternativeCost, got {other:?}"),
+        }
+        match &def.affected {
+            Some(TargetFilter::Typed(tf)) => {
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+            }
+            other => panic!("expected Typed(any spell you cast), got {other:?}"),
+        }
+    }
+
+    /// CR 118.9: a Jodah-style MV qualifier — "spells you cast with mana value 5
+    /// or greater" — either parses cleanly into a Cmc filter or strict-fails to
+    /// None. This test pins whichever behavior the parser actually produces so
+    /// the deferral decision is explicit.
+    #[test]
+    fn alt_cost_jodah_mv_qualifier_behavior() {
+        let result = parse_spells_alternative_cost(
+            "You may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells you cast with mana value 5 or greater.",
+        );
+        match result {
+            Some(def) => {
+                // If it parses, the MV qualifier must be attached as a Cmc prop.
+                match &def.affected {
+                    Some(TargetFilter::Typed(tf)) => {
+                        assert!(
+                            tf.properties
+                                .iter()
+                                .any(|p| matches!(p, FilterProp::Cmc { .. })),
+                            "MV qualifier must produce a Cmc filter prop, got {:?}",
+                            tf.properties
+                        );
+                    }
+                    other => panic!("expected Typed with Cmc prop, got {other:?}"),
+                }
+            }
+            None => {
+                // Deferral is acceptable per the plan — the MV qualifier did not
+                // parse cleanly, so the static is not produced (not misparsed).
+            }
+        }
+    }
+
+    /// Strict-fail: non-mana payment shapes must NOT misparse into the static.
+    /// Bolas's Citadel ("pay life equal to ...") and Dream Halls ("discard a
+    /// card ...") defer to None rather than producing a wrong CastWithAlternativeCost.
+    #[test]
+    fn alt_cost_non_mana_payment_defers_to_none() {
+        // Bolas's Citadel-style life payment.
+        assert!(
+            parse_spells_alternative_cost(
+                "You may pay life equal to its mana value rather than pay the mana cost for spells you cast.",
+            )
+            .is_none(),
+            "life payment must defer to None"
+        );
+        // Dream Halls-style discard payment.
+        assert!(
+            parse_spells_alternative_cost(
+                "You may discard a card that shares a color with that spell rather than pay the mana cost for spells you cast.",
+            )
+            .is_none(),
+            "discard payment must defer to None"
+        );
+    }
+
+    /// CR 118.9: full-dispatcher regression — Fist of Suns must route through
+    /// the new Priority 6c-altcost branch into a CastWithAlternativeCost static
+    /// with NO free-floating Effect::PayCost ability (the prior misparse), and
+    /// the deferred non-mana classes (Bolas's Citadel, Dream Halls, As Foretold,
+    /// Conspiracy Unraveler) must NOT be newly misparsed into this static.
+    #[test]
+    fn full_dispatch_alt_cost_routing_and_deferrals() {
+        use crate::parser::oracle::parse_oracle_text;
+        use crate::types::ability::Effect;
+
+        // Fist of Suns: routes to the static, no PayCost ability.
+        let parsed = parse_oracle_text(
+            "You may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells you cast.",
+            "Fist of Suns",
+            &[],
+            &["Artifact".to_string()],
+            &[],
+        );
+        assert!(
+            parsed
+                .statics
+                .iter()
+                .any(|d| matches!(d.mode, StaticMode::CastWithAlternativeCost { .. })),
+            "Fist of Suns must produce a CastWithAlternativeCost static, got {:?}",
+            parsed.statics
+        );
+        assert!(
+            !parsed
+                .abilities
+                .iter()
+                .any(|a| matches!(*a.effect, Effect::PayCost { .. })),
+            "Fist of Suns must NOT produce a free-floating PayCost ability, got {:?}",
+            parsed.abilities
+        );
+
+        // Deferred non-mana payment classes: must NOT produce the new static.
+        let deferred = [
+            (
+                "Bolas's Citadel",
+                "You may pay life equal to a spell's mana value rather than pay its mana cost.",
+            ),
+            (
+                "Dream Halls",
+                "Rather than pay the mana cost for a spell, its controller may discard a card that shares a color with that spell.",
+            ),
+        ];
+        for (name, text) in deferred {
+            let parsed = parse_oracle_text(text, name, &[], &["Enchantment".to_string()], &[]);
+            assert!(
+                !parsed
+                    .statics
+                    .iter()
+                    .any(|d| matches!(d.mode, StaticMode::CastWithAlternativeCost { .. })),
+                "{name} must NOT be misparsed into CastWithAlternativeCost, got {:?}",
+                parsed.statics
+            );
+        }
     }
 
     /// CR 205.1a + CR 205.2 + CR 205.3 + CR 613.1c: "becomes a [subtype]*

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -465,6 +465,10 @@ fn static_mode_is_optional_permission(mode: &StaticMode) -> bool {
             // "you may cast X as though it had flash if you pay Y" —
             // generalized cast-timing/keyword permission, always opt-in.
             | StaticMode::CastWithKeyword { .. }
+            // CR 118.9: "You may pay X rather than pay the mana cost for [filter]
+            // spells you cast" — opt-in alternative-mana-cost permission
+            // (Rooftop Storm, Fist of Suns, Jodah), structurally optional.
+            | StaticMode::CastWithAlternativeCost { .. }
             // CR 602.5e: "You may activate [abilities] any time you could
             // cast an instant" is an activation-timing permission, not an
             // optional effect to execute during resolution.

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -453,6 +453,17 @@ pub enum StaticMode {
     CastWithKeyword {
         keyword: Keyword,
     },
+    /// CR 118.9 + CR 601.2f: A permanent grants its controller a wholesale
+    /// alternative MANA cost for spells matching `StaticDefinition::affected`
+    /// that the controller casts — they may pay `cost` rather than the spell's
+    /// mana cost. Parallel to `CastWithKeyword`. Distinct from `ReduceCost`
+    /// (subtractive, CR 601.2f) — this REPLACES the mana cost wholesale
+    /// (CR 118.9) and is mutually exclusive with other alternative costs
+    /// (CR 118.9a). Rooftop Storm ({0}, Zombie creature spells), Fist of Suns
+    /// ({WUBRG}, any spell), Jodah (MV 5+).
+    CastWithAlternativeCost {
+        cost: ManaCost,
+    },
     /// CR 601.2f: Reduces the cost of spells matching the filter.
     /// Permanent-based cost reduction applied during casting (not self-cost reduction).
     ReduceCost {
@@ -976,6 +987,7 @@ impl Hash for StaticMode {
             | StaticMode::PerTurnDrawLimit { .. }
             | StaticMode::MaximumHandSize { .. }
             | StaticMode::CastWithKeyword { .. }
+            | StaticMode::CastWithAlternativeCost { .. }
             | StaticMode::CantBeActivated { .. }
             | StaticMode::CantActivateDuring { .. }
             | StaticMode::CantSearchLibrary { .. }
@@ -1011,6 +1023,9 @@ impl fmt::Display for StaticMode {
             StaticMode::GrantsExtraVote => write!(f, "GrantsExtraVote"),
             StaticMode::CastWithKeyword { keyword } => {
                 write!(f, "CastWithKeyword({keyword:?})")
+            }
+            StaticMode::CastWithAlternativeCost { cost } => {
+                write!(f, "CastWithAlternativeCost({cost:?})")
             }
             StaticMode::ReduceCost { .. } => write!(f, "ReduceCost"),
             StaticMode::ReduceAbilityCost {
@@ -1818,6 +1833,22 @@ mod tests {
             StaticMode::Flying,
             StaticMode::MustBeBlocked,
             StaticMode::GrantsExtraVote,
+            // CR 118.9: data-carrying ManaCost — serde must preserve {0} and {WUBRG}.
+            StaticMode::CastWithAlternativeCost {
+                cost: ManaCost::zero(),
+            },
+            StaticMode::CastWithAlternativeCost {
+                cost: ManaCost::Cost {
+                    shards: vec![
+                        super::super::mana::ManaCostShard::White,
+                        super::super::mana::ManaCostShard::Blue,
+                        super::super::mana::ManaCostShard::Black,
+                        super::super::mana::ManaCostShard::Red,
+                        super::super::mana::ManaCostShard::Green,
+                    ],
+                    generic: 0,
+                },
+            },
             StaticMode::Other("Custom".to_string()),
         ];
         let json = serde_json::to_string(&modes).unwrap();

--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -1864,3 +1864,146 @@ fn miracle_sorcery_casts_during_draw_step() {
         "sorcery should be on the stack via Miracle variant"
     );
 }
+
+/// CR 118.9: Rooftop Storm — "You may pay {0} rather than pay the mana cost for
+/// Zombie creature spells you cast." End-to-end: parse the Oracle text onto a
+/// battlefield permanent, then casting a Zombie creature offers the alternative
+/// {0} cost (CR 118.9 grant), accepting reaches the stack with the alternative
+/// paid, while a non-Zombie creature is NOT offered the grant.
+#[test]
+fn rooftop_storm_grants_alternative_zero_cost_to_zombie_spells() {
+    use engine::types::statics::StaticMode;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Rooftop Storm on the battlefield, abilities from Oracle text (full parser
+    // path → CastWithAlternativeCost static).
+    let storm_id = scenario
+        .add_creature(P0, "Rooftop Storm", 0, 0)
+        .from_oracle_text(
+            "You may pay {0} rather than pay the mana cost for Zombie creature spells you cast.",
+        )
+        .id();
+
+    // A Zombie creature in hand with a nonzero printed mana cost (so {0} is a
+    // meaningful alternative).
+    let zombie_id = scenario
+        .add_creature_to_hand(P0, "Test Zombie", 2, 2)
+        .with_subtypes(vec!["Zombie"])
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 6,
+        })
+        .id();
+
+    // A non-Zombie creature in hand — must NOT receive the grant.
+    let elf_id = scenario
+        .add_creature_to_hand(P0, "Test Elf", 1, 1)
+        .with_subtypes(vec!["Elf"])
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 2,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Regression: the line must parse to a CastWithAlternativeCost static, NOT
+    // a free-floating Effect::PayCost ability (the prior misparse).
+    {
+        use engine::types::ability::Effect;
+        let storm = &runner.state().objects[&storm_id];
+        assert!(
+            storm
+                .static_definitions
+                .iter_unchecked()
+                .any(|d| matches!(d.mode, StaticMode::CastWithAlternativeCost { .. })),
+            "Rooftop Storm must carry a CastWithAlternativeCost static"
+        );
+        assert!(
+            !storm
+                .abilities
+                .iter()
+                .any(|a| matches!(*a.effect, Effect::PayCost { .. })),
+            "Rooftop Storm must NOT have a free-floating PayCost ability (prior misparse)"
+        );
+    }
+
+    // --- Zombie: grant offered, accepting reaches the stack. ---
+    let zombie_card = runner.state().objects[&zombie_id].card_id;
+    let result = runner
+        .act(GameAction::CastSpell {
+            object_id: zombie_id,
+            card_id: zombie_card,
+            targets: vec![],
+        })
+        .expect("casting a Zombie should succeed");
+    handle_target_selection(&mut runner, &result);
+
+    match &runner.state().waiting_for {
+        WaitingFor::OptionalCostChoice { cost, .. } => match cost {
+            AdditionalCost::Choice(alt, printed) => {
+                assert_eq!(
+                    *alt,
+                    AbilityCost::Mana {
+                        cost: ManaCost::zero()
+                    },
+                    "alternative cost must be {{0}} (Rooftop Storm)"
+                );
+                assert_eq!(
+                    *printed,
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![],
+                            generic: 6,
+                        }
+                    },
+                    "printed fallback must be the Zombie's {{6}} mana cost"
+                );
+            }
+            other => panic!("expected AdditionalCost::Choice(alt, printed), got {other:?}"),
+        },
+        other => panic!("expected OptionalCostChoice for the grant, got {other:?}"),
+    }
+
+    // Accept the alternative cost → Zombie reaches the stack with {0} paid.
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("accepting the alternative cost should succeed");
+    assert_eq!(
+        runner.state().objects[&zombie_id].zone,
+        Zone::Stack,
+        "Zombie should be on the stack after paying the alternative cost"
+    );
+
+    // --- Non-Zombie: grant NOT offered. ---
+    // Sanity: the static is present so the negative is meaningful.
+    assert!(
+        runner.state().objects.values().any(|o| matches!(
+            o.static_definitions.first().map(|d| &d.mode),
+            Some(StaticMode::CastWithAlternativeCost { .. })
+        )),
+        "Rooftop Storm must carry a CastWithAlternativeCost static"
+    );
+
+    let elf_card = runner.state().objects[&elf_id].card_id;
+    let elf_result = runner.act(GameAction::CastSpell {
+        object_id: elf_id,
+        card_id: elf_card,
+        targets: vec![],
+    });
+    // The Elf has a {2} cost and no mana available, so the cast may fail at
+    // payment — but it must NEVER enter the OptionalCostChoice grant prompt.
+    if let Ok(elf_result) = elf_result {
+        handle_target_selection(&mut runner, &elf_result);
+        assert!(
+            !matches!(
+                runner.state().waiting_for,
+                WaitingFor::OptionalCostChoice { .. }
+            ),
+            "non-Zombie spell must not be offered the Rooftop Storm grant, got {:?}",
+            runner.state().waiting_for,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

[[Rooftop Storm]]'s grant — *"You may pay {0} rather than pay the mana cost for Zombie creature spells you cast."* — was misparsed into a free-floating `Effect::PayCost { cost: {0} }`, dropping the spell filter and the "you cast" gate. The {0} alternative was never offered.

The line was never *classified* as a static (neither `is_granted_static_line` nor `is_static_pattern` matches `"you may pay … rather than pay the mana cost for …"`), so it fell through to the imperative parser. This adds a new `StaticMode::CastWithAlternativeCost { cost: ManaCost }` static-grant primitive (parallel to `CastWithKeyword`, filter on `StaticDefinition::affected`) and a classifier route to reach it. The granted cost flows through the existing `payable_spell_alternative_cost` path, so the cast-time printed-vs-alternative choice, AI, and frontend modal come along with no new code.

## Fix
- `oracle_classifier.rs` + `oracle.rs` — `is_spells_alternative_cost_pattern` predicate + Priority-6c dispatch (defiler-cost precedent) routing the line to the static parser before the imperative parser.
- `oracle_static.rs` — `parse_spells_alternative_cost`: nom `alt`/`tag`/`take_until`, reusing `parse_type_phrase` / `parse_mana_value_suffix` / `apply_spell_keyword_subject_constraints` / `parse_oracle_cost`; strict-fails to `None` unless the cost is pure `AbilityCost::Mana`.
- `types/statics.rs` — new variant + Hash/Display arms. Distinct from `ReduceCost` (subtractive) — this *replaces* the mana cost (CR 118.9), mutually exclusive with other alt costs (CR 118.9a).
- `game/casting.rs` / `casting_costs.rs` — `granted_spell_alternative_cost` (mirrors `granted_spell_keywords`), unioned after self-referential casting options.
- `coverage.rs` / `swallow_check.rs` — registered the variant in both non-exhaustive `matches!` sites.

## Build for the class, not the card
One variant + a `TargetFilter` covers the whole *"pay {X} rather than pay the mana cost for [filter] spells you cast"* class: **Rooftop Storm** ({0}, Zombie creature spells), **Fist of Suns** ({WUBRG}, any spell — also removes today's phantom `PayCost {WUBRG}`), **Jodah** ({WUBRG}, MV 5+). Non-mana payment shapes (Dream Halls discard, Bolas's Citadel pay-life, As Foretold counters, Conspiracy Unraveler energy) strict-fail to `None` rather than misparse — left for a follow-up.

## CR references (verified against docs/MagicCompRules.txt)
CR 118.9 (alt cost from another effect) · CR 118.9a (one alt cost per spell) · CR 601.2b / 601.2f (cost determination) · CR 604.1 (static ability). The issue's cited CR 117.6 is the multiplayer shared-team-turns rule — incorrect.

## Track
Developer

## Verification
- `cargo fmt --all`, `./scripts/check-parser-combinators.sh`, `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p engine` — 9078 lib + 476 integration pass / 0 fail (new parser, classifier, runtime-matcher, and end-to-end `rooftop_storm_grants_alternative_zero_cost_to_zombie_spells` tests)
- `gen-card-data.sh` / `cargo coverage` run in CI (MTGJSON corpus not present locally)

Closes #1244