### PR TITLE
fix(parser): parse "that player controls more … than you" for phase triggers

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -6566,6 +6566,77 @@ pub mod tests {
         );
     }
 
+    /// Issue #1304 — RUNTIME: Keeper of the Accord's intervening-if must compare
+    /// the active player's creatures to the source controller's at opponent end
+    /// step, not fail closed because the condition was never hoisted/parsed.
+    #[test]
+    fn keeper_of_the_accord_creature_intervening_if_true_when_opponent_ahead() {
+        let def = crate::parser::oracle_trigger::parse_trigger_line(
+            "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.",
+            "Keeper of the Accord",
+        );
+        let condition = def
+            .condition
+            .expect("creature trigger must hoist intervening-if to def.condition");
+
+        let mut state = GameState::new_two_player(42);
+        let controller = PlayerId(0);
+        let opponent = PlayerId(1);
+        state.active_player = opponent;
+
+        let keeper = make_creature(&mut state, controller, "Keeper of the Accord", 3, 4);
+        let _opp_creature_a = make_creature(&mut state, opponent, "Opp A", 1, 1);
+        let _opp_creature_b = make_creature(&mut state, opponent, "Opp B", 1, 1);
+        let _opp_creature_c = make_creature(&mut state, opponent, "Opp C", 1, 1);
+
+        let phase_event = GameEvent::PhaseChanged {
+            phase: crate::types::phase::Phase::End,
+        };
+        assert!(
+            check_trigger_condition(
+                &state,
+                &condition,
+                controller,
+                Some(keeper),
+                Some(&phase_event),
+            ),
+            "opponent with three creatures vs controller with one (keeper) must satisfy intervening-if",
+        );
+    }
+
+    #[test]
+    fn keeper_of_the_accord_creature_intervening_if_false_when_tied() {
+        let def = crate::parser::oracle_trigger::parse_trigger_line(
+            "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.",
+            "Keeper of the Accord",
+        );
+        let condition = def.condition.unwrap();
+
+        let mut state = GameState::new_two_player(42);
+        let controller = PlayerId(0);
+        let opponent = PlayerId(1);
+        state.active_player = opponent;
+
+        let keeper = make_creature(&mut state, controller, "Keeper of the Accord", 3, 4);
+        let _self_b = make_creature(&mut state, controller, "Self B", 1, 1);
+        let _opp_a = make_creature(&mut state, opponent, "Opp A", 1, 1);
+        let _opp_b = make_creature(&mut state, opponent, "Opp B", 1, 1);
+
+        let phase_event = GameEvent::PhaseChanged {
+            phase: crate::types::phase::Phase::End,
+        };
+        assert!(
+            !check_trigger_condition(
+                &state,
+                &condition,
+                controller,
+                Some(keeper),
+                Some(&phase_event),
+            ),
+            "two creatures each must not satisfy 'more creatures than you'",
+        );
+    }
+
     /// Non-Phase triggers must NOT have scoped_player auto-bound (preserves
     /// the existing convention that ETB/Dies/SpellCast triggers leave
     /// scoped_player None and resolve "that player" via event-context refs

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -113,6 +113,7 @@ fn parse_remaining_state_presence_conditions(input: &str) -> OracleResult<'_, St
     alt((
         parse_opponent_poison_conditions,
         parse_defending_player_comparison_conditions,
+        parse_that_player_controls_more_comparison,
         parse_no_opponent_comparison_conditions,
         parse_opponent_comparison_conditions,
         parse_life_conditions,
@@ -4492,6 +4493,44 @@ fn parse_there_exists_condition(input: &str) -> OracleResult<'_, StaticCondition
     ))
 }
 
+/// Parse "that player controls more [type] than you" → QuantityComparison.
+///
+/// CR 603.2b + CR 603.4 + CR 102.1: Phase triggers such as Keeper of the Accord
+/// ("At the beginning of each opponent's end step, if that player controls more
+/// creatures than you, ...") compare the active player's battlefield to the
+/// source controller's. `ControllerRef::ScopedPlayer` binds to the event player
+/// at both detection and resolution (`resolve_quantity_for_trigger_check`).
+fn parse_that_player_controls_more_comparison(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("that player controls more ").parse(input)?;
+    let (rest, type_text) = take_until::<_, _, OracleError<'_>>(" than you").parse(rest)?;
+    let (rest, _) = tag(" than you").parse(rest)?;
+
+    let (filter, _) = parse_type_phrase(type_text.trim());
+    let scoped_filter = match filter {
+        TargetFilter::Typed(tf) => TargetFilter::Typed(tf.controller(ControllerRef::ScopedPlayer)),
+        other => other,
+    };
+    let you_filter = match parse_type_phrase(type_text.trim()) {
+        (TargetFilter::Typed(tf), _) => TargetFilter::Typed(tf.controller(ControllerRef::You)),
+        (other, _) => other,
+    };
+
+    Ok((
+        rest,
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount {
+                    filter: scoped_filter,
+                },
+            },
+            comparator: Comparator::GT,
+            rhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount { filter: you_filter },
+            },
+        },
+    ))
+}
+
 /// Parse "defending player controls more [type] than you" → QuantityComparison.
 ///
 /// CR 508.1b + CR 603.4: Attack triggers can carry intervening-if clauses
