### PR TITLE
fix(parser): route "opponents who control X" and "you own that opponents control" counts to existing slots

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -46,14 +46,15 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction,
     BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
     ChooseFromZoneConstraint, CombatDamageScope, Comparator, ConjureCard, ContinuousModification,
-    ControllerRef, DamageModification, DamageSource, DelayedTriggerCondition, DoubleTarget,
-    Duration, Effect, FilterProp, GainLifePlayer, GameRestriction, IterationKindBinding,
-    ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty, ObjectScope, PaymentCost,
-    PlayerFilter, PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PtValue,
-    QuantityExpr, QuantityRef, ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope,
-    RoundingMode, StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink,
-    TargetChoiceTiming, TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition,
-    TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition,
+    ControlPresence, ControllerRef, DamageModification, DamageSource, DelayedTriggerCondition,
+    DoubleTarget, Duration, Effect, FilterProp, GainLifePlayer, GameRestriction,
+    IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty,
+    ObjectScope, PaymentCost, PlayerFilter, PlayerScope, PreventionAmount, PreventionScope,
+    ProhibitedActivity, PtValue, QuantityExpr, QuantityRef, ReplacementDefinition,
+    RestrictionExpiry, RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition,
+    StepSkipTarget, SubAbilityLink, TargetChoiceTiming, TargetFilter, TargetSelectionMode,
+    TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
+    UntilCondition,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterType;
@@ -15748,19 +15749,67 @@ fn rebind_decline_body_recipients(clause: &mut ParsedEffectClause) {
     }
 }
 
-/// CR 109.4 + CR 700.1: Strip a "who [doesn't] control [type-phrase]" relative
-/// clause that follows an "each opponent"/"each player" subject. Returns the
+/// CR 109.4: Parse the shared "who [doesn't] control [type-phrase]" control
+/// predicate — the present/absent axis plus the controlled-permanent filter.
+/// Returns `(ControlPresence, TargetFilter, remainder)` where `remainder` is the
+/// text after the consumed object sub-phrase, or `None` when no control predicate
+/// is present (or the object resolves to the everything-matching
+/// `TargetFilter::Any`, which must not silently match every permanent).
+///
+/// The object sub-phrase ("an Elf", "a creature with power 4 or greater")
+/// delegates to the shared `parse_type_phrase_with_ctx` combinator — no bespoke
+/// string matching. This is the DRY core shared by the "each opponent who
+/// controls …" subject path (`strip_controls_permanent_clause`) and the "the
+/// number of opponents who control …" quantity path (`oracle_quantity.rs`).
+pub(crate) fn parse_controls_permanent_object<'a>(
+    rest: &'a str,
+    ctx: &mut ParseContext,
+) -> Option<(ControlPresence, TargetFilter, &'a str)> {
+    let lower = rest.to_lowercase();
+    // "who controls " / "who doesn't control " — one alt() arm per presence axis.
+    // Both singular ("each opponent who controls") and plural ("opponents who
+    // control") subject-verb agreement forms are accepted: the present/absent
+    // axis is identical regardless of grammatical number. Negative forms are
+    // longest-match-first so "doesn't/does not/don't/do not control" win before
+    // the bare affirmative; "controls " precedes "control " so the singular form
+    // is not split.
+    let (presence, after_verb) = nom_on_lower(rest, &lower, |i| {
+        preceded(
+            tag("who "),
+            alt((
+                value(ControlPresence::ControlsNone, tag("doesn't control ")),
+                value(ControlPresence::ControlsNone, tag("does not control ")),
+                value(ControlPresence::ControlsNone, tag("don't control ")),
+                value(ControlPresence::ControlsNone, tag("do not control ")),
+                value(ControlPresence::Controls, tag("controls ")),
+                value(ControlPresence::Controls, tag("control ")),
+            )),
+        )
+        .parse(i)
+    })?;
+    // The object sub-phrase is consumed by the shared type-phrase combinator.
+    let (filter, remainder) = super::oracle_target::parse_type_phrase_with_ctx(after_verb, ctx);
+    if matches!(filter, TargetFilter::Any) {
+        return None;
+    }
+    Some((presence, filter, remainder))
+}
+
+/// CR 109.4: Strip a "who [doesn't] control [type-phrase]" relative clause that
+/// follows an "each opponent"/"each player" subject. Returns the
 /// `PlayerFilter::ControlsPermanent` scope (carrying the base subject's
 /// relation, the present/absent axis, and the controlled-permanent filter) and
 /// the verb-phrase remainder. Returns `None` when no control clause is present.
 ///
