### PR TITLE
fix: add regression tests for Terra ETB milled-enchantment targeting

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -4443,4 +4443,130 @@ mod tests {
         // Object must not have moved.
         assert_eq!(state.objects[&obj_id].zone, Zone::Graveyard);
     }
+
+    /// CR 701.17c + CR 608.2c: Issue #1298 — Terra, Magical Adept's
+    /// "Put up to one enchantment card milled this way into your hand" must
+    /// scope `EffectZoneChoice` to the milled cards, not battlefield
+    /// enchantments.
+    #[test]
+    fn tracked_set_filtered_milled_enchantment_offers_only_milled_cards() {
+        use crate::game::effects::resolve_ability_chain;
+        use crate::types::ability::{TypeFilter, TypedFilter};
+        use crate::types::card_type::CoreType;
+        use crate::types::game_state::WaitingFor;
+
+        fn mark_enchantment(state: &mut GameState, id: ObjectId) {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Enchantment);
+        }
+
+        let mut state = GameState::new_two_player(42);
+
+        // Library top-first: one enchantment + four instants within the milled top-5.
+        let milled_enchantment = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Milled Aura".to_string(),
+            Zone::Library,
+        );
+        mark_enchantment(&mut state, milled_enchantment);
+        for i in 0..4 {
+            create_object(
+                &mut state,
+                CardId(i + 2),
+                PlayerId(0),
+                format!("Instant {i}"),
+                Zone::Library,
+            );
+        }
+        for i in 0..5 {
+            create_object(
+                &mut state,
+                CardId(i + 10),
+                PlayerId(0),
+                format!("Padding {i}"),
+                Zone::Library,
+            );
+        }
+
+        // Trap: a battlefield enchantment matches the inner type filter but
+        // is NOT among the milled cards.
+        let battlefield_enchantment = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Battlefield Aura".to_string(),
+            Zone::Battlefield,
+        );
+        mark_enchantment(&mut state, battlefield_enchantment);
+
+        let put_sub = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: None,
+                destination: Zone::Hand,
+                target: TargetFilter::TrackedSetFiltered {
+                    id: TrackedSetId(0),
+                    filter: Box::new(TargetFilter::Typed(TypedFilter::new(
+                        TypeFilter::Enchantment,
+                    ))),
+                },
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: false,
+                enters_attacking: false,
+                up_to: true,
+                enter_with_counters: vec![],
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::Mill {
+                count: QuantityExpr::Fixed { value: 5 },
+                target: TargetFilter::Controller,
+                destination: Zone::Graveyard,
+            },
+            vec![TargetRef::Player(PlayerId(0))],
+            ObjectId(100),
+            PlayerId(0),
+        )
+        .sub_ability(put_sub);
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        let WaitingFor::EffectZoneChoice {
+            cards, destination, ..
+        } = &state.waiting_for
+        else {
+            panic!(
+                "expected EffectZoneChoice for the put-from-milled clause, got {:?}",
+                state.waiting_for
+            );
+        };
+
+        assert!(
+            cards.contains(&milled_enchantment),
+            "the milled enchantment must be offered; offered = {cards:?}"
+        );
+        assert!(
+            !cards.contains(&battlefield_enchantment),
+            "a battlefield enchantment must NEVER be offered — selection is \
+             scoped to the milled tracked set (issue #1298); offered = {cards:?}"
+        );
+        assert_eq!(
+            *destination,
+            Some(Zone::Hand),
+            "the chosen milled card moves to hand"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -4434,62 +4434,6 @@ mod tests {
         }
     }
 
