### PR TITLE
Validate dig keep-selection against the looked-at and filtered set (CR 401.2)

### DIFF
--- a/crates/engine/src/game/effects/dig.rs
+++ b/crates/engine/src/game/effects/dig.rs
@@ -518,6 +518,134 @@ mod tests {
         );
     }
 
+    /// CR 401.2 + CR 608.2c: a `DigChoice` selection must be drawn from the cards
+    /// actually looked at. Regression guard for the freeform-selection hole — the
+    /// old handler skipped this check whenever `selectable_cards` was empty (a
+    /// filtered dig that matched nothing), so an `apply`-level `SelectCards` with
+    /// a foreign object id was accepted and moved into the chooser's hand.
+    #[test]
+    fn dig_choice_rejects_card_not_looked_at() {
+        use crate::game::engine_resolution_choices::handle_resolution_choice;
+        use crate::types::actions::GameAction;
+
+        let mut state = GameState::new_two_player(42);
+        for i in 0..3 {
+            create_object(
+                &mut state,
+                CardId(i + 1),
+                PlayerId(0),
+                format!("Card {i}"),
+                Zone::Library,
+            );
+        }
+        let cards_on_top = state.players[0].library.iter().copied().collect::<Vec<_>>();
+        // A card the dig never looked at.
+        let foreign = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Foreign".to_string(),
+            Zone::Library,
+        );
+        let original_library = state.players[0].library.iter().copied().collect::<Vec<_>>();
+
+        // Filtered dig that matched nothing -> empty selectable set (the hole).
+        let waiting = WaitingFor::DigChoice {
+            player: PlayerId(0),
+            library_owner: PlayerId(0),
+            selectable_cards: Vec::new(),
+            cards: cards_on_top,
+            keep_count: 1,
+            up_to: true,
+            kept_destination: Some(Zone::Hand),
+            rest_destination: Some(Zone::Graveyard),
+            source_id: Some(ObjectId(100)),
+        };
+
+        let mut events = Vec::new();
+        let result = handle_resolution_choice(
+            &mut state,
+            waiting,
+            GameAction::SelectCards {
+                cards: vec![foreign],
+            },
+            &mut events,
+        );
+
+        assert!(
+            result.is_err(),
+            "a card that was not looked at must be rejected (CR 401.2)"
+        );
+        assert!(
+            !state.players[0].hand.contains(&foreign),
+            "rejected selection must not move the foreign card to hand"
+        );
+        assert_eq!(
+            state.players[0].library.iter().copied().collect::<Vec<_>>(),
+            original_library,
+            "rejected selection must not mutate the library"
+        );
+    }
+
+    /// CR 401.2 + CR 608.2c: when a dig's filter matches nothing, the only legal
+    /// keep-selection is empty — a looked-at card that doesn't match the filter
+    /// must still be rejected. Regression guard for the same empty-`selectable`
+    /// hole: the old handler accepted it and moved it to hand.
+    #[test]
+    fn dig_choice_rejects_card_excluded_by_empty_filter() {
+        use crate::game::engine_resolution_choices::handle_resolution_choice;
+        use crate::types::actions::GameAction;
+
+        let mut state = GameState::new_two_player(42);
+        for i in 0..3 {
+            create_object(
+                &mut state,
+                CardId(i + 1),
+                PlayerId(0),
+                format!("Card {i}"),
+                Zone::Library,
+            );
+        }
+        let cards_on_top = state.players[0].library.iter().copied().collect::<Vec<_>>();
+        let original_library = cards_on_top.clone();
+
+        let waiting = WaitingFor::DigChoice {
+            player: PlayerId(0),
+            library_owner: PlayerId(0),
+            selectable_cards: Vec::new(),
+            cards: cards_on_top.clone(),
+            keep_count: 1,
+            up_to: true,
+            kept_destination: Some(Zone::Hand),
+            rest_destination: Some(Zone::Graveyard),
+            source_id: Some(ObjectId(100)),
+        };
+
+        let mut events = Vec::new();
+        let result = handle_resolution_choice(
+            &mut state,
+            waiting,
+            GameAction::SelectCards {
+                cards: vec![cards_on_top[0]],
+            },
+            &mut events,
+        );
+
+        assert!(
+            result.is_err(),
+            "a looked-at card that doesn't match the filter must be rejected when the filter matched nothing"
+        );
+        assert!(
+            !state.players[0].hand.contains(&cards_on_top[0]),
+            "rejected selection must not move the card to hand"
+        );
+        assert_eq!(
+            state.players[0].library.iter().copied().collect::<Vec<_>>(),
+            original_library,
+            "rejected selection must not mutate the library"
+        );
+    }
+
     #[test]
     fn dig_choice_forwards_kept_cards_to_conditional_continuation() {
         use crate::game::engine_resolution_choices::{

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -155,6 +155,47 @@ fn validate_keep_on_top_selection(
     Ok(())
 }
 
+/// CR 401.2 + CR 608.2c: Validate a `DigChoice` keep-selection. A dig
+/// ("look at the top N, put [some] into your hand/elsewhere") may only act on
+/// the cards it actually looked at, and only on those matching the effect's
+/// filter. Mirrors `validate_keep_on_top_selection` (used by scry/surveil) but
+/// additionally enforces the filter, since `DigChoice` is one of the freeform
+/// card-selection states the multiplayer server forwards unvalidated — so
+/// `apply` is the sole legality boundary.
+///
+/// `looked_at` is the full revealed set; `selectable` is the subset matching the
+/// effect's filter (equal to `looked_at` when the effect has no filter, and
+/// empty when a filter matched nothing — in which case the only legal selection
+/// is empty). Previously the filter check was skipped whenever `selectable` was
+/// empty, which let a filtered dig that matched zero cards accept arbitrary
+/// object ids — moving cards the effect never looked at into the chooser's hand,
+/// or inserting foreign ids into the library and corrupting its order.
+fn validate_dig_selection(
+    kept: &[ObjectId],
+    looked_at: &[ObjectId],
+    selectable: &[ObjectId],
+) -> Result<(), EngineError> {
+    let mut seen = std::collections::HashSet::new();
+    for id in kept {
+        if !seen.insert(*id) {
+            return Err(EngineError::InvalidAction(
+                "dig selection contains a duplicate card".to_string(),
+            ));
+        }
+        if !looked_at.contains(id) {
+            return Err(EngineError::InvalidAction(
+                "dig selection contains a card that was not looked at".to_string(),
+            ));
+        }
+        if !selectable.contains(id) {
+            return Err(EngineError::InvalidAction(
+                "dig selection contains a card that does not match the effect's filter".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// CR 701.23a + CR 614.1 / CR 110.5b: Apply a cultivate-class search-destination
 /// split. `primary_ids` are routed to `primary_destination` through the full
 /// `change_zone::resolve` ETB pipeline (carrying `enter_tapped` so ETB-tapped
@@ -862,25 +903,12 @@ pub(super) fn handle_resolution_choice(
                 )));
             }
 
-            if kept
-                .iter()
-                .enumerate()
-                .any(|(index, card_id)| kept[index + 1..].contains(card_id))
-            {
-                return Err(EngineError::InvalidAction(
-                    "Selected cards must be unique".to_string(),
-                ));
-            }
-
-            if !selectable_cards.is_empty() {
-                for card_id in &kept {
-                    if !selectable_cards.contains(card_id) {
-                        return Err(EngineError::InvalidAction(
-                            "Selected card does not match filter".to_string(),
-                        ));
-                    }
-                }
-            }
+            // CR 401.2 + CR 608.2c: the keep-selection must be unique, drawn from
+            // the cards actually looked at, and (when the dig has a filter) from
+            // the filter-matching subset. The previous check skipped filter/look-
+            // at validation entirely whenever `selectable_cards` was empty, so a
+            // filtered dig that matched nothing accepted arbitrary object ids.
+            validate_dig_selection(&kept, &cards, &selectable_cards)?;
 
             let unkept: Vec<_> = cards
                 .iter()


### PR DESCRIPTION
## Summary
The `DigChoice` keep-selection handler only validated filter membership when `selectable_cards` was non-empty, and never unconditionally checked that the kept ids were among the cards actually looked at. A dig whose filter matched **zero** of the revealed cards (empty `selectable_cards`) therefore skipped validation entirely.

`DigChoice` is one of the freeform card-selection states the multiplayer server forwards without its candidate-legality gate (alongside scry/surveil), so `apply` is the sole legality boundary. With the check skipped, a `SelectCards` payload containing **arbitrary object ids** was accepted, then:
- for a library destination, foreign ids were `insert`ed into the library (corrupting its order), and
- otherwise, objects the effect never looked at were moved into the chooser's hand.

This violates CR 401.2 (a player can't change library order beyond what the effect specifies) and CR 608.2c (an effect acts only on the objects it specifies).

## Fix
Add `validate_dig_selection`, mirroring `validate_keep_on_top_selection` (used by scry/surveil): a `HashSet` dedup pass plus an **unconditional** check that each kept id is in the looked-at set and in the filter-matching set, with distinct error messages. `selectable_cards` is already the correct allowed set - equal to the looked-at set for unfiltered digs, the filtered subset otherwise, and empty when a filter matched nothing (in which case the only legal selection is the empty one). The handler now calls the validator instead of the conditional inline checks (which also replaces an O(n^2) duplicate scan).

## CR references
CR 401.2, CR 608.2c.

## Verification
`cargo test -p engine dig` -> 39 passed, 0 failed; integration tests pass; `cargo clippy -p engine` -> no warnings; `cargo fmt --all` clean.