-/// The object sub-phrase ("an Elf") delegates to the shared `parse_type_phrase`
-/// combinator — no bespoke string matching.
+/// Delegates the control predicate to the shared
+/// `parse_controls_permanent_object` core; this function adds the subject-path
+/// concerns: deriving the relation from the base subject and enforcing a
+/// non-empty verb-phrase residual.
 fn strip_controls_permanent_clause(
     base: &PlayerFilter,
     rest: &str,
 ) -> Option<(PlayerFilter, String)> {
-    use crate::types::ability::{ControlPresence, PlayerRelation};
+    use crate::types::ability::PlayerRelation;
     // The base subject only contributes its player relation; HighestSpeed and
     // any non-relational base are out of scope for a controls qualifier.
     let relation = match base {
@@ -15768,24 +15817,9 @@ fn strip_controls_permanent_clause(
         PlayerFilter::All => PlayerRelation::All,
         _ => return None,
     };
-    let lower = rest.to_lowercase();
-    // "who controls " / "who doesn't control " — one alt() arm per presence axis.
-    let (presence, after_verb) = nom_on_lower(rest, &lower, |i| {
-        preceded(
-            tag("who "),
-            alt((
-                value(ControlPresence::ControlsNone, tag("doesn't control ")),
-                value(ControlPresence::ControlsNone, tag("does not control ")),
-                value(ControlPresence::Controls, tag("controls ")),
-            )),
-        )
-        .parse(i)
-    })?;
-    // The object sub-phrase is consumed by the shared type-phrase combinator.
-    let (filter, remainder) = super::oracle_target::parse_type_phrase(after_verb);
-    if matches!(filter, TargetFilter::Any) {
-        return None;
-    }
+    // Match today's no-ctx behaviour for the subject path.
+    let mut ctx = ParseContext::default();
+    let (presence, filter, remainder) = parse_controls_permanent_object(rest, &mut ctx)?;
     let verb_phrase = remainder.trim_start();
     if verb_phrase.is_empty() {
         return None;
@@ -31280,6 +31314,48 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    /// CR 109.4: building-block coverage for the shared control predicate
+    /// `parse_controls_permanent_object` — the present/absent presence axis, the
+    /// delegated object filter, the consumed-remainder shape, and the
+    /// `TargetFilter::Any` rejection. This is the core both the subject path
+    /// (`strip_controls_permanent_clause`) and the quantity path
+    /// (`oracle_quantity.rs` PlayerCount) compose over.
+    #[test]
+    fn parse_controls_permanent_object_core() {
+        use crate::types::ability::ControlPresence;
+
+        // Affirmative "who controls <object>" + remainder preserved.
+        let mut ctx = ParseContext::default();
+        let (presence, filter, remainder) =
+            parse_controls_permanent_object("who controls an artifact loses 1 life", &mut ctx)
+                .expect("affirmative control predicate must parse");
+        assert_eq!(presence, ControlPresence::Controls);
+        assert!(
+            !matches!(filter, TargetFilter::Any),
+            "artifact object must be captured, got {filter:?}"
+        );
+        assert_eq!(remainder.trim_start(), "loses 1 life");
+
+        // Negative "who doesn't control <object>".
+        let mut ctx = ParseContext::default();
+        let (presence, _filter, _) =
+            parse_controls_permanent_object("who doesn't control a creature", &mut ctx)
+                .expect("negative control predicate must parse");
+        assert_eq!(presence, ControlPresence::ControlsNone);
+
+        // No object after "control" → the all-matching `TargetFilter::Any` is
+        // rejected so callers never count every permanent/opponent.
+        let mut ctx = ParseContext::default();
+        assert!(
+            parse_controls_permanent_object("who controls", &mut ctx).is_none(),
+            "bare 'who controls' with no object must be rejected"
+        );
+
+        // Missing the "who …" lead → no predicate.
+        let mut ctx = ParseContext::default();
+        assert!(parse_controls_permanent_object("draws a card", &mut ctx).is_none());
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -23,6 +23,7 @@ use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_nom::quantity as nom_quantity;
 use super::oracle_nom::target as nom_target;
 use crate::parser::oracle_effect::counter::normalize_counter_type;
+use crate::parser::oracle_effect::parse_controls_permanent_object;
 use crate::parser::oracle_target::{parse_type_phrase, parse_type_phrase_with_ctx};
 use crate::types::ability::{
     AggregateFunction, ControllerRef, CountScope, DevotionColors, FilterProp, ObjectProperty,
@@ -321,6 +322,32 @@ pub(crate) fn parse_quantity_ref_with_context(
             return Some(QuantityRef::PlayerCount {
                 filter: PlayerFilter::OpponentDealtCombatDamage,
             });
+        }
+        // CR 109.4: "opponents who control <filter>" / "opponents who don't
+        // control <filter>" → PlayerCount over the opponents satisfying the
+        // shared control predicate. Consume only the population word here, then
+        // hand the "who [doesn't] control <type-phrase>" remainder to the shared
+        // `parse_controls_permanent_object` core (DRY with the "each opponent who
+        // controls …" subject path). Tried before the generic ObjectCount
+        // fall-through so the opponent population — not battlefield permanents —
+        // is counted. (Singular "opponent" is accepted for the grammatically-
+        // degenerate one-opponent phrasing.)
+        if let Ok((predicate_input, _)) =
+            alt((tag::<_, _, OracleError<'_>>("opponents "), tag("opponent "))).parse(rest)
+        {
+            if let Some((presence, filter, remainder)) =
+                parse_controls_permanent_object(predicate_input, ctx)
+            {
+                if remainder.trim().is_empty() {
+                    return Some(QuantityRef::PlayerCount {
+                        filter: PlayerFilter::ControlsPermanent {
+                            relation: PlayerRelation::Opponent,
+                            presence,
+                            filter,
+                        },
+                    });
+                }
+            }
         }
         let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
         // CR 109.1: `parse_type_phrase_with_ctx` always returns `TargetFilter::Typed`,
@@ -2229,6 +2256,110 @@ mod tests {
         assert!(
             matches!(qty, QuantityRef::ObjectCount { .. }),
             "Expected ObjectCount, got {qty:?}"
+        );
+    }
+
+    // A1: "the number of opponents who control <filter>" → PlayerCount over the
+    // opponents satisfying the shared "who controls …" control predicate.
+    #[test]
+    fn parse_quantity_ref_opponents_who_control_artifact() {
+        use crate::types::ability::ControlPresence;
+        let qty = parse_quantity_ref("the number of opponents who control an artifact").unwrap();
+        match qty {
+            QuantityRef::PlayerCount {
+                filter:
+                    PlayerFilter::ControlsPermanent {
+                        relation: PlayerRelation::Opponent,
+                        presence: ControlPresence::Controls,
+                        filter: TargetFilter::Typed(typed),
+                    },
+            } => {
+                assert_eq!(typed.type_filters, vec![TypeFilter::Artifact]);
+            }
+            other => panic!("Expected PlayerCount{{ControlsPermanent(artifact)}}, got {other:?}"),
+        }
+    }
+
+    // A1 (summon: yojimbo): the controlled-permanent filter carries the
+    // power/toughness comparison parsed by the shared type-phrase combinator.
+    #[test]
+    fn parse_quantity_ref_opponents_who_control_creature_power4() {
+        use crate::types::ability::{ControlPresence, PtStat, PtValueScope};
+        let qty = parse_quantity_ref(
+            "the number of opponents who control a creature with power 4 or greater",
+        )
+        .unwrap();
+        match qty {
+            QuantityRef::PlayerCount {
+                filter:
+                    PlayerFilter::ControlsPermanent {
+                        relation: PlayerRelation::Opponent,
+                        presence: ControlPresence::Controls,
+                        filter: TargetFilter::Typed(typed),
+                    },
+            } => {
+                assert_eq!(typed.type_filters, vec![TypeFilter::Creature]);
+                assert!(
+                    typed.properties.contains(&FilterProp::PtComparison {
+                        stat: PtStat::Power,
+                        scope: PtValueScope::Current,
+                        comparator: Comparator::GE,
+                        value: QuantityExpr::Fixed { value: 4 },
+                    }),
+                    "Expected power>=4 PtComparison, got {:?}",
+                    typed.properties
+                );
+            }
+            other => {
+                panic!("Expected PlayerCount{{ControlsPermanent(creature+pt)}}, got {other:?}")
+            }
+        }
+    }
+
+    // A1 "one plus" path: the Offset arm wraps the inner PlayerCount unchanged
+    // (no dedicated change to the offset path was needed).
+    #[test]
+    fn parse_cda_quantity_one_plus_opponents_who_control_artifact() {
+        use crate::types::ability::ControlPresence;
+        let expr =
+            parse_cda_quantity("one plus the number of opponents who control an artifact").unwrap();
+        match expr {
+            QuantityExpr::Offset { inner, offset } => {
+                assert_eq!(offset, 1);
+                assert!(
+                    matches!(
+                        *inner,
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::PlayerCount {
+                                filter: PlayerFilter::ControlsPermanent {
+                                    relation: PlayerRelation::Opponent,
+                                    presence: ControlPresence::Controls,
+                                    ..
+                                },
+                            },
+                        }
+                    ),
+                    "Expected Offset over PlayerCount{{ControlsPermanent}}, got {inner:?}"
+                );
+            }
+            other => panic!("Expected Offset{{+1}}, got {other:?}"),
+        }
+    }
+
+    // A1 negative: with no object after "control", the shared core rejects the
+    // everything-matching `TargetFilter::Any`, so we must NOT emit a
+    // PlayerCount{ControlsPermanent} that would silently match all opponents.
+    #[test]
+    fn parse_quantity_ref_opponents_who_control_no_object_rejected() {
+        let qty = parse_quantity_ref("the number of opponents who control");
+        assert!(
+            !matches!(
+                qty,
+                Some(QuantityRef::PlayerCount {
+                    filter: PlayerFilter::ControlsPermanent { .. },
+                })
+            ),
+            "Bare 'who control' with no object must not yield ControlsPermanent, got {qty:?}"
         );
     }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1798,6 +1798,30 @@ pub fn parse_type_phrase_with_ctx<'a>(
         pos += consumed;
     }
 
+    // CR 109.4: "that <player> control(s)" relative clause supplying the object
+    // controller — e.g. "permanents you own that your opponents control"
+    // (Zedruu). Placed after `parse_that_clause_suffix` so the quality/combat/
+    // attachment "that …" clauses get first crack, and gated on
+    // `controller.is_none()` so it only fills a controller not already set
+    // (e.g. by an earlier "you control"/"an opponent controls" suffix). The
+    // controller phrase delegates to `parse_controller_suffix`, which routes the
+    // bare "your opponents control"/"an opponent controls" forms through
+    // `nom_filter::parse_zone_controller`. Composes with a preceding "you own"
+    // → `FilterProp::Owned{You}`, yielding the owned-but-opponent-controlled
+    // population.
+    if controller.is_none() {
+        let remaining_that_ctrl = lower[pos..].trim_start();
+        let that_ctrl_offset = lower[pos..].len() - remaining_that_ctrl.len();
+        if let Ok((after_that, _)) =
+            tag::<_, _, OracleError<'_>>("that ").parse(remaining_that_ctrl)
+        {
+            if let Some((ctrl, consumed)) = parse_controller_suffix(after_that, ctx) {
+                controller = Some(ctrl);
+                pos += that_ctrl_offset + "that ".len() + consumed;
+            }
+        }
+    }
+
     // Check zone suffix: "card from a graveyard", "card in your graveyard", "from exile", etc.
     if let Some((zone_props, zone_ctrl, consumed)) = parse_zone_suffix(&lower[pos..]) {
         properties.extend(zone_props);
@@ -6340,6 +6364,47 @@ mod tests {
                 controller: ControllerRef::You,
             }]))
         );
+    }
+
+    // A2 (Zedruu): "you own" sets `FilterProp::Owned{You}`; the trailing
+    // "that your opponents control" relative clause supplies the object
+    // controller via the new `controller.is_none()`-gated "that <ctrl>" arm,
+    // yielding the owned-but-opponent-controlled population. The full phrase is
+    // consumed (empty remainder).
+    #[test]
+    fn permanents_you_own_that_your_opponents_control() {
+        let (f, rest) = parse_type_phrase("permanents you own that your opponents control");
+        assert_eq!(rest, "");
+        assert_eq!(
+            f,
+            TargetFilter::Typed(
+                TypedFilter::permanent()
+                    .controller(ControllerRef::Opponent)
+                    .properties(vec![FilterProp::Owned {
+                        controller: ControllerRef::You,
+                    }])
+            )
+        );
+    }
+
+    // A2: the same phrase routed through `parse_quantity_ref` yields an
+    // ObjectCount over the owned-but-opponent-controlled population.
+    #[test]
+    fn quantity_ref_permanents_you_own_that_your_opponents_control() {
+        use crate::parser::oracle_quantity::parse_quantity_ref;
+        let qty =
+            parse_quantity_ref("the number of permanents you own that your opponents control");
+        match qty {
+            Some(QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(typed),
+            }) => {
+                assert_eq!(typed.controller, Some(ControllerRef::Opponent));
+                assert!(typed.properties.contains(&FilterProp::Owned {
+                    controller: ControllerRef::You,
+                }));
+            }
+            other => panic!("Expected ObjectCount{{owned-by-you,opp-controlled}}, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Three player/object-count quantities fell through to QuantityRef::Variable{name}
(resolving to 0 at runtime). The runtime slots already exist — only the parser
couldn't reach them. No new variant.

- "the number of opponents who control <filter>" had no quantity-path arm
  (PlayerFilter::ControlsPermanent was only built on the effect-subject path).
  Extract strip_controls_permanent_clause's presence+filter core into a shared
  parse_controls_permanent_object combinator and call it from the quantity path
  -> PlayerCount{ControlsPermanent{Opponent, presence, filter}}. The core's
  presence alt() now also accepts the plural subject-verb agreement ("opponents
  who control") the quantity phrasing uses. "one plus ..." composes via the
  existing Offset arm. Fixes Journey On and Summon: Yojimbo (the inner "a creature
  with power 4 or greater" reuses FilterProp::PtComparison).

- "permanents you own that your opponents control" dropped its trailing relative
  clause (parse_that_clause_suffix had no controller arm). Add a "that <player>
  control(s)" arm to parse_type_phrase, gated on controller.is_none() and placed
  after the existing that-clause suffixes, composing with the pre-set
  FilterProp::Owned{You} -> ObjectCount{Typed(Permanent, controller:Opponent,
  [Owned{You}])}. Fixes Zedruu the Greathearted.

All route into existing runtime-wired slots — parser coverage only.

Deferred follow-ups: Tier B (gated — ControlsPermanent->ControlsCount refactor for
"control more X than you"; new PlayerFilter::PlayerAttribute for poison/hand-size
thresholds) and Tier C (event predicates: "opponents you attacked" / "dealt combat
damage by ~" / "investigated this way" -> bucket 4).

CR 109.4 (control), CR 108.3 (ownership).