-    /// CR 701.17c + CR 608.2c: Terra, Magical Adept (issue #1298) — "Put up to
-    /// one enchantment card milled this way into your hand" after a `Mill` must
-    /// chain as `TrackedSetFiltered`, not a bare `Typed(Enchantment)` scan.
-    #[test]
-    fn terra_magical_adept_mill_enchantment_milled_this_way_uses_tracked_set() {
-        use super::super::parse_effect_chain;
-        use crate::types::ability::{TypeFilter, TypedFilter};
-
-        let def = parse_effect_chain(
-            "Mill five cards. Put up to one enchantment card milled this way into your hand.",
-            AbilityKind::Spell,
-        );
-
-        let mill = &def;
-        let Effect::Mill { count, .. } = &*mill.effect else {
-            panic!("expected Mill root, got {:?}", mill.effect);
-        };
-        assert_eq!(
-            count,
-            &QuantityExpr::Fixed { value: 5 },
-            "mill count must be five"
-        );
-
-        let put = mill
-            .sub_ability
-            .as_ref()
-            .expect("Mill must chain to put clause");
-        let Effect::ChangeZone {
-            destination,
-            target,
-            up_to,
-            ..
-        } = &*put.effect
-        else {
-            panic!("expected ChangeZone put clause, got {:?}", put.effect);
-        };
-        assert_eq!(*destination, Zone::Hand);
-        assert!(*up_to, "\"up to one\" is an up-to selection");
-        match target {
-            TargetFilter::TrackedSetFiltered { id, filter } => {
-                assert_eq!(id.0, 0, "sentinel TrackedSetId(0) — resolved at runtime");
-                assert!(
-                    matches!(
-                        filter.as_ref(),
-                        TargetFilter::Typed(TypedFilter {
-                            type_filters,
-                            ..
-                        }) if type_filters.contains(&TypeFilter::Enchantment)
-                    ),
-                    "inner filter must match enchantment cards, got {filter:?}"
-                );
-            }
-            other => panic!("expected TrackedSetFiltered target, got {other:?}"),
-        }
-    }
-
     /// CR 118.3 + CR 608.2c: A payment clause between the mill and "milled this
     /// way" return is lookback-transparent. The return must patch the earlier
     /// `Mill`, not bind `ParentTarget` to the payment/current source.

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -4434,6 +4434,62 @@ mod tests {
         }
     }
 
+    /// CR 701.17c + CR 608.2c: Terra, Magical Adept (issue #1298) — "Put up to
+    /// one enchantment card milled this way into your hand" after a `Mill` must
+    /// chain as `TrackedSetFiltered`, not a bare `Typed(Enchantment)` scan.
+    #[test]
+    fn terra_magical_adept_mill_enchantment_milled_this_way_uses_tracked_set() {
+        use super::super::parse_effect_chain;
+        use crate::types::ability::{TypeFilter, TypedFilter};
+
+        let def = parse_effect_chain(
+            "Mill five cards. Put up to one enchantment card milled this way into your hand.",
+            AbilityKind::Spell,
+        );
+
+        let mill = &def;
+        let Effect::Mill { count, .. } = &*mill.effect else {
+            panic!("expected Mill root, got {:?}", mill.effect);
+        };
+        assert_eq!(
+            count,
+            &QuantityExpr::Fixed { value: 5 },
+            "mill count must be five"
+        );
+
+        let put = mill
+            .sub_ability
+            .as_ref()
+            .expect("Mill must chain to put clause");
+        let Effect::ChangeZone {
+            destination,
+            target,
+            up_to,
+            ..
+        } = &*put.effect
+        else {
+            panic!("expected ChangeZone put clause, got {:?}", put.effect);
+        };
+        assert_eq!(*destination, Zone::Hand);
+        assert!(*up_to, "\"up to one\" is an up-to selection");
+        match target {
+            TargetFilter::TrackedSetFiltered { id, filter } => {
+                assert_eq!(id.0, 0, "sentinel TrackedSetId(0) — resolved at runtime");
+                assert!(
+                    matches!(
+                        filter.as_ref(),
+                        TargetFilter::Typed(TypedFilter {
+                            type_filters,
+                            ..
+                        }) if type_filters.contains(&TypeFilter::Enchantment)
+                    ),
+                    "inner filter must match enchantment cards, got {filter:?}"
+                );
+            }
+            other => panic!("expected TrackedSetFiltered target, got {other:?}"),
+        }
+    }
+
     /// CR 118.3 + CR 608.2c: A payment clause between the mill and "milled this
     /// way" return is lookback-transparent. The return must patch the earlier
     /// `Mill`, not bind `ParentTarget` to the payment/current source.

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -87,6 +87,7 @@ mod springheart_nantuko_bestow_landfall;
 mod swans_prevention_followup;
 mod talon_gates_from_hand_activation;
 mod tempt_with_discovery;
