### PR TITLE
fix(engine): enforce CR 701.14b/c on fight damage resolution

### DIFF
--- a/crates/engine/src/game/effects/fight.rs
+++ b/crates/engine/src/game/effects/fight.rs
@@ -4,9 +4,11 @@ use crate::game::effects::{append_to_pending_continuation, mark_pending_continua
 use crate::types::ability::{
     Effect, EffectError, EffectKind, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef,
 };
+use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
+use crate::types::zones::Zone;
 
 /// CR 701.14a: Resolve the subject creature for a fight effect.
 /// - `SelfRef` → the ability's source object (default: "~ fights").
@@ -48,6 +50,13 @@ fn refers_to_attached(filter: &TargetFilter) -> bool {
         ))
 }
 
+/// CR 701.14b: A creature must be on the battlefield and still be a creature to fight.
+fn fight_eligible(state: &GameState, id: ObjectId) -> bool {
+    state.objects.get(&id).is_some_and(|obj| {
+        obj.zone == Zone::Battlefield && obj.card_types.core_types.contains(&CoreType::Creature)
+    })
+}
+
 /// CR 701.14a: Fight — each creature deals damage equal to its power to the other.
 pub fn resolve(
     state: &mut GameState,
@@ -72,6 +81,15 @@ pub fn resolve(
         })
         .ok_or_else(|| EffectError::MissingParam("Fight target".to_string()))?;
 
+    // CR 701.14b: If either fighter left the battlefield or is no longer a creature, no damage.
+    if !fight_eligible(state, source_id) || !fight_eligible(state, target_id) {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
     // Read power and controller for both creatures before mutable damage phase.
     let (source_power, source_controller) = {
         let obj = state
@@ -87,6 +105,34 @@ pub fn resolve(
             .ok_or(EffectError::ObjectNotFound(target_id))?;
         (obj.power.unwrap_or(0), obj.controller)
     };
+
+    // CR 701.14c: Self-fight deals twice the creature's power as a single damage instance.
+    if source_id == target_id {
+        if source_power > 0 {
+            let amount = (source_power as u32).saturating_mul(2);
+            let source_ctx = DamageContext::from_source(state, source_id)
+                .unwrap_or_else(|| DamageContext::fallback(source_id, source_controller));
+            if let DamageResult::NeedsChoice = apply_damage_to_target(
+                state,
+                &source_ctx,
+                TargetRef::Object(source_id),
+                amount,
+                false,
+                events,
+            )? {
+                if let Some(sub) = ability.sub_ability.as_ref() {
+                    append_to_pending_continuation(state, Some(Box::new(sub.as_ref().clone())));
+                }
+                mark_pending_continuation_parent(state, EffectKind::Fight);
+                return Ok(());
+            }
+        }
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
 
     // CR 701.14a + CR 120.2b: Fight damage is not combat damage.
     // Source deals damage to target (power of source → target's damage)
@@ -609,5 +655,91 @@ mod tests {
             fight_events, 1,
             "exactly one EffectKind::Fight event must fire across the pause-and-resume path; got events = {all_events:#?}",
         );
+    }
+
+    #[test]
+    fn fight_no_damage_when_source_left_battlefield() {
+        use crate::game::zones::move_to_zone;
+
+        let mut state = GameState::new_two_player(42);
+        let bear = make_creature(&mut state, PlayerId(0), "Bear", 3, 3);
+        let wolf = make_creature(&mut state, PlayerId(1), "Wolf", 2, 2);
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, bear, Zone::Graveyard, &mut events);
+
+        let ability = make_fight_ability(bear, wolf);
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.objects[&wolf].damage_marked, 0);
+        assert_eq!(state.objects[&bear].damage_marked, 0);
+    }
+
+    #[test]
+    fn fight_no_damage_when_source_is_no_longer_creature() {
+        let mut state = GameState::new_two_player(42);
+        let bear = make_creature(&mut state, PlayerId(0), "Bear", 3, 3);
+        let wolf = make_creature(&mut state, PlayerId(1), "Wolf", 2, 2);
+
+        state
+            .objects
+            .get_mut(&bear)
+            .unwrap()
+            .card_types
+            .core_types
+            .retain(|t| *t != CoreType::Creature);
+        state
+            .objects
+            .get_mut(&bear)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+
+        let ability = make_fight_ability(bear, wolf);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.objects[&wolf].damage_marked, 0);
+        assert_eq!(state.objects[&bear].damage_marked, 0);
+    }
+
+    #[test]
+    fn fight_no_damage_when_target_left_battlefield() {
+        use crate::game::zones::move_to_zone;
+
+        let mut state = GameState::new_two_player(42);
+        let bear = make_creature(&mut state, PlayerId(0), "Bear", 3, 3);
+        let wolf = make_creature(&mut state, PlayerId(1), "Wolf", 2, 2);
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, wolf, Zone::Exile, &mut events);
+
+        let ability = make_fight_ability(bear, wolf);
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.objects[&wolf].damage_marked, 0);
+        assert_eq!(state.objects[&bear].damage_marked, 0);
+    }
+
+    #[test]
+    fn fight_self_deals_twice_power() {
+        let mut state = GameState::new_two_player(42);
+        let bear = make_creature(&mut state, PlayerId(0), "Bear", 3, 3);
+
+        let ability = make_fight_ability(bear, bear);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.objects[&bear].damage_marked, 6);
+
+        let damage_events: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                GameEvent::DamageDealt { amount, .. } => Some(*amount),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(damage_events, vec![6]);
     }
 }

