### PR TITLE
refactor(engine): parameterize PlayerFilter::ControlsPermanent into ControlsCount

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1753,7 +1753,7 @@ fn quantity_ref_references_target_creature(qty: &QuantityRef) -> bool {
             CastManaSpentMetric::Total | CastManaSpentMetric::DistinctColors => false,
         },
         QuantityRef::PlayerCount {
-            filter: crate::types::ability::PlayerFilter::ControlsPermanent { filter, .. },
+            filter: crate::types::ability::PlayerFilter::ControlsCount { filter, .. },
         } => filter_references_target_creature_quantity(filter),
         _ => false,
     }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1161,7 +1161,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
 }
 
 fn fmt_player_filter(pf: &PlayerFilter) -> String {
-    use crate::types::ability::{ControlPresence, PlayerRelation};
+    use crate::types::ability::PlayerRelation;
     match pf {
         PlayerFilter::Controller => "you",
         PlayerFilter::Opponent => "each opponent",
@@ -1180,20 +1180,20 @@ fn fmt_player_filter(pf: &PlayerFilter) -> String {
         PlayerFilter::OpponentOtherThanTriggering => "each other opponent",
         PlayerFilter::VotedFor { .. } => "each player who voted for this option",
         PlayerFilter::ParentObjectTargetController => "the parent target's controller",
-        // CR 109.4 + CR 700.1: "each [player class] who [doesn't] control [filter]"
-        PlayerFilter::ControlsPermanent {
-            relation, presence, ..
+        // CR 109.4 + CR 109.5: "each [player class] who controls [comparator]
+        // [count] matching permanents"
+        PlayerFilter::ControlsCount {
+            relation,
+            comparator,
+            count,
+            ..
         } => {
             let who = match relation {
                 PlayerRelation::Controller => "you",
                 PlayerRelation::Opponent => "each opponent",
                 PlayerRelation::All => "each player",
             };
-            let verb = match presence {
-                ControlPresence::Controls => "who controls",
-                ControlPresence::ControlsNone => "who doesn't control",
-            };
-            return format!("{who} {verb} a matching permanent");
+            return format!("{who} who controls {comparator:?} {count:?} matching permanents");
         }
     }
     .into()
@@ -5263,7 +5263,7 @@ fn player_filter_feature(scope: &PlayerFilter) -> (&'static str, FeatureSupport)
         PlayerFilter::OpponentOtherThanTriggering => ("OpponentOtherThanTriggering", Handled),
         PlayerFilter::VotedFor { .. } => ("VotedFor", Handled),
         PlayerFilter::ParentObjectTargetController => ("ParentObjectTargetController", Handled),
-        PlayerFilter::ControlsPermanent { .. } => ("ControlsPermanent", Handled),
+        PlayerFilter::ControlsCount { .. } => ("ControlsCount", Handled),
     }
 }
 

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -913,17 +913,29 @@ fn collect_matching_players(
                     // for a damage-each-player effect (no parent object target
                     // is in scope); never matches.
                     PlayerFilter::ParentObjectTargetController => false,
-                    // CR 109.4 + CR 700.1: "each [player class] who [doesn't]
-                    // control [filter]" — candidate satisfies both `relation`
-                    // and the controls/controls-none predicate.
-                    PlayerFilter::ControlsPermanent {
+                    // CR 109.4 + CR 109.5: "each [player class] who controls
+                    // [comparator] [count] [filter]" — candidate satisfies both
+                    // `relation` and the controlled-permanent count comparison.
+                    PlayerFilter::ControlsCount {
                         ref relation,
-                        ref presence,
                         ref filter,
+                        ref comparator,
+                        ref count,
                     } => {
+                        let threshold = crate::game::quantity::resolve_quantity(
+                            state,
+                            count,
+                            source_controller,
+                            source_id,
+                        );
                         crate::game::players::matches_relation(p.id, source_controller, *relation)
-                            && crate::game::effects::player_controls_matching_permanent(
-                                state, p.id, presence, filter, source_id,
+                            && crate::game::effects::player_control_count_compares(
+                                state,
+                                p.id,
+                                filter,
+                                *comparator,
+                                threshold,
+                                source_id,
                             )
                     }
                 }
@@ -1042,20 +1054,28 @@ pub fn resolve_each_player(
                     // for a damage-each-player effect (no parent object target
                     // is in scope); never matches.
                     PlayerFilter::ParentObjectTargetController => false,
-                    // CR 109.4 + CR 700.1: "each [player class] who [doesn't]
-                    // control [filter]" — candidate satisfies both `relation`
-                    // and the controls/controls-none predicate.
-                    PlayerFilter::ControlsPermanent {
+                    // CR 109.4 + CR 109.5: "each [player class] who controls
+                    // [comparator] [count] [filter]" — candidate satisfies both
+                    // `relation` and the controlled-permanent count comparison.
+                    PlayerFilter::ControlsCount {
                         relation,
-                        presence,
                         filter,
+                        comparator,
+                        count,
                     } => {
+                        let threshold = crate::game::quantity::resolve_quantity(
+                            state,
+                            count,
+                            ability.controller,
+                            ability.source_id,
+                        );
                         crate::game::players::matches_relation(p.id, ability.controller, *relation)
-                            && crate::game::effects::player_controls_matching_permanent(
+                            && crate::game::effects::player_control_count_compares(
                                 state,
                                 p.id,
-                                presence,
                                 filter,
+                                *comparator,
+                                threshold,
                                 ability.source_id,
                             )
                     }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -280,52 +280,70 @@ pub(crate) fn matches_player_scope(
                     // `speed_effects::players_for_filter` instead, which has
                     // the ability in scope. Unreachable here.
                     PlayerFilter::ParentObjectTargetController => false,
-                    // CR 109.4 + CR 700.1: "each [player class] who [doesn't]
-                    // control [filter]" — the candidate must satisfy both the
-                    // `relation` predicate and the controls/controls-none
-                    // predicate over the permanents they control.
-                    PlayerFilter::ControlsPermanent {
+                    // CR 109.4 + CR 109.5: "each [player class] who controls
+                    // [comparator] [count] [filter]" — the candidate must
+                    // satisfy both the `relation` predicate and the
+                    // controlled-permanent count comparison.
+                    PlayerFilter::ControlsCount {
                         relation,
-                        presence,
                         filter,
+                        comparator,
+                        count,
                     } => {
+                        let threshold = crate::game::quantity::resolve_quantity(
+                            state, count, controller, source_id,
+                        );
                         crate::game::players::matches_relation(p.id, controller, *relation)
-                            && player_controls_matching_permanent(
-                                state, p.id, presence, filter, source_id,
+                            && player_control_count_compares(
+                                state,
+                                p.id,
+                                filter,
+                                *comparator,
+                                threshold,
+                                source_id,
                             )
                     }
                 }
         })
 }
 
-/// CR 109.4: Evaluate the controls / controls-none predicate of
-/// `PlayerFilter::ControlsPermanent` for one candidate player. Counts
-/// battlefield permanents the candidate controls that match `filter`;
-/// `Controls` requires at least one, `ControlsNone` requires zero.
+/// CR 109.4 + CR 109.5: Evaluate the controlled-permanent count predicate of
+/// `PlayerFilter::ControlsCount` for one candidate player. Counts battlefield
+/// permanents the candidate controls that match `filter`, then compares that
+/// count to `threshold` under `comparator`.
+///
+/// This exactly preserves the old presence semantics: `{ GE, 1 }` is the old
+/// `Controls` (count >= 1) and `{ EQ, 0 }` is the old `ControlsNone`
+/// (count == 0). Comparative "more X than you" phrasings pass `{ GT, n }` where
+/// `n` is the controller's own resolved count.
 ///
 /// The `filter` ("an Elf", "an artifact", …) carries no controller axis — the
 /// control relationship is enforced here by `obj.controller == player`, so the
 /// shared `matches_target_filter` evaluates only the printed object qualities.
-pub(crate) fn player_controls_matching_permanent(
+pub(crate) fn player_control_count_compares(
     state: &GameState,
-    player: PlayerId,
-    presence: &crate::types::ability::ControlPresence,
+    candidate_player: PlayerId,
     filter: &TargetFilter,
+    comparator: crate::types::ability::Comparator,
+    threshold: i32,
     source_id: ObjectId,
 ) -> bool {
-    use crate::types::ability::ControlPresence;
-    let ctx = filter::FilterContext::from_source_with_controller(source_id, player);
-    let controls_any = state.battlefield.iter().any(|id| {
-        state
-            .objects
-            .get(id)
-            .is_some_and(|obj| obj.controller == player)
-            && filter::matches_target_filter(state, *id, filter, &ctx)
-    });
-    match presence {
-        ControlPresence::Controls => controls_any,
-        ControlPresence::ControlsNone => !controls_any,
-    }
+    let ctx = filter::FilterContext::from_source_with_controller(source_id, candidate_player);
+    let count = state
+        .battlefield
+        .iter()
+        .filter(|id| {
+            state
+                .objects
+                .get(id)
+                .is_some_and(|obj| obj.controller == candidate_player)
+                && filter::matches_target_filter(state, **id, filter, &ctx)
+        })
+        .count();
+    comparator.evaluate(
+        crate::game::arithmetic::usize_to_i32_saturating(count),
+        threshold,
+    )
 }
 
 /// Record the outer effect's `EffectKind` on the current `pending_continuation`

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -173,25 +173,35 @@ fn players_for_filter(
                 .into_iter()
                 .collect()
         }
-        // CR 109.4 + CR 700.1: "each [player class] who [doesn't] control
-        // [filter]" — candidates satisfying both `relation` and the
-        // controls/controls-none predicate.
-        PlayerFilter::ControlsPermanent {
+        // CR 109.4 + CR 109.5: "each [player class] who controls [comparator]
+        // [count] [filter]" — candidates satisfying both `relation` and the
+        // controlled-permanent count comparison.
+        PlayerFilter::ControlsCount {
             relation,
-            presence,
             filter,
-        } => state
-            .players
-            .iter()
-            .filter(|player| !player.is_eliminated)
-            .filter(|player| {
-                crate::game::players::matches_relation(player.id, controller, *relation)
-                    && crate::game::effects::player_controls_matching_permanent(
-                        state, player.id, presence, filter, source_id,
-                    )
-            })
-            .map(|player| player.id)
-            .collect(),
+            comparator,
+            count,
+        } => {
+            let threshold =
+                crate::game::quantity::resolve_quantity(state, count, controller, source_id);
+            state
+                .players
+                .iter()
+                .filter(|player| !player.is_eliminated)
+                .filter(|player| {
+                    crate::game::players::matches_relation(player.id, controller, *relation)
+                        && crate::game::effects::player_control_count_compares(
+                            state,
+                            player.id,
+                            filter,
+                            *comparator,
+                            threshold,
+                            source_id,
+                        )
+                })
+                .map(|player| player.id)
+                .collect()
+        }
     }
 }
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2910,20 +2910,27 @@ pub(crate) fn resolve_player_count(
                         // single-player-count meaning here (no parent object
                         // target is in scope for a player-count quantity).
                         PlayerFilter::ParentObjectTargetController => false,
-                        // CR 109.4 + CR 700.1: "each [player class] who
-                        // [doesn't] control [filter]" — count candidates that
+                        // CR 109.4 + CR 109.5: "each [player class] who controls
+                        // [comparator] [count] [filter]" — count candidates that
                         // satisfy both the `relation` predicate and the
-                        // controls/controls-none predicate. Mirrors the arm in
-                        // `effects::mod::matches_player_scope` (the two copies
+                        // controlled-permanent count comparison. Mirrors the arm
+                        // in `effects::mod::matches_player_scope` (the two copies
                         // must stay in sync).
-                        PlayerFilter::ControlsPermanent {
+                        PlayerFilter::ControlsCount {
                             relation,
-                            presence,
                             filter,
+                            comparator,
+                            count,
                         } => {
+                            let threshold = resolve_quantity(state, count, controller, source_id);
                             crate::game::players::matches_relation(p.id, controller, *relation)
-                                && crate::game::effects::player_controls_matching_permanent(
-                                    state, p.id, presence, filter, source_id,
+                                && crate::game::effects::player_control_count_compares(
+                                    state,
+                                    p.id,
+                                    filter,
+                                    *comparator,
+                                    threshold,
+                                    source_id,
                                 )
                         }
                     }
@@ -5506,12 +5513,14 @@ mod tests {
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 2);
     }
 
-    /// CR 109.4: `resolve_player_count` for `PlayerFilter::ControlsPermanent`
-    /// counts candidates by the controls / controls-none predicate. Kept in
-    /// sync with `effects::matches_player_scope`'s identical arm.
+    /// CR 109.4 + CR 109.5: `resolve_player_count` for
+    /// `PlayerFilter::ControlsCount` counts candidates by the controlled-permanent
+    /// count comparison. Kept in sync with `effects::matches_player_scope`'s
+    /// identical arm. `{ EQ, Fixed(0) }` ≡ old `ControlsNone`; `{ GE, Fixed(1) }`
+    /// ≡ old `Controls`.
     #[test]
     fn resolve_player_count_controls_permanent_presence() {
-        use crate::types::ability::{ControlPresence, PlayerRelation, TypeFilter, TypedFilter};
+        use crate::types::ability::{Comparator, PlayerRelation, TypeFilter, TypedFilter};
         use crate::types::format::FormatConfig;
 
         let mut state = GameState::new(FormatConfig::commander(), 3, 42);
@@ -5532,32 +5541,130 @@ mod tests {
         let elf_filter =
             TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype("Elf".to_string())));
 
-        // "each opponent who doesn't control an Elf" — controller P0:
+        // "each opponent who doesn't control an Elf" (count == 0) — controller P0:
         // opponents are P1 (controls Elf → excluded) and P2 → count 1.
         let none = QuantityExpr::Ref {
             qty: QuantityRef::PlayerCount {
-                filter: PlayerFilter::ControlsPermanent {
+                filter: PlayerFilter::ControlsCount {
                     relation: PlayerRelation::Opponent,
-                    presence: ControlPresence::ControlsNone,
                     filter: elf_filter.clone(),
+                    comparator: Comparator::EQ,
+                    count: Box::new(QuantityExpr::Fixed { value: 0 }),
                 },
             },
         };
         assert_eq!(resolve_quantity(&state, &none, PlayerId(0), ObjectId(1)), 1);
 
-        // "each opponent who controls an Elf" — only P1 → count 1.
+        // "each opponent who controls an Elf" (count >= 1) — only P1 → count 1.
         let controls = QuantityExpr::Ref {
             qty: QuantityRef::PlayerCount {
-                filter: PlayerFilter::ControlsPermanent {
+                filter: PlayerFilter::ControlsCount {
                     relation: PlayerRelation::Opponent,
-                    presence: ControlPresence::Controls,
                     filter: elf_filter,
+                    comparator: Comparator::GE,
+                    count: Box::new(QuantityExpr::Fixed { value: 1 }),
                 },
             },
         };
         assert_eq!(
             resolve_quantity(&state, &controls, PlayerId(0), ObjectId(1)),
             1
+        );
+    }
+
+    /// CR 109.4 + CR 109.5: discriminating coverage for the comparative
+    /// "controls more <type> than you" shape. 3-player board: controller P0
+    /// controls 1 creature, opponent P1 controls 2, opponent P2 controls 0.
+    /// "the number of opponents who control more creatures than you" must count
+    /// exactly the opponent who controls *strictly more* (P1) → 1. A `GE`
+    /// comparator against the same `You` count would also include P2's tie-or-
+    /// fewer reading wrongly, so this test discriminates the GT semantics.
+    #[test]
+    fn resolve_player_count_controls_more_creatures_than_you() {
+        use crate::types::ability::{
+            Comparator, ControllerRef, PlayerRelation, TypeFilter, TypedFilter,
+        };
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+
+        let add_creature = |state: &mut GameState, owner: PlayerId, id: u64| {
+            let c = create_object(
+                state,
+                CardId(id),
+                owner,
+                format!("Bear {id}"),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&c)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        };
+        // P0 (controller): 1 creature. P1: 2 creatures. P2: 0 creatures.
+        add_creature(&mut state, PlayerId(0), 900);
+        add_creature(&mut state, PlayerId(1), 901);
+        add_creature(&mut state, PlayerId(1), 902);
+
+        let bare_creature = TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature));
+        let you_creature = TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Creature).controller(ControllerRef::You),
+        );
+
+        // GT: only P1 (2 > 1) counts; P2 (0 > 1 is false) and P0 (not an
+        // opponent) do not → 1.
+        let more_than_you = QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::ControlsCount {
+                    relation: PlayerRelation::Opponent,
+                    filter: bare_creature.clone(),
+                    comparator: Comparator::GT,
+                    count: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: you_creature.clone(),
+                        },
+                    }),
+                },
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &more_than_you, PlayerId(0), ObjectId(1)),
+            1,
+            "only the opponent with strictly more creatures than the controller counts"
+        );
+
+        // Discriminator: flipping the comparator to GE (>=1) would also include
+        // P2, whose 0 creatures is NOT >= the controller's 1 — but P1's 2 >= 1
+        // and would still count. To prove the GT/GE distinction bites, give P2
+        // exactly 1 creature (tie with controller). Then GT still yields 1 (only
+        // P1), but GE would yield 2 (P1 and P2).
+        add_creature(&mut state, PlayerId(2), 903);
+        assert_eq!(
+            resolve_quantity(&state, &more_than_you, PlayerId(0), ObjectId(1)),
+            1,
+            "a tied opponent (P2: 1 == controller's 1) is excluded by GT"
+        );
+        let at_least_you = QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::ControlsCount {
+                    relation: PlayerRelation::Opponent,
+                    filter: bare_creature,
+                    comparator: Comparator::GE,
+                    count: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: you_creature,
+                        },
+                    }),
+                },
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &at_least_you, PlayerId(0), ObjectId(1)),
+            2,
+            "GE includes the tied opponent — confirms the GT result is comparator-sensitive"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3649,7 +3649,7 @@ pub(crate) fn check_trigger_condition(
             // CR 102.1: a controls-a-permanent population predicate is
             // set-valued — it has no single-player "whose turn" semantic.
             // Fail-closed alongside the other set-valued variants.
-            | PlayerFilter::ControlsPermanent { .. }
+            | PlayerFilter::ControlsCount { .. }
             | PlayerFilter::OpponentOtherThanTriggering => false,
         },
         // CR 603.4: "if you control N or more [type]" — generalized control count.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -46,15 +46,14 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction,
     BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
     ChooseFromZoneConstraint, CombatDamageScope, Comparator, ConjureCard, ContinuousModification,
-    ControlPresence, ControllerRef, DamageModification, DamageSource, DelayedTriggerCondition,
-    DoubleTarget, Duration, Effect, FilterProp, GainLifePlayer, GameRestriction,
-    IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty,
-    ObjectScope, PaymentCost, PlayerFilter, PlayerScope, PreventionAmount, PreventionScope,
-    ProhibitedActivity, PtValue, QuantityExpr, QuantityRef, ReplacementDefinition,
-    RestrictionExpiry, RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition,
-    StepSkipTarget, SubAbilityLink, TargetChoiceTiming, TargetFilter, TargetSelectionMode,
-    TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
-    UntilCondition,
+    ControllerRef, DamageModification, DamageSource, DelayedTriggerCondition, DoubleTarget,
+    Duration, Effect, FilterProp, GainLifePlayer, GameRestriction, IterationKindBinding,
+    ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty, ObjectScope, PaymentCost,
+    PlayerFilter, PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PtValue,
+    QuantityExpr, QuantityRef, ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope,
+    RoundingMode, StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink,
+    TargetChoiceTiming, TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition,
+    TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterType;
@@ -15729,10 +15728,11 @@ fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, String) {
         return (None, text.to_string());
     };
 
-    // CR 109.4 + CR 700.1: A "who [doesn't] control [type-phrase]" relative
-    // clause restricts the player set to those who do (or don't) control a
-    // matching permanent (Thornbow Archer: "each opponent who doesn't control
-    // an Elf loses 1 life"). The clause must be consumed and reflected in the
+    // CR 109.4 + CR 109.5: A "who controls [comparator] [count] [type-phrase]"
+    // relative clause restricts the player set to those whose controlled-permanent
+    // count satisfies the comparison (Thornbow Archer: "each opponent who doesn't
+    // control an Elf loses 1 life"; Heidegger: "each opponent who controls more
+    // creatures than you"). The clause must be consumed and reflected in the
     // scope — silently dropping it over-applies the effect to every player.
     if let Some((controls_scope, after_clause)) = strip_controls_permanent_clause(&scope, rest) {
         let deconjugated = subject::deconjugate_verb(&after_clause);
@@ -15903,12 +15903,25 @@ fn rebind_decline_body_recipients(clause: &mut ParsedEffectClause) {
     }
 }
 
-/// CR 109.4: Parse the shared "who [doesn't] control [type-phrase]" control
-/// predicate — the present/absent axis plus the controlled-permanent filter.
-/// Returns `(ControlPresence, TargetFilter, remainder)` where `remainder` is the
-/// text after the consumed object sub-phrase, or `None` when no control predicate
-/// is present (or the object resolves to the everything-matching
-/// `TargetFilter::Any`, which must not silently match every permanent).
+/// CR 109.4 + CR 109.5: Parse the shared "who controls [comparator] [count]
+/// [type-phrase]" control predicate — the comparison axis (presence or
+/// comparative) plus the controlled-permanent filter.
+/// Returns `(Comparator, QuantityExpr, TargetFilter, remainder)` where
+/// `remainder` is the text after the consumed object sub-phrase, or `None` when
+/// no control predicate is present (or the object resolves to the
+/// everything-matching `TargetFilter::Any`, which must not silently match every
+/// permanent).
+///
+/// Three presence/comparison classes are recognized as a single parameterized
+/// `(Comparator, QuantityExpr)` pair:
+/// - "controls"/"control" → `(GE, Fixed(1))` (at least one matching permanent).
+/// - "doesn't/does not/don't/do not control" → `(EQ, Fixed(0))` (none).
+/// - "controls/control more <type> than you" → `(GT, Ref(ObjectCount {
+///   filter: <type>.controller(You) }))` — strictly more than the effect
+///   controller's own count of the same type (CR 109.5 — "you" is the controller
+///   of the object the ability is on). The carried `filter` is the BARE type
+///   (no controller axis); the per-candidate control relationship is enforced at
+///   runtime by `player_control_count_compares`.
 ///
 /// The object sub-phrase ("an Elf", "a creature with power 4 or greater")
 /// delegates to the shared `parse_type_phrase_with_ctx` combinator — no bespoke
@@ -15918,25 +15931,87 @@ fn rebind_decline_body_recipients(clause: &mut ParsedEffectClause) {
 pub(crate) fn parse_controls_permanent_object<'a>(
     rest: &'a str,
     ctx: &mut ParseContext,
-) -> Option<(ControlPresence, TargetFilter, &'a str)> {
+) -> Option<(Comparator, QuantityExpr, TargetFilter, &'a str)> {
     let lower = rest.to_lowercase();
+    // Comparative form tried FIRST: "who controls more <type> than you".
+    // Mirrors `oracle_nom::condition::parse_that_player_controls_more_comparison`:
+    // consume the verb prefix, then split the original-case remainder on
+    // " than you" so the isolated type text and the trailing remainder both stay
+    // in original case. `split_once_on_lower` is a structural boundary lookup
+    // (permitted), not parsing dispatch.
+    if let Some(((), after_verb)) = nom_on_lower(rest, &lower, |i| {
+        let (i, _) = tag("who ").parse(i)?;
+        let (i, _) = alt((tag("controls more "), tag("control more "))).parse(i)?;
+        Ok((i, ()))
+    }) {
+        let after_verb_lower = after_verb.to_lowercase();
+        if let Some((type_text, comparative_remainder)) =
+            crate::parser::oracle_nom::bridge::split_once_on_lower(
+                after_verb,
+                &after_verb_lower,
+                " than you",
+            )
+        {
+            let (bare_filter, _) = super::oracle_target::parse_type_phrase_with_ctx(type_text, ctx);
+            if matches!(bare_filter, TargetFilter::Any) {
+                return None;
+            }
+            // CR 109.5: the controller's own count uses a `You`-controlled filter.
+            let you_count = match &bare_filter {
+                TargetFilter::Typed(tf) => QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: TargetFilter::Typed(tf.clone().controller(ControllerRef::You)),
+                    },
+                },
+                // Non-typed filters cannot carry a controller axis; reject rather
+                // than silently mis-counting.
+                _ => return None,
+            };
+            return Some((
+                Comparator::GT,
+                you_count,
+                bare_filter,
+                comparative_remainder,
+            ));
+        }
+    }
+
     // "who controls " / "who doesn't control " — one alt() arm per presence axis.
     // Both singular ("each opponent who controls") and plural ("opponents who
     // control") subject-verb agreement forms are accepted: the present/absent
     // axis is identical regardless of grammatical number. Negative forms are
     // longest-match-first so "doesn't/does not/don't/do not control" win before
     // the bare affirmative; "controls " precedes "control " so the singular form
-    // is not split.
-    let (presence, after_verb) = nom_on_lower(rest, &lower, |i| {
+    // is not split. `(GE, Fixed(1))` ≡ old `Controls` (count >= 1);
+    // `(EQ, Fixed(0))` ≡ old `ControlsNone` (count == 0).
+    let ((comparator, count), after_verb) = nom_on_lower(rest, &lower, |i| {
         preceded(
             tag("who "),
             alt((
-                value(ControlPresence::ControlsNone, tag("doesn't control ")),
-                value(ControlPresence::ControlsNone, tag("does not control ")),
-                value(ControlPresence::ControlsNone, tag("don't control ")),
-                value(ControlPresence::ControlsNone, tag("do not control ")),
-                value(ControlPresence::Controls, tag("controls ")),
-                value(ControlPresence::Controls, tag("control ")),
+                value(
+                    (Comparator::EQ, QuantityExpr::Fixed { value: 0 }),
+                    tag("doesn't control "),
+                ),
+                value(
+                    (Comparator::EQ, QuantityExpr::Fixed { value: 0 }),
+                    tag("does not control "),
+                ),
+                value(
+                    (Comparator::EQ, QuantityExpr::Fixed { value: 0 }),
+                    tag("don't control "),
+                ),
+                value(
+                    (Comparator::EQ, QuantityExpr::Fixed { value: 0 }),
+                    tag("do not control "),
+                ),
+                value(
+                    (Comparator::GE, QuantityExpr::Fixed { value: 1 }),
+                    tag("controls "),
+                ),
+                value(
+                    (Comparator::GE, QuantityExpr::Fixed { value: 1 }),
+                    tag("control "),
+                ),
             )),
         )
         .parse(i)
@@ -15946,14 +16021,15 @@ pub(crate) fn parse_controls_permanent_object<'a>(
     if matches!(filter, TargetFilter::Any) {
         return None;
     }
-    Some((presence, filter, remainder))
+    Some((comparator, count, filter, remainder))
 }
 
-/// CR 109.4: Strip a "who [doesn't] control [type-phrase]" relative clause that
-/// follows an "each opponent"/"each player" subject. Returns the
-/// `PlayerFilter::ControlsPermanent` scope (carrying the base subject's
-/// relation, the present/absent axis, and the controlled-permanent filter) and
-/// the verb-phrase remainder. Returns `None` when no control clause is present.
+/// CR 109.4 + CR 109.5: Strip a "who controls [comparator] [count]
+/// [type-phrase]" relative clause that follows an "each opponent"/"each player"
+/// subject. Returns the `PlayerFilter::ControlsCount` scope (carrying the base
+/// subject's relation, the controlled-permanent filter, and the comparator/count
+/// pair) and the verb-phrase remainder. Returns `None` when no control clause is
+/// present.
 ///
 /// Delegates the control predicate to the shared
 /// `parse_controls_permanent_object` core; this function adds the subject-path
@@ -15973,16 +16049,17 @@ fn strip_controls_permanent_clause(
     };
     // Match today's no-ctx behaviour for the subject path.
     let mut ctx = ParseContext::default();
-    let (presence, filter, remainder) = parse_controls_permanent_object(rest, &mut ctx)?;
+    let (comparator, count, filter, remainder) = parse_controls_permanent_object(rest, &mut ctx)?;
     let verb_phrase = remainder.trim_start();
     if verb_phrase.is_empty() {
         return None;
     }
     Some((
-        PlayerFilter::ControlsPermanent {
+        PlayerFilter::ControlsCount {
             relation,
-            presence,
             filter,
+            comparator,
+            count: Box::new(count),
         },
         verb_phrase.to_string(),
     ))
@@ -31552,73 +31629,172 @@ mod tests {
         assert_eq!(result, "create an X/X token");
     }
 
-    /// CR 109.4 + CR 700.1: a "who [doesn't] control [type]" relative clause
-    /// must be captured into `PlayerFilter::ControlsPermanent`, not dropped
+    /// CR 109.4 + CR 109.5: a "who controls [comparator] [count] [type]" relative
+    /// clause must be captured into `PlayerFilter::ControlsCount`, not dropped
     /// (Thornbow Archer: "each opponent who doesn't control an Elf loses 1 life").
     #[test]
     fn strip_each_player_subject_controls_permanent_clause() {
-        use crate::types::ability::{ControlPresence, PlayerRelation};
+        use crate::types::ability::{Comparator, PlayerRelation, QuantityExpr};
 
         let (scope, result) =
             strip_each_player_subject("each opponent who doesn't control an Elf loses 1 life");
         assert_eq!(result, "lose 1 life");
         match scope {
-            Some(PlayerFilter::ControlsPermanent {
+            // "doesn't control an Elf" ≡ count == 0 (old `ControlsNone`).
+            Some(PlayerFilter::ControlsCount {
                 relation,
-                presence,
                 filter,
+                comparator,
+                count,
             }) => {
                 assert_eq!(relation, PlayerRelation::Opponent);
-                assert_eq!(presence, ControlPresence::ControlsNone);
+                assert_eq!(comparator, Comparator::EQ);
+                assert_eq!(*count, QuantityExpr::Fixed { value: 0 });
                 assert!(
                     !matches!(filter, TargetFilter::Any),
                     "Elf filter must be captured, got {filter:?}"
                 );
             }
-            other => panic!("expected ControlsPermanent scope, got {other:?}"),
+            other => panic!("expected ControlsCount scope, got {other:?}"),
         }
 
-        // The affirmative form maps to `ControlPresence::Controls`.
+        // The affirmative form maps to `{ GE, Fixed(1) }` (old `Controls`).
         let (scope, _) =
             strip_each_player_subject("each player who controls a creature draws a card");
-        assert!(matches!(
-            scope,
-            Some(PlayerFilter::ControlsPermanent {
-                relation: PlayerRelation::All,
-                presence: ControlPresence::Controls,
+        match scope {
+            Some(PlayerFilter::ControlsCount {
+                relation,
+                comparator,
+                count,
                 ..
-            })
-        ));
+            }) => {
+                assert_eq!(relation, PlayerRelation::All);
+                assert_eq!(comparator, Comparator::GE);
+                assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+            }
+            other => panic!("expected ControlsCount{{GE,Fixed(1)}}, got {other:?}"),
+        }
     }
 
-    /// CR 109.4: building-block coverage for the shared control predicate
-    /// `parse_controls_permanent_object` — the present/absent presence axis, the
-    /// delegated object filter, the consumed-remainder shape, and the
+    /// Migration regression (CR 109.4 + CR 109.5): the presence forms that used
+    /// to be `ControlPresence::Controls` / `ControlsNone` must now land as the
+    /// equivalent `{ GE, Fixed(1) }` / `{ EQ, Fixed(0) }` comparator/count pairs.
+    /// Depopulate ("each player who controls a multicolored creature draws a
+    /// card") is the affirmative class; Thornbow Archer ("each opponent who
+    /// doesn't control an Elf") is the negative class.
+    #[test]
+    fn migration_presence_forms_map_to_comparator_count() {
+        use crate::types::ability::{Comparator, PlayerRelation, QuantityExpr};
+
+        // Depopulate — affirmative "controls a multicolored creature" → GE/1.
+        let (scope, result) = strip_each_player_subject(
+            "each player who controls a multicolored creature draws a card",
+        );
+        assert_eq!(result, "draw a card");
+        match scope {
+            Some(PlayerFilter::ControlsCount {
+                relation,
+                filter,
+                comparator,
+                count,
+            }) => {
+                assert_eq!(relation, PlayerRelation::All);
+                assert_eq!(comparator, Comparator::GE);
+                assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                assert!(
+                    !matches!(filter, TargetFilter::Any),
+                    "multicolored creature filter must be captured, got {filter:?}"
+                );
+            }
+            other => panic!("expected ControlsCount{{GE,Fixed(1)}}, got {other:?}"),
+        }
+
+        // Thornbow Archer — negative "doesn't control an Elf" → EQ/0.
+        let (scope, _) =
+            strip_each_player_subject("each opponent who doesn't control an Elf loses 1 life");
+        match scope {
+            Some(PlayerFilter::ControlsCount {
+                relation,
+                comparator,
+                count,
+                ..
+            }) => {
+                assert_eq!(relation, PlayerRelation::Opponent);
+                assert_eq!(comparator, Comparator::EQ);
+                assert_eq!(*count, QuantityExpr::Fixed { value: 0 });
+            }
+            other => panic!("expected ControlsCount{{EQ,Fixed(0)}}, got {other:?}"),
+        }
+    }
+
+    /// CR 109.4 + CR 109.5: building-block coverage for the shared control
+    /// predicate `parse_controls_permanent_object` — the comparator/count pair,
+    /// the delegated object filter, the consumed-remainder shape, and the
     /// `TargetFilter::Any` rejection. This is the core both the subject path
     /// (`strip_controls_permanent_clause`) and the quantity path
     /// (`oracle_quantity.rs` PlayerCount) compose over.
     #[test]
     fn parse_controls_permanent_object_core() {
-        use crate::types::ability::ControlPresence;
+        use crate::types::ability::{Comparator, QuantityExpr, QuantityRef};
 
-        // Affirmative "who controls <object>" + remainder preserved.
+        // Affirmative "who controls <object>" → `{ GE, Fixed(1) }` + remainder
+        // preserved.
         let mut ctx = ParseContext::default();
-        let (presence, filter, remainder) =
+        let (comparator, count, filter, remainder) =
             parse_controls_permanent_object("who controls an artifact loses 1 life", &mut ctx)
                 .expect("affirmative control predicate must parse");
-        assert_eq!(presence, ControlPresence::Controls);
+        assert_eq!(comparator, Comparator::GE);
+        assert_eq!(count, QuantityExpr::Fixed { value: 1 });
         assert!(
             !matches!(filter, TargetFilter::Any),
             "artifact object must be captured, got {filter:?}"
         );
         assert_eq!(remainder.trim_start(), "loses 1 life");
 
-        // Negative "who doesn't control <object>".
+        // Negative "who doesn't control <object>" → `{ EQ, Fixed(0) }`.
         let mut ctx = ParseContext::default();
-        let (presence, _filter, _) =
+        let (comparator, count, _filter, _) =
             parse_controls_permanent_object("who doesn't control a creature", &mut ctx)
                 .expect("negative control predicate must parse");
-        assert_eq!(presence, ControlPresence::ControlsNone);
+        assert_eq!(comparator, Comparator::EQ);
+        assert_eq!(count, QuantityExpr::Fixed { value: 0 });
+
+        // Comparative "who controls more <type> than you" → `{ GT, count }`
+        // where `count` is the controller's own `You`-controlled object count.
+        // The carried `filter` is the BARE type (no controller axis).
+        let mut ctx = ParseContext::default();
+        let (comparator, count, filter, remainder) = parse_controls_permanent_object(
+            "who controls more creatures than you draws a card",
+            &mut ctx,
+        )
+        .expect("comparative control predicate must parse");
+        assert_eq!(comparator, Comparator::GT);
+        match count {
+            QuantityExpr::Ref {
+                qty:
+                    QuantityRef::ObjectCount {
+                        filter: count_filter,
+                    },
+            } => match count_filter {
+                TargetFilter::Typed(tf) => assert_eq!(
+                    tf.controller,
+                    Some(crate::types::ability::ControllerRef::You),
+                    "comparative count must read the controller's own creatures"
+                ),
+                other => panic!("expected Typed count filter, got {other:?}"),
+            },
+            other => panic!("expected Ref(ObjectCount) count, got {other:?}"),
+        }
+        // The carried filter is bare (no controller axis).
+        match filter {
+            TargetFilter::Typed(tf) => assert_eq!(
+                tf.controller, None,
+                "carried ControlsCount filter must be controller-free, got {:?}",
+                tf.controller
+            ),
+            other => panic!("expected Typed bare filter, got {other:?}"),
+        }
+        assert_eq!(remainder.trim_start(), "draws a card");
 
         // No object after "control" → the all-matching `TargetFilter::Any` is
         // rejected so callers never count every permanent/opponent.

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -323,27 +323,40 @@ pub(crate) fn parse_quantity_ref_with_context(
                 filter: PlayerFilter::OpponentDealtCombatDamage,
             });
         }
-        // CR 109.4: "opponents who control <filter>" / "opponents who don't
-        // control <filter>" → PlayerCount over the opponents satisfying the
-        // shared control predicate. Consume only the population word here, then
-        // hand the "who [doesn't] control <type-phrase>" remainder to the shared
+        // CR 109.4 + CR 109.5: "opponents who control <filter>" / "opponents who
+        // don't control <filter>" / "players who control more <type> than you" →
+        // PlayerCount over the population satisfying the shared control predicate.
+        // Consume only the population word here (capturing its relation), then
+        // hand the "who controls …" remainder to the shared
         // `parse_controls_permanent_object` core (DRY with the "each opponent who
         // controls …" subject path). Tried before the generic ObjectCount
-        // fall-through so the opponent population — not battlefield permanents —
-        // is counted. (Singular "opponent" is accepted for the grammatically-
-        // degenerate one-opponent phrasing.)
-        if let Ok((predicate_input, _)) =
-            alt((tag::<_, _, OracleError<'_>>("opponents "), tag("opponent "))).parse(rest)
+        // fall-through so the player population — not battlefield permanents — is
+        // counted. The population word also fixes the relation: "opponents"/
+        // "opponent" → Opponent; "players"/"player" → All (so "the number of
+        // players who control more lands than you", Oreskos Explorer, is covered,
+        // not just the opponent cards). (Singular forms are accepted for the
+        // grammatically-degenerate one-player phrasing.)
+        if let Ok((predicate_input, relation)) = alt((
+            value(
+                PlayerRelation::Opponent,
+                tag::<_, _, OracleError<'_>>("opponents "),
+            ),
+            value(PlayerRelation::Opponent, tag("opponent ")),
+            value(PlayerRelation::All, tag("players ")),
+            value(PlayerRelation::All, tag("player ")),
+        ))
+        .parse(rest)
         {
-            if let Some((presence, filter, remainder)) =
+            if let Some((comparator, count, filter, remainder)) =
                 parse_controls_permanent_object(predicate_input, ctx)
             {
                 if remainder.trim().is_empty() {
                     return Some(QuantityRef::PlayerCount {
-                        filter: PlayerFilter::ControlsPermanent {
-                            relation: PlayerRelation::Opponent,
-                            presence,
+                        filter: PlayerFilter::ControlsCount {
+                            relation,
                             filter,
+                            comparator,
+                            count: Box::new(count),
                         },
                     });
                 }
@@ -2276,20 +2289,22 @@ mod tests {
     // opponents satisfying the shared "who controls …" control predicate.
     #[test]
     fn parse_quantity_ref_opponents_who_control_artifact() {
-        use crate::types::ability::ControlPresence;
         let qty = parse_quantity_ref("the number of opponents who control an artifact").unwrap();
         match qty {
+            // "who control an artifact" ≡ count >= 1 (old `Controls`).
             QuantityRef::PlayerCount {
                 filter:
-                    PlayerFilter::ControlsPermanent {
+                    PlayerFilter::ControlsCount {
                         relation: PlayerRelation::Opponent,
-                        presence: ControlPresence::Controls,
                         filter: TargetFilter::Typed(typed),
+                        comparator: Comparator::GE,
+                        count,
                     },
             } => {
+                assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
                 assert_eq!(typed.type_filters, vec![TypeFilter::Artifact]);
             }
-            other => panic!("Expected PlayerCount{{ControlsPermanent(artifact)}}, got {other:?}"),
+            other => panic!("Expected PlayerCount{{ControlsCount(artifact)}}, got {other:?}"),
         }
     }
 
@@ -2297,7 +2312,7 @@ mod tests {
     // power/toughness comparison parsed by the shared type-phrase combinator.
     #[test]
     fn parse_quantity_ref_opponents_who_control_creature_power4() {
-        use crate::types::ability::{ControlPresence, PtStat, PtValueScope};
+        use crate::types::ability::{PtStat, PtValueScope};
         let qty = parse_quantity_ref(
             "the number of opponents who control a creature with power 4 or greater",
         )
@@ -2305,12 +2320,14 @@ mod tests {
         match qty {
             QuantityRef::PlayerCount {
                 filter:
-                    PlayerFilter::ControlsPermanent {
+                    PlayerFilter::ControlsCount {
                         relation: PlayerRelation::Opponent,
-                        presence: ControlPresence::Controls,
                         filter: TargetFilter::Typed(typed),
+                        comparator: Comparator::GE,
+                        count,
                     },
             } => {
+                assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
                 assert_eq!(typed.type_filters, vec![TypeFilter::Creature]);
                 assert!(
                     typed.properties.contains(&FilterProp::PtComparison {
@@ -2324,7 +2341,7 @@ mod tests {
                 );
             }
             other => {
-                panic!("Expected PlayerCount{{ControlsPermanent(creature+pt)}}, got {other:?}")
+                panic!("Expected PlayerCount{{ControlsCount(creature+pt)}}, got {other:?}")
             }
         }
     }
@@ -2333,7 +2350,6 @@ mod tests {
     // (no dedicated change to the offset path was needed).
     #[test]
     fn parse_cda_quantity_one_plus_opponents_who_control_artifact() {
-        use crate::types::ability::ControlPresence;
         let expr =
             parse_cda_quantity("one plus the number of opponents who control an artifact").unwrap();
         match expr {
@@ -2344,15 +2360,15 @@ mod tests {
                         *inner,
                         QuantityExpr::Ref {
                             qty: QuantityRef::PlayerCount {
-                                filter: PlayerFilter::ControlsPermanent {
+                                filter: PlayerFilter::ControlsCount {
                                     relation: PlayerRelation::Opponent,
-                                    presence: ControlPresence::Controls,
+                                    comparator: Comparator::GE,
                                     ..
                                 },
                             },
                         }
                     ),
-                    "Expected Offset over PlayerCount{{ControlsPermanent}}, got {inner:?}"
+                    "Expected Offset over PlayerCount{{ControlsCount}}, got {inner:?}"
                 );
             }
             other => panic!("Expected Offset{{+1}}, got {other:?}"),
@@ -2361,7 +2377,7 @@ mod tests {
 
     // A1 negative: with no object after "control", the shared core rejects the
     // everything-matching `TargetFilter::Any`, so we must NOT emit a
-    // PlayerCount{ControlsPermanent} that would silently match all opponents.
+    // PlayerCount{ControlsCount} that would silently match all opponents.
     #[test]
     fn parse_quantity_ref_opponents_who_control_no_object_rejected() {
         let qty = parse_quantity_ref("the number of opponents who control");
@@ -2369,11 +2385,122 @@ mod tests {
             !matches!(
                 qty,
                 Some(QuantityRef::PlayerCount {
-                    filter: PlayerFilter::ControlsPermanent { .. },
+                    filter: PlayerFilter::ControlsCount { .. },
                 })
             ),
-            "Bare 'who control' with no object must not yield ControlsPermanent, got {qty:?}"
+            "Bare 'who control' with no object must not yield ControlsCount, got {qty:?}"
         );
+    }
+
+    // A1 comparative (Oreskos Explorer): "the number of players who control more
+    // lands than you" → PlayerCount{ControlsCount{All, <bare land>, GT,
+    // Ref(ObjectCount{<land>.controller(You)})}}. The "players" population word
+    // sets relation All; the comparative branch sets GT against the controller's
+    // own land count.
+    #[test]
+    fn parse_quantity_ref_players_who_control_more_lands_than_you() {
+        use crate::types::ability::ControllerRef;
+        let qty =
+            parse_quantity_ref("the number of players who control more lands than you").unwrap();
+        match qty {
+            QuantityRef::PlayerCount {
+                filter:
+                    PlayerFilter::ControlsCount {
+                        relation: PlayerRelation::All,
+                        filter: TargetFilter::Typed(bare),
+                        comparator: Comparator::GT,
+                        count,
+                    },
+            } => {
+                assert_eq!(bare.type_filters, vec![TypeFilter::Land]);
+                assert_eq!(
+                    bare.controller, None,
+                    "carried ControlsCount filter must be controller-free"
+                );
+                match *count {
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ObjectCount {
+                                filter: TargetFilter::Typed(you_filter),
+                            },
+                    } => {
+                        assert_eq!(you_filter.type_filters, vec![TypeFilter::Land]);
+                        assert_eq!(
+                            you_filter.controller,
+                            Some(ControllerRef::You),
+                            "comparative count must read the controller's own lands"
+                        );
+                    }
+                    other => panic!("Expected Ref(ObjectCount) count, got {other:?}"),
+                }
+            }
+            other => {
+                panic!("Expected PlayerCount{{ControlsCount(more lands than you)}}, got {other:?}")
+            }
+        }
+    }
+
+    // A1 comparative (Heidegger, Shinra Executive): "the number of opponents who
+    // control more creatures than you" → relation Opponent + GT against the
+    // controller's own creature count.
+    #[test]
+    fn parse_quantity_ref_opponents_who_control_more_creatures_than_you() {
+        use crate::types::ability::ControllerRef;
+        let qty = parse_quantity_ref("the number of opponents who control more creatures than you")
+            .unwrap();
+        match qty {
+            QuantityRef::PlayerCount {
+                filter:
+                    PlayerFilter::ControlsCount {
+                        relation: PlayerRelation::Opponent,
+                        filter: TargetFilter::Typed(bare),
+                        comparator: Comparator::GT,
+                        count,
+                    },
+            } => {
+                assert_eq!(bare.type_filters, vec![TypeFilter::Creature]);
+                assert_eq!(bare.controller, None);
+                match *count {
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ObjectCount {
+                                filter: TargetFilter::Typed(you_filter),
+                            },
+                    } => {
+                        assert_eq!(you_filter.type_filters, vec![TypeFilter::Creature]);
+                        assert_eq!(you_filter.controller, Some(ControllerRef::You));
+                    }
+                    other => panic!("Expected Ref(ObjectCount) count, got {other:?}"),
+                }
+            }
+            other => {
+                panic!(
+                    "Expected PlayerCount{{ControlsCount(more creatures than you)}}, got {other:?}"
+                )
+            }
+        }
+    }
+
+    // A1 comparative (Priest of the Blessed Graf): "the number of opponents who
+    // control more lands than you" → relation Opponent + GT against the
+    // controller's own land count.
+    #[test]
+    fn parse_quantity_ref_opponents_who_control_more_lands_than_you() {
+        let qty =
+            parse_quantity_ref("the number of opponents who control more lands than you").unwrap();
+        match qty {
+            QuantityRef::PlayerCount {
+                filter:
+                    PlayerFilter::ControlsCount {
+                        relation: PlayerRelation::Opponent,
+                        comparator: Comparator::GT,
+                        ..
+                    },
+            } => {}
+            other => {
+                panic!("Expected PlayerCount{{ControlsCount(opponents more lands)}}, got {other:?}")
+            }
+        }
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3277,19 +3277,6 @@ pub enum PlayerRelation {
     All,
 }
 
-/// CR 109.4: Whether a player's controlled-permanent predicate is satisfied by
-/// the presence or the absence of a matching permanent. A typed two-variant
-/// enum — never a bool — so `PlayerFilter::ControlsPermanent` reads as
-/// self-documenting at every match site.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum ControlPresence {
-    /// The player controls at least one permanent matching the filter.
-    Controls,
-    /// The player controls no permanent matching the filter.
-    ControlsNone,
-}
-
 /// A filter matching players by game-state conditions.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -3365,15 +3352,31 @@ pub enum PlayerFilter {
     /// `ControllerRef::ParentTargetController`. Resolved via
     /// `ability_utils::parent_target_controller`.
     ParentObjectTargetController,
-    /// CR 109.4 + CR 700.1: Each player satisfying `relation` who controls
-    /// (`presence = Controls`) or does not control (`presence = ControlsNone`)
-    /// at least one permanent matching `filter`. Covers "each opponent who
-    /// controls an artifact", "each player who doesn't control a creature",
-    /// "each opponent who doesn't control an Elf" (Thornbow Archer), etc.
-    ControlsPermanent {
+    /// CR 109.4 + CR 109.5: Each player satisfying `relation` whose count of
+    /// controlled permanents matching `filter` compares to `count` under
+    /// `comparator`. The control relationship is enforced per-candidate at
+    /// runtime (`obj.controller == candidate`), so `filter` carries no
+    /// controller axis; `count`'s own `ObjectCount` may carry a `You`
+    /// controller (CR 109.5 — "you" is the effect controller) for comparative
+    /// "more X than you" phrasings.
+    ///
+    /// Covers the full presence/comparison class as a single parameterized
+    /// variant:
+    /// - "each opponent who controls an artifact" → `{ GE, Fixed(1) }`
+    ///   (at least one matching permanent).
+    /// - "each opponent who doesn't control an Elf" (Thornbow Archer) →
+    ///   `{ EQ, Fixed(0) }` (no matching permanent).
+    /// - "each player who controls more creatures than you" (Heidegger) →
+    ///   `{ GT, Ref(ObjectCount { filter: <creature>.controller(You) }) }`.
+    ///
+    /// `count` is boxed to break the `QuantityExpr → QuantityRef::PlayerCount →
+    /// PlayerFilter::ControlsCount → QuantityExpr` reference cycle that would
+    /// otherwise give the enum infinite size.
+    ControlsCount {
         relation: PlayerRelation,
-        presence: ControlPresence,
         filter: TargetFilter,
+        comparator: Comparator,
+        count: Box<QuantityExpr>,
     },
 }
 

--- a/crates/engine/tests/integration/belbe_thornbow_life_loss.rs
+++ b/crates/engine/tests/integration/belbe_thornbow_life_loss.rs
@@ -14,7 +14,7 @@
 //! 2. **Thornbow Archer** — "each opponent who doesn't control an Elf loses 1
 //!    life" silently dropped the "who doesn't control an Elf" qualifier, so
 //!    the effect over-applied to every opponent. After the fix the trigger
-//!    carries `PlayerFilter::ControlsPermanent { ControlsNone, <Elf> }`.
+//!    carries `PlayerFilter::ControlsCount { <Elf>, EQ, Fixed(0) }`.
 //!
 //! Both tests drive the full pipeline through `apply` — no synthetic events.
 

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -25,8 +25,8 @@
     "crates/engine/src/types/attribution.rs",
     "crates/engine/src/types/card_type.rs"
   ],
-  "enum_count": 239,
-  "variant_count": 2687,
+  "enum_count": 245,
+  "variant_count": 2769,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -430,13 +430,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8835,
+      "line": 8989,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 8853,
+          "line": 9007,
           "kind": "struct",
           "field_names": [
             "source",
@@ -454,7 +454,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 8869,
+          "line": 9023,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -465,7 +465,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 8874,
+          "line": 9028,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -479,7 +479,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 8879,
+          "line": 9033,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -489,7 +489,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 8887,
+          "line": 9041,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -499,7 +499,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 8890,
+          "line": 9044,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -511,7 +511,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 8894,
+          "line": 9048,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -524,7 +524,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 8897,
+          "line": 9051,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -537,7 +537,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 8900,
+          "line": 9054,
           "kind": "struct",
           "field_names": [
             "color",
@@ -551,7 +551,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 8906,
+          "line": 9060,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -564,7 +564,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 8914,
+          "line": 9068,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -575,7 +575,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 8917,
+          "line": 9071,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -588,7 +588,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 8922,
+          "line": 9076,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -602,7 +602,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 8926,
+          "line": 9080,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -616,7 +616,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 8935,
+          "line": 9089,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -630,7 +630,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 8940,
+          "line": 9094,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -640,7 +640,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 8942,
+          "line": 9096,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -650,7 +650,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 8945,
+          "line": 9099,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -660,7 +660,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 8949,
+          "line": 9103,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -672,7 +672,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 8954,
+          "line": 9108,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -686,7 +686,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 8962,
+          "line": 9116,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -698,7 +698,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 8967,
+          "line": 9121,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -714,7 +714,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 8979,
+          "line": 9133,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -727,7 +727,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 8983,
+          "line": 9137,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -740,7 +740,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 8987,
+          "line": 9141,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -750,7 +750,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 8995,
+          "line": 9149,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -763,7 +763,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9000,
+          "line": 9154,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -776,7 +776,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9005,
+          "line": 9159,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -788,7 +788,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 9011,
+          "line": 9165,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -800,7 +800,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 9015,
+          "line": 9169,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -814,7 +814,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9018,
+          "line": 9172,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -824,7 +824,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 9027,
+          "line": 9181,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -837,7 +837,7 @@
         },
         {
           "name": "And",
-          "line": 9032,
+          "line": 9186,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -849,7 +849,7 @@
         },
         {
           "name": "Or",
-          "line": 9037,
+          "line": 9191,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -861,7 +861,7 @@
         },
         {
           "name": "Not",
-          "line": 9045,
+          "line": 9199,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -873,7 +873,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 9049,
+          "line": 9203,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -883,7 +883,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 9051,
+          "line": 9205,
           "kind": "struct",
           "field_names": [
             "state"
@@ -895,7 +895,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 9061,
+          "line": 9215,
           "kind": "struct",
           "field_names": [
             "n"
@@ -907,7 +907,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 9064,
+          "line": 9218,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -931,13 +931,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4222,
+      "line": 4279,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 4223,
+          "line": 4280,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -947,7 +947,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 4232,
+          "line": 4289,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -960,7 +960,7 @@
         },
         {
           "name": "Tap",
-          "line": 4235,
+          "line": 4292,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -968,7 +968,7 @@
         },
         {
           "name": "Untap",
-          "line": 4236,
+          "line": 4293,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -976,7 +976,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 4237,
+          "line": 4294,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -986,7 +986,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 4240,
+          "line": 4297,
           "kind": "struct",
           "field_names": [
             "target",
@@ -997,7 +997,7 @@
         },
         {
           "name": "PayLife",
-          "line": 4252,
+          "line": 4309,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1009,7 +1009,7 @@
         },
         {
           "name": "Discard",
-          "line": 4255,
+          "line": 4312,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1022,7 +1022,7 @@
         },
         {
           "name": "Exile",
-          "line": 4266,
+          "line": 4323,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1034,7 +1034,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 4275,
+          "line": 4332,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1047,7 +1047,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 4278,
+          "line": 4335,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1058,7 +1058,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 4289,
+          "line": 4346,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1073,7 +1073,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 4295,
+          "line": 4352,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1083,7 +1083,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4299,
+          "line": 4356,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1096,7 +1096,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4307,
+          "line": 4364,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1110,7 +1110,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4316,
+          "line": 4373,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1120,7 +1120,7 @@
         },
         {
           "name": "Mill",
-          "line": 4317,
+          "line": 4374,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1130,7 +1130,7 @@
         },
         {
           "name": "Exert",
-          "line": 4320,
+          "line": 4377,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1138,7 +1138,7 @@
         },
         {
           "name": "Blight",
-          "line": 4323,
+          "line": 4380,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1148,7 +1148,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4326,
+          "line": 4383,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1159,7 +1159,7 @@
         },
         {
           "name": "Behold",
-          "line": 4334,
+          "line": 4391,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1171,7 +1171,7 @@
         },
         {
           "name": "Composite",
-          "line": 4340,
+          "line": 4397,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1181,7 +1181,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4357,
+          "line": 4414,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1194,7 +1194,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4361,
+          "line": 4418,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1204,7 +1204,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4366,
+          "line": 4423,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1217,7 +1217,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4373,
+          "line": 4430,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1229,7 +1229,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4389,
+          "line": 4446,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1243,7 +1243,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4394,
+          "line": 4451,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1256,13 +1256,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8000,
+      "line": 8128,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 8002,
+          "line": 8130,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1270,7 +1270,7 @@
         },
         {
           "name": "Activated",
-          "line": 8003,
+          "line": 8131,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1278,7 +1278,7 @@
         },
         {
           "name": "Database",
-          "line": 8004,
+          "line": 8132,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1286,7 +1286,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 8007,
+          "line": 8135,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1294,7 +1294,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 8013,
+          "line": 8141,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1307,7 +1307,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8154,
+      "line": 8282,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1315,7 +1315,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 8156,
+          "line": 8284,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1325,7 +1325,7 @@
         },
         {
           "name": "Evolve",
-          "line": 8158,
+          "line": 8286,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1335,7 +1335,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 8160,
+          "line": 8288,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1345,7 +1345,7 @@
         },
         {
           "name": "Outlast",
-          "line": 8162,
+          "line": 8290,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1358,7 +1358,7 @@
     },
     "ActivationCadence": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 385,
+      "line": 395,
       "doc": "CR 602.5b: Activation-frequency restriction on an activated-ability-like action (e.g. Crew). `OncePerTurn` models \"Activate only once each turn\"; `Unlimited` is the default with no restriction.",
       "cr_refs": [
         "CR 602.5b"
@@ -1366,7 +1366,7 @@
       "variants": [
         {
           "name": "Unlimited",
-          "line": 387,
+          "line": 397,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1374,7 +1374,7 @@
         },
         {
           "name": "OncePerTurn",
-          "line": 388,
+          "line": 398,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1414,13 +1414,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8170,
+      "line": 8298,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8171,
+          "line": 8299,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1428,7 +1428,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 8172,
+          "line": 8300,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1436,7 +1436,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8173,
+          "line": 8301,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1444,7 +1444,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8174,
+          "line": 8302,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1452,7 +1452,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8175,
+          "line": 8303,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1460,7 +1460,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8176,
+          "line": 8304,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1468,7 +1468,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8177,
+          "line": 8305,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1476,7 +1476,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 8178,
+          "line": 8306,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1484,7 +1484,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 8179,
+          "line": 8307,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1492,7 +1492,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 8180,
+          "line": 8308,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1502,7 +1502,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8183,
+          "line": 8311,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1512,7 +1512,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 8187,
+          "line": 8315,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1522,7 +1522,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 8189,
+          "line": 8317,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1534,7 +1534,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 8194,
+          "line": 8322,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1548,7 +1548,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 8205,
+          "line": 8333,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1562,7 +1562,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 8218,
+          "line": 8346,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1575,13 +1575,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4598,
+      "line": 4655,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 4604,
+          "line": 4661,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1592,7 +1592,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4614,
+          "line": 4671,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1608,7 +1608,7 @@
         },
         {
           "name": "Choice",
-          "line": 4621,
+          "line": 4678,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1616,7 +1616,7 @@
         },
         {
           "name": "Required",
-          "line": 4623,
+          "line": 4680,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1627,7 +1627,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4632,
+      "line": 4689,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1635,7 +1635,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 4634,
+          "line": 4691,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1643,7 +1643,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4635,
+          "line": 4692,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1651,7 +1651,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 4636,
+          "line": 4693,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1662,7 +1662,7 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3158,
+      "line": 3198,
       "doc": "CR 107.3e: Aggregate function applied over a set of objects.",
       "cr_refs": [
         "CR 107.3e"
@@ -1670,7 +1670,7 @@
       "variants": [
         {
           "name": "Max",
-          "line": 3159,
+          "line": 3199,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1678,7 +1678,7 @@
         },
         {
           "name": "Min",
-          "line": 3160,
+          "line": 3200,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1686,7 +1686,7 @@
         },
         {
           "name": "Sum",
-          "line": 3161,
+          "line": 3201,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1697,7 +1697,7 @@
     },
     "AlternativeCastDecision": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 71,
+      "line": 72,
       "doc": "CR 118.9: Player decision at a `WaitingFor::AlternativeCastChoice` prompt — pay the spell's printed mana cost or the keyword-granted alternative cost. Typed enum (not `bool`, per the no-bool-flags rule) so the action serializes self-describingly and survives future expansion (e.g., a third \"Decline\" path) without breaking exhaustive matches. The specific keyword whose alternative cost is in play lives on the `WaitingFor::AlternativeCastChoice` state, not on this action — the decision is structurally identical across keywords; only post-payment semantics diverge (per CR 702.74a Evoke, CR 702.96a Overload, CR 702.103a Bestow, and the custom Warp keyword).",
       "cr_refs": [
         "CR 118.9",
@@ -1708,7 +1708,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 73,
+          "line": 74,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay the spell's printed mana cost. Resolution proceeds normally.",
@@ -1716,7 +1716,7 @@
         },
         {
           "name": "Alternative",
-          "line": 78,
+          "line": 79,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay the keyword-granted alternative cost. Resolution applies the keyword's post-payment effects (Overload's target→each text change per CR 702.96b-c, Evoke's ETB-sacrifice trigger per CR 702.74b, Bestow's Aura transformation per CR 702.103b, Warp's exile-at-end-step rider).",
@@ -1731,7 +1731,7 @@
     },
     "AlternativeCastKeyword": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1380,
+      "line": 1424,
       "doc": "CR 118.9: Identifies which keyword ability granted an alternative casting cost so the `WaitingFor::AlternativeCastChoice` dispatcher can route to the keyword-specific post-payment handler. The four keywords share a single player decision shape (printed cost vs. alternative cost) but diverge in post-payment semantics — this enum keeps the prompt unified while preserving CR fidelity at resolution.  Adding a new alternative-cost keyword (e.g., Madness CR 702.35a, Spectacle CR 702.137a) is a compile error at every dispatch site until handled.",
       "cr_refs": [
         "CR 118.9",
@@ -1741,7 +1741,7 @@
       "variants": [
         {
           "name": "Warp",
-          "line": 1382,
+          "line": 1426,
           "kind": "unit",
           "field_names": [],
           "doc": "Custom Warp keyword — exile-at-end-step rider; no CR section.",
@@ -1749,7 +1749,7 @@
         },
         {
           "name": "Evoke",
-          "line": 1385,
+          "line": 1429,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: ETB + sacrifice trigger fires when the resolving permanent was cast for its evoke cost (CR 702.74b).",
@@ -1760,7 +1760,7 @@
         },
         {
           "name": "Overload",
-          "line": 1387,
+          "line": 1431,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a: Spell's text changes \"target\" to \"each\" (CR 702.96b-c).",
@@ -1771,7 +1771,7 @@
         },
         {
           "name": "Bestow",
-          "line": 1389,
+          "line": 1433,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a: Spell becomes an Aura with enchant creature (CR 702.103b).",
@@ -1779,13 +1779,24 @@
             "CR 702.103a",
             "CR 702.103b"
           ]
+        },
+        {
+          "name": "Cleave",
+          "line": 1436,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.148a-b + CR 612: Paying the cleave cost removes every square-bracketed span from the spell's text (a text-changing effect).",
+          "cr_refs": [
+            "CR 612",
+            "CR 702.148a"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "AttachmentKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1768,
+      "line": 1797,
       "doc": "CR 301 / CR 303: Kinds of attachments to permanents. Used by `FilterProp::HasAttachment` and `QuantityRef::AttachmentsOnLeavingObject` to parameterize attachment-predicate checks.",
       "cr_refs": [
         "CR 301",
@@ -1794,7 +1805,7 @@
       "variants": [
         {
           "name": "Aura",
-          "line": 1770,
+          "line": 1799,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4: Aura — enchantment subtype that attaches via Enchant ability.",
@@ -1804,7 +1815,7 @@
         },
         {
           "name": "Equipment",
-          "line": 1772,
+          "line": 1801,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5: Equipment — artifact subtype that attaches via Equip ability.",
@@ -1817,7 +1828,7 @@
     },
     "AttackTargetFilter": {
       "file": "crates/engine/src/types/triggers.rs",
-      "line": 11,
+      "line": 160,
       "doc": "CR 508.3a: Filter for attack target type in \"attacks [a target]\" triggers.",
       "cr_refs": [
         "CR 508.3a"
@@ -1825,7 +1836,7 @@
       "variants": [
         {
           "name": "Player",
-          "line": 12,
+          "line": 161,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1833,7 +1844,7 @@
         },
         {
           "name": "Planeswalker",
-          "line": 13,
+          "line": 162,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1841,7 +1852,7 @@
         },
         {
           "name": "PlayerOrPlaneswalker",
-          "line": 14,
+          "line": 163,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1849,7 +1860,7 @@
         },
         {
           "name": "Battle",
-          "line": 15,
+          "line": 164,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1860,13 +1871,13 @@
     },
     "AutoMayChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 460,
+      "line": 461,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Accept",
-          "line": 461,
+          "line": 462,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1874,7 +1885,7 @@
         },
         {
           "name": "Decline",
-          "line": 462,
+          "line": 463,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1885,13 +1896,13 @@
     },
     "AutoPassMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3125,
+      "line": 3236,
       "doc": "What the engine stores for auto-pass (includes captured state).",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3128,
+          "line": 3239,
           "kind": "struct",
           "field_names": [
             "initial_stack_len"
@@ -1901,7 +1912,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3132,
+          "line": 3243,
           "kind": "unit",
           "field_names": [],
           "doc": "Auto-pass through priority/combat stops until the flagged player's next turn starts. Interrupted by opponent stack activity (MTGA-style) or when the current phase matches the player's entry in `GameState::phase_stops`.",
@@ -1912,13 +1923,13 @@
     },
     "AutoPassRequest": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3117,
+      "line": 3228,
       "doc": "What the frontend requests for auto-pass (no internal state).  Phase stops that should interrupt `UntilEndOfTurn` are a separate per-player preference on `GameState::phase_stops`, managed via `GameAction::SetPhaseStops`. Keeping them out of the request preserves a single source of truth and lets the preference change mid-session without requiring a new auto-pass request.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3118,
+          "line": 3229,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1926,7 +1937,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3119,
+          "line": 3230,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1937,7 +1948,7 @@
     },
     "BasicLandType": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 340,
+      "line": 348,
       "doc": "The five basic land types (CR 305.6).",
       "cr_refs": [
         "CR 305.6"
@@ -1945,7 +1956,7 @@
       "variants": [
         {
           "name": "Plains",
-          "line": 341,
+          "line": 349,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1953,7 +1964,7 @@
         },
         {
           "name": "Island",
-          "line": 342,
+          "line": 350,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1961,7 +1972,7 @@
         },
         {
           "name": "Swamp",
-          "line": 343,
+          "line": 351,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1969,7 +1980,7 @@
         },
         {
           "name": "Mountain",
-          "line": 344,
+          "line": 352,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1977,7 +1988,7 @@
         },
         {
           "name": "Forest",
-          "line": 345,
+          "line": 353,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1988,13 +1999,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4214,
+      "line": 4271,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 4215,
+          "line": 4272,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2002,7 +2013,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 4216,
+          "line": 4273,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2054,7 +2065,7 @@
     },
     "BlockExceptionKind": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 369,
+      "line": 414,
       "doc": "CR 509.1b: An attacker's \"can't be blocked except by ...\" restriction. Two structural shapes share this CR sub-rule:  - `Quality`: each blocker must individually match a `TargetFilter`    (e.g. \"artifact creatures\").  - `MinBlockers`: the attacker must be blocked by `min` or more creatures    total, or not at all — the generalization of Menace (CR 702.111b, min = 2).  NOTE: this enum is deliberately NOT `#[derive(Hash)]` — `TargetFilter` does not implement `Hash`. `StaticMode::hash` handles it manually (discriminant for `Quality`, `min` for `MinBlockers`), mirroring the `CantBeBlockedBy` precedent.",
       "cr_refs": [
         "CR 509.1b",
@@ -2063,7 +2074,7 @@
       "variants": [
         {
           "name": "Quality",
-          "line": 370,
+          "line": 415,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2071,7 +2082,7 @@
         },
         {
           "name": "MinBlockers",
-          "line": 371,
+          "line": 416,
           "kind": "struct",
           "field_names": [
             "min"
@@ -2084,7 +2095,7 @@
     },
     "BloodthirstValue": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 375,
+      "line": 385,
       "doc": "CR 702.54a + CR 702.54b: Bloodthirst has fixed-N and X-count forms.",
       "cr_refs": [
         "CR 702.54a",
@@ -2093,7 +2104,7 @@
       "variants": [
         {
           "name": "Fixed",
-          "line": 376,
+          "line": 386,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2101,11 +2112,40 @@
         },
         {
           "name": "X",
-          "line": 377,
+          "line": 387,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "BounceSelection": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 4991,
+      "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
+      "cr_refs": [
+        "CR 115.1"
+      ],
+      "variants": [
+        {
+          "name": "Targeted",
+          "line": 4994,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
+          "cr_refs": []
+        },
+        {
+          "name": "AtResolution",
+          "line": 4996,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
+          "cr_refs": [
+            "CR 608.2c"
+          ]
         }
       ],
       "sibling_clusters": []
@@ -2139,13 +2179,13 @@
     },
     "CardLayout": {
       "file": "crates/engine/src/types/card.rs",
-      "line": 184,
+      "line": 207,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Single",
-          "line": 185,
+          "line": 208,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2153,7 +2193,7 @@
         },
         {
           "name": "Split",
-          "line": 186,
+          "line": 209,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2161,7 +2201,7 @@
         },
         {
           "name": "Flip",
-          "line": 187,
+          "line": 210,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2169,7 +2209,7 @@
         },
         {
           "name": "Transform",
-          "line": 188,
+          "line": 211,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2177,7 +2217,7 @@
         },
         {
           "name": "Meld",
-          "line": 189,
+          "line": 212,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2185,7 +2225,7 @@
         },
         {
           "name": "Adventure",
-          "line": 190,
+          "line": 213,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2193,7 +2233,7 @@
         },
         {
           "name": "Modal",
-          "line": 191,
+          "line": 214,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2201,7 +2241,7 @@
         },
         {
           "name": "Omen",
-          "line": 192,
+          "line": 215,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2209,7 +2249,7 @@
         },
         {
           "name": "Prepare",
-          "line": 197,
+          "line": 220,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — face `a` is the creature, face `b` is the prepare-spell (Sorcery/Instant). When the creature is prepared, its controller may cast a copy of face `b`. Assign when WotC publishes SOS CR update.",
@@ -2219,7 +2259,7 @@
         },
         {
           "name": "Specialize",
-          "line": 198,
+          "line": 221,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2230,7 +2270,7 @@
     },
     "CardPlayMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 495,
+      "line": 516,
       "doc": "CR 601.2 vs CR 305.1: Distinguishes \"cast\" (spells only) from \"play\" (spells + lands).",
       "cr_refs": [
         "CR 305.1",
@@ -2239,7 +2279,7 @@
       "variants": [
         {
           "name": "Cast",
-          "line": 498,
+          "line": 519,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2: Cast a spell (cannot play lands this way).",
@@ -2249,7 +2289,7 @@
         },
         {
           "name": "Play",
-          "line": 500,
+          "line": 521,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1: Play a card — cast if it's a spell, play as a land if it's a land.",
@@ -2262,13 +2302,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2657,
+      "line": 2688,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 2659,
+          "line": 2690,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -2282,7 +2322,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2661,
+          "line": 2692,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -2293,7 +2333,7 @@
         },
         {
           "name": "Objects",
-          "line": 2663,
+          "line": 2694,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -2308,7 +2348,7 @@
     },
     "CastChoice": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 25,
+      "line": 26,
       "doc": "CR 701.57a + CR 702.85a: Player decision for any \"you may cast that card without paying its mana cost\" mid-resolution choice (Discover, Cascade). Bool flags are not composable — this enum can grow new branches (e.g., \"Cast face-down\", \"Put into hand\" already exists for Discover) without changing call sites that already exhaustively match.",
       "cr_refs": [
         "CR 701.57a",
@@ -2317,7 +2357,7 @@
       "variants": [
         {
           "name": "Cast",
-          "line": 30,
+          "line": 31,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.57a + CR 702.85a: Cast the offered card without paying its mana cost. The cast pipeline still enforces target legality, alternative constraints (e.g., `CascadeResultingMvBelow`), and other CR 601.2 checks.",
@@ -2329,7 +2369,7 @@
         },
         {
           "name": "Decline",
-          "line": 34,
+          "line": 35,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.57a + CR 702.85a: Decline the offer. For Discover the card goes to hand; for Cascade the card joins the misses on the bottom of the library in a random order.",
@@ -2385,7 +2425,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2668,
+      "line": 2699,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -2393,7 +2433,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 2670,
+          "line": 2701,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -2401,7 +2441,7 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 2672,
+          "line": 2703,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
@@ -2412,7 +2452,7 @@
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2678,
+      "line": 2709,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -2421,7 +2461,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 2680,
+          "line": 2711,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -2429,7 +2469,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 2682,
+          "line": 2713,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -2437,7 +2477,7 @@
         },
         {
           "name": "FromSource",
-          "line": 2684,
+          "line": 2715,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -2450,7 +2490,7 @@
     },
     "CastPaymentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 784,
+      "line": 816,
       "doc": "CR 601.2g-h: Whether the engine may auto-pay an unambiguous spell mana cost or must pause after announcement so the player can activate mana abilities manually before committing payment.",
       "cr_refs": [
         "CR 601.2g"
@@ -2458,7 +2498,7 @@
       "variants": [
         {
           "name": "Auto",
-          "line": 786,
+          "line": 818,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2466,7 +2506,7 @@
         },
         {
           "name": "Manual",
-          "line": 787,
+          "line": 819,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2477,7 +2517,7 @@
     },
     "CastPermissionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1583,
+      "line": 1612,
       "doc": "CR 702.85a: Typed cast-time predicates attached to an `ExileWithAltCost` permission. Extend this enum when future mechanics need cast-time gating that cannot be evaluated at permission-grant time (e.g., X-cost spells whose mana value is only known after the caster chooses X).",
       "cr_refs": [
         "CR 702.85a"
@@ -2485,7 +2525,7 @@
       "variants": [
         {
           "name": "CascadeResultingMvBelow",
-          "line": 1594,
+          "line": 1623,
           "kind": "struct",
           "field_names": [
             "source_mv",
@@ -2498,7 +2538,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 1600,
+          "line": 1629,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -2515,7 +2555,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4188,
+      "line": 4245,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -2524,7 +2564,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 4191,
+          "line": 4248,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -2535,7 +2575,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4150,
+      "line": 4207,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -2546,7 +2586,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4152,
+          "line": 4209,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -2557,7 +2597,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4155,
+          "line": 4212,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -2567,7 +2607,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4157,
+          "line": 4214,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -2577,7 +2617,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4159,
+          "line": 4216,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -2587,7 +2627,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4162,
+          "line": 4219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -2597,7 +2637,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4168,
+          "line": 4225,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -2607,7 +2647,7 @@
         },
         {
           "name": "Escape",
-          "line": 4173,
+          "line": 4230,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -2618,7 +2658,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4176,
+          "line": 4233,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -2628,7 +2668,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4181,
+          "line": 4238,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -2642,13 +2682,13 @@
     },
     "CastingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1423,
+      "line": 1452,
       "doc": "A permission granted to a `GameObject` allowing it to be cast under specific conditions. Stored in `GameObject::casting_permissions`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdventureCreature",
-          "line": 1425,
+          "line": 1454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.5: After Adventure resolves to exile, creature face castable from exile.",
@@ -2658,7 +2698,7 @@
         },
         {
           "name": "ExileWithAltCost",
-          "line": 1430,
+          "line": 1459,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -2674,7 +2714,7 @@
         },
         {
           "name": "PlayFromExile",
-          "line": 1464,
+          "line": 1493,
           "kind": "struct",
           "field_names": [
             "duration",
@@ -2693,7 +2733,7 @@
         },
         {
           "name": "ExileWithEnergyCost",
-          "line": 1490,
+          "line": 1519,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.3: Cast from exile by paying {E} equal to the card's mana value. Building block for Amped Raptor and similar energy-based casting mechanics.",
@@ -2703,7 +2743,7 @@
         },
         {
           "name": "ExileWithAltAbilityCost",
-          "line": 1499,
+          "line": 1528,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -2718,7 +2758,7 @@
         },
         {
           "name": "WarpExile",
-          "line": 1517,
+          "line": 1546,
           "kind": "struct",
           "field_names": [
             "castable_after_turn"
@@ -2730,7 +2770,7 @@
         },
         {
           "name": "Plotted",
-          "line": 1527,
+          "line": 1556,
           "kind": "struct",
           "field_names": [
             "turn_plotted"
@@ -2743,7 +2783,7 @@
         },
         {
           "name": "Foretold",
-          "line": 1533,
+          "line": 1562,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -2822,13 +2862,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8226,
+      "line": 8354,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8227,
+          "line": 8355,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2836,7 +2876,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8228,
+          "line": 8356,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2844,7 +2884,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 8229,
+          "line": 8357,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2852,7 +2892,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8230,
+          "line": 8358,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2860,7 +2900,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8231,
+          "line": 8359,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2868,7 +2908,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 8232,
+          "line": 8360,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2876,7 +2916,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 8233,
+          "line": 8361,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2884,7 +2924,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 8234,
+          "line": 8362,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2892,7 +2932,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 8235,
+          "line": 8363,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2900,7 +2940,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 8236,
+          "line": 8364,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2908,7 +2948,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 8237,
+          "line": 8365,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2916,7 +2956,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8238,
+          "line": 8366,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2924,7 +2964,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 8239,
+          "line": 8367,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2932,7 +2972,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8240,
+          "line": 8368,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2940,7 +2980,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 8241,
+          "line": 8369,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2948,7 +2988,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8242,
+          "line": 8370,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -2961,13 +3001,13 @@
     },
     "CastingVariant": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3210,
+      "line": 3321,
       "doc": "How a spell was cast — determines zone routing and post-resolution behavior. Replaces individual boolean flags (cast_as_adventure, cast_as_warp) with a single enum that captures the casting context.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Normal",
-          "line": 3213,
+          "line": 3324,
           "kind": "unit",
           "field_names": [],
           "doc": "Normal spell cast — no special resolution behavior.",
@@ -2975,7 +3015,7 @@
         },
         {
           "name": "Adventure",
-          "line": 3216,
+          "line": 3327,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.4: Cast as the Adventure half. On resolution, exiled with AdventureCreature permission and creature face restored.",
@@ -2985,7 +3025,7 @@
         },
         {
           "name": "Omen",
-          "line": 3219,
+          "line": 3330,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 720.3d / CR 720.4: Cast as the Omen half. On resolution, shuffled into its owner's library with normal characteristics restored.",
@@ -2996,7 +3036,7 @@
         },
         {
           "name": "Warp",
-          "line": 3222,
+          "line": 3333,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.185a: Cast via Warp alternative cost from hand. On resolution, creates a delayed trigger to exile at end step with WarpExile permission.",
@@ -3006,7 +3046,7 @@
         },
         {
           "name": "Escape",
-          "line": 3225,
+          "line": 3336,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138: Cast from graveyard via Escape. On resolution, goes to appropriate zone normally (unlike Flashback which exiles).",
@@ -3016,7 +3056,7 @@
         },
         {
           "name": "Retrace",
-          "line": 3228,
+          "line": 3339,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.81a: Cast from graveyard via Retrace by discarding a land card as an additional cost. Resolution uses normal spell routing.",
@@ -3026,7 +3066,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 3231,
+          "line": 3342,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.180a: Cast from graveyard for harmonize cost. On resolution, exiled instead of going anywhere else (unlike Escape which returns to graveyard).",
@@ -3036,7 +3076,7 @@
         },
         {
           "name": "Flashback",
-          "line": 3234,
+          "line": 3345,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34a: Cast from graveyard for flashback cost. On resolution (or whenever leaving the stack for any reason), exiled instead of going anywhere else.",
@@ -3046,7 +3086,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 3237,
+          "line": 3348,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Cast an aftermath half of a split card from a graveyard. If it was cast from a graveyard, exile it any time it leaves the stack.",
@@ -3056,7 +3096,7 @@
         },
         {
           "name": "GraveyardPermission",
-          "line": 3241,
+          "line": 3352,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3072,7 +3112,7 @@
         },
         {
           "name": "HandPermission",
-          "line": 3267,
+          "line": 3378,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3086,8 +3126,24 @@
           ]
         },
         {
+          "name": "ExilePermission",
+          "line": 3394,
+          "kind": "struct",
+          "field_names": [
+            "source",
+            "frequency"
+          ],
+          "doc": "CR 601.2a + CR 113.6b + CR 118.9a: Cast from exile via a `StaticMode::ExileCastPermission` source (Maralen, Fae Ascendant). Stores the granting permanent's ObjectId for per-turn tracking; the finalize-cast step zeroes the spell's mana cost when the static carries `without_paying_mana_cost: true` (the only published shape today). The resolution-time routing matches a normal cast — no on-resolve exile behavior — so this is treated as a casting-context tag, not as an alternative cost. CR 400.7: Zone change creates a new source `ObjectId`, naturally resetting the per-turn slot when the source leaves and re-enters play.",
+          "cr_refs": [
+            "CR 113.6b",
+            "CR 118.9a",
+            "CR 400.7",
+            "CR 601.2a"
+          ]
+        },
+        {
           "name": "Sneak",
-          "line": 3284,
+          "line": 3411,
           "kind": "struct",
           "field_names": [
             "returned_creature",
@@ -3101,7 +3157,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 3293,
+          "line": 3420,
           "kind": "struct",
           "field_names": [
             "returned_creature"
@@ -3113,7 +3169,7 @@
         },
         {
           "name": "Miracle",
-          "line": 3300,
+          "line": 3427,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94a: Cast from hand via Miracle's alternative cost after revealing the card as the first card drawn this turn. The granting keyword carries the miracle mana cost, which `prepare_spell_cast_with_variant_override` substitutes for the printed mana cost. The keyword's `ManaCost` payload is read at preparation time rather than stored here because `prepare_spell_cast` already reads `obj.keywords` for analogous paths.",
@@ -3123,7 +3179,7 @@
         },
         {
           "name": "Madness",
-          "line": 3303,
+          "line": 3430,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.35a: Cast from exile via Madness after the discard replacement exiled the card and its madness triggered ability resolved.",
@@ -3133,7 +3189,7 @@
         },
         {
           "name": "Evoke",
-          "line": 3307,
+          "line": 3434,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Cast from hand via Evoke's alternative cost. On resolution, the permanent enters tagged with `CastVariantPaid::Evoke`, which fires the synthesized intervening-if ETB sacrifice trigger.",
@@ -3143,7 +3199,7 @@
         },
         {
           "name": "Suspend",
-          "line": 3314,
+          "line": 3441,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast from exile via Suspend's \"play it without paying its mana cost\" trigger after the last time counter was removed. On resolution of the resulting permanent, the stack handler tags `CastVariantPaid::Suspend` and — for creature spells — installs a transient continuous \"has haste\" effect that lasts as long as the resolution-time controller still controls the permanent.",
@@ -3153,7 +3209,7 @@
         },
         {
           "name": "Plot",
-          "line": 3321,
+          "line": 3448,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.170d: Cast from exile via the Plot \"cast without paying its mana cost\" permission during the owner's main phase on a turn after the card was plotted. Detected at cast preparation when the exile-zone source has a `CastingPermission::Plotted { turn_plotted }` and the current turn is strictly greater than `turn_plotted`. Zeroes the mana cost and routes through the normal cast pipeline; no special resolution-time behavior.",
@@ -3163,7 +3219,7 @@
         },
         {
           "name": "Foretell",
-          "line": 3328,
+          "line": 3455,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143a-c: Cast from exile via a foretold card's foretell cost on a turn after it was foretold. Detected at cast preparation when the exile-zone source has a `CastingPermission::Foretold { .. }`. The permission supplies the alternative mana cost; stack finalization tags the source with `CastVariantPaid::Foretell` so \"if this spell was foretold\" clauses can evaluate while the spell resolves.",
@@ -3173,7 +3229,7 @@
         },
         {
           "name": "Overload",
-          "line": 3338,
+          "line": 3465,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a-c: Cast from hand via Overload's alternative cost. The printed mana cost is replaced by `Keyword::Overload(cost)` at cast preparation (mirrors `Evoke`/`Warp`). Per CR 702.96b, every \"target\" in the spell's text is replaced by \"each\" — applied as a cast-time transformation of the spell's ability tree (`Destroy`→`DestroyAll`, `Pump`→`PumpAll`, `DealDamage`→`DamageAll`, `Tap`→`TapAll`, `Bounce`→`ChangeZoneAll`). Per CR 702.96c, the resulting spell has no targets, so target selection is naturally skipped because the transformed effects carry no `TargetRef` slots.",
@@ -3185,7 +3241,7 @@
         },
         {
           "name": "Bestow",
-          "line": 3353,
+          "line": 3480,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a-b: Cast from hand via Bestow's alternative cost. The printed mana cost is replaced by `Keyword::Bestow(cost)` at cast preparation; the spell becomes an Aura with `enchant creature` while on the stack and as the resulting permanent (until it becomes unattached, per CR 702.103f). The type-changing mutation is applied directly to the stack object (mirroring `swap_to_alternative_spell_face` for Adventure/Omen) — Layers cannot be used here because they only apply to battlefield/hand objects, not stack objects.  Per CR 702.103e: if the target is illegal at resolution, the type-changing effect ends and the spell resolves as a creature spell. Per CR 702.103f: when a bestowed Aura becomes unattached on the battlefield, the type-changing effect ends — it remains as an enchantment creature (overrides CR 704.5m for bestow Auras).",
@@ -3194,6 +3250,18 @@
             "CR 702.103e",
             "CR 702.103f",
             "CR 704.5m"
+          ]
+        },
+        {
+          "name": "Cleave",
+          "line": 3491,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.148a-b + CR 612: Cast from hand via Cleave's alternative cost (CR 118.9). The printed mana cost is replaced by `Keyword::Cleave(cost)` at cast preparation (mirrors `Evoke`/`Overload`). Per CR 702.148a, paying the cleave cost is a text-changing effect (CR 612) that removes every square-bracketed span from the spell's rules text. The bracket-removed ability set is parsed at build time into `CardFace::cleave_variant` and swapped onto the stack object before preparation (mirroring the Bestow object-mutation-before-prepare seam). Resolution routing matches a normal spell — there is no on-resolve special behavior, so the spell goes to its owner's graveyard like any instant/sorcery.",
+          "cr_refs": [
+            "CR 118.9",
+            "CR 612",
+            "CR 702.148a"
           ]
         }
       ],
@@ -3228,13 +3296,13 @@
     },
     "ChoiceType": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 154,
+      "line": 162,
       "doc": "What kind of named choice the player must make at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CreatureType",
-          "line": 155,
+          "line": 163,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3242,7 +3310,7 @@
         },
         {
           "name": "Color",
-          "line": 156,
+          "line": 164,
           "kind": "struct",
           "field_names": [
             "excluded"
@@ -3252,7 +3320,7 @@
         },
         {
           "name": "OddOrEven",
-          "line": 163,
+          "line": 171,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3260,7 +3328,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 164,
+          "line": 172,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3268,7 +3336,7 @@
         },
         {
           "name": "CardType",
-          "line": 165,
+          "line": 173,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3276,7 +3344,7 @@
         },
         {
           "name": "CardName",
-          "line": 166,
+          "line": 174,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3284,7 +3352,7 @@
         },
         {
           "name": "NumberRange",
-          "line": 168,
+          "line": 176,
           "kind": "struct",
           "field_names": [
             "min",
@@ -3295,7 +3363,7 @@
         },
         {
           "name": "Labeled",
-          "line": 173,
+          "line": 181,
           "kind": "struct",
           "field_names": [
             "options"
@@ -3305,7 +3373,7 @@
         },
         {
           "name": "LandType",
-          "line": 177,
+          "line": 185,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose a land type\" — includes basic + common nonbasic land types.",
@@ -3313,7 +3381,7 @@
         },
         {
           "name": "Opponent",
-          "line": 179,
+          "line": 187,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose an opponent\" — selects one opponent player (CR 800.4a).",
@@ -3323,7 +3391,7 @@
         },
         {
           "name": "Player",
-          "line": 181,
+          "line": 189,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose a player\" — selects any player in the game.",
@@ -3331,7 +3399,7 @@
         },
         {
           "name": "TwoColors",
-          "line": 183,
+          "line": 191,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose two colors\" — selects two distinct mana colors.",
@@ -3339,7 +3407,7 @@
         },
         {
           "name": "Word",
-          "line": 185,
+          "line": 193,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose a word\" — names any English word (Un-set and silver-border cards).",
@@ -3347,7 +3415,7 @@
         },
         {
           "name": "Artist",
-          "line": 187,
+          "line": 195,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose an artist\" — selects a Magic card artist name.",
@@ -3355,7 +3423,7 @@
         },
         {
           "name": "Keyword",
-          "line": 195,
+          "line": 203,
           "kind": "struct",
           "field_names": [
             "options"
@@ -3370,13 +3438,13 @@
     },
     "ChoiceValue": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 637,
+      "line": 658,
       "doc": "A typed value chosen at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Color",
-          "line": 638,
+          "line": 659,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3384,7 +3452,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 639,
+          "line": 660,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3392,7 +3460,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 640,
+          "line": 661,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3400,7 +3468,7 @@
         },
         {
           "name": "CardType",
-          "line": 641,
+          "line": 662,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3408,7 +3476,7 @@
         },
         {
           "name": "OddOrEven",
-          "line": 642,
+          "line": 663,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3416,7 +3484,7 @@
         },
         {
           "name": "CardName",
-          "line": 643,
+          "line": 664,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3424,7 +3492,7 @@
         },
         {
           "name": "Number",
-          "line": 644,
+          "line": 665,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3432,7 +3500,7 @@
         },
         {
           "name": "Label",
-          "line": 645,
+          "line": 666,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3440,7 +3508,7 @@
         },
         {
           "name": "LandType",
-          "line": 646,
+          "line": 667,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3448,7 +3516,7 @@
         },
         {
           "name": "Player",
-          "line": 647,
+          "line": 668,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3456,7 +3524,7 @@
         },
         {
           "name": "TwoColors",
-          "line": 648,
+          "line": 669,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3464,7 +3532,7 @@
         },
         {
           "name": "Keyword",
-          "line": 653,
+          "line": 674,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2d: typed-keyword choice from a `ChoiceType::Keyword` option list (Urborg / Walking Sponge). Persisted into the source's `chosen_attributes` as `ChosenAttribute::Keyword` for later `RemoveChosenKeyword` resolution.",
@@ -3477,13 +3545,13 @@
     },
     "ChooseFromZoneConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 70,
-      "doc": "Additional selection constraints for tracked-set card picks during resolution.",
+      "line": 78,
+      "doc": "Additional selection constraints for tracked-set card picks during resolution.  Internally tagged (`{ \"type\": \"DistinctCardTypes\", \"categories\": [...] }`) to match the sibling [`SearchSelectionConstraint`] convention and the frontend's `ChooseFromZoneConstraint` type, which discriminates on the `type` field. The `CardChoiceModal` confirm gate reads `constraint.type`; without the tag the default external representation (`{ \"DistinctCardTypes\": {...} }`) leaves `type` undefined and the modal can never validate a selection.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DistinctCardTypes",
-          "line": 73,
+          "line": 81,
           "kind": "struct",
           "field_names": [
             "categories"
@@ -3525,13 +3593,13 @@
     },
     "ChosenAttribute": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 540,
+      "line": 561,
       "doc": "A typed choice stored on a permanent (e.g., \"choose a color\" → Color(Red)). The variant discriminant serves as the category key.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Color",
-          "line": 541,
+          "line": 562,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3539,7 +3607,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 542,
+          "line": 563,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3547,7 +3615,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 543,
+          "line": 564,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3555,7 +3623,7 @@
         },
         {
           "name": "CardType",
-          "line": 544,
+          "line": 565,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3563,7 +3631,7 @@
         },
         {
           "name": "OddOrEven",
-          "line": 545,
+          "line": 566,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3571,7 +3639,7 @@
         },
         {
           "name": "CardName",
-          "line": 546,
+          "line": 567,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -3579,7 +3647,7 @@
         },
         {
           "name": "Number",
-          "line": 548,
+          "line": 569,
           "kind": "tuple",
           "field_names": [],
           "doc": "Stores a chosen number (e.g., \"choose a number\" for Talion).",
@@ -3587,7 +3655,7 @@
         },
         {
           "name": "Player",
-          "line": 550,
+          "line": 571,
           "kind": "tuple",
           "field_names": [],
           "doc": "Stores the chosen opponent/player ID (CR 800.4a).",
@@ -3597,7 +3665,7 @@
         },
         {
           "name": "TwoColors",
-          "line": 552,
+          "line": 573,
           "kind": "tuple",
           "field_names": [],
           "doc": "Stores two chosen colors as a pair.",
@@ -3605,7 +3673,7 @@
         },
         {
           "name": "TributeOutcome",
-          "line": 556,
+          "line": 577,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.104a + CR 702.104b: Records whether the opponent chosen for the Tribute ETB replacement paid tribute or declined. Read by the companion `TriggerCondition::TributeNotPaid` evaluator.",
@@ -3616,7 +3684,7 @@
         },
         {
           "name": "Keyword",
-          "line": 561,
+          "line": 582,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2d: Records the typed keyword chosen from a `ChoiceType::Keyword` option list (Urborg / Walking Sponge \"choose an ability the target has, remove it\"). Read by `ContinuousModification::RemoveChosenKeyword` at Layer 6 evaluation to strip the chosen keyword from the recipient.",
@@ -3626,7 +3694,7 @@
         },
         {
           "name": "Label",
-          "line": 570,
+          "line": 591,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 614.12c: Records the anchor-word label chosen as the permanent entered the battlefield (e.g. Frostcliff Siege \"Jeskai\" / \"Temur\", Khans of Tarkir Sieges \"Khans\" / \"Dragons\"). Read by `StaticCondition::ChosenLabelIs` and `TriggerCondition::ChosenLabelIs` to gate which of the two anchor-word-marked abilities (CR 607: linked abilities) functions while the permanent is on the battlefield. The label is stored case-canonicalised to match `ChoiceType::Labeled`'s capitalised option list.",
@@ -3640,13 +3708,13 @@
     },
     "ChosenSubtypeKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 705,
+      "line": 726,
       "doc": "How to specify a damage amount -- either a fixed integer or a variable reference. Which category of chosen attribute to read as a subtype. Used by `ContinuousModification::AddChosenSubtype` in layer evaluation.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CreatureType",
-          "line": 706,
+          "line": 727,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3654,7 +3722,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 707,
+          "line": 728,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3700,7 +3768,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9865,
+      "line": 10041,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -3708,7 +3776,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 9866,
+          "line": 10042,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3716,7 +3784,7 @@
         },
         {
           "name": "Lost",
-          "line": 9867,
+          "line": 10043,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3727,13 +3795,13 @@
     },
     "CollectEvidenceResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 900,
+      "line": 938,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Casting",
-          "line": 901,
+          "line": 939,
           "kind": "struct",
           "field_names": [
             "pending_cast"
@@ -3743,7 +3811,7 @@
         },
         {
           "name": "Effect",
-          "line": 904,
+          "line": 942,
           "kind": "struct",
           "field_names": [
             "pending_ability"
@@ -3756,7 +3824,7 @@
     },
     "CombatDamageAssignmentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2802,
+      "line": 2880,
       "doc": "CR 510.1c: Optional combat-damage assignment mode for attackers with text like \"you may have this creature assign its combat damage as though it weren't blocked.\"",
       "cr_refs": [
         "CR 510.1c"
@@ -3764,7 +3832,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 2804,
+          "line": 2882,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3772,7 +3840,7 @@
         },
         {
           "name": "AsThoughUnblocked",
-          "line": 2805,
+          "line": 2883,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3783,7 +3851,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10365,
+      "line": 10541,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -3791,7 +3859,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 10366,
+          "line": 10542,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3799,7 +3867,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 10367,
+          "line": 10543,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3810,13 +3878,13 @@
     },
     "CombatRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1810,
+      "line": 1839,
       "doc": "Combat relationship required by `FilterProp::CombatRelation`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "BlockingOrBlockedBy",
-          "line": 1812,
+          "line": 1841,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g/509.1h: Candidate is blocking the subject or is blocked by it.",
@@ -3829,13 +3897,13 @@
     },
     "CombatRelationSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1817,
+      "line": 1846,
       "doc": "Context object for a combat relationship filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 1819,
+          "line": 1848,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object of the resolving spell or ability.",
@@ -3843,7 +3911,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 1821,
+          "line": 1850,
           "kind": "unit",
           "field_names": [],
           "doc": "The first selected object target of the resolving spell or ability.",
@@ -3854,7 +3922,7 @@
     },
     "CombatTaxContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1101,
+      "line": 1139,
       "doc": "CR 508.1d + CR 509.1c: Which combat step a `WaitingFor::CombatTaxPayment` belongs to.  Drives the resume branch after the tax decision — on accept, the engine submits the stored attacker / blocker declaration; on decline, the engine filters the taxed creatures out of that declaration and submits the remainder.",
       "cr_refs": [
         "CR 508.1d",
@@ -3863,7 +3931,7 @@
       "variants": [
         {
           "name": "Attacking",
-          "line": 1102,
+          "line": 1140,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3871,7 +3939,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1103,
+          "line": 1141,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3882,7 +3950,7 @@
     },
     "CombatTaxPending": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1111,
+      "line": 1149,
       "doc": "CR 508.1d + CR 509.1c: The declaration that is paused awaiting a combat-tax decision. Keyed by `CombatTaxContext` — the engine resumes the matching variant on `GameAction::PayCombatTax`.",
       "cr_refs": [
         "CR 508.1d",
@@ -3891,7 +3959,7 @@
       "variants": [
         {
           "name": "Attack",
-          "line": 1112,
+          "line": 1150,
           "kind": "struct",
           "field_names": [
             "attacks"
@@ -3901,7 +3969,7 @@
         },
         {
           "name": "Block",
-          "line": 1115,
+          "line": 1153,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -3914,7 +3982,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3603,
+      "line": 3648,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -3922,7 +3990,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 3606,
+          "line": 3651,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -3933,7 +4001,7 @@
         },
         {
           "name": "Any",
-          "line": 3610,
+          "line": 3655,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -3946,7 +4014,7 @@
     },
     "CompanionCondition": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 271,
+      "line": 273,
       "doc": "CR 702.139: Companion deckbuilding conditions. Each of the 10 companion cards has a unique condition the starting deck must satisfy.",
       "cr_refs": [
         "CR 702.139"
@@ -3954,7 +4022,7 @@
       "variants": [
         {
           "name": "EvenManaValues",
-          "line": 273,
+          "line": 275,
           "kind": "unit",
           "field_names": [],
           "doc": "Gyruda: Each nonland card in your starting deck has an even mana value.",
@@ -3962,7 +4030,7 @@
         },
         {
           "name": "NoRepeatedManaSymbols",
-          "line": 275,
+          "line": 277,
           "kind": "unit",
           "field_names": [],
           "doc": "Jegantha: No card in your starting deck has more than one of the same mana symbol in its cost.",
@@ -3970,7 +4038,7 @@
         },
         {
           "name": "CreatureTypeRestriction",
-          "line": 277,
+          "line": 279,
           "kind": "tuple",
           "field_names": [],
           "doc": "Kaheera: Each creature card in your starting deck is of one of the listed types.",
@@ -3978,7 +4046,7 @@
         },
         {
           "name": "MinManaValue",
-          "line": 279,
+          "line": 281,
           "kind": "tuple",
           "field_names": [],
           "doc": "Keruga: Each nonland card in your starting deck has mana value 3 or greater.",
@@ -3986,7 +4054,7 @@
         },
         {
           "name": "MaxPermanentManaValue",
-          "line": 281,
+          "line": 283,
           "kind": "tuple",
           "field_names": [],
           "doc": "Lurrus: Each permanent card in your starting deck has mana value 2 or less.",
@@ -3994,7 +4062,7 @@
         },
         {
           "name": "Singleton",
-          "line": 283,
+          "line": 285,
           "kind": "unit",
           "field_names": [],
           "doc": "Lutri: No nonland card in your starting deck has the same name as another.",
@@ -4002,7 +4070,7 @@
         },
         {
           "name": "OddManaValues",
-          "line": 285,
+          "line": 287,
           "kind": "unit",
           "field_names": [],
           "doc": "Obosh: Each nonland card in your starting deck has an odd mana value.",
@@ -4010,7 +4078,7 @@
         },
         {
           "name": "SharedCardType",
-          "line": 287,
+          "line": 289,
           "kind": "unit",
           "field_names": [],
           "doc": "Umori: Each nonland card in your starting deck shares a card type.",
@@ -4018,7 +4086,7 @@
         },
         {
           "name": "MinDeckSizeOver",
-          "line": 289,
+          "line": 291,
           "kind": "tuple",
           "field_names": [],
           "doc": "Yorion: Your starting deck has at least 80 cards (20 over the minimum).",
@@ -4026,7 +4094,7 @@
         },
         {
           "name": "PermanentsHaveActivatedAbilities",
-          "line": 291,
+          "line": 293,
           "kind": "unit",
           "field_names": [],
           "doc": "Zirda: Each permanent card in your starting deck has an activated ability.",
@@ -4037,13 +4105,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3476,
+      "line": 3519,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 3477,
+          "line": 3520,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4051,7 +4119,7 @@
         },
         {
           "name": "LT",
-          "line": 3478,
+          "line": 3521,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4059,7 +4127,7 @@
         },
         {
           "name": "GE",
-          "line": 3479,
+          "line": 3522,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4067,7 +4135,7 @@
         },
         {
           "name": "LE",
-          "line": 3480,
+          "line": 3523,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4075,7 +4143,7 @@
         },
         {
           "name": "EQ",
-          "line": 3481,
+          "line": 3524,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4083,7 +4151,7 @@
         },
         {
           "name": "NE",
-          "line": 3482,
+          "line": 3525,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4094,13 +4162,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10781,
+      "line": 10957,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 10782,
+          "line": 10958,
           "kind": "struct",
           "field_names": [
             "values",
@@ -4111,7 +4179,7 @@
         },
         {
           "name": "SetName",
-          "line": 10797,
+          "line": 10973,
           "kind": "struct",
           "field_names": [
             "name"
@@ -4125,7 +4193,7 @@
         },
         {
           "name": "AddPower",
-          "line": 10800,
+          "line": 10976,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4135,7 +4203,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 10803,
+          "line": 10979,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4145,7 +4213,7 @@
         },
         {
           "name": "SetPower",
-          "line": 10806,
+          "line": 10982,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4155,7 +4223,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 10809,
+          "line": 10985,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4165,7 +4233,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 10812,
+          "line": 10988,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4175,7 +4243,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 10815,
+          "line": 10991,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4185,7 +4253,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 10818,
+          "line": 10994,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4195,7 +4263,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 10825,
+          "line": 11001,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -4207,7 +4275,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 10828,
+          "line": 11004,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4215,7 +4283,7 @@
         },
         {
           "name": "AddType",
-          "line": 10829,
+          "line": 11005,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4225,7 +4293,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 10832,
+          "line": 11008,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4235,7 +4303,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 10835,
+          "line": 11011,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4245,7 +4313,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 10838,
+          "line": 11014,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4255,7 +4323,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 10845,
+          "line": 11021,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4268,7 +4336,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 10851,
+          "line": 11027,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4281,7 +4349,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 10855,
+          "line": 11031,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4291,7 +4359,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 10859,
+          "line": 11035,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4301,7 +4369,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 10866,
+          "line": 11042,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4313,7 +4381,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 10871,
+          "line": 11047,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4325,7 +4393,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 10875,
+          "line": 11051,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4337,7 +4405,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 10879,
+          "line": 11055,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4349,7 +4417,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 10884,
+          "line": 11060,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4362,7 +4430,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 10890,
+          "line": 11066,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4370,7 +4438,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 10893,
+          "line": 11069,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4381,7 +4449,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 10896,
+          "line": 11072,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4391,7 +4459,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 10901,
+          "line": 11077,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4401,7 +4469,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 10908,
+          "line": 11084,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -4412,7 +4480,7 @@
         },
         {
           "name": "SetColor",
-          "line": 10909,
+          "line": 11085,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4422,7 +4490,7 @@
         },
         {
           "name": "AddColor",
-          "line": 10912,
+          "line": 11088,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4432,7 +4500,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 10917,
+          "line": 11093,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4442,7 +4510,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 10931,
+          "line": 11107,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4457,7 +4525,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 10935,
+          "line": 11111,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4467,7 +4535,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 10938,
+          "line": 11114,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -4477,7 +4545,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 10940,
+          "line": 11116,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -4487,7 +4555,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 10942,
+          "line": 11118,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -4497,7 +4565,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 10945,
+          "line": 11121,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -4507,7 +4575,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 10948,
+          "line": 11124,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -4519,7 +4587,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 10962,
+          "line": 11138,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -4531,7 +4599,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 10970,
+          "line": 11146,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4546,7 +4614,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 10979,
+          "line": 11155,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4561,7 +4629,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 10993,
+          "line": 11169,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -4577,42 +4645,15 @@
       ],
       "sibling_clusters": []
     },
-    "ControlPresence": {
-      "file": "crates/engine/src/types/ability.rs",
-      "line": 3246,
-      "doc": "CR 109.4: Whether a player's controlled-permanent predicate is satisfied by the presence or the absence of a matching permanent. A typed two-variant enum — never a bool — so `PlayerFilter::ControlsPermanent` reads as self-documenting at every match site.",
-      "cr_refs": [
-        "CR 109.4"
-      ],
-      "variants": [
-        {
-          "name": "Controls",
-          "line": 3248,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "The player controls at least one permanent matching the filter.",
-          "cr_refs": []
-        },
-        {
-          "name": "ControlsNone",
-          "line": 3250,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "The player controls no permanent matching the filter.",
-          "cr_refs": []
-        }
-      ],
-      "sibling_clusters": []
-    },
     "ControllerRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1720,
+      "line": 1749,
       "doc": "Controller reference for filter matching.",
       "cr_refs": [],
       "variants": [
         {
           "name": "You",
-          "line": 1721,
+          "line": 1750,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4620,7 +4661,7 @@
         },
         {
           "name": "Opponent",
-          "line": 1722,
+          "line": 1751,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4628,7 +4669,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 1725,
+          "line": 1754,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: Filter controller is the current player being affected by an \"each player/opponent\" instruction during resolution.",
@@ -4639,7 +4680,7 @@
         },
         {
           "name": "TargetPlayer",
-          "line": 1732,
+          "line": 1761,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 115.1: Filter controller is the player chosen as a target of the enclosing ability (e.g., \"each creature target player controls\"). At resolution time, `filter_inner` reads the first `TargetRef::Player` from `ability.targets`. At target-selection time, `collect_target_slots` surfaces a companion `TargetFilter::Player` slot so the player is chosen as part of CR 601.2c / CR 603.3d target declaration.",
@@ -4652,7 +4693,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 1736,
+          "line": 1765,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 109.4: Filter controller is the controller of the parent object target inherited by this chained effect (\"that permanent's controller may sacrifice a land\").",
@@ -4663,7 +4704,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 1741,
+          "line": 1770,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Filter controller is the defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by intervening-if quantity checks such as \"defending player controls more lands than you.\"",
@@ -4674,7 +4715,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 1752,
+          "line": 1781,
           "kind": "struct",
           "field_names": [
             "index"
@@ -4687,7 +4728,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 1761,
+          "line": 1790,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 109.4: Filter controller is the player identified by the triggering event (the drawer, life-gainer, attacker, etc.). Resolved against `state.current_trigger_event` via `extract_player_from_event`. Mirrors `PlayerFilter::TriggeringPlayer` and `TargetFilter::TriggeringPlayer`. Used by control-relative trigger restrictions (\"an opponent who controls F draws a card\").",
@@ -4711,7 +4752,7 @@
     },
     "ConvokeMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 124,
+      "line": 125,
       "doc": "CR 702.51a / Waterbend: Determines tap-to-pay behavior during mana payment.",
       "cr_refs": [
         "CR 702.51a"
@@ -4719,7 +4760,7 @@
       "variants": [
         {
           "name": "Convoke",
-          "line": 126,
+          "line": 127,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51a: Creature's color determines mana produced.",
@@ -4729,7 +4770,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 128,
+          "line": 129,
           "kind": "unit",
           "field_names": [],
           "doc": "Waterbend: always produces {1} colorless, emits Waterbend event.",
@@ -4737,7 +4778,7 @@
         },
         {
           "name": "Improvise",
-          "line": 130,
+          "line": 131,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.126a: Improvise — tap an untapped artifact to pay one generic mana.",
@@ -4750,7 +4791,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11072,
+      "line": 11248,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -4760,7 +4801,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 11075,
+          "line": 11251,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -4768,7 +4809,7 @@
         },
         {
           "name": "Finalized",
-          "line": 11077,
+          "line": 11253,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -4779,13 +4820,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4878,
+      "line": 4935,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 4879,
+          "line": 4936,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4796,7 +4837,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6783,
+      "line": 6903,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -4805,7 +4846,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 6785,
+          "line": 6905,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -4813,7 +4854,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 6787,
+          "line": 6907,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -4937,7 +4978,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4408,
+      "line": 4465,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -4945,7 +4986,7 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4409,
+          "line": 4466,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4953,7 +4994,7 @@
         },
         {
           "name": "TapsSelf",
-          "line": 4410,
+          "line": 4467,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4961,7 +5002,7 @@
         },
         {
           "name": "UntapsSelf",
-          "line": 4411,
+          "line": 4468,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4969,7 +5010,7 @@
         },
         {
           "name": "SacrificesPermanent",
-          "line": 4412,
+          "line": 4469,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4977,7 +5018,7 @@
         },
         {
           "name": "PaysLife",
-          "line": 4413,
+          "line": 4470,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4985,7 +5026,7 @@
         },
         {
           "name": "PaysLoyalty",
-          "line": 4414,
+          "line": 4471,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4993,7 +5034,7 @@
         },
         {
           "name": "Discards",
-          "line": 4415,
+          "line": 4472,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5001,7 +5042,7 @@
         },
         {
           "name": "ExilesCards",
-          "line": 4416,
+          "line": 4473,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5009,7 +5050,7 @@
         },
         {
           "name": "TapsOtherCreatures",
-          "line": 4417,
+          "line": 4474,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5017,7 +5058,7 @@
         },
         {
           "name": "RemovesCounters",
-          "line": 4418,
+          "line": 4475,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5025,7 +5066,7 @@
         },
         {
           "name": "PaysEnergy",
-          "line": 4419,
+          "line": 4476,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5033,7 +5074,7 @@
         },
         {
           "name": "PaysSpeed",
-          "line": 4420,
+          "line": 4477,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5041,7 +5082,7 @@
         },
         {
           "name": "ReturnsToHand",
-          "line": 4421,
+          "line": 4478,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5049,7 +5090,7 @@
         },
         {
           "name": "Unattaches",
-          "line": 4422,
+          "line": 4479,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5057,7 +5098,7 @@
         },
         {
           "name": "Mills",
-          "line": 4423,
+          "line": 4480,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5065,7 +5106,7 @@
         },
         {
           "name": "PutsCounters",
-          "line": 4424,
+          "line": 4481,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5073,7 +5114,7 @@
         },
         {
           "name": "Reveals",
-          "line": 4425,
+          "line": 4482,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5081,7 +5122,7 @@
         },
         {
           "name": "Exerts",
-          "line": 4426,
+          "line": 4483,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5089,7 +5130,7 @@
         },
         {
           "name": "KeywordCost",
-          "line": 4427,
+          "line": 4484,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5132,7 +5173,7 @@
     },
     "CountScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 721,
+      "line": 742,
       "doc": "Which players' zones to count across for zone-based quantity references.  CR 608.2 + CR 109.5: `Controller` and `ScopedPlayer` are distinct axes during `player_scope` iteration. `Controller` always means the printed ability's controller (the \"you\" axis from CR 109.5). `ScopedPlayer` means the player whose iteration copy is currently running (e.g., each opponent in \"Each opponent mills half of *their* library, rounded up.\" — Maddening Cacophony's kicker mode). Outside iteration, `ScopedPlayer` falls back to `Controller`. Mirrors the `ControllerRef::You` vs `ControllerRef::ScopedPlayer` split.",
       "cr_refs": [
         "CR 109.5",
@@ -5141,7 +5182,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 723,
+          "line": 744,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5: The printed ability's controller — \"you\" / \"your\" semantics.",
@@ -5151,7 +5192,7 @@
         },
         {
           "name": "Owner",
-          "line": 726,
+          "line": 747,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 404.2: The printed ability controller as owner for player-scoped queries over non-battlefield zones.",
@@ -5162,7 +5203,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 732,
+          "line": 753,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2 + CR 109.5: The currently iterated player during a `player_scope` resolution — \"they\" / \"their\" semantics relative to the iteration. Issue #310: distinguishes \"their library\" (per-iteration) from \"your library\" (always caster). Falls back to `Controller` outside iteration.",
@@ -5173,7 +5214,7 @@
         },
         {
           "name": "All",
-          "line": 733,
+          "line": 754,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5181,7 +5222,7 @@
         },
         {
           "name": "Opponents",
-          "line": 734,
+          "line": 755,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5192,7 +5233,7 @@
     },
     "CounterMatch": {
       "file": "crates/engine/src/types/counter.rs",
-      "line": 137,
+      "line": 152,
       "doc": "Which counter(s) a predicate is matching against.  CR 122.1: \"A counter is a marker placed on an object or player…\" — some Oracle text distinguishes counters by type (\"a +1/+1 counter\"), while other text refers to counters generically (\"a counter on it\", meaning any type). `CounterMatch::Any` captures the latter case so predicates can sum across every counter type on an object, and `OfType` captures the former by reusing the canonical `CounterType` enum. Prefer this over `Option<CounterType>`: \"Any\" is a first-class matching mode rather than an absence-of-specification.",
       "cr_refs": [
         "CR 122.1"
@@ -5200,7 +5241,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 139,
+          "line": 154,
           "kind": "unit",
           "field_names": [],
           "doc": "\"a counter on it\" — any counter type; predicates sum across all types.",
@@ -5208,7 +5249,7 @@
         },
         {
           "name": "OfType",
-          "line": 141,
+          "line": 156,
           "kind": "tuple",
           "field_names": [],
           "doc": "A specific counter type, matching the canonical `CounterType` enum.",
@@ -5217,9 +5258,67 @@
       ],
       "sibling_clusters": []
     },
+    "CounterMoveSelection": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 835,
+      "doc": "",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "StackTarget",
+          "line": 837,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "StackTargetAnyNumber",
+          "line": 838,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ResolutionDistributionAnyNumber",
+          "line": 839,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "CounterMoveStage": {
+      "file": "crates/engine/src/types/proposed_event.rs",
+      "line": 25,
+      "doc": "",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "Remove",
+          "line": 26,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Add",
+          "line": 27,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
     "CounterSourceRider": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 829,
+      "line": 858,
       "doc": "CR 701.6 + CR 608.2c: A follow-up instruction carried by `Effect::Counter` that acts on the *source permanent* of an ability countered by the effect.  The rider only fires when the countered object was an activated or triggered ability — per CR 701.8a / CR 110.1 a spell is not a permanent, so when a spell is countered there is no permanent for the rider to act on and it is skipped (the conditional \"if a permanent's ability is countered this way\" is encoded structurally by this spell-vs-ability gate, not by a separate `AbilityCondition`).  Both variants share one categorical axis — \"an effect applied to the countered ability's source permanent\" — so they live on a single enum rather than as sibling `Option` fields on `Effect::Counter` (parameterize, don't proliferate).",
       "cr_refs": [
         "CR 110.1",
@@ -5230,7 +5329,7 @@
       "variants": [
         {
           "name": "LosesAbilities",
-          "line": 833,
+          "line": 862,
           "kind": "struct",
           "field_names": [
             "static_def"
@@ -5242,7 +5341,7 @@
         },
         {
           "name": "Destroy",
-          "line": 836,
+          "line": 865,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8: \"destroy that permanent\" — destroys the countered ability's source permanent (Teferi's Response, Green Slime).",
@@ -5255,7 +5354,7 @@
     },
     "CounterTransferMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 806,
+      "line": 827,
       "doc": "CR 122.5 / CR 122.8: Whether a counter-transfer effect actually moves counters off the source or only puts matching counters on the destination.",
       "cr_refs": [
         "CR 122.5",
@@ -5264,7 +5363,7 @@
       "variants": [
         {
           "name": "Move",
-          "line": 808,
+          "line": 829,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.5: Remove counters from the source and put them on the target.",
@@ -5274,7 +5373,7 @@
         },
         {
           "name": "Put",
-          "line": 810,
+          "line": 831,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.8: Put matching counters on the target using source/LKI state.",
@@ -5434,7 +5533,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3170,
+      "line": 3210,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -5442,7 +5541,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 3173,
+          "line": 3213,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -5455,7 +5554,7 @@
     },
     "DamageKindFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1708,
+      "line": 1737,
       "doc": "Filter for damage type on trigger definitions. CR 120.3: Combat damage is dealt during the combat damage step; all other damage is noncombat.",
       "cr_refs": [
         "CR 120.3"
@@ -5463,7 +5562,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 1711,
+          "line": 1740,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches both combat and noncombat damage.",
@@ -5471,7 +5570,7 @@
         },
         {
           "name": "CombatOnly",
-          "line": 1713,
+          "line": 1742,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2a: Only combat damage (dealt as a result of combat).",
@@ -5481,7 +5580,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 1715,
+          "line": 1744,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2b: Only noncombat damage (dealt as an effect of a spell or ability).",
@@ -5494,7 +5593,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10242,
+      "line": 10418,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -5502,7 +5601,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10244,
+          "line": 10420,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -5510,7 +5609,7 @@
         },
         {
           "name": "Triple",
-          "line": 10246,
+          "line": 10422,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -5518,7 +5617,7 @@
         },
         {
           "name": "Plus",
-          "line": 10248,
+          "line": 10424,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5528,7 +5627,7 @@
         },
         {
           "name": "Minus",
-          "line": 10255,
+          "line": 10431,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5541,7 +5640,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 10259,
+          "line": 10435,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -5551,7 +5650,7 @@
         },
         {
           "name": "SetTo",
-          "line": 10265,
+          "line": 10441,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5563,7 +5662,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 10271,
+          "line": 10447,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -5578,7 +5677,7 @@
     },
     "DamageRedirectTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 449,
+      "line": 470,
       "doc": "CR 614.9: Recipient of a one-shot damage-redirection effect — the battle/creature/planeswalker/player the replaced damage is dealt to instead. Resolved to a concrete object/player at effect-resolution time (see `effects::create_damage_replacement::resolve`).",
       "cr_refs": [
         "CR 614.9"
@@ -5586,7 +5685,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 452,
+          "line": 473,
           "kind": "unit",
           "field_names": [],
           "doc": "\"...to you instead\" — the replacement source's controller (Jade Monolith, Goblin Psychopath).",
@@ -5594,7 +5693,7 @@
         },
         {
           "name": "SourceObject",
-          "line": 455,
+          "line": 476,
           "kind": "unit",
           "field_names": [],
           "doc": "\"...to ~ instead\" / \"...dealt to this creature instead\" — the replacement source object itself (Beacon of Destiny).",
@@ -5602,7 +5701,7 @@
         },
         {
           "name": "ChosenObjectTarget",
-          "line": 458,
+          "line": 479,
           "kind": "unit",
           "field_names": [],
           "doc": "\"...to target creature instead\" — an object chosen as a target of the creating ability (Soltari Guerrillas).",
@@ -5613,7 +5712,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4859,
+      "line": 4916,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -5621,7 +5720,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 4861,
+          "line": 4918,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -5629,7 +5728,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 4864,
+          "line": 4921,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -5643,7 +5742,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10353,
+      "line": 10529,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -5651,7 +5750,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 10355,
+          "line": 10531,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -5659,7 +5758,7 @@
         },
         {
           "name": "Player",
-          "line": 10357,
+          "line": 10533,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5669,7 +5768,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 10360,
+          "line": 10536,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5682,7 +5781,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10341,
+      "line": 10517,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -5690,7 +5789,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10342,
+          "line": 10518,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5698,7 +5797,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10343,
+          "line": 10519,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5706,7 +5805,7 @@
         },
         {
           "name": "Controller",
-          "line": 10346,
+          "line": 10522,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -5714,7 +5813,7 @@
         },
         {
           "name": "Specific",
-          "line": 10347,
+          "line": 10523,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -5725,7 +5824,7 @@
     },
     "DayNight": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 117,
+      "line": 118,
       "doc": "Tracks whether the game is in day or night state (CR 730).",
       "cr_refs": [
         "CR 730"
@@ -5733,7 +5832,7 @@
       "variants": [
         {
           "name": "Day",
-          "line": 118,
+          "line": 119,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5741,7 +5840,7 @@
         },
         {
           "name": "Night",
-          "line": 119,
+          "line": 120,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5752,13 +5851,13 @@
     },
     "DebugAction": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 643,
+      "line": 654,
       "doc": "Direct game-state manipulation actions for debugging, testing, and remediation. Bypasses `WaitingFor` validation — fires from any game state without disrupting the current prompt. Gated on `GameState::debug_mode`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MoveToZone",
-          "line": 648,
+          "line": 659,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5771,7 +5870,7 @@
         },
         {
           "name": "CreateCard",
-          "line": 663,
+          "line": 674,
           "kind": "struct",
           "field_names": [
             "card_name",
@@ -5786,7 +5885,7 @@
         },
         {
           "name": "RemoveObject",
-          "line": 671,
+          "line": 682,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -5796,7 +5895,7 @@
         },
         {
           "name": "DrawCards",
-          "line": 674,
+          "line": 685,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -5809,7 +5908,7 @@
         },
         {
           "name": "Mill",
-          "line": 676,
+          "line": 687,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -5820,7 +5919,7 @@
         },
         {
           "name": "ShuffleLibrary",
-          "line": 678,
+          "line": 689,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -5830,7 +5929,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 681,
+          "line": 692,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -5842,7 +5941,7 @@
         },
         {
           "name": "SetBasePowerToughness",
-          "line": 685,
+          "line": 696,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5854,7 +5953,7 @@
         },
         {
           "name": "ModifyCounters",
-          "line": 692,
+          "line": 703,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5866,7 +5965,7 @@
         },
         {
           "name": "SetTapped",
-          "line": 698,
+          "line": 709,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5877,7 +5976,7 @@
         },
         {
           "name": "SetController",
-          "line": 700,
+          "line": 711,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5888,7 +5987,7 @@
         },
         {
           "name": "SetSummoningSickness",
-          "line": 705,
+          "line": 716,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5899,7 +5998,7 @@
         },
         {
           "name": "SetFaceState",
-          "line": 707,
+          "line": 718,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5912,7 +6011,7 @@
         },
         {
           "name": "Attach",
-          "line": 717,
+          "line": 728,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5926,7 +6025,7 @@
         },
         {
           "name": "Detach",
-          "line": 722,
+          "line": 733,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -5936,7 +6035,7 @@
         },
         {
           "name": "GrantKeyword",
-          "line": 724,
+          "line": 735,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5947,7 +6046,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 729,
+          "line": 740,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -5958,7 +6057,7 @@
         },
         {
           "name": "SetLife",
-          "line": 736,
+          "line": 747,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -5969,7 +6068,7 @@
         },
         {
           "name": "ModifyPlayerCounters",
-          "line": 738,
+          "line": 749,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -5981,7 +6080,7 @@
         },
         {
           "name": "ModifyEnergy",
-          "line": 744,
+          "line": 755,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -5992,7 +6091,7 @@
         },
         {
           "name": "AddMana",
-          "line": 746,
+          "line": 757,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6003,7 +6102,7 @@
         },
         {
           "name": "SetPhase",
-          "line": 753,
+          "line": 764,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -6014,7 +6113,7 @@
         },
         {
           "name": "RunStateBasedActions",
-          "line": 758,
+          "line": 769,
           "kind": "unit",
           "field_names": [],
           "doc": "Explicitly run state-based actions. Use after a batch of raw mutations.",
@@ -6022,7 +6121,7 @@
         },
         {
           "name": "CreateToken",
-          "line": 771,
+          "line": 782,
           "kind": "struct",
           "field_names": [
             "request"
@@ -6036,7 +6135,7 @@
         },
         {
           "name": "CreateTokenCopy",
-          "line": 774,
+          "line": 785,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -6052,13 +6151,13 @@
     },
     "DebugTokenRequest": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 782,
+      "line": 793,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Preset",
-          "line": 783,
+          "line": 794,
           "kind": "struct",
           "field_names": [
             "preset_id",
@@ -6070,7 +6169,7 @@
         },
         {
           "name": "Custom",
-          "line": 789,
+          "line": 800,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -6085,7 +6184,7 @@
     },
     "DelayedTriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1609,
+      "line": 1638,
       "doc": "When a delayed triggered ability fires (CR 603.7).",
       "cr_refs": [
         "CR 603.7"
@@ -6093,7 +6192,7 @@
       "variants": [
         {
           "name": "AtNextPhase",
-          "line": 1612,
+          "line": 1641,
           "kind": "struct",
           "field_names": [
             "phase"
@@ -6105,7 +6204,7 @@
         },
         {
           "name": "AtNextPhaseForPlayer",
-          "line": 1615,
+          "line": 1644,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -6116,7 +6215,7 @@
         },
         {
           "name": "WhenLeavesPlay",
-          "line": 1617,
+          "line": 1646,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -6126,7 +6225,7 @@
         },
         {
           "name": "WhenDies",
-          "line": 1623,
+          "line": 1652,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6138,7 +6237,7 @@
         },
         {
           "name": "WhenLeavesPlayFiltered",
-          "line": 1626,
+          "line": 1655,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6150,7 +6249,7 @@
         },
         {
           "name": "WhenEntersBattlefield",
-          "line": 1629,
+          "line": 1658,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6162,7 +6261,7 @@
         },
         {
           "name": "WhenDiesOrExiled",
-          "line": 1632,
+          "line": 1661,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6172,7 +6271,7 @@
         },
         {
           "name": "WheneverEvent",
-          "line": 1637,
+          "line": 1666,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -6184,7 +6283,7 @@
         },
         {
           "name": "WhenNextEvent",
-          "line": 1641,
+          "line": 1670,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -6199,7 +6298,7 @@
     },
     "DevotionColors": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 917,
+      "line": 946,
       "doc": "CR 700.5: Which color set a devotion quantity counts.",
       "cr_refs": [
         "CR 700.5"
@@ -6207,7 +6306,7 @@
       "variants": [
         {
           "name": "Fixed",
-          "line": 919,
+          "line": 948,
           "kind": "tuple",
           "field_names": [],
           "doc": "Count devotion to one or more fixed colors.",
@@ -6215,7 +6314,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 922,
+          "line": 951,
           "kind": "unit",
           "field_names": [],
           "doc": "Count devotion to the color chosen by the source's current choice effect or persisted chosen-color attribute.",
@@ -6224,9 +6323,40 @@
       ],
       "sibling_clusters": []
     },
+    "DieRollModifier": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 427,
+      "doc": "CR 706.2: Modifier applied to a die roll's natural result before the effect's result table is consulted. \"Roll a d20 and add the number of cards in your hand\" → `Add(QuantityExpr::Ref(HandSize { player: Controller }))`. \"Roll a d20 and subtract the number of cards in your hand\" → `Subtract(...)`.",
+      "cr_refs": [
+        "CR 706.2"
+      ],
+      "variants": [
+        {
+          "name": "Add",
+          "line": 429,
+          "kind": "struct",
+          "field_names": [
+            "value"
+          ],
+          "doc": "Add the resolved quantity to the natural roll.",
+          "cr_refs": []
+        },
+        {
+          "name": "Subtract",
+          "line": 431,
+          "kind": "struct",
+          "field_names": [
+            "value"
+          ],
+          "doc": "Subtract the resolved quantity from the natural roll.",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
     "DistributionUnit": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2821,
+      "line": 2899,
       "doc": "CR 601.2d: What is being distributed (damage, counters, life).",
       "cr_refs": [
         "CR 601.2d"
@@ -6234,7 +6364,7 @@
       "variants": [
         {
           "name": "Damage",
-          "line": 2822,
+          "line": 2900,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6242,7 +6372,7 @@
         },
         {
           "name": "EvenSplitDamage",
-          "line": 2825,
+          "line": 2903,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2d: Even split — engine auto-computes `total / num_targets` (rounded down). No player choice needed; bypasses `WaitingFor::DistributeAmong`.",
@@ -6252,7 +6382,7 @@
         },
         {
           "name": "Counters",
-          "line": 2826,
+          "line": 2904,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6260,7 +6390,7 @@
         },
         {
           "name": "Life",
-          "line": 2827,
+          "line": 2905,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6271,7 +6401,7 @@
     },
     "DoublePTMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 797,
+      "line": 818,
       "doc": "CR 701.10a: Which P/T characteristics to double.",
       "cr_refs": [
         "CR 701.10a"
@@ -6279,7 +6409,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 798,
+          "line": 819,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6287,7 +6417,7 @@
         },
         {
           "name": "Toughness",
-          "line": 799,
+          "line": 820,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6295,7 +6425,7 @@
         },
         {
           "name": "PowerAndToughness",
-          "line": 800,
+          "line": 821,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6306,7 +6436,7 @@
     },
     "DoubleTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 784,
+      "line": 805,
       "doc": "CR 701.10d-f: What aspect to double (counters, life total, or mana pool). Used by `Effect::Double` per locked decision D-05. DoublePT/DoublePTAll handle CR 701.10a-c (power/toughness) separately.",
       "cr_refs": [
         "CR 701.10a",
@@ -6315,7 +6445,7 @@
       "variants": [
         {
           "name": "Counters",
-          "line": 787,
+          "line": 808,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -6327,7 +6457,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 789,
+          "line": 810,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.10d: Double a player's life total.",
@@ -6337,7 +6467,7 @@
         },
         {
           "name": "ManaPool",
-          "line": 792,
+          "line": 813,
           "kind": "struct",
           "field_names": [
             "color"
@@ -6352,13 +6482,13 @@
     },
     "Duration": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1308,
+      "line": 1337,
       "doc": "Duration for temporary effects.  Player-axis variants are parameterized by `PlayerScope` per the workspace \"Parameterize, don't proliferate\" principle. `PlayerScope::Controller` recovers the legacy \"until your next turn\" / \"controller's next step\" semantics; future `Target` / `Opponent` / `AllPlayers` readings unblock cards whose duration is bound to a non-controller player.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilEndOfTurn",
-          "line": 1310,
+          "line": 1339,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of turn (cleanup step).",
@@ -6368,7 +6498,7 @@
         },
         {
           "name": "UntilEndOfCombat",
-          "line": 1312,
+          "line": 1341,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of combat phase.",
@@ -6378,7 +6508,7 @@
         },
         {
           "name": "UntilNextTurnOf",
-          "line": 1316,
+          "line": 1345,
           "kind": "struct",
           "field_names": [
             "player"
@@ -6391,7 +6521,7 @@
         },
         {
           "name": "UntilHostLeavesPlay",
-          "line": 1321,
+          "line": 1350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a: Effect expires when the source object leaves the battlefield.",
@@ -6401,7 +6531,7 @@
         },
         {
           "name": "UntilNextStepOf",
-          "line": 1327,
+          "line": 1356,
           "kind": "struct",
           "field_names": [
             "step",
@@ -6417,7 +6547,7 @@
         },
         {
           "name": "ForAsLongAs",
-          "line": 1333,
+          "line": 1362,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -6429,7 +6559,7 @@
         },
         {
           "name": "Permanent",
-          "line": 1336,
+          "line": 1365,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6440,13 +6570,13 @@
     },
     "DynamicKeywordKind": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 224,
+      "line": 226,
       "doc": "Keywords that accept a dynamic numeric parameter via \"where X is [quantity]\". Used by `ContinuousModification::AddDynamicKeyword` to construct the runtime keyword.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Annihilator",
-          "line": 225,
+          "line": 227,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6454,7 +6584,7 @@
         },
         {
           "name": "Modular",
-          "line": 226,
+          "line": 228,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6465,13 +6595,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4940,
+      "line": 5017,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 4942,
+          "line": 5019,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -6483,7 +6613,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 4948,
+          "line": 5025,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -6498,7 +6628,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 4959,
+          "line": 5036,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6510,7 +6640,7 @@
         },
         {
           "name": "Draw",
-          "line": 4979,
+          "line": 5056,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6526,7 +6656,7 @@
         },
         {
           "name": "Pump",
-          "line": 4985,
+          "line": 5062,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6538,7 +6668,7 @@
         },
         {
           "name": "PairWith",
-          "line": 4996,
+          "line": 5073,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6551,7 +6681,7 @@
         },
         {
           "name": "Destroy",
-          "line": 4999,
+          "line": 5076,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6562,7 +6692,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 5007,
+          "line": 5084,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6574,7 +6704,7 @@
         },
         {
           "name": "Counter",
-          "line": 5011,
+          "line": 5088,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6585,7 +6715,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 5032,
+          "line": 5109,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6599,7 +6729,7 @@
         },
         {
           "name": "Token",
-          "line": 5036,
+          "line": 5113,
           "kind": "struct",
           "field_names": [
             "name",
@@ -6622,7 +6752,7 @@
         },
         {
           "name": "GainLife",
-          "line": 5074,
+          "line": 5151,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6633,7 +6763,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 5081,
+          "line": 5158,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6644,7 +6774,7 @@
         },
         {
           "name": "Tap",
-          "line": 5088,
+          "line": 5165,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6654,7 +6784,7 @@
         },
         {
           "name": "Untap",
-          "line": 5092,
+          "line": 5169,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6664,7 +6794,7 @@
         },
         {
           "name": "TapAll",
-          "line": 5097,
+          "line": 5174,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6676,7 +6806,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 5102,
+          "line": 5179,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6688,7 +6818,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 5106,
+          "line": 5183,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6700,7 +6830,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 5113,
+          "line": 5190,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6712,7 +6842,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5121,
+          "line": 5198,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6724,7 +6854,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 5142,
+          "line": 5219,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6735,7 +6865,7 @@
         },
         {
           "name": "Mill",
-          "line": 5148,
+          "line": 5225,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6747,7 +6877,7 @@
         },
         {
           "name": "Scry",
-          "line": 5165,
+          "line": 5242,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6762,7 +6892,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 5171,
+          "line": 5248,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6774,7 +6904,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 5185,
+          "line": 5262,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6791,7 +6921,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 5209,
+          "line": 5286,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6804,7 +6934,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 5213,
+          "line": 5290,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6815,7 +6945,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 5220,
+          "line": 5297,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6834,7 +6964,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 5271,
+          "line": 5348,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6847,7 +6977,7 @@
         },
         {
           "name": "Dig",
-          "line": 5284,
+          "line": 5361,
           "kind": "struct",
           "field_names": [
             "player",
@@ -6867,7 +6997,7 @@
         },
         {
           "name": "GainControl",
-          "line": 5310,
+          "line": 5387,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6877,7 +7007,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 5314,
+          "line": 5391,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6888,7 +7018,7 @@
         },
         {
           "name": "Attach",
-          "line": 5320,
+          "line": 5397,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -6899,7 +7029,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 5332,
+          "line": 5409,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -6912,7 +7042,7 @@
         },
         {
           "name": "Surveil",
-          "line": 5344,
+          "line": 5421,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6927,7 +7057,7 @@
         },
         {
           "name": "Fight",
-          "line": 5350,
+          "line": 5427,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6938,18 +7068,19 @@
         },
         {
           "name": "Bounce",
-          "line": 5358,
+          "line": 5435,
           "kind": "struct",
           "field_names": [
             "target",
-            "destination"
+            "destination",
+            "selection"
           ],
           "doc": "",
           "cr_refs": []
         },
         {
           "name": "BounceAll",
-          "line": 5371,
+          "line": 5454,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6964,7 +7095,7 @@
         },
         {
           "name": "Explore",
-          "line": 5379,
+          "line": 5462,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6972,7 +7103,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 5383,
+          "line": 5466,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6984,7 +7115,7 @@
         },
         {
           "name": "Investigate",
-          "line": 5388,
+          "line": 5471,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.136: Investigate — create a Clue artifact token.",
@@ -6994,7 +7125,7 @@
         },
         {
           "name": "Tribute",
-          "line": 5395,
+          "line": 5478,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7007,7 +7138,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 5401,
+          "line": 5484,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -7017,7 +7148,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 5403,
+          "line": 5486,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -7027,7 +7158,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 5404,
+          "line": 5487,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7035,7 +7166,7 @@
         },
         {
           "name": "Populate",
-          "line": 5406,
+          "line": 5489,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -7045,7 +7176,7 @@
         },
         {
           "name": "Clash",
-          "line": 5408,
+          "line": 5491,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -7055,7 +7186,7 @@
         },
         {
           "name": "Vote",
-          "line": 5423,
+          "line": 5506,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7071,7 +7202,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 5467,
+          "line": 5550,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -7091,7 +7222,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 5486,
+          "line": 5569,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7103,7 +7234,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 5490,
+          "line": 5573,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7113,8 +7244,21 @@
           "cr_refs": []
         },
         {
+          "name": "CastCopyOfCard",
+          "line": 5582,
+          "kind": "struct",
+          "field_names": [
+            "target",
+            "cost"
+          ],
+          "doc": "CR 707.12: Create a copy of a card/object in its zone and cast that copy while the resolving spell or ability continues resolving.",
+          "cr_refs": [
+            "CR 707.12"
+          ]
+        },
+        {
           "name": "CopyTokenOf",
-          "line": 5500,
+          "line": 5593,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7134,7 +7278,7 @@
         },
         {
           "name": "Myriad",
-          "line": 5547,
+          "line": 5640,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -7144,7 +7288,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 5550,
+          "line": 5643,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7160,7 +7304,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 5560,
+          "line": 5653,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7171,7 +7315,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 5566,
+          "line": 5659,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7183,7 +7327,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 5574,
+          "line": 5667,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7197,7 +7341,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 5581,
+          "line": 5674,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7209,7 +7353,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 5589,
+          "line": 5682,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7222,7 +7366,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 5595,
+          "line": 5688,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7235,13 +7379,14 @@
         },
         {
           "name": "MoveCounters",
-          "line": 5603,
+          "line": 5696,
           "kind": "struct",
           "field_names": [
             "source",
             "counter_type",
             "count",
             "mode",
+            "selection",
             "target"
           ],
           "doc": "CR 122.5 + CR 122.8: Transfer counters from source onto target. `mode` records whether Oracle says to move counters (remove then put) or to put matching counters from source/LKI state.",
@@ -7252,7 +7397,7 @@
         },
         {
           "name": "Animate",
-          "line": 5621,
+          "line": 5716,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7267,7 +7412,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 5655,
+          "line": 5750,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -7291,7 +7436,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 5671,
+          "line": 5766,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -7301,7 +7446,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 5675,
+          "line": 5770,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -7313,7 +7458,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 5683,
+          "line": 5778,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -7330,7 +7475,7 @@
         },
         {
           "name": "Mana",
-          "line": 5701,
+          "line": 5796,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -7344,7 +7489,7 @@
         },
         {
           "name": "Discard",
-          "line": 5724,
+          "line": 5819,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7358,7 +7503,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 5746,
+          "line": 5841,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7368,7 +7513,7 @@
         },
         {
           "name": "Transform",
-          "line": 5750,
+          "line": 5845,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7378,7 +7523,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 5756,
+          "line": 5851,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7393,7 +7538,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 5798,
+          "line": 5893,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7411,7 +7556,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 5809,
+          "line": 5904,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7425,7 +7570,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 5833,
+          "line": 5928,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7438,7 +7583,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5844,
+          "line": 5939,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7451,7 +7596,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 5849,
+          "line": 5944,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7464,7 +7609,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 5858,
+          "line": 5953,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7476,7 +7621,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 5881,
+          "line": 5976,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7486,7 +7631,7 @@
         },
         {
           "name": "Choose",
-          "line": 5887,
+          "line": 5982,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -7497,7 +7642,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 5898,
+          "line": 5993,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -7510,7 +7655,7 @@
         },
         {
           "name": "Suspect",
-          "line": 5903,
+          "line": 5998,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7522,7 +7667,7 @@
         },
         {
           "name": "Connive",
-          "line": 5910,
+          "line": 6005,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7536,7 +7681,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 5918,
+          "line": 6013,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7548,7 +7693,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 5925,
+          "line": 6020,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7560,7 +7705,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 5930,
+          "line": 6025,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7572,7 +7717,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 5935,
+          "line": 6030,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -7582,7 +7727,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 5942,
+          "line": 6037,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7594,7 +7739,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 5949,
+          "line": 6044,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7606,7 +7751,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 5954,
+          "line": 6049,
           "kind": "struct",
           "field_names": [
             "level"
@@ -7618,7 +7763,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 5959,
+          "line": 6054,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -7632,7 +7777,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 5989,
+          "line": 6084,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -7646,7 +7791,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 5995,
+          "line": 6090,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -7658,7 +7803,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 6000,
+          "line": 6095,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7671,7 +7816,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 6007,
+          "line": 6102,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -7684,7 +7829,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 6016,
+          "line": 6111,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7697,7 +7842,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 6024,
+          "line": 6119,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -7711,7 +7856,7 @@
         },
         {
           "name": "PayCost",
-          "line": 6034,
+          "line": 6129,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -7724,7 +7869,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 6045,
+          "line": 6140,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7742,7 +7887,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 6075,
+          "line": 6170,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7758,7 +7903,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 6114,
+          "line": 6209,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -7779,7 +7924,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 6144,
+          "line": 6239,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: A player who meets this effect's condition loses the game. The affected player is determined by resolution context (controller's opponent if untargeted, or explicit target if targeted).",
@@ -7789,7 +7934,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 6146,
+          "line": 6241,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: The controller wins the game — all opponents lose.",
@@ -7799,20 +7944,22 @@
         },
         {
           "name": "RollDie",
-          "line": 6149,
+          "line": 6246,
           "kind": "struct",
           "field_names": [
             "sides",
-            "results"
+            "results",
+            "modifier"
           ],
-          "doc": "CR 706: Roll a die with the given number of sides. If `results` is non-empty, execute the matching branch.",
+          "doc": "CR 706: Roll a die with the given number of sides. If `results` is non-empty, execute the matching branch. CR 706.2: `modifier` adjusts the natural roll before result-branch lookup. `None` means the natural result is used unchanged.",
           "cr_refs": [
-            "CR 706"
+            "CR 706",
+            "CR 706.2"
           ]
         },
         {
           "name": "FlipCoin",
-          "line": 6155,
+          "line": 6254,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -7825,7 +7972,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 6167,
+          "line": 6266,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7839,7 +7986,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 6176,
+          "line": 6275,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -7851,7 +7998,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 6181,
+          "line": 6280,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -7861,7 +8008,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 6184,
+          "line": 6283,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -7871,7 +8018,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 6186,
+          "line": 6285,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -7883,7 +8030,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 6191,
+          "line": 6290,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -7894,7 +8041,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 6194,
+          "line": 6293,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -7904,7 +8051,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 6197,
+          "line": 6296,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -7916,7 +8063,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 6214,
+          "line": 6313,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7935,7 +8082,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 6247,
+          "line": 6346,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -7950,7 +8097,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 6260,
+          "line": 6359,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -7964,7 +8111,7 @@
         },
         {
           "name": "Exploit",
-          "line": 6269,
+          "line": 6368,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7976,7 +8123,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 6274,
+          "line": 6373,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -7988,7 +8135,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 6279,
+          "line": 6378,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -8003,7 +8150,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 6291,
+          "line": 6390,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8015,7 +8162,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 6303,
+          "line": 6402,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8031,7 +8178,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 6314,
+          "line": 6413,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8039,6 +8186,7 @@
             "kept_destination",
             "rest_destination",
             "enter_tapped",
+            "enters_attacking",
             "kept_optional_to"
           ],
           "doc": "CR 701.20a: Reveal cards from the top of a player's library one at a time until that player reveals a card matching the filter. The matching card goes to `kept_destination`, the rest go to `rest_destination`.",
@@ -8048,7 +8196,7 @@
         },
         {
           "name": "Discover",
-          "line": 6342,
+          "line": 6447,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -8060,7 +8208,7 @@
         },
         {
           "name": "Cascade",
-          "line": 6354,
+          "line": 6459,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -8070,7 +8218,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 6358,
+          "line": 6463,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8082,7 +8230,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 6363,
+          "line": 6468,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8094,7 +8242,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 6376,
+          "line": 6481,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8106,7 +8254,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 6385,
+          "line": 6490,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8118,7 +8266,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 6394,
+          "line": 6499,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8128,7 +8276,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 6399,
+          "line": 6504,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -8138,7 +8286,7 @@
         },
         {
           "name": "Goad",
-          "line": 6405,
+          "line": 6510,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8150,7 +8298,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 6412,
+          "line": 6517,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8162,7 +8310,7 @@
         },
         {
           "name": "Detain",
-          "line": 6419,
+          "line": 6524,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8174,7 +8322,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 6430,
+          "line": 6535,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -8188,7 +8336,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 6441,
+          "line": 6546,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8202,7 +8350,7 @@
         },
         {
           "name": "Manifest",
-          "line": 6456,
+          "line": 6561,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8215,7 +8363,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 6462,
+          "line": 6567,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -8225,7 +8373,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 6466,
+          "line": 6571,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8237,7 +8385,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 6480,
+          "line": 6585,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8250,7 +8398,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 6491,
+          "line": 6596,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8263,7 +8411,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 6501,
+          "line": 6606,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8277,7 +8425,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 6513,
+          "line": 6618,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8293,7 +8441,7 @@
         },
         {
           "name": "Double",
-          "line": 6524,
+          "line": 6629,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -8307,7 +8455,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 6532,
+          "line": 6637,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -8319,7 +8467,7 @@
         },
         {
           "name": "Incubate",
-          "line": 6538,
+          "line": 6643,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8331,7 +8479,7 @@
         },
         {
           "name": "Amass",
-          "line": 6546,
+          "line": 6651,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -8344,7 +8492,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 6554,
+          "line": 6659,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8356,7 +8504,7 @@
         },
         {
           "name": "Renown",
-          "line": 6560,
+          "line": 6665,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8368,7 +8516,7 @@
         },
         {
           "name": "Bolster",
-          "line": 6566,
+          "line": 6671,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8380,7 +8528,7 @@
         },
         {
           "name": "Adapt",
-          "line": 6572,
+          "line": 6677,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8392,7 +8540,7 @@
         },
         {
           "name": "Learn",
-          "line": 6578,
+          "line": 6683,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -8402,7 +8550,7 @@
         },
         {
           "name": "Forage",
-          "line": 6580,
+          "line": 6685,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -8412,7 +8560,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6582,
+          "line": 6687,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8424,7 +8572,7 @@
         },
         {
           "name": "Endure",
-          "line": 6589,
+          "line": 6694,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8437,7 +8585,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 6594,
+          "line": 6699,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8449,7 +8597,7 @@
         },
         {
           "name": "Seek",
-          "line": 6599,
+          "line": 6704,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -8463,7 +8611,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 6616,
+          "line": 6721,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8475,8 +8623,24 @@
           ]
         },
         {
+          "name": "ExchangeLifeWithStat",
+          "line": 6736,
+          "kind": "struct",
+          "field_names": [
+            "player",
+            "stat"
+          ],
+          "doc": "CR 701.12a: Exchange a player's life total with the source permanent's power or toughness. The player's life total becomes the stat's current value (CR 119.5 gain/lose-to-reach), and the source gains an indefinite layer-7b continuous effect setting that stat to the player's previous life total (CR 613.4b). All-or-nothing per CR 701.12a: if the life change is forbidden (CR 119.7/119.8 can't-gain/can't-lose), no part occurs. `player` selects the player (Controller for \"your\", Opponent for \"target opponent\"); `stat` selects which of the source's stats is exchanged. Tree of Redemption (your life ↔ toughness), Tree of Perdition (target opponent's life ↔ toughness), Evra, Halcyon Witness (your life ↔ power).",
+          "cr_refs": [
+            "CR 119.5",
+            "CR 119.7",
+            "CR 613.4b",
+            "CR 701.12a"
+          ]
+        },
+        {
           "name": "SetDayNight",
-          "line": 6623,
+          "line": 6743,
           "kind": "struct",
           "field_names": [
             "to"
@@ -8488,7 +8652,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 6628,
+          "line": 6748,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8501,7 +8665,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 6637,
+          "line": 6757,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8513,7 +8677,7 @@
         },
         {
           "name": "Conjure",
-          "line": 6644,
+          "line": 6764,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -8525,7 +8689,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 6665,
+          "line": 6785,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8539,7 +8703,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6676,
+          "line": 6796,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8634,13 +8798,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11460,
+      "line": 11636,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 11462,
+          "line": 11638,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8648,7 +8812,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 11464,
+          "line": 11640,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8656,7 +8820,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 11466,
+          "line": 11642,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8664,7 +8828,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 11468,
+          "line": 11644,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8672,7 +8836,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 11470,
+          "line": 11646,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8680,7 +8844,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 11472,
+          "line": 11648,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8691,13 +8855,13 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7646,
+      "line": 7770,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7647,
+          "line": 7771,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8705,7 +8869,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 7648,
+          "line": 7772,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8713,7 +8877,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 7649,
+          "line": 7773,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8721,7 +8885,7 @@
         },
         {
           "name": "Draw",
-          "line": 7650,
+          "line": 7774,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8729,7 +8893,7 @@
         },
         {
           "name": "Pump",
-          "line": 7651,
+          "line": 7775,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8737,7 +8901,7 @@
         },
         {
           "name": "PairWith",
-          "line": 7652,
+          "line": 7776,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8745,7 +8909,7 @@
         },
         {
           "name": "Destroy",
-          "line": 7653,
+          "line": 7777,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8753,7 +8917,7 @@
         },
         {
           "name": "Counter",
-          "line": 7654,
+          "line": 7778,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8761,7 +8925,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 7655,
+          "line": 7779,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8769,7 +8933,7 @@
         },
         {
           "name": "Token",
-          "line": 7656,
+          "line": 7780,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8777,7 +8941,7 @@
         },
         {
           "name": "GainLife",
-          "line": 7657,
+          "line": 7781,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8785,7 +8949,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 7658,
+          "line": 7782,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8793,7 +8957,7 @@
         },
         {
           "name": "Tap",
-          "line": 7659,
+          "line": 7783,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8801,7 +8965,7 @@
         },
         {
           "name": "Untap",
-          "line": 7660,
+          "line": 7784,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8809,7 +8973,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 7661,
+          "line": 7785,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8817,7 +8981,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 7662,
+          "line": 7786,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8825,7 +8989,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 7663,
+          "line": 7787,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8833,7 +8997,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 7664,
+          "line": 7788,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8841,7 +9005,7 @@
         },
         {
           "name": "Mill",
-          "line": 7665,
+          "line": 7789,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8849,7 +9013,7 @@
         },
         {
           "name": "Scry",
-          "line": 7666,
+          "line": 7790,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8857,7 +9021,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 7667,
+          "line": 7791,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8865,7 +9029,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 7668,
+          "line": 7792,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8873,7 +9037,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 7669,
+          "line": 7793,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8881,7 +9045,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 7670,
+          "line": 7794,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8889,7 +9053,7 @@
         },
         {
           "name": "TapAll",
-          "line": 7671,
+          "line": 7795,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8897,7 +9061,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 7672,
+          "line": 7796,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8905,7 +9069,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 7673,
+          "line": 7797,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8913,7 +9077,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 7674,
+          "line": 7798,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8921,7 +9085,7 @@
         },
         {
           "name": "Dig",
-          "line": 7675,
+          "line": 7799,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8929,7 +9093,7 @@
         },
         {
           "name": "GainControl",
-          "line": 7676,
+          "line": 7800,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8937,7 +9101,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 7677,
+          "line": 7801,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8945,7 +9109,7 @@
         },
         {
           "name": "Attach",
-          "line": 7678,
+          "line": 7802,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8953,7 +9117,7 @@
         },
         {
           "name": "AttachAll",
-          "line": 7679,
+          "line": 7803,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8961,7 +9125,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 7680,
+          "line": 7804,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8969,7 +9133,7 @@
         },
         {
           "name": "Surveil",
-          "line": 7681,
+          "line": 7805,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8977,7 +9141,7 @@
         },
         {
           "name": "Fight",
-          "line": 7682,
+          "line": 7806,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8985,7 +9149,7 @@
         },
         {
           "name": "Bounce",
-          "line": 7683,
+          "line": 7807,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8993,7 +9157,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 7684,
+          "line": 7808,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9001,7 +9165,7 @@
         },
         {
           "name": "Explore",
-          "line": 7685,
+          "line": 7809,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9009,7 +9173,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 7686,
+          "line": 7810,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9017,7 +9181,7 @@
         },
         {
           "name": "Investigate",
-          "line": 7687,
+          "line": 7811,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9025,7 +9189,7 @@
         },
         {
           "name": "Tribute",
-          "line": 7688,
+          "line": 7812,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9033,7 +9197,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 7689,
+          "line": 7813,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9041,7 +9205,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 7690,
+          "line": 7814,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9049,7 +9213,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 7691,
+          "line": 7815,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9057,7 +9221,7 @@
         },
         {
           "name": "Populate",
-          "line": 7692,
+          "line": 7816,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9065,7 +9229,7 @@
         },
         {
           "name": "Clash",
-          "line": 7693,
+          "line": 7817,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9073,7 +9237,7 @@
         },
         {
           "name": "Vote",
-          "line": 7695,
+          "line": 7819,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -9083,7 +9247,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7697,
+          "line": 7821,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -9093,7 +9257,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7698,
+          "line": 7822,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9101,7 +9265,15 @@
         },
         {
           "name": "CopySpell",
-          "line": 7699,
+          "line": 7823,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CastCopyOfCard",
+          "line": 7824,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9109,7 +9281,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 7700,
+          "line": 7825,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9117,7 +9289,7 @@
         },
         {
           "name": "Myriad",
-          "line": 7701,
+          "line": 7826,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9125,7 +9297,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 7702,
+          "line": 7827,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9133,7 +9305,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 7703,
+          "line": 7828,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9141,7 +9313,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 7704,
+          "line": 7829,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9149,7 +9321,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 7705,
+          "line": 7830,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9157,7 +9329,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 7706,
+          "line": 7831,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9165,7 +9337,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 7707,
+          "line": 7832,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9173,7 +9345,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 7708,
+          "line": 7833,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9181,7 +9353,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 7709,
+          "line": 7834,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9189,7 +9361,7 @@
         },
         {
           "name": "Animate",
-          "line": 7710,
+          "line": 7835,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9197,7 +9369,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 7711,
+          "line": 7836,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9205,7 +9377,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 7712,
+          "line": 7837,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9213,7 +9385,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 7713,
+          "line": 7838,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9221,7 +9393,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 7714,
+          "line": 7839,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9229,7 +9401,7 @@
         },
         {
           "name": "Mana",
-          "line": 7715,
+          "line": 7840,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9237,7 +9409,7 @@
         },
         {
           "name": "Discard",
-          "line": 7716,
+          "line": 7841,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9245,7 +9417,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 7717,
+          "line": 7842,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9253,7 +9425,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 7718,
+          "line": 7843,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9261,7 +9433,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 7719,
+          "line": 7844,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9269,7 +9441,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 7720,
+          "line": 7845,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9277,7 +9449,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 7721,
+          "line": 7846,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9285,7 +9457,7 @@
         },
         {
           "name": "Choose",
-          "line": 7722,
+          "line": 7847,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9293,7 +9465,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 7723,
+          "line": 7848,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9301,7 +9473,7 @@
         },
         {
           "name": "Suspect",
-          "line": 7724,
+          "line": 7849,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9309,7 +9481,7 @@
         },
         {
           "name": "Connive",
-          "line": 7725,
+          "line": 7850,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9317,7 +9489,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 7726,
+          "line": 7851,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9325,7 +9497,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 7727,
+          "line": 7852,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9333,7 +9505,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 7728,
+          "line": 7853,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9341,7 +9513,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 7729,
+          "line": 7854,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9349,7 +9521,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 7731,
+          "line": 7856,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -9359,7 +9531,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 7733,
+          "line": 7858,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -9369,7 +9541,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 7734,
+          "line": 7859,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9377,7 +9549,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 7735,
+          "line": 7860,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9385,7 +9557,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 7736,
+          "line": 7861,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9393,7 +9565,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 7737,
+          "line": 7862,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9401,7 +9573,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 7738,
+          "line": 7863,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9409,7 +9581,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 7739,
+          "line": 7864,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9417,7 +9589,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 7740,
+          "line": 7865,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9425,7 +9597,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 7741,
+          "line": 7866,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9433,7 +9605,7 @@
         },
         {
           "name": "PayCost",
-          "line": 7742,
+          "line": 7867,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9441,7 +9613,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 7743,
+          "line": 7868,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9449,7 +9621,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 7744,
+          "line": 7869,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9457,7 +9629,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 7745,
+          "line": 7870,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9465,7 +9637,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 7746,
+          "line": 7871,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9473,7 +9645,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 7747,
+          "line": 7872,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9481,7 +9653,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 7748,
+          "line": 7873,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9489,7 +9661,7 @@
         },
         {
           "name": "RollDie",
-          "line": 7749,
+          "line": 7874,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9497,7 +9669,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 7750,
+          "line": 7875,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9505,7 +9677,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 7751,
+          "line": 7876,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9513,7 +9685,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 7752,
+          "line": 7877,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9521,7 +9693,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 7753,
+          "line": 7878,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9529,7 +9701,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 7754,
+          "line": 7879,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9537,7 +9709,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 7755,
+          "line": 7880,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9545,7 +9717,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 7756,
+          "line": 7881,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9553,7 +9725,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 7757,
+          "line": 7882,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9561,7 +9733,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 7758,
+          "line": 7883,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9569,7 +9741,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 7759,
+          "line": 7884,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9577,7 +9749,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 7760,
+          "line": 7885,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9585,7 +9757,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 7761,
+          "line": 7886,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9593,7 +9765,7 @@
         },
         {
           "name": "Exploit",
-          "line": 7762,
+          "line": 7887,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9601,7 +9773,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 7763,
+          "line": 7888,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9609,7 +9781,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 7764,
+          "line": 7889,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9617,7 +9789,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 7765,
+          "line": 7890,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9625,7 +9797,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 7766,
+          "line": 7891,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9633,7 +9805,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 7767,
+          "line": 7892,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9641,7 +9813,7 @@
         },
         {
           "name": "Discover",
-          "line": 7768,
+          "line": 7893,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9649,7 +9821,7 @@
         },
         {
           "name": "Cascade",
-          "line": 7769,
+          "line": 7894,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9657,7 +9829,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 7770,
+          "line": 7895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9665,7 +9837,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 7771,
+          "line": 7896,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9673,7 +9845,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 7772,
+          "line": 7897,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9681,7 +9853,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 7773,
+          "line": 7898,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9689,7 +9861,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 7774,
+          "line": 7899,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9697,7 +9869,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 7775,
+          "line": 7900,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9705,7 +9877,7 @@
         },
         {
           "name": "Goad",
-          "line": 7776,
+          "line": 7901,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9713,7 +9885,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 7777,
+          "line": 7902,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9721,7 +9893,7 @@
         },
         {
           "name": "Detain",
-          "line": 7778,
+          "line": 7903,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9729,7 +9901,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 7779,
+          "line": 7904,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9737,7 +9909,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 7780,
+          "line": 7905,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9745,7 +9917,7 @@
         },
         {
           "name": "Incubate",
-          "line": 7781,
+          "line": 7906,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9753,7 +9925,7 @@
         },
         {
           "name": "Amass",
-          "line": 7782,
+          "line": 7907,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9761,7 +9933,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 7783,
+          "line": 7908,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9769,7 +9941,7 @@
         },
         {
           "name": "Renown",
-          "line": 7784,
+          "line": 7909,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9777,7 +9949,7 @@
         },
         {
           "name": "Bolster",
-          "line": 7785,
+          "line": 7910,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9785,7 +9957,7 @@
         },
         {
           "name": "Adapt",
-          "line": 7786,
+          "line": 7911,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9793,7 +9965,7 @@
         },
         {
           "name": "Manifest",
-          "line": 7787,
+          "line": 7912,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9801,7 +9973,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 7788,
+          "line": 7913,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9809,7 +9981,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 7789,
+          "line": 7914,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9817,7 +9989,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 7790,
+          "line": 7915,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9825,7 +9997,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 7791,
+          "line": 7916,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9833,7 +10005,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 7792,
+          "line": 7917,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9841,7 +10013,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 7793,
+          "line": 7918,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9849,7 +10021,7 @@
         },
         {
           "name": "Double",
-          "line": 7794,
+          "line": 7919,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9857,7 +10029,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 7795,
+          "line": 7920,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9865,7 +10037,7 @@
         },
         {
           "name": "Learn",
-          "line": 7796,
+          "line": 7921,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9873,7 +10045,7 @@
         },
         {
           "name": "Forage",
-          "line": 7797,
+          "line": 7922,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9881,7 +10053,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 7798,
+          "line": 7923,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9889,7 +10061,7 @@
         },
         {
           "name": "Endure",
-          "line": 7799,
+          "line": 7924,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9897,7 +10069,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 7800,
+          "line": 7925,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9905,7 +10077,7 @@
         },
         {
           "name": "Seek",
-          "line": 7801,
+          "line": 7926,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9913,7 +10085,15 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 7802,
+          "line": 7927,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExchangeLifeWithStat",
+          "line": 7928,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9921,7 +10101,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 7803,
+          "line": 7929,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9929,7 +10109,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 7804,
+          "line": 7930,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9937,7 +10117,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 7805,
+          "line": 7931,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9945,7 +10125,7 @@
         },
         {
           "name": "Conjure",
-          "line": 7806,
+          "line": 7932,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9953,7 +10133,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 7807,
+          "line": 7933,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9961,7 +10141,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 7808,
+          "line": 7934,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9969,7 +10149,7 @@
         },
         {
           "name": "Equip",
-          "line": 7810,
+          "line": 7936,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -9977,7 +10157,7 @@
         },
         {
           "name": "Crew",
-          "line": 7812,
+          "line": 7938,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -9987,7 +10167,7 @@
         },
         {
           "name": "Station",
-          "line": 7814,
+          "line": 7940,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -9997,7 +10177,7 @@
         },
         {
           "name": "Saddle",
-          "line": 7816,
+          "line": 7942,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -10007,7 +10187,7 @@
         },
         {
           "name": "Reveal",
-          "line": 7818,
+          "line": 7944,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -10015,7 +10195,7 @@
         },
         {
           "name": "Transform",
-          "line": 7819,
+          "line": 7945,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10023,7 +10203,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 7820,
+          "line": 7946,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10031,7 +10211,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 7821,
+          "line": 7947,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10131,13 +10311,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8819,
+      "line": 8973,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 8823,
+          "line": 8977,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -10148,7 +10328,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 8826,
+          "line": 8980,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -10198,13 +10378,13 @@
     },
     "EtbTapState": {
       "file": "crates/engine/src/types/proposed_event.rs",
-      "line": 25,
+      "line": 31,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Unspecified",
-          "line": 27,
+          "line": 33,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10212,7 +10392,7 @@
         },
         {
           "name": "Tapped",
-          "line": 28,
+          "line": 34,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10220,7 +10400,7 @@
         },
         {
           "name": "Untapped",
-          "line": 29,
+          "line": 35,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10257,6 +10437,37 @@
       ],
       "sibling_clusters": []
     },
+    "ExileCastCost": {
+      "file": "crates/engine/src/types/statics.rs",
+      "line": 322,
+      "doc": "CR 118.9 + CR 601.2a: The cost axis for `StaticMode::ExileCastPermission`.  Sibling to `CastFrequency` and `CardPlayMode` — each axis of the exile-cast permission is a typed enum rather than a `bool` so the design space stays open. `bool` fields cannot grow to accommodate future cost shapes (e.g. an alternative life cost analogous to Bolas's Citadel).  - `PayNormalCost` — cast at the spell's normal mana cost. No shipping   printing uses this shape today, but it is the natural default; if a future   card prints \"Once each turn, you may cast a spell from among cards exiled   with ~ this turn.\" (no \"without paying\" rider), this is the variant. - `WithoutPayingManaCost` — CR 118.9a: cast without paying the printed mana   cost. Maralen, Fae Ascendant (\"...without paying its mana cost.\") is the   type specimen and the only shipping printing today.",
+      "cr_refs": [
+        "CR 118.9",
+        "CR 118.9a",
+        "CR 601.2a"
+      ],
+      "variants": [
+        {
+          "name": "PayNormalCost",
+          "line": 324,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Cast at the spell's normal mana cost — no alternative cost applied.",
+          "cr_refs": []
+        },
+        {
+          "name": "WithoutPayingManaCost",
+          "line": 328,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 118.9a: Cast without paying the spell's printed mana cost (Maralen, Fae Ascendant).",
+          "cr_refs": [
+            "CR 118.9a"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "ExileCostSourceZone": {
       "file": "crates/engine/src/types/zones.rs",
       "line": 26,
@@ -10289,7 +10500,7 @@
     },
     "ExileLinkKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 539,
+      "line": 540,
       "doc": "CR 607.2a + CR 406.6: Tracks the link between an exiling source and the exiled card. When the source leaves the battlefield, the exiled card returns (CR 610.3a).",
       "cr_refs": [
         "CR 406.6",
@@ -10299,7 +10510,7 @@
       "variants": [
         {
           "name": "UntilSourceLeaves",
-          "line": 541,
+          "line": 542,
           "kind": "struct",
           "field_names": [
             "return_zone"
@@ -10311,7 +10522,7 @@
         },
         {
           "name": "TrackedBySource",
-          "line": 543,
+          "line": 544,
           "kind": "unit",
           "field_names": [],
           "doc": "Track cards \"exiled with\" a source without creating an automatic return.",
@@ -10319,7 +10530,7 @@
         },
         {
           "name": "ParadigmSource",
-          "line": 552,
+          "line": 553,
           "kind": "struct",
           "field_names": [
             "player"
@@ -10337,13 +10548,13 @@
     },
     "FilterProp": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1827,
+      "line": 1856,
       "doc": "Individual filter properties that can be combined in a Typed filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Token",
-          "line": 1829,
+          "line": 1858,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are tokens.",
@@ -10353,7 +10564,7 @@
         },
         {
           "name": "NonToken",
-          "line": 1831,
+          "line": 1860,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are not tokens.",
@@ -10363,7 +10574,7 @@
         },
         {
           "name": "Attacking",
-          "line": 1832,
+          "line": 1861,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10371,7 +10582,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1834,
+          "line": 1863,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Matches creatures that are blocking.",
@@ -10381,7 +10592,7 @@
         },
         {
           "name": "BlockingSource",
-          "line": 1837,
+          "line": 1866,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g: Matches creatures currently blocking the filter source. Used for \"creature(s) blocking it\" source-relative quantities and filters.",
@@ -10391,7 +10602,7 @@
         },
         {
           "name": "CombatRelation",
-          "line": 1840,
+          "line": 1869,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -10404,7 +10615,7 @@
         },
         {
           "name": "Unblocked",
-          "line": 1845,
+          "line": 1874,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Matches attacking creatures with no blockers assigned.",
@@ -10414,7 +10625,7 @@
         },
         {
           "name": "Tapped",
-          "line": 1846,
+          "line": 1875,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10422,7 +10633,7 @@
         },
         {
           "name": "Untapped",
-          "line": 1848,
+          "line": 1877,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 / CR 110.5: Untapped status as targeting qualifier.",
@@ -10433,7 +10644,7 @@
         },
         {
           "name": "WithKeyword",
-          "line": 1849,
+          "line": 1878,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10443,7 +10654,7 @@
         },
         {
           "name": "HasKeywordKind",
-          "line": 1852,
+          "line": 1881,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10453,7 +10664,7 @@
         },
         {
           "name": "WithoutKeyword",
-          "line": 1857,
+          "line": 1886,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10465,7 +10676,7 @@
         },
         {
           "name": "WithoutKeywordKind",
-          "line": 1860,
+          "line": 1889,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10475,7 +10686,7 @@
         },
         {
           "name": "CanEnchant",
-          "line": 1868,
+          "line": 1897,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10488,7 +10699,7 @@
         },
         {
           "name": "Counters",
-          "line": 1878,
+          "line": 1907,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -10502,7 +10713,7 @@
         },
         {
           "name": "Cmc",
-          "line": 1888,
+          "line": 1917,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -10515,7 +10726,7 @@
         },
         {
           "name": "ManaCostIn",
-          "line": 1895,
+          "line": 1924,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -10528,7 +10739,7 @@
         },
         {
           "name": "InZone",
-          "line": 1898,
+          "line": 1927,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -10538,7 +10749,7 @@
         },
         {
           "name": "Owned",
-          "line": 1901,
+          "line": 1930,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -10548,7 +10759,7 @@
         },
         {
           "name": "Foretold",
-          "line": 1907,
+          "line": 1936,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c-d: Matches cards in exile that have the foretold designation. This is a status of the exiled card, not equivalent to having the Foretell keyword or a generic exile casting permission.",
@@ -10558,7 +10769,7 @@
         },
         {
           "name": "EnchantedBy",
-          "line": 1908,
+          "line": 1937,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10566,7 +10777,7 @@
         },
         {
           "name": "EquippedBy",
-          "line": 1909,
+          "line": 1938,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10574,7 +10785,7 @@
         },
         {
           "name": "AttachedToSource",
-          "line": 1915,
+          "line": 1944,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the matched object's `attached_to` field equals the filter source's object ID. Inverse of `EnchantedBy`/`EquippedBy`, which check whether the source has an attachment. Used for \"Aura and Equipment attached to ~\" quantity clauses (Kellan, the Fae-Blooded) and for any compound filter whose subject is \"attached to <self>\".",
@@ -10585,7 +10796,7 @@
         },
         {
           "name": "AttachedToRecipient",
-          "line": 1929,
+          "line": 1958,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4 + CR 613.4c: True when the matched object's `attached_to` field equals the *recipient* of the resolving effect (the per-object `id` in a layer's affected list). Distinct from `AttachedToSource` — for an Aura/Equipment static \"Enchanted/Equipped creature gets +N/+M for each X attached to it\", the pronoun \"it\" refers to the affected creature, not to the static's source object. The recipient is supplied through `FilterContext::recipient_id`; when recipient is unknown (no per-recipient context), this prop evaluates to false. Covers ~25 cards: Strong Back, Mantle of the Ancients, Auramancer's Guise, Champion of the Flame, Bruenor Battlehammer's \"Each creature you control gets +2/+0 for each Equipment attached to it\", and the broader \"<subject> gets +N/+M for each Aura/Equipment attached to it\" family.",
@@ -10597,7 +10808,7 @@
         },
         {
           "name": "HasAttachment",
-          "line": 1941,
+          "line": 1970,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -10611,7 +10822,7 @@
         },
         {
           "name": "HasAnyAttachmentOf",
-          "line": 1952,
+          "line": 1981,
           "kind": "struct",
           "field_names": [
             "kinds",
@@ -10625,7 +10836,7 @@
         },
         {
           "name": "Another",
-          "line": 1958,
+          "line": 1987,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches any object that is NOT the trigger source (for \"another creature\" triggers).",
@@ -10633,7 +10844,7 @@
         },
         {
           "name": "Unpaired",
-          "line": 1960,
+          "line": 1989,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Matches objects that are not paired with another creature.",
@@ -10643,7 +10854,7 @@
         },
         {
           "name": "OtherThanTriggerObject",
-          "line": 1969,
+          "line": 1998,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 109.3: Matches any object that is NOT the object that caused the currently-evaluating trigger to fire (the \"triggering object\"). Distinct from `Another`, which excludes the *ability source*. Used for intervening-if count predicates like Valakut, the Molten Pinnacle's \"if you control at least five other Mountains\" — here \"other\" means \"other than the newly- entered Mountain,\" not \"other than Valakut.\" Resolves against `FilterContext::triggering_object_id`, populated at trigger-condition evaluation from the current `GameEvent`.",
@@ -10654,7 +10865,7 @@
         },
         {
           "name": "HasColor",
-          "line": 1971,
+          "line": 2000,
           "kind": "struct",
           "field_names": [
             "color"
@@ -10664,7 +10875,7 @@
         },
         {
           "name": "PtComparison",
-          "line": 1996,
+          "line": 2027,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -10672,7 +10883,7 @@
             "comparator",
             "value"
           ],
-          "doc": "CR 208 (Power/Toughness) + CR 208.4b (base vs current) + CR 613.4b (layer 7b: base P/T is set before counters/modifiers in 7c): Matches objects whose power or toughness satisfies `comparator` against `value`.  Replaces the former `PowerLE`/`PowerGE`/`ToughnessLE`/`ToughnessGE` sibling cluster (a `stat × comparator` cross-product) with a single parameterized predicate, mirroring the `Cmc` and `Counters` refactors. Three orthogonal axes: - `stat`: which characteristic to read — power (CR 208.1) or toughness. - `scope`: `Current` reads the live `power`/`toughness` (after all layers);   `Base` reads `base_power`/`base_toughness` per CR 208.4b — the value   after CDAs and set effects (layers 7a/7b) but ignoring counters and   modifying effects (layer 7c). A 1/1 with a +1/+1 counter has base   power 1 but current power 2. - `comparator`: any `Comparator` (LE/GE/EQ/LT/GT/NE).  The disjunctive natural-language form \"power or toughness N or less\" composes two `PtComparison` props under `AnyOf`.  Card data is regenerated from Oracle text at build time, so no legacy-tag deserialization shim is required; `scope` defaults to `Current` when absent for forward-compatible hand-authored fixtures.",
+          "doc": "CR 208 (Power/Toughness) + CR 208.4b (base vs current) + CR 613.4b (layer 7b: base P/T is set before counters/modifiers in 7c): Matches objects whose power, toughness, or total power and toughness satisfies `comparator` against `value`.  Replaces the former `PowerLE`/`PowerGE`/`ToughnessLE`/`ToughnessGE` sibling cluster (a `stat × comparator` cross-product) with a single parameterized predicate, mirroring the `Cmc` and `Counters` refactors. Three orthogonal axes: - `stat`: which P/T metric to read — power (CR 208.1), toughness, or   their total. - `scope`: `Current` reads the live `power`/`toughness` (after all layers);   `Base` reads `base_power`/`base_toughness` per CR 208.4b — the value   after CDAs and set effects (layers 7a/7b) but ignoring counters and   modifying effects (layer 7c). A 1/1 with a +1/+1 counter has base   power 1 but current power 2. - `comparator`: any `Comparator` (LE/GE/EQ/LT/GT/NE).  The disjunctive natural-language form \"power or toughness N or less\" composes two `PtComparison` props under `AnyOf`.  Card data is regenerated from Oracle text at build time, so no legacy-tag deserialization shim is required; `scope` defaults to `Current` when absent for forward-compatible hand-authored fixtures.",
           "cr_refs": [
             "CR 208",
             "CR 208.1",
@@ -10682,7 +10893,7 @@
         },
         {
           "name": "PowerGTSource",
-          "line": 2005,
+          "line": 2036,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: Matches objects whose power is strictly greater than the source object's power. Used for \"creatures with greater power\" blocking restrictions (relative comparison).",
@@ -10692,7 +10903,7 @@
         },
         {
           "name": "ColorCount",
-          "line": 2009,
+          "line": 2040,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -10705,7 +10916,7 @@
         },
         {
           "name": "HasSupertype",
-          "line": 2014,
+          "line": 2045,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10715,7 +10926,7 @@
         },
         {
           "name": "IsChosenCreatureType",
-          "line": 2019,
+          "line": 2050,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose subtypes include the source object's chosen creature type. Used for \"of the chosen type\" patterns (Cavern of Souls, Metallic Mimic).",
@@ -10723,7 +10934,7 @@
         },
         {
           "name": "MostPrevalentCreatureTypeIn",
-          "line": 2032,
+          "line": 2063,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -10737,7 +10948,7 @@
         },
         {
           "name": "IsChosenColor",
-          "line": 2041,
+          "line": 2072,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose colors include the source object's chosen color. Used for \"of the chosen color\" patterns (Hall of Triumph, Runed Stalactite). Reads `ChosenAttribute::Color` from the source permanent.",
@@ -10745,7 +10956,7 @@
         },
         {
           "name": "IsChosenCardType",
-          "line": 2045,
+          "line": 2076,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose core type includes the source object's chosen card type. Used for \"spells of the chosen type\" patterns (Archon of Valor's Reach). Reads `ChosenAttribute::CardType` from the source permanent.",
@@ -10753,7 +10964,7 @@
         },
         {
           "name": "IsChosenLandOrNonlandKind",
-          "line": 2050,
+          "line": 2081,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.2 + CR 608.2c: Matches objects by the transient \"land or nonland\" choice made earlier in the same resolving instruction sequence. Used by \"of the chosen kind\" library filters, where \"Land\" means cards with the land card type and \"Nonland\" means cards without it.",
@@ -10764,7 +10975,7 @@
         },
         {
           "name": "HasSingleTarget",
-          "line": 2053,
+          "line": 2084,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.7: Matches stack entries that have exactly one target. Used for \"with a single target\" qualifiers on retarget effects.",
@@ -10774,7 +10985,7 @@
         },
         {
           "name": "NotColor",
-          "line": 2056,
+          "line": 2087,
           "kind": "struct",
           "field_names": [
             "color"
@@ -10786,7 +10997,7 @@
         },
         {
           "name": "NotSupertype",
-          "line": 2061,
+          "line": 2092,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10798,7 +11009,7 @@
         },
         {
           "name": "Suspected",
-          "line": 2065,
+          "line": 2096,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.60b: Matches suspected creatures.",
@@ -10808,7 +11019,7 @@
         },
         {
           "name": "Renowned",
-          "line": 2067,
+          "line": 2098,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112b: Matches permanents with the renowned designation.",
@@ -10818,7 +11029,7 @@
         },
         {
           "name": "ToughnessGTPower",
-          "line": 2069,
+          "line": 2100,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: Matches creatures whose toughness is greater than their power.",
@@ -10828,7 +11039,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 2076,
+          "line": 2107,
           "kind": "struct",
           "field_names": [
             "props"
@@ -10838,7 +11049,7 @@
         },
         {
           "name": "Modified",
-          "line": 2088,
+          "line": 2119,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.9: A permanent is modified if it has one or more counters on it (CR 122), if it is equipped (CR 301.5), or if it is enchanted by an Aura that is controlled by that permanent's controller (CR 303.4).  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.9 names \"modified\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Modified` for \"modified creature(s)\" subjects, analogous to how `FilterProp::Suspected` models CR 701.60b's \"suspected\" status.",
@@ -10852,7 +11063,7 @@
         },
         {
           "name": "Historic",
-          "line": 2098,
+          "line": 2129,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: An object is historic if it has the legendary supertype, the artifact card type, or the Saga subtype.  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.6 names \"historic\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Historic` for \"historic permanent\" / \"historic spell\" / \"historic card\" subjects, mirroring `FilterProp::Modified` for CR 700.9's \"modified\" predicate.",
@@ -10863,7 +11074,7 @@
         },
         {
           "name": "DifferentNameFrom",
-          "line": 2102,
+          "line": 2133,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -10873,7 +11084,7 @@
         },
         {
           "name": "InAnyZone",
-          "line": 2107,
+          "line": 2138,
           "kind": "struct",
           "field_names": [
             "zones"
@@ -10885,7 +11096,7 @@
         },
         {
           "name": "SharesQuality",
-          "line": 2113,
+          "line": 2144,
           "kind": "struct",
           "field_names": [
             "quality",
@@ -10897,7 +11108,7 @@
         },
         {
           "name": "WasDealtDamageThisTurn",
-          "line": 2122,
+          "line": 2153,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1: Object was dealt damage during this turn. Checks `damage_marked > 0` (damage persists until cleanup step).",
@@ -10907,7 +11118,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2125,
+          "line": 2156,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: Object entered the battlefield during this turn. Checks `entered_battlefield_turn == Some(current_turn)`.",
@@ -10917,7 +11128,7 @@
         },
         {
           "name": "ZoneChangedThisTurn",
-          "line": 2130,
+          "line": 2161,
           "kind": "struct",
           "field_names": [
             "from",
@@ -10931,7 +11142,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 2138,
+          "line": 2169,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Creature was declared as an attacker this turn. Checks `creatures_attacked_this_turn` tracking set on GameState.",
@@ -10941,7 +11152,7 @@
         },
         {
           "name": "BlockedThisTurn",
-          "line": 2141,
+          "line": 2172,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Creature was declared as a blocker this turn. Checks `creatures_blocked_this_turn` tracking set on GameState.",
@@ -10951,7 +11162,7 @@
         },
         {
           "name": "AttackedOrBlockedThisTurn",
-          "line": 2144,
+          "line": 2175,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a + CR 509.1a: Creature attacked or blocked this turn. Compound check used by \"that attacked or blocked this turn\" Oracle text.",
@@ -10962,7 +11173,7 @@
         },
         {
           "name": "FaceDown",
-          "line": 2147,
+          "line": 2178,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.2: Matches face-down objects on the battlefield. Used for \"face-down creature\" trigger subjects.",
@@ -10972,7 +11183,7 @@
         },
         {
           "name": "TargetsOnly",
-          "line": 2152,
+          "line": 2183,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -10984,7 +11195,7 @@
         },
         {
           "name": "Targets",
-          "line": 2158,
+          "line": 2189,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -10997,7 +11208,7 @@
         },
         {
           "name": "HasXInManaCost",
-          "line": 2167,
+          "line": 2198,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 202.1: Matches spells/objects whose printed mana cost contains an `{X}` shard. Used for \"spell with {X} in its mana cost\" qualifier on spell-cast triggers (Lattice Library, Nev the Practical Dean, Owlin Spiralmancer, Brass Infiniscope, Elementalist's Palette). Evaluated against `SpellCastRecord.has_x_in_cost` in the spell-history filter path and against `cost_has_x(&obj.mana_cost)` for live objects.",
@@ -11008,7 +11219,7 @@
         },
         {
           "name": "HasManaAbility",
-          "line": 2171,
+          "line": 2202,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1: Matches objects that have at least one ability classified as a mana ability by the engine's authoritative mana-ability classifier. Used for library filters such as \"artifact card with a mana ability\".",
@@ -11018,7 +11229,7 @@
         },
         {
           "name": "HasNoAbilities",
-          "line": 2175,
+          "line": 2206,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.1 + CR 113.3: Matches objects that currently have no abilities: no keyword, activated, triggered, replacement, or static abilities. Used for library filters such as \"creature card with no abilities\".",
@@ -11029,7 +11240,7 @@
         },
         {
           "name": "Named",
-          "line": 2179,
+          "line": 2210,
           "kind": "struct",
           "field_names": [
             "name"
@@ -11042,7 +11253,7 @@
         },
         {
           "name": "SameName",
-          "line": 2184,
+          "line": 2215,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects with the same name as a previously-referenced card. Used for \"search your library for a card with that name\" patterns.",
@@ -11050,7 +11261,7 @@
         },
         {
           "name": "SameNameAsParentTarget",
-          "line": 2197,
+          "line": 2228,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: Matches objects whose name equals the name of the resolving ability's first object target. Used by chained sub-abilities where a prior step targeted/exiled a card and the next step references \"cards with that name\" — e.g., Deadly Cover-Up's \"search ... for any number of cards with that name and exile them\" (the \"that name\" is the name of the card exiled by the immediately preceding effect, which is inherited as the first target via `TargetFilter::ParentTarget`).  Differs from `SameName` (which reads the source object's name): this reads from `ability.targets[0]` when that target is `TargetRef::Object`, looking up the name from `state.objects` (or `lki_cache` if the target has already left its zone).",
@@ -11060,7 +11271,7 @@
         },
         {
           "name": "NameMatchesAnyPermanent",
-          "line": 2204,
+          "line": 2235,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -11073,7 +11284,7 @@
         },
         {
           "name": "AttackingController",
-          "line": 2210,
+          "line": 2241,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1b: Matches attacking creatures whose defending player equals the filter's source controller (\"creatures attacking you\"). Distinct from `Attacking`, which matches any attacker regardless of defender.",
@@ -11083,7 +11294,7 @@
         },
         {
           "name": "IsCommander",
-          "line": 2217,
+          "line": 2248,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 903.3d: Matches permanents on the battlefield that are a commander. Reads `GameObject::is_commander`, set during deck construction per CR 903.3 (the legendary card designated as that deck's commander). Used for \"commander(s) you control\", \"your commander\" subject phrases and for \"target commander\" in commander-format effects (Codsworth, Falthis, Anara, Champions of Archery, etc.).",
@@ -11094,7 +11305,7 @@
         },
         {
           "name": "Other",
-          "line": 2218,
+          "line": 2249,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11192,13 +11403,13 @@
     },
     "GainLifePlayer": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 753,
+      "line": 774,
       "doc": "Who gains life from a GainLife effect.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 756,
+          "line": 777,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's controller (default).",
@@ -11206,7 +11417,7 @@
         },
         {
           "name": "TargetedController",
-          "line": 758,
+          "line": 779,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the targeted permanent.",
@@ -11214,7 +11425,7 @@
         },
         {
           "name": "TargetPlayer",
-          "line": 766,
+          "line": 787,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.2 + CR 601.2c + CR 119.3: An announced target player. The engine resolves this via `ResolvedAbility::target_player()`, which returns the first `TargetRef::Player` from `ability.targets` (and falls back to controller when no Player target was announced). Set by the parser/converter when the Oracle text is \"target player gains N life\" rather than \"you gain N life\" or \"[permanent's] controller gains N life.\"",
@@ -11229,13 +11440,13 @@
     },
     "GameAction": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 108,
+      "line": 109,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "PassPriority",
-          "line": 109,
+          "line": 110,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11243,7 +11454,7 @@
         },
         {
           "name": "PlayLand",
-          "line": 110,
+          "line": 111,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11254,7 +11465,7 @@
         },
         {
           "name": "CastSpell",
-          "line": 114,
+          "line": 115,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11266,7 +11477,7 @@
         },
         {
           "name": "CastSpellWithPaymentMode",
-          "line": 119,
+          "line": 120,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11279,7 +11490,7 @@
         },
         {
           "name": "Foretell",
-          "line": 129,
+          "line": 130,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11292,7 +11503,7 @@
         },
         {
           "name": "ActivateAbility",
-          "line": 133,
+          "line": 134,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -11303,7 +11514,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 137,
+          "line": 138,
           "kind": "struct",
           "field_names": [
             "attacks"
@@ -11313,7 +11524,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 140,
+          "line": 141,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -11323,7 +11534,7 @@
         },
         {
           "name": "ChooseUntap",
-          "line": 145,
+          "line": 146,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11335,8 +11546,21 @@
           ]
         },
         {
+          "name": "ChooseExert",
+          "line": 153,
+          "kind": "struct",
+          "field_names": [
+            "exert"
+          ],
+          "doc": "CR 508.1g + CR 701.43d: The active player's decision whether to pay the optional \"exert this creature as it attacks\" cost for the attacker named in the pending `WaitingFor::ExertChoice`. `exert: false` declines.",
+          "cr_refs": [
+            "CR 508.1g",
+            "CR 701.43d"
+          ]
+        },
+        {
           "name": "MulliganDecision",
-          "line": 151,
+          "line": 158,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -11348,7 +11572,7 @@
         },
         {
           "name": "ReorderHand",
-          "line": 163,
+          "line": 170,
           "kind": "struct",
           "field_names": [
             "order"
@@ -11360,7 +11584,7 @@
         },
         {
           "name": "TapLandForMana",
-          "line": 166,
+          "line": 173,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -11370,7 +11594,7 @@
         },
         {
           "name": "UntapLandForMana",
-          "line": 171,
+          "line": 178,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -11382,7 +11606,7 @@
         },
         {
           "name": "SelectCards",
-          "line": 174,
+          "line": 181,
           "kind": "struct",
           "field_names": [
             "cards"
@@ -11392,7 +11616,7 @@
         },
         {
           "name": "ChooseOutsideGameCards",
-          "line": 180,
+          "line": 187,
           "kind": "struct",
           "field_names": [
             "selections"
@@ -11405,7 +11629,7 @@
         },
         {
           "name": "SelectTargets",
-          "line": 183,
+          "line": 190,
           "kind": "struct",
           "field_names": [
             "targets"
@@ -11415,7 +11639,7 @@
         },
         {
           "name": "ChooseTarget",
-          "line": 186,
+          "line": 193,
           "kind": "struct",
           "field_names": [
             "target"
@@ -11425,7 +11649,7 @@
         },
         {
           "name": "ChooseReplacement",
-          "line": 189,
+          "line": 196,
           "kind": "struct",
           "field_names": [
             "index"
@@ -11435,7 +11659,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 196,
+          "line": 203,
           "kind": "struct",
           "field_names": [
             "order"
@@ -11448,7 +11672,7 @@
         },
         {
           "name": "CancelCast",
-          "line": 199,
+          "line": 206,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11456,7 +11680,7 @@
         },
         {
           "name": "Equip",
-          "line": 200,
+          "line": 207,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -11467,7 +11691,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 207,
+          "line": 214,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -11480,7 +11704,7 @@
         },
         {
           "name": "ActivateStation",
-          "line": 215,
+          "line": 222,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -11493,7 +11717,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 224,
+          "line": 231,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -11506,7 +11730,7 @@
         },
         {
           "name": "Transform",
-          "line": 228,
+          "line": 235,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -11516,7 +11740,7 @@
         },
         {
           "name": "PlayFaceDown",
-          "line": 231,
+          "line": 238,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11527,7 +11751,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 235,
+          "line": 242,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -11537,7 +11761,7 @@
         },
         {
           "name": "SubmitSideboard",
-          "line": 238,
+          "line": 245,
           "kind": "struct",
           "field_names": [
             "main",
@@ -11548,7 +11772,7 @@
         },
         {
           "name": "ChoosePlayDraw",
-          "line": 242,
+          "line": 249,
           "kind": "struct",
           "field_names": [
             "play_first"
@@ -11558,7 +11782,7 @@
         },
         {
           "name": "ChooseOption",
-          "line": 245,
+          "line": 252,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -11568,7 +11792,7 @@
         },
         {
           "name": "SubmitPilePartition",
-          "line": 254,
+          "line": 261,
           "kind": "struct",
           "field_names": [
             "pile_a"
@@ -11582,7 +11806,7 @@
         },
         {
           "name": "ChoosePile",
-          "line": 261,
+          "line": 268,
           "kind": "struct",
           "field_names": [
             "pile"
@@ -11594,7 +11818,7 @@
         },
         {
           "name": "ChooseBranch",
-          "line": 265,
+          "line": 272,
           "kind": "struct",
           "field_names": [
             "index"
@@ -11606,7 +11830,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 269,
+          "line": 276,
           "kind": "struct",
           "field_names": [
             "source"
@@ -11618,7 +11842,7 @@
         },
         {
           "name": "SelectModes",
-          "line": 272,
+          "line": 279,
           "kind": "struct",
           "field_names": [
             "indices"
@@ -11628,7 +11852,7 @@
         },
         {
           "name": "DecideOptionalCost",
-          "line": 275,
+          "line": 282,
           "kind": "struct",
           "field_names": [
             "pay"
@@ -11638,7 +11862,7 @@
         },
         {
           "name": "ChooseAdventureFace",
-          "line": 279,
+          "line": 286,
           "kind": "struct",
           "field_names": [
             "creature"
@@ -11650,7 +11874,7 @@
         },
         {
           "name": "ChooseModalFace",
-          "line": 283,
+          "line": 290,
           "kind": "struct",
           "field_names": [
             "back_face"
@@ -11662,7 +11886,7 @@
         },
         {
           "name": "ChooseAlternativeCast",
-          "line": 293,
+          "line": 300,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -11677,7 +11901,7 @@
         },
         {
           "name": "ChooseCastingVariant",
-          "line": 298,
+          "line": 305,
           "kind": "struct",
           "field_names": [
             "index"
@@ -11689,7 +11913,7 @@
         },
         {
           "name": "KeepAllCopyTargets",
-          "line": 304,
+          "line": 311,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.10c: Resolve a `WaitingFor::CopyRetarget` by leaving every remaining slot's target unchanged. Single action so the UI can offer \"Keep Current Targets\" without N round-trips through `ChooseTarget`.",
@@ -11699,7 +11923,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 307,
+          "line": 314,
           "kind": "struct",
           "field_names": [
             "slot"
@@ -11711,7 +11935,7 @@
         },
         {
           "name": "ActivateNinjutsu",
-          "line": 311,
+          "line": 318,
           "kind": "struct",
           "field_names": [
             "ninjutsu_object_id",
@@ -11724,7 +11948,7 @@
         },
         {
           "name": "CastSpellAsSneak",
-          "line": 329,
+          "line": 336,
           "kind": "struct",
           "field_names": [
             "hand_object",
@@ -11739,7 +11963,7 @@
         },
         {
           "name": "CastSpellAsSneakWithPaymentMode",
-          "line": 334,
+          "line": 341,
           "kind": "struct",
           "field_names": [
             "hand_object",
@@ -11752,7 +11976,7 @@
         },
         {
           "name": "CastSpellAsWebSlinging",
-          "line": 342,
+          "line": 349,
           "kind": "struct",
           "field_names": [
             "hand_object",
@@ -11766,7 +11990,7 @@
         },
         {
           "name": "CastSpellAsWebSlingingWithPaymentMode",
-          "line": 347,
+          "line": 354,
           "kind": "struct",
           "field_names": [
             "hand_object",
@@ -11779,7 +12003,7 @@
         },
         {
           "name": "CastSpellForFree",
-          "line": 363,
+          "line": 370,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11794,7 +12018,7 @@
         },
         {
           "name": "CastSpellForFreeWithPaymentMode",
-          "line": 368,
+          "line": 375,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11807,7 +12031,7 @@
         },
         {
           "name": "CastSpellAsMiracle",
-          "line": 379,
+          "line": 386,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11821,7 +12045,7 @@
         },
         {
           "name": "CastSpellAsMiracleWithPaymentMode",
-          "line": 383,
+          "line": 390,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11833,7 +12057,7 @@
         },
         {
           "name": "CastSpellAsMadness",
-          "line": 391,
+          "line": 398,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11846,7 +12070,7 @@
         },
         {
           "name": "CastSpellAsMadnessWithPaymentMode",
-          "line": 395,
+          "line": 402,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11858,7 +12082,7 @@
         },
         {
           "name": "DecideOptionalEffect",
-          "line": 401,
+          "line": 408,
           "kind": "struct",
           "field_names": [
             "accept"
@@ -11870,7 +12094,7 @@
         },
         {
           "name": "DecideOptionalEffectAndRemember",
-          "line": 404,
+          "line": 411,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -11880,7 +12104,7 @@
         },
         {
           "name": "PayUnlessCost",
-          "line": 408,
+          "line": 415,
           "kind": "struct",
           "field_names": [
             "pay"
@@ -11892,7 +12116,7 @@
         },
         {
           "name": "ChooseUnlessCostBranch",
-          "line": 416,
+          "line": 423,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -11904,7 +12128,7 @@
         },
         {
           "name": "ChooseActivationCostBranch",
-          "line": 420,
+          "line": 427,
           "kind": "struct",
           "field_names": [
             "index"
@@ -11916,7 +12140,7 @@
         },
         {
           "name": "PayCombatTax",
-          "line": 428,
+          "line": 435,
           "kind": "struct",
           "field_names": [
             "accept"
@@ -11931,7 +12155,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 432,
+          "line": 439,
           "kind": "struct",
           "field_names": [
             "target"
@@ -11943,7 +12167,7 @@
         },
         {
           "name": "ChoosePair",
-          "line": 437,
+          "line": 444,
           "kind": "struct",
           "field_names": [
             "partner"
@@ -11956,7 +12180,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 441,
+          "line": 448,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -11968,7 +12192,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 445,
+          "line": 452,
           "kind": "struct",
           "field_names": [
             "room_index"
@@ -11980,7 +12204,7 @@
         },
         {
           "name": "UnlockRoomDoor",
-          "line": 449,
+          "line": 456,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11993,7 +12217,7 @@
         },
         {
           "name": "TapForConvoke",
-          "line": 455,
+          "line": 462,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12007,7 +12231,7 @@
         },
         {
           "name": "HarmonizeTap",
-          "line": 461,
+          "line": 468,
           "kind": "struct",
           "field_names": [
             "creature_id"
@@ -12019,7 +12243,7 @@
         },
         {
           "name": "DeclareCompanion",
-          "line": 465,
+          "line": 472,
           "kind": "struct",
           "field_names": [
             "card_index"
@@ -12031,7 +12255,7 @@
         },
         {
           "name": "CompanionToHand",
-          "line": 470,
+          "line": 477,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.139a: Pay {3} to put companion into hand (special action, see rule 116.2g).",
@@ -12041,7 +12265,7 @@
         },
         {
           "name": "DiscoverChoice",
-          "line": 472,
+          "line": 479,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -12053,7 +12277,7 @@
         },
         {
           "name": "CascadeChoice",
-          "line": 476,
+          "line": 483,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -12065,7 +12289,7 @@
         },
         {
           "name": "ChooseTopOrBottom",
-          "line": 480,
+          "line": 487,
           "kind": "struct",
           "field_names": [
             "top"
@@ -12077,7 +12301,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 484,
+          "line": 491,
           "kind": "struct",
           "field_names": [
             "keep"
@@ -12089,7 +12313,7 @@
         },
         {
           "name": "ChooseBattleProtector",
-          "line": 489,
+          "line": 496,
           "kind": "struct",
           "field_names": [
             "protector"
@@ -12103,7 +12327,7 @@
         },
         {
           "name": "SetAutoPass",
-          "line": 493,
+          "line": 500,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -12115,7 +12339,7 @@
         },
         {
           "name": "CancelAutoPass",
-          "line": 497,
+          "line": 504,
           "kind": "unit",
           "field_names": [],
           "doc": "Cancel any active auto-pass for the acting player.",
@@ -12123,7 +12347,7 @@
         },
         {
           "name": "SetPhaseStops",
-          "line": 502,
+          "line": 509,
           "kind": "struct",
           "field_names": [
             "stops"
@@ -12133,7 +12357,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 507,
+          "line": 514,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -12148,7 +12372,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 517,
+          "line": 524,
           "kind": "struct",
           "field_names": [
             "distribution"
@@ -12159,8 +12383,21 @@
           ]
         },
         {
+          "name": "ChooseCounterMoveDistribution",
+          "line": 528,
+          "kind": "struct",
+          "field_names": [
+            "selections"
+          ],
+          "doc": "CR 122.5 + CR 608.2d: Submit resolution-time counter-move distribution.",
+          "cr_refs": [
+            "CR 122.5",
+            "CR 608.2d"
+          ]
+        },
+        {
           "name": "SubmitPayAmount",
-          "line": 523,
+          "line": 534,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -12173,7 +12410,7 @@
         },
         {
           "name": "RetargetSpell",
-          "line": 527,
+          "line": 538,
           "kind": "struct",
           "field_names": [
             "new_targets"
@@ -12185,7 +12422,7 @@
         },
         {
           "name": "LearnDecision",
-          "line": 531,
+          "line": 542,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -12197,7 +12434,7 @@
         },
         {
           "name": "SelectCategoryPermanents",
-          "line": 537,
+          "line": 548,
           "kind": "struct",
           "field_names": [
             "choices"
@@ -12210,7 +12447,7 @@
         },
         {
           "name": "ChooseX",
-          "line": 543,
+          "line": 554,
           "kind": "struct",
           "field_names": [
             "value"
@@ -12223,7 +12460,7 @@
         },
         {
           "name": "SubmitPhyrexianChoices",
-          "line": 549,
+          "line": 560,
           "kind": "struct",
           "field_names": [
             "choices"
@@ -12236,7 +12473,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 563,
+          "line": 574,
           "kind": "struct",
           "field_names": [
             "choice",
@@ -12251,7 +12488,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 573,
+          "line": 584,
           "kind": "struct",
           "field_names": [
             "payment"
@@ -12265,7 +12502,7 @@
         },
         {
           "name": "CastPreparedCopy",
-          "line": 582,
+          "line": 593,
           "kind": "struct",
           "field_names": [
             "source"
@@ -12277,7 +12514,7 @@
         },
         {
           "name": "CastParadigmCopy",
-          "line": 589,
+          "line": 600,
           "kind": "struct",
           "field_names": [
             "source"
@@ -12289,7 +12526,7 @@
         },
         {
           "name": "PassParadigmOffer",
-          "line": 596,
+          "line": 607,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — decline the turn-based offer during `WaitingFor::ParadigmCastOffer`. The exiled source stays in exile and may be offered again next turn. Assign when WotC publishes SOS CR update.",
@@ -12299,7 +12536,7 @@
         },
         {
           "name": "Debug",
-          "line": 600,
+          "line": 611,
           "kind": "tuple",
           "field_names": [],
           "doc": "Debug/remediation action — bypasses WaitingFor validation (like Concede). Gated on `GameState::debug_mode`. Rejected in multiplayer at both the WASM and server-core layers.",
@@ -12307,7 +12544,7 @@
         },
         {
           "name": "GrantDebugPermission",
-          "line": 606,
+          "line": 617,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12317,7 +12554,7 @@
         },
         {
           "name": "RevokeDebugPermission",
-          "line": 612,
+          "line": 623,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12327,7 +12564,7 @@
         },
         {
           "name": "Concede",
-          "line": 623,
+          "line": 634,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12542,8 +12779,21 @@
           "cr_refs": []
         },
         {
+          "name": "CreatureExerted",
+          "line": 229,
+          "kind": "struct",
+          "field_names": [
+            "object_id"
+          ],
+          "doc": "CR 701.43a + CR 701.43d: A creature was exerted as it attacked. Fires the linked `TriggerMode::Exerted` \"when you do\" trigger (Combat Celebrant, Glory-Bound Initiate, ...).",
+          "cr_refs": [
+            "CR 701.43a",
+            "CR 701.43d"
+          ]
+        },
+        {
           "name": "PlayerLost",
-          "line": 226,
+          "line": 232,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12553,7 +12803,7 @@
         },
         {
           "name": "MulliganStarted",
-          "line": 229,
+          "line": 235,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12561,7 +12811,7 @@
         },
         {
           "name": "CardsDrawn",
-          "line": 230,
+          "line": 236,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12572,7 +12822,7 @@
         },
         {
           "name": "CardDrawn",
-          "line": 234,
+          "line": 240,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12585,7 +12835,7 @@
         },
         {
           "name": "PermanentUntapped",
-          "line": 251,
+          "line": 257,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12595,7 +12845,7 @@
         },
         {
           "name": "PermanentPhasedOut",
-          "line": 257,
+          "line": 263,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12609,7 +12859,7 @@
         },
         {
           "name": "PermanentPhasedIn",
-          "line": 263,
+          "line": 269,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12621,7 +12871,7 @@
         },
         {
           "name": "PlayerPhasedOut",
-          "line": 271,
+          "line": 277,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12633,7 +12883,7 @@
         },
         {
           "name": "PlayerPhasedIn",
-          "line": 276,
+          "line": 282,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12643,7 +12893,7 @@
         },
         {
           "name": "LandPlayed",
-          "line": 279,
+          "line": 285,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12655,7 +12905,7 @@
         },
         {
           "name": "StackPushed",
-          "line": 284,
+          "line": 290,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12665,7 +12915,7 @@
         },
         {
           "name": "StackResolved",
-          "line": 287,
+          "line": 293,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12675,7 +12925,7 @@
         },
         {
           "name": "Discarded",
-          "line": 290,
+          "line": 296,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12686,7 +12936,7 @@
         },
         {
           "name": "DamageCleared",
-          "line": 294,
+          "line": 300,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12696,7 +12946,7 @@
         },
         {
           "name": "GameOver",
-          "line": 297,
+          "line": 303,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -12706,7 +12956,7 @@
         },
         {
           "name": "DamageDealt",
-          "line": 300,
+          "line": 306,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -12720,7 +12970,7 @@
         },
         {
           "name": "DamagePrevented",
-          "line": 311,
+          "line": 317,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -12734,7 +12984,7 @@
         },
         {
           "name": "SpellCountered",
-          "line": 316,
+          "line": 322,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12745,7 +12995,7 @@
         },
         {
           "name": "CounterAdded",
-          "line": 320,
+          "line": 326,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12757,7 +13007,7 @@
         },
         {
           "name": "Evolved",
-          "line": 327,
+          "line": 333,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12769,7 +13019,7 @@
         },
         {
           "name": "CounterRemoved",
-          "line": 330,
+          "line": 336,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12781,7 +13031,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 335,
+          "line": 341,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12792,7 +13042,7 @@
         },
         {
           "name": "ObjectConjured",
-          "line": 340,
+          "line": 346,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12803,7 +13053,7 @@
         },
         {
           "name": "CreatureDestroyed",
-          "line": 344,
+          "line": 350,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12813,7 +13063,7 @@
         },
         {
           "name": "PermanentSacrificed",
-          "line": 347,
+          "line": 353,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12824,7 +13074,7 @@
         },
         {
           "name": "EffectResolved",
-          "line": 351,
+          "line": 357,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -12835,7 +13085,7 @@
         },
         {
           "name": "Unattached",
-          "line": 357,
+          "line": 363,
           "kind": "struct",
           "field_names": [
             "attachment_id",
@@ -12848,7 +13098,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 361,
+          "line": 367,
           "kind": "struct",
           "field_names": [
             "attacker_ids",
@@ -12860,7 +13110,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 368,
+          "line": 374,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -12870,7 +13120,7 @@
         },
         {
           "name": "CombatTaxPaid",
-          "line": 373,
+          "line": 379,
           "kind": "struct",
           "field_names": [
             "player",
@@ -12884,7 +13134,7 @@
         },
         {
           "name": "CombatTaxDeclined",
-          "line": 379,
+          "line": 385,
           "kind": "struct",
           "field_names": [
             "player",
@@ -12898,10 +13148,10 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 383,
+          "line": 389,
           "kind": "struct",
           "field_names": [
-            "object_id",
+            "target",
             "source_id"
           ],
           "doc": "",
@@ -12909,7 +13159,7 @@
         },
         {
           "name": "VehicleCrewed",
-          "line": 389,
+          "line": 395,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -12922,7 +13172,7 @@
         },
         {
           "name": "Stationed",
-          "line": 399,
+          "line": 405,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -12936,7 +13186,7 @@
         },
         {
           "name": "Saddled",
-          "line": 409,
+          "line": 415,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -12949,7 +13199,7 @@
         },
         {
           "name": "ReplacementApplied",
-          "line": 413,
+          "line": 419,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -12960,26 +13210,6 @@
         },
         {
           "name": "Transformed",
-          "line": 417,
-          "kind": "struct",
-          "field_names": [
-            "object_id"
-          ],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DayNightChanged",
-          "line": 420,
-          "kind": "struct",
-          "field_names": [
-            "new_state"
-          ],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TurnedFaceUp",
           "line": 423,
           "kind": "struct",
           "field_names": [
@@ -12989,8 +13219,28 @@
           "cr_refs": []
         },
         {
-          "name": "CardsRevealed",
+          "name": "DayNightChanged",
           "line": 426,
+          "kind": "struct",
+          "field_names": [
+            "new_state"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TurnedFaceUp",
+          "line": 429,
+          "kind": "struct",
+          "field_names": [
+            "object_id"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CardsRevealed",
+          "line": 432,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13002,7 +13252,7 @@
         },
         {
           "name": "CombatDamageDealtToPlayer",
-          "line": 432,
+          "line": 438,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13013,7 +13263,7 @@
         },
         {
           "name": "PlayerEliminated",
-          "line": 436,
+          "line": 442,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13023,7 +13273,7 @@
         },
         {
           "name": "CrimeCommitted",
-          "line": 439,
+          "line": 445,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13033,7 +13283,7 @@
         },
         {
           "name": "Cycled",
-          "line": 442,
+          "line": 448,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13044,7 +13294,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 446,
+          "line": 452,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13055,7 +13305,7 @@
         },
         {
           "name": "Regenerated",
-          "line": 451,
+          "line": 457,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13067,7 +13317,7 @@
         },
         {
           "name": "CreatureSuspected",
-          "line": 455,
+          "line": 461,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13078,8 +13328,20 @@
           ]
         },
         {
+          "name": "Detained",
+          "line": 468,
+          "kind": "struct",
+          "field_names": [
+            "object_id"
+          ],
+          "doc": "CR 701.35a: A permanent was detained — until the detaining player's next turn it can't attack or block and its activated abilities can't be activated. Display-relevant for mana sources: detaining a mana dork makes its mana ability un-activatable.",
+          "cr_refs": [
+            "CR 701.35a"
+          ]
+        },
+        {
           "name": "BecamePrepared",
-          "line": 461,
+          "line": 474,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13091,7 +13353,7 @@
         },
         {
           "name": "BecameUnprepared",
-          "line": 467,
+          "line": 480,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13103,7 +13365,7 @@
         },
         {
           "name": "CaseSolved",
-          "line": 471,
+          "line": 484,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13115,7 +13377,7 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 475,
+          "line": 488,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13128,7 +13390,7 @@
         },
         {
           "name": "MonarchChanged",
-          "line": 480,
+          "line": 493,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13140,7 +13402,7 @@
         },
         {
           "name": "CityBlessingGained",
-          "line": 484,
+          "line": 497,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13152,7 +13414,7 @@
         },
         {
           "name": "DieRolled",
-          "line": 488,
+          "line": 501,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13166,7 +13428,7 @@
         },
         {
           "name": "CoinFlipped",
-          "line": 494,
+          "line": 507,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13179,7 +13441,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 499,
+          "line": 512,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13191,7 +13453,7 @@
         },
         {
           "name": "RoomEntered",
-          "line": 503,
+          "line": 516,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13206,7 +13468,7 @@
         },
         {
           "name": "RoomDoorUnlocked",
-          "line": 510,
+          "line": 523,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13221,7 +13483,7 @@
         },
         {
           "name": "BecomesPlotted",
-          "line": 517,
+          "line": 530,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13234,7 +13496,7 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 522,
+          "line": 535,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13247,7 +13509,7 @@
         },
         {
           "name": "InitiativeTaken",
-          "line": 527,
+          "line": 540,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13259,7 +13521,7 @@
         },
         {
           "name": "Firebend",
-          "line": 531,
+          "line": 544,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13270,7 +13532,7 @@
         },
         {
           "name": "Airbend",
-          "line": 536,
+          "line": 549,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13281,7 +13543,7 @@
         },
         {
           "name": "Earthbend",
-          "line": 541,
+          "line": 554,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13292,7 +13554,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 546,
+          "line": 559,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13303,7 +13565,7 @@
         },
         {
           "name": "CompanionRevealed",
-          "line": 551,
+          "line": 564,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13316,7 +13578,7 @@
         },
         {
           "name": "CompanionMovedToHand",
-          "line": 556,
+          "line": 569,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13329,7 +13591,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 563,
+          "line": 576,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13342,7 +13604,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 573,
+          "line": 586,
           "kind": "struct",
           "field_names": [
             "ability_tag",
@@ -13359,7 +13621,7 @@
         },
         {
           "name": "CreatureExploited",
-          "line": 581,
+          "line": 594,
           "kind": "struct",
           "field_names": [
             "exploiter",
@@ -13372,7 +13634,7 @@
         },
         {
           "name": "EnergyChanged",
-          "line": 586,
+          "line": 599,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13385,7 +13647,7 @@
         },
         {
           "name": "SpeedChanged",
-          "line": 591,
+          "line": 604,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13399,7 +13661,7 @@
         },
         {
           "name": "PlayerCounterChanged",
-          "line": 597,
+          "line": 610,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13413,7 +13675,7 @@
         },
         {
           "name": "ManaExpended",
-          "line": 603,
+          "line": 616,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13427,7 +13689,7 @@
         },
         {
           "name": "Clash",
-          "line": 609,
+          "line": 622,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -13443,7 +13705,7 @@
         },
         {
           "name": "VoteCast",
-          "line": 620,
+          "line": 633,
           "kind": "struct",
           "field_names": [
             "voter",
@@ -13457,7 +13719,7 @@
         },
         {
           "name": "VoteResolved",
-          "line": 628,
+          "line": 641,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13470,7 +13732,7 @@
         },
         {
           "name": "PowerToughnessChanged",
-          "line": 634,
+          "line": 647,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13484,7 +13746,7 @@
         },
         {
           "name": "CascadeMissed",
-          "line": 645,
+          "line": 658,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -13498,7 +13760,7 @@
         },
         {
           "name": "DebugActionUsed",
-          "line": 653,
+          "line": 666,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13509,7 +13771,7 @@
         },
         {
           "name": "DebugPermissionGranted",
-          "line": 659,
+          "line": 672,
           "kind": "struct",
           "field_names": [
             "host",
@@ -13520,7 +13782,7 @@
         },
         {
           "name": "DebugPermissionRevoked",
-          "line": 664,
+          "line": 677,
           "kind": "struct",
           "field_names": [
             "host",
@@ -13687,13 +13949,13 @@
     },
     "GameRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1347,
+      "line": 1376,
       "doc": "A game-level restriction that modifies how rules are applied. Stored in `GameState::restrictions` and evaluated by relevant game systems.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DamagePreventionDisabled",
-          "line": 1349,
+          "line": 1378,
           "kind": "struct",
           "field_names": [
             "source",
@@ -13707,7 +13969,7 @@
         },
         {
           "name": "ProhibitActivity",
-          "line": 1357,
+          "line": 1386,
           "kind": "struct",
           "field_names": [
             "source",
@@ -13727,13 +13989,13 @@
     },
     "GiftKind": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 297,
+      "line": 299,
       "doc": "The type of gift promised by the Gift keyword.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Card",
-          "line": 299,
+          "line": 301,
           "kind": "unit",
           "field_names": [],
           "doc": "Opponent draws a card.",
@@ -13741,7 +14003,7 @@
         },
         {
           "name": "Treasure",
-          "line": 301,
+          "line": 303,
           "kind": "unit",
           "field_names": [],
           "doc": "Opponent creates a Treasure token.",
@@ -13749,7 +14011,7 @@
         },
         {
           "name": "Food",
-          "line": 303,
+          "line": 305,
           "kind": "unit",
           "field_names": [],
           "doc": "Opponent creates a Food token.",
@@ -13757,7 +14019,7 @@
         },
         {
           "name": "TappedFish",
-          "line": 305,
+          "line": 307,
           "kind": "unit",
           "field_names": [],
           "doc": "Opponent creates a tapped 1/1 blue Fish creature token.",
@@ -13803,7 +14065,7 @@
     },
     "HexproofFilter": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 312,
+      "line": 314,
       "doc": "CR 702.11d: What a hexproof-from keyword protects against. Mirrors ProtectionTarget but only applies to targeting (not DEBT).",
       "cr_refs": [
         "CR 702.11d"
@@ -13811,7 +14073,7 @@
       "variants": [
         {
           "name": "Color",
-          "line": 313,
+          "line": 315,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -13819,7 +14081,7 @@
         },
         {
           "name": "CardType",
-          "line": 315,
+          "line": 317,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"hexproof from artifacts\", \"hexproof from instants\", \"hexproof from planeswalkers\"",
@@ -13827,7 +14089,7 @@
         },
         {
           "name": "Quality",
-          "line": 317,
+          "line": 319,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"hexproof from monocolored\", \"hexproof from multicolored\"",
@@ -13835,7 +14097,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 321,
+          "line": 323,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.11d + CR 105.4 + CR 609.6: \"Hexproof from that color\" / \"from the chosen color\" — resolved at runtime from the source permanent's `chosen_attributes`. Parallels `ProtectionTarget::ChosenColor`.",
@@ -13848,15 +14110,35 @@
       ],
       "sibling_clusters": []
     },
+    "IterationKindBinding": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 8767,
+      "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
+      "cr_refs": [
+        "CR 122.1",
+        "CR 608.2c"
+      ],
+      "variants": [
+        {
+          "name": "RebindToIteratedKind",
+          "line": 8770,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
     "Keyword": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 399,
+      "line": 409,
       "doc": "All MTG keywords as typed enum variants. Simple (unit) variants for keywords with no parameters. Parameterized variants carry associated data (ManaCost for costs, amounts, etc.). Unknown captures any unrecognized keyword string for forward compatibility.  Custom Deserialize: accepts both the typed externally-tagged format (new) and plain \"Name:Param\" strings (legacy card-data.json).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Flying",
-          "line": 401,
+          "line": 411,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13864,7 +14146,7 @@
         },
         {
           "name": "FirstStrike",
-          "line": 402,
+          "line": 412,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13872,7 +14154,7 @@
         },
         {
           "name": "DoubleStrike",
-          "line": 403,
+          "line": 413,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13880,7 +14162,7 @@
         },
         {
           "name": "Trample",
-          "line": 404,
+          "line": 414,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13888,7 +14170,7 @@
         },
         {
           "name": "TrampleOverPlaneswalkers",
-          "line": 406,
+          "line": 416,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.19c: Trample over planeswalkers — excess damage can spill to PW controller.",
@@ -13898,7 +14180,7 @@
         },
         {
           "name": "Deathtouch",
-          "line": 407,
+          "line": 417,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13906,7 +14188,7 @@
         },
         {
           "name": "Lifelink",
-          "line": 408,
+          "line": 418,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13914,7 +14196,7 @@
         },
         {
           "name": "Vigilance",
-          "line": 409,
+          "line": 419,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13922,7 +14204,7 @@
         },
         {
           "name": "Haste",
-          "line": 410,
+          "line": 420,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13930,7 +14212,7 @@
         },
         {
           "name": "Reach",
-          "line": 411,
+          "line": 421,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13938,7 +14220,7 @@
         },
         {
           "name": "Defender",
-          "line": 412,
+          "line": 422,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13946,7 +14228,7 @@
         },
         {
           "name": "Menace",
-          "line": 413,
+          "line": 423,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13954,7 +14236,7 @@
         },
         {
           "name": "Indestructible",
-          "line": 414,
+          "line": 424,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13962,7 +14244,7 @@
         },
         {
           "name": "Hexproof",
-          "line": 415,
+          "line": 425,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13970,7 +14252,7 @@
         },
         {
           "name": "HexproofFrom",
-          "line": 417,
+          "line": 427,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.11d: \"Hexproof from [quality]\" — prevents targeting by sources with the quality.",
@@ -13980,70 +14262,6 @@
         },
         {
           "name": "Shroud",
-          "line": 418,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Flash",
-          "line": 419,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Fear",
-          "line": 420,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Intimidate",
-          "line": 421,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Skulk",
-          "line": 422,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Shadow",
-          "line": 423,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Horsemanship",
-          "line": 424,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Wither",
-          "line": 427,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Infect",
           "line": 428,
           "kind": "unit",
           "field_names": [],
@@ -14051,8 +14269,72 @@
           "cr_refs": []
         },
         {
-          "name": "Afflict",
+          "name": "Flash",
+          "line": 429,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Fear",
           "line": 430,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Intimidate",
+          "line": 431,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Skulk",
+          "line": 432,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Shadow",
+          "line": 433,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Horsemanship",
+          "line": 434,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Wither",
+          "line": 437,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Infect",
+          "line": 438,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Afflict",
+          "line": 440,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.130a: \"Afflict N\" — when blocked, defending player loses N life.",
@@ -14062,86 +14344,6 @@
         },
         {
           "name": "Prowess",
-          "line": 433,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Undying",
-          "line": 434,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Persist",
-          "line": 435,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Cascade",
-          "line": 436,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Exalted",
-          "line": 437,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Flanking",
-          "line": 438,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Evolve",
-          "line": 439,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Extort",
-          "line": 440,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Exploit",
-          "line": 441,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Explore",
-          "line": 442,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Ascend",
           "line": 443,
           "kind": "unit",
           "field_names": [],
@@ -14149,8 +14351,88 @@
           "cr_refs": []
         },
         {
-          "name": "StartYourEngines",
+          "name": "Undying",
+          "line": 444,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Persist",
           "line": 445,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Cascade",
+          "line": 446,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Exalted",
+          "line": 447,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Flanking",
+          "line": 448,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Evolve",
+          "line": 449,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Extort",
+          "line": 450,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Exploit",
+          "line": 451,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Explore",
+          "line": 452,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Ascend",
+          "line": 453,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "StartYourEngines",
+          "line": 455,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179: Grants the player a speed value via SBA and enables the inherent speed trigger.",
@@ -14160,7 +14442,7 @@
         },
         {
           "name": "Dredge",
-          "line": 446,
+          "line": 456,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14168,7 +14450,7 @@
         },
         {
           "name": "Modular",
-          "line": 447,
+          "line": 457,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14176,7 +14458,7 @@
         },
         {
           "name": "Renown",
-          "line": 448,
+          "line": 458,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14184,7 +14466,7 @@
         },
         {
           "name": "Fabricate",
-          "line": 449,
+          "line": 459,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14192,7 +14474,7 @@
         },
         {
           "name": "Annihilator",
-          "line": 450,
+          "line": 460,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14200,7 +14482,7 @@
         },
         {
           "name": "Bushido",
-          "line": 451,
+          "line": 461,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14208,7 +14490,7 @@
         },
         {
           "name": "Tribute",
-          "line": 452,
+          "line": 462,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14216,7 +14498,7 @@
         },
         {
           "name": "Soulbond",
-          "line": 453,
+          "line": 463,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14224,7 +14506,7 @@
         },
         {
           "name": "Unearth",
-          "line": 454,
+          "line": 464,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14232,46 +14514,6 @@
         },
         {
           "name": "Convoke",
-          "line": 457,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Waterbend",
-          "line": 459,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "Waterbend: tap-to-pay keyword for Avatar waterbending abilities.",
-          "cr_refs": []
-        },
-        {
-          "name": "Delve",
-          "line": 460,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Devoid",
-          "line": 461,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Changeling",
-          "line": 464,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Phasing",
           "line": 467,
           "kind": "unit",
           "field_names": [],
@@ -14279,7 +14521,15 @@
           "cr_refs": []
         },
         {
-          "name": "Battlecry",
+          "name": "Waterbend",
+          "line": 469,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Waterbend: tap-to-pay keyword for Avatar waterbending abilities.",
+          "cr_refs": []
+        },
+        {
+          "name": "Delve",
           "line": 470,
           "kind": "unit",
           "field_names": [],
@@ -14287,7 +14537,7 @@
           "cr_refs": []
         },
         {
-          "name": "Decayed",
+          "name": "Devoid",
           "line": 471,
           "kind": "unit",
           "field_names": [],
@@ -14295,8 +14545,40 @@
           "cr_refs": []
         },
         {
+          "name": "Changeling",
+          "line": 474,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Phasing",
+          "line": 477,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Battlecry",
+          "line": 480,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Decayed",
+          "line": 481,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Unleash",
-          "line": 472,
+          "line": 482,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14304,7 +14586,7 @@
         },
         {
           "name": "Riot",
-          "line": 473,
+          "line": 483,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14312,7 +14594,7 @@
         },
         {
           "name": "Afterlife",
-          "line": 474,
+          "line": 484,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14320,7 +14602,7 @@
         },
         {
           "name": "Enchant",
-          "line": 477,
+          "line": 487,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14328,7 +14610,7 @@
         },
         {
           "name": "EtbCounter",
-          "line": 480,
+          "line": 490,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -14339,7 +14621,7 @@
         },
         {
           "name": "Reconfigure",
-          "line": 486,
+          "line": 496,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14347,7 +14629,7 @@
         },
         {
           "name": "LivingWeapon",
-          "line": 487,
+          "line": 497,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14355,7 +14637,7 @@
         },
         {
           "name": "JobSelect",
-          "line": 490,
+          "line": 500,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.182a: Job select — \"When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this Equipment to it.\"",
@@ -14365,7 +14647,7 @@
         },
         {
           "name": "TotemArmor",
-          "line": 491,
+          "line": 501,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14373,7 +14655,7 @@
         },
         {
           "name": "Bestow",
-          "line": 492,
+          "line": 502,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14381,54 +14663,6 @@
         },
         {
           "name": "Embalm",
-          "line": 495,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Eternalize",
-          "line": 496,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Fading",
-          "line": 499,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Vanishing",
-          "line": 500,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Protection",
-          "line": 503,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Kicker",
-          "line": 504,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Cycling",
           "line": 505,
           "kind": "tuple",
           "field_names": [],
@@ -14436,7 +14670,7 @@
           "cr_refs": []
         },
         {
-          "name": "Flashback",
+          "name": "Eternalize",
           "line": 506,
           "kind": "tuple",
           "field_names": [],
@@ -14444,23 +14678,7 @@
           "cr_refs": []
         },
         {
-          "name": "Ward",
-          "line": 507,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Equip",
-          "line": 508,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Landwalk",
+          "name": "Fading",
           "line": 509,
           "kind": "tuple",
           "field_names": [],
@@ -14468,7 +14686,7 @@
           "cr_refs": []
         },
         {
-          "name": "Rampage",
+          "name": "Vanishing",
           "line": 510,
           "kind": "tuple",
           "field_names": [],
@@ -14476,8 +14694,72 @@
           "cr_refs": []
         },
         {
+          "name": "Protection",
+          "line": 513,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Kicker",
+          "line": 514,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Cycling",
+          "line": 515,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Flashback",
+          "line": 516,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Ward",
+          "line": 517,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 518,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Landwalk",
+          "line": 519,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Rampage",
+          "line": 520,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Absorb",
-          "line": 511,
+          "line": 521,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14485,7 +14767,7 @@
         },
         {
           "name": "Crew",
-          "line": 515,
+          "line": 525,
           "kind": "struct",
           "field_names": [
             "power",
@@ -14499,7 +14781,7 @@
         },
         {
           "name": "Partner",
-          "line": 520,
+          "line": 530,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.124: Partner and its variant keywords for co-commander pairing.",
@@ -14509,7 +14791,7 @@
         },
         {
           "name": "Companion",
-          "line": 523,
+          "line": 533,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.139: Companion — deckbuilding restriction that allows this card to be declared as a companion from outside the game.",
@@ -14519,7 +14801,7 @@
         },
         {
           "name": "Ninjutsu",
-          "line": 524,
+          "line": 534,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14527,7 +14809,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 526,
+          "line": 536,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -14537,7 +14819,7 @@
         },
         {
           "name": "Prowl",
-          "line": 529,
+          "line": 539,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14545,7 +14827,7 @@
         },
         {
           "name": "Morph",
-          "line": 530,
+          "line": 540,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14553,7 +14835,7 @@
         },
         {
           "name": "Megamorph",
-          "line": 531,
+          "line": 541,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14561,7 +14843,7 @@
         },
         {
           "name": "Madness",
-          "line": 532,
+          "line": 542,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14569,7 +14851,7 @@
         },
         {
           "name": "Miracle",
-          "line": 541,
+          "line": 551,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.94a: Miracle {cost} — static ability linked (CR 603.11) to a triggered ability. Static: \"You may reveal this card from your hand as you draw it if it's the first card you've drawn this turn.\" Linked trigger: \"When you reveal this card this way, you may cast it by paying [cost] rather than its mana cost.\" Runtime support: draw event populates `first_card_drawn_this_turn`; on that event a `WaitingFor::MiracleReveal` prompt is offered for miracle-keyworded cards. Casting uses `CastingVariant::Miracle` with the miracle mana cost.",
@@ -14580,7 +14862,7 @@
         },
         {
           "name": "Dash",
-          "line": 542,
+          "line": 552,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14588,7 +14870,7 @@
         },
         {
           "name": "Emerge",
-          "line": 543,
+          "line": 553,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14596,7 +14878,7 @@
         },
         {
           "name": "Escape",
-          "line": 546,
+          "line": 556,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -14609,7 +14891,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 552,
+          "line": 562,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.180: Harmonize {cost} — cast from graveyard for harmonize cost, tap up to one creature to reduce cost by its power, exile on resolution.",
@@ -14619,7 +14901,7 @@
         },
         {
           "name": "Evoke",
-          "line": 556,
+          "line": 566,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.74a + CR 118.9: see `EvokeCost` for the mana / non-mana split. Pure-mana evoke (Lorwyn cycle) is `EvokeCost::Mana`; MH2 Incarnations (Solitude et al.) carry `EvokeCost::NonMana(AbilityCost::Exile { .. })`.",
@@ -14630,7 +14912,7 @@
         },
         {
           "name": "Foretell",
-          "line": 557,
+          "line": 567,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14638,7 +14920,7 @@
         },
         {
           "name": "Mutate",
-          "line": 558,
+          "line": 568,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14646,7 +14928,7 @@
         },
         {
           "name": "Disturb",
-          "line": 559,
+          "line": 569,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14654,7 +14936,7 @@
         },
         {
           "name": "Disguise",
-          "line": 560,
+          "line": 570,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14662,7 +14944,7 @@
         },
         {
           "name": "Blitz",
-          "line": 561,
+          "line": 571,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14670,7 +14952,7 @@
         },
         {
           "name": "Overload",
-          "line": 562,
+          "line": 572,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14678,7 +14960,7 @@
         },
         {
           "name": "Spectacle",
-          "line": 563,
+          "line": 573,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14686,7 +14968,7 @@
         },
         {
           "name": "Surge",
-          "line": 564,
+          "line": 574,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14694,7 +14976,7 @@
         },
         {
           "name": "Encore",
-          "line": 565,
+          "line": 575,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14702,7 +14984,7 @@
         },
         {
           "name": "Buyback",
-          "line": 568,
+          "line": 578,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.27a: Buyback — optional additional cost; if paid, the spell returns to its owner's hand instead of the graveyard as it resolves.",
@@ -14712,7 +14994,7 @@
         },
         {
           "name": "Casualty",
-          "line": 571,
+          "line": 581,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.153a: Casualty N — as an additional cost, you may sacrifice a creature with power N or greater. When you do, copy this spell.",
@@ -14722,7 +15004,7 @@
         },
         {
           "name": "Echo",
-          "line": 572,
+          "line": 582,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14730,7 +15012,7 @@
         },
         {
           "name": "Entwine",
-          "line": 574,
+          "line": 584,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.42a: Entwine — pay additional cost to choose all modes of a modal spell.",
@@ -14740,7 +15022,7 @@
         },
         {
           "name": "Outlast",
-          "line": 575,
+          "line": 585,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14748,15 +15030,28 @@
         },
         {
           "name": "Scavenge",
-          "line": 576,
+          "line": 586,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
+          "name": "Reinforce",
+          "line": 589,
+          "kind": "struct",
+          "field_names": [
+            "count",
+            "cost"
+          ],
+          "doc": "CR 702.77a: Reinforce N—[cost] means \"[Cost], Discard this card: Put N +1/+1 counters on target creature.\"",
+          "cr_refs": [
+            "CR 702.77a"
+          ]
+        },
+        {
           "name": "Fortify",
-          "line": 577,
+          "line": 593,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14764,7 +15059,7 @@
         },
         {
           "name": "Prototype",
-          "line": 581,
+          "line": 597,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler. CR 702.160a: Prototype — alt-cast using the secondary P/T and mana cost characteristics.",
@@ -14774,7 +15069,7 @@
         },
         {
           "name": "Plot",
-          "line": 582,
+          "line": 598,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14782,7 +15077,7 @@
         },
         {
           "name": "Craft",
-          "line": 583,
+          "line": 599,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14790,7 +15085,7 @@
         },
         {
           "name": "Offspring",
-          "line": 584,
+          "line": 600,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -14798,7 +15093,7 @@
         },
         {
           "name": "Impending",
-          "line": 588,
+          "line": 604,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler. CR 702.176a: Impending N—{cost} — alt-cast that enters with N time counters and is not a creature until they're gone.",
@@ -14808,7 +15103,7 @@
         },
         {
           "name": "LevelUp",
-          "line": 591,
+          "line": 607,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.87a: Level up is an activated ability that puts a level counter on this permanent. Activate only as a sorcery.",
@@ -14818,7 +15113,7 @@
         },
         {
           "name": "Affinity",
-          "line": 594,
+          "line": 610,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.41a: Affinity for [type] — this spell costs {1} less for each [type] you control.",
@@ -14828,7 +15123,7 @@
         },
         {
           "name": "CumulativeUpkeep",
-          "line": 601,
+          "line": 617,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.24a: cost paid per age counter on this permanent at the start of the controller's upkeep, or sacrifice. The typed `AbilityCost` lets the synthesis pipeline wire the cumulative-upkeep trigger uniformly across mana / life / sacrifice / disjunctive cost shapes.",
@@ -14838,7 +15133,7 @@
         },
         {
           "name": "Banding",
-          "line": 604,
+          "line": 620,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14846,7 +15141,7 @@
         },
         {
           "name": "Epic",
-          "line": 605,
+          "line": 621,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14854,7 +15149,7 @@
         },
         {
           "name": "Fuse",
-          "line": 606,
+          "line": 622,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14862,7 +15157,7 @@
         },
         {
           "name": "Gravestorm",
-          "line": 607,
+          "line": 623,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14870,7 +15165,7 @@
         },
         {
           "name": "Haunt",
-          "line": 608,
+          "line": 624,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14878,7 +15173,7 @@
         },
         {
           "name": "Hideaway",
-          "line": 610,
+          "line": 626,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.74a: Hideaway N — look at top N cards, exile one face down, rest on bottom.",
@@ -14888,7 +15183,7 @@
         },
         {
           "name": "Improvise",
-          "line": 611,
+          "line": 627,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14896,7 +15191,7 @@
         },
         {
           "name": "Ingest",
-          "line": 612,
+          "line": 628,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14904,7 +15199,7 @@
         },
         {
           "name": "Melee",
-          "line": 613,
+          "line": 629,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14912,7 +15207,7 @@
         },
         {
           "name": "Mentor",
-          "line": 614,
+          "line": 630,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14920,7 +15215,7 @@
         },
         {
           "name": "Myriad",
-          "line": 615,
+          "line": 631,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14928,7 +15223,7 @@
         },
         {
           "name": "Provoke",
-          "line": 616,
+          "line": 632,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14936,7 +15231,7 @@
         },
         {
           "name": "Rebound",
-          "line": 617,
+          "line": 633,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14944,7 +15239,7 @@
         },
         {
           "name": "Retrace",
-          "line": 618,
+          "line": 634,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14952,7 +15247,7 @@
         },
         {
           "name": "Ripple",
-          "line": 619,
+          "line": 635,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14960,7 +15255,7 @@
         },
         {
           "name": "SplitSecond",
-          "line": 620,
+          "line": 636,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14968,7 +15263,7 @@
         },
         {
           "name": "Storm",
-          "line": 621,
+          "line": 637,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14976,7 +15271,7 @@
         },
         {
           "name": "Suspend",
-          "line": 624,
+          "line": 640,
           "kind": "struct",
           "field_names": [
             "count",
@@ -14989,7 +15284,7 @@
         },
         {
           "name": "Totem",
-          "line": 628,
+          "line": 644,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14997,7 +15292,7 @@
         },
         {
           "name": "Warp",
-          "line": 631,
+          "line": 647,
           "kind": "tuple",
           "field_names": [],
           "doc": "Warp {cost}: alternative casting cost. Cast from hand for warp cost, exile at next end step, then may cast from exile later.",
@@ -15005,7 +15300,7 @@
         },
         {
           "name": "Sneak",
-          "line": 636,
+          "line": 652,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.190a: Sneak {cost} — alternative cost to cast this card from graveyard during the declare-blockers step by returning an unblocked attacker. CR 702.190b: the resulting permanent enters tapped and attacking the same defender.",
@@ -15016,7 +15311,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 638,
+          "line": 654,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.49 variant: Web-slinging — return a tapped creature to cast.",
@@ -15026,7 +15321,7 @@
         },
         {
           "name": "Mobilize",
-          "line": 641,
+          "line": 657,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mobilize N — when this creature attacks, create N 1/1 red Warrior tokens tapped and attacking, sacrifice them at end of combat.",
@@ -15034,7 +15329,7 @@
         },
         {
           "name": "Gift",
-          "line": 644,
+          "line": 660,
           "kind": "tuple",
           "field_names": [],
           "doc": "Gift — optional casting-time promise. If promised, opponent receives the gift at resolution before the spell's other effects.",
@@ -15042,7 +15337,7 @@
         },
         {
           "name": "Discover",
-          "line": 646,
+          "line": 662,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 701.57a: Discover N — exile from top until nonland card with MV ≤ N.",
@@ -15052,7 +15347,7 @@
         },
         {
           "name": "Spree",
-          "line": 647,
+          "line": 663,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15060,7 +15355,7 @@
         },
         {
           "name": "Ravenous",
-          "line": 648,
+          "line": 664,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15068,7 +15363,7 @@
         },
         {
           "name": "Daybound",
-          "line": 649,
+          "line": 665,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15076,7 +15371,7 @@
         },
         {
           "name": "Nightbound",
-          "line": 650,
+          "line": 666,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15084,7 +15379,7 @@
         },
         {
           "name": "Enlist",
-          "line": 651,
+          "line": 667,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15092,7 +15387,7 @@
         },
         {
           "name": "ReadAhead",
-          "line": 652,
+          "line": 668,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15100,7 +15395,7 @@
         },
         {
           "name": "Compleated",
-          "line": 653,
+          "line": 669,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15108,7 +15403,7 @@
         },
         {
           "name": "Conspire",
-          "line": 654,
+          "line": 670,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15116,7 +15411,7 @@
         },
         {
           "name": "Demonstrate",
-          "line": 655,
+          "line": 671,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15124,7 +15419,7 @@
         },
         {
           "name": "Dethrone",
-          "line": 656,
+          "line": 672,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15132,7 +15427,7 @@
         },
         {
           "name": "DoubleTeam",
-          "line": 657,
+          "line": 673,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15140,7 +15435,7 @@
         },
         {
           "name": "LivingMetal",
-          "line": 658,
+          "line": 674,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15148,7 +15443,7 @@
         },
         {
           "name": "Poisonous",
-          "line": 659,
+          "line": 675,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15156,7 +15451,7 @@
         },
         {
           "name": "Bloodthirst",
-          "line": 660,
+          "line": 676,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15164,7 +15459,7 @@
         },
         {
           "name": "Amplify",
-          "line": 661,
+          "line": 677,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15172,7 +15467,7 @@
         },
         {
           "name": "Graft",
-          "line": 662,
+          "line": 678,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15180,7 +15475,7 @@
         },
         {
           "name": "Devour",
-          "line": 669,
+          "line": 685,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: synthesized as-enters replacement by `database/synthesis.rs::synthesize_devour` — a `ReplacementEvent::Moved` replacement on `SelfRef` whose execute chain is a ranged `Effect::Sacrifice` over the controller's creatures + a per-sacrifice `PutCounter(+1/+1)` sub-ability. CR 702.82a: Devour N — as it enters, you may sacrifice any number of creatures; it enters with N +1/+1 counters per sacrifice.",
@@ -15190,7 +15485,7 @@
         },
         {
           "name": "Toxic",
-          "line": 673,
+          "line": 689,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.164: Toxic N — when this creature deals combat damage to a player, that player gets N poison counters.",
@@ -15200,7 +15495,7 @@
         },
         {
           "name": "Saddle",
-          "line": 675,
+          "line": 691,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.171a: Saddle N — tap creatures with total power N+ to saddle this Mount.",
@@ -15210,7 +15505,7 @@
         },
         {
           "name": "Soulshift",
-          "line": 678,
+          "line": 694,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.46: Soulshift N — when this creature dies, return target Spirit card with mana value N or less from your graveyard to your hand.",
@@ -15220,7 +15515,7 @@
         },
         {
           "name": "Backup",
-          "line": 683,
+          "line": 699,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (ETB +1/+1 counters + ability-grant trigger not wired). CR 702.165: Backup N — when this creature enters, put N +1/+1 counters on target creature, which gains this creature's other abilities until EOT.",
@@ -15230,7 +15525,7 @@
         },
         {
           "name": "Squad",
-          "line": 690,
+          "line": 706,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (variable additional cost + ETB token-per-payment not wired). CR 702.157: Squad {cost} — as an additional cost to cast, you may pay {cost} any number of times; ETB creates that many tokens.",
@@ -15240,7 +15535,7 @@
         },
         {
           "name": "Typecycling",
-          "line": 694,
+          "line": 710,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -15253,7 +15548,7 @@
         },
         {
           "name": "Firebending",
-          "line": 700,
+          "line": 716,
           "kind": "tuple",
           "field_names": [],
           "doc": "Firebending N — produces N {R} when this creature attacks (Avatar crossover).",
@@ -15261,7 +15556,7 @@
         },
         {
           "name": "Splice",
-          "line": 704,
+          "line": 720,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.46a: Splice onto [type] — reveal from hand and pay splice cost while casting a spell of the specified type to add this card's effects to that spell.",
@@ -15271,7 +15566,7 @@
         },
         {
           "name": "Bargain",
-          "line": 707,
+          "line": 723,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Bargain — you may sacrifice an artifact, enchantment, or token as an additional cost to cast this spell.",
@@ -15281,7 +15576,7 @@
         },
         {
           "name": "Sunburst",
-          "line": 709,
+          "line": 725,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.43a: Sunburst — enters with a counter for each color of mana spent to cast it.",
@@ -15291,7 +15586,7 @@
         },
         {
           "name": "Champion",
-          "line": 712,
+          "line": 728,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.72a: Champion a [type] — exile a creature of the specified type you control when this enters; return it when this leaves.",
@@ -15301,7 +15596,7 @@
         },
         {
           "name": "Training",
-          "line": 715,
+          "line": 731,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.149a: Training — whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.",
@@ -15311,7 +15606,7 @@
         },
         {
           "name": "Assist",
-          "line": 717,
+          "line": 733,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.132a: Assist — another player can help pay the generic mana cost of this spell.",
@@ -15321,7 +15616,7 @@
         },
         {
           "name": "Augment",
-          "line": 721,
+          "line": 737,
           "kind": "unit",
           "field_names": [],
           "doc": "Acorn/Un-set keyword: Augment. Runtime host-combine semantics are not implemented; the keyword identity is used for characteristic filters such as \"a card with augment\".",
@@ -15329,7 +15624,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 725,
+          "line": 741,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Aftermath allows casting this half of a split card only from a graveyard, and exiles the spell any time it leaves the stack if it was cast from a graveyard.",
@@ -15339,7 +15634,7 @@
         },
         {
           "name": "JumpStart",
-          "line": 727,
+          "line": 743,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.133a: Jump-start — cast from graveyard by discarding a card, then exile.",
@@ -15349,7 +15644,7 @@
         },
         {
           "name": "Cipher",
-          "line": 730,
+          "line": 746,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.98a: Cipher — exile this spell encoded on a creature you control; whenever that creature deals combat damage to a player, cast a copy.",
@@ -15359,7 +15654,7 @@
         },
         {
           "name": "Transmute",
-          "line": 733,
+          "line": 749,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.52a: Transmute {cost} — discard this card and pay {cost} to search your library for a card with the same mana value.",
@@ -15369,7 +15664,7 @@
         },
         {
           "name": "Escalate",
-          "line": 736,
+          "line": 752,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.120a: Escalate [cost] — additional cost for each mode chosen beyond the first on a modal spell.",
@@ -15379,7 +15674,7 @@
         },
         {
           "name": "Recover",
-          "line": 740,
+          "line": 756,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.59a: Recover {cost} — triggered ability: when a creature is put into your graveyard from the battlefield, you may pay {cost} to return this card from your graveyard to your hand; otherwise exile it.",
@@ -15389,7 +15684,7 @@
         },
         {
           "name": "Cleave",
-          "line": 742,
+          "line": 758,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.148a: Cleave — alternative cost that removes bracketed text from Oracle text.",
@@ -15399,7 +15694,7 @@
         },
         {
           "name": "Undaunted",
-          "line": 744,
+          "line": 760,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.125a: Undaunted — costs {1} less for each opponent.",
@@ -15409,7 +15704,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 752,
+          "line": 768,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — a keyword on instants/sorceries. Reminder: \"Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile without paying its mana cost at the beginning of each of your first main phases.\" Runtime hooks in `stack.rs` (first-resolution arming) and `turns.rs` (first-main-phase offer) carry the semantics. Assign when WotC publishes SOS CR update.",
@@ -15419,7 +15714,7 @@
         },
         {
           "name": "Station",
-          "line": 760,
+          "line": 776,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Station — \"Tap another untapped creature you control: Put a number of charge counters on this permanent equal to the tapped creature's power. Activate only as a sorcery.\" The keyword is fixed (no parameter) — the full semantics come from the rule text. Runtime activation is handled via `GameAction::ActivateStation`, not through the generic activated-ability dispatch.",
@@ -15429,7 +15724,7 @@
         },
         {
           "name": "Replicate",
-          "line": 772,
+          "line": 788,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (no copy-on-cast hook reads it). CR 702.56a: Replicate {cost} — additional-cost-on-cast copy mechanic. \"As an additional cost to cast this spell, you may pay [cost] any number of times\" + \"When you cast this spell, if a replicate cost was paid for it, copy it for each time its replicate cost was paid. If the spell has any targets, you may choose new targets for any of the copies.\" Carries the per-copy mana cost; runtime semantics are not yet implemented (no copy-on-cast hook reads this keyword).",
@@ -15439,7 +15734,7 @@
         },
         {
           "name": "Awaken",
-          "line": 779,
+          "line": 795,
           "kind": "struct",
           "field_names": [
             "count",
@@ -15452,7 +15747,7 @@
         },
         {
           "name": "ForMirrodin",
-          "line": 788,
+          "line": 804,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.163a: For Mirrodin! — Equipment-only triggered ability. \"When this Equipment enters, create a 2/2 red Rebel creature token, then attach this Equipment to it.\" Bare keyword; ETB trigger semantics are synthesized in `database::synthesis`.",
@@ -15462,7 +15757,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 796,
+          "line": 812,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (alt-cost cast hook not wired). CR 702.162a: More Than Meets the Eye {cost} — alternative cost (Transformers crossover). \"You may cast this card converted by paying [cost] rather than its mana cost.\" Stores the alt mana cost; the runtime alt-cost cast hook is not yet wired.",
@@ -15472,7 +15767,7 @@
         },
         {
           "name": "Freerunning",
-          "line": 807,
+          "line": 823,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (alt-cast hook + combat-damage-this-turn predicate not wired). CR 702.173a: Freerunning {cost} — alternative cost. \"You may pay [cost] rather than pay this spell's mana cost if a player was dealt combat damage this turn by a creature that, at the time it dealt that damage, was an Assassin creature or a commander under your control.\" Stores the alt mana cost; runtime alt-cast hook (combat-damage-this-turn predicate) is not yet wired.",
@@ -15482,7 +15777,7 @@
         },
         {
           "name": "Increment",
-          "line": 817,
+          "line": 833,
           "kind": "unit",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (spell-cast trigger not wired). CR 702.191a: Increment — triggered ability. \"Whenever you cast a spell, if this permanent is a creature and the amount of mana spent to cast that spell is greater than this creature's power or this creature's toughness, put a +1/+1 counter on this creature.\" Bare keyword; ETB / spell-cast trigger is not yet wired.",
@@ -15492,7 +15787,7 @@
         },
         {
           "name": "Specialize",
-          "line": 830,
+          "line": 846,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (choose-color + transform hooks not wired). CR ???: Specialize {cost} — not in CR text (needs manual verification). Strixhaven student-into-mage transformation: activated alt-cast that turns the source into a colour-specific version. Stores the activation mana cost; the choose-color and transform hooks are not yet wired. mtgish encodes activation timing modifiers and from-graveyard variants separately; this keyword carries only the cost (the engine drops the activation modifier and the from-graveyard hint, mirroring how `LevelUp` drops its `Vec<Level>` payload).",
@@ -15500,7 +15795,7 @@
         },
         {
           "name": "Offering",
-          "line": 841,
+          "line": 857,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (cost-reduction + cast-as-instant hooks not wired). CR 702.48a: \"[Quality] offering\" — additional-cost-on-cast that sacrifices a permanent matching `Quality`. \"If you chose to pay the additional cost, this spell's total cost is reduced by the sacrificed permanent's mana cost, and you may cast this spell any time you could cast an instant.\" Carries the canonical subtype string (e.g. \"Spirit\", \"Dragon\"); cost-reduction and cast-as- instant runtime hooks are not yet wired.",
@@ -15510,7 +15805,7 @@
         },
         {
           "name": "Unknown",
-          "line": 844,
+          "line": 860,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized keywords.",
@@ -15521,7 +15816,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11028,
+      "line": 11204,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -15530,7 +15825,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 11030,
+          "line": 11206,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -15543,7 +15838,7 @@
         },
         {
           "name": "Crew",
-          "line": 11036,
+          "line": 11212,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -15556,7 +15851,7 @@
         },
         {
           "name": "Saddle",
-          "line": 11042,
+          "line": 11218,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -15569,7 +15864,7 @@
         },
         {
           "name": "Station",
-          "line": 11050,
+          "line": 11226,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -15912,23 +16207,17 @@
           "cr_refs": []
         },
         {
-          "name": "Annihilator",
-          "line": 111,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Bushido",
+          "name": "Graft",
           "line": 112,
           "kind": "unit",
           "field_names": [],
-          "doc": "",
-          "cr_refs": []
+          "doc": "CR 702.58a: Graft N — see `Keyword::Graft`.",
+          "cr_refs": [
+            "CR 702.58a"
+          ]
         },
         {
-          "name": "Tribute",
+          "name": "Annihilator",
           "line": 113,
           "kind": "unit",
           "field_names": [],
@@ -15936,7 +16225,7 @@
           "cr_refs": []
         },
         {
-          "name": "Soulbond",
+          "name": "Bushido",
           "line": 114,
           "kind": "unit",
           "field_names": [],
@@ -15944,7 +16233,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unearth",
+          "name": "Tribute",
           "line": 115,
           "kind": "unit",
           "field_names": [],
@@ -15952,7 +16241,7 @@
           "cr_refs": []
         },
         {
-          "name": "Convoke",
+          "name": "Soulbond",
           "line": 116,
           "kind": "unit",
           "field_names": [],
@@ -15960,7 +16249,7 @@
           "cr_refs": []
         },
         {
-          "name": "Waterbend",
+          "name": "Unearth",
           "line": 117,
           "kind": "unit",
           "field_names": [],
@@ -15968,7 +16257,7 @@
           "cr_refs": []
         },
         {
-          "name": "Delve",
+          "name": "Convoke",
           "line": 118,
           "kind": "unit",
           "field_names": [],
@@ -15976,7 +16265,7 @@
           "cr_refs": []
         },
         {
-          "name": "Devoid",
+          "name": "Waterbend",
           "line": 119,
           "kind": "unit",
           "field_names": [],
@@ -15984,7 +16273,7 @@
           "cr_refs": []
         },
         {
-          "name": "Changeling",
+          "name": "Delve",
           "line": 120,
           "kind": "unit",
           "field_names": [],
@@ -15992,7 +16281,7 @@
           "cr_refs": []
         },
         {
-          "name": "Phasing",
+          "name": "Devoid",
           "line": 121,
           "kind": "unit",
           "field_names": [],
@@ -16000,7 +16289,7 @@
           "cr_refs": []
         },
         {
-          "name": "Battlecry",
+          "name": "Changeling",
           "line": 122,
           "kind": "unit",
           "field_names": [],
@@ -16008,7 +16297,7 @@
           "cr_refs": []
         },
         {
-          "name": "Decayed",
+          "name": "Phasing",
           "line": 123,
           "kind": "unit",
           "field_names": [],
@@ -16016,7 +16305,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unleash",
+          "name": "Battlecry",
           "line": 124,
           "kind": "unit",
           "field_names": [],
@@ -16024,7 +16313,7 @@
           "cr_refs": []
         },
         {
-          "name": "Riot",
+          "name": "Decayed",
           "line": 125,
           "kind": "unit",
           "field_names": [],
@@ -16032,7 +16321,7 @@
           "cr_refs": []
         },
         {
-          "name": "Afterlife",
+          "name": "Unleash",
           "line": 126,
           "kind": "unit",
           "field_names": [],
@@ -16040,7 +16329,7 @@
           "cr_refs": []
         },
         {
-          "name": "Enchant",
+          "name": "Riot",
           "line": 127,
           "kind": "unit",
           "field_names": [],
@@ -16048,7 +16337,7 @@
           "cr_refs": []
         },
         {
-          "name": "EtbCounter",
+          "name": "Afterlife",
           "line": 128,
           "kind": "unit",
           "field_names": [],
@@ -16056,7 +16345,7 @@
           "cr_refs": []
         },
         {
-          "name": "Reconfigure",
+          "name": "Enchant",
           "line": 129,
           "kind": "unit",
           "field_names": [],
@@ -16064,7 +16353,7 @@
           "cr_refs": []
         },
         {
-          "name": "LivingWeapon",
+          "name": "EtbCounter",
           "line": 130,
           "kind": "unit",
           "field_names": [],
@@ -16072,7 +16361,7 @@
           "cr_refs": []
         },
         {
-          "name": "JobSelect",
+          "name": "Reconfigure",
           "line": 131,
           "kind": "unit",
           "field_names": [],
@@ -16080,7 +16369,7 @@
           "cr_refs": []
         },
         {
-          "name": "TotemArmor",
+          "name": "LivingWeapon",
           "line": 132,
           "kind": "unit",
           "field_names": [],
@@ -16088,7 +16377,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bestow",
+          "name": "JobSelect",
           "line": 133,
           "kind": "unit",
           "field_names": [],
@@ -16096,7 +16385,7 @@
           "cr_refs": []
         },
         {
-          "name": "Embalm",
+          "name": "TotemArmor",
           "line": 134,
           "kind": "unit",
           "field_names": [],
@@ -16104,7 +16393,7 @@
           "cr_refs": []
         },
         {
-          "name": "Eternalize",
+          "name": "Bestow",
           "line": 135,
           "kind": "unit",
           "field_names": [],
@@ -16112,7 +16401,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fading",
+          "name": "Embalm",
           "line": 136,
           "kind": "unit",
           "field_names": [],
@@ -16120,7 +16409,7 @@
           "cr_refs": []
         },
         {
-          "name": "Vanishing",
+          "name": "Eternalize",
           "line": 137,
           "kind": "unit",
           "field_names": [],
@@ -16128,7 +16417,7 @@
           "cr_refs": []
         },
         {
-          "name": "Protection",
+          "name": "Fading",
           "line": 138,
           "kind": "unit",
           "field_names": [],
@@ -16136,7 +16425,7 @@
           "cr_refs": []
         },
         {
-          "name": "Kicker",
+          "name": "Vanishing",
           "line": 139,
           "kind": "unit",
           "field_names": [],
@@ -16144,7 +16433,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cycling",
+          "name": "Protection",
           "line": 140,
           "kind": "unit",
           "field_names": [],
@@ -16152,7 +16441,7 @@
           "cr_refs": []
         },
         {
-          "name": "Flashback",
+          "name": "Kicker",
           "line": 141,
           "kind": "unit",
           "field_names": [],
@@ -16160,7 +16449,7 @@
           "cr_refs": []
         },
         {
-          "name": "Retrace",
+          "name": "Cycling",
           "line": 142,
           "kind": "unit",
           "field_names": [],
@@ -16168,7 +16457,7 @@
           "cr_refs": []
         },
         {
-          "name": "Ward",
+          "name": "Flashback",
           "line": 143,
           "kind": "unit",
           "field_names": [],
@@ -16176,7 +16465,7 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "Retrace",
           "line": 144,
           "kind": "unit",
           "field_names": [],
@@ -16184,7 +16473,7 @@
           "cr_refs": []
         },
         {
-          "name": "Landwalk",
+          "name": "Ward",
           "line": 145,
           "kind": "unit",
           "field_names": [],
@@ -16192,7 +16481,7 @@
           "cr_refs": []
         },
         {
-          "name": "Rampage",
+          "name": "Equip",
           "line": 146,
           "kind": "unit",
           "field_names": [],
@@ -16200,7 +16489,7 @@
           "cr_refs": []
         },
         {
-          "name": "Absorb",
+          "name": "Landwalk",
           "line": 147,
           "kind": "unit",
           "field_names": [],
@@ -16208,7 +16497,7 @@
           "cr_refs": []
         },
         {
-          "name": "Crew",
+          "name": "Rampage",
           "line": 148,
           "kind": "unit",
           "field_names": [],
@@ -16216,7 +16505,7 @@
           "cr_refs": []
         },
         {
-          "name": "Partner",
+          "name": "Absorb",
           "line": 149,
           "kind": "unit",
           "field_names": [],
@@ -16224,7 +16513,7 @@
           "cr_refs": []
         },
         {
-          "name": "Companion",
+          "name": "Crew",
           "line": 150,
           "kind": "unit",
           "field_names": [],
@@ -16232,7 +16521,7 @@
           "cr_refs": []
         },
         {
-          "name": "Doctor",
+          "name": "Partner",
           "line": 151,
           "kind": "unit",
           "field_names": [],
@@ -16240,7 +16529,7 @@
           "cr_refs": []
         },
         {
-          "name": "Background",
+          "name": "Companion",
           "line": 152,
           "kind": "unit",
           "field_names": [],
@@ -16248,7 +16537,7 @@
           "cr_refs": []
         },
         {
-          "name": "CommanderNinjutsu",
+          "name": "Doctor",
           "line": 153,
           "kind": "unit",
           "field_names": [],
@@ -16256,7 +16545,7 @@
           "cr_refs": []
         },
         {
-          "name": "Ninjutsu",
+          "name": "Background",
           "line": 154,
           "kind": "unit",
           "field_names": [],
@@ -16264,7 +16553,7 @@
           "cr_refs": []
         },
         {
-          "name": "Sneak",
+          "name": "CommanderNinjutsu",
           "line": 155,
           "kind": "unit",
           "field_names": [],
@@ -16272,7 +16561,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mutate",
+          "name": "Ninjutsu",
           "line": 156,
           "kind": "unit",
           "field_names": [],
@@ -16280,7 +16569,7 @@
           "cr_refs": []
         },
         {
-          "name": "Escape",
+          "name": "Sneak",
           "line": 157,
           "kind": "unit",
           "field_names": [],
@@ -16288,7 +16577,7 @@
           "cr_refs": []
         },
         {
-          "name": "Morph",
+          "name": "Mutate",
           "line": 158,
           "kind": "unit",
           "field_names": [],
@@ -16296,7 +16585,7 @@
           "cr_refs": []
         },
         {
-          "name": "Megamorph",
+          "name": "Escape",
           "line": 159,
           "kind": "unit",
           "field_names": [],
@@ -16304,7 +16593,7 @@
           "cr_refs": []
         },
         {
-          "name": "Suspend",
+          "name": "Morph",
           "line": 160,
           "kind": "unit",
           "field_names": [],
@@ -16312,7 +16601,7 @@
           "cr_refs": []
         },
         {
-          "name": "Blitz",
+          "name": "Megamorph",
           "line": 161,
           "kind": "unit",
           "field_names": [],
@@ -16320,7 +16609,7 @@
           "cr_refs": []
         },
         {
-          "name": "Disturb",
+          "name": "Suspend",
           "line": 162,
           "kind": "unit",
           "field_names": [],
@@ -16328,7 +16617,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnearthAlt",
+          "name": "Blitz",
           "line": 163,
           "kind": "unit",
           "field_names": [],
@@ -16336,7 +16625,7 @@
           "cr_refs": []
         },
         {
-          "name": "Foretell",
+          "name": "Disturb",
           "line": 164,
           "kind": "unit",
           "field_names": [],
@@ -16344,7 +16633,7 @@
           "cr_refs": []
         },
         {
-          "name": "Plot",
+          "name": "UnearthAlt",
           "line": 165,
           "kind": "unit",
           "field_names": [],
@@ -16352,7 +16641,7 @@
           "cr_refs": []
         },
         {
-          "name": "Gift",
+          "name": "Foretell",
           "line": 166,
           "kind": "unit",
           "field_names": [],
@@ -16360,7 +16649,7 @@
           "cr_refs": []
         },
         {
-          "name": "Outlast",
+          "name": "Plot",
           "line": 167,
           "kind": "unit",
           "field_names": [],
@@ -16368,7 +16657,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dash",
+          "name": "Gift",
           "line": 168,
           "kind": "unit",
           "field_names": [],
@@ -16376,7 +16665,7 @@
           "cr_refs": []
         },
         {
-          "name": "Craft",
+          "name": "Outlast",
           "line": 169,
           "kind": "unit",
           "field_names": [],
@@ -16384,7 +16673,7 @@
           "cr_refs": []
         },
         {
-          "name": "Harmonize",
+          "name": "Dash",
           "line": 170,
           "kind": "unit",
           "field_names": [],
@@ -16392,7 +16681,7 @@
           "cr_refs": []
         },
         {
-          "name": "Warp",
+          "name": "Craft",
           "line": 171,
           "kind": "unit",
           "field_names": [],
@@ -16400,7 +16689,7 @@
           "cr_refs": []
         },
         {
-          "name": "Devour",
+          "name": "Harmonize",
           "line": 172,
           "kind": "unit",
           "field_names": [],
@@ -16408,7 +16697,7 @@
           "cr_refs": []
         },
         {
-          "name": "Offspring",
+          "name": "Warp",
           "line": 173,
           "kind": "unit",
           "field_names": [],
@@ -16416,7 +16705,7 @@
           "cr_refs": []
         },
         {
-          "name": "Splice",
+          "name": "Devour",
           "line": 174,
           "kind": "unit",
           "field_names": [],
@@ -16424,7 +16713,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bargain",
+          "name": "Offspring",
           "line": 175,
           "kind": "unit",
           "field_names": [],
@@ -16432,7 +16721,7 @@
           "cr_refs": []
         },
         {
-          "name": "Sunburst",
+          "name": "Splice",
           "line": 176,
           "kind": "unit",
           "field_names": [],
@@ -16440,7 +16729,7 @@
           "cr_refs": []
         },
         {
-          "name": "Champion",
+          "name": "Bargain",
           "line": 177,
           "kind": "unit",
           "field_names": [],
@@ -16448,7 +16737,7 @@
           "cr_refs": []
         },
         {
-          "name": "Training",
+          "name": "Sunburst",
           "line": 178,
           "kind": "unit",
           "field_names": [],
@@ -16456,7 +16745,7 @@
           "cr_refs": []
         },
         {
-          "name": "Assist",
+          "name": "Champion",
           "line": 179,
           "kind": "unit",
           "field_names": [],
@@ -16464,8 +16753,24 @@
           "cr_refs": []
         },
         {
+          "name": "Training",
+          "line": 180,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Assist",
+          "line": 181,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Augment",
-          "line": 182,
+          "line": 184,
           "kind": "unit",
           "field_names": [],
           "doc": "Acorn/Un-set keyword: Augment. Not present in the main Comprehensive Rules file, but it is still a keyword characteristic for card filters.",
@@ -16473,7 +16778,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 184,
+          "line": 186,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127: Aftermath — see `Keyword::Aftermath`.",
@@ -16483,22 +16788,6 @@
         },
         {
           "name": "JumpStart",
-          "line": 185,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Cipher",
-          "line": 186,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Transmute",
           "line": 187,
           "kind": "unit",
           "field_names": [],
@@ -16506,7 +16795,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cleave",
+          "name": "Cipher",
           "line": 188,
           "kind": "unit",
           "field_names": [],
@@ -16514,7 +16803,7 @@
           "cr_refs": []
         },
         {
-          "name": "Undaunted",
+          "name": "Transmute",
           "line": 189,
           "kind": "unit",
           "field_names": [],
@@ -16522,7 +16811,7 @@
           "cr_refs": []
         },
         {
-          "name": "Station",
+          "name": "Cleave",
           "line": 190,
           "kind": "unit",
           "field_names": [],
@@ -16530,8 +16819,24 @@
           "cr_refs": []
         },
         {
-          "name": "Paradigm",
+          "name": "Undaunted",
+          "line": 191,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Station",
           "line": 192,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Paradigm",
+          "line": 194,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — see `Keyword::Paradigm`.",
@@ -16541,7 +16846,7 @@
         },
         {
           "name": "Miracle",
-          "line": 194,
+          "line": 196,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94: Miracle — see `Keyword::Miracle`.",
@@ -16551,7 +16856,7 @@
         },
         {
           "name": "Replicate",
-          "line": 196,
+          "line": 198,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.56: Replicate — see `Keyword::Replicate`.",
@@ -16561,7 +16866,7 @@
         },
         {
           "name": "Awaken",
-          "line": 198,
+          "line": 200,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113: Awaken — see `Keyword::Awaken`.",
@@ -16571,7 +16876,7 @@
         },
         {
           "name": "ForMirrodin",
-          "line": 200,
+          "line": 202,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.163: For Mirrodin! — see `Keyword::ForMirrodin`.",
@@ -16581,7 +16886,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 202,
+          "line": 204,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.162: More Than Meets the Eye — see `Keyword::MoreThanMeetsTheEye`.",
@@ -16591,7 +16896,7 @@
         },
         {
           "name": "Freerunning",
-          "line": 204,
+          "line": 206,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.173: Freerunning — see `Keyword::Freerunning`.",
@@ -16601,7 +16906,7 @@
         },
         {
           "name": "Increment",
-          "line": 206,
+          "line": 208,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.191: Increment — see `Keyword::Increment`.",
@@ -16611,7 +16916,7 @@
         },
         {
           "name": "Firebending",
-          "line": 208,
+          "line": 210,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.189: Firebending — see `Keyword::Firebending`.",
@@ -16621,7 +16926,7 @@
         },
         {
           "name": "Specialize",
-          "line": 211,
+          "line": 213,
           "kind": "unit",
           "field_names": [],
           "doc": "CR ???: Specialize — not in CR text (needs manual verification). See `Keyword::Specialize`.",
@@ -16629,7 +16934,7 @@
         },
         {
           "name": "Offering",
-          "line": 213,
+          "line": 215,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.48: Offering — see `Keyword::Offering`.",
@@ -16639,7 +16944,7 @@
         },
         {
           "name": "Escalate",
-          "line": 215,
+          "line": 217,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.120: Escalate — see `Keyword::Escalate`.",
@@ -16649,7 +16954,7 @@
         },
         {
           "name": "Recover",
-          "line": 217,
+          "line": 219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.59: Recover — see `Keyword::Recover`.",
@@ -16659,7 +16964,7 @@
         },
         {
           "name": "Unknown",
-          "line": 218,
+          "line": 220,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16670,7 +16975,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9171,
+      "line": 9325,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -16680,7 +16985,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 9173,
+          "line": 9327,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -16690,7 +16995,7 @@
         },
         {
           "name": "Second",
-          "line": 9176,
+          "line": 9330,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -16825,7 +17130,7 @@
     },
     "LayoutKind": {
       "file": "crates/engine/src/types/card.rs",
-      "line": 167,
+      "line": 190,
       "doc": "Runtime layout discriminant for double-faced cards.  Stored on `BackFaceData` so the engine can distinguish Modal DFCs (which allow face-choice per CR 712.12) from Transform DFCs at runtime. Intentionally separate from `database::synthesis::LayoutKind` which is a build-pipeline type without serialization derives.",
       "cr_refs": [
         "CR 712.12"
@@ -16833,7 +17138,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 168,
+          "line": 191,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16841,7 +17146,7 @@
         },
         {
           "name": "Split",
-          "line": 169,
+          "line": 192,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16849,7 +17154,7 @@
         },
         {
           "name": "Flip",
-          "line": 170,
+          "line": 193,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16857,7 +17162,7 @@
         },
         {
           "name": "Transform",
-          "line": 171,
+          "line": 194,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16865,7 +17170,7 @@
         },
         {
           "name": "Meld",
-          "line": 172,
+          "line": 195,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16873,7 +17178,7 @@
         },
         {
           "name": "Adventure",
-          "line": 173,
+          "line": 196,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16881,7 +17186,7 @@
         },
         {
           "name": "Modal",
-          "line": 174,
+          "line": 197,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16889,7 +17194,7 @@
         },
         {
           "name": "Omen",
-          "line": 175,
+          "line": 198,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16897,7 +17202,7 @@
         },
         {
           "name": "Prepare",
-          "line": 180,
+          "line": 203,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) frame mechanic — a two-face card whose face `b` is a \"prepare spell\" (Sorcery/Instant). When face `a` is prepared, a copy of face `b` can be cast. Structurally an Adventure analog. Assign when WotC publishes SOS CR update.",
@@ -16910,7 +17215,7 @@
     },
     "LearnOption": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 631,
+      "line": 642,
       "doc": "CR 701.48a: Learn choice — rummage a specific card, or skip entirely.",
       "cr_refs": [
         "CR 701.48a"
@@ -16918,7 +17223,7 @@
       "variants": [
         {
           "name": "Rummage",
-          "line": 633,
+          "line": 644,
           "kind": "struct",
           "field_names": [
             "card_id"
@@ -16928,7 +17233,7 @@
         },
         {
           "name": "Skip",
-          "line": 635,
+          "line": 646,
           "kind": "unit",
           "field_names": [],
           "doc": "Decline to learn (skip).",
@@ -16939,13 +17244,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4845,
+      "line": 4902,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 4846,
+          "line": 4903,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16953,7 +17258,7 @@
         },
         {
           "name": "Bottom",
-          "line": 4847,
+          "line": 4904,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16961,7 +17266,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 4849,
+          "line": 4906,
           "kind": "struct",
           "field_names": [
             "n"
@@ -16974,13 +17279,13 @@
     },
     "LifeAmount": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 772,
+      "line": 793,
       "doc": "How much life is gained — a fixed amount or derived from the targeted permanent.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Fixed",
-          "line": 774,
+          "line": 795,
           "kind": "tuple",
           "field_names": [],
           "doc": "Gain a specific number of life.",
@@ -16988,7 +17293,7 @@
         },
         {
           "name": "TargetPower",
-          "line": 776,
+          "line": 797,
           "kind": "unit",
           "field_names": [],
           "doc": "Gain life equal to the targeted permanent's power.",
@@ -16999,7 +17304,7 @@
     },
     "LinkedExileScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1099,
+      "line": 1128,
       "doc": "CR 607.2a + CR 406.6 + CR 610.3: Which exile-link relation a mana ability reads when computing legal colors. Typed enum — never a bool — so future extensions (e.g. links to a different host than `~` itself) slot in cleanly.",
       "cr_refs": [
         "CR 406.6",
@@ -17009,7 +17314,7 @@
       "variants": [
         {
           "name": "ThisObject",
-          "line": 1103,
+          "line": 1132,
           "kind": "unit",
           "field_names": [],
           "doc": "Read `state.exile_links` keyed to this ability's source object (the activating permanent).",
@@ -17196,13 +17501,13 @@
     },
     "ManaAbilityResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 910,
+      "line": 948,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 911,
+          "line": 949,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17210,7 +17515,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 912,
+          "line": 950,
           "kind": "struct",
           "field_names": [
             "convoke_mode"
@@ -17220,7 +17525,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 916,
+          "line": 954,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -17237,7 +17542,7 @@
     },
     "ManaChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 982,
+      "line": 1020,
       "doc": "CR 608.2d + CR 605.3b: Player's answer to a `ManaChoicePrompt`, carried by `GameAction::ChooseManaColor`. Shape mirrors the prompt variant.",
       "cr_refs": [
         "CR 605.3b",
@@ -17246,7 +17551,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 983,
+          "line": 1021,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17254,7 +17559,7 @@
         },
         {
           "name": "Combination",
-          "line": 984,
+          "line": 1022,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17265,7 +17570,7 @@
     },
     "ManaChoiceContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 992,
+      "line": 1030,
       "doc": "CR 106.3 + CR 608.2d + CR 605.3b: What resumes after a mana-color choice. Mana abilities and resolving spell/ability effects share the same prompt and response action, but resume through different rules paths.",
       "cr_refs": [
         "CR 106.3",
@@ -17275,7 +17580,7 @@
       "variants": [
         {
           "name": "ManaAbility",
-          "line": 993,
+          "line": 1031,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17283,7 +17588,7 @@
         },
         {
           "name": "ResolvingEffect",
-          "line": 994,
+          "line": 1032,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17294,7 +17599,7 @@
     },
     "ManaChoicePrompt": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 965,
+      "line": 1003,
       "doc": "CR 608.2d + CR 605.3b: The shape of the prompt surfaced via `WaitingFor::ChooseManaColor`. Typed enum rather than a bool discriminator: the continuation logic is identical (validate choice → produce mana → resume), only the option set differs.",
       "cr_refs": [
         "CR 605.3b",
@@ -17303,7 +17608,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 968,
+          "line": 1006,
           "kind": "struct",
           "field_names": [
             "options"
@@ -17313,7 +17618,7 @@
         },
         {
           "name": "Combination",
-          "line": 970,
+          "line": 1008,
           "kind": "struct",
           "field_names": [
             "options"
@@ -17323,7 +17628,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 972,
+          "line": 1010,
           "kind": "struct",
           "field_names": [
             "count",
@@ -17386,7 +17691,7 @@
     },
     "ManaContribution": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 897,
+      "line": 926,
       "doc": "CR 605.1a + CR 107.4a: Whether a mana-production effect is the *base* mana addition (e.g. a basic Forest tapping for `{G}`) or an *additional* mana addition that piggy-backs on another mana event (e.g. Fertile Ground's \"adds an additional one mana\"). Typed enum — never a bool — so the parser and resolver can dispatch on the contribution role without conflating it with other dimensions of mana production.",
       "cr_refs": [
         "CR 107.4a",
@@ -17395,7 +17700,7 @@
       "variants": [
         {
           "name": "Base",
-          "line": 900,
+          "line": 929,
           "kind": "unit",
           "field_names": [],
           "doc": "The mana addition stands on its own (most mana abilities).",
@@ -17403,7 +17708,7 @@
         },
         {
           "name": "Additional",
-          "line": 903,
+          "line": 932,
           "kind": "unit",
           "field_names": [],
           "doc": "The mana addition is additive — it augments another mana event (Utopia Sprawl, Fertile Ground, Wild Growth, Carpet of Flowers).",
@@ -17838,7 +18143,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10312,
+      "line": 10488,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -17847,7 +18152,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 10315,
+          "line": 10491,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -17859,7 +18164,7 @@
         },
         {
           "name": "Multiply",
-          "line": 10318,
+          "line": 10494,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -17934,13 +18239,13 @@
     },
     "ManaProduction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 964,
+      "line": 993,
       "doc": "Mana production descriptor for `Effect::Mana`.  Custom Deserialize: accepts both the tagged format `{\"type\":\"Fixed\",\"colors\":[\"White\"]}` (new) and a plain array of `ManaColor` like `[\"White\",\"Green\"]` (legacy, pre-ManaProduction refactor).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Fixed",
-          "line": 966,
+          "line": 995,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -17951,7 +18256,7 @@
         },
         {
           "name": "Colorless",
-          "line": 977,
+          "line": 1006,
           "kind": "struct",
           "field_names": [
             "count"
@@ -17961,7 +18266,7 @@
         },
         {
           "name": "Mixed",
-          "line": 982,
+          "line": 1011,
           "kind": "struct",
           "field_names": [
             "colorless_count",
@@ -17972,7 +18277,7 @@
         },
         {
           "name": "AnyOneColor",
-          "line": 987,
+          "line": 1016,
           "kind": "struct",
           "field_names": [
             "count",
@@ -17984,7 +18289,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 1000,
+          "line": 1029,
           "kind": "struct",
           "field_names": [
             "count",
@@ -17995,7 +18300,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 1007,
+          "line": 1036,
           "kind": "struct",
           "field_names": [
             "count",
@@ -18007,7 +18312,7 @@
         },
         {
           "name": "OpponentLandColors",
-          "line": 1024,
+          "line": 1053,
           "kind": "struct",
           "field_names": [
             "count"
@@ -18019,7 +18324,7 @@
         },
         {
           "name": "AnyTypeProduceableBy",
-          "line": 1038,
+          "line": 1067,
           "kind": "struct",
           "field_names": [
             "count",
@@ -18034,7 +18339,7 @@
         },
         {
           "name": "ChoiceAmongExiledColors",
-          "line": 1048,
+          "line": 1077,
           "kind": "struct",
           "field_names": [
             "source"
@@ -18048,7 +18353,7 @@
         },
         {
           "name": "ChoiceAmongCombinations",
-          "line": 1058,
+          "line": 1087,
           "kind": "struct",
           "field_names": [
             "options"
@@ -18061,7 +18366,7 @@
         },
         {
           "name": "AnyInCommandersColorIdentity",
-          "line": 1068,
+          "line": 1097,
           "kind": "struct",
           "field_names": [
             "count",
@@ -18076,7 +18381,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 1084,
+          "line": 1113,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -18090,7 +18395,7 @@
         },
         {
           "name": "TriggerEventManaType",
-          "line": 1091,
+          "line": 1120,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c + CR 106.3: Produce one mana of the same type as the mana produced by the triggering `ManaAdded` event. Used by `TapsForMana` triggers of the form \"add one mana of any type that land produced\" (Vorinclex, Voice of Hunger; Dictate of Karametra). Resolves from `state.current_trigger_event` at resolution time; emits no mana if the current trigger event is absent or not a `ManaAdded` event (CR 106.5).",
@@ -18105,7 +18410,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10324,
+      "line": 10500,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -18114,7 +18419,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10327,
+          "line": 10503,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -18122,7 +18427,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 10329,
+          "line": 10505,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -18251,7 +18556,7 @@
     },
     "ManaSpendPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1538,
+      "line": 1567,
       "doc": "CR 609.4b: Permission modifying how mana may be spent to pay a cost.",
       "cr_refs": [
         "CR 609.4b"
@@ -18259,7 +18564,7 @@
       "variants": [
         {
           "name": "AnyTypeOrColor",
-          "line": 1542,
+          "line": 1571,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana may be spent as though it were mana of any type or color for this payment. This preserves the Oracle distinction without changing the actual mana spent.",
@@ -18270,13 +18575,13 @@
     },
     "ManaSpendRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1276,
+      "line": 1305,
       "doc": "Parse-time template for mana spend restrictions.  Unlike [`ManaRestriction`](super::mana::ManaRestriction) which carries concrete values on a `ManaUnit`, this enum is stored on `Effect::Mana` and resolved at production time by reading runtime state (e.g., chosen creature type from the source object).",
       "cr_refs": [],
       "variants": [
         {
           "name": "SpellOnly",
-          "line": 1278,
+          "line": 1307,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells.\"",
@@ -18284,7 +18589,7 @@
         },
         {
           "name": "SpellType",
-          "line": 1280,
+          "line": 1309,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast creature spells.\"",
@@ -18292,7 +18597,7 @@
         },
         {
           "name": "ChosenCreatureType",
-          "line": 1283,
+          "line": 1312,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast a creature spell of the chosen type.\" Resolved at runtime from the source's `chosen_creature_type()`.",
@@ -18300,7 +18605,7 @@
         },
         {
           "name": "SpellTypeOrAbilityActivation",
-          "line": 1287,
+          "line": 1316,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 106.12: \"Spend this mana only to cast creature spells or activate abilities of creatures.\" Combined restriction with OR semantics: allowed for spells of the type OR ability activations on permanents of the type. The `String` is the card type (e.g., \"Creature\").",
@@ -18310,7 +18615,7 @@
         },
         {
           "name": "ActivateOnly",
-          "line": 1290,
+          "line": 1319,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to activate abilities.\" Cannot be used to cast spells; only for ability activation costs.",
@@ -18318,7 +18623,7 @@
         },
         {
           "name": "XCostOnly",
-          "line": 1293,
+          "line": 1322,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only on costs that include {X}.\" Only permits spending on spells or abilities with {X} in their cost.",
@@ -18326,7 +18631,7 @@
         },
         {
           "name": "SpellWithKeywordKind",
-          "line": 1295,
+          "line": 1324,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback.\"",
@@ -18334,7 +18639,7 @@
         },
         {
           "name": "SpellWithKeywordKindFromZone",
-          "line": 1297,
+          "line": 1326,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -18504,13 +18809,13 @@
     },
     "MayTriggerOrigin": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 467,
+      "line": 468,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Printed",
-          "line": 468,
+          "line": 469,
           "kind": "struct",
           "field_names": [
             "trigger_index"
@@ -18520,7 +18825,7 @@
         },
         {
           "name": "Keyword",
-          "line": 469,
+          "line": 470,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -18533,13 +18838,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8079,
+      "line": 8207,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 8081,
+          "line": 8209,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -18551,7 +18856,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8084,
+          "line": 8212,
           "kind": "struct",
           "field_names": [
             "source",
@@ -18570,13 +18875,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8059,
+      "line": 8187,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 8060,
+          "line": 8188,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18584,7 +18889,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 8063,
+          "line": 8191,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -18599,7 +18904,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 8070,
+          "line": 8198,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -18609,7 +18914,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 8073,
+          "line": 8201,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -18622,7 +18927,7 @@
     },
     "MulliganChoice": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 50,
+      "line": 51,
       "doc": "CR 103.5 + Serum Powder Oracle text: Player decision at a `MulliganDecision` prompt. The three branches correspond to the three actions a player can take while still pending in the mulligan-decision phase: - `Keep` — lock in the current opening hand (CR 103.5). - `Mulligan` — shuffle the hand back, redraw the starting hand size, and   remain pending (CR 103.5). - `UseSerumPowder` — exile every card in hand and redraw the same number,   without taking a mulligan and without incrementing the mulligan counter.   Only available when `object_id` references a card named \"Serum Powder\" in   the actor's hand (CR 103.5b and Serum Powder Oracle text). The player   remains pending and may keep, mulligan, or use another Serum Powder next.",
       "cr_refs": [
         "CR 103.5",
@@ -18631,14 +18936,6 @@
       "variants": [
         {
           "name": "Keep",
-          "line": 51,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Mulligan",
           "line": 52,
           "kind": "unit",
           "field_names": [],
@@ -18646,8 +18943,16 @@
           "cr_refs": []
         },
         {
+          "name": "Mulligan",
+          "line": 53,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "UseSerumPowder",
-          "line": 55,
+          "line": 56,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -18662,7 +18967,7 @@
     },
     "NextSpellModifier": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 297,
+      "line": 298,
       "doc": "CR 601.2f: The kind of modification to apply to the next qualifying spell.",
       "cr_refs": [
         "CR 601.2f"
@@ -18670,7 +18975,7 @@
       "variants": [
         {
           "name": "CantBeCountered",
-          "line": 299,
+          "line": 300,
           "kind": "unit",
           "field_names": [],
           "doc": "\"The next spell you cast this turn can't be countered.\"",
@@ -18678,7 +18983,7 @@
         },
         {
           "name": "HasKeyword",
-          "line": 301,
+          "line": 302,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -18688,7 +18993,7 @@
         },
         {
           "name": "CastAsThoughFlash",
-          "line": 303,
+          "line": 304,
           "kind": "unit",
           "field_names": [],
           "doc": "\"The next spell you cast this turn can be cast as though it had flash.\"",
@@ -18699,7 +19004,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4132,
+      "line": 4189,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -18709,7 +19014,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4134,
+          "line": 4191,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -18719,7 +19024,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4136,
+          "line": 4193,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -18732,13 +19037,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3178,
+      "line": 3218,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 3179,
+          "line": 3219,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18746,7 +19051,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3180,
+          "line": 3220,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18754,7 +19059,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 3181,
+          "line": 3221,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18765,13 +19070,13 @@
     },
     "ObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2613,
+      "line": 2644,
       "doc": "Scope selector for object-axis quantities (Round Π-5). Picks WHICH object to read from when a `QuantityRef` (and future per-object conditions) is per-object. Mirrors `PlayerScope` for the player axis.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 2619,
+          "line": 2650,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.7 + CR 113.7a: The source object of the resolving ability — \"this creature\", \"~\", \"it\" (when \"it\" anaphors back to the source). CR 113.7 defines the source as the object that generated the ability; CR 113.7a keeps the ability (and thus its source reference) valid on the stack even after the source leaves its expected zone, via LKI.",
@@ -18782,7 +19087,7 @@
         },
         {
           "name": "Target",
-          "line": 2622,
+          "line": 2653,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The first object target of the resolving ability — \"that creature\", \"the creature\", \"it\" (when \"it\" anaphors back to a target).",
@@ -18792,7 +19097,7 @@
         },
         {
           "name": "Recipient",
-          "line": 2628,
+          "line": 2659,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4c + CR 115.10: The object currently receiving an effect. In layer evaluation this is the per-object recipient. Outside layers, it resolves to the first object target when present, then to the source. Used for recipient-relative \"its colors\" boosts such as Blessing of the Nephilim and Civic Saber.",
@@ -18803,7 +19108,7 @@
         },
         {
           "name": "EventSource",
-          "line": 2630,
+          "line": 2661,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: The object referenced by the current trigger event.",
@@ -18813,7 +19118,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2637,
+          "line": 2668,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: The specific untargeted object previously referred to by this ability's cost OR trigger condition. Resolved (first match wins) via `ResolvedAbility.cost_paid_object` → trigger-event source → `effect_context_object`. Subsumes the former `EventContextSource*` trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger referent are the two enumerated members of CR 608.2k's single clause).",
@@ -18826,7 +19131,7 @@
         },
         {
           "name": "Anaphoric",
-          "line": 2651,
+          "line": 2682,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: A deferred anaphoric pronoun (\"it\" / \"its\") whose object referent is bound at parse time. The parser remaps this to a concrete scope wherever it can — `Source` when the clause subject is the ability source, `Target` when the recipient is \"itself\". For triggered abilities no remap applies and `Anaphoric` survives to runtime, where it resolves identically to `CostPaidObject` (behavior-preserving — these cards parsed to `CostPaidObject` before this variant existed). General rules-correct runtime resolution of triggered-ability anaphora (e.g. \"its mana value\" after a reveal — see issue #511) is separate per-card parser work. Distinguishing this from an explicit cost-paid possessive (\"the sacrificed creature's power\", CR 608.2k -> `CostPaidObject`) is what prevents the subject-injection rewrite from clobbering correctly-scoped possessives.",
@@ -18839,7 +19144,7 @@
     },
     "OpeningHandBottomReason": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1261,
+      "line": 1305,
       "doc": "CR 103.5 / TL:R 906.6a: Why a player is bottoming cards from an opening hand before the normal mulligan-decision step.",
       "cr_refs": [
         "CR 103.5"
@@ -18847,7 +19152,7 @@
       "variants": [
         {
           "name": "TinyLeadersMultiCommander",
-          "line": 1262,
+          "line": 1306,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18858,7 +19163,7 @@
     },
     "OpponentMayScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 147,
+      "line": 155,
       "doc": "CR 608.2d: Who may choose to perform an optional effect during resolution. Used with `AbilityDefinition::optional_for` to route the \"you may\" prompt to opponents.",
       "cr_refs": [
         "CR 608.2d"
@@ -18866,7 +19171,7 @@
       "variants": [
         {
           "name": "AnyOpponent",
-          "line": 149,
+          "line": 157,
           "kind": "unit",
           "field_names": [],
           "doc": "\"any opponent may\" — each opponent in APNAP order gets the chance; first accept wins.",
@@ -18877,7 +19182,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9797,
+      "line": 9973,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -18887,7 +19192,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 9799,
+          "line": 9975,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -18895,7 +19200,7 @@
         },
         {
           "name": "Equals",
-          "line": 9801,
+          "line": 9977,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -18903,7 +19208,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 9804,
+          "line": 9980,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -18911,7 +19216,7 @@
         },
         {
           "name": "OneOf",
-          "line": 9806,
+          "line": 9982,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -18922,7 +19227,7 @@
     },
     "OutsideGameChoiceSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1211,
+      "line": 1255,
       "doc": "CR 400.11 + CR 406.3: A discriminated source for one outside-game selection. Sideboard entries (the wishboard pool) and face-up exile cards (the Karn / Coax wishboard return pool) are surfaced through one choice list so the caster picks across both pools in a single decision.  The size delta between the two variants (`Sideboard` carries a full `CardFace` so the UI can render the wishboard card without a sideboard lookup; `FaceUpExile` holds only an `ObjectId`) is intentional — `OutsideGameChoiceEntry` lists are short-lived (one entry per offered candidate while a single `WaitingFor::OutsideGameChoice` is active) and never collected by the million, so the asymmetry doesn't warrant boxing every CardFace through a heap indirection.",
       "cr_refs": [
         "CR 400.11",
@@ -18931,7 +19236,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 1213,
+          "line": 1257,
           "kind": "struct",
           "field_names": [
             "sideboard_index",
@@ -18944,7 +19249,7 @@
         },
         {
           "name": "FaceUpExile",
-          "line": 1218,
+          "line": 1262,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -18959,7 +19264,7 @@
     },
     "OutsideGameSelection": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 99,
+      "line": 100,
       "doc": "CR 400.11 + CR 406.3: One discriminated selection committed for an outside-game choice. The two source pools (sideboard and face-up exile) are expressed as parallel variants so the action wire format is uniform.",
       "cr_refs": [
         "CR 400.11",
@@ -18968,7 +19273,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 101,
+          "line": 102,
           "kind": "struct",
           "field_names": [
             "sideboard_index"
@@ -18980,7 +19285,7 @@
         },
         {
           "name": "FaceUpExile",
-          "line": 103,
+          "line": 104,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -18995,7 +19300,7 @@
     },
     "OutsideGameSourcePool": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 108,
+      "line": 116,
       "doc": "CR 400.11 + CR 406.3: Candidate pool for outside-game searches. The baseline pool is the player's sideboard; Karn/Coax-class text widens that pool to include owned face-up exile cards that match the same filter.",
       "cr_refs": [
         "CR 400.11",
@@ -19004,7 +19309,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 111,
+          "line": 119,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.11a: Tournament sideboard / casual outside-the-game collection.",
@@ -19014,7 +19319,7 @@
         },
         {
           "name": "SideboardAndFaceUpExile",
-          "line": 113,
+          "line": 121,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.11a + CR 406.3: Sideboard plus matching owned face-up exile.",
@@ -19028,13 +19333,13 @@
     },
     "Parity": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 399,
+      "line": 407,
       "doc": "Odd or even — used by cards like \"choose odd or even.\"",
       "cr_refs": [],
       "variants": [
         {
           "name": "Odd",
-          "line": 400,
+          "line": 408,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19042,7 +19347,7 @@
         },
         {
           "name": "Even",
-          "line": 401,
+          "line": 409,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19053,7 +19358,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3858,
+      "line": 3915,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -19062,7 +19367,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 3859,
+          "line": 3916,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -19072,7 +19377,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3863,
+          "line": 3920,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -19082,7 +19387,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 3864,
+          "line": 3921,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19090,7 +19395,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3866,
+          "line": 3923,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -19100,7 +19405,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 3867,
+          "line": 3924,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19110,7 +19415,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 3870,
+          "line": 3927,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -19121,7 +19426,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 3874,
+          "line": 3931,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -19131,7 +19436,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3878,
+          "line": 3935,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -19141,7 +19446,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 3880,
+          "line": 3937,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -19151,7 +19456,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 3881,
+          "line": 3938,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19159,7 +19464,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 3882,
+          "line": 3939,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -19169,7 +19474,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 3885,
+          "line": 3942,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -19179,7 +19484,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 3888,
+          "line": 3945,
           "kind": "struct",
           "field_names": [
             "color"
@@ -19189,7 +19494,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 3891,
+          "line": 3948,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19197,7 +19502,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 3892,
+          "line": 3949,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19205,7 +19510,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 3893,
+          "line": 3950,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19213,7 +19518,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 3894,
+          "line": 3951,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19224,7 +19529,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 3898,
+          "line": 3955,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19235,7 +19540,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 3902,
+          "line": 3959,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19247,7 +19552,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3907,
+          "line": 3964,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19257,7 +19562,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 3910,
+          "line": 3967,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19267,7 +19572,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 3913,
+          "line": 3970,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -19277,7 +19582,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 3918,
+          "line": 3975,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19289,7 +19594,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3927,
+          "line": 3984,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19304,7 +19609,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 3932,
+          "line": 3989,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19314,7 +19619,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 3935,
+          "line": 3992,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -19324,7 +19629,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 3938,
+          "line": 3995,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -19335,7 +19640,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 3942,
+          "line": 3999,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -19346,7 +19651,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 3946,
+          "line": 4003,
           "kind": "struct",
           "field_names": [
             "color",
@@ -19357,7 +19662,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 3950,
+          "line": 4007,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -19367,7 +19672,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 3953,
+          "line": 4010,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19375,7 +19680,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 3954,
+          "line": 4011,
           "kind": "struct",
           "field_names": [
             "name"
@@ -19385,7 +19690,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 3961,
+          "line": 4018,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -19398,7 +19703,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 3965,
+          "line": 4022,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19408,7 +19713,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 3968,
+          "line": 4025,
           "kind": "struct",
           "field_names": [
             "power",
@@ -19419,7 +19724,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 3972,
+          "line": 4029,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19427,7 +19732,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 3973,
+          "line": 4030,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19437,7 +19742,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 3976,
+          "line": 4033,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19447,7 +19752,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 3979,
+          "line": 4036,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19457,7 +19762,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 3982,
+          "line": 4039,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19465,7 +19770,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 3983,
+          "line": 4040,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19473,7 +19778,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 3984,
+          "line": 4041,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19483,7 +19788,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 3990,
+          "line": 4047,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -19491,7 +19796,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 3993,
+          "line": 4050,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19504,7 +19809,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 3997,
+          "line": 4054,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19512,7 +19817,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 3998,
+          "line": 4055,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19522,7 +19827,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 4001,
+          "line": 4058,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19530,7 +19835,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 4002,
+          "line": 4059,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19538,7 +19843,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 4003,
+          "line": 4060,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19546,7 +19851,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 4004,
+          "line": 4061,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19554,7 +19859,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 4006,
+          "line": 4063,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -19564,7 +19869,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 4007,
+          "line": 4064,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19572,7 +19877,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 4008,
+          "line": 4065,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19580,7 +19885,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 4009,
+          "line": 4066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19588,7 +19893,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 4010,
+          "line": 4067,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19599,7 +19904,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 4014,
+          "line": 4071,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19609,7 +19914,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 4019,
+          "line": 4076,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19622,7 +19927,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4024,
+          "line": 4081,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -19632,7 +19937,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 4032,
+          "line": 4089,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -19642,7 +19947,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 4045,
+          "line": 4102,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19656,7 +19961,7 @@
         },
         {
           "name": "And",
-          "line": 4053,
+          "line": 4110,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -19669,7 +19974,7 @@
         },
         {
           "name": "Or",
-          "line": 4059,
+          "line": 4116,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -19682,7 +19987,7 @@
         },
         {
           "name": "Not",
-          "line": 4066,
+          "line": 4123,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -19698,7 +20003,7 @@
     },
     "PartnerType": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 252,
+      "line": 254,
       "doc": "CR 702.124: Partner variant keywords for co-commander deckbuilding. Each variant specifies which other partner types it can legally pair with.",
       "cr_refs": [
         "CR 702.124"
@@ -19706,7 +20011,7 @@
       "variants": [
         {
           "name": "Generic",
-          "line": 254,
+          "line": 256,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124a: Generic \"Partner\" — pairs with any other generic Partner.",
@@ -19716,7 +20021,7 @@
         },
         {
           "name": "With",
-          "line": 256,
+          "line": 258,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.124c: \"Partner with [Name]\" — pairs only with the named card.",
@@ -19726,7 +20031,7 @@
         },
         {
           "name": "FriendsForever",
-          "line": 258,
+          "line": 260,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124f: \"Friends forever\" — pairs with any other Friends Forever card.",
@@ -19736,7 +20041,7 @@
         },
         {
           "name": "CharacterSelect",
-          "line": 260,
+          "line": 262,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124: \"Partner—Character select\" — pairs with any other Character Select card.",
@@ -19746,7 +20051,7 @@
         },
         {
           "name": "DoctorsCompanion",
-          "line": 262,
+          "line": 264,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124: \"Doctor's companion\" — pairs with any creature with the Doctor subtype.",
@@ -19756,7 +20061,7 @@
         },
         {
           "name": "ChooseABackground",
-          "line": 264,
+          "line": 266,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124: \"Choose a Background\" — pairs with any enchantment with Background subtype.",
@@ -19769,7 +20074,7 @@
     },
     "PayableResource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2835,
+      "line": 2913,
       "doc": "CR 107.14 + CR 118.8: Resource that can be paid in a \"pay any amount of X\" prompt. Typed so the same `WaitingFor::PayAmountChoice` variant generalizes to future classes (energy, life, mana) without re-introducing boolean flags.",
       "cr_refs": [
         "CR 107.14",
@@ -19778,7 +20083,7 @@
       "variants": [
         {
           "name": "Energy",
-          "line": 2837,
+          "line": 2915,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.",
@@ -19788,7 +20093,7 @@
         },
         {
           "name": "ManaGeneric",
-          "line": 2839,
+          "line": 2917,
           "kind": "struct",
           "field_names": [
             "per_x"
@@ -19842,7 +20147,7 @@
     },
     "PaymentCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4079,
+      "line": 4136,
       "doc": "CR 118.1: A cost paid as part of an effect's resolution. Distinct from AbilityCost (which gates activation before the colon).",
       "cr_refs": [
         "CR 118.1"
@@ -19850,7 +20155,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 4080,
+          "line": 4137,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -19860,7 +20165,7 @@
         },
         {
           "name": "Life",
-          "line": 4088,
+          "line": 4145,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -19873,7 +20178,7 @@
         },
         {
           "name": "Speed",
-          "line": 4092,
+          "line": 4149,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -19886,7 +20191,7 @@
         },
         {
           "name": "Energy",
-          "line": 4097,
+          "line": 4154,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -19898,7 +20203,7 @@
         },
         {
           "name": "AbilityCost",
-          "line": 4104,
+          "line": 4161,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -19911,7 +20216,7 @@
         },
         {
           "name": "ScaledMana",
-          "line": 4114,
+          "line": 4171,
           "kind": "struct",
           "field_names": [
             "base",
@@ -19928,7 +20233,7 @@
     },
     "PermissionGrantee": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1561,
+      "line": 1590,
       "doc": "CR 611.2a + CR 108.3: Identifies which player a `CastingPermission` is granted to at resolution time. Resolved to a concrete `PlayerId` by `grant_permission::resolve` before the permission is written to the target `GameObject`. Drives both `granted_to` binding and, for durations scoped to that player (e.g., `UntilNextTurnOf`), the prune step in `layers.rs`.  Default is `AbilityController` for all pre-existing parser call sites. Additional variants support compound-exile patterns where multiple objects are granted distinct permissions tied to different players: - `ObjectOwner` — Suspend Aggression: \"its owner may play it\". Each object   in the tracked set is granted to its own owner (CR 108.3). - `ParentTargetController` — Expedited Inheritance: \"its controller may   exile [N] ... They may play those cards\". The grant is tied to the   parent effect's player target rather than the triggered-ability controller.",
       "cr_refs": [
         "CR 108.3",
@@ -19937,7 +20242,7 @@
       "variants": [
         {
           "name": "AbilityController",
-          "line": 1564,
+          "line": 1593,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a default — the controller of the effect that created the grant.",
@@ -19947,7 +20252,7 @@
         },
         {
           "name": "ObjectOwner",
-          "line": 1566,
+          "line": 1595,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 — each iterated object's owner (per-object binding).",
@@ -19957,7 +20262,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 1568,
+          "line": 1597,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 — the player target of the parent effect in the chain.",
@@ -20107,7 +20412,7 @@
     },
     "PileSide": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1348,
+      "line": 1392,
       "doc": "CR 700.3: Identifies one of the two piles produced by a `SeparateIntoPiles` partition. Typed rather than `bool` so the `GameAction::ChoosePile` payload and the engine handler share a self-documenting domain and the parser/AI cannot accidentally swap pile semantics. Pile A is the partitioner's chosen subset; pile B is `eligible \\ pile_a`.",
       "cr_refs": [
         "CR 700.3"
@@ -20115,7 +20420,7 @@
       "variants": [
         {
           "name": "A",
-          "line": 1349,
+          "line": 1393,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20123,7 +20428,7 @@
         },
         {
           "name": "B",
-          "line": 1350,
+          "line": 1394,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20239,13 +20544,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3256,
+      "line": 3283,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 3260,
+          "line": 3287,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -20255,7 +20560,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3262,
+          "line": 3289,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -20263,7 +20568,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3264,
+          "line": 3291,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -20273,7 +20578,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 3266,
+          "line": 3293,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -20281,7 +20586,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 3268,
+          "line": 3295,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -20289,7 +20594,7 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 3274,
+          "line": 3301,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.1 + CR 510.1: Each opponent who was dealt combat damage this turn. Resolved against `state.damage_dealt_this_turn` records whose `is_combat = true` and `target = Player(p.id)`. Used by partner-quality \"for each opponent that was dealt combat damage this turn\" cards (Tymna the Weaver).",
@@ -20300,7 +20605,7 @@
         },
         {
           "name": "All",
-          "line": 3276,
+          "line": 3303,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -20308,7 +20613,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 3278,
+          "line": 3305,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -20318,7 +20623,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 3281,
+          "line": 3308,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -20326,7 +20631,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 3285,
+          "line": 3312,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20340,7 +20645,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 3291,
+          "line": 3318,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -20348,7 +20653,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3295,
+          "line": 3322,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -20359,7 +20664,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 3304,
+          "line": 3331,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -20370,7 +20675,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 3315,
+          "line": 3342,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -20383,7 +20688,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3327,
+          "line": 3354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -20393,18 +20698,19 @@
           ]
         },
         {
-          "name": "ControlsPermanent",
-          "line": 3333,
+          "name": "ControlsCount",
+          "line": 3375,
           "kind": "struct",
           "field_names": [
             "relation",
-            "presence",
-            "filter"
+            "filter",
+            "comparator",
+            "count"
           ],
-          "doc": "CR 109.4 + CR 700.1: Each player satisfying `relation` who controls (`presence = Controls`) or does not control (`presence = ControlsNone`) at least one permanent matching `filter`. Covers \"each opponent who controls an artifact\", \"each player who doesn't control a creature\", \"each opponent who doesn't control an Elf\" (Thornbow Archer), etc.",
+          "doc": "CR 109.4 + CR 109.5: Each player satisfying `relation` whose count of controlled permanents matching `filter` compares to `count` under `comparator`. The control relationship is enforced per-candidate at runtime (`obj.controller == candidate`), so `filter` carries no controller axis; `count`'s own `ObjectCount` may carry a `You` controller (CR 109.5 — \"you\" is the effect controller) for comparative \"more X than you\" phrasings.  Covers the full presence/comparison class as a single parameterized variant: - \"each opponent who controls an artifact\" → `{ GE, Fixed(1) }`   (at least one matching permanent). - \"each opponent who doesn't control an Elf\" (Thornbow Archer) →   `{ EQ, Fixed(0) }` (no matching permanent). - \"each player who controls more creatures than you\" (Heidegger) →   `{ GT, Ref(ObjectCount { filter: <creature>.controller(You) }) }`.  `count` is boxed to break the `QuantityExpr → QuantityRef::PlayerCount → PlayerFilter::ControlsCount → QuantityExpr` reference cycle that would otherwise give the enum infinite size.",
           "cr_refs": [
             "CR 109.4",
-            "CR 700.1"
+            "CR 109.5"
           ]
         }
       ],
@@ -20421,7 +20727,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3231,
+      "line": 3271,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -20431,7 +20737,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 3233,
+          "line": 3273,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -20439,7 +20745,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3235,
+          "line": 3275,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -20447,7 +20753,7 @@
         },
         {
           "name": "All",
-          "line": 3237,
+          "line": 3277,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -20458,7 +20764,7 @@
     },
     "PlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2561,
+      "line": 2592,
       "doc": "CR 102 + CR 119 + CR 402: Player axis for player-scoped quantity references.  Parameterizes the player whose hand size, life total, or other per-player scalar is being read. Replaces sibling enum variants like `LifeTotal` / `TargetLifeTotal` / `OpponentLifeTotal` and `HandSize` / `OpponentHandSize` with a single parameterized form.  Categorical-boundary check (per the \"Parameterize, don't proliferate\" principle): every variant is a player-relativity choice within a single CR section. Aggregate scopes (`Opponent`, `AllPlayers`) compose `AggregateFunction` to express max/min/sum across a population — they do not introduce a new abstraction layer.",
       "cr_refs": [
         "CR 102",
@@ -20468,7 +20774,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 2563,
+          "line": 2594,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 / CR 113.6: The controller of the source ability or effect.",
@@ -20479,7 +20785,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2567,
+          "line": 2598,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This keeps \"their\" quantities separate from \"you\" quantities.",
@@ -20490,7 +20796,7 @@
         },
         {
           "name": "Target",
-          "line": 2570,
+          "line": 2601,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 113.6 + CR 115.1: The first player target of the resolving ability (read from `ability.targets`).",
@@ -20502,7 +20808,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2574,
+          "line": 2605,
           "kind": "struct",
           "field_names": [
             "aggregate"
@@ -20515,7 +20821,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2579,
+          "line": 2610,
           "kind": "struct",
           "field_names": [
             "aggregate",
@@ -20528,7 +20834,7 @@
         },
         {
           "name": "RecipientController",
-          "line": 2593,
+          "line": 2624,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4m + CR 613.4c: The controller of the object currently receiving a layer effect. Used for Aura/Equipment statics such as \"enchanted creature gets +1/+1 for each card in its controller's hand\", where \"its\" refers to the enchanted creature, not the Aura.",
@@ -20539,7 +20845,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2599,
+          "line": 2630,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by attack-trigger intervening-if quantities such as \"no opponent has more life than that player.\"",
@@ -20550,7 +20856,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 2605,
+          "line": 2636,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"that opponent\" anaphoring the controller of a bounced/destroyed creature). The player-scalar-axis analogue of `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -20591,7 +20897,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10426,
+      "line": 10602,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -20600,7 +20906,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 10427,
+          "line": 10603,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20608,7 +20914,7 @@
         },
         {
           "name": "Resolved",
-          "line": 10428,
+          "line": 10604,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20619,7 +20925,7 @@
     },
     "PreventionAmount": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 436,
+      "line": 457,
       "doc": "CR 615: How much damage to prevent.",
       "cr_refs": [
         "CR 615"
@@ -20627,7 +20933,7 @@
       "variants": [
         {
           "name": "Next",
-          "line": 438,
+          "line": 459,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Prevent the next N damage\"",
@@ -20635,7 +20941,7 @@
         },
         {
           "name": "All",
-          "line": 440,
+          "line": 461,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Prevent all damage\"",
@@ -20646,7 +20952,7 @@
     },
     "PreventionScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 426,
+      "line": 447,
       "doc": "CR 615: Damage prevention scope.",
       "cr_refs": [
         "CR 615"
@@ -20654,7 +20960,7 @@
       "variants": [
         {
           "name": "AllDamage",
-          "line": 429,
+          "line": 450,
           "kind": "unit",
           "field_names": [],
           "doc": "Prevent all damage (combat + noncombat).",
@@ -20662,7 +20968,7 @@
         },
         {
           "name": "CombatDamage",
-          "line": 431,
+          "line": 452,
           "kind": "unit",
           "field_names": [],
           "doc": "Prevent only combat damage.",
@@ -20673,7 +20979,7 @@
     },
     "ProductionOverride": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 948,
+      "line": 986,
       "doc": "CR 605.3b + CR 106.1a: A pre-resolved choice that short-circuits the normal `ChooseManaColor` prompt. Auto-tap sets this when the cost-payment planner has already determined the exact mana to produce; manual activation leaves it `None` so the player is prompted.  Typed enum (never a bool): `SingleColor` covers the one-color-repeated variants (`AnyOneColor`, `ChoiceAmongExiledColors`), while `Combination` carries the full pre-chosen multi-mana sequence for fixed combinations (`ChoiceAmongCombinations`) and free per-slot choices (`AnyCombination`).",
       "cr_refs": [
         "CR 106.1a",
@@ -20682,7 +20988,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 952,
+          "line": 990,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked a single color; every unit of mana the ability produces becomes this color (mirrors the pre-widening `Option<ManaType>` semantics).",
@@ -20690,7 +20996,7 @@
         },
         {
           "name": "Combination",
-          "line": 955,
+          "line": 993,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked one complete mana sequence; the ability produces exactly these mana types in order.",
@@ -20701,13 +21007,13 @@
     },
     "ProhibitedActivity": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1367,
+      "line": 1396,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "CastOnlyFromZones",
-          "line": 1369,
+          "line": 1398,
           "kind": "struct",
           "field_names": [
             "allowed_zones"
@@ -20720,7 +21026,7 @@
         },
         {
           "name": "CastSpells",
-          "line": 1371,
+          "line": 1400,
           "kind": "struct",
           "field_names": [
             "spell_filter"
@@ -20732,7 +21038,7 @@
         },
         {
           "name": "ActivateAbilities",
-          "line": 1377,
+          "line": 1406,
           "kind": "struct",
           "field_names": [
             "exemption"
@@ -20795,13 +21101,13 @@
     },
     "ProposedEvent": {
       "file": "crates/engine/src/types/proposed_event.rs",
-      "line": 124,
+      "line": 130,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ZoneChange",
-          "line": 125,
+          "line": 131,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -20819,7 +21125,7 @@
         },
         {
           "name": "Damage",
-          "line": 148,
+          "line": 154,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -20833,7 +21139,7 @@
         },
         {
           "name": "Draw",
-          "line": 155,
+          "line": 161,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -20845,7 +21151,7 @@
         },
         {
           "name": "Scry",
-          "line": 162,
+          "line": 168,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -20860,7 +21166,7 @@
         },
         {
           "name": "Mill",
-          "line": 170,
+          "line": 176,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -20876,7 +21182,7 @@
         },
         {
           "name": "LifeGain",
-          "line": 176,
+          "line": 182,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -20888,7 +21194,7 @@
         },
         {
           "name": "LifeLoss",
-          "line": 181,
+          "line": 187,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -20900,7 +21206,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 186,
+          "line": 192,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -20914,7 +21220,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 194,
+          "line": 200,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -20926,8 +21232,27 @@
           "cr_refs": []
         },
         {
-          "name": "CreateToken",
+          "name": "MoveCounter",
           "line": 209,
+          "kind": "struct",
+          "field_names": [
+            "actor",
+            "source_id",
+            "destination_id",
+            "counter_type",
+            "remove_count",
+            "add_count",
+            "stage",
+            "applied"
+          ],
+          "doc": "CR 122.5: Moving a counter is atomic: remove it from one object and put it on another. Replacement effects see the remove and add stages, but the physical counter mutation is committed only after both stages survive.",
+          "cr_refs": [
+            "CR 122.5"
+          ]
+        },
+        {
+          "name": "CreateToken",
+          "line": 229,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -20944,7 +21269,7 @@
         },
         {
           "name": "Discard",
-          "line": 222,
+          "line": 242,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -20957,7 +21282,7 @@
         },
         {
           "name": "Tap",
-          "line": 229,
+          "line": 249,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -20968,7 +21293,7 @@
         },
         {
           "name": "Untap",
-          "line": 233,
+          "line": 253,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -20979,7 +21304,7 @@
         },
         {
           "name": "Destroy",
-          "line": 237,
+          "line": 257,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -20992,7 +21317,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 244,
+          "line": 264,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -21004,7 +21329,7 @@
         },
         {
           "name": "BeginTurn",
-          "line": 255,
+          "line": 275,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -21021,7 +21346,7 @@
         },
         {
           "name": "BeginPhase",
-          "line": 265,
+          "line": 285,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -21036,7 +21361,7 @@
         },
         {
           "name": "ProduceMana",
-          "line": 274,
+          "line": 294,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -21054,7 +21379,7 @@
         },
         {
           "name": "EmptyManaPool",
-          "line": 303,
+          "line": 323,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -21074,7 +21399,7 @@
     },
     "ProtectionTarget": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 326,
+      "line": 328,
       "doc": "What a Protection keyword protects from (CR 702.16).",
       "cr_refs": [
         "CR 702.16"
@@ -21082,22 +21407,6 @@
       "variants": [
         {
           "name": "Color",
-          "line": 327,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CardType",
-          "line": 328,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Quality",
           "line": 329,
           "kind": "tuple",
           "field_names": [],
@@ -21105,8 +21414,24 @@
           "cr_refs": []
         },
         {
-          "name": "Multicolored",
+          "name": "CardType",
           "line": 330,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Quality",
+          "line": 331,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Multicolored",
+          "line": 332,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21114,7 +21439,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 333,
+          "line": 335,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16: Protection from the chosen color — resolved at runtime from the source permanent's `chosen_attributes`.",
@@ -21124,7 +21449,7 @@
         },
         {
           "name": "ChosenCardType",
-          "line": 337,
+          "line": 339,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16 + CR 205.2: \"Protection from the chosen card type\" — resolved at runtime from the source permanent's `chosen_attributes` (the `CardType` chosen as the permanent entered). Parallels `ChosenColor`.",
@@ -21135,7 +21460,7 @@
         },
         {
           "name": "Everything",
-          "line": 341,
+          "line": 343,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16j: \"Protection from everything\" — protection from each object regardless of that object's characteristic values. Matches every source in `source_matches_protection_target`.",
@@ -21145,12 +21470,23 @@
         },
         {
           "name": "Filter",
-          "line": 349,
+          "line": 351,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.16a: \"Protection from [quality]\" where the quality is a characteristic-value predicate expressible as a `TargetFilter`. Covers \"protection from mana value N or less/greater\" and any future filter-based protection (e.g., \"protection from power 2 or less\"). Evaluated by testing the source object's characteristics against the filter's properties — only `FilterProp` predicates that can be resolved from the object alone (without game state) are valid here.",
           "cr_refs": [
             "CR 702.16a"
+          ]
+        },
+        {
+          "name": "FromPlayer",
+          "line": 359,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 702.16k: \"Protection from [a player]\" — protection from each object controlled by the scoped player(s), relative to the protected object's controller, regardless of the source's characteristic values. Covers \"protection from each of your opponents\" (Figure of Fable's Avatar form) via `ControllerRef::Opponent`. CR 702.16i makes \"each of your opponents\" behave as protection from every opponent, which the Opponent scope captures in one variant.",
+          "cr_refs": [
+            "CR 702.16i",
+            "CR 702.16k"
           ]
         }
       ],
@@ -21158,15 +21494,15 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3516,
-      "doc": "CR 208: Selects which creature characteristic a `FilterProp::PtComparison` reads. Power and toughness are both defined in CR 208 (Power/Toughness) and are read identically by a filter — only the field differs — so they are a leaf-level parameterization axis, not a cross-section conflation.",
+      "line": 3559,
+      "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
       ],
       "variants": [
         {
           "name": "Power",
-          "line": 3518,
+          "line": 3561,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -21176,10 +21512,20 @@
         },
         {
           "name": "Toughness",
-          "line": 3520,
+          "line": 3563,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
+          "cr_refs": [
+            "CR 208.1"
+          ]
+        },
+        {
+          "name": "TotalPowerToughness",
+          "line": 3565,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 208.1: The sum of the creature's power and toughness.",
           "cr_refs": [
             "CR 208.1"
           ]
@@ -21189,13 +21535,13 @@
     },
     "PtValue": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 845,
+      "line": 874,
       "doc": "Power/toughness value -- either a fixed integer or a variable reference (e.g. \"*\", \"X\").  Custom Deserialize: accepts both the tagged format `{\"type\":\"Fixed\",\"value\":2}` (new) and plain strings like `\"2\"` or `\"*\"` (legacy card-data.json).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Fixed",
-          "line": 846,
+          "line": 875,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21203,7 +21549,7 @@
         },
         {
           "name": "Variable",
-          "line": 847,
+          "line": 876,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21211,7 +21557,7 @@
         },
         {
           "name": "Quantity",
-          "line": 848,
+          "line": 877,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21222,7 +21568,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3529,
+      "line": 3574,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -21231,7 +21577,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 3532,
+          "line": 3577,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -21241,7 +21587,7 @@
         },
         {
           "name": "Base",
-          "line": 3535,
+          "line": 3580,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -21254,13 +21600,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3344,
+      "line": 3387,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 3346,
+          "line": 3389,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -21270,7 +21616,7 @@
         },
         {
           "name": "Fixed",
-          "line": 3348,
+          "line": 3391,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21280,7 +21626,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 3352,
+          "line": 3395,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21294,7 +21640,7 @@
         },
         {
           "name": "Offset",
-          "line": 3359,
+          "line": 3402,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21307,7 +21653,7 @@
         },
         {
           "name": "Multiply",
-          "line": 3364,
+          "line": 3407,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -21318,7 +21664,7 @@
         },
         {
           "name": "Sum",
-          "line": 3373,
+          "line": 3416,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -21328,7 +21674,7 @@
         },
         {
           "name": "UpTo",
-          "line": 3398,
+          "line": 3441,
           "kind": "struct",
           "field_names": [
             "max"
@@ -21341,7 +21687,7 @@
         },
         {
           "name": "Power",
-          "line": 3404,
+          "line": 3447,
           "kind": "struct",
           "field_names": [
             "base",
@@ -21354,7 +21700,7 @@
         },
         {
           "name": "Difference",
-          "line": 3419,
+          "line": 3462,
           "kind": "struct",
           "field_names": [
             "left",
@@ -21370,7 +21716,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10278,
+      "line": 10454,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -21378,7 +21724,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10280,
+          "line": 10456,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -21386,7 +21732,7 @@
         },
         {
           "name": "Plus",
-          "line": 10282,
+          "line": 10458,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21396,7 +21742,7 @@
         },
         {
           "name": "Minus",
-          "line": 10284,
+          "line": 10460,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21406,7 +21752,7 @@
         },
         {
           "name": "Prevent",
-          "line": 10304,
+          "line": 10480,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -21423,13 +21769,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2690,
+      "line": 2721,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 2694,
+          "line": 2725,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21441,7 +21787,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 2697,
+          "line": 2728,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21453,7 +21799,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 2703,
+          "line": 2734,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21465,7 +21811,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 2706,
+          "line": 2737,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -21473,7 +21819,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 2708,
+          "line": 2739,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -21483,7 +21829,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 2711,
+          "line": 2742,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21493,7 +21839,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 2728,
+          "line": 2759,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -21507,7 +21853,7 @@
         },
         {
           "name": "PlayerCount",
-          "line": 2735,
+          "line": 2766,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21517,7 +21863,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 2756,
+          "line": 2787,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -21530,7 +21876,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 2765,
+          "line": 2796,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -21543,7 +21889,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 2784,
+          "line": 2815,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -21560,7 +21906,7 @@
         },
         {
           "name": "Variable",
-          "line": 2789,
+          "line": 2820,
           "kind": "struct",
           "field_names": [
             "name"
@@ -21570,7 +21916,7 @@
         },
         {
           "name": "Power",
-          "line": 2796,
+          "line": 2827,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -21584,7 +21930,7 @@
         },
         {
           "name": "Toughness",
-          "line": 2801,
+          "line": 2832,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -21598,7 +21944,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 2807,
+          "line": 2838,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -21611,7 +21957,7 @@
         },
         {
           "name": "ObjectColorCount",
-          "line": 2813,
+          "line": 2844,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -21624,7 +21970,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 2818,
+          "line": 2849,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -21637,7 +21983,7 @@
         },
         {
           "name": "ManaSymbolsInManaCost",
-          "line": 2825,
+          "line": 2856,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -21651,7 +21997,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 2837,
+          "line": 2868,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -21663,7 +22009,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 2839,
+          "line": 2870,
           "kind": "struct",
           "field_names": [
             "function",
@@ -21677,7 +22023,7 @@
         },
         {
           "name": "ControlledByEachPlayer",
-          "line": 2856,
+          "line": 2887,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -21691,7 +22037,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 2863,
+          "line": 2894,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -21701,7 +22047,7 @@
         },
         {
           "name": "Devotion",
-          "line": 2865,
+          "line": 2896,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -21713,7 +22059,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 2869,
+          "line": 2900,
           "kind": "struct",
           "field_names": [
             "source"
@@ -21725,7 +22071,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 2874,
+          "line": 2905,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -21736,7 +22082,7 @@
         },
         {
           "name": "ZoneCardCount",
-          "line": 2878,
+          "line": 2909,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -21750,7 +22096,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 2885,
+          "line": 2916,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -21762,7 +22108,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 2889,
+          "line": 2920,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -21772,7 +22118,7 @@
         },
         {
           "name": "ExiledFromHandThisResolution",
-          "line": 2895,
+          "line": 2926,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -21783,7 +22129,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 2899,
+          "line": 2930,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -21793,7 +22139,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 2914,
+          "line": 2945,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21806,7 +22152,7 @@
         },
         {
           "name": "PartySize",
-          "line": 2923,
+          "line": 2954,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21819,7 +22165,7 @@
         },
         {
           "name": "Speed",
-          "line": 2930,
+          "line": 2961,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21831,7 +22177,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 2933,
+          "line": 2964,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -21841,7 +22187,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 2941,
+          "line": 2972,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -21855,7 +22201,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 2953,
+          "line": 2984,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -21867,7 +22213,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 2956,
+          "line": 2987,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -21880,7 +22226,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2963,
+          "line": 2994,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21890,7 +22236,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 2969,
+          "line": 3000,
           "kind": "struct",
           "field_names": [
             "player",
@@ -21903,7 +22249,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 2974,
+          "line": 3005,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -21913,7 +22259,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 2980,
+          "line": 3011,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21925,7 +22271,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 2985,
+          "line": 3016,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21937,7 +22283,7 @@
         },
         {
           "name": "LandsPlayedThisTurn",
-          "line": 2989,
+          "line": 3020,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21950,7 +22296,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 2992,
+          "line": 3023,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -21960,7 +22306,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 2996,
+          "line": 3027,
           "kind": "struct",
           "field_names": [
             "from",
@@ -21975,7 +22321,7 @@
         },
         {
           "name": "DamageDealtThisTurn",
-          "line": 3016,
+          "line": 3047,
           "kind": "struct",
           "field_names": [
             "source",
@@ -21992,7 +22338,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 3029,
+          "line": 3060,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -22000,7 +22346,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 3033,
+          "line": 3064,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Number of creatures the controller attacked with this turn. Used for \"if you attacked this turn\" and \"for each creature you attacked with this turn\" patterns.",
@@ -22010,7 +22356,7 @@
         },
         {
           "name": "DescendedThisTurn",
-          "line": 3035,
+          "line": 3066,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -22020,7 +22366,7 @@
         },
         {
           "name": "LoyaltyAbilitiesActivatedThisTurn",
-          "line": 3043,
+          "line": 3074,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22034,7 +22380,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 3046,
+          "line": 3077,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -22044,7 +22390,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 3060,
+          "line": 3091,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22058,7 +22404,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 3071,
+          "line": 3102,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -22073,7 +22419,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 3080,
+          "line": 3111,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22086,7 +22432,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 3085,
+          "line": 3116,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22100,7 +22446,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 3093,
+          "line": 3124,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22114,7 +22460,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 3098,
+          "line": 3129,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -22124,7 +22470,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 3105,
+          "line": 3136,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -22134,7 +22480,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 3108,
+          "line": 3139,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -22145,7 +22491,7 @@
         },
         {
           "name": "AdditionalCostPaymentCount",
-          "line": 3112,
+          "line": 3143,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost payments made for the source spell. Used by Squad so its payment count remains distinct from Kicker's CR 702.33 payment model.",
@@ -22157,7 +22503,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 3116,
+          "line": 3147,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -22167,7 +22513,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 3121,
+          "line": 3152,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22181,7 +22527,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 3132,
+          "line": 3163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -22192,7 +22538,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 3137,
+          "line": 3168,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -22202,7 +22548,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 3144,
+          "line": 3175,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22212,6 +22558,20 @@
             "CR 105.1",
             "CR 106.1",
             "CR 109.1"
+          ]
+        },
+        {
+          "name": "DistinctCounterKindsAmong",
+          "line": 3184,
+          "kind": "struct",
+          "field_names": [
+            "filter"
+          ],
+          "doc": "CR 122.1: distinct counter kinds among filter-matched permanents (controller-relative, CR 109.4). Counter-side dual of `DistinctColorsAmongPermanents` — counts each distinct `CounterType` appearing on at least one permanent matching `filter` exactly once. Used by Bribe Taker's \"for each kind of counter on permanents you control\" iteration source. Kept a separate variant from the color dual because counters (CR 122.1) and colors (CR 105/106) are distinct rule sections the engine resolves independently.",
+          "cr_refs": [
+            "CR 105",
+            "CR 109.4",
+            "CR 122.1"
           ]
         }
       ],
@@ -22285,7 +22645,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8613,
+      "line": 8752,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -22294,7 +22654,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 8617,
+          "line": 8756,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -22307,13 +22667,25 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9596,
+      "line": 9761,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
+          "name": "And",
+          "line": 9764,
+          "kind": "struct",
+          "field_names": [
+            "conditions"
+          ],
+          "doc": "CR 614.1d: A replacement may carry multiple independent restrictions. Every child condition must match for the replacement to apply.",
+          "cr_refs": [
+            "CR 614.1d"
+          ]
+        },
+        {
           "name": "UnlessControlsSubtype",
-          "line": 9600,
+          "line": 9770,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22323,7 +22695,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 9607,
+          "line": 9777,
           "kind": "struct",
           "field_names": [
             "count",
@@ -22336,7 +22708,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 9612,
+          "line": 9782,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22348,7 +22720,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 9617,
+          "line": 9787,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -22361,7 +22733,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 9620,
+          "line": 9790,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -22373,7 +22745,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 9623,
+          "line": 9793,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -22383,7 +22755,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 9626,
+          "line": 9796,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -22394,7 +22766,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 9634,
+          "line": 9804,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22407,7 +22779,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 9648,
+          "line": 9818,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22420,7 +22792,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9657,
+          "line": 9827,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -22431,7 +22803,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 9660,
+          "line": 9830,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -22441,7 +22813,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9666,
+          "line": 9836,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -22453,7 +22825,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9671,
+          "line": 9841,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22465,7 +22837,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 9676,
+          "line": 9846,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -22476,7 +22848,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 9685,
+          "line": 9855,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -22488,7 +22860,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 9692,
+          "line": 9862,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -22502,7 +22874,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 9700,
+          "line": 9870,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -22512,7 +22884,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 9705,
+          "line": 9875,
           "kind": "struct",
           "field_names": [
             "source"
@@ -22526,7 +22898,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 9709,
+          "line": 9879,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -22539,7 +22911,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 9714,
+          "line": 9884,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -22550,7 +22922,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 9725,
+          "line": 9895,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22563,7 +22935,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9736,
+          "line": 9906,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -22575,7 +22947,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 9744,
+          "line": 9914,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -22587,8 +22959,20 @@
           ]
         },
         {
+          "name": "ClassLevelGE",
+          "line": 9924,
+          "kind": "struct",
+          "field_names": [
+            "level"
+          ],
+          "doc": "CR 716.2a: Replacement effect granted by a Class enchantment level — applies only while the source Class is at `level` or higher. Parallels `StaticCondition::ClassLevelGE`. Innkeeper's Talent level 3 (the \"twice that many of each of those kinds of counters\" doubling replacement) is the canonical case.",
+          "cr_refs": [
+            "CR 716.2a"
+          ]
+        },
+        {
           "name": "Unrecognized",
-          "line": 9753,
+          "line": 9929,
           "kind": "struct",
           "field_names": [
             "text"
@@ -22992,13 +23376,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10392,
+      "line": 10568,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 10395,
+          "line": 10571,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -23006,7 +23390,7 @@
         },
         {
           "name": "Optional",
-          "line": 10397,
+          "line": 10573,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -23016,7 +23400,7 @@
         },
         {
           "name": "MayCost",
-          "line": 10404,
+          "line": 10580,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -23033,7 +23417,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10380,
+      "line": 10556,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 614.1a"
@@ -23041,7 +23425,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 10382,
+          "line": 10558,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source's controller.",
@@ -23049,7 +23433,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10384,
+          "line": 10560,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source's controller.",
@@ -23057,7 +23441,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 10386,
+          "line": 10562,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -23068,13 +23452,13 @@
     },
     "RestrictionExpiry": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1383,
+      "line": 1412,
       "doc": "When a game restriction expires.",
       "cr_refs": [],
       "variants": [
         {
           "name": "EndOfTurn",
-          "line": 1384,
+          "line": 1413,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23082,7 +23466,7 @@
         },
         {
           "name": "EndOfCombat",
-          "line": 1385,
+          "line": 1414,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23090,7 +23474,7 @@
         },
         {
           "name": "UntilPlayerNextTurn",
-          "line": 1386,
+          "line": 1415,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23103,13 +23487,13 @@
     },
     "RestrictionPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1401,
+      "line": 1430,
       "doc": "Identifies which players are affected by a temporary game restriction.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 1402,
+          "line": 1431,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23117,7 +23501,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 1403,
+          "line": 1432,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -23125,7 +23509,7 @@
         },
         {
           "name": "TargetedPlayer",
-          "line": 1406,
+          "line": 1435,
           "kind": "unit",
           "field_names": [],
           "doc": "Placeholder used by parser lowering for effects that target a player. Resolved to `SpecificPlayer` by `add_restriction` at resolution time.",
@@ -23133,7 +23517,7 @@
         },
         {
           "name": "ParentTargetedPlayer",
-          "line": 1411,
+          "line": 1440,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Anaphoric \"that player\" in a sub-ability reuses a player target already chosen for an earlier instruction in the same chain. Resolved to `SpecificPlayer` by `add_restriction` after parent target propagation, without declaring a second target slot.",
@@ -23143,7 +23527,7 @@
         },
         {
           "name": "OpponentsOfSourceController",
-          "line": 1412,
+          "line": 1441,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23154,13 +23538,13 @@
     },
     "RestrictionScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1392,
+      "line": 1421,
       "doc": "Limits the scope of a game restriction to specific sources or targets.",
       "cr_refs": [],
       "variants": [
         {
           "name": "SourcesControlledBy",
-          "line": 1393,
+          "line": 1422,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -23168,7 +23552,7 @@
         },
         {
           "name": "SpecificSource",
-          "line": 1394,
+          "line": 1423,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -23176,7 +23560,7 @@
         },
         {
           "name": "DamageToTarget",
-          "line": 1395,
+          "line": 1424,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -23187,7 +23571,7 @@
     },
     "RetargetScope": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2852,
+      "line": 2930,
       "doc": "CR 115.7: Scope of retargeting — single target, all targets, or forced.",
       "cr_refs": [
         "CR 115.7"
@@ -23195,7 +23579,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 2853,
+          "line": 2931,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23203,7 +23587,7 @@
         },
         {
           "name": "All",
-          "line": 2854,
+          "line": 2932,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23211,7 +23595,7 @@
         },
         {
           "name": "ForcedTo",
-          "line": 2855,
+          "line": 2933,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -23222,7 +23606,7 @@
     },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3151,
+      "line": 3191,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -23230,7 +23614,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 3152,
+          "line": 3192,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23238,7 +23622,7 @@
         },
         {
           "name": "Down",
-          "line": 3153,
+          "line": 3193,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23249,7 +23633,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4208,
+      "line": 4265,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -23257,7 +23641,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 4210,
+          "line": 4267,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -23268,13 +23652,13 @@
     },
     "SearchSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 82,
+      "line": 90,
       "doc": "Selection constraint applied to multi-card library searches at the `WaitingFor::SearchChoice` step. Lives one abstraction up from `count` / `up_to` so the engine can reject illegal combinations and the AI can prune its candidate space without bespoke per-card knowledge.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 85,
+          "line": 93,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: No restriction beyond `count` (and `up_to`).",
@@ -23284,7 +23668,7 @@
         },
         {
           "name": "DistinctQualities",
-          "line": 90,
+          "line": 98,
           "kind": "struct",
           "field_names": [
             "qualities"
@@ -23296,7 +23680,7 @@
         },
         {
           "name": "TotalManaValue",
-          "line": 95,
+          "line": 103,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -23310,7 +23694,7 @@
         },
         {
           "name": "MatchEachFilter",
-          "line": 100,
+          "line": 108,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -23326,7 +23710,7 @@
     },
     "ShardChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1144,
+      "line": 1182,
       "doc": "CR 107.4f + CR 601.2f: The caster's resolved choice for one Phyrexian shard.",
       "cr_refs": [
         "CR 107.4f",
@@ -23335,7 +23719,7 @@
       "variants": [
         {
           "name": "PayMana",
-          "line": 1146,
+          "line": 1184,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay one mana of the shard's color (or either component color for hybrid-Phyrexian).",
@@ -23343,7 +23727,7 @@
         },
         {
           "name": "PayLife",
-          "line": 1148,
+          "line": 1186,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay 2 life.",
@@ -23354,7 +23738,7 @@
     },
     "ShardOptions": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1132,
+      "line": 1170,
       "doc": "CR 107.4f + CR 601.2h: Which legal payments a single Phyrexian shard offers to the caster. Computed from the mana pool state (Phyrexian color availability) combined with the caster's life total and CantLoseLife status (CR 118.3 + CR 119.8).  The engine pauses at `WaitingFor::PhyrexianPayment` whenever any shard would deduct life — both `ManaOrLife` (player explicitly picks mana vs life) and `LifeOnly` (life is the only remaining payment route; player confirms or cancels via `CancelCast`). Only `ManaOnly` shards auto-resolve without surfacing the prompt, since they have no life consequence (issue #704: silent life deduction violated CR 601.2h's right to refuse the cast).",
       "cr_refs": [
         "CR 107.4f",
@@ -23365,7 +23749,7 @@
       "variants": [
         {
           "name": "ManaOrLife",
-          "line": 1134,
+          "line": 1172,
           "kind": "unit",
           "field_names": [],
           "doc": "Both mana and 2 life are legal payments; player must choose.",
@@ -23373,7 +23757,7 @@
         },
         {
           "name": "ManaOnly",
-          "line": 1136,
+          "line": 1174,
           "kind": "unit",
           "field_names": [],
           "doc": "Only mana is legal (insufficient life or CR 119.8 CantLoseLife lock).",
@@ -23383,7 +23767,7 @@
         },
         {
           "name": "LifeOnly",
-          "line": 1138,
+          "line": 1176,
           "kind": "unit",
           "field_names": [],
           "doc": "Only 2 life is legal (no mana of the shard's color available, given restrictions).",
@@ -23394,13 +23778,13 @@
     },
     "SharedQuality": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1778,
+      "line": 1807,
       "doc": "Qualities that can be shared across multi-target selections. Used by `FilterProp::SharesQuality` for group constraint validation at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Name",
-          "line": 1780,
+          "line": 1809,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: object names compared by shared name.",
@@ -23410,7 +23794,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 1782,
+          "line": 1811,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: mana value.",
@@ -23420,7 +23804,7 @@
         },
         {
           "name": "Power",
-          "line": 1784,
+          "line": 1813,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: power.",
@@ -23430,7 +23814,7 @@
         },
         {
           "name": "Toughness",
-          "line": 1786,
+          "line": 1815,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: toughness.",
@@ -23440,7 +23824,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 1788,
+          "line": 1817,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: sum of power and toughness.",
@@ -23450,7 +23834,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 1789,
+          "line": 1818,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23458,7 +23842,7 @@
         },
         {
           "name": "Color",
-          "line": 1790,
+          "line": 1819,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23466,7 +23850,7 @@
         },
         {
           "name": "CardType",
-          "line": 1791,
+          "line": 1820,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23474,7 +23858,7 @@
         },
         {
           "name": "LandType",
-          "line": 1793,
+          "line": 1822,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.6: land subtypes, including the five basic land types.",
@@ -23488,13 +23872,13 @@
     },
     "SharedQualityRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1798,
+      "line": 1827,
       "doc": "Relationship required by `FilterProp::SharesQuality`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Shares",
-          "line": 1800,
+          "line": 1829,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23502,7 +23886,7 @@
         },
         {
           "name": "DoesNotShare",
-          "line": 1801,
+          "line": 1830,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23513,13 +23897,13 @@
     },
     "ShieldKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 463,
+      "line": 484,
       "doc": "Shield type for one-shot replacement effects that expire at cleanup.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 465,
+          "line": 486,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23527,7 +23911,7 @@
         },
         {
           "name": "Regeneration",
-          "line": 467,
+          "line": 488,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.19a: Regeneration shield — consumed on use, expires at cleanup.",
@@ -23537,7 +23921,7 @@
         },
         {
           "name": "Prevention",
-          "line": 469,
+          "line": 490,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -23549,7 +23933,7 @@
         },
         {
           "name": "DamageReplacementOneShot",
-          "line": 476,
+          "line": 497,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.5 + CR 614.1a: One-shot damage-amount replacement created by an effect (\"the next time ... would deal damage this turn, it deals double that damage instead\" — Desperate Gambit). Gets one opportunity to affect a damage event, is consumed on use, and expires at cleanup. Distinct from a continuous static `damage_modification` (Furnace of Rath), which keeps `ShieldKind::None` and re-applies to every damage event.",
@@ -23560,7 +23944,7 @@
         },
         {
           "name": "Redirection",
-          "line": 480,
+          "line": 501,
           "kind": "struct",
           "field_names": [
             "recipient"
@@ -23611,7 +23995,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3542,
+      "line": 3587,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -23620,7 +24004,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 3544,
+          "line": 3589,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -23632,7 +24016,7 @@
         },
         {
           "name": "Text",
-          "line": 3550,
+          "line": 3595,
           "kind": "struct",
           "field_names": [
             "description"
@@ -23645,7 +24029,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4886,
+      "line": 4943,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -23653,7 +24037,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 4888,
+          "line": 4945,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -23663,7 +24047,7 @@
         },
         {
           "name": "Decrease",
-          "line": 4890,
+          "line": 4947,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -23676,13 +24060,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4695,
+      "line": 4752,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 4696,
+          "line": 4753,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23690,7 +24074,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 4697,
+          "line": 4754,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23698,7 +24082,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 4698,
+          "line": 4755,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23706,7 +24090,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 4700,
+          "line": 4757,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -23719,13 +24103,13 @@
     },
     "StackEntryKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3389,
+      "line": 3527,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 3390,
+          "line": 3528,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -23738,7 +24122,7 @@
         },
         {
           "name": "ActivatedAbility",
-          "line": 3404,
+          "line": 3542,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -23749,7 +24133,7 @@
         },
         {
           "name": "TriggeredAbility",
-          "line": 3408,
+          "line": 3546,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -23765,7 +24149,7 @@
         },
         {
           "name": "KeywordAction",
-          "line": 3444,
+          "line": 3582,
           "kind": "struct",
           "field_names": [
             "action"
@@ -23781,13 +24165,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3616,
+      "line": 3661,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 3617,
+          "line": 3662,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -23798,7 +24182,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 3621,
+          "line": 3666,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23808,7 +24192,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 3627,
+          "line": 3672,
           "kind": "struct",
           "field_names": [
             "color"
@@ -23818,7 +24202,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 3636,
+          "line": 3681,
           "kind": "struct",
           "field_names": [
             "label"
@@ -23831,7 +24215,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3642,
+          "line": 3687,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -23843,7 +24227,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 3648,
+          "line": 3693,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -23853,7 +24237,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 3650,
+          "line": 3695,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -23866,7 +24250,7 @@
         },
         {
           "name": "And",
-          "line": 3654,
+          "line": 3699,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -23876,7 +24260,7 @@
         },
         {
           "name": "Or",
-          "line": 3658,
+          "line": 3703,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -23886,7 +24270,7 @@
         },
         {
           "name": "Not",
-          "line": 3664,
+          "line": 3709,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -23896,7 +24280,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 3668,
+          "line": 3713,
           "kind": "struct",
           "field_names": [
             "state"
@@ -23908,7 +24292,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 3677,
+          "line": 3722,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -23924,7 +24308,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 3688,
+          "line": 3733,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -23939,7 +24323,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 3696,
+          "line": 3741,
           "kind": "struct",
           "field_names": [
             "level"
@@ -23951,7 +24335,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 3703,
+          "line": 3748,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23963,7 +24347,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 3707,
+          "line": 3752,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -23973,7 +24357,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3711,
+          "line": 3756,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -23984,7 +24368,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 3715,
+          "line": 3760,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -23995,7 +24379,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3719,
+          "line": 3764,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -24005,7 +24389,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 3721,
+          "line": 3766,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -24015,7 +24399,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 3724,
+          "line": 3769,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -24025,7 +24409,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 3726,
+          "line": 3771,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -24035,7 +24419,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 3729,
+          "line": 3774,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -24045,7 +24429,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 3735,
+          "line": 3780,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -24057,7 +24441,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 3743,
+          "line": 3788,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -24069,7 +24453,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3747,
+          "line": 3792,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24081,7 +24465,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 3772,
+          "line": 3817,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -24099,7 +24483,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 3781,
+          "line": 3826,
           "kind": "struct",
           "field_names": [
             "text"
@@ -24109,7 +24493,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 3784,
+          "line": 3829,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24117,7 +24501,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3787,
+          "line": 3832,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -24127,7 +24511,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 3789,
+          "line": 3834,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -24137,7 +24521,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 3791,
+          "line": 3836,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24149,7 +24533,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 3797,
+          "line": 3842,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -24163,7 +24547,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 3802,
+          "line": 3847,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -24173,7 +24557,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 3809,
+          "line": 3854,
           "kind": "struct",
           "field_names": [
             "player"
@@ -24186,7 +24570,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 3814,
+          "line": 3859,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -24196,7 +24580,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 3818,
+          "line": 3863,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -24206,7 +24590,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 3822,
+          "line": 3867,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -24217,7 +24601,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 3826,
+          "line": 3871,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24228,8 +24612,20 @@
           ]
         },
         {
+          "name": "RecipientMatchesFilter",
+          "line": 3883,
+          "kind": "struct",
+          "field_names": [
+            "filter"
+          ],
+          "doc": "CR 611.3a: the recipient (effective subject) of the continuous effect matches `filter`; re-evaluated per affected object each layer cycle (mirrors `RecipientHasCounters`, the recipient analog of `HasCounters`). CR 611.3a: \"A continuous effect generated by a static ability isn't 'locked in'; it applies at any given moment to whatever its text indicates\" — so the anaphoric \"it\" in \"... as long as it's a Zombie\" binds to whatever object is currently receiving the effect: an Aura's enchanted creature, the source itself (SelfRef), or each affected object in a per-recipient anthem. `filter` is a plain type/subtype/color/supertype `TargetFilter::Typed` — no attachment prop, no recipient prop.",
+          "cr_refs": [
+            "CR 611.3a"
+          ]
+        },
+        {
           "name": "SourceIsPaired",
-          "line": 3830,
+          "line": 3887,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -24239,7 +24635,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 3833,
+          "line": 3890,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -24251,7 +24647,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 3839,
+          "line": 3896,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -24262,7 +24658,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 3844,
+          "line": 3901,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ReduceCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -24273,7 +24669,7 @@
         },
         {
           "name": "None",
-          "line": 3845,
+          "line": 3902,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24284,13 +24680,13 @@
     },
     "StaticMode": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 377,
+      "line": 422,
       "doc": "All static ability modes from Forge's static ability registry. Matched case-sensitively against Forge mode strings.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Continuous",
-          "line": 378,
+          "line": 423,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24298,7 +24694,7 @@
         },
         {
           "name": "CantAttack",
-          "line": 379,
+          "line": 424,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24306,7 +24702,7 @@
         },
         {
           "name": "CantBlock",
-          "line": 380,
+          "line": 425,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24314,7 +24710,7 @@
         },
         {
           "name": "CantAttackOrBlock",
-          "line": 381,
+          "line": 426,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24322,7 +24718,7 @@
         },
         {
           "name": "MaxAttackersEachCombat",
-          "line": 384,
+          "line": 429,
           "kind": "struct",
           "field_names": [
             "max"
@@ -24334,7 +24730,7 @@
         },
         {
           "name": "MaxBlockersEachCombat",
-          "line": 389,
+          "line": 434,
           "kind": "struct",
           "field_names": [
             "max"
@@ -24346,7 +24742,7 @@
         },
         {
           "name": "CantBeTargeted",
-          "line": 392,
+          "line": 437,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24354,7 +24750,7 @@
         },
         {
           "name": "CantBeCast",
-          "line": 395,
+          "line": 440,
           "kind": "struct",
           "field_names": [
             "who"
@@ -24366,7 +24762,7 @@
         },
         {
           "name": "CantBeActivated",
-          "line": 421,
+          "line": 466,
           "kind": "struct",
           "field_names": [
             "who",
@@ -24382,7 +24778,7 @@
         },
         {
           "name": "CantSearchLibrary",
-          "line": 434,
+          "line": 479,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -24395,7 +24791,7 @@
         },
         {
           "name": "CastWithFlash",
-          "line": 437,
+          "line": 482,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24403,7 +24799,7 @@
         },
         {
           "name": "GrantsExtraVote",
-          "line": 449,
+          "line": 494,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38d: While voting, the controller of this permanent may vote an additional time. Each active source grants +1 to the controller's `Player::extra_votes_per_session` snapshot taken at vote-session start (Tivit, Seller of Secrets — \"While voting, you may vote an additional time.\").  The vote-effect resolver scans the battlefield for permanents with this static at session start (CR 701.38d: extra votes happen at the same time the player would otherwise have voted). It does *not* feed into layer 7 — there is no continuous P/T or keyword grant; the static is a pure \"session-start +1 votes\" signal.",
@@ -24413,7 +24809,7 @@
         },
         {
           "name": "CastWithKeyword",
-          "line": 453,
+          "line": 498,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -24424,8 +24820,22 @@
           ]
         },
         {
+          "name": "CastWithAlternativeCost",
+          "line": 509,
+          "kind": "struct",
+          "field_names": [
+            "cost"
+          ],
+          "doc": "CR 118.9 + CR 601.2f: A permanent grants its controller a wholesale alternative MANA cost for spells matching `StaticDefinition::affected` that the controller casts — they may pay `cost` rather than the spell's mana cost. Parallel to `CastWithKeyword`. Distinct from `ReduceCost` (subtractive, CR 601.2f) — this REPLACES the mana cost wholesale (CR 118.9) and is mutually exclusive with other alternative costs (CR 118.9a). Rooftop Storm ({0}, Zombie creature spells), Fist of Suns ({WUBRG}, any spell), Jodah (MV 5+).",
+          "cr_refs": [
+            "CR 118.9",
+            "CR 118.9a",
+            "CR 601.2f"
+          ]
+        },
+        {
           "name": "ReduceCost",
-          "line": 458,
+          "line": 514,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -24439,7 +24849,7 @@
         },
         {
           "name": "ReduceAbilityCost",
-          "line": 467,
+          "line": 523,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -24454,7 +24864,7 @@
         },
         {
           "name": "ModifyActivationLimit",
-          "line": 482,
+          "line": 538,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -24467,7 +24877,7 @@
         },
         {
           "name": "ActivateAsInstant",
-          "line": 492,
+          "line": 548,
           "kind": "struct",
           "field_names": [
             "cost_category"
@@ -24480,7 +24890,7 @@
         },
         {
           "name": "RaiseCost",
-          "line": 497,
+          "line": 553,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -24494,7 +24904,7 @@
         },
         {
           "name": "MinimumCost",
-          "line": 525,
+          "line": 581,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -24507,7 +24917,7 @@
         },
         {
           "name": "CantPayCost",
-          "line": 536,
+          "line": 592,
           "kind": "struct",
           "field_names": [
             "who",
@@ -24522,7 +24932,7 @@
         },
         {
           "name": "CantGainLife",
-          "line": 540,
+          "line": 596,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24530,7 +24940,7 @@
         },
         {
           "name": "CantLoseLife",
-          "line": 541,
+          "line": 597,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24538,7 +24948,7 @@
         },
         {
           "name": "PlayerProtection",
-          "line": 550,
+          "line": 606,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.16: The scoped player(s) have protection from a quality — e.g. Serra's Emissary's \"You ... have protection from the chosen card type.\" Player scope rides on `StaticDefinition::affected` (identical to `CantGainLife`); `ProtectionTarget` is the canonical protection-quality axis. Data-carrying variant — not registry-registered (see `coverage::is_data_carrying_static`); consumed by direct pattern-match in `player_protection_from`. Only the `ChosenCardType` arm is runtime-implemented; other arms are inert.",
@@ -24548,7 +24958,7 @@
         },
         {
           "name": "MustAttack",
-          "line": 551,
+          "line": 607,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24556,7 +24966,7 @@
         },
         {
           "name": "MustBlock",
-          "line": 552,
+          "line": 608,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24564,7 +24974,7 @@
         },
         {
           "name": "CantDraw",
-          "line": 553,
+          "line": 609,
           "kind": "struct",
           "field_names": [
             "who"
@@ -24574,7 +24984,7 @@
         },
         {
           "name": "DoubleTriggers",
-          "line": 560,
+          "line": 616,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -24586,7 +24996,7 @@
         },
         {
           "name": "IgnoreHexproof",
-          "line": 563,
+          "line": 619,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24594,7 +25004,7 @@
         },
         {
           "name": "ExtraBlockers",
-          "line": 566,
+          "line": 622,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24607,7 +25017,7 @@
         },
         {
           "name": "RevealTopOfLibrary",
-          "line": 571,
+          "line": 627,
           "kind": "struct",
           "field_names": [
             "all_players"
@@ -24619,7 +25029,7 @@
         },
         {
           "name": "GraveyardCastPermission",
-          "line": 576,
+          "line": 632,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -24634,7 +25044,7 @@
         },
         {
           "name": "TopOfLibraryCastPermission",
-          "line": 606,
+          "line": 662,
           "kind": "struct",
           "field_names": [
             "play_mode",
@@ -24649,7 +25059,7 @@
         },
         {
           "name": "CastFromHandFree",
-          "line": 623,
+          "line": 679,
           "kind": "struct",
           "field_names": [
             "frequency"
@@ -24661,8 +25071,24 @@
           ]
         },
         {
+          "name": "ExileCastPermission",
+          "line": 706,
+          "kind": "struct",
+          "field_names": [
+            "frequency",
+            "play_mode",
+            "cost"
+          ],
+          "doc": "CR 601.2a + CR 113.6b + CR 118.9: Static ability granting permission to cast cards exiled with this source — restricted to cards exiled *this turn* — typically without paying the mana cost. Maralen, Fae Ascendant is the type specimen (\"Once each turn, you may cast a spell with mana value less than or equal to the number of Elves and Faeries you control from among cards exiled with Maralen this turn without paying its mana cost.\").  The source pool is the per-turn list `GameState::cards_exiled_with_source_this_turn[source_id]`. The static's `affected: TargetFilter` constrains the eligible cards (type, mana value, etc.). Per-turn frequency tracking is keyed on `source_id` in `GameState::exile_cast_permissions_used` for `OncePerTurn`; `Unlimited` skips tracking.  Distinct from `GraveyardCastPermission`: the source pool is exile (per-turn-scoped), not the controller's graveyard. Distinct from `TopOfLibraryCastPermission`: the eligible cards are a tracked exile set carved out by a prior exile-with-source effect, not the live top of library. Distinct from `Effect::CastFromZone` (Court of Locthwain, Mizzix's Mastery): that is a one-shot effect that grants per-card permissions; this is a continuous static that grants the controller a recurring per-turn cast slot.",
+          "cr_refs": [
+            "CR 113.6b",
+            "CR 118.9",
+            "CR 601.2a"
+          ]
+        },
+        {
           "name": "CantBeCountered",
-          "line": 628,
+          "line": 725,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2: This spell/permanent can't be countered.",
@@ -24672,7 +25098,7 @@
         },
         {
           "name": "CantBeCopied",
-          "line": 631,
+          "line": 728,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2 + CR 707.10: This spell can't be copied by spells or abilities. Enforced in `copy_spell::resolve` when selecting the spell to copy.",
@@ -24683,7 +25109,7 @@
         },
         {
           "name": "CantEnterBattlefieldFrom",
-          "line": 633,
+          "line": 730,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 604.3: Cards in specified zones can't enter the battlefield.",
@@ -24693,7 +25119,7 @@
         },
         {
           "name": "CantCastFrom",
-          "line": 635,
+          "line": 732,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 604.3: Players can't cast spells from specified zones.",
@@ -24703,7 +25129,7 @@
         },
         {
           "name": "CantCastDuring",
-          "line": 639,
+          "line": 736,
           "kind": "struct",
           "field_names": [
             "who",
@@ -24716,7 +25142,7 @@
         },
         {
           "name": "CantActivateDuring",
-          "line": 666,
+          "line": 763,
           "kind": "struct",
           "field_names": [
             "who",
@@ -24734,7 +25160,7 @@
         },
         {
           "name": "PerTurnCastLimit",
-          "line": 676,
+          "line": 773,
           "kind": "struct",
           "field_names": [
             "who",
@@ -24749,7 +25175,7 @@
         },
         {
           "name": "PerTurnDrawLimit",
-          "line": 684,
+          "line": 781,
           "kind": "struct",
           "field_names": [
             "who",
@@ -24762,7 +25188,7 @@
         },
         {
           "name": "SuppressTriggers",
-          "line": 711,
+          "line": 808,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -24777,7 +25203,7 @@
         },
         {
           "name": "CantBeBlocked",
-          "line": 718,
+          "line": 815,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: This creature can't be blocked.",
@@ -24787,7 +25213,7 @@
         },
         {
           "name": "CantBeBlockedExceptBy",
-          "line": 720,
+          "line": 817,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -24799,7 +25225,7 @@
         },
         {
           "name": "CantBeBlockedBy",
-          "line": 725,
+          "line": 822,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24811,7 +25237,7 @@
         },
         {
           "name": "Protection",
-          "line": 729,
+          "line": 826,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16: Protection prevents targeting, blocking, damage, and attachment.",
@@ -24821,7 +25247,7 @@
         },
         {
           "name": "Indestructible",
-          "line": 731,
+          "line": 828,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.12: Indestructible — prevents destruction by lethal damage and destroy effects.",
@@ -24831,7 +25257,7 @@
         },
         {
           "name": "CantBeDestroyed",
-          "line": 733,
+          "line": 830,
           "kind": "unit",
           "field_names": [],
           "doc": "Permanent cannot be destroyed (distinct from Indestructible).",
@@ -24839,7 +25265,7 @@
         },
         {
           "name": "FlashBack",
-          "line": 735,
+          "line": 832,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34: Flashback — allows casting from graveyard, exiled after resolution.",
@@ -24849,7 +25275,7 @@
         },
         {
           "name": "Shroud",
-          "line": 737,
+          "line": 834,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.18: Shroud — permanent cannot be the target of spells or abilities.",
@@ -24859,7 +25285,7 @@
         },
         {
           "name": "Hexproof",
-          "line": 742,
+          "line": 839,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.11: Hexproof — affected player/permanent cannot be the target of spells or abilities an opponent controls. Applied at the player scope (\"You have hexproof.\") mirroring `Shroud`; permanent-scope hexproof grants flow through `ContinuousModification::AddKeyword` instead.",
@@ -24869,7 +25295,7 @@
         },
         {
           "name": "Vigilance",
-          "line": 744,
+          "line": 841,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.20: Vigilance — attacking doesn't cause this creature to tap.",
@@ -24879,7 +25305,7 @@
         },
         {
           "name": "Menace",
-          "line": 746,
+          "line": 843,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.111: Menace — can't be blocked except by two or more creatures.",
@@ -24889,7 +25315,7 @@
         },
         {
           "name": "Reach",
-          "line": 748,
+          "line": 845,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.17: Reach — can block creatures with flying.",
@@ -24899,7 +25325,7 @@
         },
         {
           "name": "Flying",
-          "line": 750,
+          "line": 847,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.9: Flying — can't be blocked except by creatures with flying or reach.",
@@ -24909,7 +25335,7 @@
         },
         {
           "name": "Trample",
-          "line": 752,
+          "line": 849,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.19: Trample — excess combat damage is assigned to the defending player.",
@@ -24919,7 +25345,7 @@
         },
         {
           "name": "Deathtouch",
-          "line": 754,
+          "line": 851,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.2: Deathtouch — any amount of damage dealt is lethal.",
@@ -24929,7 +25355,7 @@
         },
         {
           "name": "Lifelink",
-          "line": 756,
+          "line": 853,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.15: Lifelink — damage dealt also causes controller to gain that much life.",
@@ -24939,7 +25365,7 @@
         },
         {
           "name": "CantTap",
-          "line": 759,
+          "line": 856,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24947,7 +25373,7 @@
         },
         {
           "name": "CantUntap",
-          "line": 760,
+          "line": 857,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24955,7 +25381,7 @@
         },
         {
           "name": "MustBeBlocked",
-          "line": 762,
+          "line": 859,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: This creature must be blocked if able.",
@@ -24965,7 +25391,7 @@
         },
         {
           "name": "Goaded",
-          "line": 766,
+          "line": 863,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.15b: This creature is goaded for as long as the static applies. The source controller is the goading player for the \"attack another player if able\" requirement.",
@@ -24975,7 +25401,7 @@
         },
         {
           "name": "CantAttackAlone",
-          "line": 767,
+          "line": 864,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24983,7 +25409,7 @@
         },
         {
           "name": "CantBlockAlone",
-          "line": 768,
+          "line": 865,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24991,7 +25417,7 @@
         },
         {
           "name": "MayLookAtTopOfLibrary",
-          "line": 769,
+          "line": 866,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24999,7 +25425,7 @@
         },
         {
           "name": "MayChooseNotToUntap",
-          "line": 773,
+          "line": 870,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3: You may choose not to untap this permanent during your untap step.",
@@ -25009,7 +25435,7 @@
         },
         {
           "name": "AdditionalLandDrop",
-          "line": 776,
+          "line": 873,
           "kind": "struct",
           "field_names": [
             "count"
@@ -25021,7 +25447,7 @@
         },
         {
           "name": "EmblemStatic",
-          "line": 779,
+          "line": 876,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25029,7 +25455,7 @@
         },
         {
           "name": "BlockRestriction",
-          "line": 780,
+          "line": 877,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25037,7 +25463,7 @@
         },
         {
           "name": "NoMaximumHandSize",
-          "line": 782,
+          "line": 879,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 402.2: No maximum hand size.",
@@ -25047,7 +25473,7 @@
         },
         {
           "name": "MaximumHandSize",
-          "line": 785,
+          "line": 882,
           "kind": "struct",
           "field_names": [
             "modification"
@@ -25060,7 +25486,7 @@
         },
         {
           "name": "MayPlayAdditionalLand",
-          "line": 788,
+          "line": 885,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25068,7 +25494,7 @@
         },
         {
           "name": "CantHaveKeyword",
-          "line": 792,
+          "line": 889,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -25080,7 +25506,7 @@
         },
         {
           "name": "CantWinTheGame",
-          "line": 797,
+          "line": 894,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: This player can't win the game (Platinum Angel effect).",
@@ -25090,7 +25516,7 @@
         },
         {
           "name": "CantLoseTheGame",
-          "line": 799,
+          "line": 896,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3b: This player can't lose the game (Platinum Angel effect).",
@@ -25099,8 +25525,18 @@
           ]
         },
         {
+          "name": "LegendRuleDoesntApply",
+          "line": 905,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 704.5j: The \"legend rule\" doesn't apply to the affected permanents, so they are excluded from the same-name legendary grouping in the legend-rule SBA. Scope rides on `StaticDefinition::affected`: `None` = global (Mirror Gallery, \"the legend rule doesn't apply\"); a controller-scoped filter = \"doesn't apply to [permanents/tokens/Slivers/commanders] you control\" (Sakashima of a Thousand Faces, Mirror Box, Cadric, Sliver Gravemother, Try-My-Deck Elemental, ...). Enforced per-permanent in `sba.rs` via `check_static_ability` with the candidate as the target object.",
+          "cr_refs": [
+            "CR 704.5j"
+          ]
+        },
+        {
           "name": "SpeedCanIncreaseBeyondFour",
-          "line": 801,
+          "line": 907,
           "kind": "unit",
           "field_names": [],
           "doc": "Speed may increase beyond 4, and 4+ still counts as max speed for that player.",
@@ -25108,7 +25544,7 @@
         },
         {
           "name": "DefilerCostReduction",
-          "line": 805,
+          "line": 911,
           "kind": "struct",
           "field_names": [
             "color",
@@ -25122,7 +25558,7 @@
         },
         {
           "name": "SkipStep",
-          "line": 815,
+          "line": 921,
           "kind": "struct",
           "field_names": [
             "step"
@@ -25135,7 +25571,7 @@
         },
         {
           "name": "SpendManaAsAnyColor",
-          "line": 820,
+          "line": 926,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.4b: \"You may spend mana as though it were mana of any color.\" Allows the controller to pay colored mana costs with mana of any color.",
@@ -25145,7 +25581,7 @@
         },
         {
           "name": "PayLifeAsColoredMana",
-          "line": 832,
+          "line": 938,
           "kind": "struct",
           "field_names": [
             "color"
@@ -25157,7 +25593,7 @@
         },
         {
           "name": "StepEndUnspentMana",
-          "line": 846,
+          "line": 952,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25173,7 +25609,7 @@
         },
         {
           "name": "CanAttackWithDefender",
-          "line": 852,
+          "line": 958,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.3b: Allows creatures with defender to attack despite having the keyword. \"can attack as though it didn't have defender\" overrides the defender restriction.",
@@ -25183,7 +25619,7 @@
         },
         {
           "name": "IgnoreLandwalkForBlocking",
-          "line": 869,
+          "line": 975,
           "kind": "struct",
           "field_names": [
             "qualifier"
@@ -25198,7 +25634,7 @@
         },
         {
           "name": "CanActivateAbilitiesAsThoughHaste",
-          "line": 877,
+          "line": 983,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.5a: Bypasses the summoning-sickness gate on a creature's `{T}`/`{Q}` activated abilities — \"You may activate abilities of creatures you control as though those creatures had haste.\" This is NOT `AddKeyword(Haste)`: only the CR 602.5a activation restriction is lifted, combat attacker validation (CR 508.1a) is untouched. Canonical card: Tyvar, Jubilant Brawler.",
@@ -25209,7 +25645,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 881,
+          "line": 987,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage. Used for creatures like Ornithopter of Paradise and various Walls that can attack/block but deal 0 combat damage.",
@@ -25219,7 +25655,7 @@
         },
         {
           "name": "UntapsDuringEachOtherPlayersUntapStep",
-          "line": 890,
+          "line": 996,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3 + CR 113.6: Continuous static that grants a second untap pass during each OTHER player's untap step. The source's controller untaps the permanents matching `StaticDefinition.affected` — NOT the active player's permanents. Canonical card: Seedborn Muse (\"Untap all permanents you control during each other player's untap step.\"). Runtime: `turns::execute_untap` runs a second pass after the active player's normal untap, scanning the battlefield for this variant on permanents whose controller != active_player.",
@@ -25230,7 +25666,7 @@
         },
         {
           "name": "Other",
-          "line": 892,
+          "line": 998,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized static mode strings.",
@@ -25272,7 +25708,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4898,
+      "line": 4955,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -25281,7 +25717,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 4899,
+          "line": 4956,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25289,7 +25725,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 4900,
+          "line": 4957,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25300,7 +25736,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8578,
+      "line": 8717,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -25308,7 +25744,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 8586,
+          "line": 8725,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -25316,7 +25752,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 8591,
+          "line": 8730,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -25495,7 +25931,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8259,
+      "line": 8387,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -25505,7 +25941,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 8261,
+          "line": 8389,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25513,7 +25949,7 @@
         },
         {
           "name": "Resolution",
-          "line": 8262,
+          "line": 8390,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25524,13 +25960,13 @@
     },
     "TargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2356,
+      "line": 2387,
       "doc": "Typed target filter replacing all Forge filter strings and TargetSpec.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 2357,
+          "line": 2388,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25538,7 +25974,7 @@
         },
         {
           "name": "Any",
-          "line": 2358,
+          "line": 2389,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25546,7 +25982,7 @@
         },
         {
           "name": "Player",
-          "line": 2359,
+          "line": 2390,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25554,7 +25990,7 @@
         },
         {
           "name": "Controller",
-          "line": 2360,
+          "line": 2391,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25562,7 +25998,7 @@
         },
         {
           "name": "SelfRef",
-          "line": 2361,
+          "line": 2392,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25570,7 +26006,7 @@
         },
         {
           "name": "SourceOrPaired",
-          "line": 2364,
+          "line": 2395,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Resolves to the source object and the creature it is paired with. If the source is not paired, this matches no objects.",
@@ -25580,7 +26016,7 @@
         },
         {
           "name": "Typed",
-          "line": 2365,
+          "line": 2396,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25588,7 +26024,7 @@
         },
         {
           "name": "Not",
-          "line": 2366,
+          "line": 2397,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25598,7 +26034,7 @@
         },
         {
           "name": "Or",
-          "line": 2369,
+          "line": 2400,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -25608,7 +26044,7 @@
         },
         {
           "name": "And",
-          "line": 2372,
+          "line": 2403,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -25618,7 +26054,7 @@
         },
         {
           "name": "StackAbility",
-          "line": 2377,
+          "line": 2408,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -25628,7 +26064,7 @@
         },
         {
           "name": "StackSpell",
-          "line": 2383,
+          "line": 2414,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches spells on the stack (not activated/triggered abilities). CR 115.1a: Used by \"becomes the target of a spell\" triggers to filter source type.",
@@ -25638,7 +26074,7 @@
         },
         {
           "name": "SpecificObject",
-          "line": 2387,
+          "line": 2418,
           "kind": "struct",
           "field_names": [
             "id"
@@ -25648,7 +26084,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 2395,
+          "line": 2426,
           "kind": "struct",
           "field_names": [
             "id"
@@ -25661,7 +26097,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2401,
+          "line": 2432,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This is not the ability controller; \"you\" and \"your\" still refer to `controller`.",
@@ -25672,7 +26108,7 @@
         },
         {
           "name": "AttachedTo",
-          "line": 2404,
+          "line": 2435,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches the permanent that the trigger source (Equipment/Aura) is attached to. Used for \"equipped creature\" / \"enchanted creature\" trigger subjects.",
@@ -25680,7 +26116,7 @@
         },
         {
           "name": "LastCreated",
-          "line": 2407,
+          "line": 2438,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the most recently created token(s) from Effect::Token. Used for \"create X and [verb] it\" patterns (e.g. \"create a token and suspect it\").",
@@ -25688,7 +26124,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2411,
+          "line": 2442,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the resolving spell or ability. Used by effects such as \"the exiled card\" after an exile-as-cost clause.",
@@ -25699,7 +26135,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 2414,
+          "line": 2445,
           "kind": "struct",
           "field_names": [
             "id"
@@ -25711,7 +26147,7 @@
         },
         {
           "name": "TrackedSetFiltered",
-          "line": 2429,
+          "line": 2460,
           "kind": "struct",
           "field_names": [
             "id",
@@ -25725,7 +26161,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2435,
+          "line": 2466,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 610.3: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
@@ -25735,7 +26171,7 @@
         },
         {
           "name": "TriggeringSpellController",
-          "line": 2437,
+          "line": 2468,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the controller of the spell/ability that triggered this.",
@@ -25745,7 +26181,7 @@
         },
         {
           "name": "TriggeringSpellOwner",
-          "line": 2439,
+          "line": 2470,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the owner of the spell/ability that triggered this.",
@@ -25755,7 +26191,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 2441,
+          "line": 2472,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the player involved in the triggering event.",
@@ -25765,7 +26201,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 2443,
+          "line": 2474,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the source object of the triggering event.",
@@ -25775,7 +26211,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 2448,
+          "line": 2479,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the same target(s) as the parent ability. Used for anaphoric \"it\"/\"that creature\"/\"that player\" in compound effects (e.g., \"tap target creature and put a stun counter on it\"). At resolution time, the sub_ability chain inherits parent targets automatically.",
@@ -25783,7 +26219,7 @@
         },
         {
           "name": "ParentTargetSlot",
-          "line": 2453,
+          "line": 2484,
           "kind": "struct",
           "field_names": [
             "index"
@@ -25795,7 +26231,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2459,
+          "line": 2490,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Resolves to the controller of the parent ability's target object. Used for \"its controller\" in compound effects (e.g., \"counter target spell. Its controller loses 2 life.\"). At resolution time, looks up the controller of the first parent target.",
@@ -25805,7 +26241,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 2470,
+          "line": 2501,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 608.2c: Resolves to the *owner* of the parent ability's target object. Used for \"its owner\" anaphoric references where the acting player is the owner of a previously-mentioned permanent — e.g., Enslave's \"enchanted creature deals 1 damage to its owner\" or Bomb Squad's \"that creature deals 4 damage to its owner\". Resolution mirrors `ParentTargetController` (parent target slot → trigger-event source → AttachedTo host on source for Aura phase triggers), but returns the resolved object's `owner` rather than `controller` per CR 108.3.  Distinct from `Owner` (which always reads the source object's owner) and `ParentTargetController` (which returns the controller per CR 109.4).",
@@ -25817,7 +26253,7 @@
         },
         {
           "name": "OriginalController",
-          "line": 2491,
+          "line": 2522,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 + CR 608.2c: Resolves to the ability's *original* controller — the player who put the spell or ability on the stack — even when a surrounding `player_scope` iteration has rebound `ResolvedAbility::controller` to a different player for the current per-player iteration.  At resolution time, returns `ability.original_controller.unwrap_or(ability.controller)`. This mirrors the quantity-layer behavior in `resolve_quantity_with_targets`, where \"you\" / \"your\" quantities always read the original controller.  Used by parser-level distribution of compound subjects like \"you and that player each Y\" — the first half (\"you\") MUST resolve to the printed ability controller, not the iterated voter, even when the parent ability has `player_scope: PlayerFilter::VotedFor` (Master of Ceremonies pattern, CR 800.4g).  Distinct from `Controller` (which resolves to `ability.controller` and is rebound per-iteration by the player_scope driver in `resolve_ability_chain`). Distinct from `ParentTargetController` (parent's target's controller) and `PostReplacementSourceController` (replacement-context source's controller).",
@@ -25829,7 +26265,7 @@
         },
         {
           "name": "PostReplacementSourceController",
-          "line": 2510,
+          "line": 2541,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5 + CR 609.7: Resolves to the controller of the *prevented event's* damage source. Used by prevention follow-up sentences such as \"the source's controller draws cards equal to the damage prevented this way\" (Swans of Bryn Argoll) and \"deals damage to that source's controller\" (Deflecting Palm class). At resolution time, looks up `state.post_replacement_event_source` and returns its controller.  Distinct from `ParentTargetController` (which resolves via the parent ability's target slot) and `TriggeringSpellController` (which resolves via `state.current_trigger_event`, which is `None` during post-replacement resolution). Architectural twin of the quantity-side `last_effect_count` fallback at `replacement.rs:317` — both stash event context that lives outside the trigger window. The parser never emits this variant directly; the prevention follow-up call site rewrites `ParentTargetController` → `PostReplacementSourceController` via `each_target_filter_mut` after `parse_effect_chain` returns, so the surface phrase \"the source's controller\" can stay consolidated in `parse_target` for non-prevention callers.",
@@ -25840,7 +26276,7 @@
         },
         {
           "name": "PostReplacementDamageTarget",
-          "line": 2515,
+          "line": 2546,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5: Resolves to the player or permanent that was the target of the prevented damage event. Used by prevention follow-up sentences such as \"that player exiles that many cards\" where the affected player is the damage recipient, not the replacement source or damage source.",
@@ -25850,7 +26286,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2519,
+          "line": 2550,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Resolves to the defending player for the source attacking creature, looked up per attacker through `combat::defending_player_for_attacker`.",
@@ -25861,7 +26297,7 @@
         },
         {
           "name": "HasChosenName",
-          "line": 2522,
+          "line": 2553,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose name equals the source's ChosenAttribute::CardName. Used for \"card with the chosen name\" patterns.",
@@ -25869,7 +26305,7 @@
         },
         {
           "name": "ChosenDamageSource",
-          "line": 2526,
+          "line": 2557,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.7a: Matches the object stored as the source's chosen damage source. Resolution-time prevention effects should resolve this to `SpecificObject` when the shield is created so global shields do not depend on a live source.",
@@ -25879,7 +26315,7 @@
         },
         {
           "name": "Named",
-          "line": 2529,
+          "line": 2560,
           "kind": "struct",
           "field_names": [
             "name"
@@ -25889,7 +26325,7 @@
         },
         {
           "name": "Owner",
-          "line": 2537,
+          "line": 2568,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.3: Resolves to the owner of the object referenced by `source_id`. Used for \"its owner's library/hand/graveyard\" phrasings where the acting player must be the card's owner, not its current controller (e.g., Nexus of Fate's shuffle-back replacement when the card is under opposing control via Mind Control).",
@@ -25899,7 +26335,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2544,
+          "line": 2575,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.12a: Every player in the game (controller + opponents), polled in APNAP order. The unless-payer population for \"[Effect] unless any player pays ...\" clauses (Cleansing, Rhystic cycle, Soul Strings). Resolution is a sequential poll — the first player to pay prevents the effect — so this variant is only valid as an `UnlessPayModifier.payer`; it is never used as a target or affected filter.",
@@ -25930,13 +26366,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11010,
+      "line": 11186,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 11011,
+          "line": 11187,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25944,7 +26380,7 @@
         },
         {
           "name": "Player",
-          "line": 11012,
+          "line": 11188,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25955,13 +26391,13 @@
     },
     "TargetSelectionConstraint": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1088,
+      "line": 1126,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 1089,
+          "line": 1127,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25969,7 +26405,7 @@
         },
         {
           "name": "DifferentObjectControllers",
-          "line": 1091,
+          "line": 1129,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1 + CR 601.2c: Object targets must be controlled by different players.",
@@ -25983,7 +26419,7 @@
     },
     "TargetSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2335,
+      "line": 2366,
       "doc": "CR 115.1 + CR 701.9b: How a target slot's referent is selected.  CR 115.1: Default — the spell/ability's controller chooses each target. CR 701.9b: Some effects override the controller-choice default by requiring the game to make the selection (analogous to \"random discard\" — the affected player does not choose). Magic Oracle text expresses this with the modifier \"random target [predicate]\" appearing immediately before the target word (Mana Clash, Goblin Lyre, Pixie Queen, Vexing Sphinx, Maddening Hex, etc.).  Categorical-boundary check (per CLAUDE.md \"Parameterize, don't proliferate\"): this enum is the *selection-mode* axis — one level above the predicate (`TargetFilter`) and orthogonal to slot count (`MultiTargetSpec`). It does not belong on `TargetFilter` (which captures *what* matches), nor on `MultiTargetSpec` (which captures *how many*). It captures *who selects*.",
       "cr_refs": [
         "CR 115.1",
@@ -25992,7 +26428,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 2338,
+          "line": 2369,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The spell or ability's controller chooses each target.",
@@ -26002,7 +26438,7 @@
         },
         {
           "name": "Random",
-          "line": 2341,
+          "line": 2372,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9b (analogous): The game selects each target uniformly at random from the legal-target set. The controller does not choose.",
@@ -26015,7 +26451,7 @@
     },
     "TributeOutcome": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 529,
+      "line": 550,
       "doc": "CR 702.104a + CR 702.104b: The outcome of the Tribute choice the chosen opponent made as the creature entered the battlefield. Persisted as a `ChosenAttribute` on the Tribute creature so the companion \"if tribute wasn't paid\" trigger (CR 702.104b) can read the decision. A typed enum rather than a `bool` so the absence of any `TributeOutcome` remains distinguishable from an explicit `Declined`.",
       "cr_refs": [
         "CR 702.104a",
@@ -26024,7 +26460,7 @@
       "variants": [
         {
           "name": "Paid",
-          "line": 531,
+          "line": 552,
           "kind": "unit",
           "field_names": [],
           "doc": "The chosen opponent placed the Tribute +1/+1 counters (CR 702.104a).",
@@ -26034,7 +26470,7 @@
         },
         {
           "name": "Declined",
-          "line": 533,
+          "line": 554,
           "kind": "unit",
           "field_names": [],
           "doc": "The chosen opponent declined (CR 702.104b: \"if tribute wasn't paid\").",
@@ -26047,7 +26483,7 @@
     },
     "TriggerCause": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 319,
+      "line": 364,
       "doc": "CR 603.2d: The cause-predicate axis for trigger-doubling static abilities.  \"An effect that states a triggered ability of an object triggers additional times\" may be restricted to triggers caused by specific events (Panharmonicon: artifact/creature entering the battlefield; Isshin: creature attacking). A wildcard `Any` cause covers hypothetical unrestricted doublers.  This is a typed enum rather than a boolean because the design space is open-ended: new cards routinely introduce novel cause predicates, and `bool` fields cannot grow to accommodate them.",
       "cr_refs": [
         "CR 603.2d"
@@ -26055,7 +26491,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 321,
+          "line": 366,
           "kind": "unit",
           "field_names": [],
           "doc": "Unrestricted doubler — matches any trigger cause.",
@@ -26063,7 +26499,7 @@
         },
         {
           "name": "EntersBattlefield",
-          "line": 327,
+          "line": 372,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -26075,7 +26511,7 @@
         },
         {
           "name": "CreatureAttacking",
-          "line": 334,
+          "line": 379,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1 + CR 308.1: Trigger was caused by a creature attacking (Isshin-class). Matches `GameEvent::AttackersDeclared` regardless of attack target (player, planeswalker, or battle).",
@@ -26086,7 +26522,7 @@
         },
         {
           "name": "CreatureDying",
-          "line": 340,
+          "line": 385,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6c + CR 700.4: Trigger was caused by a creature dying — a creature moving from the battlefield to the graveyard (Drivnod-class). Matches `GameEvent::ZoneChanged` from `Battlefield` to `Graveyard` for an object whose snapshot included `Creature` in its core types.",
@@ -26100,13 +26536,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9303,
+      "line": 9457,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 9306,
+          "line": 9460,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26116,7 +26552,7 @@
         },
         {
           "name": "LostLife",
-          "line": 9308,
+          "line": 9462,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -26124,7 +26560,7 @@
         },
         {
           "name": "Descended",
-          "line": 9310,
+          "line": 9464,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -26132,7 +26568,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 9312,
+          "line": 9466,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26142,7 +26578,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 9314,
+          "line": 9468,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -26152,7 +26588,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 9316,
+          "line": 9470,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -26162,7 +26598,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 9326,
+          "line": 9480,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26175,7 +26611,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9329,
+          "line": 9483,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -26186,7 +26622,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 9332,
+          "line": 9486,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -26196,7 +26632,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 9336,
+          "line": 9490,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26208,7 +26644,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 9339,
+          "line": 9493,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -26218,7 +26654,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9342,
+          "line": 9496,
           "kind": "struct",
           "field_names": [
             "level"
@@ -26230,7 +26666,7 @@
         },
         {
           "name": "WasCast",
-          "line": 9347,
+          "line": 9501,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you cast it\" — zoneless cast check (unlike CastFromZone which requires a specific zone). CR 701.57a: Used by Discover ETB triggers. Negation (\"if it wasn't cast\") is expressed via `Not { Box::new(WasCast) }`.",
@@ -26240,7 +26676,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 9351,
+          "line": 9505,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -26251,7 +26687,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 9356,
+          "line": 9510,
           "kind": "struct",
           "field_names": [
             "source",
@@ -26267,7 +26703,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 9372,
+          "line": 9526,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -26277,7 +26713,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9378,
+          "line": 9532,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26292,7 +26728,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 9382,
+          "line": 9536,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -26303,7 +26739,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 9386,
+          "line": 9540,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -26314,7 +26750,7 @@
         },
         {
           "name": "WasType",
-          "line": 9391,
+          "line": 9545,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -26327,7 +26763,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 9394,
+          "line": 9548,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26339,7 +26775,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 9398,
+          "line": 9552,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26352,7 +26788,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 9402,
+          "line": 9556,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26364,7 +26800,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 9406,
+          "line": 9560,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -26374,7 +26810,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9409,
+          "line": 9563,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -26386,7 +26822,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 9413,
+          "line": 9567,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26398,7 +26834,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 9416,
+          "line": 9570,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26410,7 +26846,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9422,
+          "line": 9576,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -26420,7 +26856,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9425,
+          "line": 9579,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -26430,7 +26866,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 9428,
+          "line": 9582,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -26440,7 +26876,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9435,
+          "line": 9589,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26452,7 +26888,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9440,
+          "line": 9594,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26464,7 +26900,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9444,
+          "line": 9598,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -26474,7 +26910,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 9449,
+          "line": 9603,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -26486,7 +26922,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9455,
+          "line": 9609,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -26496,7 +26932,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 9460,
+          "line": 9614,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -26506,7 +26942,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 9463,
+          "line": 9617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -26516,7 +26952,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 9466,
+          "line": 9620,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -26526,7 +26962,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 9468,
+          "line": 9622,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -26538,7 +26974,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 9471,
+          "line": 9625,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -26548,7 +26984,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 9475,
+          "line": 9629,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -26558,7 +26994,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 9479,
+          "line": 9633,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26571,7 +27007,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 9482,
+          "line": 9636,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -26581,7 +27017,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9486,
+          "line": 9640,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -26594,7 +27030,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9489,
+          "line": 9643,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -26607,7 +27043,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9491,
+          "line": 9645,
           "kind": "struct",
           "field_names": [
             "color",
@@ -26620,7 +27056,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 9493,
+          "line": 9647,
           "kind": "struct",
           "field_names": [
             "text"
@@ -26632,7 +27068,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 9495,
+          "line": 9649,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -26644,7 +27080,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 9499,
+          "line": 9653,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -26658,7 +27094,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 9501,
+          "line": 9655,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -26668,7 +27104,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 9506,
+          "line": 9660,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -26683,7 +27119,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9517,
+          "line": 9671,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -26699,7 +27135,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 9532,
+          "line": 9686,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -26711,7 +27147,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9535,
+          "line": 9689,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26724,7 +27160,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 9545,
+          "line": 9699,
           "kind": "struct",
           "field_names": [
             "label"
@@ -26738,7 +27174,7 @@
         },
         {
           "name": "AttackersDeclaredMin",
-          "line": 9558,
+          "line": 9712,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26754,7 +27190,7 @@
         },
         {
           "name": "NoneOfAttackersTargetedYou",
-          "line": 9563,
+          "line": 9717,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 603.4: Intervening-if \"if none of those creatures attacked you\". Reads the triggering `AttackersDeclared` event's per-attacker `AttackTarget` tuples (CR 508.1b) and returns true iff no attacker in the batch targeted the trigger's controller directly (`AttackTarget::Player(trigger_controller)`).",
@@ -26766,7 +27202,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9573,
+          "line": 9727,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -26777,8 +27213,20 @@
           ]
         },
         {
+          "name": "PlacedByAbilitySource",
+          "line": 9738,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
+          "cr_refs": [
+            "CR 400.7",
+            "CR 603.4",
+            "CR 603.6a"
+          ]
+        },
+        {
           "name": "And",
-          "line": 9577,
+          "line": 9742,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -26788,7 +27236,7 @@
         },
         {
           "name": "Or",
-          "line": 9579,
+          "line": 9744,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -26798,7 +27246,7 @@
         },
         {
           "name": "Not",
-          "line": 9589,
+          "line": 9754,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -26814,13 +27262,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9759,
+      "line": 9935,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 9761,
+          "line": 9937,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -26828,7 +27276,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 9763,
+          "line": 9939,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -26836,7 +27284,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 9765,
+          "line": 9941,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -26844,7 +27292,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 9770,
+          "line": 9946,
           "kind": "struct",
           "field_names": [
             "n",
@@ -26855,7 +27303,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 9777,
+          "line": 9953,
           "kind": "struct",
           "field_names": [
             "n"
@@ -26865,7 +27313,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 9779,
+          "line": 9955,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -26873,7 +27321,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 9783,
+          "line": 9959,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -26883,7 +27331,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 9785,
+          "line": 9961,
           "kind": "struct",
           "field_names": [
             "level"
@@ -26895,7 +27343,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 9788,
+          "line": 9964,
           "kind": "struct",
           "field_names": [
             "max"
@@ -26908,9 +27356,499 @@
       ],
       "sibling_clusters": []
     },
+    "TriggerEventKey": {
+      "file": "crates/engine/src/types/triggers.rs",
+      "line": 23,
+      "doc": "CR 603.2: Event-keyed bucket discriminator for the battlefield `TriggerIndex`. Indexes the small set of structural axes that statically constrain which event a battlefield trigger could match. A given event maps to one or more keys; a given trigger definition maps to one or more keys (or to the `unclassified` bucket via empty derivation).  CR 603.2 over-approximation invariant: it is correctness-preserving to emit MORE keys for an event or for a trigger definition than are strictly necessary; it is a silent trigger-drop bug to emit FEWER. The index's `unclassified` bucket is the safety net for any `TriggerMode` whose match shape is dynamic (filter depends on game state) or not yet classified here.",
+      "cr_refs": [
+        "CR 603.2"
+      ],
+      "variants": [
+        {
+          "name": "EnterBattlefield",
+          "line": 30,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 603.6a: A permanent entered the battlefield. `Some(core_type)` is emitted for triggers whose `valid_card` filter narrows to exactly one `CoreType`; `None` covers the unrestricted \"whenever a permanent enters\" shape. The event-side deriver emits BOTH the broad `None` key AND one `Some(ct)` per element of `ZoneChangeRecord.core_types` so narrow and broad listeners both fire.",
+          "cr_refs": [
+            "CR 603.6a"
+          ]
+        },
+        {
+          "name": "LeaveBattlefield",
+          "line": 33,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 603.6c: A permanent moved from battlefield to any other zone (death, exile, return-to-hand, library shuffle, library bottom).",
+          "cr_refs": [
+            "CR 603.6c"
+          ]
+        },
+        {
+          "name": "Dies",
+          "line": 38,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 603.6c + CR 701.8 (Destroy) + CR 404 (graveyard zone): Subset of `LeaveBattlefield` where the destination is the graveyard. Emitted on the event side as BOTH `LeaveBattlefield` AND `Dies` so dies-triggers (Blood Artist) and leaves-triggers (Skyclave Apparition) can coexist.",
+          "cr_refs": [
+            "CR 404",
+            "CR 603.6c",
+            "CR 701.8"
+          ]
+        },
+        {
+          "name": "SpellCast",
+          "line": 42,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 601.2i: A spell was cast OR copied (CR 707.10). `Some(core_type)` is emitted for triggers whose `valid_card` filter narrows to exactly one `CoreType` (e.g. \"whenever a player casts a creature spell\").",
+          "cr_refs": [
+            "CR 601.2i",
+            "CR 707.10"
+          ]
+        },
+        {
+          "name": "BecomesTarget",
+          "line": 45,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 603.2 + CR 115.1: An object or player became the target of a spell or ability.",
+          "cr_refs": [
+            "CR 115.1",
+            "CR 603.2"
+          ]
+        },
+        {
+          "name": "Attacks",
+          "line": 47,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 508.1: One or more creatures were declared as attackers.",
+          "cr_refs": [
+            "CR 508.1"
+          ]
+        },
+        {
+          "name": "Blocks",
+          "line": 50,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 509.1: A creature was declared as a blocker (or a creature became blocked).",
+          "cr_refs": [
+            "CR 509.1"
+          ]
+        },
+        {
+          "name": "DealsDamage",
+          "line": 54,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 119.1 + CR 120.1 (damage): Damage was dealt. Coarsely keyed — the per-trigger matcher resolves source/target/amount/combat-vs-noncombat at match time.",
+          "cr_refs": [
+            "CR 119.1",
+            "CR 120.1"
+          ]
+        },
+        {
+          "name": "DamagePrevented",
+          "line": 56,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 615 (prevention): Damage was prevented.",
+          "cr_refs": [
+            "CR 615"
+          ]
+        },
+        {
+          "name": "CardsDrawn",
+          "line": 58,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 121.1: One or more cards were drawn.",
+          "cr_refs": [
+            "CR 121.1"
+          ]
+        },
+        {
+          "name": "LifeChanged",
+          "line": 60,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 119.3 + CR 118.4 (life gain/loss): A player's life total changed.",
+          "cr_refs": [
+            "CR 118.4",
+            "CR 119.3"
+          ]
+        },
+        {
+          "name": "ManaProduced",
+          "line": 64,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 106 (mana) + CR 605 (mana abilities): Mana was added to a player's mana pool, OR a permanent emitted a `TappedForMana` event. Coarse key — the matcher distinguishes the two TriggerModes.",
+          "cr_refs": [
+            "CR 106",
+            "CR 605"
+          ]
+        },
+        {
+          "name": "ManaSpent",
+          "line": 66,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 700.14 (cost-paid context): cumulative mana spent on a spell.",
+          "cr_refs": [
+            "CR 700.14"
+          ]
+        },
+        {
+          "name": "CounterAdded",
+          "line": 70,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 122.1 (counter rules): One or more counters were added to a permanent or player. The bucket covers all `CounterAdded*` variants (the matcher distinguishes per-counter-type at match time).",
+          "cr_refs": [
+            "CR 122.1"
+          ]
+        },
+        {
+          "name": "CounterRemoved",
+          "line": 72,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 122.1: One or more counters were removed.",
+          "cr_refs": [
+            "CR 122.1"
+          ]
+        },
+        {
+          "name": "BeginningOfPhase",
+          "line": 75,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 603.2b: A phase or step began. Keyed by the specific `Phase` so at-the-beginning-of-Upkeep triggers do not consult on every step.",
+          "cr_refs": [
+            "CR 603.2b"
+          ]
+        },
+        {
+          "name": "Taps",
+          "line": 77,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.26: A permanent became tapped.",
+          "cr_refs": [
+            "CR 701.26"
+          ]
+        },
+        {
+          "name": "TapsForMana",
+          "line": 80,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 605 (mana abilities): A permanent became tapped specifically for mana.",
+          "cr_refs": [
+            "CR 605"
+          ]
+        },
+        {
+          "name": "Untaps",
+          "line": 82,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.26: A permanent became untapped.",
+          "cr_refs": [
+            "CR 701.26"
+          ]
+        },
+        {
+          "name": "Sacrificed",
+          "line": 84,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.21: A permanent was sacrificed.",
+          "cr_refs": [
+            "CR 701.21"
+          ]
+        },
+        {
+          "name": "Destroyed",
+          "line": 86,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.8: A permanent was destroyed.",
+          "cr_refs": [
+            "CR 701.8"
+          ]
+        },
+        {
+          "name": "ChangesController",
+          "line": 94,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 611.3 (continuous-effect rules covering control-changing statics) — a permanent's controller changed via a `GainControl` effect. NOTE: Administrative control transfers on player elimination (CR 800.4) do NOT produce an `EffectResolved { kind: GainControl }` event and therefore do NOT flow through this bucket — they are not caught by `TriggerMode::ChangesController` either (see `match_changes_controller`).",
+          "cr_refs": [
+            "CR 611.3",
+            "CR 800.4"
+          ]
+        },
+        {
+          "name": "Discarded",
+          "line": 96,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.9: A player discarded a card.",
+          "cr_refs": [
+            "CR 701.9"
+          ]
+        },
+        {
+          "name": "Milled",
+          "line": 98,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.17: A player put cards into their graveyard from their library.",
+          "cr_refs": [
+            "CR 701.17"
+          ]
+        },
+        {
+          "name": "TokenCreated",
+          "line": 100,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 111.1: A token was created (or a card was conjured).",
+          "cr_refs": [
+            "CR 111.1"
+          ]
+        },
+        {
+          "name": "AttachmentChanged",
+          "line": 103,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.3 (Attach) + CR 702.6 (Equip): An Aura/Equipment/Fortification became attached (or unattached).",
+          "cr_refs": [
+            "CR 701.3",
+            "CR 702.6"
+          ]
+        },
+        {
+          "name": "FaceOrTransform",
+          "line": 106,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.40 (Manifest) + CR 712 (face-down spells/permanents): A permanent transformed or turned face up.",
+          "cr_refs": [
+            "CR 701.40",
+            "CR 712"
+          ]
+        },
+        {
+          "name": "PlayerCounterChanged",
+          "line": 109,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 122 (counters) + CR 704 / poison: A player counter (poison, experience, energy, rad) changed.",
+          "cr_refs": [
+            "CR 122",
+            "CR 704"
+          ]
+        },
+        {
+          "name": "DieOrCoin",
+          "line": 112,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 705 (flipping a coin) + CR 706 (rolling a die): A die was rolled or a coin was flipped.",
+          "cr_refs": [
+            "CR 705",
+            "CR 706"
+          ]
+        },
+        {
+          "name": "MonarchOrInitiative",
+          "line": 114,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 725 (Monarch) + CR 726 (Initiative): Designation changed hands.",
+          "cr_refs": [
+            "CR 725",
+            "CR 726"
+          ]
+        },
+        {
+          "name": "PlayerLost",
+          "line": 116,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 104.3: A player lost the game.",
+          "cr_refs": [
+            "CR 104.3"
+          ]
+        },
+        {
+          "name": "Clashed",
+          "line": 118,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.30: A clash occurred.",
+          "cr_refs": [
+            "CR 701.30"
+          ]
+        },
+        {
+          "name": "Voted",
+          "line": 120,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.38: A vote was cast or resolved.",
+          "cr_refs": [
+            "CR 701.38"
+          ]
+        },
+        {
+          "name": "DayNightChanged",
+          "line": 122,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 731: Day/Night designation flipped.",
+          "cr_refs": [
+            "CR 731"
+          ]
+        },
+        {
+          "name": "DungeonOrClassOrCase",
+          "line": 126,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 309 (Dungeon) + CR 716 (Class) + CR 719 (Case): Dungeon/Class/Case state change (room entered, class level gained, case solved, dungeon completed).",
+          "cr_refs": [
+            "CR 309",
+            "CR 716",
+            "CR 719"
+          ]
+        },
+        {
+          "name": "PlayerActionPerformed",
+          "line": 130,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.22 (Scry) / CR 701.25 (Surveil) / CR 701.23 (Search) / CR 701.59 (Collect Evidence) / CR 701.34 (Proliferate): generic player-action events routed through `PlayerPerformedAction`.",
+          "cr_refs": [
+            "CR 701.22",
+            "CR 701.23",
+            "CR 701.25",
+            "CR 701.34",
+            "CR 701.59"
+          ]
+        },
+        {
+          "name": "Bending",
+          "line": 133,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Avatar crossover (no CR — set-specific mechanic): Bending events (Firebend, Airbend, Earthbend, Waterbend, ElementalBend).",
+          "cr_refs": []
+        },
+        {
+          "name": "TurnStarted",
+          "line": 137,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 500 (turn structure) + CR 603.2b: `TurnStarted` event. Distinct from `BeginningOfPhase` because `TurnBegin` triggers fire on the per-turn boundary, not on any specific in-turn phase.",
+          "cr_refs": [
+            "CR 500",
+            "CR 603.2b"
+          ]
+        },
+        {
+          "name": "Exiled",
+          "line": 139,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.13: An exile resolution event.",
+          "cr_refs": [
+            "CR 701.13"
+          ]
+        },
+        {
+          "name": "Revealed",
+          "line": 141,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.20: A card was revealed.",
+          "cr_refs": [
+            "CR 701.20"
+          ]
+        },
+        {
+          "name": "AbilityOrCopyActivated",
+          "line": 144,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 602.1 (activated abilities) + CR 603.1 (triggered abilities): keyword-activated, ability-copy, and ninjutsu activation events.",
+          "cr_refs": [
+            "CR 602.1",
+            "CR 603.1"
+          ]
+        },
+        {
+          "name": "Renowned",
+          "line": 146,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.112: A creature became renowned.",
+          "cr_refs": [
+            "CR 702.112"
+          ]
+        },
+        {
+          "name": "BecomesMonstrous",
+          "line": 148,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.37: A creature became monstrous.",
+          "cr_refs": [
+            "CR 701.37"
+          ]
+        },
+        {
+          "name": "ManifestDreadResolved",
+          "line": 150,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.62: A manifest-dread resolution.",
+          "cr_refs": [
+            "CR 701.62"
+          ]
+        },
+        {
+          "name": "Explored",
+          "line": 152,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.44: An explore resolution.",
+          "cr_refs": [
+            "CR 701.44"
+          ]
+        },
+        {
+          "name": "Fight",
+          "line": 155,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.14: A fight resolution (separate from generic deals-damage because the matcher dispatches on `EffectResolved { kind: Fight }`).",
+          "cr_refs": [
+            "CR 701.14"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "TriggerMode": {
       "file": "crates/engine/src/types/triggers.rs",
-      "line": 27,
+      "line": 176,
       "doc": "All trigger modes from Forge's TriggerType enum (CR 603).  Triggered abilities have a trigger condition and an effect, written as \"[When/Whenever/At] [trigger condition], [effect]\" (CR 603.1). When a game event matches a trigger condition, the ability automatically triggers (CR 603.2) and is placed on the stack the next time a player would receive priority (CR 603.3).  Matched case-sensitively against Forge trigger mode strings.",
       "cr_refs": [
         "CR 603",
@@ -26921,7 +27859,7 @@
       "variants": [
         {
           "name": "ChangesZone",
-          "line": 30,
+          "line": 179,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6a: Enters-the-battlefield and other zone-change triggers.",
@@ -26931,7 +27869,7 @@
         },
         {
           "name": "ChangesZoneAll",
-          "line": 32,
+          "line": 181,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6: Zone change affecting all objects matching a filter.",
@@ -26941,7 +27879,7 @@
         },
         {
           "name": "ChangesController",
-          "line": 34,
+          "line": 183,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2e: \"Becomes\" trigger — fires when control changes, not while state persists.",
@@ -26951,7 +27889,7 @@
         },
         {
           "name": "LeavesBattlefield",
-          "line": 36,
+          "line": 185,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6c: Leaves-the-battlefield trigger — fires when a permanent moves from battlefield.",
@@ -26961,7 +27899,7 @@
         },
         {
           "name": "DamageDone",
-          "line": 40,
+          "line": 189,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2: Trigger when a source deals damage.",
@@ -26971,7 +27909,7 @@
         },
         {
           "name": "DamageDoneOnce",
-          "line": 41,
+          "line": 190,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26979,7 +27917,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 42,
+          "line": 191,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26987,7 +27925,7 @@
         },
         {
           "name": "DamageDealtOnce",
-          "line": 43,
+          "line": 192,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26995,7 +27933,7 @@
         },
         {
           "name": "DamageDoneOnceByController",
-          "line": 44,
+          "line": 193,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27003,7 +27941,7 @@
         },
         {
           "name": "DamageReceived",
-          "line": 46,
+          "line": 195,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2: Trigger when an object or player is dealt damage.",
@@ -27013,7 +27951,7 @@
         },
         {
           "name": "DamagePreventedOnce",
-          "line": 47,
+          "line": 196,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27021,7 +27959,7 @@
         },
         {
           "name": "ExcessDamage",
-          "line": 48,
+          "line": 197,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27029,7 +27967,7 @@
         },
         {
           "name": "ExcessDamageAll",
-          "line": 49,
+          "line": 198,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27037,7 +27975,7 @@
         },
         {
           "name": "SpellCast",
-          "line": 53,
+          "line": 202,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2i: Triggers when a spell becomes cast.",
@@ -27047,7 +27985,7 @@
         },
         {
           "name": "SpellCopy",
-          "line": 54,
+          "line": 203,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27055,7 +27993,7 @@
         },
         {
           "name": "SpellCastOrCopy",
-          "line": 55,
+          "line": 204,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27063,7 +28001,7 @@
         },
         {
           "name": "AbilityCast",
-          "line": 56,
+          "line": 205,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27071,7 +28009,7 @@
         },
         {
           "name": "AbilityResolves",
-          "line": 57,
+          "line": 206,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27079,7 +28017,7 @@
         },
         {
           "name": "AbilityTriggered",
-          "line": 58,
+          "line": 207,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27087,7 +28025,7 @@
         },
         {
           "name": "SpellAbilityCast",
-          "line": 59,
+          "line": 208,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27095,7 +28033,7 @@
         },
         {
           "name": "SpellAbilityCopy",
-          "line": 60,
+          "line": 209,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27103,7 +28041,7 @@
         },
         {
           "name": "Countered",
-          "line": 62,
+          "line": 211,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2g: Triggers when a spell or ability is countered (event must actually occur).",
@@ -27113,7 +28051,7 @@
         },
         {
           "name": "Attacks",
-          "line": 66,
+          "line": 215,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3a: \"Whenever [a creature] attacks\" — triggers when declared as attacker.",
@@ -27123,7 +28061,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 68,
+          "line": 217,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d: \"Whenever [a player] attacks\" — triggers when one or more creatures attack.",
@@ -27133,7 +28071,7 @@
         },
         {
           "name": "YouAttack",
-          "line": 70,
+          "line": 219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d: \"Whenever you attack\" — triggers for the attacking player.",
@@ -27143,7 +28081,7 @@
         },
         {
           "name": "AttackersDeclaredOneTarget",
-          "line": 71,
+          "line": 220,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27151,7 +28089,7 @@
         },
         {
           "name": "AttackerBlocked",
-          "line": 73,
+          "line": 222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Triggers when an attacking creature becomes blocked.",
@@ -27161,7 +28099,7 @@
         },
         {
           "name": "AttackerBlockedOnce",
-          "line": 74,
+          "line": 223,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27169,7 +28107,7 @@
         },
         {
           "name": "AttackerBlockedByCreature",
-          "line": 76,
+          "line": 225,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Triggers when a specific creature blocks the attacker.",
@@ -27179,7 +28117,7 @@
         },
         {
           "name": "AttackerUnblocked",
-          "line": 77,
+          "line": 226,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27187,7 +28125,7 @@
         },
         {
           "name": "AttackerUnblockedOnce",
-          "line": 78,
+          "line": 227,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27195,7 +28133,7 @@
         },
         {
           "name": "Blocks",
-          "line": 82,
+          "line": 231,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: \"Whenever [a creature] blocks\" — triggers when declared as blocker.",
@@ -27205,7 +28143,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 84,
+          "line": 233,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.4: Triggers after all blockers are declared.",
@@ -27215,7 +28153,7 @@
         },
         {
           "name": "BecomesBlocked",
-          "line": 86,
+          "line": 235,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h + CR 603.2e: \"Becomes blocked\" trigger.",
@@ -27226,7 +28164,7 @@
         },
         {
           "name": "CounterAdded",
-          "line": 90,
+          "line": 239,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.6: Triggers when one or more counters are placed on a permanent or player.",
@@ -27236,7 +28174,7 @@
         },
         {
           "name": "CounterAddedOnce",
-          "line": 91,
+          "line": 240,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27244,7 +28182,7 @@
         },
         {
           "name": "CounterAddedAll",
-          "line": 92,
+          "line": 241,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27252,7 +28190,7 @@
         },
         {
           "name": "CounterPlayerAddedAll",
-          "line": 93,
+          "line": 242,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27260,7 +28198,7 @@
         },
         {
           "name": "CounterTypeAddedAll",
-          "line": 94,
+          "line": 243,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27268,7 +28206,7 @@
         },
         {
           "name": "CounterRemoved",
-          "line": 95,
+          "line": 244,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27276,7 +28214,7 @@
         },
         {
           "name": "CounterRemovedOnce",
-          "line": 96,
+          "line": 245,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27284,7 +28222,7 @@
         },
         {
           "name": "Sacrificed",
-          "line": 100,
+          "line": 249,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.21: Triggers when a permanent is sacrificed.",
@@ -27294,7 +28232,7 @@
         },
         {
           "name": "SacrificedOnce",
-          "line": 101,
+          "line": 250,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27302,7 +28240,7 @@
         },
         {
           "name": "Destroyed",
-          "line": 103,
+          "line": 252,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8: Triggers when a permanent is destroyed.",
@@ -27312,7 +28250,7 @@
         },
         {
           "name": "Taps",
-          "line": 105,
+          "line": 254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26: Triggers when a permanent becomes tapped.",
@@ -27322,7 +28260,7 @@
         },
         {
           "name": "TapsForMana",
-          "line": 107,
+          "line": 256,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.12a: Triggers when a permanent is tapped for mana.",
@@ -27332,7 +28270,7 @@
         },
         {
           "name": "TapAll",
-          "line": 108,
+          "line": 257,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27340,7 +28278,7 @@
         },
         {
           "name": "Untaps",
-          "line": 110,
+          "line": 259,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26: Triggers when a permanent becomes untapped.",
@@ -27350,7 +28288,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 111,
+          "line": 260,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27358,7 +28296,7 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 115,
+          "line": 264,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2e: \"Becomes the target\" trigger — fires when a spell/ability targets an object.",
@@ -27368,7 +28306,7 @@
         },
         {
           "name": "BecomesTargetOnce",
-          "line": 116,
+          "line": 265,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27376,7 +28314,7 @@
         },
         {
           "name": "Drawn",
-          "line": 120,
+          "line": 269,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1: Triggers when a player draws a card.",
@@ -27386,7 +28324,7 @@
         },
         {
           "name": "Discarded",
-          "line": 122,
+          "line": 271,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9: Triggers when a player discards a card.",
@@ -27396,7 +28334,7 @@
         },
         {
           "name": "DiscardedAll",
-          "line": 123,
+          "line": 272,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27404,7 +28342,7 @@
         },
         {
           "name": "Milled",
-          "line": 125,
+          "line": 274,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.17: Triggers when cards are milled (put from library into graveyard).",
@@ -27414,7 +28352,7 @@
         },
         {
           "name": "MilledOnce",
-          "line": 126,
+          "line": 275,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27422,7 +28360,7 @@
         },
         {
           "name": "MilledAll",
-          "line": 127,
+          "line": 276,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27430,7 +28368,7 @@
         },
         {
           "name": "Exiled",
-          "line": 128,
+          "line": 277,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27438,7 +28376,7 @@
         },
         {
           "name": "Revealed",
-          "line": 129,
+          "line": 278,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27446,7 +28384,7 @@
         },
         {
           "name": "Shuffled",
-          "line": 131,
+          "line": 280,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.24: Triggers when a library is shuffled.",
@@ -27456,7 +28394,7 @@
         },
         {
           "name": "LifeGained",
-          "line": 135,
+          "line": 284,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player gains life.",
@@ -27466,7 +28404,7 @@
         },
         {
           "name": "LifeLost",
-          "line": 137,
+          "line": 286,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player loses life.",
@@ -27476,7 +28414,7 @@
         },
         {
           "name": "LifeLostAll",
-          "line": 138,
+          "line": 287,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27484,7 +28422,7 @@
         },
         {
           "name": "PayLife",
-          "line": 139,
+          "line": 288,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27492,7 +28430,7 @@
         },
         {
           "name": "PayCumulativeUpkeep",
-          "line": 141,
+          "line": 290,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.24: Cumulative upkeep trigger.",
@@ -27502,7 +28440,7 @@
         },
         {
           "name": "PayEcho",
-          "line": 143,
+          "line": 292,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30: Echo trigger.",
@@ -27512,7 +28450,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 147,
+          "line": 296,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Triggers when a token is created.",
@@ -27522,7 +28460,7 @@
         },
         {
           "name": "TokenCreatedOnce",
-          "line": 148,
+          "line": 297,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27530,7 +28468,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 152,
+          "line": 301,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.37e: Triggers when a face-down permanent is turned face up (morph/manifest/cloak).",
@@ -27540,7 +28478,7 @@
         },
         {
           "name": "Transformed",
-          "line": 154,
+          "line": 303,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27: Triggers when a permanent transforms.",
@@ -27550,7 +28488,7 @@
         },
         {
           "name": "Phase",
-          "line": 158,
+          "line": 307,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2b: \"At the beginning of [phase/step]\" — triggers at phase start.",
@@ -27560,7 +28498,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 160,
+          "line": 309,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26: Triggers when a phased-out permanent phases in.",
@@ -27570,7 +28508,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 162,
+          "line": 311,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26: Triggers when a permanent phases out.",
@@ -27580,7 +28518,7 @@
         },
         {
           "name": "PhaseOutAll",
-          "line": 163,
+          "line": 312,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27588,7 +28526,7 @@
         },
         {
           "name": "TurnBegin",
-          "line": 165,
+          "line": 314,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2b: \"At the beginning of [a player's] turn\" trigger.",
@@ -27598,7 +28536,7 @@
         },
         {
           "name": "NewGame",
-          "line": 166,
+          "line": 315,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27606,7 +28544,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 170,
+          "line": 319,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725: Triggers when a player becomes the monarch.",
@@ -27616,7 +28554,7 @@
         },
         {
           "name": "TakesInitiative",
-          "line": 172,
+          "line": 321,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725: Triggers when a player takes the initiative.",
@@ -27626,7 +28564,7 @@
         },
         {
           "name": "LosesGame",
-          "line": 176,
+          "line": 325,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: Triggers when a player loses the game.",
@@ -27636,7 +28574,7 @@
         },
         {
           "name": "Championed",
-          "line": 180,
+          "line": 329,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.72: Champion trigger.",
@@ -27646,7 +28584,7 @@
         },
         {
           "name": "Exerted",
-          "line": 182,
+          "line": 331,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.43: Triggers when a creature is exerted.",
@@ -27656,7 +28594,7 @@
         },
         {
           "name": "Crewed",
-          "line": 184,
+          "line": 333,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122: Triggers when a Vehicle becomes crewed.",
@@ -27666,7 +28604,7 @@
         },
         {
           "name": "Crews",
-          "line": 186,
+          "line": 335,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122: Actor-side crew trigger — fires when this permanent crews a Vehicle.",
@@ -27676,7 +28614,7 @@
         },
         {
           "name": "Saddled",
-          "line": 188,
+          "line": 337,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: Triggers when a creature becomes saddled.",
@@ -27686,7 +28624,7 @@
         },
         {
           "name": "Saddles",
-          "line": 191,
+          "line": 340,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171c: Actor-side saddle trigger — fires when this permanent saddles a Mount. Reserved — no cards today print this without the compound form.",
@@ -27696,7 +28634,7 @@
         },
         {
           "name": "SaddlesOrCrews",
-          "line": 194,
+          "line": 343,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122 + CR 702.171c: Compound actor-side trigger — fires on either saddling a Mount OR crewing a Vehicle.",
@@ -27707,7 +28645,7 @@
         },
         {
           "name": "Cycled",
-          "line": 196,
+          "line": 345,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29: Triggers when a card is cycled.",
@@ -27717,7 +28655,7 @@
         },
         {
           "name": "CycledOrDiscarded",
-          "line": 199,
+          "line": 348,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29d: Triggers when a card is cycled or discarded. Fires on either event but only once per cycling action.",
@@ -27727,7 +28665,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 201,
+          "line": 350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Triggers when a player activates a ninjutsu-family ability.",
@@ -27737,7 +28675,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 205,
+          "line": 354,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.107a + CR 702.142b + CR 702.177a: Triggers when a player activates a keyword ability tagged by `AbilityTag`. Parameterized to avoid per-keyword sibling proliferation: `AbilityTag::Boast`, `AbilityTag::Exhaust`, `AbilityTag::Outlast` are the current values.",
@@ -27749,7 +28687,7 @@
         },
         {
           "name": "AbilityActivated",
-          "line": 218,
+          "line": 367,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.1 + CR 605.1a: Triggers when any activated ability is activated. Listens to `GameEvent::AbilityActivated`, which is emitted only for stack-using activated abilities — by CR 605.3b, mana abilities resolve without using the stack and do not produce this event. The \"that isn't a mana ability\" qualifier on cards like Burning-Tree Shaman and Flamescroll Celebrant is thus automatically satisfied by listening here, and is additionally preserved in the AST via `TriggerCondition::ActivatedAbilityIsNonMana` for future-proofing should the event family ever widen. Player scope (`a player` / `an opponent` / `you`) lives on `valid_target` (`TargetFilter`); source-object filters (e.g., \"an ability of an artifact source\") live on `valid_card` — both reuse existing infrastructure shared with `KeywordAbilityActivated`.",
@@ -27761,7 +28699,7 @@
         },
         {
           "name": "Evolve",
-          "line": 220,
+          "line": 369,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: Evolve keyword trigger — when a creature enters with greater power/toughness.",
@@ -27771,7 +28709,7 @@
         },
         {
           "name": "Evolved",
-          "line": 222,
+          "line": 371,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100b: Triggers when a creature evolves.",
@@ -27781,7 +28719,7 @@
         },
         {
           "name": "Explored",
-          "line": 224,
+          "line": 373,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.44: Triggers when a creature explores.",
@@ -27791,7 +28729,7 @@
         },
         {
           "name": "Exploited",
-          "line": 226,
+          "line": 375,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.110: Exploit trigger — when a creature exploits another creature.",
@@ -27801,7 +28739,7 @@
         },
         {
           "name": "Enlisted",
-          "line": 228,
+          "line": 377,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.154: Triggers when a creature becomes enlisted.",
@@ -27811,7 +28749,7 @@
         },
         {
           "name": "ManaAdded",
-          "line": 232,
+          "line": 381,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.4: Triggers when mana is added to a player's mana pool.",
@@ -27821,7 +28759,7 @@
         },
         {
           "name": "ManaExpend",
-          "line": 233,
+          "line": 382,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27829,7 +28767,7 @@
         },
         {
           "name": "LandPlayed",
-          "line": 237,
+          "line": 386,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 505.6b: Triggers when a land is played.",
@@ -27840,7 +28778,7 @@
         },
         {
           "name": "Attached",
-          "line": 241,
+          "line": 390,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3: Triggers when an Aura, Equipment, or Fortification becomes attached.",
@@ -27850,7 +28788,7 @@
         },
         {
           "name": "Unattach",
-          "line": 243,
+          "line": 392,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3: Triggers when an Equipment or Aura becomes unattached.",
@@ -27860,7 +28798,7 @@
         },
         {
           "name": "Adapt",
-          "line": 247,
+          "line": 396,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.46: Triggers when a creature adapts.",
@@ -27870,7 +28808,7 @@
         },
         {
           "name": "Foretell",
-          "line": 249,
+          "line": 398,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143: Triggers when a card is foretold.",
@@ -27880,7 +28818,7 @@
         },
         {
           "name": "Investigated",
-          "line": 251,
+          "line": 400,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Triggers when a player investigates.",
@@ -27890,7 +28828,7 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 254,
+          "line": 403,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27898,7 +28836,7 @@
         },
         {
           "name": "RoomEntered",
-          "line": 255,
+          "line": 404,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27906,7 +28844,7 @@
         },
         {
           "name": "PlanarDice",
-          "line": 258,
+          "line": 407,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27914,7 +28852,7 @@
         },
         {
           "name": "PlaneswalkedFrom",
-          "line": 259,
+          "line": 408,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27922,7 +28860,7 @@
         },
         {
           "name": "PlaneswalkedTo",
-          "line": 260,
+          "line": 409,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27930,7 +28868,7 @@
         },
         {
           "name": "ChaosEnsues",
-          "line": 261,
+          "line": 410,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27938,7 +28876,7 @@
         },
         {
           "name": "RolledDie",
-          "line": 264,
+          "line": 413,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27946,7 +28884,7 @@
         },
         {
           "name": "RolledDieOnce",
-          "line": 265,
+          "line": 414,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27954,7 +28892,7 @@
         },
         {
           "name": "FlippedCoin",
-          "line": 266,
+          "line": 415,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27962,7 +28900,7 @@
         },
         {
           "name": "Clashed",
-          "line": 267,
+          "line": 416,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27970,7 +28908,7 @@
         },
         {
           "name": "DayTimeChanges",
-          "line": 271,
+          "line": 420,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730: Triggers when it becomes day or night.",
@@ -27980,7 +28918,7 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 274,
+          "line": 423,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27988,7 +28926,7 @@
         },
         {
           "name": "Copied",
-          "line": 277,
+          "line": 426,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27996,7 +28934,7 @@
         },
         {
           "name": "ConjureAll",
-          "line": 278,
+          "line": 427,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28004,7 +28942,7 @@
         },
         {
           "name": "Vote",
-          "line": 281,
+          "line": 430,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28012,7 +28950,7 @@
         },
         {
           "name": "BecomeRenowned",
-          "line": 285,
+          "line": 434,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112: Triggers when a creature becomes renowned.",
@@ -28022,7 +28960,7 @@
         },
         {
           "name": "BecomeMonstrous",
-          "line": 287,
+          "line": 436,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99: Triggers when a creature becomes monstrous.",
@@ -28032,7 +28970,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 291,
+          "line": 440,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.34: Triggers when a player proliferates.",
@@ -28042,7 +28980,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 292,
+          "line": 441,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28050,7 +28988,7 @@
         },
         {
           "name": "Surveil",
-          "line": 296,
+          "line": 445,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.25: Triggers when a player surveils.",
@@ -28060,7 +28998,7 @@
         },
         {
           "name": "Scry",
-          "line": 298,
+          "line": 447,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.22: Triggers when a player scries.",
@@ -28070,7 +29008,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 300,
+          "line": 449,
           "kind": "unit",
           "field_names": [],
           "doc": "General typed player-action trigger for joined action lists.",
@@ -28078,7 +29016,7 @@
         },
         {
           "name": "Fight",
-          "line": 304,
+          "line": 453,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.14: Triggers when creatures fight.",
@@ -28088,7 +29026,7 @@
         },
         {
           "name": "FightOnce",
-          "line": 305,
+          "line": 454,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28096,7 +29034,7 @@
         },
         {
           "name": "Abandoned",
-          "line": 308,
+          "line": 457,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28104,7 +29042,7 @@
         },
         {
           "name": "CaseSolved",
-          "line": 309,
+          "line": 458,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28112,7 +29050,7 @@
         },
         {
           "name": "ClaimPrize",
-          "line": 310,
+          "line": 459,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28120,7 +29058,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 311,
+          "line": 460,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28128,7 +29066,7 @@
         },
         {
           "name": "CommitCrime",
-          "line": 312,
+          "line": 461,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28136,7 +29074,7 @@
         },
         {
           "name": "CrankContraption",
-          "line": 313,
+          "line": 462,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28144,7 +29082,7 @@
         },
         {
           "name": "Devoured",
-          "line": 314,
+          "line": 463,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28152,7 +29090,7 @@
         },
         {
           "name": "Discover",
-          "line": 315,
+          "line": 464,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28160,7 +29098,7 @@
         },
         {
           "name": "Forage",
-          "line": 316,
+          "line": 465,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28168,7 +29106,7 @@
         },
         {
           "name": "FullyUnlock",
-          "line": 317,
+          "line": 466,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28176,7 +29114,7 @@
         },
         {
           "name": "GiveGift",
-          "line": 318,
+          "line": 467,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28184,7 +29122,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 319,
+          "line": 468,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28192,7 +29130,7 @@
         },
         {
           "name": "Mentored",
-          "line": 320,
+          "line": 469,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28200,7 +29138,7 @@
         },
         {
           "name": "Mutates",
-          "line": 321,
+          "line": 470,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28208,7 +29146,7 @@
         },
         {
           "name": "SearchedLibrary",
-          "line": 322,
+          "line": 471,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28216,7 +29154,7 @@
         },
         {
           "name": "SeekAll",
-          "line": 323,
+          "line": 472,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28224,7 +29162,7 @@
         },
         {
           "name": "SetInMotion",
-          "line": 324,
+          "line": 473,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28232,7 +29170,7 @@
         },
         {
           "name": "Specializes",
-          "line": 325,
+          "line": 474,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28240,7 +29178,7 @@
         },
         {
           "name": "Stationed",
-          "line": 326,
+          "line": 475,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28248,7 +29186,7 @@
         },
         {
           "name": "Trains",
-          "line": 327,
+          "line": 476,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28256,7 +29194,7 @@
         },
         {
           "name": "UnlockDoor",
-          "line": 328,
+          "line": 477,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28264,7 +29202,7 @@
         },
         {
           "name": "VisitAttraction",
-          "line": 329,
+          "line": 478,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28272,7 +29210,7 @@
         },
         {
           "name": "BecomesCrewed",
-          "line": 330,
+          "line": 479,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28280,7 +29218,7 @@
         },
         {
           "name": "BecomesPlotted",
-          "line": 331,
+          "line": 480,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28288,7 +29226,7 @@
         },
         {
           "name": "BecomesSaddled",
-          "line": 332,
+          "line": 481,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28296,7 +29234,7 @@
         },
         {
           "name": "Immediate",
-          "line": 333,
+          "line": 482,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28304,7 +29242,7 @@
         },
         {
           "name": "Always",
-          "line": 335,
+          "line": 484,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.1: \"Always\" — a special trigger mode representing a continuous trigger condition.",
@@ -28314,7 +29252,7 @@
         },
         {
           "name": "EntersOrAttacks",
-          "line": 339,
+          "line": 488,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Whenever ~ enters or attacks\" — fires on both ETB (CR 603.6a) and attack (CR 508.3a) events.",
@@ -28325,7 +29263,7 @@
         },
         {
           "name": "AttacksOrBlocks",
-          "line": 341,
+          "line": 490,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Whenever ~ attacks or blocks\" — fires on both attack (CR 508.3a) and block (CR 509.1h) events.",
@@ -28336,7 +29274,7 @@
         },
         {
           "name": "StateCondition",
-          "line": 347,
+          "line": 496,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.8: State trigger — fires when a game-state condition becomes true, rather than in response to an event. Checked whenever a player would receive priority. The engine tracks whether the trigger is already on the stack to prevent re-triggering until the ability has resolved, been countered, or otherwise left the stack.",
@@ -28346,7 +29284,7 @@
         },
         {
           "name": "Airbend",
-          "line": 350,
+          "line": 499,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28354,7 +29292,7 @@
         },
         {
           "name": "Earthbend",
-          "line": 351,
+          "line": 500,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28362,7 +29300,7 @@
         },
         {
           "name": "Firebend",
-          "line": 352,
+          "line": 501,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28370,7 +29308,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 353,
+          "line": 502,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28378,7 +29316,7 @@
         },
         {
           "name": "ElementalBend",
-          "line": 354,
+          "line": 503,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28386,7 +29324,7 @@
         },
         {
           "name": "Unknown",
-          "line": 357,
+          "line": 506,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized trigger mode strings.",
@@ -28454,13 +29392,13 @@
     },
     "TypeFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1681,
+      "line": 1710,
       "doc": "Type filter for card type matching in filters.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Creature",
-          "line": 1682,
+          "line": 1711,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28468,7 +29406,7 @@
         },
         {
           "name": "Land",
-          "line": 1683,
+          "line": 1712,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28476,7 +29414,7 @@
         },
         {
           "name": "Artifact",
-          "line": 1684,
+          "line": 1713,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28484,7 +29422,7 @@
         },
         {
           "name": "Enchantment",
-          "line": 1685,
+          "line": 1714,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28492,7 +29430,7 @@
         },
         {
           "name": "Instant",
-          "line": 1686,
+          "line": 1715,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28500,7 +29438,7 @@
         },
         {
           "name": "Sorcery",
-          "line": 1687,
+          "line": 1716,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28508,7 +29446,7 @@
         },
         {
           "name": "Planeswalker",
-          "line": 1688,
+          "line": 1717,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28516,7 +29454,7 @@
         },
         {
           "name": "Battle",
-          "line": 1690,
+          "line": 1719,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 310: Battle — a permanent type introduced in March of the Machine.",
@@ -28526,7 +29464,7 @@
         },
         {
           "name": "Permanent",
-          "line": 1691,
+          "line": 1720,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28534,7 +29472,7 @@
         },
         {
           "name": "Card",
-          "line": 1692,
+          "line": 1721,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28542,7 +29480,7 @@
         },
         {
           "name": "Any",
-          "line": 1693,
+          "line": 1722,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28550,7 +29488,7 @@
         },
         {
           "name": "Non",
-          "line": 1696,
+          "line": 1725,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.4b: Negation — matches objects whose type does NOT match the inner filter. \"noncreature\" → `Non(Box::new(Creature))`, \"non-Human\" → `Non(Box::new(Subtype(\"Human\")))`",
@@ -28560,7 +29498,7 @@
         },
         {
           "name": "Subtype",
-          "line": 1699,
+          "line": 1728,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.3: Matches objects with a specific subtype (creature type, land type, etc.). String because MTG has 250+ creature subtypes (CR 205.3m) with new ones each set.",
@@ -28571,7 +29509,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 1702,
+          "line": 1731,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2b: Disjunction — matches if ANY inner filter matches. \"creature or enchantment\" → `AnyOf(vec![Creature, Enchantment])`",
@@ -28621,7 +29559,7 @@
     },
     "UnlessCostBranch": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 89,
+      "line": 90,
       "doc": "CR 118.12a: Player decision at an `UnlessPaymentChooseCost` prompt — the disjunctive (\"unless they X or Y\") unless-cost choice. `Decline` falls through to the effect happening (mirrors `PayUnlessCost { pay: false }`); `Pay { index }` selects the sub-cost by its position in `WaitingFor::UnlessPaymentChooseCost::costs` and routes back into the standard single-cost `handle_unless_payment` path.",
       "cr_refs": [
         "CR 118.12a"
@@ -28629,7 +29567,7 @@
       "variants": [
         {
           "name": "Decline",
-          "line": 90,
+          "line": 91,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28637,7 +29575,7 @@
         },
         {
           "name": "Pay",
-          "line": 91,
+          "line": 92,
           "kind": "struct",
           "field_names": [
             "index"
@@ -28650,7 +29588,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3569,
+      "line": 3614,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -28659,7 +29597,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 3571,
+          "line": 3616,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28667,7 +29605,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 3572,
+          "line": 3617,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28675,7 +29613,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 3573,
+          "line": 3618,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -28685,7 +29623,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 3576,
+          "line": 3621,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -28695,7 +29633,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 3588,
+          "line": 3633,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -28711,7 +29649,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3203,
+      "line": 3243,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -28724,7 +29662,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 3207,
+          "line": 3247,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28737,7 +29675,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 3211,
+          "line": 3251,
           "kind": "struct",
           "field_names": [
             "property",
@@ -28755,7 +29693,7 @@
     },
     "VoteActor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1323,
+      "line": 1367,
       "doc": "CR 101.4 + CR 608.2 (Battlebond friend-or-foe keyword action — no explicit CR section): The \"who acts\" semantic for a `WaitingFor::VoteChoice` step.  * `SubjectActs` — the player named by `player` casts the vote for   themselves. Classic Council's-dilemma (CR 701.38) is exclusively this   case: each voter acts on their own behalf and APNAP iteration changes   both subject and actor together. * `Delegated(actor)` — a fixed `actor` casts every vote on behalf of the   cycling subjects. The Battlebond friend-or-foe spell controller pins   themselves here so `player` cycles through every player in APNAP order   while authorization stays with the controller.  Stored on `WaitingFor::VoteChoice` instead of `Option<PlayerId>` so the \"is this delegated?\" discriminator is a named sum type with a meaningful pair of variant names, not a boolean-flavored optional. Callers route through [`VoteActor::resolve`] to get the authorized submitter without branching at every call site.",
       "cr_refs": [
         "CR 101.4",
@@ -28765,7 +29703,7 @@
       "variants": [
         {
           "name": "SubjectActs",
-          "line": 1324,
+          "line": 1368,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28773,7 +29711,7 @@
         },
         {
           "name": "Delegated",
-          "line": 1325,
+          "line": 1369,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -28784,7 +29722,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6992,
+      "line": 7112,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -28793,7 +29731,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 6995,
+          "line": 7115,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -28803,7 +29741,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 6999,
+          "line": 7119,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -28813,7 +29751,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 7007,
+          "line": 7127,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",
@@ -28827,13 +29765,13 @@
     },
     "WaitingFor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1403,
+      "line": 1450,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1404,
+          "line": 1451,
           "kind": "struct",
           "field_names": [
             "player"
@@ -28843,7 +29781,7 @@
         },
         {
           "name": "MulliganDecision",
-          "line": 1420,
+          "line": 1467,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -28858,7 +29796,7 @@
         },
         {
           "name": "MulliganBottomCards",
-          "line": 1433,
+          "line": 1480,
           "kind": "struct",
           "field_names": [
             "pending"
@@ -28870,7 +29808,7 @@
         },
         {
           "name": "OpeningHandBottomCards",
-          "line": 1439,
+          "line": 1486,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -28881,7 +29819,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1443,
+          "line": 1490,
           "kind": "struct",
           "field_names": [
             "player",
@@ -28892,7 +29830,7 @@
         },
         {
           "name": "ChooseXValue",
-          "line": 1461,
+          "line": 1508,
           "kind": "struct",
           "field_names": [
             "player",
@@ -28909,7 +29847,7 @@
         },
         {
           "name": "TargetSelection",
-          "line": 1470,
+          "line": 1517,
           "kind": "struct",
           "field_names": [
             "player",
@@ -28922,7 +29860,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 1477,
+          "line": 1524,
           "kind": "struct",
           "field_names": [
             "player",
@@ -28934,7 +29872,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 1483,
+          "line": 1530,
           "kind": "struct",
           "field_names": [
             "player",
@@ -28947,7 +29885,7 @@
         },
         {
           "name": "UntapChoice",
-          "line": 1499,
+          "line": 1546,
           "kind": "struct",
           "field_names": [
             "player",
@@ -28960,8 +29898,23 @@
           ]
         },
         {
+          "name": "ExertChoice",
+          "line": 1558,
+          "kind": "struct",
+          "field_names": [
+            "player",
+            "attacker",
+            "remaining"
+          ],
+          "doc": "CR 508.1g + CR 701.43d: As attackers are declared, the active player may pay the optional \"exert this creature as it attacks\" cost on each attacker that has an exert-as-attack ability and hasn't been exerted this turn. `attacker` is the creature currently being decided; `remaining` is the queue of further exert candidates this declaration. Mirrors the one-at-a-time loop of `UntapChoice`.",
+          "cr_refs": [
+            "CR 508.1g",
+            "CR 701.43d"
+          ]
+        },
+        {
           "name": "GameOver",
-          "line": 1505,
+          "line": 1564,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -28971,7 +29924,7 @@
         },
         {
           "name": "ReplacementChoice",
-          "line": 1508,
+          "line": 1567,
           "kind": "struct",
           "field_names": [
             "player",
@@ -28983,7 +29936,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 1521,
+          "line": 1580,
           "kind": "struct",
           "field_names": [
             "player",
@@ -28998,7 +29951,7 @@
         },
         {
           "name": "CopyTargetChoice",
-          "line": 1527,
+          "line": 1586,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29013,7 +29966,7 @@
         },
         {
           "name": "ExploreChoice",
-          "line": 1537,
+          "line": 1596,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29029,7 +29982,7 @@
         },
         {
           "name": "ReturnAsAuraTarget",
-          "line": 1559,
+          "line": 1618,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29052,7 +30005,7 @@
         },
         {
           "name": "EquipTarget",
-          "line": 1576,
+          "line": 1635,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29064,7 +30017,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 1582,
+          "line": 1641,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29079,7 +30032,7 @@
         },
         {
           "name": "StationTarget",
-          "line": 1593,
+          "line": 1652,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29093,7 +30046,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 1601,
+          "line": 1660,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29108,7 +30061,7 @@
         },
         {
           "name": "ScryChoice",
-          "line": 1609,
+          "line": 1668,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29119,7 +30072,7 @@
         },
         {
           "name": "DigChoice",
-          "line": 1614,
+          "line": 1673,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29139,7 +30092,7 @@
         },
         {
           "name": "SurveilChoice",
-          "line": 1638,
+          "line": 1697,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29150,7 +30103,7 @@
         },
         {
           "name": "RevealChoice",
-          "line": 1642,
+          "line": 1701,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29164,7 +30117,7 @@
         },
         {
           "name": "SearchChoice",
-          "line": 1661,
+          "line": 1720,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29180,7 +30133,7 @@
         },
         {
           "name": "SearchPartitionChoice",
-          "line": 1695,
+          "line": 1754,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29199,7 +30152,7 @@
         },
         {
           "name": "OutsideGameChoice",
-          "line": 1708,
+          "line": 1767,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29218,7 +30171,7 @@
         },
         {
           "name": "ChooseFromZoneChoice",
-          "line": 1722,
+          "line": 1781,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29235,7 +30188,7 @@
         },
         {
           "name": "ChooseOneOfBranch",
-          "line": 1734,
+          "line": 1793,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29254,7 +30207,7 @@
         },
         {
           "name": "ConniveDiscard",
-          "line": 1752,
+          "line": 1811,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29270,7 +30223,7 @@
         },
         {
           "name": "DiscardChoice",
-          "line": 1761,
+          "line": 1820,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29288,7 +30241,7 @@
         },
         {
           "name": "EffectZoneChoice",
-          "line": 1777,
+          "line": 1836,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29315,7 +30268,7 @@
         },
         {
           "name": "DrawnThisTurnTopdeckChoice",
-          "line": 1830,
+          "line": 1889,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29330,7 +30283,7 @@
         },
         {
           "name": "LearnChoice",
-          "line": 1840,
+          "line": 1899,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29343,7 +30296,7 @@
         },
         {
           "name": "ManifestDreadChoice",
-          "line": 1846,
+          "line": 1905,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29356,7 +30309,7 @@
         },
         {
           "name": "TriggerTargetSelection",
-          "line": 1850,
+          "line": 1909,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29371,7 +30324,7 @@
         },
         {
           "name": "BetweenGamesSideboard",
-          "line": 1864,
+          "line": 1923,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29383,7 +30336,7 @@
         },
         {
           "name": "BetweenGamesChoosePlayDraw",
-          "line": 1869,
+          "line": 1928,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29395,7 +30348,7 @@
         },
         {
           "name": "NamedChoice",
-          "line": 1875,
+          "line": 1934,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29408,7 +30361,7 @@
         },
         {
           "name": "DamageSourceChoice",
-          "line": 1885,
+          "line": 1944,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29422,7 +30375,7 @@
         },
         {
           "name": "ModeChoice",
-          "line": 1891,
+          "line": 1950,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29434,7 +30387,7 @@
         },
         {
           "name": "DiscardToHandSize",
-          "line": 1897,
+          "line": 1956,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29446,7 +30399,7 @@
         },
         {
           "name": "OptionalCostChoice",
-          "line": 1905,
+          "line": 1964,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29459,7 +30412,7 @@
         },
         {
           "name": "DefilerPayment",
-          "line": 1917,
+          "line": 1976,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29474,7 +30427,7 @@
         },
         {
           "name": "AdventureCastChoice",
-          "line": 1927,
+          "line": 1986,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29489,7 +30442,7 @@
         },
         {
           "name": "ModalFaceChoice",
-          "line": 1944,
+          "line": 2003,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29505,7 +30458,7 @@
         },
         {
           "name": "AlternativeCastChoice",
-          "line": 1967,
+          "line": 2026,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29531,7 +30484,7 @@
         },
         {
           "name": "CastingVariantChoice",
-          "line": 1999,
+          "line": 2058,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29547,7 +30500,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 2011,
+          "line": 2070,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29564,7 +30517,7 @@
         },
         {
           "name": "MultiTargetSelection",
-          "line": 2022,
+          "line": 2081,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29580,7 +30533,7 @@
         },
         {
           "name": "AbilityModeChoice",
-          "line": 2033,
+          "line": 2092,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29597,7 +30550,7 @@
         },
         {
           "name": "OptionalEffectChoice",
-          "line": 2056,
+          "line": 2115,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29612,7 +30565,7 @@
         },
         {
           "name": "PairChoice",
-          "line": 2067,
+          "line": 2126,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29627,7 +30580,7 @@
         },
         {
           "name": "TributeChoice",
-          "line": 2078,
+          "line": 2137,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29642,7 +30595,7 @@
         },
         {
           "name": "MiracleReveal",
-          "line": 2090,
+          "line": 2149,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29657,7 +30610,7 @@
         },
         {
           "name": "MiracleCastOffer",
-          "line": 2100,
+          "line": 2159,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29672,7 +30625,7 @@
         },
         {
           "name": "MadnessCastOffer",
-          "line": 2109,
+          "line": 2168,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29686,7 +30639,7 @@
         },
         {
           "name": "OpponentMayChoice",
-          "line": 2116,
+          "line": 2175,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29702,7 +30655,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 2129,
+          "line": 2188,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29720,7 +30673,7 @@
         },
         {
           "name": "UnlessPaymentChooseCost",
-          "line": 2163,
+          "line": 2222,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29738,7 +30691,7 @@
         },
         {
           "name": "WardDiscardChoice",
-          "line": 2193,
+          "line": 2252,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29752,7 +30705,7 @@
         },
         {
           "name": "WardSacrificeChoice",
-          "line": 2201,
+          "line": 2260,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29767,7 +30720,7 @@
         },
         {
           "name": "UnlessBounceChoice",
-          "line": 2212,
+          "line": 2271,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29782,7 +30735,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 2220,
+          "line": 2279,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29795,7 +30748,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 2225,
+          "line": 2284,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29808,7 +30761,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 2230,
+          "line": 2289,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29823,7 +30776,7 @@
         },
         {
           "name": "DiscardForCost",
-          "line": 2238,
+          "line": 2297,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29838,7 +30791,7 @@
         },
         {
           "name": "SacrificeForCost",
-          "line": 2248,
+          "line": 2307,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29854,7 +30807,7 @@
         },
         {
           "name": "ReturnToHandForCost",
-          "line": 2258,
+          "line": 2317,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29870,7 +30823,7 @@
         },
         {
           "name": "ActivationCostOneOfChoice",
-          "line": 2268,
+          "line": 2327,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29884,7 +30837,7 @@
         },
         {
           "name": "RemoveCounterForCost",
-          "line": 2275,
+          "line": 2334,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29902,7 +30855,7 @@
         },
         {
           "name": "BlightChoice",
-          "line": 2285,
+          "line": 2344,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29915,7 +30868,7 @@
         },
         {
           "name": "TapCreaturesForSpellCost",
-          "line": 2296,
+          "line": 2355,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29931,7 +30884,7 @@
         },
         {
           "name": "BeholdForCost",
-          "line": 2304,
+          "line": 2363,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29945,7 +30898,7 @@
         },
         {
           "name": "TapCreaturesForManaAbility",
-          "line": 2312,
+          "line": 2371,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29961,7 +30914,7 @@
         },
         {
           "name": "DiscardForManaAbility",
-          "line": 2319,
+          "line": 2378,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29977,7 +30930,7 @@
         },
         {
           "name": "ExileForManaAbility",
-          "line": 2329,
+          "line": 2388,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29995,7 +30948,7 @@
         },
         {
           "name": "SacrificeForManaAbility",
-          "line": 2341,
+          "line": 2400,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30012,7 +30965,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 2357,
+          "line": 2416,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30028,7 +30981,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 2367,
+          "line": 2426,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30044,7 +30997,7 @@
         },
         {
           "name": "ExileForCost",
-          "line": 2380,
+          "line": 2439,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30063,7 +31016,7 @@
         },
         {
           "name": "CollectEvidenceChoice",
-          "line": 2395,
+          "line": 2454,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30079,7 +31032,7 @@
         },
         {
           "name": "HarmonizeTapChoice",
-          "line": 2404,
+          "line": 2463,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30096,7 +31049,7 @@
         },
         {
           "name": "DiscoverChoice",
-          "line": 2412,
+          "line": 2471,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30110,14 +31063,16 @@
         },
         {
           "name": "RevealUntilKeptChoice",
-          "line": 2424,
+          "line": 2483,
           "kind": "struct",
           "field_names": [
             "player",
             "hit_card",
+            "source_id",
             "accept_zone",
             "decline_zone",
             "enter_tapped",
+            "enters_attacking",
             "revealed_misses",
             "rest_destination"
           ],
@@ -30129,7 +31084,7 @@
         },
         {
           "name": "RepeatDecision",
-          "line": 2437,
+          "line": 2504,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30143,7 +31098,7 @@
         },
         {
           "name": "CascadeChoice",
-          "line": 2447,
+          "line": 2514,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30158,7 +31113,7 @@
         },
         {
           "name": "TopOrBottomChoice",
-          "line": 2463,
+          "line": 2530,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30171,7 +31126,7 @@
         },
         {
           "name": "ParadigmCastOffer",
-          "line": 2472,
+          "line": 2539,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30184,7 +31139,7 @@
         },
         {
           "name": "PopulateChoice",
-          "line": 2477,
+          "line": 2544,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30198,7 +31153,7 @@
         },
         {
           "name": "ClashCardPlacement",
-          "line": 2485,
+          "line": 2552,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30212,7 +31167,7 @@
         },
         {
           "name": "VoteChoice",
-          "line": 2496,
+          "line": 2563,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30234,7 +31189,7 @@
         },
         {
           "name": "SeparatePilesPartition",
-          "line": 2555,
+          "line": 2622,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30255,7 +31210,7 @@
         },
         {
           "name": "SeparatePilesChoice",
-          "line": 2585,
+          "line": 2652,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30272,7 +31227,7 @@
         },
         {
           "name": "CompanionReveal",
-          "line": 2600,
+          "line": 2667,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30285,7 +31240,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 2607,
+          "line": 2674,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30299,7 +31254,7 @@
         },
         {
           "name": "CommanderZoneChoice",
-          "line": 2616,
+          "line": 2683,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30313,7 +31268,7 @@
         },
         {
           "name": "BattleProtectorChoice",
-          "line": 2627,
+          "line": 2694,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30329,7 +31284,7 @@
         },
         {
           "name": "ProliferateChoice",
-          "line": 2634,
+          "line": 2701,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30342,7 +31297,7 @@
         },
         {
           "name": "ChooseObjectsSelection",
-          "line": 2644,
+          "line": 2711,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30356,7 +31311,7 @@
         },
         {
           "name": "CategoryChoice",
-          "line": 2657,
+          "line": 2724,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30376,7 +31331,7 @@
         },
         {
           "name": "CopyRetarget",
-          "line": 2680,
+          "line": 2747,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30391,7 +31346,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 2690,
+          "line": 2757,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30413,7 +31368,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 2714,
+          "line": 2781,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30427,8 +31382,26 @@
           ]
         },
         {
+          "name": "MoveCountersDistribution",
+          "line": 2789,
+          "kind": "struct",
+          "field_names": [
+            "player",
+            "source_id",
+            "counter_type",
+            "available",
+            "destinations",
+            "pending_effect"
+          ],
+          "doc": "CR 122.5 + CR 608.2d: \"Move any number of counters ... onto [set]\" chooses destinations and counts as the ability resolves.",
+          "cr_refs": [
+            "CR 122.5",
+            "CR 608.2d"
+          ]
+        },
+        {
           "name": "PayAmountChoice",
-          "line": 2725,
+          "line": 2803,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30446,7 +31419,7 @@
         },
         {
           "name": "RetargetChoice",
-          "line": 2738,
+          "line": 2816,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30462,7 +31435,7 @@
         },
         {
           "name": "CombatTaxPayment",
-          "line": 2760,
+          "line": 2838,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30482,7 +31455,7 @@
         },
         {
           "name": "PhyrexianPayment",
-          "line": 2778,
+          "line": 2856,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30501,7 +31474,7 @@
     },
     "WardCost": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 355,
+      "line": 365,
       "doc": "CR 702.21a: Ward cost — what the targeting player must pay.",
       "cr_refs": [
         "CR 702.21a"
@@ -30509,7 +31482,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 356,
+          "line": 366,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30517,7 +31490,7 @@
         },
         {
           "name": "PayLife",
-          "line": 357,
+          "line": 367,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30525,7 +31498,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 358,
+          "line": 368,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30533,7 +31506,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 360,
+          "line": 370,
           "kind": "struct",
           "field_names": [
             "count",
@@ -30546,7 +31519,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 366,
+          "line": 376,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.21a: Ward cost paid via waterbend — tap artifacts/creatures to help pay. Distinct from Mana because waterbend has unique payment semantics (CR 701.67).",
@@ -30557,7 +31530,7 @@
         },
         {
           "name": "Compound",
-          "line": 369,
+          "line": 379,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.21a: Compound ward cost — multiple costs that must all be paid. Used for \"Ward—{2}, Pay 2 life\" where comma-separated sub-costs are conjoined.",
@@ -30681,13 +31654,13 @@
     },
     "ZoneRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 743,
+      "line": 764,
       "doc": "Which zone to count cards in (for `QuantityRef::ZoneCardCount`).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Graveyard",
-          "line": 744,
+          "line": 765,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30695,7 +31668,7 @@
         },
         {
           "name": "Exile",
-          "line": 745,
+          "line": 766,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30703,7 +31676,7 @@
         },
         {
           "name": "Library",
-          "line": 746,
+          "line": 767,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30711,7 +31684,7 @@
         },
         {
           "name": "Hand",
-          "line": 747,
+          "line": 768,
           "kind": "unit",
           "field_names": [],
           "doc": "",


### PR DESCRIPTION
Replace the binary ControlsPermanent{presence: ControlPresence} with the
parameterized ControlsCount{filter, comparator: Comparator, count: QuantityExpr},
absorbing the presence axis (Controls -> {GE, Fixed(1)}, ControlsNone ->
{EQ, Fixed(0)}) and unlocking comparative population predicates
("control more X than you" -> {GT, count: ObjectCount{filter, You}}).

This is a Round-Pi parameterization (CR 109.4 + CR 109.5): one variant where there
were two, eliminating the ControlPresence sibling enum. Migrates all 9 PlayerFilter
match sites (5 runtime + 4 non-runtime), the parser builders, and the test suite in
lockstep; the runtime player_control_count_compares counts the candidate's matching
permanents and compares via the typed Comparator. Behavior-preserving for the 12
existing ControlsPermanent cards (verified at runtime: Thornbow Archer {EQ,Fixed(0)},
Depopulate {GE,Fixed(1)}), and fixes Heidegger, Shinra Executive and Priest of the
Blessed Graf ("the number of opponents who control more {creatures|lands} than you").
The quantity arm also accepts a "players" relation (-> All) for the broader class.

Drops 9 stray "CR 700.1" misannotations (700.1 is "anything that happens is an event",
inapplicable to a control predicate) in favor of CR 109.4. Regenerates the tracked
engine-inventory.json; card-data.json (gitignored) regenerated so the 12 cards migrate
from ControlsPermanent to ControlsCount.

Follow-up (separate parser path): Oreskos Explorer ("players who control more lands than
you") routes through parse_where_x_is_trigger -> the nom-combinator parser, which lacks
the comparative arm, so it stays Variable. `count` is Box<QuantityExpr> to break the
QuantityExpr -> PlayerCount -> ControlsCount -> QuantityExpr recursive type cycle.

CR 109.4 (control), CR 109.5 ("you"/"your").