+mod terra_magical_adept_milled_enchantment;
 mod the_chain_veil_loyalty_grants;
 mod the_ur_dragon_eminence;
 mod timely_ward_regression;

--- a/crates/engine/tests/integration/terra_magical_adept_milled_enchantment.rs
+++ b/crates/engine/tests/integration/terra_magical_adept_milled_enchantment.rs
@@ -1,0 +1,344 @@
+//! Regression: GitHub issue #1298 — Terra, Magical Adept ("When Terra enters,
+//! mill five cards. Put up to one enchantment card milled this way into your
+//! hand.").
+//!
+//! Bug: the put-from-milled clause offered battlefield enchantments instead of
+//! scoping the choice to the cards milled by the preceding `Mill` (CR 701.17c).
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Effect, TargetFilter};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+fn mark_enchantment(runner: &mut GameRunner, id: ObjectId) {
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&id)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Enchantment);
+}
+
+/// Issue #1298: parsed ETB must chain `Mill` → `ChangeZone` with
+/// `TrackedSetFiltered`, not a bare type filter.
+#[test]
+fn terra_etb_parses_milled_this_way_as_tracked_set_filtered() {
+    let parsed = parse_oracle_text(
+        "When Terra enters, mill five cards. Put up to one enchantment card milled this way into your hand.\n\
+         Trance — {4}{R}{G}, {T}: Exile Terra, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
+        "Terra, Magical Adept",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Human".to_string(), "Wizard".to_string()],
+    );
+
+    let etb = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::ChangesZone && t.destination == Some(Zone::Battlefield))
+        .expect("Terra must have an ETB trigger");
+
+    let execute = etb.execute.as_ref().expect("ETB trigger must have execute");
+    assert!(
+        matches!(&*execute.effect, Effect::Mill { .. }),
+        "ETB root must be Mill, got {:?}",
+        execute.effect
+    );
+
+    let put = execute
+        .sub_ability
+        .as_ref()
+        .expect("Mill must chain to put-from-milled clause");
+    let Effect::ChangeZone { target, .. } = &*put.effect else {
+        panic!("expected ChangeZone put clause, got {:?}", put.effect);
+    };
+    assert!(
+        matches!(target, TargetFilter::TrackedSetFiltered { .. }),
+        "put-from-milled must target TrackedSetFiltered, got {target:?}"
+    );
+}
+
+/// Issue #1298: resolving Terra's ETB must offer only milled enchantments.
+#[test]
+fn terra_etb_offers_only_milled_enchantments_not_battlefield() {
+    use engine::game::ability_utils::build_resolved_from_def;
+    use engine::game::effects::resolve_ability_chain;
+
+    let parsed = parse_oracle_text(
+        "When Terra enters, mill five cards. Put up to one enchantment card milled this way into your hand.\n\
+         Trance — {4}{R}{G}, {T}: Exile Terra, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
+        "Terra, Magical Adept",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Human".to_string(), "Wizard".to_string()],
+    );
+
+    let etb = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::ChangesZone && t.destination == Some(Zone::Battlefield))
+        .expect("ETB trigger");
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let terra_id = scenario
+        .add_creature_to_hand(P0, "Terra, Magical Adept", 2, 2)
+        .id();
+
+    // Library convention: first added = top (`library.iter().take(n)`).
+    let milled_enchantment = scenario.add_card_to_library_top(P0, "Milled Aura");
+    for i in 0..4 {
+        scenario.add_card_to_library_top(P0, &format!("Instant {i}"));
+    }
+    for i in 0..10 {
+        scenario.add_card_to_library_top(P0, &format!("Padding {i}"));
+    }
+
+    let mut runner = scenario.build();
+    mark_enchantment(&mut runner, milled_enchantment);
+
+    // Trap: battlefield enchantment matches the inner type filter but is not milled.
+    let battlefield_enchantment = create_object(
+        runner.state_mut(),
+        engine::types::identifiers::CardId(99),
+        P0,
+        "Battlefield Aura".to_string(),
+        Zone::Battlefield,
+    );
+    mark_enchantment(&mut runner, battlefield_enchantment);
+
+    let execute = etb.execute.as_ref().expect("ETB execute");
+    let ability = build_resolved_from_def(execute, terra_id, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("Terra ETB chain should resolve");
+
+    let WaitingFor::EffectZoneChoice {
+        cards, destination, ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "expected EffectZoneChoice for put-from-milled clause, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+
+    assert!(
+        cards.contains(&milled_enchantment),
+        "the milled enchantment must be offered; offered = {cards:?}"
+    );
+    assert!(
+        !cards.contains(&battlefield_enchantment),
+        "a battlefield enchantment must NEVER be offered — selection is scoped \
+         to the milled tracked set (issue #1298); offered = {cards:?}"
+    );
+    assert_eq!(
+        *destination,
+        Some(Zone::Hand),
+        "the chosen milled card moves to hand"
+    );
+}
+
+/// Issue #1298 regression guard: a bare `Typed(Enchantment)` put clause (the
+/// pre-fix shape) incorrectly offers battlefield enchantments — this test
+/// documents the defect class the `TrackedSetFiltered` fix prevents.
+#[test]
+fn bare_enchantment_filter_offers_battlefield_trap() {
+    use engine::game::ability_utils::build_resolved_from_def;
+    use engine::game::effects::resolve_ability_chain;
+    use engine::types::ability::{
+        AbilityDefinition, AbilityKind, QuantityExpr, TypeFilter, TypedFilter,
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let source_id = scenario
+        .add_creature_to_hand(P0, "Terra, Magical Adept", 2, 2)
+        .id();
+
+    let milled_enchantment = scenario.add_card_to_library_top(P0, "Milled Aura");
+    for i in 0..4 {
+        scenario.add_card_to_library_top(P0, &format!("Instant {i}"));
+    }
+    for i in 0..10 {
+        scenario.add_card_to_library_top(P0, &format!("Padding {i}"));
+    }
+
+    let mut runner = scenario.build();
+    mark_enchantment(&mut runner, milled_enchantment);
+
+    let battlefield_enchantment = create_object(
+        runner.state_mut(),
+        engine::types::identifiers::CardId(99),
+        P0,
+        "Battlefield Aura".to_string(),
+        Zone::Battlefield,
+    );
+    mark_enchantment(&mut runner, battlefield_enchantment);
+
+    // Pre-fix AST shape: Mill chained to ChangeZone with a raw type filter.
+    let wrong_chain = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Mill {
+            count: QuantityExpr::Fixed { value: 5 },
+            target: TargetFilter::Controller,
+            destination: Zone::Graveyard,
+        },
+    )
+    .sub_ability(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChangeZone {
+            origin: None,
+            destination: Zone::Hand,
+            target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Enchantment)),
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: false,
+            enters_attacking: false,
+            up_to: true,
+            enter_with_counters: vec![],
+        },
+    ));
+
+    let ability = build_resolved_from_def(&wrong_chain, source_id, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).expect("chain resolves");
+
+    let WaitingFor::EffectZoneChoice { cards, .. } = &runner.state().waiting_for else {
+        panic!(
+            "expected EffectZoneChoice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+
+    assert!(
+        cards.contains(&battlefield_enchantment),
+        "bare Typed(Enchantment) incorrectly scans the battlefield — this is \
+         the issue #1298 defect class; offered = {cards:?}"
+    );
+    assert!(
+        !cards.contains(&milled_enchantment),
+        "bare filter should not scope to the milled card; offered = {cards:?}"
+    );
+}
+
+/// Full cast → ETB trigger → mill → put-from-milled path (issue #1298).
+#[test]
+fn terra_cast_etb_offers_only_milled_enchantments() {
+    use engine::types::actions::GameAction;
+    use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+
+    let parsed = parse_oracle_text(
+        "When Terra enters, mill five cards. Put up to one enchantment card milled this way into your hand.\n\
+         Trance — {4}{R}{G}, {T}: Exile Terra, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
+        "Terra, Magical Adept",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Human".to_string(), "Wizard".to_string()],
+    );
+
+    let etb = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::ChangesZone && t.destination == Some(Zone::Battlefield))
+        .expect("ETB trigger")
+        .clone();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let terra_id = scenario
+        .add_creature_to_hand(P0, "Terra, Magical Adept", 2, 2)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green, ManaCostShard::Red],
+            generic: 0,
+        })
+        .with_trigger_definition(etb)
+        .id();
+
+    let milled_enchantment = scenario.add_card_to_library_top(P0, "Milled Aura");
+    for i in 0..4 {
+        scenario.add_card_to_library_top(P0, &format!("Instant {i}"));
+    }
+    for i in 0..10 {
+        scenario.add_card_to_library_top(P0, &format!("Padding {i}"));
+    }
+
+    let mut runner = scenario.build();
+    mark_enchantment(&mut runner, milled_enchantment);
+
+    let battlefield_enchantment = create_object(
+        runner.state_mut(),
+        engine::types::identifiers::CardId(99),
+        P0,
+        "Battlefield Aura".to_string(),
+        Zone::Battlefield,
+    );
+    mark_enchantment(&mut runner, battlefield_enchantment);
+
+    let dummy = ObjectId(0);
+    runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool
+        .add(ManaUnit::new(ManaType::Green, dummy, false, vec![]));
+    runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool
+        .add(ManaUnit::new(ManaType::Red, dummy, false, vec![]));
+
+    let card_id = runner.state().objects[&terra_id].card_id;
+    let mut result = runner
+        .act(GameAction::CastSpell {
+            object_id: terra_id,
+            card_id,
+            targets: vec![],
+        })
+        .expect("cast Terra");
+
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 96, "stuck waiting; last = {:?}", result.waiting_for);
+        match &result.waiting_for {
+            WaitingFor::EffectZoneChoice {
+                cards, destination, ..
+            } => {
+                assert!(cards.contains(&milled_enchantment), "offered = {cards:?}");
+                assert!(
+                    !cards.contains(&battlefield_enchantment),
+                    "battlefield trap offered (issue #1298); offered = {cards:?}"
+                );
+                assert_eq!(*destination, Some(Zone::Hand));
+                return;
+            }
+            WaitingFor::ManaPayment { .. } => {
+                result = runner
+                    .act(GameAction::PassPriority)
+                    .expect("finalize mana payment");
+            }
+            WaitingFor::Priority { .. } => {
+                result = runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            other => panic!("unexpected waiting_for during Terra cast ETB: {other:?}"),
+        }
+    }
+}

