### PR TITLE
Add Vigor

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5944,8 +5944,25 @@ fn try_parse_for_each_effect(text: &str, ctx: &mut ParseContext) -> Option<Parse
         } else {
             after_counter_on
         };
+        // CR 608.2c: "put a counter on that <type> for each X" — when the
+        // counter target is an anaphoric back-reference (`that creature`,
+        // `that permanent`, etc.), `parse_subject_application` signals it
+        // with `inherits_parent: true` and returns the type filter as a
+        // suggestion. The contract documented inside `parse_subject_application`
+        // is that the call site must lower this to `TargetFilter::ParentTarget`
+        // so the counter lands on the inherited parent target (or, in passive
+        // contexts where there is no parent, on the post-replacement event
+        // recipient via the caller's post-parse rewrite). Without this, the
+        // typed `Creature` filter leaks through and the counter is placed on
+        // an unrelated creature.
         let target = parse_subject_application(counter_target_text, &mut ParseContext::default())
-            .map(|app| app.affected)
+            .map(|app| {
+                if app.inherits_parent {
+                    TargetFilter::ParentTarget
+                } else {
+                    app.affected
+                }
+            })
             .unwrap_or_else(|| {
                 ctx.push_diagnostic(OracleDiagnostic::TargetFallback {
                     context: "unrecognized counter target".into(),

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4770,6 +4770,12 @@ fn parse_damage_prevention_replacement(
     if let Some(sf) = damage_source_filter {
         def = def.damage_source_filter(sf);
     }
+    // Capture whether the recipient filter was event-driven (typed
+    // `valid_card`) before moving it onto `def` — the follow-up rewrite
+    // below uses this signal to distinguish the Vigor cohort (rewrite
+    // `ParentTarget` → `PostReplacementDamageTarget`) from the spell-driven
+    // cohort (keep `ParentTarget` for the real spell target).
+    let recipient_is_event_filter = valid_card_filter.is_some();
     if let Some(vc) = valid_card_filter {
         def = def.valid_card(vc);
     }
@@ -4785,14 +4791,29 @@ fn parse_damage_prevention_replacement(
     // consumes the damage. Class members: Phyrexian Hydra, Vigor, Stormwild
     // Capridor, Hostility.
     if let Some(followup) = extract_prevention_followup(original_text) {
-        // CR 608.2k: Static self-prevention replacements (Anti-Venom, Vigor,
-        // Phyrexian Hydra, Stormwild Capridor) host their followup on the
-        // shield-bearing permanent itself. Bare pronouns ("him"/"it"/"this
-        // creature"/"this enchantment") in the rider must bind to `SelfRef`
-        // so PutCounter targets the permanent, not a non-existent parent
-        // target. The rider parse runs through the standard chain pipeline
-        // with `subject: SelfRef` so `resolve_pronoun_target` returns
-        // `SelfRef` per its typed-subject carve-out.
+        // CR 608.2k: Static self-prevention replacements split into two
+        // anaphor cohorts depending on what the rider counter/effect targets:
+        //
+        // 1. Rider targets the shield-bearing permanent itself (Anti-Venom,
+        //    Phyrexian Hydra, Stormwild Capridor, Hostility). The rider's
+        //    bare pronouns ("him"/"it"/"this creature"/"this enchantment"/
+        //    "~") must bind to `SelfRef` so the counter lands on the source.
+        //    Threading `subject: SelfRef` makes `resolve_pronoun_target`
+        //    return `SelfRef` per its typed-subject carve-out.
+        //
+        // 2. Rider targets the prevented event's damage recipient (Vigor:
+        //    "If damage would be dealt to another creature you control,
+        //    prevent that damage. Put a +1/+1 counter on that creature ..."
+        //    — "that creature" is the recipient, not the source). The rider
+        //    parser lowers "that creature" to `TargetFilter::ParentTarget`
+        //    by the generic CR 608.2c anaphor path, but there is no parent
+        //    target slot in a passive replacement context, so the binding
+        //    is dangling. Post-parse rewrite (below) remaps it to
+        //    `PostReplacementDamageTarget`. Cohort 2 is detected by the
+        //    presence of a typed `valid_card` recipient filter — that's the
+        //    structural signal that the shield is event-driven (no spell
+        //    target), so any `ParentTarget` in the rider can only refer to
+        //    the event recipient.
         let mut followup_ctx = ParseContext {
             subject: Some(TargetFilter::SelfRef),
             in_replacement: true,
@@ -4810,12 +4831,35 @@ fn parse_damage_prevention_replacement(
         // avoids parser-context plumbing. Single building-block walker
         // (`each_target_filter_mut`) handles every target-bearing effect arm.
         rewrite_parent_target_controller_to_post_replacement_source(&mut followup_def);
+        // CR 615.5 + CR 608.2c: Object-anaphor rewrite for cohort 2 (Vigor
+        // class). When the shield is event-driven (signalled by a typed
+        // `valid_card_filter`), `ParentTarget` in the rider can only refer
+        // to the prevented event's damage recipient — there is no parent
+        // target slot. Remap dangling `ParentTarget` to
+        // `PostReplacementDamageTarget` so the runtime resolves it against
+        // `state.post_replacement_event_target`. Spell-driven prevention
+        // (Test of Faith — "prevent the next 3 damage that would be dealt to
+        // target creature this turn") has `valid_card_filter = None` because
+        // its all-consuming recipient terminator fails, so this rewrite
+        // does not fire and `ParentTarget` correctly inherits the spell's
+        // chosen target.
+        if recipient_is_event_filter {
+            rewrite_parent_target_to_post_replacement_damage_target(&mut followup_def);
+        }
         def = def.execute(followup_def);
     }
 
     Some(def)
 }
 
+/// CR 614.1a: Extract the typed event-recipient filter from a damage-prevention
+/// shield's "dealt to <filter>" clause. The clause may close at the end of the
+/// sentence (`.`, `this turn`, `until end of turn`, or input end) or continue
+/// into a sibling prevention imperative (`, prevent that damage. ...` — Vigor,
+/// Phyrexian Hydra, Stormwild Capridor class of static prevention shields with
+/// follow-up rider). The `peek(", prevent")` boundary keeps the filter scoped
+/// to the recipient phrase without consuming the comma + imperative, leaving
+/// the follow-up extractor (`extract_prevention_followup`) to claim it.
 fn parse_damage_recipient_valid_card_filter(working_lower: &str) -> Option<TargetFilter> {
     nom_primitives::scan_at_word_boundaries(working_lower, |input| {
         let (after_to, _) = tag::<_, _, OracleError<'_>>("dealt to ").parse(input)?;
@@ -4828,7 +4872,7 @@ fn parse_damage_recipient_valid_card_filter(working_lower: &str) -> Option<Targe
         }
 
         let rest = rest.trim_start();
-        if all_consuming(alt((
+        let fully_consumed = all_consuming(alt((
             value((), eof::<&str, OracleError<'_>>),
             value((), tag::<_, _, OracleError<'_>>(".")),
             value(
@@ -4847,8 +4891,16 @@ fn parse_damage_recipient_valid_card_filter(working_lower: &str) -> Option<Targe
             ),
         )))
         .parse(rest)
-        .is_ok()
-        {
+        .is_ok();
+        // CR 614.1a + CR 615.5: A static prevention shield with a same-sentence
+        // imperative ("if damage would be dealt to <filter>, prevent that damage")
+        // closes the recipient phrase at the clause boundary `, prevent`, not at
+        // sentence end. `peek` acknowledges the boundary without consuming so
+        // the follow-up extractor still claims the imperative and its rider.
+        let clause_boundary = peek(tag::<_, _, OracleError<'_>>(", prevent"))
+            .parse(rest)
+            .is_ok();
+        if fully_consumed || clause_boundary {
             Ok((rest, filter))
         } else {
             Err(nom::Err::Error(OracleError::new(
@@ -4874,6 +4926,37 @@ fn rewrite_parent_target_controller_to_post_replacement_source(def: &mut Ability
     }
     if let Some(else_branch) = def.else_ability.as_mut() {
         rewrite_parent_target_controller_to_post_replacement_source(else_branch);
+    }
+}
+
+/// CR 615.5 + CR 608.2c: In a prevention follow-up whose shield is event-driven
+/// (Vigor class: "If damage would be dealt to <typed filter>, prevent that
+/// damage. Put a +1/+1 counter on that creature ..."), the rider's anaphor
+/// "that creature" refers to the prevented event's damage recipient. The
+/// ordinary `parse_target` path lowers "that <type phrase>" to
+/// `TargetFilter::ParentTarget` per CR 608.2c, but in a passive replacement
+/// there is no parent target slot to bind against. Rewrite each dangling
+/// `ParentTarget` to `PostReplacementDamageTarget` so the runtime resolves
+/// it against `state.post_replacement_event_target`.
+///
+/// Sibling of `rewrite_damage_recipient_to_post_replacement_target` which
+/// handles the player-anaphor cohort ("that player draws cards ..."). Kept
+/// separate so the player walker stays scoped to player refs and this walker
+/// only fires when the caller has confirmed the shield is event-driven (via
+/// a typed `valid_card_filter` signal) — spell-driven prevention with a real
+/// `target creature` slot must keep its `ParentTarget` binding intact (Test
+/// of Faith).
+fn rewrite_parent_target_to_post_replacement_damage_target(def: &mut AbilityDefinition) {
+    super::oracle_effect::each_target_filter_mut(&mut def.effect, &mut |f| {
+        if matches!(f, TargetFilter::ParentTarget) {
+            *f = TargetFilter::PostReplacementDamageTarget;
+        }
+    });
+    if let Some(sub) = def.sub_ability.as_mut() {
+        rewrite_parent_target_to_post_replacement_damage_target(sub);
+    }
+    if let Some(else_branch) = def.else_ability.as_mut() {
+        rewrite_parent_target_to_post_replacement_damage_target(else_branch);
     }
 }
 
@@ -5748,6 +5831,97 @@ mod tests {
                 target: TargetFilter::ParentTarget,
             } if *counter_type == CounterType::Plus1Plus1
         ));
+    }
+
+    /// CR 614.1a + CR 615.5 + CR 608.2c: Vigor — "If damage would be dealt to
+    /// another creature you control, prevent that damage. Put a +1/+1 counter
+    /// on that creature for each 1 damage prevented this way."
+    ///
+    /// Three building-block assertions:
+    ///
+    /// 1. The recipient phrase parses through `parse_damage_recipient_valid_card_filter`
+    ///    even though it closes at `", prevent"` (the same-sentence clause
+    ///    boundary), and the resulting typed filter retains `controller: You`
+    ///    and `FilterProp::Another`. Previously the all-consuming terminator
+    ///    rejected the comma + imperative, silently dropping `valid_card` and
+    ///    causing the shield to fire on ANY creature (including opponents').
+    ///
+    /// 2. The rider's anaphor "that creature" (which `parse_target` lowers to
+    ///    `TargetFilter::ParentTarget` per CR 608.2c) is rewritten at the
+    ///    parser call site to `TargetFilter::PostReplacementDamageTarget` so
+    ///    the +1/+1 counter lands on the prevented event's damage recipient
+    ///    rather than dangling against a nonexistent parent target slot.
+    ///
+    /// 3. The rider count resolves to `QuantityRef::EventContextAmount` (the
+    ///    prevented amount), via the existing `for each 1 damage prevented
+    ///    this way` post-target suffix path.
+
+    #[test]
+    fn vigor_event_recipient_filter_and_counter_target_rewrite() {
+        let def = parse_replacement_line(
+            "If damage would be dealt to another creature you control, prevent that damage. \
+             Put a +1/+1 counter on that creature for each 1 damage prevented this way.",
+            "Vigor",
+        )
+        .expect("Vigor should parse as a damage prevention replacement");
+
+        // (1) valid_card recipient filter — Typed Creature, controller=You, Another.
+        let valid_card = def
+            .valid_card
+            .as_ref()
+            .expect("Vigor's recipient filter must survive the parser");
+        match valid_card {
+            TargetFilter::Typed(tf) => {
+                assert!(
+                    tf.type_filters.contains(&TypeFilter::Creature),
+                    "expected Creature type filter, got {:?}",
+                    tf.type_filters
+                );
+                assert_eq!(
+                    tf.controller,
+                    Some(ControllerRef::You),
+                    "expected controller=You, got {:?}",
+                    tf.controller
+                );
+                assert!(
+                    tf.properties.contains(&FilterProp::Another),
+                    "expected FilterProp::Another in {:?}",
+                    tf.properties
+                );
+            }
+            other => panic!("expected Typed recipient filter, got {other:?}"),
+        }
+
+        // (2) + (3) rider PutCounter targets the event recipient with
+        // EventContextAmount (driven by the per-1-damage repeat).
+        let execute = def.execute.as_ref().expect("execute present");
+        match &*execute.effect {
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target,
+            } => {
+                assert_eq!(*counter_type, CounterType::Plus1Plus1);
+                assert_eq!(*target, TargetFilter::PostReplacementDamageTarget);
+                let repeat_or_count_uses_event_amount = matches!(
+                    execute.repeat_for,
+                    Some(QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount
+                    })
+                ) || matches!(
+                    count,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount
+                    }
+                );
+                assert!(
+                    repeat_or_count_uses_event_amount,
+                    "expected either repeat_for or count to be EventContextAmount; got repeat_for={:?}, count={:?}",
+                    execute.repeat_for, count
+                );
+            }
+            other => panic!("expected Effect::PutCounter, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -5893,7 +5893,7 @@ mod tests {
         }
 
         // (2) + (3) rider PutCounter targets the event recipient with
-        // EventContextAmount (driven by the per-1-damage repeat).
+        // EventContextAmount on the `count` field.
         let execute = def.execute.as_ref().expect("execute present");
         match &*execute.effect {
             Effect::PutCounter {
@@ -5903,21 +5903,19 @@ mod tests {
             } => {
                 assert_eq!(*counter_type, CounterType::Plus1Plus1);
                 assert_eq!(*target, TargetFilter::PostReplacementDamageTarget);
-                let repeat_or_count_uses_event_amount = matches!(
-                    execute.repeat_for,
-                    Some(QuantityExpr::Ref {
-                        qty: QuantityRef::EventContextAmount
-                    })
-                ) || matches!(
-                    count,
-                    QuantityExpr::Ref {
-                        qty: QuantityRef::EventContextAmount
-                    }
-                );
+                // The suffix-form for-each ("... for each 1 damage prevented
+                // this way") lands the prevented amount on the PutCounter
+                // `count` field via `try_parse_for_each_effect`, so pin the
+                // exact field rather than accepting an either/or shape.
                 assert!(
-                    repeat_or_count_uses_event_amount,
-                    "expected either repeat_for or count to be EventContextAmount; got repeat_for={:?}, count={:?}",
-                    execute.repeat_for, count
+                    matches!(
+                        count,
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::EventContextAmount
+                        }
+                    ),
+                    "expected count to be EventContextAmount; got count={count:?}, repeat_for={:?}",
+                    execute.repeat_for
                 );
             }
             other => panic!("expected Effect::PutCounter, got {other:?}"),

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -95,6 +95,7 @@ mod tyvar_activate_as_though_haste;
 mod ureni_attack_trigger;
 mod urzas_saga_chapter_two;
 mod urzas_tower_conditional_mana;
+mod vigor_regression;
 mod virulent_emissary_trigger;
 mod volatile_fault_that_player_search;
 mod wedding_ring_etb_token_copy;

--- a/crates/engine/tests/integration/vigor_regression.rs
+++ b/crates/engine/tests/integration/vigor_regression.rs
@@ -1,0 +1,161 @@
+//! Vigor — damage prevention applies only to other creatures you control, and
+//! the +1/+1 counter rider uses the prevented event's recipient.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{ShieldKind, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::replacements::ReplacementEvent;
+const VIGOR_ORACLE: &str = "Trample\n\
+If damage would be dealt to another creature you control, prevent that damage. \
+Put a +1/+1 counter on that creature for each 1 damage prevented this way.";
+
+fn plus_one_counters(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .and_then(|obj| obj.counters.get(&CounterType::Plus1Plus1))
+        .copied()
+        .unwrap_or(0)
+}
+
+fn cast_bolt_at_creature(
+    runner: &mut engine::game::scenario::GameRunner,
+    bolt_id: ObjectId,
+    target: ObjectId,
+) {
+    let bolt_card_id = runner.state().objects[&bolt_id].card_id;
+    let result = runner
+        .act(GameAction::CastSpell {
+            object_id: bolt_id,
+            card_id: bolt_card_id,
+            targets: vec![],
+        })
+        .expect("cast bolt");
+    if matches!(result.waiting_for, WaitingFor::TargetSelection { .. }) {
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![engine::types::ability::TargetRef::Object(target)],
+            })
+            .expect("select creature target");
+    }
+    runner.advance_until_stack_empty();
+}
+
+#[test]
+fn vigor_does_not_prevent_damage_to_opponents_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Vigor", 6, 6, VIGOR_ORACLE);
+    let goblin = scenario.add_creature(P1, "Goblin", 1, 1).id();
+    let bolt = scenario.add_bolt_to_hand(P1);
+    scenario.with_mana_pool(
+        P1,
+        vec![ManaUnit::new(
+            ManaType::Red,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        )],
+    );
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+
+    cast_bolt_at_creature(&mut runner, bolt, goblin);
+
+    assert_eq!(
+        runner.state().objects[&goblin].damage_marked,
+        3,
+        "damage to an opponent's creature must not be prevented by Vigor"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, goblin),
+        0,
+        "Vigor must not put counters on a creature it did not protect"
+    );
+}
+
+#[test]
+fn vigor_prevents_damage_and_puts_counters_on_your_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let vigor = scenario
+        .add_creature_from_oracle(P0, "Vigor", 6, 6, VIGOR_ORACLE)
+        .id();
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let bolt = scenario.add_bolt_to_hand(P1);
+    scenario.with_mana_pool(
+        P1,
+        vec![ManaUnit::new(
+            ManaType::Red,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        )],
+    );
+
+    let mut runner = scenario.build();
+    let vigor_repl = runner
+        .state()
+        .objects
+        .get(&vigor)
+        .expect("Vigor must exist")
+        .replacement_definitions
+        .iter_unchecked()
+        .find(|r| r.event == ReplacementEvent::DamageDone)
+        .expect("Vigor should carry a damage prevention replacement");
+    assert!(matches!(
+        vigor_repl.shield_kind,
+        ShieldKind::Prevention { .. }
+    ));
+    if let TargetFilter::Typed(tf) = vigor_repl.valid_card.as_ref().expect("scoped recipient") {
+        assert!(tf
+            .type_filters
+            .contains(&engine::types::ability::TypeFilter::Creature));
+        assert!(tf
+            .properties
+            .contains(&engine::types::ability::FilterProp::Another));
+        assert_eq!(
+            tf.controller,
+            Some(engine::types::ability::ControllerRef::You)
+        );
+    } else {
+        panic!("expected typed valid_card on Vigor's prevention replacement");
+    }
+
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+
+    cast_bolt_at_creature(&mut runner, bolt, bear);
+
+    assert_eq!(
+        runner.state().objects[&bear].damage_marked,
+        0,
+        "damage to your other creature must be fully prevented"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, bear),
+        3,
+        "one +1/+1 counter per 1 damage prevented (CR 615.5)"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, vigor),
+        0,
+        "Vigor must not receive counters from protecting another creature"
+    );
+}


### PR DESCRIPTION
## Summary
Adds engine support for **Vigor** (#1417). Two parser bugs combined to break Vigor on both sides of its damage-prevention replacement: the recipient `valid_card` filter was silently dropped at the `", prevent"` clause boundary, and the rider's `"that creature"` anaphor dangled at runtime because passive replacements have no parent target slot. A third latent bug in the put-counter-for-each suffix path ignored the documented `inherits_parent` subject-application contract.

## Files changed
- crates/engine/src/parser/oracle_replacement.rs
- crates/engine/src/parser/oracle_effect/mod.rs

## CR references
- CR 614.1a — replacement-effect application
- CR 615.5 — damage prevention
- CR 608.2c — object anaphor resolution ("that creature")

## Track
Developer

## LLM
Model: Claude Opus 4.7
Thinking level: high

## Verification
- `cargo fmt --all -- --check` clean
- `cargo test -p engine` green, including the new `vigor_event_recipient_filter_and_counter_target_rewrite` unit test
- Sibling test `prevention_counter_followup_uses_prevented_amount_repeat` (Test of Faith, spell-driven `ParentTarget` path) still passes — the rewrite is correctly gated on `recipient_is_event_filter = valid_card_filter.is_some()`

## Scope Expansion
Fix #3 (honoring `SubjectApplication::inherits_parent` in the put-counter-for-each suffix path) is a class-wide latent fix beyond Vigor. It corrects at least 5 other cards (Dig Deep, Grave Strength, Mask of the Schemer, Raffine / Scheming Seer, Spymaster's Vault) that previously parsed `"that creature"` as a broad Typed filter. The fix follows the canonical contract already documented at `subject.rs:1100-1102`, so this is honoring an existing contract rather than introducing new infrastructure.

## Follow-up Notes
The recipient-terminator combinator change uses `peek(tag(", prevent"))` to keep the recipient filter bound through the same-sentence imperative shape. If future replacement clauses introduce a different post-recipient continuation (e.g. `", that damage is dealt to ..."`), the terminator alt list will need a corresponding peek arm — flagged here for the next reviewer touching `parse_damage_recipient_valid_card_filter`.