### PR TITLE
Fix The Scarab God X count and copy tokens

### DIFF
--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -474,23 +474,30 @@ fn apply_token_modifications(
                     token.base_card_types.subtypes.retain(|s| s != subtype);
                 }
             }
+            // CR 707.9b: Copy exceptions that modify subtypes become copiable
+            // values of the token copy.
             ContinuousModification::RemoveAllSubtypes { set } => {
-                let all_creature_types = state.all_creature_types.clone();
-                if let Some(token) = state.objects.get_mut(&token_id) {
-                    remove_subtype_set(&mut token.card_types.subtypes, *set, &all_creature_types);
+                let all_creature_types = &state.all_creature_types;
+                let objects = &mut state.objects;
+                if let Some(token) = objects.get_mut(&token_id) {
+                    remove_subtype_set(&mut token.card_types.subtypes, *set, all_creature_types);
                     remove_subtype_set(
                         &mut token.base_card_types.subtypes,
                         *set,
-                        &all_creature_types,
+                        all_creature_types,
                     );
                 }
             }
+            // CR 707.9b: Copy exceptions that set color become copiable values
+            // of the token copy.
             ContinuousModification::SetColor { colors } => {
                 if let Some(token) = state.objects.get_mut(&token_id) {
                     token.color = colors.clone();
                     token.base_color = colors.clone();
                 }
             }
+            // CR 707.9b: Copy exceptions that add color become copiable values
+            // of the token copy.
             ContinuousModification::AddColor { color } => {
                 if let Some(token) = state.objects.get_mut(&token_id) {
                     if !token.color.contains(color) {

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -6,6 +6,7 @@ use crate::types::ability::{
     ContinuousModification, Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter,
     TargetRef,
 };
+use crate::types::card_type::SubtypeSet;
 #[cfg(test)]
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
@@ -473,6 +474,33 @@ fn apply_token_modifications(
                     token.base_card_types.subtypes.retain(|s| s != subtype);
                 }
             }
+            ContinuousModification::RemoveAllSubtypes { set } => {
+                let all_creature_types = state.all_creature_types.clone();
+                if let Some(token) = state.objects.get_mut(&token_id) {
+                    remove_subtype_set(&mut token.card_types.subtypes, *set, &all_creature_types);
+                    remove_subtype_set(
+                        &mut token.base_card_types.subtypes,
+                        *set,
+                        &all_creature_types,
+                    );
+                }
+            }
+            ContinuousModification::SetColor { colors } => {
+                if let Some(token) = state.objects.get_mut(&token_id) {
+                    token.color = colors.clone();
+                    token.base_color = colors.clone();
+                }
+            }
+            ContinuousModification::AddColor { color } => {
+                if let Some(token) = state.objects.get_mut(&token_id) {
+                    if !token.color.contains(color) {
+                        token.color.push(*color);
+                    }
+                    if !token.base_color.contains(color) {
+                        token.base_color.push(*color);
+                    }
+                }
+            }
             // CR 707.9b: "except it's 1/1" — set base and live P/T so the
             // override persists through layer resets. Used by Offspring
             // (CR 702.175a) and Saw in Half.
@@ -536,6 +564,32 @@ fn apply_token_modifications(
             // future except body needing them should route through the
             // BecomeCopy layered path instead.
             _ => {}
+        }
+    }
+}
+
+fn remove_subtype_set(subtypes: &mut Vec<String>, set: SubtypeSet, all_creature_types: &[String]) {
+    match set {
+        SubtypeSet::Creature => {
+            subtypes.retain(|s| {
+                !all_creature_types
+                    .iter()
+                    .any(|creature_type| creature_type == s)
+            });
+        }
+        SubtypeSet::Land => subtypes.retain(|s| !crate::types::card_type::is_land_subtype(s)),
+        SubtypeSet::Artifact => {
+            subtypes.retain(|s| !crate::types::card_type::ARTIFACT_SUBTYPES.contains(&s.as_str()))
+        }
+        SubtypeSet::Enchantment => subtypes
+            .retain(|s| !crate::types::card_type::ENCHANTMENT_SUBTYPES.contains(&s.as_str())),
+        SubtypeSet::Planeswalker => subtypes
+            .retain(|s| !crate::types::card_type::PLANESWALKER_SUBTYPES.contains(&s.as_str())),
+        SubtypeSet::Spell => {
+            subtypes.retain(|s| !crate::types::card_type::SPELL_SUBTYPES.contains(&s.as_str()));
+        }
+        SubtypeSet::Battle => {
+            subtypes.retain(|s| !crate::types::card_type::BATTLE_SUBTYPES.contains(&s.as_str()));
         }
     }
 }
@@ -742,6 +796,96 @@ mod tests {
         assert_eq!(token.power, Some(2));
         assert_eq!(token.toughness, Some(2));
         assert!(token.is_token);
+    }
+
+    #[test]
+    fn copy_token_exceptions_stamp_pt_color_and_subtype() {
+        let mut state = GameState::new_two_player(42);
+        state.all_creature_types = vec![
+            "Human".to_string(),
+            "Soldier".to_string(),
+            "Zombie".to_string(),
+        ];
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Elite Vanguard".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let source = state.objects.get_mut(&source_id).unwrap();
+            source.base_power = Some(2);
+            source.base_toughness = Some(1);
+            source.power = Some(2);
+            source.toughness = Some(1);
+            source.base_color = vec![ManaColor::White];
+            source.color = vec![ManaColor::White];
+            source.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec!["Human".to_string(), "Soldier".to_string()],
+            };
+            source.card_types = source.base_card_types.clone();
+        }
+
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::SelfRef,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![
+                    ContinuousModification::SetPower { value: 4 },
+                    ContinuousModification::SetToughness { value: 4 },
+                    ContinuousModification::SetColor {
+                        colors: vec![ManaColor::Black],
+                    },
+                    ContinuousModification::RemoveAllSubtypes {
+                        set: SubtypeSet::Creature,
+                    },
+                    ContinuousModification::AddType {
+                        core_type: CoreType::Creature,
+                    },
+                    ContinuousModification::AddSubtype {
+                        subtype: "Zombie".to_string(),
+                    },
+                ],
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let token_id = ObjectId(state.next_object_id - 1);
+        let token = state.objects.get(&token_id).unwrap();
+        assert_eq!(token.power, Some(4));
+        assert_eq!(token.toughness, Some(4));
+        assert_eq!(token.color, vec![ManaColor::Black]);
+        assert!(token.card_types.subtypes.contains(&"Zombie".to_string()));
+        assert!(!token.card_types.subtypes.contains(&"Human".to_string()));
+        assert!(!token.card_types.subtypes.contains(&"Soldier".to_string()));
+        assert_eq!(token.base_power, Some(4));
+        assert_eq!(token.base_toughness, Some(4));
+        assert_eq!(token.base_color, vec![ManaColor::Black]);
+        assert!(token
+            .base_card_types
+            .subtypes
+            .contains(&"Zombie".to_string()));
+        assert!(!token
+            .base_card_types
+            .subtypes
+            .contains(&"Human".to_string()));
+        assert!(!token
+            .base_card_types
+            .subtypes
+            .contains(&"Soldier".to_string()));
     }
 
     /// CR 109.4 + CR 111.2: "target opponent creates a token that's a copy of

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -391,6 +391,8 @@ fn parse_subject_pt_and_types(input: &str) -> Option<(&str, Vec<ContinuousModifi
     Some((rest, mods))
 }
 
