### PR TITLE
fix(client): restore combat card-slam for collapsed creature swarms

### DIFF
--- a/client/src/components/animation/AnimationOverlay.tsx
+++ b/client/src/components/animation/AnimationOverlay.tsx
@@ -72,6 +72,20 @@ let shatterIdCounter = 0;
 let castArcIdCounter = 0;
 let millRevealIdCounter = 0;
 
+/**
+ * Resolve the rendered card element for an object id. Collapsed identical-
+ * permanent groups (GroupedPermanent collapsed mode) render only their
+ * representative card, which carries `data-grouped-ids` listing every id it
+ * stands in for — so a non-rendered swarm member falls back to that
+ * representative instead of resolving to nothing (no slam, no impact FX).
+ */
+function findCardElement(objectId: number): HTMLElement | null {
+  return (
+    document.querySelector<HTMLElement>(`[data-object-id="${objectId}"]`) ??
+    document.querySelector<HTMLElement>(`[data-grouped-ids~="${objectId}"]`)
+  );
+}
+
 export function AnimationOverlay({ containerRef }: AnimationOverlayProps) {
   const activeStep = useAnimationStore((s) => s.activeStep);
   const advanceStep = useAnimationStore((s) => s.advanceStep);
@@ -92,10 +106,13 @@ export function AnimationOverlay({ containerRef }: AnimationOverlayProps) {
 
   const getObjectPosition = useCallback(
     (objectId: number): { x: number; y: number } | null => {
-      // Check snapshot first (pre-dispatch positions), then live registry
-      const snapshotRect = currentSnapshot.get(objectId);
-      const registryRect = getPosition(objectId);
-      const rect = snapshotRect ?? registryRect;
+      // Fallback chain: pre-dispatch snapshot, then live registry, then the
+      // group representative for a collapsed swarm member that has no node of
+      // its own (resolved live via data-grouped-ids — see findCardElement).
+      const rect =
+        currentSnapshot.get(objectId) ??
+        getPosition(objectId) ??
+        findCardElement(objectId)?.getBoundingClientRect();
       if (!rect) return null;
       return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
     },
@@ -147,12 +164,11 @@ export function AnimationOverlay({ containerRef }: AnimationOverlayProps) {
                 (e.event.data.target as { Object: number }).Object === source_id,
             );
 
-            if (!isPairedReturn) {
-              const sourceEl = document.querySelector<HTMLElement>(
-                `[data-object-id="${source_id}"]`,
-              );
-              if (sourceEl) {
-                applyCardSlam(sourceEl, pos.x, pos.y, speedMultiplier, () => {
+            // Resolve via the group representative when this attacker is a
+            // non-rendered member of a collapsed swarm (findCardElement).
+            const sourceEl = isPairedReturn ? null : findCardElement(source_id);
+            const slammed = sourceEl
+              ? applyCardSlam(sourceEl, pos.x, pos.y, speedMultiplier, () => {
                   // Impact effects: SFX, shockwave, floating number, screen shake
                   audioManager.playSfx("DamageDealt");
                   particleRef.current?.slamImpact(pos.x, pos.y, amount);
@@ -167,48 +183,50 @@ export function AnimationOverlay({ containerRef }: AnimationOverlayProps) {
                     const intensity = amount >= 7 ? "heavy" : amount >= 4 ? "medium" : "light";
                     applyScreenShake(containerRef.current, intensity, speedMultiplier);
                   }
-                });
-                break;
-              }
-            }
+                })
+              : false;
 
-            // Paired return or source element not found: just show floating damage + immediate SFX
-            audioManager.playSfx("DamageDealt");
-            const floatId = ++floatIdCounter;
-            setActiveFloats((prev) => [
-              ...prev,
-              { id: floatId, value: -amount, position: pos, color: "#ef4444" },
-            ]);
+            if (!slammed) {
+              // Paired return, missing source element, or representative already
+              // mid-slam: show the floating damage number (+ SFX) without a slam.
+              audioManager.playSfx("DamageDealt");
+              const floatId = ++floatIdCounter;
+              setActiveFloats((prev) => [
+                ...prev,
+                { id: floatId, value: -amount, position: pos, color: "#ef4444" },
+              ]);
+            }
             break;
           }
 
           // Creature-to-player: card slam at the player HUD
           {
-            const sourceEl = document.querySelector<HTMLElement>(
-              `[data-object-id="${source_id}"]`,
-            );
-            if (sourceEl && vfxQuality !== "minimal") {
-              applyCardSlam(sourceEl, pos.x, pos.y, speedMultiplier, () => {
-                audioManager.playSfx("DamageDealt");
-                particleRef.current?.playerDamage(pos.x, pos.y, amount);
+            // Resolve via the group representative for a collapsed swarm member.
+            const sourceEl = vfxQuality !== "minimal" ? findCardElement(source_id) : null;
+            const slammed = sourceEl
+              ? applyCardSlam(sourceEl, pos.x, pos.y, speedMultiplier, () => {
+                  audioManager.playSfx("DamageDealt");
+                  particleRef.current?.playerDamage(pos.x, pos.y, amount);
 
-                const fid = ++floatIdCounter;
-                setActiveFloats((prev) => [
-                  ...prev,
-                  { id: fid, value: -amount, position: pos, color: "#ef4444" },
-                ]);
+                  const fid = ++floatIdCounter;
+                  setActiveFloats((prev) => [
+                    ...prev,
+                    { id: fid, value: -amount, position: pos, color: "#ef4444" },
+                  ]);
 
-                if (vfxQuality === "full" && containerRef.current) {
-                  const intensity = amount >= 7 ? "heavy" : amount >= 4 ? "medium" : "light";
-                  applyScreenShake(containerRef.current, intensity, speedMultiplier);
-                }
+                  if (vfxQuality === "full" && containerRef.current) {
+                    const intensity = amount >= 7 ? "heavy" : amount >= 4 ? "medium" : "light";
+                    applyScreenShake(containerRef.current, intensity, speedMultiplier);
+                  }
 
-                if (isPlayerTarget) {
-                  setActiveVignette({ damageAmount: amount });
-                  setTimeout(() => setActiveVignette(null), 500 * speedMultiplier);
-                }
-              });
-            } else {
+                  if (isPlayerTarget) {
+                    setActiveVignette({ damageAmount: amount });
+                    setTimeout(() => setActiveVignette(null), 500 * speedMultiplier);
+                  }
+                })
+              : false;
+
+            if (!slammed) {
               audioManager.playSfx("DamageDealt");
               const fid = ++floatIdCounter;
               setActiveFloats((prev) => [

--- a/client/src/components/animation/CardSlamAnimation.tsx
+++ b/client/src/components/animation/CardSlamAnimation.tsx
@@ -1,6 +1,16 @@
 import { CARD_SLAM_FLIGHT_MS } from "../../animation/types.ts";
 
 /**
+ * Elements with a slam currently in flight. A collapsed identical-permanent
+ * group renders one representative card for the whole swarm, so several
+ * DamageDealt events in the same combat step resolve to the *same* DOM node.
+ * Without this guard each would start its own rAF loop fighting over the
+ * element's `translate`/`scale`. We animate it once; callers fall back to a
+ * floating number for the rest (so every hit still shows a number).
+ */
+const activeSlams = new WeakSet<HTMLElement>();
+
+/**
  * Arena-style card slam: animates the ACTUAL card DOM element from its
  * battlefield position toward the target, impacts with jitter, then
  * slides back to its original position.
@@ -8,6 +18,10 @@ import { CARD_SLAM_FLIGHT_MS } from "../../animation/types.ts";
  * Uses independent CSS `translate`/`scale` properties so the animation
  * composes on top of Framer Motion's `transform` (rotate, opacity, y)
  * without conflict.
+ *
+ * Returns `true` if the slam started (and will fire `onImpact`), or `false`
+ * if the element is already mid-slam — letting the caller show a floating
+ * number instead of dropping the hit entirely.
  */
 export function applyCardSlam(
   element: HTMLElement,
@@ -15,7 +29,10 @@ export function applyCardSlam(
   targetY: number,
   speedMultiplier: number,
   onImpact: () => void,
-): void {
+): boolean {
+  if (activeSlams.has(element)) return false;
+  activeSlams.add(element);
+
   const rect = element.getBoundingClientRect();
   const centerX = rect.x + rect.width / 2;
   const centerY = rect.y + rect.height / 2;
@@ -40,6 +57,7 @@ export function applyCardSlam(
       element.style.translate = "";
       element.style.scale = "";
       element.style.zIndex = originalZ;
+      activeSlams.delete(element);
       return;
     }
 
@@ -72,4 +90,5 @@ export function applyCardSlam(
   };
 
   requestAnimationFrame(frame);
+  return true;
 }

--- a/client/src/components/board/GroupedPermanent.tsx
+++ b/client/src/components/board/GroupedPermanent.tsx
@@ -193,6 +193,7 @@ export const GroupedPermanentDisplay = memo(function GroupedPermanentDisplay({
         <div className={`relative rounded-lg ${aggregateRingClass}`}>
           <PermanentCard
             objectId={group.ids[0]}
+            coveredIds={group.ids}
             onPrimaryClickOverride={canOpenPicker ? () => setPickerOpen(true) : undefined}
           />
           {aggregateRingClass && (

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -33,6 +33,12 @@ interface PermanentCardProps {
   objectId: number;
   attachmentsLiftedByAncestor?: boolean;
   onPrimaryClickOverride?: () => void;
+  /** When this card is the visible representative of a collapsed identical-permanent
+   *  group (see GroupedPermanent collapsed mode), the full list of object ids it
+   *  stands in for. Rendered as `data-grouped-ids` so DOM-driven animations
+   *  (card slam, position lookup) can resolve a non-rendered swarm member to this
+   *  visible card instead of silently no-op'ing. */
+  coveredIds?: number[];
 }
 
 const EXILE_GHOST_OFFSET_PX = 20;
@@ -101,7 +107,7 @@ function objectIdFromRelatedTarget(target: EventTarget | null): number | null {
   return Number.isFinite(objectId) ? objectId : null;
 }
 
-export const PermanentCard = memo(function PermanentCard({ objectId, attachmentsLiftedByAncestor = false, onPrimaryClickOverride }: PermanentCardProps) {
+export const PermanentCard = memo(function PermanentCard({ objectId, attachmentsLiftedByAncestor = false, onPrimaryClickOverride, coveredIds }: PermanentCardProps) {
   const { t } = useTranslation("game");
   const isMobile = useIsMobile();
   const playerId = usePlayerId();
@@ -458,6 +464,7 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
     <motion.div
       ref={cardRef}
       data-object-id={objectId}
+      data-grouped-ids={coveredIds && coveredIds.length > 1 ? coveredIds.join(" ") : undefined}
       data-card-hover
       layoutId={`permanent-${objectId}`}
       className="relative inline-flex w-fit cursor-pointer overflow-visible rounded-lg self-end select-none"


### PR DESCRIPTION
The Arena-style card slam resolves the attacking card via
document.querySelector('[data-object-id]'), but GroupedPermanent's
collapsed mode (>=5 identical permanents) renders only the representative
card. Non-representative swarm members had no DOM node, so their combat
damage silently fell back to a floating number with no slam/particles/shake.

Resolve a swarm member to its visible representative: the representative
card now carries data-grouped-ids, and AnimationOverlay's findCardElement
falls back to [data-grouped-ids~="<id>"] (used by both DamageDealt slam
branches and as a third tier of getObjectPosition's fallback chain).
applyCardSlam dedupes concurrent slams on the same element via a WeakSet
and returns whether it started, so a swarm lunges once while every hit
still shows its damage number.