@@ -7457,6 +7496,38 @@ mod tests {
                         qty: QuantityRef::ObjectCount { .. },
                     },
             } => {}
+            other => panic!("expected ObjectCount GT ObjectCount, got {other:?}"),
+        }
+    }
+
+    /// CR 603.2b + CR 603.4: Keeper of the Accord — "that player" is the active
+    /// player whose phase is beginning, not a generic opponent aggregate.
+    #[test]
+    fn test_that_player_controls_more_creatures_than_you() {
+        let (rest, c) =
+            parse_inner_condition("that player controls more creatures than you").unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ObjectCount {
+                                filter: TargetFilter::Typed(lhs),
+                            },
+                    },
+                comparator: Comparator::GT,
+                rhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ObjectCount {
+                                filter: TargetFilter::Typed(rhs),
+                            },
+                    },
+            } => {
+                assert_eq!(lhs.controller, Some(ControllerRef::ScopedPlayer));
+                assert_eq!(rhs.controller, Some(ControllerRef::You));
+            }
             other => panic!("expected ObjectCount GT ObjectCount, got {other:?}"),
         }
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -17056,6 +17056,71 @@ mod tests {
         );
     }
 
+    /// CR 513.1 + CR 603.4: Keeper of the Accord — opponent end-step token trigger
+    /// with intervening-if comparing that player's creatures to yours.
+    #[test]
+    fn keeper_of_the_accord_opponent_end_step_creature_token() {
+        let def = parse_trigger_line(
+            "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.",
+            "Keeper of the Accord",
+        );
+        assert_eq!(def.mode, TriggerMode::Phase);
+        assert_eq!(def.phase, Some(Phase::End));
+        assert_eq!(
+            def.constraint,
+            Some(TriggerConstraint::OnlyDuringOpponentsTurn)
+        );
+        match def.condition.as_ref() {
+            Some(TriggerCondition::QuantityComparison {
+                lhs,
+                comparator: Comparator::GT,
+                rhs,
+            }) => {
+                match lhs {
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ObjectCount {
+                                filter: TargetFilter::Typed(tf),
+                            },
+                    } => {
+                        assert_eq!(tf.controller, Some(ControllerRef::ScopedPlayer));
+                    }
+                    other => panic!("expected scoped ObjectCount lhs, got {other:?}"),
+                }
+                match rhs {
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ObjectCount {
+                                filter: TargetFilter::Typed(tf),
+                            },
+                    } => {
+                        assert_eq!(tf.controller, Some(ControllerRef::You));
+                    }
+                    other => panic!("expected you-scoped ObjectCount rhs, got {other:?}"),
+                }
+            }
+            other => panic!("expected QuantityComparison intervening-if, got {other:?}"),
+        }
+        assert!(matches!(
+            def.execute.as_ref().map(|a| a.effect.as_ref()),
+            Some(Effect::Token { .. })
+        ));
+    }
+
+    /// CR 513.1 + CR 603.4: Keeper of the Accord — optional Plains search when
+    /// that player controls more lands.
+    #[test]
+    fn keeper_of_the_accord_opponent_end_step_plains_search() {
+        let def = parse_trigger_line(
+            "At the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.",
+            "Keeper of the Accord",
+        );
+        assert_eq!(def.mode, TriggerMode::Phase);
+        assert_eq!(def.phase, Some(Phase::End));
+        assert!(def.optional);
+        assert!(def.condition.is_some());
+    }
+
     #[test]
     fn phase_trigger_each_combat_no_constraint() {
         let def = parse_trigger_line(


### PR DESCRIPTION
## Summary

Fixes #1304

Keeper of the Accord should trigger at each opponent's end step when that opponent controls more creatures or lands than you. The card was fully parsed, but the intervening-if `"if that player controls more [type] than you"` was not recognized by the condition parser — only `"an opponent controls more …"` and `"defending player controls more …"` were handled.

This adds `parse_that_player_controls_more_comparison`, mapping:
- **LHS** → `ObjectCount` scoped to `ControllerRef::ScopedPlayer` (the active player whose end step is starting)
- **RHS** → `ObjectCount` scoped to `ControllerRef::You` (Keeper's controller)

This composes with existing phase-trigger wiring (`OnlyDuringOpponentsTurn`, `Phase::End`, and `resolve_quantity_for_trigger_check` binding scoped player from `PhaseChanged`).

## Test plan

- [x] `test_that_player_controls_more_creatures_than_you` — condition combinator emits correct ScopedPlayer/You scopes
- [x] `keeper_of_the_accord_opponent_end_step_creature_token` — trigger AST: Phase::End, OnlyDuringOpponentsTurn, hoisted QuantityComparison, Token effect
- [x] `keeper_of_the_accord_opponent_end_step_plains_search` — second ability parses with optional + condition
- [x] `keeper_of_the_accord_creature_intervening_if_true_when_opponent_ahead` — runtime check passes when opponent has more creatures
- [x] `keeper_of_the_accord_creature_intervening_if_false_when_tied` — runtime check fails on equal counts
- [x] `cargo clippy -p engine --tests`
- [ ] Regenerate `card-data` after merge so production JSON picks up corrected trigger conditions