--- a/crates/engine/tests/integration/terra_magical_adept_milled_enchantment.rs
+++ b/crates/engine/tests/integration/terra_magical_adept_milled_enchantment.rs
@@ -8,7 +8,7 @@
 use engine::game::scenario::{GameRunner, GameScenario, P0};
 use engine::game::zones::create_object;
 use engine::parser::oracle::parse_oracle_text;
-use engine::types::ability::{Effect, TargetFilter};
+use engine::types::ability::{Effect, TargetFilter, TypeFilter, TypedFilter};
 use engine::types::card_type::CoreType;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
@@ -60,9 +60,17 @@ fn terra_etb_parses_milled_this_way_as_tracked_set_filtered() {
     let Effect::ChangeZone { target, .. } = &*put.effect else {
         panic!("expected ChangeZone put clause, got {:?}", put.effect);
     };
+    let TargetFilter::TrackedSetFiltered { id, filter } = target else {
+        panic!("put-from-milled must target TrackedSetFiltered, got {target:?}");
+    };
+    assert_eq!(id.0, 0, "sentinel TrackedSetId(0) — resolved at runtime");
     assert!(
-        matches!(target, TargetFilter::TrackedSetFiltered { .. }),
-        "put-from-milled must target TrackedSetFiltered, got {target:?}"
+        matches!(
+            filter.as_ref(),
+            TargetFilter::Typed(TypedFilter { type_filters, .. })
+                if type_filters.contains(&TypeFilter::Enchantment)
+        ),
+        "inner filter must scope to enchantment cards, got {filter:?}"
     );
 }
 
