### PR TITLE
fix(parser): parse Emissary Green aggregate vote-tally into Effect::Vote 

### DIFF
--- a/crates/engine/src/parser/oracle_vote.rs
+++ b/crates/engine/src/parser/oracle_vote.rs
@@ -805,9 +805,10 @@ mod tests {
                             TargetFilter::Typed(tf) => {
                                 assert_eq!(tf.controller, Some(ControllerRef::You));
                                 assert!(
-                                    tf.type_filters
-                                        .iter()
-                                        .any(|t| format!("{t:?}").contains("Creature")),
+                                    tf.type_filters.iter().any(|t| matches!(
+                                        t,
+                                        crate::types::ability::TypeFilter::Creature
+                                    )),
                                     "expected a Creature type filter, got {:?}",
                                     tf.type_filters
                                 );

--- a/crates/engine/src/parser/oracle_vote.rs
+++ b/crates/engine/src/parser/oracle_vote.rs
@@ -19,11 +19,11 @@
 //!   `AbilityDefinition`. Failure to match returns `None`, leaving the caller
 //!   free to fall back to the standard chain parser.
 
-use crate::parser::oracle_nom::error::OracleError;
-use crate::parser::oracle_nom::primitives::scan_split_at_phrase;
+use crate::parser::oracle_nom::error::{OracleError, OracleResult};
+use crate::parser::oracle_nom::primitives::{parse_number, scan_preceded, scan_split_at_phrase};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, tag_no_case, take_while1};
-use nom::combinator::value;
+use nom::combinator::{map, success, value};
 use nom::Parser;
 
 use crate::types::ability::{
@@ -75,19 +75,45 @@ pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityD
     let mut slots: Vec<Option<Box<AbilityDefinition>>> = (0..choices.len()).map(|_| None).collect();
     let mut walk = i.trim_start();
     while !walk.is_empty() {
-        let (rest, (choice, effect_text, who_chose)) = if is_controller_labels {
-            parse_each_class_clause(walk, &choices)?
+        // Each iteration consumes exactly one per-choice clause. Shapes are
+        // tried in priority order (ControllerLabels is mutually exclusive with
+        // the other two):
+        //   1. ControllerLabels  → "Each <choice> <effect>."         (Battlebond)
+        //   2. "For each <choice> vote, <effect>." / "...who chose..." (classic)
+        //   3. Aggregate tally   → "<effect ...a number of...> equal to
+        //      [<multiplier>] the number of <choice> votes."          (Emissary Green)
+        // `voted_for` records whether the parsed sub-effect must fan out across
+        // the players who chose this option (CR 701.38 + CR 101.4); the
+        // aggregate-tally shape is controller-performed, so it stays `false`.
+        let (rest, idx, mut parsed, voted_for) = if is_controller_labels {
+            let (rest, (choice, effect_text, who_chose)) = parse_each_class_clause(walk, &choices)?;
+            let idx = choices.iter().position(|c| c == &choice)?;
+            let parsed =
+                parse_effect_chain_with_context(effect_text, kind, &mut ParseContext::default());
+            (rest, idx, parsed, who_chose)
+        } else if let Some((rest, (choice, effect_text, who_chose))) =
+            parse_for_each_vote_clause(walk, &choices)
+        {
+            let idx = choices.iter().position(|c| c == &choice)?;
+            let parsed =
+                parse_effect_chain_with_context(effect_text, kind, &mut ParseContext::default());
+            (rest, idx, parsed, who_chose)
         } else {
-            parse_for_each_vote_clause(walk, &choices)?
+            // CR 701.38 + CR 122.1: aggregate-tally shape (Emissary Green). The
+            // per-vote multiplier folds into the sub-effect's fixed count, and
+            // the Vote resolver runs each per-choice sub-effect once per tallied
+            // vote, so `count = multiplier` yields `multiplier × votes` total.
+            let (rest, choice, rewritten) = parse_aggregate_tally_clause(walk, &choices)?;
+            let idx = choices.iter().position(|c| c == &choice)?;
+            let parsed =
+                parse_effect_chain_with_context(&rewritten, kind, &mut ParseContext::default());
+            (rest, idx, parsed, false)
         };
-        let idx = choices.iter().position(|c| c == &choice)?;
         if slots[idx].is_some() {
             // Same choice referenced twice — shape we don't yet model.
             return None;
         }
-        let mut parsed =
-            parse_effect_chain_with_context(effect_text, kind, &mut ParseContext::default());
-        if who_chose || is_controller_labels {
+        if voted_for {
             // CR 701.38 + CR 101.4: Wire the per-vote sub-effect to fan out
             // across the players who received this choice index.
             // - "for each player who chose <choice>, <effect>" (Master of
@@ -373,6 +399,89 @@ fn read_effect_until_next_clause(input: &str) -> (&str, &str) {
     (head_no_period.trim(), tail.trim_start())
 }
 
+/// Parse one aggregate-tally per-choice clause (Emissary Green):
+///
+///   `"<effect ...a number of <X>...> equal to [<multiplier>] the number of <choice> votes."`
+///
+/// Canonical bodies:
+///   * "You create a number of Treasure tokens equal to twice the number of profit votes."
+///   * "Put a number of +1/+1 counters on each creature you control equal to the number of security votes."
+///
+/// The per-vote multiplier ("twice" → 2, "<n> times" → n, absent → 1) folds
+/// into the sub-effect's fixed count. The Vote resolver runs each per-choice
+/// sub-effect once per tallied vote (CR 701.38), so a `count = multiplier`
+/// sub-effect produces `multiplier × votes` total — exactly the aggregate the
+/// Oracle text describes.
+///
+/// Returns `(remainder_after_sentence, choice_lowercase, rewritten_effect_text)`.
+/// `None` when the clause is not in this shape, letting the caller fall through.
+fn parse_aggregate_tally_clause<'a>(
+    input: &'a str,
+    choices: &[String],
+) -> Option<(&'a str, String, String)> {
+    let (sentence, rest) = read_sentence(input);
+    // Locate "equal to [<multiplier>] the number of <choice> votes" at a word
+    // boundary via a single combinator; `scan_preceded` returns the head before
+    // the match, the parsed (choice, multiplier), and the post-match remainder.
+    let suffix = |i: &'a str| -> nom::IResult<&'a str, (String, u32), OracleError<'a>> {
+        let (i, _) = tag_no_case("equal to ").parse(i)?;
+        let (i, multiplier) = parse_tally_multiplier(i)?;
+        let (i, _) = tag_no_case("the number of ").parse(i)?;
+        let (i, choice) =
+            take_while1(|c: char| c.is_alphanumeric() || c == '\'' || c == '-').parse(i)?;
+        if !choices.iter().any(|c| c.eq_ignore_ascii_case(choice)) {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                i,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+        let (i, _) = tag_no_case(" votes").parse(i)?;
+        Ok((i, (choice.to_lowercase(), multiplier)))
+    };
+    let (head, (choice, multiplier), tail) = scan_preceded(sentence, suffix)?;
+    // The tally clause must be the sentence suffix — reject trailing text we
+    // are not modeling (keeps the detector tight).
+    if !tail.trim().is_empty() {
+        return None;
+    }
+    let rewritten = rewrite_a_number_of(head.trim_end(), multiplier)?;
+    Some((rest, choice, rewritten))
+}
+
+/// Parse the optional per-vote multiplier preceding "the number of <choice>
+/// votes": `"twice "` → 2, `"<n> times "` → n (digit or English word), and an
+/// absent multiplier → 1. Always succeeds so it composes inside the tally
+/// combinator.
+fn parse_tally_multiplier(input: &str) -> OracleResult<'_, u32> {
+    alt((
+        value(2u32, tag_no_case("twice ")),
+        map((parse_number, tag_no_case(" times ")), |(n, _)| n),
+        success(1u32),
+    ))
+    .parse(input)
+}
+
+/// Rewrite an effect head of the form `"...a number of <X>..."` into the
+/// fixed-count imperative `"...<count> <X>..."`, which the standard effect
+/// chain parser maps to a `Fixed` count. Returns `None` when the head lacks the
+/// "a number of " quantity phrase (i.e. not an aggregate-tally effect).
+fn rewrite_a_number_of(head: &str, count: u32) -> Option<String> {
+    let (before, _, after) = scan_preceded(head, |i| {
+        tag_no_case::<_, _, OracleError<'_>>("a number of ").parse(i)
+    })?;
+    Some(format!("{before}{count} {after}"))
+}
+
+/// Split the input at the first period: returns `(sentence, remainder)` with
+/// surrounding whitespace trimmed. The final clause may lack a trailing period,
+/// in which case the whole input is the sentence and the remainder is empty.
+fn read_sentence(input: &str) -> (&str, &str) {
+    match input.find('.') {
+        Some(idx) => (input[..idx].trim(), input[idx + 1..].trim_start()),
+        None => (input.trim(), ""),
+    }
+}
+
 /// Read a word (alphanumeric + apostrophes). Returns (word, remainder).
 fn read_word(input: &str) -> Option<(&str, &str)> {
     let end = input
@@ -651,6 +760,107 @@ mod tests {
     #[test]
     fn rejects_non_vote_text() {
         assert!(parse_vote_block("Draw a card.", AbilityKind::Spell).is_none());
+    }
+
+    /// CR 701.38 + CR 122.1: Emissary Green's aggregate-tally vote. The
+    /// per-choice effects reference the vote count via "a number of … equal to
+    /// [twice] the number of <choice> votes" rather than the classic "For each
+    /// <choice> vote, …" repetition. Each per-choice sub-effect must carry a
+    /// fixed count equal to the multiplier (the Vote resolver runs it once per
+    /// tallied vote), and must NOT be VotedFor-scoped (controller-performed).
+    #[test]
+    fn parses_emissary_green_aggregate_vote_block() {
+        use crate::types::ability::QuantityExpr;
+        let text = "starting with you, each player votes for profit or security. \
+                    You create a number of Treasure tokens equal to twice the number of profit votes. \
+                    Put a number of +1/+1 counters on each creature you control equal to the number of security votes.";
+        let def = parse_vote_block(text, AbilityKind::Spell).expect("vote block parses");
+        match *def.effect {
+            Effect::Vote {
+                ref choices,
+                ref per_choice_effect,
+                starting_with,
+                voter_scope,
+            } => {
+                assert_eq!(choices, &vec!["profit".to_string(), "security".to_string()]);
+                assert_eq!(starting_with, ControllerRef::You);
+                assert_eq!(voter_scope, VoterScope::AllPlayers);
+                assert_eq!(per_choice_effect.len(), 2);
+
+                // profit → "create Treasure tokens", count = 2 (the "twice"
+                // multiplier), so each profit vote makes 2 Treasures.
+                match &*per_choice_effect[0].effect {
+                    Effect::Token { name, count, .. } => {
+                        assert_eq!(name, "Treasure");
+                        assert_eq!(*count, QuantityExpr::Fixed { value: 2 });
+                    }
+                    other => panic!("expected profit → Token, got {:?}", other),
+                }
+                // security → "put +1/+1 counters on each creature you control",
+                // count = 1, so each security vote adds one counter to each.
+                match &*per_choice_effect[1].effect {
+                    Effect::PutCounterAll { count, target, .. } => {
+                        assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                        match target {
+                            TargetFilter::Typed(tf) => {
+                                assert_eq!(tf.controller, Some(ControllerRef::You));
+                                assert!(
+                                    tf.type_filters
+                                        .iter()
+                                        .any(|t| format!("{t:?}").contains("Creature")),
+                                    "expected a Creature type filter, got {:?}",
+                                    tf.type_filters
+                                );
+                            }
+                            other => panic!("expected Typed creature target, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected security → PutCounterAll, got {:?}", other),
+                }
+
+                // Controller-performed: no per-voter fan-out wiring.
+                assert!(per_choice_effect[0].player_scope.is_none());
+                assert!(per_choice_effect[1].player_scope.is_none());
+            }
+            other => panic!("expected Vote, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_tally_multiplier_covers_twice_times_and_default() {
+        // "twice " → 2
+        let (rest, m) = parse_tally_multiplier("twice the number of profit votes").unwrap();
+        assert_eq!(m, 2);
+        assert_eq!(rest, "the number of profit votes");
+        // "three times " → 3 (English word via parse_number)
+        let (rest, m) = parse_tally_multiplier("three times the number of x votes").unwrap();
+        assert_eq!(m, 3);
+        assert_eq!(rest, "the number of x votes");
+        // "4 times " → 4 (digit)
+        let (_, m) = parse_tally_multiplier("4 times the number of x votes").unwrap();
+        assert_eq!(m, 4);
+        // absent → 1, consuming nothing
+        let (rest, m) = parse_tally_multiplier("the number of security votes").unwrap();
+        assert_eq!(m, 1);
+        assert_eq!(rest, "the number of security votes");
+    }
+
+    #[test]
+    fn rewrite_a_number_of_inserts_fixed_count() {
+        assert_eq!(
+            rewrite_a_number_of("You create a number of Treasure tokens", 2).unwrap(),
+            "You create 2 Treasure tokens"
+        );
+        assert_eq!(
+            rewrite_a_number_of(
+                "Put a number of +1/+1 counters on each creature you control",
+                1
+            )
+            .unwrap(),
+            "Put 1 +1/+1 counters on each creature you control"
+        );
+        // No "a number of " phrase → not an aggregate-tally effect.
+        assert!(rewrite_a_number_of("create a Treasure token", 1).is_none());
     }
 
     /// CR 608.2c + CR 701.38: Documented parser gap (R5 in the

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -31,7 +31,13 @@ use crate::types::ability::{
 use crate::types::statics::StaticMode;
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
-use nom::{branch::alt, bytes::complete::tag, Parser};
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_while1},
+    character::complete::digit1,
+    combinator::{opt, value},
+    Parser,
+};
 
 /// Strip parenthesized reminder text. Reminder text is the parser's
 /// responsibility to ignore at the keyword level — keywords themselves are
@@ -1232,11 +1238,92 @@ fn detect_dynamic_qty(
     if cleaned_for_each_is_only_decline_iteration(cleaned) && json_has_any(ast_json, &["\"Not\""]) {
         return;
     }
+    // CR 701.38: Council's-dilemma vote-tally payoffs ("create a number of X
+    // equal to [twice] the number of <choice> votes" — Emissary Green) realize
+    // their dynamic count through the Vote resolver's per-vote fan-out: each
+    // per-choice sub-effect runs once per tallied vote, with the multiplier
+    // folded into a fixed per-vote count. The dynamic quantity is therefore
+    // represented by the `Vote` structure, not a `QuantityExpr` carrier. When
+    // the AST is a Vote and every dynamic marker is tally phrasing, nothing was
+    // swallowed.
+    if cleaned_dynamic_is_only_vote_tally(cleaned) && json_has_any(ast_json, &["\"type\":\"Vote\""])
+    {
+        return;
+    }
     diagnostics.push(OracleDiagnostic::SwallowedClause {
         detector: "DynamicQty".into(),
         description: truncate(original, 140).into(),
         line_index: 0,
     });
+}
+
+/// CR 701.38: True when every dynamic-quantity marker in `cleaned` belongs to a
+/// Council's-dilemma vote tally — "[equal to [twice|N times] ]the number of
+/// <choice> votes". Such tallies are realized by the Vote resolver's per-vote
+/// fan-out, not by a `QuantityExpr` carrier, so when the AST is a `Vote` the
+/// marker is not a swallowed clause. Kept narrow: any non-tally dynamic marker
+/// (a per-choice body's own swallowed "equal to its power", a "for each", a
+/// "half …") keeps the warning.
+fn cleaned_dynamic_is_only_vote_tally(cleaned: &str) -> bool {
+    // allow-noncombinator: swallow detector marker scan on classified text
+    if !cleaned.contains("votes") {
+        return false;
+    }
+    // No non-tally dynamic marker may be present.
+    let has_foreign_marker = [
+        "for each ",
+        "where x is ",
+        "half your ",
+        "half their ",
+        "half its ",
+        "half the ",
+    ]
+    .iter()
+    // allow-noncombinator: swallow detector marker scan on classified text
+    .any(|marker| cleaned.contains(marker));
+    if has_foreign_marker {
+        return false;
+    }
+    // Every "the number of " must read "the number of <word> votes".
+    let all_number_of_are_vote = cleaned
+        // allow-noncombinator: swallow detector marker scan on classified text
+        .match_indices("the number of ")
+        .all(|(idx, _)| vote_tally_count_suffix(&cleaned[idx..]));
+    if !all_number_of_are_vote {
+        return false;
+    }
+    // Every " equal to " must lead (through an optional multiplier) into a tally.
+    cleaned
+        // allow-noncombinator: swallow detector marker scan on classified text
+        .match_indices(" equal to ")
+        .all(|(idx, _)| equal_to_vote_tally_suffix(&cleaned[idx..]))
+}
+
+/// nom: `"the number of <word> votes"`.
+fn vote_tally_count_suffix(input: &str) -> bool {
+    let res: nom::IResult<&str, _, nom::error::Error<&str>> = (
+        tag("the number of "),
+        take_while1(|c: char| c.is_alphanumeric() || c == '\'' || c == '-'),
+        tag(" votes"),
+    )
+        .parse(input);
+    res.is_ok()
+}
+
+/// nom: `" equal to [twice |<n> times ]the number of <word> votes"`.
+fn equal_to_vote_tally_suffix(input: &str) -> bool {
+    let res: nom::IResult<&str, _, nom::error::Error<&str>> = (
+        tag(" equal to "),
+        opt(alt((
+            value((), tag("twice ")),
+            value((), (digit1, tag(" times "))),
+        ))),
+        tag("the number of "),
+        take_while1(|c: char| c.is_alphanumeric() || c == '\'' || c == '-'),
+        tag(" votes"),
+    )
+        .parse(input);
+    res.is_ok()
 }
 
 /// CR 608.2e + CR 608.2c + CR 101.3: True when every "for each " occurrence in
@@ -2580,6 +2667,34 @@ mod tests {
         );
 
         assert!(!has_swallowed_detector(&parsed, "DynamicQty"));
+    }
+
+    /// CR 701.38: Emissary Green's aggregate vote tally ("a number of X equal to
+    /// [twice] the number of <choice> votes") is realized by the Vote per-vote
+    /// fan-out, so the DynamicQty detector must not flag it as swallowed.
+    #[test]
+    fn dynamic_qty_accepts_emissary_green_vote_tally() {
+        let parsed = parse_named(
+            "Whenever Emissary Green attacks, starting with you, each player votes for profit or security. \
+             You create a number of Treasure tokens equal to twice the number of profit votes. \
+             Put a number of +1/+1 counters on each creature you control equal to the number of security votes.",
+            "Emissary Green",
+            &["Creature"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "DynamicQty"));
+    }
+
+    /// Guard against over-suppression: a vote card whose per-choice body has its
+    /// own swallowed dynamic ("equal to its power", not a vote tally) must still
+    /// flag DynamicQty.
+    #[test]
+    fn dynamic_qty_keeps_warning_for_non_tally_dynamic_in_vote_body() {
+        assert!(!super::equal_to_vote_tally_suffix(" equal to its power"));
+        assert!(!super::cleaned_dynamic_is_only_vote_tally(
+            "each player votes for a or b. for each a vote, draw cards equal to your life total. \
+             for each b vote, do nothing."
+        ));
     }
 
     #[test]

--- a/crates/engine/tests/integration/emissary_green.rs
+++ b/crates/engine/tests/integration/emissary_green.rs
@@ -1,0 +1,185 @@
+//! Regression coverage for issue #888: Emissary Green's attack-triggered vote.
+//!
+//! Oracle text:
+//! > Whenever Emissary Green attacks, starting with you, each player votes for
+//! > profit or security. You create a number of Treasure tokens equal to twice
+//! > the number of profit votes. Put a number of +1/+1 counters on each
+//! > creature you control equal to the number of security votes.
+//!
+//! Before the fix the per-choice effects used the aggregate-tally phrasing
+//! ("a number of … equal to [twice] the number of <choice> votes"), which the
+//! vote parser did not recognize — the trigger degraded to `Effect::Unimplemented`
+//! and no vote prompt was ever shown. These tests drive the real
+//! combat → Attacks trigger → `WaitingFor::VoteChoice` → tally pipeline and
+//! assert the per-vote fan-out math:
+//!   * each `profit` vote creates 2 Treasures (the "twice" multiplier), and
+//!   * each `security` vote puts one +1/+1 counter on each creature you control.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+use super::rules::AttackTarget;
+
+const EMISSARY_GREEN_ORACLE: &str = "Whenever Emissary Green attacks, starting with you, \
+each player votes for profit or security. You create a number of Treasure tokens equal to \
+twice the number of profit votes. Put a number of +1/+1 counters on each creature you control \
+equal to the number of security votes.";
+
+/// Count Treasure tokens on the battlefield owned by `player`.
+fn treasure_count(runner: &GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .battlefield
+        .iter()
+        .filter_map(|id| runner.state().objects.get(id))
+        .filter(|obj| obj.owner == player)
+        .filter(|obj| obj.name.eq_ignore_ascii_case("Treasure"))
+        .count()
+}
+
+/// +1/+1 counters currently on `id`.
+fn plus_counters(runner: &GameRunner, id: ObjectId) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .and_then(|o| o.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0)
+}
+
+/// Build a 2-player board with Emissary Green (from real Oracle text) and a
+/// second creature, both controlled by P0, and declare Emissary Green as an
+/// attacker. Returns the runner plus the two creature ids.
+fn attack_with_emissary() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::DeclareAttackers);
+    let emissary = scenario
+        .add_creature_from_oracle(P0, "Emissary Green", 3, 3, EMISSARY_GREEN_ORACLE)
+        .id();
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: P0,
+            valid_attacker_ids: vec![emissary],
+            valid_attack_targets: vec![AttackTarget::Player(P1)],
+        };
+    }
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(emissary, AttackTarget::Player(P1))],
+        })
+        .expect("declaring Emissary Green as attacker should succeed");
+    (runner, emissary, bear)
+}
+
+/// Pass priority until the attack-triggered vote prompt appears.
+fn advance_to_vote_prompt(runner: &mut GameRunner) {
+    for _ in 0..20 {
+        if matches!(runner.state().waiting_for, WaitingFor::VoteChoice { .. }) {
+            return;
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+    panic!(
+        "Emissary Green's attack must produce a vote prompt, got {:?}",
+        runner.waiting_for_kind()
+    );
+}
+
+/// Submit the supplied choices in voter-queue order. The queue is
+/// `[P0, P1]` (AllPlayers, starting with you), so `choices[0]` is P0's vote
+/// and `choices[1]` is P1's.
+fn cast_votes(runner: &mut GameRunner, choices: [&str; 2]) {
+    for choice in choices {
+        assert!(
+            matches!(runner.state().waiting_for, WaitingFor::VoteChoice { .. }),
+            "expected a VoteChoice prompt before casting '{choice}'"
+        );
+        runner
+            .act(GameAction::ChooseOption {
+                choice: choice.to_string(),
+            })
+            .unwrap_or_else(|e| panic!("casting vote '{choice}' should succeed: {e:?}"));
+    }
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::VoteChoice { .. }),
+        "all votes cast — the tally should have resolved"
+    );
+}
+
+/// Both players vote `profit` → 2 profit votes × 2 Treasures each = 4 Treasures
+/// for the controller; zero security votes → no +1/+1 counters.
+#[test]
+fn issue_888_both_profit_creates_four_treasures() {
+    let (mut runner, emissary, bear) = attack_with_emissary();
+    advance_to_vote_prompt(&mut runner);
+    cast_votes(&mut runner, ["profit", "profit"]);
+
+    assert_eq!(
+        treasure_count(&runner, P0),
+        4,
+        "two profit votes × twice = 4 Treasures for the controller"
+    );
+    assert_eq!(treasure_count(&runner, P1), 0, "opponent gets no Treasures");
+    assert_eq!(plus_counters(&runner, emissary), 0);
+    assert_eq!(plus_counters(&runner, bear), 0);
+}
+
+/// Both players vote `security` → 2 security votes → each creature you control
+/// gains 2 +1/+1 counters; zero profit votes → no Treasures.
+#[test]
+fn issue_888_both_security_adds_counters_to_each_creature() {
+    let (mut runner, emissary, bear) = attack_with_emissary();
+    advance_to_vote_prompt(&mut runner);
+    cast_votes(&mut runner, ["security", "security"]);
+
+    assert_eq!(
+        treasure_count(&runner, P0),
+        0,
+        "no profit votes → no Treasures"
+    );
+    assert_eq!(
+        plus_counters(&runner, emissary),
+        2,
+        "two security votes → 2 counters on Emissary Green"
+    );
+    assert_eq!(
+        plus_counters(&runner, bear),
+        2,
+        "two security votes → 2 counters on the other creature you control"
+    );
+}
+
+/// Split vote: P0 profit, P1 security → 1 profit vote (2 Treasures) and 1
+/// security vote (one +1/+1 counter on each creature you control).
+#[test]
+fn issue_888_split_vote_mixes_treasures_and_counters() {
+    let (mut runner, emissary, bear) = attack_with_emissary();
+    advance_to_vote_prompt(&mut runner);
+    cast_votes(&mut runner, ["profit", "security"]);
+
+    assert_eq!(
+        treasure_count(&runner, P0),
+        2,
+        "one profit vote × twice = 2 Treasures"
+    );
+    assert_eq!(
+        plus_counters(&runner, emissary),
+        1,
+        "one security vote → 1 counter on Emissary Green"
+    );
+    assert_eq!(
+        plus_counters(&runner, bear),
+        1,
+        "one security vote → 1 counter on the other creature you control"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -31,6 +31,7 @@ mod dralnu_dealt_damage_sacrifice;
 mod dredgers_insight_mill_from_among;
 mod elemental_spectacle_regression;
 mod elusive_otter_repro;
+mod emissary_green;
 #[cfg(feature = "proptest")]
 mod engine_invariants;
 mod enlightened_tutor_regression;


### PR DESCRIPTION
## Summary

Close #888 
 
Emissary Green's attack trigger showed up on the stack but never asked anyone to vote, so it never made Treasures or added counters.

The vote effect itself (`Effect::Vote`) already works fine. The problem was that the parser couldn't read Emissary Green's wording, so the trigger fell back to `Unimplemented`.

## What was wrong

The vote parser only understood the "For each X vote, do Y" style. Emissary Green phrases its payoffs as totals instead:

> You create a number of Treasure tokens equal to twice the number of profit votes.
> Put a number of +1/+1 counters on each creature you control equal to the number of security votes.

Since neither line starts with "For each", the whole vote block bailed out and the trigger became `Unimplemented`.

## Fix

Added support for the "... equal to [twice] the number of <choice> votes" wording. The multiplier (twice = 2, "N times" = N, otherwise 1) becomes the per-vote count. The resolver already replays each per-choice effect once per vote, so a count of 2 with two profit votes gives 4 Treasures, etc.

Emissary Green now parses to a proper `Vote`:
- profit: create 2 Treasures per vote
- security: put 1 +1/+1 counter on each creature you control per vote

No engine changes were needed, and the new parsing is done with the usual nom combinators.

## Testing

- Parser unit tests for the new wording, the multiplier, and the count rewrite.
- Integration tests that actually attack with Emissary Green and run the vote:
  - both profit: 4 Treasures, no counters
  - both security: no Treasures, +2 counters on each of your creatures
  - one each: 2 Treasures, +1 counter on each of your creatures
- Existing vote cards (Tivit, Master of Ceremonies, Pir's Whim) still pass.
- fmt, clippy, and the parser combinator check are clean.
