### PR TITLE
fix(parser): reach existing filter slots for outlaws, "other than ~", and type-disjunction counts

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -679,13 +679,27 @@ fn parse_controlled_by_extremum_player(input: &str) -> OracleResult<'_, Quantity
 
 /// Parse "[type(s)] you control" after "the number of".
 fn parse_number_of_controlled_type(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, tf) = parse_type_filter_word(input)?;
+    let (rest, head) = parse_type_filter_word(input)?;
     let (rest, _) = tag(" you control").parse(rest)?;
+    // CR 205.2b: "<head> you control that are <t1> and/or <t2>" restricts the
+    // controlled population to objects that have any of the listed card types.
+    // CR 205.2b makes a multi-type object satisfy any of its types, so a
+    // permanent that is both a creature and a Vehicle is counted once via the
+    // `AnyOf` disjunction (Collision Course). When the relative clause names a
+    // single type, that type alone replaces the head. A non-type "that are"
+    // clause (e.g. "that are tapped") leaves the suffix unconsumed so a later
+    // arm can handle it rather than mis-parsing it here.
+    let (rest, type_filters) =
+        match opt(preceded(tag(" that are "), parse_type_filter_list)).parse(rest)? {
+            (r, Some(list)) if list.len() > 1 => (r, vec![TypeFilter::AnyOf(list)]),
+            (r, Some(list)) => (r, list),
+            (r, None) => (r, vec![head]),
+        };
     Ok((
         rest,
         QuantityRef::ObjectCount {
             filter: TargetFilter::Typed(TypedFilter {
-                type_filters: vec![tf],
+                type_filters,
                 controller: Some(ControllerRef::You),
                 properties: Vec::new(),
             }),
@@ -4798,5 +4812,114 @@ mod tests {
                 "phrase {phrase:?} must yield ObjectManaValue{{CostPaidObject}}"
             );
         }
+    }
+
+    /// CR 700.12: "the number of outlaws you control" counts every permanent
+    /// with an outlaw creature type (Assassin/Mercenary/Pirate/Rogue/Warlock).
+    /// Laughing Jasper Flint. Routes through `parse_number_of_controlled_type`
+    /// once `parse_type_filter_word` recognizes the "outlaws" head noun.
+    #[test]
+    fn parse_quantity_ref_the_number_of_outlaws_you_control() {
+        let outlaws = TypeFilter::AnyOf(
+            ["Assassin", "Mercenary", "Pirate", "Rogue", "Warlock"]
+                .iter()
+                .map(|s| TypeFilter::Subtype((*s).to_string()))
+                .collect(),
+        );
+        let (rest, q) = parse_quantity_ref("the number of outlaws you control").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            q,
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![outlaws],
+                    controller: Some(ControllerRef::You),
+                    properties: Vec::new(),
+                }),
+            }
+        );
+    }
+
+    /// CR 205.2b: "permanents you control that are creatures and/or Vehicles"
+    /// restricts the controlled population to the listed types, merged into an
+    /// `AnyOf` disjunction so a creature-Vehicle is counted once. Collision
+    /// Course.
+    #[test]
+    fn parse_quantity_ref_controlled_type_disjunction_clause() {
+        let (rest, q) = parse_quantity_ref(
+            "the number of permanents you control that are creatures and/or vehicles",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            q,
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::AnyOf(vec![
+                        TypeFilter::Creature,
+                        TypeFilter::Subtype("Vehicle".to_string()),
+                    ])],
+                    controller: Some(ControllerRef::You),
+                    properties: Vec::new(),
+                }),
+            }
+        );
+    }
+
+    /// Regression: a plain controlled-type count without a "that are" clause
+    /// keeps the single head type.
+    #[test]
+    fn parse_quantity_ref_controlled_type_no_clause_keeps_head() {
+        let (rest, q) = parse_quantity_ref("the number of creatures you control").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            q,
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Creature],
+                    controller: Some(ControllerRef::You),
+                    properties: Vec::new(),
+                }),
+            }
+        );
+    }
+
+    /// A single-type "that are" clause replaces the head with that one type
+    /// (no `AnyOf` wrapper).
+    #[test]
+    fn parse_quantity_ref_controlled_type_single_clause() {
+        let (rest, q) =
+            parse_quantity_ref("the number of permanents you control that are artifacts").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            q,
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Artifact],
+                    controller: Some(ControllerRef::You),
+                    properties: Vec::new(),
+                }),
+            }
+        );
+    }
+
+    /// A non-type "that are" clause (e.g. "that are tapped") must NOT be
+    /// consumed by the optional type-list clause — the `opt` returns `None` and
+    /// the count keeps the head type, leaving the clause for a later parser.
+    #[test]
+    fn parse_quantity_ref_controlled_type_non_type_clause_falls_through() {
+        let (rest, q) =
+            parse_number_of_controlled_type("creatures you control that are tapped").unwrap();
+        assert_eq!(rest, " that are tapped");
+        assert_eq!(
+            q,
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Creature],
+                    controller: Some(ControllerRef::You),
+                    properties: Vec::new(),
+                }),
+            }
+        );
     }
 }