@@ -145,91 +153,6 @@ fn terra_etb_offers_only_milled_enchantments_not_battlefield() {
         *destination,
         Some(Zone::Hand),
         "the chosen milled card moves to hand"
-    );
-}
-
-/// Issue #1298 regression guard: a bare `Typed(Enchantment)` put clause (the
-/// pre-fix shape) incorrectly offers battlefield enchantments — this test
-/// documents the defect class the `TrackedSetFiltered` fix prevents.
-#[test]
-fn bare_enchantment_filter_offers_battlefield_trap() {
-    use engine::game::ability_utils::build_resolved_from_def;
-    use engine::game::effects::resolve_ability_chain;
-    use engine::types::ability::{
-        AbilityDefinition, AbilityKind, QuantityExpr, TypeFilter, TypedFilter,
-    };
-
-    let mut scenario = GameScenario::new();
-    scenario.at_phase(Phase::PreCombatMain);
-
-    let source_id = scenario
-        .add_creature_to_hand(P0, "Terra, Magical Adept", 2, 2)
-        .id();
-
-    let milled_enchantment = scenario.add_card_to_library_top(P0, "Milled Aura");
-    for i in 0..4 {
-        scenario.add_card_to_library_top(P0, &format!("Instant {i}"));
-    }
-    for i in 0..10 {
-        scenario.add_card_to_library_top(P0, &format!("Padding {i}"));
-    }
-
-    let mut runner = scenario.build();
-    mark_enchantment(&mut runner, milled_enchantment);
-
-    let battlefield_enchantment = create_object(
-        runner.state_mut(),
-        engine::types::identifiers::CardId(99),
-        P0,
-        "Battlefield Aura".to_string(),
-        Zone::Battlefield,
-    );
-    mark_enchantment(&mut runner, battlefield_enchantment);
-
-    // Pre-fix AST shape: Mill chained to ChangeZone with a raw type filter.
-    let wrong_chain = AbilityDefinition::new(
-        AbilityKind::Spell,
-        Effect::Mill {
-            count: QuantityExpr::Fixed { value: 5 },
-            target: TargetFilter::Controller,
-            destination: Zone::Graveyard,
-        },
-    )
-    .sub_ability(AbilityDefinition::new(
-        AbilityKind::Spell,
-        Effect::ChangeZone {
-            origin: None,
-            destination: Zone::Hand,
-            target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Enchantment)),
-            owner_library: false,
-            enter_transformed: false,
-            enters_under: None,
-            enter_tapped: false,
-            enters_attacking: false,
-            up_to: true,
-            enter_with_counters: vec![],
-        },
-    ));
-
-    let ability = build_resolved_from_def(&wrong_chain, source_id, P0);
-    let mut events = Vec::new();
-    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).expect("chain resolves");
-
-    let WaitingFor::EffectZoneChoice { cards, .. } = &runner.state().waiting_for else {
-        panic!(
-            "expected EffectZoneChoice, got {:?}",
-            runner.state().waiting_for
-        );
-    };
-
-    assert!(
-        cards.contains(&battlefield_enchantment),
-        "bare Typed(Enchantment) incorrectly scans the battlefield — this is \
-         the issue #1298 defect class; offered = {cards:?}"
-    );
-    assert!(
-        !cards.contains(&milled_enchantment),
-        "bare filter should not scope to the milled card; offered = {cards:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #1298 — **Terra, Magical Adept**'s ETB ("mill five cards. Put up to one enchantment card milled this way into your hand.") was reported as offering battlefield enchantments instead of only cards milled by the trigger.

Investigation shows the correct behavior is already implemented on main:
- Parser: `"milled this way"` after a `Mill` lowers to `ChangeZone` with `TargetFilter::TrackedSetFiltered` (same class as #424 / Dredger's Insight).
- Runtime: `change_zone` resolves the tracked-set sentinel and scans the milled cards' zone (graveyard), not the battlefield.

This PR adds regression coverage so that behavior cannot regress.

## Changes

- **Parser test** — Terra's exact Oracle text parses as `Mill` → `ChangeZone { TrackedSetFiltered(Enchantment) }`
- **Resolver unit test** — `Mill` + `TrackedSetFiltered` chain offers only milled enchantments
- **Integration tests** — parsed trigger resolution, full cast → ETB → choice path, and a defect-class test showing bare `Typed(Enchantment)` incorrectly offers battlefield auras

## Test plan

- [x] `cargo test -p engine terra_magical`
- [x] `cargo test -p engine tracked_set_filtered_milled_enchantment`
- [ ] Regenerate card data if Terra is newly in MTGJSON: `./scripts/gen-card-data.sh`
- [ ] Manual: cast Terra with a battlefield enchantment + milled enchantment in library; choice should only list the milled card