--- a/crates/engine/src/game/effects/fight.rs
+++ b/crates/engine/src/game/effects/fight.rs
@@ -50,10 +50,16 @@ fn refers_to_attached(filter: &TargetFilter) -> bool {
         ))
 }
 
-/// CR 701.14b: A creature must be on the battlefield and still be a creature to fight.
+/// CR 701.14b + CR 702.26b: A creature can fight only while it is on the
+/// battlefield, still a creature, and phased in. A phased-out permanent is
+/// treated as though it does not exist (CR 702.26b), so a creature that phased
+/// out in response to the fight (e.g. via Teferi's Protection) deals and takes
+/// no damage even though its `zone` is still `Battlefield`.
 fn fight_eligible(state: &GameState, id: ObjectId) -> bool {
     state.objects.get(&id).is_some_and(|obj| {
-        obj.zone == Zone::Battlefield && obj.card_types.core_types.contains(&CoreType::Creature)
+        obj.zone == Zone::Battlefield
+            && obj.card_types.core_types.contains(&CoreType::Creature)
+            && obj.is_phased_in()
     })
 }
 
@@ -720,6 +726,39 @@ mod tests {
 
         assert_eq!(state.objects[&wolf].damage_marked, 0);
         assert_eq!(state.objects[&bear].damage_marked, 0);
+    }
+
+    /// CR 701.14b + CR 702.26b: a fighter that phased out in response to the
+    /// fight (e.g. via Teferi's Protection) is treated as though it does not
+    /// exist — neither creature deals damage, even though its zone is still
+    /// `Battlefield` and it is still a creature. This discriminates the
+    /// `is_phased_in()` gate: without it, the stale phased-out creature would
+    /// pass `fight_eligible` and wrongly deal/take damage.
+    #[test]
+    fn fight_no_damage_when_source_phased_out() {
+        use crate::game::game_object::{PhaseOutCause, PhaseStatus};
+
+        let mut state = GameState::new_two_player(42);
+        let bear = make_creature(&mut state, PlayerId(0), "Bear", 3, 3);
+        let wolf = make_creature(&mut state, PlayerId(1), "Wolf", 2, 2);
+        // Bear phases out (still on the battlefield, still a creature) before the
+        // fight resolves.
+        state.objects.get_mut(&bear).unwrap().phase_status = PhaseStatus::PhasedOut {
+            cause: PhaseOutCause::Directly,
+        };
+
+        let ability = make_fight_ability(bear, wolf);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.objects[&wolf].damage_marked, 0,
+            "wolf takes no damage"
+        );
+        assert_eq!(
+            state.objects[&bear].damage_marked, 0,
+            "phased-out bear deals no damage"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enforce **CR 701.14b**: if either fighter has left the battlefield or is no longer a creature at resolution, neither deals damage (fixes stale `state.objects` reads after zone changes).
- Enforce **CR 701.14c**: self-fights deal a single instance of damage equal to twice the creature's power (not two separate instances).
- Add regression tests for source/target leaving the battlefield, source becoming a noncreature, and self-fight damage amount.
Fixes #1435
## Test plan
- [x] `cargo test -p engine -- fight` (17 tests pass)
- [ ] CI: `cargo clippy --all-targets -- -D warnings`