### PR TITLE
fix(parser): wire 'tapped and attacking' in ReturnDestination (CR 508.4)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1306,6 +1306,7 @@ pub(super) fn parse_targeted_action_ast(
                         enter_transformed: d.transformed,
                         enters_under: d.enters_under,
                         enter_tapped: d.enter_tapped,
+                        enters_attacking: d.enters_attacking,
                         enter_with_counters: d.enter_with_counters,
                     })
                 }
@@ -1495,6 +1496,7 @@ pub(super) fn lower_targeted_action_ast(ast: TargetedImperativeAst) -> Effect {
             enter_transformed,
             enters_under,
             enter_tapped,
+            enters_attacking,
             enter_with_counters,
         } => Effect::ChangeZone {
             origin,
@@ -1504,7 +1506,7 @@ pub(super) fn lower_targeted_action_ast(ast: TargetedImperativeAst) -> Effect {
             enter_transformed,
             enters_under,
             enter_tapped,
-            enters_attacking: false,
+            enters_attacking,
             up_to: false,
             enter_with_counters,
         },

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7126,6 +7126,7 @@ fn try_parse_verb_and_target<'a>(
                             enter_transformed: d.transformed,
                             enters_under: d.enters_under,
                             enter_tapped: d.enter_tapped,
+                            enters_attacking: d.enters_attacking,
                             enter_with_counters: d.enter_with_counters,
                         },
                         rem,
@@ -16701,6 +16702,8 @@ struct ReturnDestination {
     enters_under: Option<ControllerRef>,
     // CR 614.1: "tapped" — enters the battlefield tapped.
     enter_tapped: bool,
+    // CR 508.4: "tapped and attacking" — enters attacking.
+    enters_attacking: bool,
     // CR 122.1 + CR 122.6: Counters placed on the returned object as it enters.
     enter_with_counters: Vec<(CounterType, QuantityExpr)>,
 }