--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -12,7 +12,7 @@ use nom::Parser;
 
 use super::error::{OracleError, OracleResult};
 use super::primitives::parse_color;
-use crate::parser::oracle_util::parse_subtype;
+use crate::parser::oracle_util::{parse_subtype, OUTLAW_SUBTYPES};
 use crate::types::ability::{ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter};
 use crate::types::card_type::Supertype;
 use crate::types::mana::ManaColor;
@@ -180,6 +180,15 @@ pub fn parse_type_filter_word(input: &str) -> OracleResult<'_, TypeFilter> {
         ("spell", TypeFilter::Card),
     ];
 
+    // CR 700.12: "outlaw"/"outlaws" is a head noun for the Assassin, Mercenary,
+    // Pirate, Rogue, and/or Warlock creature types. Tried before the bare-prefix
+    // TYPE_WORDS scan and the subtype table because it expands to a disjunction
+    // rather than a single subtype. The word-boundary guard prevents "outlawry"
+    // (and similar prefixed words) from matching.
+    if let Ok((rest, tf)) = parse_outlaw_type(input) {
+        return Ok((rest, tf));
+    }
+
     for &(word, ref tf) in TYPE_WORDS {
         if let Some(rest) = input.strip_prefix(word) {
             return Ok((rest, tf.clone()));
@@ -194,6 +203,30 @@ pub fn parse_type_filter_word(input: &str) -> OracleResult<'_, TypeFilter> {
         input,
         nom::error::ErrorKind::Fail,
     )))
+}
+
+/// CR 700.12: Parse the "outlaw"/"outlaws" head noun into a disjunction of the
+/// Assassin, Mercenary, Pirate, Rogue, and Warlock creature types. Matches the
+/// plural form first (longest-match), then requires a non-alphanumeric word
+/// boundary so words like "outlawry" never match.
+fn parse_outlaw_type(input: &str) -> OracleResult<'_, TypeFilter> {
+    let (rest, _) = alt((tag("outlaws"), tag("outlaw"))).parse(input)?;
+    match rest.chars().next() {
+        // Word boundary: end of input or non-alphanumeric follower.
+        None => {}
+        Some(c) if !c.is_alphanumeric() => {}
+        _ => {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Fail,
+            )))
+        }
+    }
+    let any_of = OUTLAW_SUBTYPES
+        .iter()
+        .map(|s| TypeFilter::Subtype((*s).to_string()))
+        .collect();
+    Ok((rest, TypeFilter::AnyOf(any_of)))
 }
 
 /// Parse a self-reference from Oracle text: "~", "it", "this creature",
