### PR TITLE
fix(parser): resolve fall-through dynamic quantities to typed refs

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17225,7 +17225,17 @@ fn try_parse_damage_with_remainder<'a>(
             .parse(amount_lower.as_str())
             .ok()?;
         let qty_text = amount_text[..before_to.len()].trim();
+        // CR 120.1: The amount of a "deals damage equal to <qty>" clause may be a
+        // dynamic count ("the number of creatures you control" — Ajani, Nacatl
+        // Avenger). Mirror the sibling "damage to <target> equal to <amount>"
+        // branch: try the event-context refs first, then fall back to the general
+        // CDA quantity parser (`the number of … you control`, `your life total`,
+        // …). Without this fallback the phrase degrades to a raw `Variable`, which
+        // resolves to 0 at runtime — the damage silently no-ops.
         let qty = crate::parser::oracle_quantity::parse_event_context_quantity(qty_text)
+            .or_else(|| {
+                crate::parser::oracle_quantity::parse_cda_quantity_with_context(qty_text, ctx)
+            })
             .unwrap_or_else(|| QuantityExpr::Ref {
                 qty: QuantityRef::Variable {
                     name: qty_text.to_string(),
@@ -20660,6 +20670,36 @@ mod tests {
                 }
             ),
             "expected source-power DealDamage, got: {:?}",
+            clause.effect
+        );
+    }
+
+    /// CR 120.1: "deals damage equal to <count> to <target>" must resolve the
+    /// dynamic count via the CDA quantity parser, not degrade to a raw
+    /// `Variable` (which resolves to 0 — a silent no-op). Ajani, Nacatl
+    /// Avenger's reflexive trigger ("he deals damage equal to the number of
+    /// creatures you control to any target") is the repro; the "<count> to
+    /// <target>" word order previously skipped the CDA fallback that the
+    /// "<target> equal to <count>" word order already had.
+    #[test]
+    fn damage_equal_to_object_count_resolves_to_object_count_not_variable() {
+        let clause = parse_effect_clause(
+            "~ deals damage equal to the number of creatures you control to any target",
+            &mut ParseContext::default(),
+        );
+
+        assert!(
+            matches!(
+                clause.effect,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { .. },
+                    },
+                    target: TargetFilter::Any,
+                    damage_source: None,
+                }
+            ),
+            "expected ObjectCount-amount DealDamage to Any, got: {:?}",
             clause.effect
         );
     }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -544,6 +544,52 @@ pub(crate) fn parse_cda_quantity_with_context(
         }
     }
 
+    // CR 107.x: Binary arithmetic over two dynamic quantities, e.g. "the number
+    // of Caves you control plus the number of Cave cards in your graveyard"
+    // (Calamitous Cave-In) or "the number of cards in their hand minus 4"
+    // (Bant Charm class). Composes the existing Sum/Multiply/Offset variants
+    // over recursively-parsed operands so the whole arithmetic class types
+    // instead of falling through to an unresolved `Variable` (which resolves to
+    // 0 at runtime — a silent no-op). Mirrors the leading-number "N plus inner"
+    // arm above for the reversed operand order. Placed after the specific arms
+    // and before the single-ref delegate; it only fires when the LEFT operand is
+    // itself a dynamic quantity, so single refs and unparseable tails fall
+    // through untouched. The runtime clamps a negative total to 0 (CR 107.1b),
+    // matching the existing "N minus inner" handling.
+    for (separator, negate) in [(" plus ", false), (" minus ", true)] {
+        let Ok((_, (left_text, right_text))) = nom_primitives::split_once_on(text, separator)
+        else {
+            continue;
+        };
+        let Some(left) = parse_cda_quantity_with_context(left_text, ctx) else {
+            continue;
+        };
+        // Right operand is either another dynamic quantity (→ Sum) or a bare
+        // integer offset (→ Offset).
+        if let Some(right) = parse_cda_quantity_with_context(right_text, ctx) {
+            let right = if negate {
+                QuantityExpr::Multiply {
+                    factor: -1,
+                    inner: Box::new(right),
+                }
+            } else {
+                right
+            };
+            return Some(QuantityExpr::Sum {
+                exprs: vec![left, right],
+            });
+        }
+        if let Ok((rest, n)) = nom_primitives::parse_number(right_text.trim()) {
+            if rest.trim().is_empty() {
+                let offset = if negate { -(n as i32) } else { n as i32 };
+                return Some(QuantityExpr::Offset {
+                    inner: Box::new(left),
+                    offset,
+                });
+            }
+        }
+    }
+
     // Delegate to existing parse_quantity_ref for patterns like
     // "the number of {type} you control", "your devotion to X"
     if let Some(qty) = parse_quantity_ref_with_context(text, ctx) {


### PR DESCRIPTION
Two parser sites degraded dynamic quantity phrases to QuantityRef::Variable{name},
which resolves to 0 at runtime -- a silent no-op (the ability asks for a target,
then deals 0 / draws 0 / etc.):

- "deals damage equal to <qty> to <target>" only tried event-context amounts
  before falling back to Variable, unlike its sibling "<target> equal to <qty>"
  word order. Add the parse_cda_quantity_with_context fallback so dynamic counts
  type correctly. Fixes Ajani, Nacatl Avenger's +0 (now ObjectCount of creatures
  you control) and clears the 8-card "the number of creatures you control" class.

- parse_cda_quantity couldn't compose binary arithmetic over two dynamic
  quantities. Add "<count> +/- <count>" -> Sum and "<count> +/- N" -> Offset,
  composed recursively over existing variants (no new variant). Clears the
  count-arithmetic class: Calamitous Cave-In, Reckless Crew, Hobbit's Sting,
  Slash of Light, Sinuous Benthisaur, and the "minus 4" hand-size payoffs.
  CR 107.1b governs the negative-total clamp.