@@ -16717,12 +16720,12 @@ fn strip_return_destination_ext_with_remainder(
     let lower = text.to_lowercase();
     // Ordered longest-first to avoid partial matches.
     // "transformed" variants must come before their non-transformed counterparts.
-    // Tuples: (phrase, zone, transformed, enters_under_you, enter_tapped)
+    // Tuples: (phrase, zone, transformed, enters_under_you, enter_tapped, enters_attacking)
     // The `enters_under_you` bool is the parser-table carrier for the
     // controller-override flag; it maps to `Some(ControllerRef::You)` / `None`
     // at the `ReturnDestination` construction site below (CR 110.2a).
     // Ordered longest-first; compound patterns must precede their shorter substrings.
-    let patterns: &[(&str, Zone, bool, bool, bool)] = &[
+    let patterns: &[(&str, Zone, bool, bool, bool, bool)] = &[
         // Tapped + transformed + owner's control (compound, longest)
         (
             " to the battlefield tapped and transformed under its owner's control",
@@ -16730,6 +16733,7 @@ fn strip_return_destination_ext_with_remainder(
             true,
             false,
             true,
+            false,
         ),
         // Transformed + your control
         (
@@ -16737,6 +16741,7 @@ fn strip_return_destination_ext_with_remainder(
             Zone::Battlefield,
             true,
             true,
+            false,
             false,
         ),
         // Transformed + owner's control variants
@@ -16746,11 +16751,13 @@ fn strip_return_destination_ext_with_remainder(
             true,
             false,
             false,
+            false,
         ),
         (
             " to the battlefield transformed under its owner's control",
             Zone::Battlefield,
             true,
+            false,
             false,
             false,
         ),
@@ -16760,11 +16767,13 @@ fn strip_return_destination_ext_with_remainder(
             true,
             false,
             false,
+            false,
         ),
         (
             " to the battlefield transformed under her owner's control",
             Zone::Battlefield,
             true,
+            false,
             false,
             false,
         ),
@@ -16774,6 +16783,24 @@ fn strip_return_destination_ext_with_remainder(
             true,
             false,
             false,
+            false,
+        ),
+        // CR 508.4: Tapped and attacking (must precede shorter "tapped" variants)
+        (
+            " to the battlefield tapped and attacking",
+            Zone::Battlefield,
+            false,
+            false,
+            true,
+            true,
+        ),
+        (
+            " onto the battlefield tapped and attacking",
+            Zone::Battlefield,
+            false,
+            false,
+            true,
+            true,
         ),
         // Tapped + control variants (must precede shorter "tapped" and "under X control")
         (
@@ -16782,6 +16809,7 @@ fn strip_return_destination_ext_with_remainder(
             false,
             false,
             true,
+            false,
         ),
         (
             " to the battlefield tapped under its owner's control",
@@ -16789,6 +16817,7 @@ fn strip_return_destination_ext_with_remainder(
             false,
             false,
             true,
+            false,
         ),
         (
             " to the battlefield tapped under your control",
@@ -16796,6 +16825,7 @@ fn strip_return_destination_ext_with_remainder(
             false,
             true,
             true,
+            false,
         ),
         // Simple control variants
         (
@@ -16804,10 +16834,12 @@ fn strip_return_destination_ext_with_remainder(
             false,
             false,
             false,
+            false,
         ),
         (
             " to the battlefield under its owner's control",
             Zone::Battlefield,
+            false,
             false,
             false,
             false,
@@ -16819,6 +16851,7 @@ fn strip_return_destination_ext_with_remainder(
             false,
             true,
             false,
+            false,
         ),
         // CR 614.1: "tapped" — enters tapped.
         (
@@ -16827,10 +16860,12 @@ fn strip_return_destination_ext_with_remainder(
             false,
             false,
             true,
+            false,
         ),
         (
             " to the battlefield",
             Zone::Battlefield,
+            false,
             false,
             false,
             false,
@@ -16842,6 +16877,7 @@ fn strip_return_destination_ext_with_remainder(
             false,
             true,
             false,
+            false,
         ),
         (
             " onto the battlefield tapped",
@@ -16849,6 +16885,7 @@ fn strip_return_destination_ext_with_remainder(
             false,
             false,
             true,
+            false,
         ),
         (
             " onto the battlefield",
@@ -16856,17 +16893,40 @@ fn strip_return_destination_ext_with_remainder(
             false,
             false,
             false,
+            false,
         ),
         // Hand destinations
-        (" to its owner's hand", Zone::Hand, false, false, false),
-        (" to their owner's hand", Zone::Hand, false, false, false),
-        (" to their owners' hands", Zone::Hand, false, false, false),
-        (" to their hand", Zone::Hand, false, false, false),
-        (" to your hand", Zone::Hand, false, false, false),
+        (
+            " to its owner's hand",
+            Zone::Hand,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            " to their owner's hand",
+            Zone::Hand,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            " to their owners' hands",
+            Zone::Hand,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (" to their hand", Zone::Hand, false, false, false, false),
+        (" to your hand", Zone::Hand, false, false, false, false),
         // Graveyard destinations
         (
             " to its owner's graveyard",
             Zone::Graveyard,
+            false,
             false,
             false,
             false,
@@ -16877,6 +16937,7 @@ fn strip_return_destination_ext_with_remainder(
             false,
             false,
             false,
+            false,
         ),
         (
             " to their owners' graveyards",
@@ -16884,15 +16945,30 @@ fn strip_return_destination_ext_with_remainder(
             false,
             false,
             false,
+            false,
         ),
-        (" to your graveyard", Zone::Graveyard, false, false, false),
+        (
+            " to your graveyard",
+            Zone::Graveyard,
+            false,
+            false,
+            false,
+            false,
+        ),
         // Command-zone destinations
-        (" to the command zone", Zone::Command, false, false, false),
+        (
+            " to the command zone",
+            Zone::Command,
+            false,
+            false,
+            false,
+            false,
+        ),
         // NOTE: Library destinations ("to the top/bottom of owner's library") are
         // intentionally NOT handled here. They require PutAtLibraryPosition (positional
         // placement without shuffling), not ChangeZone (which auto-shuffles).
     ];
-    for (phrase, zone, transformed, enters_under_you, enter_tapped) in patterns {
+    for (phrase, zone, transformed, enters_under_you, enter_tapped, enters_attacking) in patterns {
         if let Some(pos) = lower.rfind(phrase) {
             let after_destination = &lower[pos + phrase.len()..];
             let original_after_destination = &text[pos + phrase.len()..];
@@ -16903,6 +16979,7 @@ fn strip_return_destination_ext_with_remainder(
                     transformed: *transformed,
                     enters_under: enters_under_you.then_some(ControllerRef::You),
                     enter_tapped: *enter_tapped,
+                    enters_attacking: *enters_attacking,
                     enter_with_counters: parse_with_counters_suffix(after_destination),
                 }),
                 original_after_destination,
@@ -16941,11 +17018,13 @@ fn parse_leading_battlefield_return_destination(
         tag("onto the battlefield"),
     ))
     .parse(input)?;
+    // (transformed, enter_tapped, enters_attacking)
     let (input, modifier) = alt((
-        value((true, true), tag(" tapped and transformed")),
-        value((true, false), tag(" transformed")),
-        value((false, true), tag(" tapped")),
-        value((false, false), tag("")),
+        value((true, true, false), tag(" tapped and transformed")),
+        value((true, false, false), tag(" transformed")),
+        value((false, true, true), tag(" tapped and attacking")),
+        value((false, true, false), tag(" tapped")),
+        value((false, false, false), tag("")),
     ))
     .parse(input)?;
     // CR 110.2a: parse the controller-override clause (or its absence) directly
@@ -16970,6 +17049,7 @@ fn parse_leading_battlefield_return_destination(
             transformed: modifier.0,
             enters_under,
             enter_tapped: modifier.1,
+            enters_attacking: modifier.2,
             enter_with_counters: vec![],
         },
     ))
@@ -16991,6 +17071,7 @@ fn parse_leading_hand_return_destination(input: &str) -> OracleResult<'_, Return
             transformed: false,
             enters_under: None,
             enter_tapped: false,
+            enters_attacking: false,
             enter_with_counters: vec![],
         },
     ))
@@ -17011,6 +17092,7 @@ fn parse_leading_graveyard_return_destination(input: &str) -> OracleResult<'_, R
             transformed: false,
             enters_under: None,
             enter_tapped: false,
+            enters_attacking: false,
             enter_with_counters: vec![],
         },
     ))
@@ -17025,6 +17107,7 @@ fn parse_leading_command_return_destination(input: &str) -> OracleResult<'_, Ret
             transformed: false,
             enters_under: None,
             enter_tapped: false,
+            enters_attacking: false,
             enter_with_counters: vec![],
         },
     ))
@@ -33733,6 +33816,45 @@ mod tests {
         assert_eq!(d.enters_under, None);
         assert!(!d.enter_tapped);
         assert!(!d.transformed);
+    }
+
+    #[test]
+    fn return_destination_tapped_and_attacking() {
+        let (target_text, dest) = strip_return_destination_ext(
+            "target creature card to the battlefield tapped and attacking",
+        );
+        assert_eq!(target_text, "target creature card");
+        let d = dest.expect("should parse destination");
+        assert_eq!(d.zone, Zone::Battlefield);
+        assert!(d.enter_tapped);
+        assert!(d.enters_attacking);
+        assert!(!d.transformed);
+        assert_eq!(d.enters_under, None);
+    }
+
+    /// CR 508.4: "return target creature card from your graveyard to the
+    /// battlefield tapped and attacking" (Dauntless Avenger / Yore-Tiller
+    /// Nephilim) must lower to `Effect::ChangeZone` with `enters_attacking: true`.
+    #[test]
+    fn effect_return_from_graveyard_tapped_and_attacking() {
+        let e = parse_effect(
+            "return target creature card from your graveyard to the battlefield tapped and attacking",
+        );
+        match e {
+            Effect::ChangeZone {
+                origin,
+                destination,
+                enter_tapped,
+                enters_attacking,
+                ..
+            } => {
+                assert_eq!(origin, Some(Zone::Graveyard));
+                assert_eq!(destination, Zone::Battlefield);
+                assert!(enter_tapped);
+                assert!(enters_attacking);
+            }
+            other => panic!("expected Effect::ChangeZone, got {other:?}"),
+        }
     }
 
     /// Collect all effects in a sub_ability chain into a flat Vec.

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -662,6 +662,8 @@ pub(crate) enum TargetedImperativeAst {
         enters_under: Option<ControllerRef>,
         /// CR 614.1: "tapped" — enters tapped.
         enter_tapped: bool,
+        /// CR 508.4: "tapped and attacking" — enters attacking.
+        enters_attacking: bool,
         /// CR 122.1 + CR 122.6: Counters placed on the returned object as it
         /// enters the battlefield.
         enter_with_counters: Vec<(CounterType, QuantityExpr)>,


### PR DESCRIPTION
## Summary

The parser's `ReturnDestination` pattern table only matched `" to the battlefield tapped"`, so oracle text like "return target creature card from your graveyard to the battlefield tapped and attacking" consumed only "tapped" and left "and attacking" as a remainder that fell through to `Effect::Unimplemented { name: "attacking" }`. This blocked 4 cards from coverage.

## Changes

| Area | Change |
|------|--------|
| `ReturnDestination` | Add `enters_attacking: bool` field |
| `TargetedImperativeAst::ReturnToBattlefield` | Add `enters_attacking: bool` field |
| Pattern table | Extend 5-tuple → 6-tuple; add "tapped and attacking" patterns (to/onto) |
| `parse_leading_battlefield_return_destination` | Handle "tapped and attacking" modifier |
| `imperative.rs` lowering | Thread `enters_attacking` from AST → Effect |
| Tests | 2 new tests (unit + integration) |

## Cards unlocked (4)

Dauntless Avenger, Yore-Tiller Nephilim, Alesha Who Smiles at Death, Olivia Crimson Bride

## CR Reference

**CR 508.4** — A creature that enters the battlefield attacking is never declared as an attacker; it is simply put onto the battlefield attacking.