@@ -649,6 +682,45 @@ mod tests {
         let (rest, t) = parse_type_filter_word("spell").unwrap();
         assert!(matches!(t, TypeFilter::Card), "expected Card for spell");
         assert_eq!(rest, "");
+    }
+
+    /// CR 700.12: the expected outlaw disjunction (Assassin, Mercenary, Pirate,
+    /// Rogue, Warlock) produced by the "outlaw[s]" head noun.
+    fn outlaw_any_of() -> TypeFilter {
+        TypeFilter::AnyOf(
+            ["Assassin", "Mercenary", "Pirate", "Rogue", "Warlock"]
+                .iter()
+                .map(|s| TypeFilter::Subtype((*s).to_string()))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn test_parse_type_filter_word_outlaws() {
+        // CR 700.12: "outlaws" expands to the five outlaw creature types.
+        let (rest, t) = parse_type_filter_word("outlaws you control").unwrap();
+        assert_eq!(t, outlaw_any_of());
+        assert_eq!(rest, " you control");
+    }
+
+    #[test]
+    fn test_parse_type_filter_word_outlaw_singular() {
+        let (rest, t) = parse_type_filter_word("outlaw").unwrap();
+        assert_eq!(t, outlaw_any_of());
+        assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn test_parse_type_filter_word_outlawry_does_not_match_outlaw() {
+        // Word-boundary guard: "outlawry" must NOT match the "outlaw" head noun.
+        // An `Err` is also acceptable — "outlawry" is not a type word at all.
+        if let Ok((_, tf)) = parse_type_filter_word("outlawry") {
+            assert_ne!(
+                tf,
+                outlaw_any_of(),
+                "outlawry must not parse as the outlaw disjunction"
+            );
+        }
     }
 
     // --- parse_stack_object_target (CR 701.6a + CR 115.1) ---

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1754,6 +1754,36 @@ pub fn parse_type_phrase_with_ctx<'a>(
         );
     }
 
+    // CR 700.9 (modified) + CR 109.4 (control): "<typed filter> other than ~"
+    // excludes the ability source from the population. FilterProp::Another
+    // (filter.rs:2206) matches every object except the source, so the count
+    // omits the source permanent (Thundering Raiju: "modified creatures you
+    // control other than this creature" — normalized to "~"). The trailing
+    // self-reference is recognized via `nom_target::parse_self_reference`
+    // ("~"/"it"/"this creature"/…) plus an explicit "itself" alternative, which
+    // `parse_self_reference` does not cover.
+    {
+        let remaining_other_than = lower[pos..].trim_start();
+        let other_than_offset = lower[pos..].len() - remaining_other_than.len();
+        if let Ok((rest, _)) = (
+            tag::<_, _, OracleError<'_>>("other than "),
+            alt((
+                nom_target::parse_self_reference,
+                value(
+                    TargetFilter::SelfRef,
+                    tag::<_, _, OracleError<'_>>("itself"),
+                ),
+            )),
+        )
+            .parse(remaining_other_than)
+        {
+            if !properties.contains(&FilterProp::Another) {
+                properties.push(FilterProp::Another);
+            }
+            pos += other_than_offset + (remaining_other_than.len() - rest.len());
+        }
+    }
+
     // CR 205.3 + CR 205.4b: "that isn't a <Subtype>" relative-clause negation.
     // Checked before `parse_that_clause_suffix` so the subtype exclusion short-circuits
     // the generic that-clause branch (which does not recognize subtype negation).
@@ -8897,6 +8927,68 @@ mod tests {
         } else {
             panic!("Expected Typed filter, got {filter:?}");
         }
+    }
+
+    /// CR 700.9 + CR 109.4: "modified creatures you control other than ~"
+    /// (Thundering Raiju). The "modified" adjective adds `FilterProp::Modified`
+    /// and the trailing "other than ~" adds `FilterProp::Another` so the count
+    /// omits the source permanent.
+    #[test]
+    fn parse_type_phrase_modified_creatures_other_than_self() {
+        let (filter, rest) = parse_type_phrase("modified creatures you control other than ~");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        let TargetFilter::Typed(tf) = &filter else {
+            panic!("Expected Typed filter, got {filter:?}");
+        };
+        assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(
+            tf.properties.contains(&FilterProp::Modified),
+            "missing Modified in {:?}",
+            tf.properties
+        );
+        assert!(
+            tf.properties.contains(&FilterProp::Another),
+            "missing Another in {:?}",
+            tf.properties
+        );
+    }
+
+    /// CR 109.4: "other than this creature" (the un-normalized form) also adds
+    /// `FilterProp::Another` via the "other than <self-ref>" suffix.
+    #[test]
+    fn parse_type_phrase_other_than_this_creature() {
+        let (filter, rest) = parse_type_phrase("creatures you control other than this creature");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        let TargetFilter::Typed(tf) = &filter else {
+            panic!("Expected Typed filter, got {filter:?}");
+        };
+        assert!(
+            tf.properties.contains(&FilterProp::Another),
+            "missing Another in {:?}",
+            tf.properties
+        );
+    }
+
+    /// CR 700.9 + CR 109.4: end-to-end quantity ref for Thundering Raiju —
+    /// "the number of modified creatures you control other than ~" →
+    /// `ObjectCount { Typed(Creature, You, [Modified, Another]) }`.
+    #[test]
+    fn parse_quantity_ref_modified_creatures_other_than_self() {
+        let q = crate::parser::oracle_quantity::parse_quantity_ref(
+            "the number of modified creatures you control other than ~",
+        )
+        .expect("should parse");
+        let QuantityRef::ObjectCount { filter } = q else {
+            panic!("Expected ObjectCount, got {q:?}");
+        };
+        let TargetFilter::Typed(tf) = &filter else {
+            panic!("Expected Typed filter, got {filter:?}");
+        };
+        assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(tf.properties.contains(&FilterProp::Modified));
+        assert!(tf.properties.contains(&FilterProp::Another));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -771,6 +771,11 @@ const SUBTYPE_PLURALS: &[(&str, &str)] = &[
     ("berserkers", "Berserker"),
 ];
 
+/// CR 700.12: An outlaw is an object with the Assassin, Mercenary, Pirate,
+/// Rogue, and/or Warlock creature type. Shared by every parser path that
+/// recognizes the "outlaw[s]" head noun.
+pub const OUTLAW_SUBTYPES: [&str; 5] = ["Assassin", "Mercenary", "Pirate", "Rogue", "Warlock"];
+
 /// Comprehensive list of MTG subtypes (creature types, land types, spell types, etc.).
 /// Case-insensitive matching is done by lowercasing the input.
 /// This covers the standard MTGJSON subtype list plus common Oracle text usage.


### PR DESCRIPTION
Three "the number of <predicated> you control" quantities fell through to
QuantityRef::Variable{name} (resolving to 0 at runtime) because the parser
couldn't build the filter — even though the runtime slots already exist. No new
variant.

- "outlaws" wasn't a recognized type noun. Recognize "outlaw[s]"
  (boundary-guarded so "outlawry" won't match) -> TypeFilter::AnyOf of the five
  CR 700.12 outlaw subtypes (Assassin, Mercenary, Pirate, Rogue, Warlock), via a
  shared OUTLAW_SUBTYPES const so every parser path reuses it. Fixes Laughing
  Jasper Flint.

- "... other than ~" self-exclusion was only parsed as a leading prefix, never a
  trailing suffix. Add the suffix arm -> FilterProp::Another, composing with the
  existing Modified adjective. Fixes Thundering Raiju
  (Typed(Creature, You, [Modified, Another])).

- "permanents you control that are creatures and/or Vehicles" silently dropped
  the relative clause. Parse "that are <type-list>" -> TypeFilter::AnyOf (a
  permanent matching both card types is counted once, CR 205.2b). Fixes Collision
  Course.

All three route into existing runtime-wired slots (AnyOf, Another, Modified) —
parser coverage only.

Deferred (clause-swallow defect class, separate change): Cloudspire Coordinator's
"that entered the battlefield under your control this turn" has its " this turn"
stolen by strip_trailing_duration — a shared duration-stripper fix, not a quantity
gap.

CR 700.12 (outlaw), CR 700.9 (modified), CR 109.4 (control), CR 205.2b (multi-type objects).
