### PR TITLE
Fix Vigor prevention scope and counter follow-up

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4825,7 +4825,8 @@ fn damage_recipient_phrase_rest_complete(rest: &str) -> bool {
     if rest.is_empty() {
         return true;
     }
-    if rest.starts_with(',') {
+    // Comma may precede the prevention result without ending the string (Vigor).
+    if char::<_, OracleError<'_>>(',').parse(rest).is_ok() {
         return true;
     }
     all_consuming(alt((

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4810,10 +4810,43 @@ fn parse_damage_prevention_replacement(
         // avoids parser-context plumbing. Single building-block walker
         // (`each_target_filter_mut`) handles every target-bearing effect arm.
         rewrite_parent_target_controller_to_post_replacement_source(&mut followup_def);
+        rewrite_damage_recipient_to_post_replacement_target(&mut followup_def);
         def = def.execute(followup_def);
     }
 
     Some(def)
+}
+
+/// True when the text after a `dealt to <type phrase>` recipient ends the
+/// recipient description. Accepts a trailing comma before the prevention result
+/// ("dealt to another creature you control, prevent that damage" — Vigor).
+fn damage_recipient_phrase_rest_complete(rest: &str) -> bool {
+    let rest = rest.trim_start();
+    if rest.is_empty() {
+        return true;
+    }
+    if rest.starts_with(',') {
+        return true;
+    }
+    all_consuming(alt((
+        value((), tag::<_, _, OracleError<'_>>(".")),
+        value(
+            (),
+            terminated(
+                tag::<_, _, OracleError<'_>>("this turn"),
+                opt(tag::<_, _, OracleError<'_>>(".")),
+            ),
+        ),
+        value(
+            (),
+            terminated(
+                tag::<_, _, OracleError<'_>>("until end of turn"),
+                opt(tag::<_, _, OracleError<'_>>(".")),
+            ),
+        ),
+    )))
+    .parse(rest)
+    .is_ok()
 }
 
 fn parse_damage_recipient_valid_card_filter(working_lower: &str) -> Option<TargetFilter> {
@@ -4827,28 +4860,7 @@ fn parse_damage_recipient_valid_card_filter(working_lower: &str) -> Option<Targe
             )));
         }
 
-        let rest = rest.trim_start();
-        if all_consuming(alt((
-            value((), eof::<&str, OracleError<'_>>),
-            value((), tag::<_, _, OracleError<'_>>(".")),
-            value(
-                (),
-                terminated(
-                    tag::<_, _, OracleError<'_>>("this turn"),
-                    opt(tag::<_, _, OracleError<'_>>(".")),
-                ),
-            ),
-            value(
-                (),
-                terminated(
-                    tag::<_, _, OracleError<'_>>("until end of turn"),
-                    opt(tag::<_, _, OracleError<'_>>(".")),
-                ),
-            ),
-        )))
-        .parse(rest)
-        .is_ok()
-        {
+        if damage_recipient_phrase_rest_complete(rest) {
             Ok((rest, filter))
         } else {
             Err(nom::Err::Error(OracleError::new(
@@ -4886,6 +4898,12 @@ fn rewrite_parent_target_controller_to_post_replacement_source(def: &mut Ability
 /// Neither resolves correctly here (there is no parent target and no trigger
 /// event), so rewrite the anaphoric recipient to `PostReplacementDamageTarget`
 /// at the call site.
+fn is_unscoped_creature_typed_filter(tf: &TypedFilter) -> bool {
+    tf.type_filters == [TypeFilter::Creature]
+        && tf.controller.is_none()
+        && tf.properties.is_empty()
+}
+
 fn rewrite_damage_recipient_to_post_replacement_target(def: &mut AbilityDefinition) {
     super::oracle_effect::each_target_filter_mut(&mut def.effect, &mut |f| {
         if matches!(
@@ -4893,8 +4911,17 @@ fn rewrite_damage_recipient_to_post_replacement_target(def: &mut AbilityDefiniti
             TargetFilter::Player
                 | TargetFilter::TriggeringPlayer
                 | TargetFilter::ParentTargetController
+                | TargetFilter::TriggeringSource
         ) {
             *f = TargetFilter::PostReplacementDamageTarget;
+        } else if let TargetFilter::Typed(tf) = f {
+            // CR 615.5: "that creature" in a prevention follow-up (Vigor,
+            // Test of Faith) sometimes lowers to an unscoped Typed(Creature)
+            // when no trigger event is active. Bind it to the prevented
+            // damage recipient instead of any creature on the battlefield.
+            if is_unscoped_creature_typed_filter(tf) {
+                *f = TargetFilter::PostReplacementDamageTarget;
+            }
         }
     });
     if let Some(sub) = def.sub_ability.as_mut() {
@@ -5748,6 +5775,54 @@ mod tests {
                 target: TargetFilter::ParentTarget,
             } if *counter_type == CounterType::Plus1Plus1
         ));
+    }
+
+    #[test]
+    fn vigor_prevention_scopes_to_other_creatures_you_control() {
+        let def = parse_replacement_line(
+            "If damage would be dealt to another creature you control, prevent that damage. \
+             Put a +1/+1 counter on that creature for each 1 damage prevented this way.",
+            "Vigor",
+        )
+        .expect("Vigor prevention replacement should parse");
+
+        assert_eq!(def.event, ReplacementEvent::DamageDone);
+        assert_eq!(
+            def.shield_kind,
+            ShieldKind::Prevention {
+                amount: PreventionAmount::All
+            }
+        );
+        let valid = def
+            .valid_card
+            .as_ref()
+            .expect("recipient filter must be present");
+        if let TargetFilter::Typed(tf) = valid {
+            assert!(tf.type_filters.contains(&TypeFilter::Creature));
+            assert!(tf.properties.contains(&FilterProp::Another));
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+        } else {
+            panic!("expected Typed valid_card filter, got {valid:?}");
+        }
+
+        let execute = def.execute.as_ref().expect("counter follow-up present");
+        match &*execute.effect {
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target,
+            } => {
+                assert_eq!(*counter_type, CounterType::Plus1Plus1);
+                assert!(matches!(
+                    count,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount
+                    }
+                ));
+                assert_eq!(*target, TargetFilter::PostReplacementDamageTarget);
+            }
+            other => panic!("expected PutCounter follow-up, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -99,6 +99,7 @@ mod tyvar_activate_as_though_haste;
 mod ureni_attack_trigger;
 mod urzas_saga_chapter_two;
 mod urzas_tower_conditional_mana;
+mod vigor_regression;
 mod virulent_emissary_trigger;
 mod volatile_fault_that_player_search;
 mod wedding_ring_etb_token_copy;

--- a/crates/engine/tests/integration/vigor_regression.rs
+++ b/crates/engine/tests/integration/vigor_regression.rs
@@ -1,0 +1,154 @@
+//! Vigor — damage prevention applies only to other creatures you control, and
+//! the +1/+1 counter rider uses the prevented event's recipient.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{ShieldKind, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::replacements::ReplacementEvent;
+const VIGOR_ORACLE: &str = "Trample\n\
+If damage would be dealt to another creature you control, prevent that damage. \
+Put a +1/+1 counter on that creature for each 1 damage prevented this way.";
+
+fn plus_one_counters(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .and_then(|obj| obj.counters.get(&CounterType::Plus1Plus1))
+        .copied()
+        .unwrap_or(0)
+}
+
+fn cast_bolt_at_creature(
+    runner: &mut engine::game::scenario::GameRunner,
+    bolt_id: ObjectId,
+    target: ObjectId,
+) {
+    let bolt_card_id = runner.state().objects[&bolt_id].card_id;
+    let result = runner
+        .act(GameAction::CastSpell {
+            object_id: bolt_id,
+            card_id: bolt_card_id,
+            targets: vec![],
+        })
+        .expect("cast bolt");
+    if matches!(result.waiting_for, WaitingFor::TargetSelection { .. }) {
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![engine::types::ability::TargetRef::Object(target)],
+            })
+            .expect("select creature target");
+    }
+    runner.advance_until_stack_empty();
+}
+
+#[test]
+fn vigor_does_not_prevent_damage_to_opponents_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Vigor", 6, 6, VIGOR_ORACLE);
+    let goblin = scenario.add_creature(P1, "Goblin", 1, 1).id();
+    let bolt = scenario.add_bolt_to_hand(P1);
+    scenario.with_mana_pool(
+        P1,
+        vec![ManaUnit::new(
+            ManaType::Red,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        )],
+    );
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+
+    cast_bolt_at_creature(&mut runner, bolt, goblin);
+
+    assert_eq!(
+        runner.state().objects[&goblin].damage_marked,
+        3,
+        "damage to an opponent's creature must not be prevented by Vigor"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, goblin),
+        0,
+        "Vigor must not put counters on a creature it did not protect"
+    );
+}
+
+#[test]
+fn vigor_prevents_damage_and_puts_counters_on_your_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let vigor = scenario
+        .add_creature_from_oracle(P0, "Vigor", 6, 6, VIGOR_ORACLE)
+        .id();
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let bolt = scenario.add_bolt_to_hand(P1);
+    scenario.with_mana_pool(
+        P1,
+        vec![ManaUnit::new(
+            ManaType::Red,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        )],
+    );
+
+    let mut runner = scenario.build();
+    let vigor_repl = runner
+        .state()
+        .objects
+        .get(&vigor)
+        .expect("Vigor must exist")
+        .replacement_definitions
+        .iter_unchecked()
+        .find(|r| r.event == ReplacementEvent::DamageDone)
+        .expect("Vigor should carry a damage prevention replacement");
+    assert!(matches!(
+        vigor_repl.shield_kind,
+        ShieldKind::Prevention { .. }
+    ));
+    if let TargetFilter::Typed(tf) = vigor_repl.valid_card.as_ref().expect("scoped recipient") {
+        assert!(tf.type_filters.contains(&engine::types::ability::TypeFilter::Creature));
+        assert!(tf.properties.contains(&engine::types::ability::FilterProp::Another));
+        assert_eq!(tf.controller, Some(engine::types::ability::ControllerRef::You));
+    } else {
+        panic!("expected typed valid_card on Vigor's prevention replacement");
+    }
+
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+
+    cast_bolt_at_creature(&mut runner, bolt, bear);
+
+    assert_eq!(
+        runner.state().objects[&bear].damage_marked,
+        0,
+        "damage to your other creature must be fully prevented"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, bear),
+        3,
+        "one +1/+1 counter per 1 damage prevented (CR 615.5)"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, vigor),
+        0,
+        "Vigor must not receive counters from protecting another creature"
+    );
+}


### PR DESCRIPTION
## Summary
- Scope Vigor's damage prevention to other creatures you control via `valid_card`.
- Route the +1/+1 counter rider to the prevented damage recipient.
- Add parser and integration regression tests.
Fixes #1417
## Test plan
- [x] `cargo test -p engine vigor_prevention_scopes_to_other_creatures_you_control`
- [x] `cargo test -p engine --test integration vigor`