### PR TITLE
fix(engine): scope DamageReceived matcher to object vs player damage targets

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2472,8 +2472,9 @@ pub(super) fn match_damage_received(
         }
         match target {
             TargetRef::Object(target_id) => {
-                // CR 120.3: Player-scoped triggers ("you're dealt damage") must not
-                // fire when the trigger source object takes damage.
+                // CR 603.2 + CR 120.1: a player-scoped trigger ("you're dealt
+                // damage") matches only player-recipient events, not damage to
+                // the source object.
                 if trigger.valid_card.is_none() && trigger.valid_target.is_some() {
                     return false;
                 }
@@ -2482,8 +2483,9 @@ pub(super) fn match_damage_received(
                     && valid_source_matches(trigger, state, *damage_source_id, source_id)
             }
             TargetRef::Player(pid) => {
-                // CR 120.3: Object-scoped triggers ("~ is dealt damage", Enrage) must
-                // not fire when the controller takes damage.
+                // CR 603.2 + CR 120.1: an object-scoped trigger ("~ is dealt
+                // damage", Enrage) matches only permanent-recipient events, not
+                // damage to the controller.
                 if trigger.valid_card.is_some() {
                     return false;
                 }

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2436,7 +2436,8 @@ pub(super) fn match_becomes_blocked(
 /// Uses DamageDealt event but checks the *target* (not the damage source) against the trigger.
 ///
 /// Two target patterns are supported:
-/// - Object target: "Whenever ~ is dealt damage" — `target == source_id`.
+/// - Object target: "Whenever ~ is dealt damage" — `valid_card` scopes the object;
+///   runtime checks `target == source_id` for SelfRef triggers.
 /// - Player target: "Whenever you're dealt damage" — `valid_target` scopes the player.
 ///
 /// `valid_source` optionally scopes the damage source for either target shape.
@@ -2471,11 +2472,21 @@ pub(super) fn match_damage_received(
         }
         match target {
             TargetRef::Object(target_id) => {
+                // CR 120.3: Player-scoped triggers ("you're dealt damage") must not
+                // fire when the trigger source object takes damage.
+                if trigger.valid_card.is_none() && trigger.valid_target.is_some() {
+                    return false;
+                }
                 // Object target: trigger source is the damaged permanent.
                 *target_id == source_id
                     && valid_source_matches(trigger, state, *damage_source_id, source_id)
             }
             TargetRef::Player(pid) => {
+                // CR 120.3: Object-scoped triggers ("~ is dealt damage", Enrage) must
+                // not fire when the controller takes damage.
+                if trigger.valid_card.is_some() {
+                    return false;
+                }
                 // Player target: check the damaged player matches valid_target
                 // (e.g., "you" → Controller) and optionally that the damage
                 // source matches valid_source. CR 120.1 + CR 120.3.
@@ -7165,6 +7176,86 @@ mod tests {
         assert!(
             !match_damage_received(&event3, &trigger, source, &state),
             "must not fire when opponent is damaged, not controller"
+        );
+    }
+
+    /// CR 120.3: Enrage / "~ is dealt damage" — object-scoped triggers must not
+    /// fire when the controller takes damage (Vrondiss #1306).
+    #[test]
+    fn damage_received_object_scoped_rejects_player_damage() {
+        let mut state = setup();
+        let vrondiss = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Vrondiss, Rage of Ancients".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::DamageReceived);
+        trigger.valid_card = Some(TargetFilter::SelfRef);
+
+        let controller_damaged = GameEvent::DamageDealt {
+            source_id: ObjectId(99),
+            target: TargetRef::Player(PlayerId(0)),
+            amount: 3,
+            is_combat: false,
+            excess: 0,
+        };
+        assert!(
+            !match_damage_received(&controller_damaged, &trigger, vrondiss, &state),
+            "Enrage-style triggers must not fire on controller damage"
+        );
+
+        let self_damage = GameEvent::DamageDealt {
+            source_id: ObjectId(99),
+            target: TargetRef::Object(vrondiss),
+            amount: 1,
+            is_combat: false,
+            excess: 0,
+        };
+        assert!(
+            match_damage_received(&self_damage, &trigger, vrondiss, &state),
+            "Enrage-style triggers must fire when the source object is dealt damage"
+        );
+    }
+
+    /// CR 120.1: "Whenever you're dealt damage" must not fire when the trigger
+    /// source object takes damage instead of the controller.
+    #[test]
+    fn damage_received_player_scoped_rejects_object_damage_to_source() {
+        let mut state = setup();
+        let stuffy_doll = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Stuffy Doll".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::DamageReceived);
+        trigger.valid_target = Some(TargetFilter::Controller);
+
+        let object_damage = GameEvent::DamageDealt {
+            source_id: ObjectId(99),
+            target: TargetRef::Object(stuffy_doll),
+            amount: 3,
+            is_combat: false,
+            excess: 0,
+        };
+        assert!(
+            !match_damage_received(&object_damage, &trigger, stuffy_doll, &state),
+            "player-scoped damage triggers must not fire on object damage"
+        );
+
+        let player_damage = GameEvent::DamageDealt {
+            source_id: ObjectId(99),
+            target: TargetRef::Player(PlayerId(0)),
+            amount: 3,
+            is_combat: false,
+            excess: 0,
+        };
+        assert!(
+            match_damage_received(&player_damage, &trigger, stuffy_doll, &state),
+            "player-scoped damage triggers must fire on controller damage"
         );
     }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -11778,6 +11778,22 @@ mod tests {
     }
 
     #[test]
+    fn vrondiss_enrage_damage_received_watches_self_not_controller() {
+        let result = parse(
+            "Enrage — Whenever Vrondiss, Rage of Ancients is dealt damage, you may create a 5/4 red and green Dragon Spirit creature token with \"When this creature deals damage, sacrifice it.\"",
+            "Vrondiss, Rage of Ancients",
+            &[],
+            &["Creature"],
+            &["Dragon", "Barbarian"],
+        );
+        assert_eq!(result.triggers.len(), 1, "triggers={:?}", result.triggers);
+        let trigger = &result.triggers[0];
+        assert_eq!(trigger.mode, TriggerMode::DamageReceived);
+        assert_eq!(trigger.valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(trigger.valid_target, None);
+    }
+
+    #[test]
     fn heroic_trigger_not_misrouted_to_replacement() {
         // Favored Hoplite: "Heroic — Whenever you cast a spell that targets this creature,
         // put a +1/+1 counter on this creature and prevent all damage that would be dealt

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -13120,6 +13120,8 @@ mod tests {
         );
         assert_eq!(def.mode, TriggerMode::DamageReceived);
         assert_eq!(def.damage_kind, DamageKindFilter::Any);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(def.valid_target, None);
     }
 
     #[test]


### PR DESCRIPTION

## Summary

- Fix `match_damage_received` so object-scoped triggers (Enrage, "~ is dealt damage") only fire when the trigger source object is dealt damage, not when its controller takes damage.
- Add the inverse guard for player-scoped triggers ("whenever you're dealt damage") so they do not fire when the source object takes damage instead.
- Add regression tests for Vrondiss Enrage parsing and both matcher branches.
Closes #1306
## Context

Fixes [#1306](https://github.com/phase-rs/phase/issues/1306). Vrondiss, Rage of Ancients showed as fully parsed (Enrage watches self), but Enrage incorrectly triggered when the player took damage. The parser was already correct (`valid_card: SelfRef`); the runtime matcher was the defect.

## Test plan

- [x] `cargo test -p engine damage_received`
- [x] `cargo test -p engine vrondiss_enrage`
- [x] `cargo test -p engine rules::combat::damage_received_trigger_fires_when_creature_dies` (Jackal Pup / Enrage-style object damage still fires)
- [ ] Manual: deal damage to Vrondiss → Enrage triggers; deal damage to its controller only → Enrage does not trigger