+/// CR 707.9b: Copy exceptions that modify color or subtype become copiable
+/// values of the copy.
 fn append_color_and_type_modifications(
     type_text: &str,
     replace_creature_subtypes: bool,

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -76,7 +76,7 @@ use crate::parser::oracle_ir::context::ParseContext;
 use crate::types::ability::{
     ContinuousModification, ObjectScope, QuantityExpr, QuantityRef, RoundingMode,
 };
-use crate::types::card_type::{CoreType, Supertype};
+use crate::types::card_type::{noncreature_subtype_set, CoreType, SubtypeSet, Supertype};
 
 /// CR 707.9a: "[,] except {except_body} [and {except_body}]*[.]"
 ///
@@ -340,14 +340,14 @@ fn parse_rounding_sentence(input: &str) -> Option<(&str, RoundingMode)> {
     rounding.map(|(_, rounding, _)| (rest, rounding))
 }
 
-/// CR 707.9b: "<subject> N/M {type list} in addition to its other types" where
+/// CR 707.9b: "<subject> N/M {type list} [in addition to its other types]" where
 /// the subject is a pronoun-contraction ("he's" / "she's" / "it's" with either
 /// straight or curly apostrophes). Produces `SetPower` + `SetToughness`
 /// (overriding the copied P/T per CR 707.9b) and one `AddType`/`AddSubtype`
-/// per word in the type list. Layer placement is automatic from the variants'
-/// own `layer()` methods: SetPT at layer 7b, type additions at layer 4
-/// (CR 613.1d) — the layer system applies type additions after the copy's
-/// own types via timestamp order.
+/// per word in the type list. Color words produce `SetColor` so clauses like
+/// "it's a 4/4 black Zombie" stamp color alongside the P/T and subtype.
+/// Layer placement is automatic from the variants' own `layer()` methods:
+/// SetPT at layer 7b, color at layer 5, type additions at layer 4 (CR 613.1d).
 fn parse_subject_pt_and_types(input: &str) -> Option<(&str, Vec<ContinuousModification>)> {
     let (rest, _) = alt((
         tag::<_, _, OracleError<'_>>("he's a "),
@@ -364,37 +364,79 @@ fn parse_subject_pt_and_types(input: &str) -> Option<(&str, Vec<ContinuousModifi
     let (rest, (power, toughness)) = parse_pt_pair(rest)?;
     let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest).ok()?;
 
-    // Grab the type list up to " in addition to its/his/her other types".
-    let (type_text, rest) = split_on_first_of(
+    // Grab the characteristic words. The older Spark Double / Superior
+    // Spider-Man shape has an explicit "in addition to its other types" tail;
+    // The Scarab God shape terminates at the body/sentence boundary instead.
+    let (type_text, rest, in_addition) = if let Some((type_text, rest)) = split_on_first_of(
         rest,
         &[
             " in addition to its other types",
             " in addition to his other types",
             " in addition to her other types",
         ],
-    )?;
+    ) {
+        (type_text, rest, true)
+    } else {
+        let (type_text, rest) = split_at_body_boundary(rest);
+        (type_text, rest, false)
+    };
 
     let mut mods = vec![
         ContinuousModification::SetPower { value: power },
         ContinuousModification::SetToughness { value: toughness },
     ];
 
-    // Type list is space-separated in the copy class ("Spider Human Hero").
-    // Reuse the shared core-type vs subtype dispatch from parse_its_a_type_in_addition.
+    append_color_and_type_modifications(type_text, !in_addition, &mut mods);
+
+    Some((rest, mods))
+}
+
+fn append_color_and_type_modifications(
+    type_text: &str,
+    replace_creature_subtypes: bool,
+    mods: &mut Vec<ContinuousModification>,
+) {
+    let mut colors = Vec::new();
+    let mut type_mods = Vec::new();
+    let mut has_exact_creature_subtype = false;
     for word in type_text.split_whitespace() {
-        if word.is_empty() {
+        if word.is_empty() || word == "and" {
             continue;
+        }
+        if let Ok((rest, color)) = nom_primitives::parse_color(word) {
+            if rest.is_empty() {
+                if !colors.contains(&color) {
+                    colors.push(color);
+                }
+                continue;
+            }
         }
         let canonical = canonicalize_subtype_name(word);
         let modification = if let Ok(core_type) = CoreType::from_str(&canonical) {
             ContinuousModification::AddType { core_type }
         } else {
+            if noncreature_subtype_set(&canonical).is_none() {
+                has_exact_creature_subtype = true;
+            }
             ContinuousModification::AddSubtype { subtype: canonical }
         };
-        mods.push(modification);
+        type_mods.push(modification);
     }
-
-    Some((rest, mods))
+    if !colors.is_empty() {
+        mods.push(ContinuousModification::SetColor { colors });
+    }
+    if replace_creature_subtypes && has_exact_creature_subtype {
+        type_mods.insert(
+            0,
+            ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            },
+        );
+        mods.push(ContinuousModification::RemoveAllSubtypes {
+            set: SubtypeSet::Creature,
+        });
+    }
+    mods.extend(type_mods);
 }
 
 /// CR 707.9a: "<subject pronoun> has this ability" — emit a
@@ -821,6 +863,7 @@ mod tests {
     use super::*;
     use crate::types::ability::{ObjectScope, QuantityRef, RoundingMode};
     use crate::types::keywords::Keyword;
+    use crate::types::mana::ManaColor;
 
     #[test]
     fn name_override_emits_set_name() {
@@ -1308,6 +1351,62 @@ mod tests {
                 ContinuousModification::AddSubtype { subtype } if subtype == "Hero"
             )),
             "missing AddSubtype(Hero); got {mods:?}"
+        );
+    }
+
+    /// CR 707.9b: The Scarab God class uses a compact exception with P/T,
+    /// color, and subtype but no "in addition to its other types" suffix.
+    /// Each characteristic still becomes part of the copy token's copiable
+    /// values.
+    #[test]
+    fn compact_pt_color_subtype_exception_sets_all_characteristics() {
+        let (_, mods) = parse_except_clause(
+            ", except it's a 4/4 black zombie",
+            "Card",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert!(
+            mods.iter()
+                .any(|m| matches!(m, ContinuousModification::SetPower { value: 4 })),
+            "missing SetPower(4); got {mods:?}"
+        );
+        assert!(
+            mods.iter()
+                .any(|m| matches!(m, ContinuousModification::SetToughness { value: 4 })),
+            "missing SetToughness(4); got {mods:?}"
+        );
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::SetColor { colors } if colors == &vec![ManaColor::Black]
+            )),
+            "missing SetColor(Black); got {mods:?}"
+        );
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::RemoveAllSubtypes {
+                    set: SubtypeSet::Creature
+                }
+            )),
+            "missing RemoveAllSubtypes(Creature); got {mods:?}"
+        );
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddType {
+                    core_type: CoreType::Creature
+                }
+            )),
+            "missing AddType(Creature); got {mods:?}"
+        );
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddSubtype { subtype } if subtype == "Zombie"
+            )),
+            "missing AddSubtype(Zombie); got {mods:?}"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17698,6 +17698,7 @@ fn apply_where_x_effect_expression(effect: &mut Effect, where_x_expression: Opti
         | Effect::LoseLife { amount, .. }
         | Effect::ChangeSpeed { amount, .. }
         | Effect::Draw { count: amount, .. }
+        | Effect::Scry { count: amount, .. }
         | Effect::Mill { count: amount, .. }
         | Effect::PutCounter { count: amount, .. }
         | Effect::PutCounterAll { count: amount, .. }
@@ -19925,6 +19926,33 @@ mod tests {
                 other => panic!("expected GainLife Aggregate, got {other:?}"),
             },
             other => panic!("expected GainLife, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn where_x_binds_scry_sub_ability_count() {
+        let def = parse_effect_chain(
+            "Each opponent loses X life and you scry X, where X is the number of Zombies you control.",
+            AbilityKind::Spell,
+        );
+        match &*def.effect {
+            Effect::LoseLife { amount, .. } => match amount {
+                QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                } => assert!(matches!(filter, TargetFilter::Typed(_))),
+                other => panic!("expected LoseLife ObjectCount, got {other:?}"),
+            },
+            other => panic!("expected LoseLife, got {other:?}"),
+        }
+        let sub = def.sub_ability.as_ref().expect("scry sub-ability");
+        match &*sub.effect {
+            Effect::Scry { count, .. } => match count {
+                QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                } => assert!(matches!(filter, TargetFilter::Typed(_))),
+                other => panic!("expected Scry ObjectCount, got {other:?}"),
+            },
+            other => panic!("expected Scry, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -1075,6 +1075,52 @@ mod tests {
     }
 
     #[test]
+    fn copy_token_exception_compact_pt_color_subtype() {
+        let effect = try_parse_token(
+            "create a token that's a copy of it, except it's a 4/4 black zombie",
+            "Create a token that's a copy of it, except it's a 4/4 black Zombie",
+            &mut ParseContext::default(),
+        )
+        .expect("expected CopyTokenOf");
+        let Effect::CopyTokenOf {
+            target,
+            additional_modifications,
+            ..
+        } = effect
+        else {
+            panic!("expected CopyTokenOf, got {effect:?}");
+        };
+        assert_eq!(target, TargetFilter::ParentTarget);
+        assert!(additional_modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetPower { value: 4 })));
+        assert!(additional_modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetToughness { value: 4 })));
+        assert!(additional_modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::SetColor { colors }
+                if colors == &vec![ManaColor::Black]
+        )));
+        assert!(additional_modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::RemoveAllSubtypes {
+                set: crate::types::card_type::SubtypeSet::Creature
+            }
+        )));
+        assert!(additional_modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddType {
+                core_type: CoreType::Creature
+            }
+        )));
+        assert!(additional_modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddSubtype { subtype } if subtype == "Zombie"
+        )));
+    }
+
+    #[test]
     fn copy_token_half_pt_exception_emits_dynamic_modifications() {
         let effect = try_parse_token(
             "create two tokens that are copies of that creature, except their power is half that creature's power and their toughness is half that creature's toughness. round up each time",


### PR DESCRIPTION
## Summary
Fixes The Scarab God issue #1424.

## Files changed
- crates/engine/src/game/effects/token_copy.rs
- crates/engine/src/parser/oracle_effect/become_copy_except.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/parser/oracle_effect/token.rs

## CR references
- CR 707.9b
- CR 613.1d

## Track
Developer

## LLM
Model: codex-gpt-5
Thinking: high
Tier: Standard

## Anchored on
- crates/engine/src/game/effects/token_copy.rs:445 - existing copy-token characteristic modifications stamp type changes onto both live and base token values.
- crates/engine/src/parser/oracle_effect/become_copy_except.rs:343 - existing CR 707.9b P/T-plus-type exception parser for copy effects.
- crates/engine/src/parser/oracle_effect/mod.rs:17692 - existing `where X is ...` dynamic quantity substitution across effect count/amount fields.

## Gate A
`./scripts/check-parser-combinators.sh` exited 0.

```text
```

## Verification
- `cargo fmt --all` - clean
- `./scripts/check-parser-combinators.sh` - clean
- `cargo clippy --all-targets -- -D warnings` - clean
- `cargo test -p engine` - 9077 unit tests and 475 integration tests passed, 0 failed
- `./scripts/gen-card-data.sh` - clean
- The Scarab God export check - 0 Unimplemented ability entries, 0 Unknown triggers; upkeep loss and scry both use Zombie-count X, and the copy-token exception exports 4/4 black Zombie modifications

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
