### PR TITLE
feat(engine): add PlayerFilter::PlayerAttribute for per-candidate player thresholds

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1755,6 +1755,12 @@ fn quantity_ref_references_target_creature(qty: &QuantityRef) -> bool {
         QuantityRef::PlayerCount {
             filter: crate::types::ability::PlayerFilter::ControlsCount { filter, .. },
         } => filter_references_target_creature_quantity(filter),
+        // CR 402.1 / 119.1 / 122.1f / 404.1: a player-scalar predicate is read
+        // off each candidate player, never off a target creature, so it cannot
+        // reference the resolving ability's target-creature slot.
+        QuantityRef::PlayerCount {
+            filter: crate::types::ability::PlayerFilter::PlayerAttribute { .. },
+        } => false,
         _ => false,
     }
 }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1195,6 +1195,21 @@ fn fmt_player_filter(pf: &PlayerFilter) -> String {
             };
             return format!("{who} who controls {comparator:?} {count:?} matching permanents");
         }
+        // CR 402.1 / 119.1 / 122.1f / 404.1: "each [player class] whose [scalar
+        // attr] [comparator] [value]"
+        PlayerFilter::PlayerAttribute {
+            relation,
+            attr,
+            comparator,
+            value,
+        } => {
+            let who = match relation {
+                PlayerRelation::Controller => "you",
+                PlayerRelation::Opponent => "each opponent",
+                PlayerRelation::All => "each player",
+            };
+            return format!("{who} whose {attr:?} {comparator:?} {value:?}");
+        }
     }
     .into()
 }
@@ -5264,6 +5279,7 @@ fn player_filter_feature(scope: &PlayerFilter) -> (&'static str, FeatureSupport)
         PlayerFilter::VotedFor { .. } => ("VotedFor", Handled),
         PlayerFilter::ParentObjectTargetController => ("ParentObjectTargetController", Handled),
         PlayerFilter::ControlsCount { .. } => ("ControlsCount", Handled),
+        PlayerFilter::PlayerAttribute { .. } => ("PlayerAttribute", Handled),
     }
 }
 

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -938,6 +938,27 @@ fn collect_matching_players(
                                 source_id,
                             )
                     }
+                    // CR 402.1 / 119.1 / 122.1f / 404.1: "each [player class]
+                    // whose [scalar attr] [comparator] [value]" — candidate
+                    // satisfies both `relation` and the per-candidate scalar
+                    // comparison. `attr` is read directly off `p`; `value` is
+                    // the controller-relative threshold, resolved once.
+                    PlayerFilter::PlayerAttribute {
+                        ref relation,
+                        ref attr,
+                        ref comparator,
+                        ref value,
+                    } => {
+                        let threshold = crate::game::quantity::resolve_quantity(
+                            state,
+                            value,
+                            source_controller,
+                            source_id,
+                        );
+                        crate::game::players::matches_relation(p.id, source_controller, *relation)
+                            && crate::game::effects::candidate_player_scalar(p, attr)
+                                .is_some_and(|lhs| comparator.evaluate(lhs, threshold))
+                    }
                 }
         })
         .map(|p| p.id)
@@ -1078,6 +1099,27 @@ pub fn resolve_each_player(
                                 threshold,
                                 ability.source_id,
                             )
+                    }
+                    // CR 402.1 / 119.1 / 122.1f / 404.1: "each [player class]
+                    // whose [scalar attr] [comparator] [value]" — candidate
+                    // satisfies both `relation` and the per-candidate scalar
+                    // comparison. `attr` is read directly off `p`; `value` is
+                    // the controller-relative threshold, resolved once.
+                    PlayerFilter::PlayerAttribute {
+                        relation,
+                        attr,
+                        comparator,
+                        value,
+                    } => {
+                        let threshold = crate::game::quantity::resolve_quantity(
+                            state,
+                            value,
+                            ability.controller,
+                            ability.source_id,
+                        );
+                        crate::game::players::matches_relation(p.id, ability.controller, *relation)
+                            && crate::game::effects::candidate_player_scalar(p, attr)
+                                .is_some_and(|lhs| comparator.evaluate(lhs, threshold))
                     }
                 }
         })

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -16,7 +16,7 @@ use crate::types::game_state::{
 };
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::mana::ManaCost;
-use crate::types::player::PlayerId;
+use crate::types::player::{Player, PlayerId};
 
 pub mod adapt;
 pub mod add_restriction;
@@ -303,6 +303,24 @@ pub(crate) fn matches_player_scope(
                                 source_id,
                             )
                     }
+                    // CR 402.1 / 119.1 / 122.1f / 404.1: "each [player class]
+                    // whose [scalar attr] [comparator] [value]" — the candidate
+                    // satisfies both `relation` and the per-candidate scalar
+                    // comparison. `value` is the controller-relative threshold,
+                    // resolved once; `attr` is read directly off the candidate.
+                    PlayerFilter::PlayerAttribute {
+                        relation,
+                        attr,
+                        comparator,
+                        value,
+                    } => {
+                        let threshold = crate::game::quantity::resolve_quantity(
+                            state, value, controller, source_id,
+                        );
+                        crate::game::players::matches_relation(p.id, controller, *relation)
+                            && candidate_player_scalar(p, attr)
+                                .is_some_and(|lhs| comparator.evaluate(lhs, threshold))
+                    }
                 }
         })
 }
@@ -344,6 +362,30 @@ pub(crate) fn player_control_count_compares(
         crate::game::arithmetic::usize_to_i32_saturating(count),
         threshold,
     )
+}
+
+/// CR 402.1 / 119.1 / 122.1f / 404.1: Read scalar `attr` for one candidate
+/// player DIRECTLY off the candidate `Player` (NOT via the controller-scoped
+/// `resolve_quantity`), so `PlayerFilter::PlayerAttribute` reads each player's
+/// own hand size / life / graveyard / player-counter rather than the
+/// controller's. Returns `None` for any non-scalar `QuantityRef`; the parser
+/// invariant guarantees only the scalar subset reaches here, and `None` fails
+/// the candidate predicate closed.
+pub(crate) fn candidate_player_scalar(p: &Player, attr: &QuantityRef) -> Option<i32> {
+    use crate::game::arithmetic::{u32_to_i32_saturating, usize_to_i32_saturating};
+    match attr {
+        // CR 402.1: cards in the candidate's hand.
+        QuantityRef::HandSize { .. } => Some(usize_to_i32_saturating(p.hand.len())),
+        // CR 119.1: the candidate's current life total.
+        QuantityRef::LifeTotal { .. } => Some(p.life),
+        // CR 404.1: cards in the candidate's graveyard.
+        QuantityRef::GraveyardSize { .. } => Some(usize_to_i32_saturating(p.graveyard.len())),
+        // CR 122.1f (poison) + CR 122.1: the candidate's named player-counter total.
+        QuantityRef::PlayerCounter { kind, .. } => {
+            Some(u32_to_i32_saturating(p.player_counter(kind)))
+        }
+        _ => None,
+    }
 }
 
 /// Record the outer effect's `EffectKind` on the current `pending_continuation`
@@ -12630,6 +12672,100 @@ mod tests {
         assert_eq!(
             state.waiting_for, initial_waiting,
             "empty counter set must not prompt"
+        );
+    }
+
+    /// CR 402.1 / 119.1 / 122.1f / 404.1: `candidate_player_scalar` reads each
+    /// of the four scalar `QuantityRef` attributes directly off the candidate
+    /// `Player`, and returns `None` for any non-scalar `QuantityRef` (failing
+    /// the predicate closed). Exercises the building block across its full input
+    /// range, not a single card.
+    #[test]
+    fn candidate_player_scalar_reads_each_attribute() {
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+        // Give the player distinguishable scalar values so the wrong attribute
+        // can never accidentally pass.
+        {
+            let p = &mut state.players[1];
+            p.life = 17;
+            p.poison_counters = 4;
+            p.hand.push_back(ObjectId(1));
+            p.hand.push_back(ObjectId(2));
+            p.hand.push_back(ObjectId(3));
+            p.graveyard.push_back(ObjectId(4));
+            p.graveyard.push_back(ObjectId(5));
+            p.player_counter(&PlayerCounterKind::Experience); // no-op read
+            p.add_player_counters(&PlayerCounterKind::Experience, 6);
+        }
+        let p = &state.players[1];
+
+        // CR 402.1: hand size reads p.hand.len(), ignoring the inert PlayerScope.
+        assert_eq!(
+            candidate_player_scalar(
+                p,
+                &QuantityRef::HandSize {
+                    player: PlayerScope::Controller
+                }
+            ),
+            Some(3)
+        );
+        // CR 119.1: life total reads p.life.
+        assert_eq!(
+            candidate_player_scalar(
+                p,
+                &QuantityRef::LifeTotal {
+                    player: PlayerScope::ScopedPlayer
+                }
+            ),
+            Some(17)
+        );
+        // CR 404.1: graveyard size reads p.graveyard.len().
+        assert_eq!(
+            candidate_player_scalar(
+                p,
+                &QuantityRef::GraveyardSize {
+                    player: PlayerScope::Controller
+                }
+            ),
+            Some(2)
+        );
+        // CR 122.1f: poison reads the dedicated poison_counters field.
+        assert_eq!(
+            candidate_player_scalar(
+                p,
+                &QuantityRef::PlayerCounter {
+                    kind: PlayerCounterKind::Poison,
+                    scope: crate::types::ability::CountScope::ScopedPlayer,
+                }
+            ),
+            Some(4)
+        );
+        // CR 122.1: a generic player counter reads the player_counters map.
+        assert_eq!(
+            candidate_player_scalar(
+                p,
+                &QuantityRef::PlayerCounter {
+                    kind: PlayerCounterKind::Experience,
+                    scope: crate::types::ability::CountScope::ScopedPlayer,
+                }
+            ),
+            Some(6)
+        );
+        // Non-scalar QuantityRef → None (parser invariant; fails the predicate
+        // closed rather than reading a controller-scoped quantity off a
+        // candidate).
+        assert_eq!(
+            candidate_player_scalar(p, &QuantityRef::Variable { name: "X".into() }),
+            None
+        );
+        assert_eq!(
+            candidate_player_scalar(
+                p,
+                &QuantityRef::ObjectCount {
+                    filter: TargetFilter::Any
+                }
+            ),
+            None
         );
     }
 }

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -202,6 +202,31 @@ fn players_for_filter(
                 .map(|player| player.id)
                 .collect()
         }
+        // CR 402.1 / 119.1 / 122.1f / 404.1: "each [player class] whose [scalar
+        // attr] [comparator] [value]" — candidates satisfying both `relation`
+        // and the per-candidate scalar comparison. `attr` is read directly off
+        // each candidate; `value` is the controller-relative threshold,
+        // resolved once.
+        PlayerFilter::PlayerAttribute {
+            relation,
+            attr,
+            comparator,
+            value,
+        } => {
+            let threshold =
+                crate::game::quantity::resolve_quantity(state, value, controller, source_id);
+            state
+                .players
+                .iter()
+                .filter(|player| !player.is_eliminated)
+                .filter(|player| {
+                    crate::game::players::matches_relation(player.id, controller, *relation)
+                        && crate::game::effects::candidate_player_scalar(player, attr)
+                            .is_some_and(|lhs| comparator.evaluate(lhs, threshold))
+                })
+                .map(|player| player.id)
+                .collect()
+        }
     }
 }
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2933,6 +2933,24 @@ pub(crate) fn resolve_player_count(
                                     source_id,
                                 )
                         }
+                        // CR 402.1 / 119.1 / 122.1f / 404.1: "each [player class]
+                        // whose [scalar attr] [comparator] [value]" — count
+                        // candidates satisfying both the `relation` predicate and
+                        // the per-candidate scalar comparison. Mirrors the arm in
+                        // `effects::mod::matches_player_scope` (the two copies must
+                        // stay in sync). `attr` is read directly off `p`; `value`
+                        // is the controller-relative threshold, resolved once.
+                        PlayerFilter::PlayerAttribute {
+                            relation,
+                            attr,
+                            comparator,
+                            value,
+                        } => {
+                            let threshold = resolve_quantity(state, value, controller, source_id);
+                            crate::game::players::matches_relation(p.id, controller, *relation)
+                                && crate::game::effects::candidate_player_scalar(p, attr)
+                                    .is_some_and(|lhs| comparator.evaluate(lhs, threshold))
+                        }
                     }
             })
             .count(),
@@ -5665,6 +5683,100 @@ mod tests {
             resolve_quantity(&state, &at_least_you, PlayerId(0), ObjectId(1)),
             2,
             "GE includes the tied opponent — confirms the GT result is comparator-sensitive"
+        );
+    }
+
+    /// CR 122.1f: discriminating coverage for Glissa's Retriever — "the number
+    /// of opponents who have three or more poison counters". The per-candidate
+    /// poison total must be read off each candidate player, NOT the controller.
+    /// 3-player board: opp1 poison=3 (≥3 → counts), opp2 poison=1 (<3 →
+    /// excluded), CONTROLLER poison=5 (≥3 but is not an opponent → must NOT
+    /// leak in). Expect 1. A controller-scoped read of the threshold would have
+    /// nothing to do with this — the discriminator is that the controller's own
+    /// 5 poison never inflates the result, proving `candidate_player_scalar`
+    /// reads each candidate directly.
+    #[test]
+    fn resolve_player_count_opponents_who_have_n_poison_counters_is_per_candidate() {
+        use crate::types::ability::{Comparator, PlayerRelation};
+        use crate::types::format::FormatConfig;
+        use crate::types::player::PlayerCounterKind;
+
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+        // Controller P0 has the MOST poison; if the read were controller-scoped
+        // instead of per-candidate, every opponent would erroneously satisfy the
+        // ≥3 test (the threshold N=3 is fixed; the leak would be on the attribute
+        // side). P1 qualifies, P2 does not, P0 is excluded as the controller.
+        state.players[0].poison_counters = 5;
+        state.players[1].poison_counters = 3;
+        state.players[2].poison_counters = 1;
+
+        let glissa = QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::PlayerAttribute {
+                    relation: PlayerRelation::Opponent,
+                    attr: Box::new(QuantityRef::PlayerCounter {
+                        kind: PlayerCounterKind::Poison,
+                        scope: CountScope::ScopedPlayer,
+                    }),
+                    comparator: Comparator::GE,
+                    value: Box::new(QuantityExpr::Fixed { value: 3 }),
+                },
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &glissa, PlayerId(0), ObjectId(1)),
+            1,
+            "only opp1 (poison 3 ≥ 3) counts; opp2 (1) is excluded and the \
+             controller's own 5 poison must NOT leak in — proves per-candidate read"
+        );
+
+        // Discriminator on the threshold side: dropping opp1 below the threshold
+        // must drop the count to 0, confirming the comparison bites per candidate.
+        state.players[1].poison_counters = 2;
+        assert_eq!(
+            resolve_quantity(&state, &glissa, PlayerId(0), ObjectId(1)),
+            0,
+            "with no opponent at ≥3, the count is 0 even though the controller has 5"
+        );
+    }
+
+    /// CR 402.1: discriminating coverage for Wolfcaller's Howl — "the number of
+    /// your opponents with four or more cards in hand". Hand size is read off
+    /// each candidate. 3-player board: opp1 hand=4 (counts), opp2 hand=2
+    /// (excluded), CONTROLLER hand=9 (not an opponent → must not leak). Expect 1.
+    #[test]
+    fn resolve_player_count_opponents_with_n_cards_in_hand_is_per_candidate() {
+        use crate::types::ability::{Comparator, PlayerRelation, PlayerScope};
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+        let fill_hand = |state: &mut GameState, pid: usize, n: u64| {
+            for i in 0..n {
+                state.players[pid]
+                    .hand
+                    .push_back(ObjectId(1000 + pid as u64 * 100 + i));
+            }
+        };
+        fill_hand(&mut state, 0, 9); // controller — must not leak
+        fill_hand(&mut state, 1, 4); // opp1 — counts
+        fill_hand(&mut state, 2, 2); // opp2 — excluded
+
+        let wolfcaller = QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::PlayerAttribute {
+                    relation: PlayerRelation::Opponent,
+                    attr: Box::new(QuantityRef::HandSize {
+                        player: PlayerScope::ScopedPlayer,
+                    }),
+                    comparator: Comparator::GE,
+                    value: Box::new(QuantityExpr::Fixed { value: 4 }),
+                },
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &wolfcaller, PlayerId(0), ObjectId(1)),
+            1,
+            "only opp1 (hand 4 ≥ 4) counts; the controller's 9-card hand must not leak in"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3650,6 +3650,9 @@ pub(crate) fn check_trigger_condition(
             // set-valued — it has no single-player "whose turn" semantic.
             // Fail-closed alongside the other set-valued variants.
             | PlayerFilter::ControlsCount { .. }
+            // CR 402.1 / 119.1 / 122.1f / 404.1: a player-scalar population
+            // predicate is likewise set-valued — no "whose turn" semantic.
+            | PlayerFilter::PlayerAttribute { .. }
             | PlayerFilter::OpponentOtherThanTriggering => false,
         },
         // CR 603.4: "if you control N or more [type]" — generalized control count.

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2527,8 +2527,11 @@ pub fn parse_the_number_of_player_counters(input: &str) -> OracleResult<'_, Quan
 }
 
 /// CR 122.1: Typed alt over named player-counter kinds. Each arm emits the
-/// `PlayerCounterKind` variant directly (no intermediate string).
-fn parse_player_counter_kind(input: &str) -> OracleResult<'_, PlayerCounterKind> {
+/// `PlayerCounterKind` variant directly (no intermediate string). `pub(crate)`
+/// so the `PlayerCounter` player-attribute predicate parser
+/// (`oracle_quantity::parse_player_attribute_predicate`) shares this single
+/// kind grammar rather than re-enumerating counter tags.
+pub(crate) fn parse_player_counter_kind(input: &str) -> OracleResult<'_, PlayerCounterKind> {
     alt((
         value(PlayerCounterKind::Experience, tag("experience")),
         value(PlayerCounterKind::Poison, tag("poison")),

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -26,9 +26,9 @@ use crate::parser::oracle_effect::counter::normalize_counter_type;
 use crate::parser::oracle_effect::parse_controls_permanent_object;
 use crate::parser::oracle_target::{parse_type_phrase, parse_type_phrase_with_ctx};
 use crate::types::ability::{
-    AggregateFunction, ControllerRef, CountScope, DevotionColors, FilterProp, ObjectProperty,
-    ObjectScope, PlayerFilter, PlayerRelation, PlayerScope, QuantityExpr, QuantityRef,
-    TargetFilter, TypeFilter, TypedFilter, ZoneRef,
+    AggregateFunction, Comparator, ControllerRef, CountScope, DevotionColors, FilterProp,
+    ObjectProperty, ObjectScope, PlayerFilter, PlayerRelation, PlayerScope, QuantityExpr,
+    QuantityRef, TargetFilter, TypeFilter, TypedFilter, ZoneRef,
 };
 #[cfg(test)]
 use crate::types::counter::CounterType;
@@ -360,6 +360,17 @@ pub(crate) fn parse_quantity_ref_with_context(
                         },
                     });
                 }
+            }
+        }
+        // CR 402.1 / 119.1 / 122.1f / 404.1: "opponents who have N or more
+        // <kind> counters" (Glissa's Retriever) / "your opponents with N or
+        // more cards in hand" (Wolfcaller's Howl) → PlayerCount over the
+        // population whose per-candidate scalar attribute compares to N. Tried
+        // before the generic ObjectCount fall-through so the player population —
+        // not battlefield permanents — is counted.
+        if let Ok((remainder, filter)) = parse_player_attribute_predicate(rest) {
+            if remainder.trim().is_empty() {
+                return Some(QuantityRef::PlayerCount { filter });
             }
         }
         let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
@@ -826,6 +837,95 @@ fn parse_opponent_dealt_combat_damage_clause(
     ))
     .parse(input)
     .map(|(rest, _)| (rest, ()))
+}
+
+/// CR 402.1 / 119.1 / 122.1f / 404.1: Parse a player population whose scalar
+/// attribute crosses a threshold, into `PlayerFilter::PlayerAttribute`. Reached
+/// after `"the number of "` has been stripped.
+///
+/// Grammar (composed by prefix dispatch, not enumerated permutations):
+///   `<population> <attr-clause>`
+/// where `<population>` fixes the `PlayerRelation` and `<attr-clause>` is one of
+/// the per-player-scalar shapes — currently:
+///   - `who have <N> or more <kind> counters` → `PlayerCounter { kind }`
+///     (Glissa's Retriever; `parse_player_counter_kind` covers poison / rad /
+///     experience / ticket, so the whole counter class is handled, not one card).
+///   - `with <N> or more cards in hand` → `HandSize` (Wolfcaller's Howl).
+///
+/// All shapes are `GE`-against-`Fixed(N)` ("N or more"). The embedded
+/// `PlayerScope` / `CountScope` is inert at runtime (`candidate_player_scalar`
+/// reads the candidate directly), so a neutral `ScopedPlayer` is emitted to
+/// document "their" / "each player's own" semantics.
+fn parse_player_attribute_predicate(input: &str) -> OracleResult<'_, PlayerFilter> {
+    let (input, relation) = parse_player_population(input)?;
+    let (input, (attr, count)) = alt((
+        parse_player_counter_attr_clause,
+        parse_hand_size_attr_clause,
+    ))
+    .parse(input)?;
+    Ok((
+        input,
+        PlayerFilter::PlayerAttribute {
+            relation,
+            attr: Box::new(attr),
+            comparator: Comparator::GE,
+            value: Box::new(QuantityExpr::Fixed { value: count }),
+        },
+    ))
+}
+
+/// CR 102.2 + CR 109.5: Population word fixing the `PlayerRelation`. The
+/// optional `"your "` possessive and singular forms are accepted for the
+/// grammatically-degenerate phrasings. "opponents"/"opponent" → Opponent;
+/// "players"/"player" → All.
+fn parse_player_population(input: &str) -> OracleResult<'_, PlayerRelation> {
+    let (input, _) = opt(tag("your ")).parse(input)?;
+    alt((
+        value(PlayerRelation::Opponent, tag("opponents ")),
+        value(PlayerRelation::Opponent, tag("opponent ")),
+        value(PlayerRelation::All, tag("players ")),
+        value(PlayerRelation::All, tag("player ")),
+    ))
+    .parse(input)
+}
+
+/// CR 122.1f + CR 122.1: "who have N or more <kind> counters" → the candidate's
+/// named player-counter total. Delegates kind recognition to the shared
+/// `parse_player_counter_kind` grammar so poison / rad / experience / ticket are
+/// all covered.
+fn parse_player_counter_attr_clause(input: &str) -> OracleResult<'_, (QuantityRef, i32)> {
+    let (input, _) = tag("who have ").parse(input)?;
+    let (input, n) = nom_primitives::parse_number(input)?;
+    let (input, _) = tag(" or more ").parse(input)?;
+    let (input, kind) = nom_quantity::parse_player_counter_kind(input)?;
+    let (input, _) = tag(" counter").parse(input)?;
+    let (input, _) = opt(tag("s")).parse(input)?;
+    Ok((
+        input,
+        (
+            QuantityRef::PlayerCounter {
+                kind,
+                scope: CountScope::ScopedPlayer,
+            },
+            n as i32,
+        ),
+    ))
+}
+
+/// CR 402.1: "with N or more cards in hand" → the candidate's hand size.
+fn parse_hand_size_attr_clause(input: &str) -> OracleResult<'_, (QuantityRef, i32)> {
+    let (input, _) = tag("with ").parse(input)?;
+    let (input, n) = nom_primitives::parse_number(input)?;
+    let (input, _) = tag(" or more cards in hand").parse(input)?;
+    Ok((
+        input,
+        (
+            QuantityRef::HandSize {
+                player: PlayerScope::ScopedPlayer,
+            },
+            n as i32,
+        ),
+    ))
 }
 
 fn anaphoric_power_expr() -> QuantityExpr {
@@ -2500,6 +2600,131 @@ mod tests {
             other => {
                 panic!("Expected PlayerCount{{ControlsCount(opponents more lands)}}, got {other:?}")
             }
+        }
+    }
+
+    // CR 122.1f: Glissa's Retriever — "the number of opponents who have three or
+    // more poison counters" → PlayerCount{PlayerAttribute{Opponent,
+    // PlayerCounter{Poison}, GE, Fixed(3)}}. The "N or more <kind> counters"
+    // clause routes the poison kind through the shared player-counter-kind
+    // grammar, so rad / experience / ticket parse for free.
+    #[test]
+    fn parse_quantity_ref_opponents_who_have_n_poison_counters() {
+        use crate::types::player::PlayerCounterKind;
+        let qty =
+            parse_quantity_ref("the number of opponents who have three or more poison counters")
+                .unwrap();
+        match qty {
+            QuantityRef::PlayerCount {
+                filter:
+                    PlayerFilter::PlayerAttribute {
+                        relation: PlayerRelation::Opponent,
+                        attr,
+                        comparator: Comparator::GE,
+                        value,
+                    },
+            } => {
+                assert_eq!(
+                    *attr,
+                    QuantityRef::PlayerCounter {
+                        kind: PlayerCounterKind::Poison,
+                        scope: CountScope::ScopedPlayer,
+                    }
+                );
+                assert_eq!(*value, QuantityExpr::Fixed { value: 3 });
+            }
+            other => panic!("Expected PlayerCount{{PlayerAttribute(poison)}}, got {other:?}"),
+        }
+    }
+
+    // CR 122.1: the player-counter attribute clause covers the whole counter
+    // class, not just Glissa's poison — rad / experience parse identically.
+    #[test]
+    fn parse_quantity_ref_opponents_who_have_n_counters_covers_class() {
+        use crate::types::player::PlayerCounterKind;
+        for (phrase, kind) in [
+            ("rad", PlayerCounterKind::Rad),
+            ("experience", PlayerCounterKind::Experience),
+        ] {
+            let text = format!("the number of opponents who have two or more {phrase} counters");
+            match parse_quantity_ref(&text) {
+                Some(QuantityRef::PlayerCount {
+                    filter:
+                        PlayerFilter::PlayerAttribute {
+                            attr,
+                            comparator: Comparator::GE,
+                            value,
+                            ..
+                        },
+                }) => {
+                    assert_eq!(
+                        *attr,
+                        QuantityRef::PlayerCounter {
+                            kind,
+                            scope: CountScope::ScopedPlayer,
+                        }
+                    );
+                    assert_eq!(*value, QuantityExpr::Fixed { value: 2 });
+                }
+                other => panic!("Expected PlayerAttribute({phrase}), got {other:?}"),
+            }
+        }
+    }
+
+    // CR 402.1: Wolfcaller's Howl — "the number of your opponents with four or
+    // more cards in hand" → PlayerCount{PlayerAttribute{Opponent, HandSize, GE,
+    // Fixed(4)}}. The optional leading "your " possessive is stripped before the
+    // population word.
+    #[test]
+    fn parse_quantity_ref_your_opponents_with_n_cards_in_hand() {
+        let qty =
+            parse_quantity_ref("the number of your opponents with four or more cards in hand")
+                .unwrap();
+        match qty {
+            QuantityRef::PlayerCount {
+                filter:
+                    PlayerFilter::PlayerAttribute {
+                        relation: PlayerRelation::Opponent,
+                        attr,
+                        comparator: Comparator::GE,
+                        value,
+                    },
+            } => {
+                assert_eq!(
+                    *attr,
+                    QuantityRef::HandSize {
+                        player: PlayerScope::ScopedPlayer,
+                    }
+                );
+                assert_eq!(*value, QuantityExpr::Fixed { value: 4 });
+            }
+            other => panic!("Expected PlayerCount{{PlayerAttribute(hand)}}, got {other:?}"),
+        }
+    }
+
+    // The "your " possessive is optional — bare "opponents with N or more cards
+    // in hand" parses to the same shape.
+    #[test]
+    fn parse_quantity_ref_opponents_with_n_cards_in_hand_no_possessive() {
+        match parse_quantity_ref("the number of opponents with two or more cards in hand") {
+            Some(QuantityRef::PlayerCount {
+                filter:
+                    PlayerFilter::PlayerAttribute {
+                        relation: PlayerRelation::Opponent,
+                        attr,
+                        comparator: Comparator::GE,
+                        value,
+                    },
+            }) => {
+                assert_eq!(
+                    *attr,
+                    QuantityRef::HandSize {
+                        player: PlayerScope::ScopedPlayer,
+                    }
+                );
+                assert_eq!(*value, QuantityExpr::Fixed { value: 2 });
+            }
+            other => panic!("Expected PlayerAttribute(hand, no possessive), got {other:?}"),
         }
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3378,6 +3378,30 @@ pub enum PlayerFilter {
         comparator: Comparator,
         count: Box<QuantityExpr>,
     },
+    /// CR 402.1 (hand) / CR 119.1 (life) / CR 122.1f (poison) / CR 404.1
+    /// (graveyard): Each player satisfying `relation` whose scalar player
+    /// attribute `attr`, read PER CANDIDATE PLAYER, satisfies `comparator`
+    /// against `value`. `attr` is the per-player-scalar `QuantityRef` subset
+    /// (`HandSize` / `LifeTotal` / `GraveyardSize` / `PlayerCounter`) — read
+    /// directly off the candidate `Player` at runtime, never via the
+    /// controller-scoped quantity resolver, so its embedded `PlayerScope` /
+    /// `CountScope` carries no game-state meaning here.
+    ///
+    /// Covers "opponents who have N or more poison counters" (Glissa's
+    /// Retriever) and "your opponents with N or more cards in hand"
+    /// (Wolfcaller's Howl). `value` is the controller-relative threshold,
+    /// resolved once per evaluation (candidate-independent).
+    ///
+    /// `attr` and `value` are boxed to break the `QuantityExpr →
+    /// QuantityRef::PlayerCount → PlayerFilter::PlayerAttribute →
+    /// {QuantityRef, QuantityExpr}` reference cycle that would otherwise give
+    /// the enum infinite size.
+    PlayerAttribute {
+        relation: PlayerRelation,
+        attr: Box<QuantityRef>,
+        comparator: Comparator,
+        value: Box<QuantityExpr>,
+    },
 }
 
 /// An expression that produces an integer for quantity comparisons.

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -26,7 +26,7 @@
     "crates/engine/src/types/card_type.rs"
   ],
   "enum_count": 245,
-  "variant_count": 2769,
+  "variant_count": 2770,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -430,13 +430,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8989,
+      "line": 9013,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 9007,
+          "line": 9031,
           "kind": "struct",
           "field_names": [
             "source",
@@ -454,7 +454,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 9023,
+          "line": 9047,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -465,7 +465,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 9028,
+          "line": 9052,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -479,7 +479,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 9033,
+          "line": 9057,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -489,7 +489,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 9041,
+          "line": 9065,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -499,7 +499,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9044,
+          "line": 9068,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -511,7 +511,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9048,
+          "line": 9072,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -524,7 +524,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9051,
+          "line": 9075,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -537,7 +537,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9054,
+          "line": 9078,
           "kind": "struct",
           "field_names": [
             "color",
@@ -551,7 +551,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 9060,
+          "line": 9084,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -564,7 +564,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9068,
+          "line": 9092,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -575,7 +575,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9071,
+          "line": 9095,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -588,7 +588,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 9076,
+          "line": 9100,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -602,7 +602,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 9080,
+          "line": 9104,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -616,7 +616,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 9089,
+          "line": 9113,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -630,7 +630,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9094,
+          "line": 9118,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -640,7 +640,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9096,
+          "line": 9120,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -650,7 +650,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9099,
+          "line": 9123,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -660,7 +660,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 9103,
+          "line": 9127,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -672,7 +672,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 9108,
+          "line": 9132,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -686,7 +686,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9116,
+          "line": 9140,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -698,7 +698,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9121,
+          "line": 9145,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -714,7 +714,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 9133,
+          "line": 9157,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -727,7 +727,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 9137,
+          "line": 9161,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -740,7 +740,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 9141,
+          "line": 9165,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -750,7 +750,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9149,
+          "line": 9173,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -763,7 +763,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9154,
+          "line": 9178,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -776,7 +776,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9159,
+          "line": 9183,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -788,7 +788,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 9165,
+          "line": 9189,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -800,7 +800,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 9169,
+          "line": 9193,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -814,7 +814,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9172,
+          "line": 9196,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -824,7 +824,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 9181,
+          "line": 9205,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -837,7 +837,7 @@
         },
         {
           "name": "And",
-          "line": 9186,
+          "line": 9210,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -849,7 +849,7 @@
         },
         {
           "name": "Or",
-          "line": 9191,
+          "line": 9215,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -861,7 +861,7 @@
         },
         {
           "name": "Not",
-          "line": 9199,
+          "line": 9223,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -873,7 +873,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 9203,
+          "line": 9227,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -883,7 +883,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 9205,
+          "line": 9229,
           "kind": "struct",
           "field_names": [
             "state"
@@ -895,7 +895,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 9215,
+          "line": 9239,
           "kind": "struct",
           "field_names": [
             "n"
@@ -907,7 +907,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 9218,
+          "line": 9242,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -931,13 +931,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4279,
+      "line": 4303,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 4280,
+          "line": 4304,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -947,7 +947,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 4289,
+          "line": 4313,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -960,7 +960,7 @@
         },
         {
           "name": "Tap",
-          "line": 4292,
+          "line": 4316,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -968,7 +968,7 @@
         },
         {
           "name": "Untap",
-          "line": 4293,
+          "line": 4317,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -976,7 +976,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 4294,
+          "line": 4318,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -986,7 +986,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 4297,
+          "line": 4321,
           "kind": "struct",
           "field_names": [
             "target",
@@ -997,7 +997,7 @@
         },
         {
           "name": "PayLife",
-          "line": 4309,
+          "line": 4333,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1009,7 +1009,7 @@
         },
         {
           "name": "Discard",
-          "line": 4312,
+          "line": 4336,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1022,7 +1022,7 @@
         },
         {
           "name": "Exile",
-          "line": 4323,
+          "line": 4347,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1034,7 +1034,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 4332,
+          "line": 4356,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1047,7 +1047,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 4335,
+          "line": 4359,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1058,7 +1058,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 4346,
+          "line": 4370,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1073,7 +1073,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 4352,
+          "line": 4376,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1083,7 +1083,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4356,
+          "line": 4380,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1096,7 +1096,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4364,
+          "line": 4388,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1110,7 +1110,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4373,
+          "line": 4397,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1120,7 +1120,7 @@
         },
         {
           "name": "Mill",
-          "line": 4374,
+          "line": 4398,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1130,7 +1130,7 @@
         },
         {
           "name": "Exert",
-          "line": 4377,
+          "line": 4401,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1138,7 +1138,7 @@
         },
         {
           "name": "Blight",
-          "line": 4380,
+          "line": 4404,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1148,7 +1148,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4383,
+          "line": 4407,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1159,7 +1159,7 @@
         },
         {
           "name": "Behold",
-          "line": 4391,
+          "line": 4415,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1171,7 +1171,7 @@
         },
         {
           "name": "Composite",
-          "line": 4397,
+          "line": 4421,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1181,7 +1181,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4414,
+          "line": 4438,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1194,7 +1194,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4418,
+          "line": 4442,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1204,7 +1204,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4423,
+          "line": 4447,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1217,7 +1217,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4430,
+          "line": 4454,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1229,7 +1229,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4446,
+          "line": 4470,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1243,7 +1243,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4451,
+          "line": 4475,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1256,13 +1256,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8128,
+      "line": 8152,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 8130,
+          "line": 8154,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1270,7 +1270,7 @@
         },
         {
           "name": "Activated",
-          "line": 8131,
+          "line": 8155,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1278,7 +1278,7 @@
         },
         {
           "name": "Database",
-          "line": 8132,
+          "line": 8156,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1286,7 +1286,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 8135,
+          "line": 8159,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1294,7 +1294,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 8141,
+          "line": 8165,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1307,7 +1307,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8282,
+      "line": 8306,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1315,7 +1315,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 8284,
+          "line": 8308,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1325,7 +1325,7 @@
         },
         {
           "name": "Evolve",
-          "line": 8286,
+          "line": 8310,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1335,7 +1335,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 8288,
+          "line": 8312,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1345,7 +1345,7 @@
         },
         {
           "name": "Outlast",
-          "line": 8290,
+          "line": 8314,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1414,13 +1414,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8298,
+      "line": 8322,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8299,
+          "line": 8323,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1428,7 +1428,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 8300,
+          "line": 8324,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1436,7 +1436,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8301,
+          "line": 8325,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1444,7 +1444,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8302,
+          "line": 8326,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1452,7 +1452,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8303,
+          "line": 8327,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1460,7 +1460,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8304,
+          "line": 8328,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1468,7 +1468,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8305,
+          "line": 8329,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1476,7 +1476,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 8306,
+          "line": 8330,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1484,7 +1484,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 8307,
+          "line": 8331,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1492,7 +1492,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 8308,
+          "line": 8332,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1502,7 +1502,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8311,
+          "line": 8335,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1512,7 +1512,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 8315,
+          "line": 8339,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1522,7 +1522,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 8317,
+          "line": 8341,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1534,7 +1534,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 8322,
+          "line": 8346,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1548,7 +1548,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 8333,
+          "line": 8357,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1562,7 +1562,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 8346,
+          "line": 8370,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1575,13 +1575,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4655,
+      "line": 4679,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 4661,
+          "line": 4685,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1592,7 +1592,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4671,
+          "line": 4695,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1608,7 +1608,7 @@
         },
         {
           "name": "Choice",
-          "line": 4678,
+          "line": 4702,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1616,7 +1616,7 @@
         },
         {
           "name": "Required",
-          "line": 4680,
+          "line": 4704,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1627,7 +1627,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4689,
+      "line": 4713,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1635,7 +1635,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 4691,
+          "line": 4715,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1643,7 +1643,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4692,
+          "line": 4716,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1651,7 +1651,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 4693,
+          "line": 4717,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1999,13 +1999,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4271,
+      "line": 4295,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 4272,
+          "line": 4296,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2013,7 +2013,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 4273,
+          "line": 4297,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2123,7 +2123,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4991,
+      "line": 5015,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2131,7 +2131,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 4994,
+          "line": 5018,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2139,7 +2139,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 4996,
+          "line": 5020,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2555,7 +2555,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4245,
+      "line": 4269,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -2564,7 +2564,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 4248,
+          "line": 4272,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -2575,7 +2575,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4207,
+      "line": 4231,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -2586,7 +2586,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4209,
+          "line": 4233,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -2597,7 +2597,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4212,
+          "line": 4236,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -2607,7 +2607,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4214,
+          "line": 4238,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -2617,7 +2617,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4216,
+          "line": 4240,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -2627,7 +2627,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4219,
+          "line": 4243,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -2637,7 +2637,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4225,
+          "line": 4249,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -2647,7 +2647,7 @@
         },
         {
           "name": "Escape",
-          "line": 4230,
+          "line": 4254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -2658,7 +2658,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4233,
+          "line": 4257,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -2668,7 +2668,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4238,
+          "line": 4262,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -2862,13 +2862,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8354,
+      "line": 8378,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8355,
+          "line": 8379,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2876,7 +2876,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8356,
+          "line": 8380,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2884,7 +2884,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 8357,
+          "line": 8381,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2892,7 +2892,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8358,
+          "line": 8382,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2900,7 +2900,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8359,
+          "line": 8383,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2908,7 +2908,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 8360,
+          "line": 8384,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2916,7 +2916,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 8361,
+          "line": 8385,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2924,7 +2924,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 8362,
+          "line": 8386,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2932,7 +2932,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 8363,
+          "line": 8387,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2940,7 +2940,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 8364,
+          "line": 8388,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2948,7 +2948,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 8365,
+          "line": 8389,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2956,7 +2956,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8366,
+          "line": 8390,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2964,7 +2964,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 8367,
+          "line": 8391,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2972,7 +2972,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8368,
+          "line": 8392,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2980,7 +2980,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 8369,
+          "line": 8393,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2988,7 +2988,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8370,
+          "line": 8394,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3768,7 +3768,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10041,
+      "line": 10065,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -3776,7 +3776,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 10042,
+          "line": 10066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3784,7 +3784,7 @@
         },
         {
           "name": "Lost",
-          "line": 10043,
+          "line": 10067,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3851,7 +3851,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10541,
+      "line": 10565,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -3859,7 +3859,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 10542,
+          "line": 10566,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3867,7 +3867,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 10543,
+          "line": 10567,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3982,7 +3982,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3648,
+      "line": 3672,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -3990,7 +3990,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 3651,
+          "line": 3675,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -4001,7 +4001,7 @@
         },
         {
           "name": "Any",
-          "line": 3655,
+          "line": 3679,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -4105,13 +4105,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3519,
+      "line": 3543,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 3520,
+          "line": 3544,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4119,7 +4119,7 @@
         },
         {
           "name": "LT",
-          "line": 3521,
+          "line": 3545,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4127,7 +4127,7 @@
         },
         {
           "name": "GE",
-          "line": 3522,
+          "line": 3546,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4135,7 +4135,7 @@
         },
         {
           "name": "LE",
-          "line": 3523,
+          "line": 3547,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4143,7 +4143,7 @@
         },
         {
           "name": "EQ",
-          "line": 3524,
+          "line": 3548,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4151,7 +4151,7 @@
         },
         {
           "name": "NE",
-          "line": 3525,
+          "line": 3549,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4162,13 +4162,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10957,
+      "line": 10981,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 10958,
+          "line": 10982,
           "kind": "struct",
           "field_names": [
             "values",
@@ -4179,7 +4179,7 @@
         },
         {
           "name": "SetName",
-          "line": 10973,
+          "line": 10997,
           "kind": "struct",
           "field_names": [
             "name"
@@ -4193,7 +4193,7 @@
         },
         {
           "name": "AddPower",
-          "line": 10976,
+          "line": 11000,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4203,7 +4203,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 10979,
+          "line": 11003,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4213,7 +4213,7 @@
         },
         {
           "name": "SetPower",
-          "line": 10982,
+          "line": 11006,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4223,7 +4223,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 10985,
+          "line": 11009,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4233,7 +4233,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 10988,
+          "line": 11012,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4243,7 +4243,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 10991,
+          "line": 11015,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4253,7 +4253,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 10994,
+          "line": 11018,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4263,7 +4263,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 11001,
+          "line": 11025,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -4275,7 +4275,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 11004,
+          "line": 11028,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4283,7 +4283,7 @@
         },
         {
           "name": "AddType",
-          "line": 11005,
+          "line": 11029,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4293,7 +4293,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 11008,
+          "line": 11032,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4303,7 +4303,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 11011,
+          "line": 11035,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4313,7 +4313,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 11014,
+          "line": 11038,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4323,7 +4323,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 11021,
+          "line": 11045,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4336,7 +4336,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 11027,
+          "line": 11051,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4349,7 +4349,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 11031,
+          "line": 11055,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4359,7 +4359,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 11035,
+          "line": 11059,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4369,7 +4369,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 11042,
+          "line": 11066,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4381,7 +4381,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 11047,
+          "line": 11071,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4393,7 +4393,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 11051,
+          "line": 11075,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4405,7 +4405,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 11055,
+          "line": 11079,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4417,7 +4417,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 11060,
+          "line": 11084,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4430,7 +4430,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 11066,
+          "line": 11090,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4438,7 +4438,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 11069,
+          "line": 11093,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4449,7 +4449,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 11072,
+          "line": 11096,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4459,7 +4459,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 11077,
+          "line": 11101,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4469,7 +4469,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 11084,
+          "line": 11108,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -4480,7 +4480,7 @@
         },
         {
           "name": "SetColor",
-          "line": 11085,
+          "line": 11109,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4490,7 +4490,7 @@
         },
         {
           "name": "AddColor",
-          "line": 11088,
+          "line": 11112,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4500,7 +4500,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 11093,
+          "line": 11117,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4510,7 +4510,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 11107,
+          "line": 11131,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4525,7 +4525,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 11111,
+          "line": 11135,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4535,7 +4535,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 11114,
+          "line": 11138,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -4545,7 +4545,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 11116,
+          "line": 11140,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -4555,7 +4555,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 11118,
+          "line": 11142,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -4565,7 +4565,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 11121,
+          "line": 11145,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -4575,7 +4575,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 11124,
+          "line": 11148,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -4587,7 +4587,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 11138,
+          "line": 11162,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -4599,7 +4599,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 11146,
+          "line": 11170,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4614,7 +4614,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 11155,
+          "line": 11179,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4629,7 +4629,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 11169,
+          "line": 11193,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -4791,7 +4791,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11248,
+      "line": 11272,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -4801,7 +4801,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 11251,
+          "line": 11275,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -4809,7 +4809,7 @@
         },
         {
           "name": "Finalized",
-          "line": 11253,
+          "line": 11277,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -4820,13 +4820,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4935,
+      "line": 4959,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 4936,
+          "line": 4960,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4837,7 +4837,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6903,
+      "line": 6927,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -4846,7 +4846,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 6905,
+          "line": 6929,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -4854,7 +4854,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 6907,
+          "line": 6931,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -4978,7 +4978,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4465,
+      "line": 4489,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -4986,7 +4986,7 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4466,
+          "line": 4490,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4994,7 +4994,7 @@
         },
         {
           "name": "TapsSelf",
-          "line": 4467,
+          "line": 4491,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5002,7 +5002,7 @@
         },
         {
           "name": "UntapsSelf",
-          "line": 4468,
+          "line": 4492,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5010,7 +5010,7 @@
         },
         {
           "name": "SacrificesPermanent",
-          "line": 4469,
+          "line": 4493,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5018,7 +5018,7 @@
         },
         {
           "name": "PaysLife",
-          "line": 4470,
+          "line": 4494,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5026,7 +5026,7 @@
         },
         {
           "name": "PaysLoyalty",
-          "line": 4471,
+          "line": 4495,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5034,7 +5034,7 @@
         },
         {
           "name": "Discards",
-          "line": 4472,
+          "line": 4496,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5042,7 +5042,7 @@
         },
         {
           "name": "ExilesCards",
-          "line": 4473,
+          "line": 4497,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5050,7 +5050,7 @@
         },
         {
           "name": "TapsOtherCreatures",
-          "line": 4474,
+          "line": 4498,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5058,7 +5058,7 @@
         },
         {
           "name": "RemovesCounters",
-          "line": 4475,
+          "line": 4499,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5066,7 +5066,7 @@
         },
         {
           "name": "PaysEnergy",
-          "line": 4476,
+          "line": 4500,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5074,7 +5074,7 @@
         },
         {
           "name": "PaysSpeed",
-          "line": 4477,
+          "line": 4501,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5082,7 +5082,7 @@
         },
         {
           "name": "ReturnsToHand",
-          "line": 4478,
+          "line": 4502,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5090,7 +5090,7 @@
         },
         {
           "name": "Unattaches",
-          "line": 4479,
+          "line": 4503,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5098,7 +5098,7 @@
         },
         {
           "name": "Mills",
-          "line": 4480,
+          "line": 4504,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5106,7 +5106,7 @@
         },
         {
           "name": "PutsCounters",
-          "line": 4481,
+          "line": 4505,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5114,7 +5114,7 @@
         },
         {
           "name": "Reveals",
-          "line": 4482,
+          "line": 4506,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5122,7 +5122,7 @@
         },
         {
           "name": "Exerts",
-          "line": 4483,
+          "line": 4507,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5130,7 +5130,7 @@
         },
         {
           "name": "KeywordCost",
-          "line": 4484,
+          "line": 4508,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5593,7 +5593,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10418,
+      "line": 10442,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -5601,7 +5601,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10420,
+          "line": 10444,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -5609,7 +5609,7 @@
         },
         {
           "name": "Triple",
-          "line": 10422,
+          "line": 10446,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -5617,7 +5617,7 @@
         },
         {
           "name": "Plus",
-          "line": 10424,
+          "line": 10448,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5627,7 +5627,7 @@
         },
         {
           "name": "Minus",
-          "line": 10431,
+          "line": 10455,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5640,7 +5640,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 10435,
+          "line": 10459,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -5650,7 +5650,7 @@
         },
         {
           "name": "SetTo",
-          "line": 10441,
+          "line": 10465,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5662,7 +5662,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 10447,
+          "line": 10471,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -5712,7 +5712,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4916,
+      "line": 4940,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -5720,7 +5720,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 4918,
+          "line": 4942,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -5728,7 +5728,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 4921,
+          "line": 4945,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -5742,7 +5742,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10529,
+      "line": 10553,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -5750,7 +5750,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 10531,
+          "line": 10555,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -5758,7 +5758,7 @@
         },
         {
           "name": "Player",
-          "line": 10533,
+          "line": 10557,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5768,7 +5768,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 10536,
+          "line": 10560,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5781,7 +5781,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10517,
+      "line": 10541,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -5789,7 +5789,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10518,
+          "line": 10542,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5797,7 +5797,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10519,
+          "line": 10543,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5805,7 +5805,7 @@
         },
         {
           "name": "Controller",
-          "line": 10522,
+          "line": 10546,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -5813,7 +5813,7 @@
         },
         {
           "name": "Specific",
-          "line": 10523,
+          "line": 10547,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6595,13 +6595,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5017,
+      "line": 5041,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 5019,
+          "line": 5043,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -6613,7 +6613,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 5025,
+          "line": 5049,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -6628,7 +6628,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 5036,
+          "line": 5060,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6640,7 +6640,7 @@
         },
         {
           "name": "Draw",
-          "line": 5056,
+          "line": 5080,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6656,7 +6656,7 @@
         },
         {
           "name": "Pump",
-          "line": 5062,
+          "line": 5086,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6668,7 +6668,7 @@
         },
         {
           "name": "PairWith",
-          "line": 5073,
+          "line": 5097,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6681,7 +6681,7 @@
         },
         {
           "name": "Destroy",
-          "line": 5076,
+          "line": 5100,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6692,7 +6692,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 5084,
+          "line": 5108,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6704,7 +6704,7 @@
         },
         {
           "name": "Counter",
-          "line": 5088,
+          "line": 5112,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6715,7 +6715,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 5109,
+          "line": 5133,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6729,7 +6729,7 @@
         },
         {
           "name": "Token",
-          "line": 5113,
+          "line": 5137,
           "kind": "struct",
           "field_names": [
             "name",
@@ -6752,7 +6752,7 @@
         },
         {
           "name": "GainLife",
-          "line": 5151,
+          "line": 5175,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6763,7 +6763,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 5158,
+          "line": 5182,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6774,7 +6774,7 @@
         },
         {
           "name": "Tap",
-          "line": 5165,
+          "line": 5189,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6784,7 +6784,7 @@
         },
         {
           "name": "Untap",
-          "line": 5169,
+          "line": 5193,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6794,7 +6794,7 @@
         },
         {
           "name": "TapAll",
-          "line": 5174,
+          "line": 5198,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6806,7 +6806,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 5179,
+          "line": 5203,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6818,7 +6818,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 5183,
+          "line": 5207,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6830,7 +6830,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 5190,
+          "line": 5214,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6842,7 +6842,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5198,
+          "line": 5222,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6854,7 +6854,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 5219,
+          "line": 5243,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6865,7 +6865,7 @@
         },
         {
           "name": "Mill",
-          "line": 5225,
+          "line": 5249,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6877,7 +6877,7 @@
         },
         {
           "name": "Scry",
-          "line": 5242,
+          "line": 5266,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6892,7 +6892,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 5248,
+          "line": 5272,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6904,7 +6904,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 5262,
+          "line": 5286,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6921,7 +6921,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 5286,
+          "line": 5310,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6934,7 +6934,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 5290,
+          "line": 5314,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6945,7 +6945,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 5297,
+          "line": 5321,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6964,7 +6964,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 5348,
+          "line": 5372,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6977,7 +6977,7 @@
         },
         {
           "name": "Dig",
-          "line": 5361,
+          "line": 5385,
           "kind": "struct",
           "field_names": [
             "player",
@@ -6997,7 +6997,7 @@
         },
         {
           "name": "GainControl",
-          "line": 5387,
+          "line": 5411,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7007,7 +7007,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 5391,
+          "line": 5415,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7018,7 +7018,7 @@
         },
         {
           "name": "Attach",
-          "line": 5397,
+          "line": 5421,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7029,7 +7029,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 5409,
+          "line": 5433,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7042,7 +7042,7 @@
         },
         {
           "name": "Surveil",
-          "line": 5421,
+          "line": 5445,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7057,7 +7057,7 @@
         },
         {
           "name": "Fight",
-          "line": 5427,
+          "line": 5451,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7068,7 +7068,7 @@
         },
         {
           "name": "Bounce",
-          "line": 5435,
+          "line": 5459,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7080,7 +7080,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 5454,
+          "line": 5478,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7095,7 +7095,7 @@
         },
         {
           "name": "Explore",
-          "line": 5462,
+          "line": 5486,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7103,7 +7103,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 5466,
+          "line": 5490,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7115,7 +7115,7 @@
         },
         {
           "name": "Investigate",
-          "line": 5471,
+          "line": 5495,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.136: Investigate — create a Clue artifact token.",
@@ -7125,7 +7125,7 @@
         },
         {
           "name": "Tribute",
-          "line": 5478,
+          "line": 5502,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7138,7 +7138,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 5484,
+          "line": 5508,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -7148,7 +7148,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 5486,
+          "line": 5510,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -7158,7 +7158,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 5487,
+          "line": 5511,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7166,7 +7166,7 @@
         },
         {
           "name": "Populate",
-          "line": 5489,
+          "line": 5513,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -7176,7 +7176,7 @@
         },
         {
           "name": "Clash",
-          "line": 5491,
+          "line": 5515,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -7186,7 +7186,7 @@
         },
         {
           "name": "Vote",
-          "line": 5506,
+          "line": 5530,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7202,7 +7202,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 5550,
+          "line": 5574,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -7222,7 +7222,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 5569,
+          "line": 5593,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7234,7 +7234,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 5573,
+          "line": 5597,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7245,7 +7245,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 5582,
+          "line": 5606,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7258,7 +7258,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 5593,
+          "line": 5617,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7278,7 +7278,7 @@
         },
         {
           "name": "Myriad",
-          "line": 5640,
+          "line": 5664,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -7288,7 +7288,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 5643,
+          "line": 5667,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7304,7 +7304,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 5653,
+          "line": 5677,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7315,7 +7315,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 5659,
+          "line": 5683,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7327,7 +7327,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 5667,
+          "line": 5691,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7341,7 +7341,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 5674,
+          "line": 5698,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7353,7 +7353,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 5682,
+          "line": 5706,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7366,7 +7366,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 5688,
+          "line": 5712,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7379,7 +7379,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 5696,
+          "line": 5720,
           "kind": "struct",
           "field_names": [
             "source",
@@ -7397,7 +7397,7 @@
         },
         {
           "name": "Animate",
-          "line": 5716,
+          "line": 5740,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7412,7 +7412,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 5750,
+          "line": 5774,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -7436,7 +7436,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 5766,
+          "line": 5790,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -7446,7 +7446,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 5770,
+          "line": 5794,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -7458,7 +7458,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 5778,
+          "line": 5802,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -7475,7 +7475,7 @@
         },
         {
           "name": "Mana",
-          "line": 5796,
+          "line": 5820,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -7489,7 +7489,7 @@
         },
         {
           "name": "Discard",
-          "line": 5819,
+          "line": 5843,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7503,7 +7503,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 5841,
+          "line": 5865,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7513,7 +7513,7 @@
         },
         {
           "name": "Transform",
-          "line": 5845,
+          "line": 5869,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7523,7 +7523,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 5851,
+          "line": 5875,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7538,7 +7538,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 5893,
+          "line": 5917,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7556,7 +7556,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 5904,
+          "line": 5928,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7570,7 +7570,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 5928,
+          "line": 5952,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7583,7 +7583,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5939,
+          "line": 5963,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7596,7 +7596,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 5944,
+          "line": 5968,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7609,7 +7609,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 5953,
+          "line": 5977,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7621,7 +7621,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 5976,
+          "line": 6000,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7631,7 +7631,7 @@
         },
         {
           "name": "Choose",
-          "line": 5982,
+          "line": 6006,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -7642,7 +7642,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 5993,
+          "line": 6017,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -7655,7 +7655,7 @@
         },
         {
           "name": "Suspect",
-          "line": 5998,
+          "line": 6022,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7667,7 +7667,7 @@
         },
         {
           "name": "Connive",
-          "line": 6005,
+          "line": 6029,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7681,7 +7681,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 6013,
+          "line": 6037,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7693,7 +7693,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 6020,
+          "line": 6044,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7705,7 +7705,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 6025,
+          "line": 6049,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7717,7 +7717,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 6030,
+          "line": 6054,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -7727,7 +7727,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 6037,
+          "line": 6061,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7739,7 +7739,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 6044,
+          "line": 6068,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7751,7 +7751,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 6049,
+          "line": 6073,
           "kind": "struct",
           "field_names": [
             "level"
@@ -7763,7 +7763,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 6054,
+          "line": 6078,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -7777,7 +7777,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 6084,
+          "line": 6108,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -7791,7 +7791,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 6090,
+          "line": 6114,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -7803,7 +7803,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 6095,
+          "line": 6119,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7816,7 +7816,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 6102,
+          "line": 6126,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -7829,7 +7829,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 6111,
+          "line": 6135,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7842,7 +7842,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 6119,
+          "line": 6143,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -7856,7 +7856,7 @@
         },
         {
           "name": "PayCost",
-          "line": 6129,
+          "line": 6153,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -7869,7 +7869,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 6140,
+          "line": 6164,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7887,7 +7887,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 6170,
+          "line": 6194,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7903,7 +7903,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 6209,
+          "line": 6233,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -7924,7 +7924,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 6239,
+          "line": 6263,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: A player who meets this effect's condition loses the game. The affected player is determined by resolution context (controller's opponent if untargeted, or explicit target if targeted).",
@@ -7934,7 +7934,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 6241,
+          "line": 6265,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: The controller wins the game — all opponents lose.",
@@ -7944,7 +7944,7 @@
         },
         {
           "name": "RollDie",
-          "line": 6246,
+          "line": 6270,
           "kind": "struct",
           "field_names": [
             "sides",
@@ -7959,7 +7959,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 6254,
+          "line": 6278,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -7972,7 +7972,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 6266,
+          "line": 6290,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7986,7 +7986,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 6275,
+          "line": 6299,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -7998,7 +7998,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 6280,
+          "line": 6304,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -8008,7 +8008,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 6283,
+          "line": 6307,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -8018,7 +8018,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 6285,
+          "line": 6309,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -8030,7 +8030,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 6290,
+          "line": 6314,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -8041,7 +8041,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 6293,
+          "line": 6317,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -8051,7 +8051,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 6296,
+          "line": 6320,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -8063,7 +8063,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 6313,
+          "line": 6337,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8082,7 +8082,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 6346,
+          "line": 6370,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8097,7 +8097,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 6359,
+          "line": 6383,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -8111,7 +8111,7 @@
         },
         {
           "name": "Exploit",
-          "line": 6368,
+          "line": 6392,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8123,7 +8123,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 6373,
+          "line": 6397,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8135,7 +8135,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 6378,
+          "line": 6402,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -8150,7 +8150,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 6390,
+          "line": 6414,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8162,7 +8162,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 6402,
+          "line": 6426,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8178,7 +8178,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 6413,
+          "line": 6437,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8196,7 +8196,7 @@
         },
         {
           "name": "Discover",
-          "line": 6447,
+          "line": 6471,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -8208,7 +8208,7 @@
         },
         {
           "name": "Cascade",
-          "line": 6459,
+          "line": 6483,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -8218,7 +8218,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 6463,
+          "line": 6487,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8230,7 +8230,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 6468,
+          "line": 6492,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8242,7 +8242,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 6481,
+          "line": 6505,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8254,7 +8254,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 6490,
+          "line": 6514,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8266,7 +8266,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 6499,
+          "line": 6523,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8276,7 +8276,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 6504,
+          "line": 6528,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -8286,7 +8286,7 @@
         },
         {
           "name": "Goad",
-          "line": 6510,
+          "line": 6534,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8298,7 +8298,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 6517,
+          "line": 6541,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8310,7 +8310,7 @@
         },
         {
           "name": "Detain",
-          "line": 6524,
+          "line": 6548,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8322,7 +8322,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 6535,
+          "line": 6559,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -8336,7 +8336,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 6546,
+          "line": 6570,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8350,7 +8350,7 @@
         },
         {
           "name": "Manifest",
-          "line": 6561,
+          "line": 6585,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8363,7 +8363,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 6567,
+          "line": 6591,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -8373,7 +8373,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 6571,
+          "line": 6595,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8385,7 +8385,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 6585,
+          "line": 6609,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8398,7 +8398,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 6596,
+          "line": 6620,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8411,7 +8411,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 6606,
+          "line": 6630,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8425,7 +8425,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 6618,
+          "line": 6642,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8441,7 +8441,7 @@
         },
         {
           "name": "Double",
-          "line": 6629,
+          "line": 6653,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -8455,7 +8455,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 6637,
+          "line": 6661,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -8467,7 +8467,7 @@
         },
         {
           "name": "Incubate",
-          "line": 6643,
+          "line": 6667,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8479,7 +8479,7 @@
         },
         {
           "name": "Amass",
-          "line": 6651,
+          "line": 6675,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -8492,7 +8492,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 6659,
+          "line": 6683,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8504,7 +8504,7 @@
         },
         {
           "name": "Renown",
-          "line": 6665,
+          "line": 6689,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8516,7 +8516,7 @@
         },
         {
           "name": "Bolster",
-          "line": 6671,
+          "line": 6695,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8528,7 +8528,7 @@
         },
         {
           "name": "Adapt",
-          "line": 6677,
+          "line": 6701,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8540,7 +8540,7 @@
         },
         {
           "name": "Learn",
-          "line": 6683,
+          "line": 6707,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -8550,7 +8550,7 @@
         },
         {
           "name": "Forage",
-          "line": 6685,
+          "line": 6709,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -8560,7 +8560,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6687,
+          "line": 6711,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8572,7 +8572,7 @@
         },
         {
           "name": "Endure",
-          "line": 6694,
+          "line": 6718,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8585,7 +8585,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 6699,
+          "line": 6723,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8597,7 +8597,7 @@
         },
         {
           "name": "Seek",
-          "line": 6704,
+          "line": 6728,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -8611,7 +8611,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 6721,
+          "line": 6745,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8624,7 +8624,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 6736,
+          "line": 6760,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8640,7 +8640,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 6743,
+          "line": 6767,
           "kind": "struct",
           "field_names": [
             "to"
@@ -8652,7 +8652,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 6748,
+          "line": 6772,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8665,7 +8665,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 6757,
+          "line": 6781,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8677,7 +8677,7 @@
         },
         {
           "name": "Conjure",
-          "line": 6764,
+          "line": 6788,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -8689,7 +8689,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 6785,
+          "line": 6809,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8703,7 +8703,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6796,
+          "line": 6820,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8798,13 +8798,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11636,
+      "line": 11660,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 11638,
+          "line": 11662,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8812,7 +8812,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 11640,
+          "line": 11664,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8820,7 +8820,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 11642,
+          "line": 11666,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8828,7 +8828,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 11644,
+          "line": 11668,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8836,7 +8836,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 11646,
+          "line": 11670,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8844,7 +8844,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 11648,
+          "line": 11672,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8855,204 +8855,12 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7770,
+      "line": 7794,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7771,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeSpeed",
-          "line": 7772,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DealDamage",
-          "line": 7773,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Draw",
-          "line": 7774,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Pump",
-          "line": 7775,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PairWith",
-          "line": 7776,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Destroy",
-          "line": 7777,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Counter",
-          "line": 7778,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterAll",
-          "line": 7779,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Token",
-          "line": 7780,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GainLife",
-          "line": 7781,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseLife",
-          "line": 7782,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Tap",
-          "line": 7783,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Untap",
-          "line": 7784,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddCounter",
-          "line": 7785,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RemoveCounter",
-          "line": 7786,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Sacrifice",
-          "line": 7787,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DiscardCard",
-          "line": 7788,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Mill",
-          "line": 7789,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Scry",
-          "line": 7790,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PumpAll",
-          "line": 7791,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DamageAll",
-          "line": 7792,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DamageEachPlayer",
-          "line": 7793,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DestroyAll",
-          "line": 7794,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TapAll",
           "line": 7795,
           "kind": "unit",
           "field_names": [],
@@ -9060,7 +8868,7 @@
           "cr_refs": []
         },
         {
-          "name": "UntapAll",
+          "name": "ChangeSpeed",
           "line": 7796,
           "kind": "unit",
           "field_names": [],
@@ -9068,7 +8876,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZone",
+          "name": "DealDamage",
           "line": 7797,
           "kind": "unit",
           "field_names": [],
@@ -9076,7 +8884,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZoneAll",
+          "name": "Draw",
           "line": 7798,
           "kind": "unit",
           "field_names": [],
@@ -9084,7 +8892,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dig",
+          "name": "Pump",
           "line": 7799,
           "kind": "unit",
           "field_names": [],
@@ -9092,7 +8900,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainControl",
+          "name": "PairWith",
           "line": 7800,
           "kind": "unit",
           "field_names": [],
@@ -9100,7 +8908,7 @@
           "cr_refs": []
         },
         {
-          "name": "ControlNextTurn",
+          "name": "Destroy",
           "line": 7801,
           "kind": "unit",
           "field_names": [],
@@ -9108,7 +8916,7 @@
           "cr_refs": []
         },
         {
-          "name": "Attach",
+          "name": "Counter",
           "line": 7802,
           "kind": "unit",
           "field_names": [],
@@ -9116,7 +8924,7 @@
           "cr_refs": []
         },
         {
-          "name": "AttachAll",
+          "name": "CounterAll",
           "line": 7803,
           "kind": "unit",
           "field_names": [],
@@ -9124,7 +8932,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnattachAll",
+          "name": "Token",
           "line": 7804,
           "kind": "unit",
           "field_names": [],
@@ -9132,7 +8940,7 @@
           "cr_refs": []
         },
         {
-          "name": "Surveil",
+          "name": "GainLife",
           "line": 7805,
           "kind": "unit",
           "field_names": [],
@@ -9140,7 +8948,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fight",
+          "name": "LoseLife",
           "line": 7806,
           "kind": "unit",
           "field_names": [],
@@ -9148,7 +8956,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bounce",
+          "name": "Tap",
           "line": 7807,
           "kind": "unit",
           "field_names": [],
@@ -9156,7 +8964,7 @@
           "cr_refs": []
         },
         {
-          "name": "BounceAll",
+          "name": "Untap",
           "line": 7808,
           "kind": "unit",
           "field_names": [],
@@ -9164,7 +8972,7 @@
           "cr_refs": []
         },
         {
-          "name": "Explore",
+          "name": "AddCounter",
           "line": 7809,
           "kind": "unit",
           "field_names": [],
@@ -9172,7 +8980,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExploreAll",
+          "name": "RemoveCounter",
           "line": 7810,
           "kind": "unit",
           "field_names": [],
@@ -9180,7 +8988,7 @@
           "cr_refs": []
         },
         {
-          "name": "Investigate",
+          "name": "Sacrifice",
           "line": 7811,
           "kind": "unit",
           "field_names": [],
@@ -9188,7 +8996,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tribute",
+          "name": "DiscardCard",
           "line": 7812,
           "kind": "unit",
           "field_names": [],
@@ -9196,7 +9004,7 @@
           "cr_refs": []
         },
         {
-          "name": "TimeTravel",
+          "name": "Mill",
           "line": 7813,
           "kind": "unit",
           "field_names": [],
@@ -9204,7 +9012,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomeMonarch",
+          "name": "Scry",
           "line": 7814,
           "kind": "unit",
           "field_names": [],
@@ -9212,7 +9020,7 @@
           "cr_refs": []
         },
         {
-          "name": "Proliferate",
+          "name": "PumpAll",
           "line": 7815,
           "kind": "unit",
           "field_names": [],
@@ -9220,7 +9028,7 @@
           "cr_refs": []
         },
         {
-          "name": "Populate",
+          "name": "DamageAll",
           "line": 7816,
           "kind": "unit",
           "field_names": [],
@@ -9228,7 +9036,7 @@
           "cr_refs": []
         },
         {
-          "name": "Clash",
+          "name": "DamageEachPlayer",
           "line": 7817,
           "kind": "unit",
           "field_names": [],
@@ -9236,8 +9044,200 @@
           "cr_refs": []
         },
         {
-          "name": "Vote",
+          "name": "DestroyAll",
+          "line": 7818,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TapAll",
           "line": 7819,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "UntapAll",
+          "line": 7820,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChangeZone",
+          "line": 7821,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChangeZoneAll",
+          "line": 7822,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Dig",
+          "line": 7823,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GainControl",
+          "line": 7824,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ControlNextTurn",
+          "line": 7825,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Attach",
+          "line": 7826,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AttachAll",
+          "line": 7827,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "UnattachAll",
+          "line": 7828,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Surveil",
+          "line": 7829,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Fight",
+          "line": 7830,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Bounce",
+          "line": 7831,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BounceAll",
+          "line": 7832,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Explore",
+          "line": 7833,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExploreAll",
+          "line": 7834,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Investigate",
+          "line": 7835,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Tribute",
+          "line": 7836,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TimeTravel",
+          "line": 7837,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomeMonarch",
+          "line": 7838,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Proliferate",
+          "line": 7839,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Populate",
+          "line": 7840,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Clash",
+          "line": 7841,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Vote",
+          "line": 7843,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -9247,7 +9247,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7821,
+          "line": 7845,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -9257,198 +9257,6 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7822,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopySpell",
-          "line": 7823,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastCopyOfCard",
-          "line": 7824,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopyTokenOf",
-          "line": 7825,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Myriad",
-          "line": 7826,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BecomeCopy",
-          "line": 7827,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseCard",
-          "line": 7828,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutCounter",
-          "line": 7829,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutCounterAll",
-          "line": 7830,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MultiplyCounter",
-          "line": 7831,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DoublePT",
-          "line": 7832,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DoublePTAll",
-          "line": 7833,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MoveCounters",
-          "line": 7834,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Animate",
-          "line": 7835,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReturnAsAura",
-          "line": 7836,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RegisterBending",
-          "line": 7837,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GenericEffect",
-          "line": 7838,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Cleanup",
-          "line": 7839,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Mana",
-          "line": 7840,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Discard",
-          "line": 7841,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Shuffle",
-          "line": 7842,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SearchLibrary",
-          "line": 7843,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SearchOutsideGame",
-          "line": 7844,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ExileTop",
-          "line": 7845,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TargetOnly",
           "line": 7846,
           "kind": "unit",
           "field_names": [],
@@ -9456,7 +9264,7 @@
           "cr_refs": []
         },
         {
-          "name": "Choose",
+          "name": "CopySpell",
           "line": 7847,
           "kind": "unit",
           "field_names": [],
@@ -9464,7 +9272,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDamageSource",
+          "name": "CastCopyOfCard",
           "line": 7848,
           "kind": "unit",
           "field_names": [],
@@ -9472,7 +9280,7 @@
           "cr_refs": []
         },
         {
-          "name": "Suspect",
+          "name": "CopyTokenOf",
           "line": 7849,
           "kind": "unit",
           "field_names": [],
@@ -9480,7 +9288,7 @@
           "cr_refs": []
         },
         {
-          "name": "Connive",
+          "name": "Myriad",
           "line": 7850,
           "kind": "unit",
           "field_names": [],
@@ -9488,7 +9296,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseOut",
+          "name": "BecomeCopy",
           "line": 7851,
           "kind": "unit",
           "field_names": [],
@@ -9496,7 +9304,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseIn",
+          "name": "ChooseCard",
           "line": 7852,
           "kind": "unit",
           "field_names": [],
@@ -9504,7 +9312,7 @@
           "cr_refs": []
         },
         {
-          "name": "ForceBlock",
+          "name": "PutCounter",
           "line": 7853,
           "kind": "unit",
           "field_names": [],
@@ -9512,7 +9320,7 @@
           "cr_refs": []
         },
         {
-          "name": "SolveCase",
+          "name": "PutCounterAll",
           "line": 7854,
           "kind": "unit",
           "field_names": [],
@@ -9520,8 +9328,200 @@
           "cr_refs": []
         },
         {
-          "name": "BecomePrepared",
+          "name": "MultiplyCounter",
+          "line": 7855,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DoublePT",
           "line": 7856,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DoublePTAll",
+          "line": 7857,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MoveCounters",
+          "line": 7858,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Animate",
+          "line": 7859,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ReturnAsAura",
+          "line": 7860,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RegisterBending",
+          "line": 7861,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GenericEffect",
+          "line": 7862,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Cleanup",
+          "line": 7863,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Mana",
+          "line": 7864,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Discard",
+          "line": 7865,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Shuffle",
+          "line": 7866,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SearchLibrary",
+          "line": 7867,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SearchOutsideGame",
+          "line": 7868,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExileTop",
+          "line": 7869,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TargetOnly",
+          "line": 7870,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Choose",
+          "line": 7871,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseDamageSource",
+          "line": 7872,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Suspect",
+          "line": 7873,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Connive",
+          "line": 7874,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseOut",
+          "line": 7875,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseIn",
+          "line": 7876,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ForceBlock",
+          "line": 7877,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SolveCase",
+          "line": 7878,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomePrepared",
+          "line": 7880,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -9531,7 +9531,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 7858,
+          "line": 7882,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -9541,198 +9541,6 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 7859,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDelayedTrigger",
-          "line": 7860,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddTargetReplacement",
-          "line": 7861,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddRestriction",
-          "line": 7862,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReduceNextSpellCost",
-          "line": 7863,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantNextSpellAbility",
-          "line": 7864,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddPendingETBCounters",
-          "line": 7865,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateEmblem",
-          "line": 7866,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PayCost",
-          "line": 7867,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastFromZone",
-          "line": 7868,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PreventDamage",
-          "line": 7869,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDamageReplacement",
-          "line": 7870,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Regenerate",
-          "line": 7871,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseTheGame",
-          "line": 7872,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "WinTheGame",
-          "line": 7873,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RollDie",
-          "line": 7874,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoin",
-          "line": 7875,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoins",
-          "line": 7876,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoinUntilLose",
-          "line": 7877,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RingTemptsYou",
-          "line": 7878,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "VentureIntoDungeon",
-          "line": 7879,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "VentureInto",
-          "line": 7880,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TakeTheInitiative",
-          "line": 7881,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ProcessRadCounters",
-          "line": 7882,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantCastingPermission",
           "line": 7883,
           "kind": "unit",
           "field_names": [],
@@ -9740,7 +9548,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseFromZone",
+          "name": "CreateDelayedTrigger",
           "line": 7884,
           "kind": "unit",
           "field_names": [],
@@ -9748,7 +9556,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseObjectsIntoTrackedSet",
+          "name": "AddTargetReplacement",
           "line": 7885,
           "kind": "unit",
           "field_names": [],
@@ -9756,7 +9564,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseAndSacrificeRest",
+          "name": "AddRestriction",
           "line": 7886,
           "kind": "unit",
           "field_names": [],
@@ -9764,7 +9572,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exploit",
+          "name": "ReduceNextSpellCost",
           "line": 7887,
           "kind": "unit",
           "field_names": [],
@@ -9772,7 +9580,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainEnergy",
+          "name": "GrantNextSpellAbility",
           "line": 7888,
           "kind": "unit",
           "field_names": [],
@@ -9780,7 +9588,7 @@
           "cr_refs": []
         },
         {
-          "name": "GivePlayerCounter",
+          "name": "AddPendingETBCounters",
           "line": 7889,
           "kind": "unit",
           "field_names": [],
@@ -9788,7 +9596,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseAllPlayerCounters",
+          "name": "CreateEmblem",
           "line": 7890,
           "kind": "unit",
           "field_names": [],
@@ -9796,7 +9604,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileFromTopUntil",
+          "name": "PayCost",
           "line": 7891,
           "kind": "unit",
           "field_names": [],
@@ -9804,7 +9612,7 @@
           "cr_refs": []
         },
         {
-          "name": "RevealUntil",
+          "name": "CastFromZone",
           "line": 7892,
           "kind": "unit",
           "field_names": [],
@@ -9812,7 +9620,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discover",
+          "name": "PreventDamage",
           "line": 7893,
           "kind": "unit",
           "field_names": [],
@@ -9820,7 +9628,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cascade",
+          "name": "CreateDamageReplacement",
           "line": 7894,
           "kind": "unit",
           "field_names": [],
@@ -9828,7 +9636,7 @@
           "cr_refs": []
         },
         {
-          "name": "MiracleCast",
+          "name": "Regenerate",
           "line": 7895,
           "kind": "unit",
           "field_names": [],
@@ -9836,7 +9644,7 @@
           "cr_refs": []
         },
         {
-          "name": "MadnessCast",
+          "name": "LoseTheGame",
           "line": 7896,
           "kind": "unit",
           "field_names": [],
@@ -9844,7 +9652,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutAtLibraryPosition",
+          "name": "WinTheGame",
           "line": 7897,
           "kind": "unit",
           "field_names": [],
@@ -9852,7 +9660,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDrawnThisTurnPayOrTopdeck",
+          "name": "RollDie",
           "line": 7898,
           "kind": "unit",
           "field_names": [],
@@ -9860,7 +9668,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutOnTopOrBottom",
+          "name": "FlipCoin",
           "line": 7899,
           "kind": "unit",
           "field_names": [],
@@ -9868,7 +9676,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiftDelivery",
+          "name": "FlipCoins",
           "line": 7900,
           "kind": "unit",
           "field_names": [],
@@ -9876,7 +9684,7 @@
           "cr_refs": []
         },
         {
-          "name": "Goad",
+          "name": "FlipCoinUntilLose",
           "line": 7901,
           "kind": "unit",
           "field_names": [],
@@ -9884,7 +9692,7 @@
           "cr_refs": []
         },
         {
-          "name": "GoadAll",
+          "name": "RingTemptsYou",
           "line": 7902,
           "kind": "unit",
           "field_names": [],
@@ -9892,7 +9700,7 @@
           "cr_refs": []
         },
         {
-          "name": "Detain",
+          "name": "VentureIntoDungeon",
           "line": 7903,
           "kind": "unit",
           "field_names": [],
@@ -9900,7 +9708,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeControl",
+          "name": "VentureInto",
           "line": 7904,
           "kind": "unit",
           "field_names": [],
@@ -9908,7 +9716,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeTargets",
+          "name": "TakeTheInitiative",
           "line": 7905,
           "kind": "unit",
           "field_names": [],
@@ -9916,7 +9724,7 @@
           "cr_refs": []
         },
         {
-          "name": "Incubate",
+          "name": "ProcessRadCounters",
           "line": 7906,
           "kind": "unit",
           "field_names": [],
@@ -9924,7 +9732,7 @@
           "cr_refs": []
         },
         {
-          "name": "Amass",
+          "name": "GrantCastingPermission",
           "line": 7907,
           "kind": "unit",
           "field_names": [],
@@ -9932,7 +9740,7 @@
           "cr_refs": []
         },
         {
-          "name": "Monstrosity",
+          "name": "ChooseFromZone",
           "line": 7908,
           "kind": "unit",
           "field_names": [],
@@ -9940,7 +9748,7 @@
           "cr_refs": []
         },
         {
-          "name": "Renown",
+          "name": "ChooseObjectsIntoTrackedSet",
           "line": 7909,
           "kind": "unit",
           "field_names": [],
@@ -9948,7 +9756,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bolster",
+          "name": "ChooseAndSacrificeRest",
           "line": 7910,
           "kind": "unit",
           "field_names": [],
@@ -9956,7 +9764,7 @@
           "cr_refs": []
         },
         {
-          "name": "Adapt",
+          "name": "Exploit",
           "line": 7911,
           "kind": "unit",
           "field_names": [],
@@ -9964,7 +9772,7 @@
           "cr_refs": []
         },
         {
-          "name": "Manifest",
+          "name": "GainEnergy",
           "line": 7912,
           "kind": "unit",
           "field_names": [],
@@ -9972,7 +9780,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "GivePlayerCounter",
           "line": 7913,
           "kind": "unit",
           "field_names": [],
@@ -9980,7 +9788,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExtraTurn",
+          "name": "LoseAllPlayerCounters",
           "line": 7914,
           "kind": "unit",
           "field_names": [],
@@ -9988,7 +9796,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantExtraLoyaltyActivations",
+          "name": "ExileFromTopUntil",
           "line": 7915,
           "kind": "unit",
           "field_names": [],
@@ -9996,7 +9804,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextTurn",
+          "name": "RevealUntil",
           "line": 7916,
           "kind": "unit",
           "field_names": [],
@@ -10004,7 +9812,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextStep",
+          "name": "Discover",
           "line": 7917,
           "kind": "unit",
           "field_names": [],
@@ -10012,7 +9820,7 @@
           "cr_refs": []
         },
         {
-          "name": "AdditionalPhase",
+          "name": "Cascade",
           "line": 7918,
           "kind": "unit",
           "field_names": [],
@@ -10020,7 +9828,7 @@
           "cr_refs": []
         },
         {
-          "name": "Double",
+          "name": "MiracleCast",
           "line": 7919,
           "kind": "unit",
           "field_names": [],
@@ -10028,7 +9836,7 @@
           "cr_refs": []
         },
         {
-          "name": "RuntimeHandled",
+          "name": "MadnessCast",
           "line": 7920,
           "kind": "unit",
           "field_names": [],
@@ -10036,7 +9844,7 @@
           "cr_refs": []
         },
         {
-          "name": "Learn",
+          "name": "PutAtLibraryPosition",
           "line": 7921,
           "kind": "unit",
           "field_names": [],
@@ -10044,7 +9852,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "ChooseDrawnThisTurnPayOrTopdeck",
           "line": 7922,
           "kind": "unit",
           "field_names": [],
@@ -10052,7 +9860,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "PutOnTopOrBottom",
           "line": 7923,
           "kind": "unit",
           "field_names": [],
@@ -10060,7 +9868,7 @@
           "cr_refs": []
         },
         {
-          "name": "Endure",
+          "name": "GiftDelivery",
           "line": 7924,
           "kind": "unit",
           "field_names": [],
@@ -10068,7 +9876,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlightEffect",
+          "name": "Goad",
           "line": 7925,
           "kind": "unit",
           "field_names": [],
@@ -10076,7 +9884,7 @@
           "cr_refs": []
         },
         {
-          "name": "Seek",
+          "name": "GoadAll",
           "line": 7926,
           "kind": "unit",
           "field_names": [],
@@ -10084,7 +9892,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetLifeTotal",
+          "name": "Detain",
           "line": 7927,
           "kind": "unit",
           "field_names": [],
@@ -10092,7 +9900,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeLifeWithStat",
+          "name": "ExchangeControl",
           "line": 7928,
           "kind": "unit",
           "field_names": [],
@@ -10100,7 +9908,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetDayNight",
+          "name": "ChangeTargets",
           "line": 7929,
           "kind": "unit",
           "field_names": [],
@@ -10108,7 +9916,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveControl",
+          "name": "Incubate",
           "line": 7930,
           "kind": "unit",
           "field_names": [],
@@ -10116,7 +9924,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveFromCombat",
+          "name": "Amass",
           "line": 7931,
           "kind": "unit",
           "field_names": [],
@@ -10124,7 +9932,7 @@
           "cr_refs": []
         },
         {
-          "name": "Conjure",
+          "name": "Monstrosity",
           "line": 7932,
           "kind": "unit",
           "field_names": [],
@@ -10132,7 +9940,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseOneOf",
+          "name": "Renown",
           "line": 7933,
           "kind": "unit",
           "field_names": [],
@@ -10140,7 +9948,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unimplemented",
+          "name": "Bolster",
           "line": 7934,
           "kind": "unit",
           "field_names": [],
@@ -10148,8 +9956,200 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "Adapt",
+          "line": 7935,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Manifest",
           "line": 7936,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ManifestDread",
+          "line": 7937,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExtraTurn",
+          "line": 7938,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GrantExtraLoyaltyActivations",
+          "line": 7939,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SkipNextTurn",
+          "line": 7940,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SkipNextStep",
+          "line": 7941,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AdditionalPhase",
+          "line": 7942,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Double",
+          "line": 7943,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RuntimeHandled",
+          "line": 7944,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Learn",
+          "line": 7945,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Forage",
+          "line": 7946,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CollectEvidence",
+          "line": 7947,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Endure",
+          "line": 7948,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BlightEffect",
+          "line": 7949,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Seek",
+          "line": 7950,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetLifeTotal",
+          "line": 7951,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExchangeLifeWithStat",
+          "line": 7952,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetDayNight",
+          "line": 7953,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GiveControl",
+          "line": 7954,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RemoveFromCombat",
+          "line": 7955,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Conjure",
+          "line": 7956,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseOneOf",
+          "line": 7957,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unimplemented",
+          "line": 7958,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 7960,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -10157,7 +10157,7 @@
         },
         {
           "name": "Crew",
-          "line": 7938,
+          "line": 7962,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -10167,7 +10167,7 @@
         },
         {
           "name": "Station",
-          "line": 7940,
+          "line": 7964,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -10177,7 +10177,7 @@
         },
         {
           "name": "Saddle",
-          "line": 7942,
+          "line": 7966,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -10187,7 +10187,7 @@
         },
         {
           "name": "Reveal",
-          "line": 7944,
+          "line": 7968,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -10195,7 +10195,7 @@
         },
         {
           "name": "Transform",
-          "line": 7945,
+          "line": 7969,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10203,7 +10203,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 7946,
+          "line": 7970,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10211,7 +10211,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 7947,
+          "line": 7971,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10311,13 +10311,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8973,
+      "line": 8997,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 8977,
+          "line": 9001,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -10328,7 +10328,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 8980,
+          "line": 9004,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -14112,7 +14112,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8767,
+      "line": 8791,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -14121,7 +14121,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 8770,
+          "line": 8794,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -15816,7 +15816,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11204,
+      "line": 11228,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -15825,7 +15825,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 11206,
+          "line": 11230,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -15838,7 +15838,7 @@
         },
         {
           "name": "Crew",
-          "line": 11212,
+          "line": 11236,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -15851,7 +15851,7 @@
         },
         {
           "name": "Saddle",
-          "line": 11218,
+          "line": 11242,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -15864,7 +15864,7 @@
         },
         {
           "name": "Station",
-          "line": 11226,
+          "line": 11250,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -16975,7 +16975,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9325,
+      "line": 9349,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -16985,7 +16985,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 9327,
+          "line": 9351,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -16995,7 +16995,7 @@
         },
         {
           "name": "Second",
-          "line": 9330,
+          "line": 9354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -17244,13 +17244,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4902,
+      "line": 4926,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 4903,
+          "line": 4927,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17258,7 +17258,7 @@
         },
         {
           "name": "Bottom",
-          "line": 4904,
+          "line": 4928,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17266,7 +17266,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 4906,
+          "line": 4930,
           "kind": "struct",
           "field_names": [
             "n"
@@ -18143,7 +18143,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10488,
+      "line": 10512,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -18152,7 +18152,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 10491,
+          "line": 10515,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -18164,7 +18164,7 @@
         },
         {
           "name": "Multiply",
-          "line": 10494,
+          "line": 10518,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -18410,7 +18410,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10500,
+      "line": 10524,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -18419,7 +18419,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10503,
+          "line": 10527,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -18427,7 +18427,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 10505,
+          "line": 10529,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -18838,13 +18838,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8207,
+      "line": 8231,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 8209,
+          "line": 8233,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -18856,7 +18856,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8212,
+          "line": 8236,
           "kind": "struct",
           "field_names": [
             "source",
@@ -18875,13 +18875,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8187,
+      "line": 8211,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 8188,
+          "line": 8212,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18889,7 +18889,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 8191,
+          "line": 8215,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -18904,7 +18904,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 8198,
+          "line": 8222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -18914,7 +18914,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 8201,
+          "line": 8225,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -19004,7 +19004,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4189,
+      "line": 4213,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -19014,7 +19014,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4191,
+          "line": 4215,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -19024,7 +19024,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4193,
+          "line": 4217,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -19182,7 +19182,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9973,
+      "line": 9997,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -19192,7 +19192,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 9975,
+          "line": 9999,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -19200,7 +19200,7 @@
         },
         {
           "name": "Equals",
-          "line": 9977,
+          "line": 10001,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -19208,7 +19208,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 9980,
+          "line": 10004,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -19216,7 +19216,7 @@
         },
         {
           "name": "OneOf",
-          "line": 9982,
+          "line": 10006,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -19358,7 +19358,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3915,
+      "line": 3939,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -19367,7 +19367,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 3916,
+          "line": 3940,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -19377,7 +19377,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3920,
+          "line": 3944,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -19387,7 +19387,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 3921,
+          "line": 3945,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19395,7 +19395,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3923,
+          "line": 3947,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -19405,7 +19405,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 3924,
+          "line": 3948,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19415,7 +19415,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 3927,
+          "line": 3951,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -19426,7 +19426,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 3931,
+          "line": 3955,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -19436,7 +19436,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3935,
+          "line": 3959,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -19446,7 +19446,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 3937,
+          "line": 3961,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -19456,7 +19456,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 3938,
+          "line": 3962,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19464,7 +19464,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 3939,
+          "line": 3963,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -19474,7 +19474,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 3942,
+          "line": 3966,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -19484,7 +19484,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 3945,
+          "line": 3969,
           "kind": "struct",
           "field_names": [
             "color"
@@ -19494,7 +19494,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 3948,
+          "line": 3972,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19502,7 +19502,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 3949,
+          "line": 3973,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19510,7 +19510,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 3950,
+          "line": 3974,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19518,7 +19518,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 3951,
+          "line": 3975,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19529,7 +19529,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 3955,
+          "line": 3979,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19540,7 +19540,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 3959,
+          "line": 3983,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19552,7 +19552,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3964,
+          "line": 3988,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19562,7 +19562,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 3967,
+          "line": 3991,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19572,7 +19572,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 3970,
+          "line": 3994,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -19582,7 +19582,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 3975,
+          "line": 3999,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19594,7 +19594,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3984,
+          "line": 4008,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19609,7 +19609,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 3989,
+          "line": 4013,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19619,7 +19619,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 3992,
+          "line": 4016,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -19629,7 +19629,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 3995,
+          "line": 4019,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -19640,7 +19640,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 3999,
+          "line": 4023,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -19651,7 +19651,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 4003,
+          "line": 4027,
           "kind": "struct",
           "field_names": [
             "color",
@@ -19662,7 +19662,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 4007,
+          "line": 4031,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -19672,7 +19672,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 4010,
+          "line": 4034,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19680,7 +19680,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 4011,
+          "line": 4035,
           "kind": "struct",
           "field_names": [
             "name"
@@ -19690,7 +19690,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 4018,
+          "line": 4042,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -19703,7 +19703,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 4022,
+          "line": 4046,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19713,7 +19713,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 4025,
+          "line": 4049,
           "kind": "struct",
           "field_names": [
             "power",
@@ -19724,7 +19724,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 4029,
+          "line": 4053,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19732,7 +19732,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 4030,
+          "line": 4054,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19742,7 +19742,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 4033,
+          "line": 4057,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19752,7 +19752,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 4036,
+          "line": 4060,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19762,7 +19762,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 4039,
+          "line": 4063,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19770,7 +19770,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 4040,
+          "line": 4064,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19778,7 +19778,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 4041,
+          "line": 4065,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19788,7 +19788,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 4047,
+          "line": 4071,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -19796,7 +19796,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 4050,
+          "line": 4074,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19809,7 +19809,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 4054,
+          "line": 4078,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19817,7 +19817,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 4055,
+          "line": 4079,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19827,7 +19827,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 4058,
+          "line": 4082,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19835,7 +19835,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 4059,
+          "line": 4083,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19843,7 +19843,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 4060,
+          "line": 4084,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19851,7 +19851,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 4061,
+          "line": 4085,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19859,7 +19859,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 4063,
+          "line": 4087,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -19869,7 +19869,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 4064,
+          "line": 4088,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19877,7 +19877,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 4065,
+          "line": 4089,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19885,7 +19885,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 4066,
+          "line": 4090,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19893,7 +19893,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 4067,
+          "line": 4091,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19904,7 +19904,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 4071,
+          "line": 4095,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19914,7 +19914,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 4076,
+          "line": 4100,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19927,7 +19927,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4081,
+          "line": 4105,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -19937,7 +19937,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 4089,
+          "line": 4113,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -19947,7 +19947,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 4102,
+          "line": 4126,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19961,7 +19961,7 @@
         },
         {
           "name": "And",
-          "line": 4110,
+          "line": 4134,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -19974,7 +19974,7 @@
         },
         {
           "name": "Or",
-          "line": 4116,
+          "line": 4140,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -19987,7 +19987,7 @@
         },
         {
           "name": "Not",
-          "line": 4123,
+          "line": 4147,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -20147,7 +20147,7 @@
     },
     "PaymentCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4136,
+      "line": 4160,
       "doc": "CR 118.1: A cost paid as part of an effect's resolution. Distinct from AbilityCost (which gates activation before the colon).",
       "cr_refs": [
         "CR 118.1"
@@ -20155,7 +20155,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 4137,
+          "line": 4161,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20165,7 +20165,7 @@
         },
         {
           "name": "Life",
-          "line": 4145,
+          "line": 4169,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20178,7 +20178,7 @@
         },
         {
           "name": "Speed",
-          "line": 4149,
+          "line": 4173,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20191,7 +20191,7 @@
         },
         {
           "name": "Energy",
-          "line": 4154,
+          "line": 4178,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20203,7 +20203,7 @@
         },
         {
           "name": "AbilityCost",
-          "line": 4161,
+          "line": 4185,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20216,7 +20216,7 @@
         },
         {
           "name": "ScaledMana",
-          "line": 4171,
+          "line": 4195,
           "kind": "struct",
           "field_names": [
             "base",
@@ -20712,6 +20712,24 @@
             "CR 109.4",
             "CR 109.5"
           ]
+        },
+        {
+          "name": "PlayerAttribute",
+          "line": 3399,
+          "kind": "struct",
+          "field_names": [
+            "relation",
+            "attr",
+            "comparator",
+            "value"
+          ],
+          "doc": "CR 402.1 (hand) / CR 119.1 (life) / CR 122.1f (poison) / CR 404.1 (graveyard): Each player satisfying `relation` whose scalar player attribute `attr`, read PER CANDIDATE PLAYER, satisfies `comparator` against `value`. `attr` is the per-player-scalar `QuantityRef` subset (`HandSize` / `LifeTotal` / `GraveyardSize` / `PlayerCounter`) — read directly off the candidate `Player` at runtime, never via the controller-scoped quantity resolver, so its embedded `PlayerScope` / `CountScope` carries no game-state meaning here.  Covers \"opponents who have N or more poison counters\" (Glissa's Retriever) and \"your opponents with N or more cards in hand\" (Wolfcaller's Howl). `value` is the controller-relative threshold, resolved once per evaluation (candidate-independent).  `attr` and `value` are boxed to break the `QuantityExpr → QuantityRef::PlayerCount → PlayerFilter::PlayerAttribute → {QuantityRef, QuantityExpr}` reference cycle that would otherwise give the enum infinite size.",
+          "cr_refs": [
+            "CR 119.1",
+            "CR 122.1f",
+            "CR 402.1",
+            "CR 404.1"
+          ]
         }
       ],
       "sibling_clusters": [
@@ -20897,7 +20915,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10602,
+      "line": 10626,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -20906,7 +20924,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 10603,
+          "line": 10627,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20914,7 +20932,7 @@
         },
         {
           "name": "Resolved",
-          "line": 10604,
+          "line": 10628,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21494,7 +21512,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3559,
+      "line": 3583,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -21502,7 +21520,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 3561,
+          "line": 3585,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -21512,7 +21530,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3563,
+          "line": 3587,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -21522,7 +21540,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 3565,
+          "line": 3589,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -21568,7 +21586,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3574,
+      "line": 3598,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -21577,7 +21595,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 3577,
+          "line": 3601,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -21587,7 +21605,7 @@
         },
         {
           "name": "Base",
-          "line": 3580,
+          "line": 3604,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -21600,13 +21618,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3387,
+      "line": 3411,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 3389,
+          "line": 3413,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -21616,7 +21634,7 @@
         },
         {
           "name": "Fixed",
-          "line": 3391,
+          "line": 3415,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21626,7 +21644,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 3395,
+          "line": 3419,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21640,7 +21658,7 @@
         },
         {
           "name": "Offset",
-          "line": 3402,
+          "line": 3426,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21653,7 +21671,7 @@
         },
         {
           "name": "Multiply",
-          "line": 3407,
+          "line": 3431,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -21664,7 +21682,7 @@
         },
         {
           "name": "Sum",
-          "line": 3416,
+          "line": 3440,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -21674,7 +21692,7 @@
         },
         {
           "name": "UpTo",
-          "line": 3441,
+          "line": 3465,
           "kind": "struct",
           "field_names": [
             "max"
@@ -21687,7 +21705,7 @@
         },
         {
           "name": "Power",
-          "line": 3447,
+          "line": 3471,
           "kind": "struct",
           "field_names": [
             "base",
@@ -21700,7 +21718,7 @@
         },
         {
           "name": "Difference",
-          "line": 3462,
+          "line": 3486,
           "kind": "struct",
           "field_names": [
             "left",
@@ -21716,7 +21734,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10454,
+      "line": 10478,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -21724,7 +21742,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10456,
+          "line": 10480,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -21732,7 +21750,7 @@
         },
         {
           "name": "Plus",
-          "line": 10458,
+          "line": 10482,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21742,7 +21760,7 @@
         },
         {
           "name": "Minus",
-          "line": 10460,
+          "line": 10484,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21752,7 +21770,7 @@
         },
         {
           "name": "Prevent",
-          "line": 10480,
+          "line": 10504,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -22645,7 +22663,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8752,
+      "line": 8776,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -22654,7 +22672,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 8756,
+          "line": 8780,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -22667,13 +22685,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9761,
+      "line": 9785,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 9764,
+          "line": 9788,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -22685,7 +22703,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 9770,
+          "line": 9794,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22695,7 +22713,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 9777,
+          "line": 9801,
           "kind": "struct",
           "field_names": [
             "count",
@@ -22708,7 +22726,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 9782,
+          "line": 9806,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22720,7 +22738,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 9787,
+          "line": 9811,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -22733,7 +22751,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 9790,
+          "line": 9814,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -22745,7 +22763,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 9793,
+          "line": 9817,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -22755,7 +22773,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 9796,
+          "line": 9820,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -22766,7 +22784,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 9804,
+          "line": 9828,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22779,7 +22797,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 9818,
+          "line": 9842,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22792,7 +22810,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9827,
+          "line": 9851,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -22803,7 +22821,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 9830,
+          "line": 9854,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -22813,7 +22831,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9836,
+          "line": 9860,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -22825,7 +22843,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9841,
+          "line": 9865,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22837,7 +22855,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 9846,
+          "line": 9870,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -22848,7 +22866,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 9855,
+          "line": 9879,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -22860,7 +22878,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 9862,
+          "line": 9886,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -22874,7 +22892,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 9870,
+          "line": 9894,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -22884,7 +22902,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 9875,
+          "line": 9899,
           "kind": "struct",
           "field_names": [
             "source"
@@ -22898,7 +22916,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 9879,
+          "line": 9903,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -22911,7 +22929,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 9884,
+          "line": 9908,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -22922,7 +22940,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 9895,
+          "line": 9919,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22935,7 +22953,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9906,
+          "line": 9930,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -22947,7 +22965,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 9914,
+          "line": 9938,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -22960,7 +22978,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9924,
+          "line": 9948,
           "kind": "struct",
           "field_names": [
             "level"
@@ -22972,7 +22990,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 9929,
+          "line": 9953,
           "kind": "struct",
           "field_names": [
             "text"
@@ -23376,13 +23394,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10568,
+      "line": 10592,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 10571,
+          "line": 10595,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -23390,7 +23408,7 @@
         },
         {
           "name": "Optional",
-          "line": 10573,
+          "line": 10597,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -23400,7 +23418,7 @@
         },
         {
           "name": "MayCost",
-          "line": 10580,
+          "line": 10604,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -23417,7 +23435,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10556,
+      "line": 10580,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 614.1a"
@@ -23425,7 +23443,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 10558,
+          "line": 10582,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source's controller.",
@@ -23433,7 +23451,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10560,
+          "line": 10584,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source's controller.",
@@ -23441,7 +23459,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 10562,
+          "line": 10586,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -23633,7 +23651,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4265,
+      "line": 4289,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -23641,7 +23659,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 4267,
+          "line": 4291,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -23995,7 +24013,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3587,
+      "line": 3611,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -24004,7 +24022,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 3589,
+          "line": 3613,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -24016,7 +24034,7 @@
         },
         {
           "name": "Text",
-          "line": 3595,
+          "line": 3619,
           "kind": "struct",
           "field_names": [
             "description"
@@ -24029,7 +24047,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4943,
+      "line": 4967,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -24037,7 +24055,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 4945,
+          "line": 4969,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -24047,7 +24065,7 @@
         },
         {
           "name": "Decrease",
-          "line": 4947,
+          "line": 4971,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -24060,13 +24078,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4752,
+      "line": 4776,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 4753,
+          "line": 4777,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24074,7 +24092,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 4754,
+          "line": 4778,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24082,7 +24100,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 4755,
+          "line": 4779,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24090,7 +24108,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 4757,
+          "line": 4781,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -24165,13 +24183,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3661,
+      "line": 3685,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 3662,
+          "line": 3686,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -24182,7 +24200,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 3666,
+          "line": 3690,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24192,7 +24210,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 3672,
+          "line": 3696,
           "kind": "struct",
           "field_names": [
             "color"
@@ -24202,7 +24220,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 3681,
+          "line": 3705,
           "kind": "struct",
           "field_names": [
             "label"
@@ -24215,7 +24233,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3687,
+          "line": 3711,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -24227,7 +24245,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 3693,
+          "line": 3717,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -24237,7 +24255,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 3695,
+          "line": 3719,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -24250,7 +24268,7 @@
         },
         {
           "name": "And",
-          "line": 3699,
+          "line": 3723,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24260,7 +24278,7 @@
         },
         {
           "name": "Or",
-          "line": 3703,
+          "line": 3727,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24270,7 +24288,7 @@
         },
         {
           "name": "Not",
-          "line": 3709,
+          "line": 3733,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -24280,7 +24298,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 3713,
+          "line": 3737,
           "kind": "struct",
           "field_names": [
             "state"
@@ -24292,7 +24310,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 3722,
+          "line": 3746,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24308,7 +24326,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 3733,
+          "line": 3757,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24323,7 +24341,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 3741,
+          "line": 3765,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24335,7 +24353,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 3748,
+          "line": 3772,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24347,7 +24365,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 3752,
+          "line": 3776,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -24357,7 +24375,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3756,
+          "line": 3780,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -24368,7 +24386,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 3760,
+          "line": 3784,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -24379,7 +24397,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3764,
+          "line": 3788,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -24389,7 +24407,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 3766,
+          "line": 3790,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -24399,7 +24417,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 3769,
+          "line": 3793,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -24409,7 +24427,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 3771,
+          "line": 3795,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -24419,7 +24437,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 3774,
+          "line": 3798,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -24429,7 +24447,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 3780,
+          "line": 3804,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -24441,7 +24459,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 3788,
+          "line": 3812,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -24453,7 +24471,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3792,
+          "line": 3816,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24465,7 +24483,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 3817,
+          "line": 3841,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -24483,7 +24501,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 3826,
+          "line": 3850,
           "kind": "struct",
           "field_names": [
             "text"
@@ -24493,7 +24511,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 3829,
+          "line": 3853,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24501,7 +24519,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3832,
+          "line": 3856,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -24511,7 +24529,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 3834,
+          "line": 3858,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -24521,7 +24539,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 3836,
+          "line": 3860,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24533,7 +24551,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 3842,
+          "line": 3866,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -24547,7 +24565,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 3847,
+          "line": 3871,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -24557,7 +24575,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 3854,
+          "line": 3878,
           "kind": "struct",
           "field_names": [
             "player"
@@ -24570,7 +24588,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 3859,
+          "line": 3883,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -24580,7 +24598,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 3863,
+          "line": 3887,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -24590,7 +24608,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 3867,
+          "line": 3891,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -24601,7 +24619,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 3871,
+          "line": 3895,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24613,7 +24631,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 3883,
+          "line": 3907,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24625,7 +24643,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 3887,
+          "line": 3911,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -24635,7 +24653,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 3890,
+          "line": 3914,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -24647,7 +24665,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 3896,
+          "line": 3920,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -24658,7 +24676,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 3901,
+          "line": 3925,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ReduceCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -24669,7 +24687,7 @@
         },
         {
           "name": "None",
-          "line": 3902,
+          "line": 3926,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25708,7 +25726,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4955,
+      "line": 4979,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -25717,7 +25735,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 4956,
+          "line": 4980,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25725,7 +25743,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 4957,
+          "line": 4981,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25736,7 +25754,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8717,
+      "line": 8741,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -25744,7 +25762,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 8725,
+          "line": 8749,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -25752,7 +25770,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 8730,
+          "line": 8754,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -25931,7 +25949,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8387,
+      "line": 8411,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -25941,7 +25959,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 8389,
+          "line": 8413,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25949,7 +25967,7 @@
         },
         {
           "name": "Resolution",
-          "line": 8390,
+          "line": 8414,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26366,13 +26384,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11186,
+      "line": 11210,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 11187,
+          "line": 11211,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26380,7 +26398,7 @@
         },
         {
           "name": "Player",
-          "line": 11188,
+          "line": 11212,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26536,13 +26554,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9457,
+      "line": 9481,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 9460,
+          "line": 9484,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26552,7 +26570,7 @@
         },
         {
           "name": "LostLife",
-          "line": 9462,
+          "line": 9486,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -26560,7 +26578,7 @@
         },
         {
           "name": "Descended",
-          "line": 9464,
+          "line": 9488,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -26568,7 +26586,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 9466,
+          "line": 9490,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26578,7 +26596,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 9468,
+          "line": 9492,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -26588,7 +26606,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 9470,
+          "line": 9494,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -26598,7 +26616,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 9480,
+          "line": 9504,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26611,7 +26629,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9483,
+          "line": 9507,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -26622,7 +26640,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 9486,
+          "line": 9510,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -26632,7 +26650,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 9490,
+          "line": 9514,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26644,7 +26662,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 9493,
+          "line": 9517,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -26654,7 +26672,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9496,
+          "line": 9520,
           "kind": "struct",
           "field_names": [
             "level"
@@ -26666,7 +26684,7 @@
         },
         {
           "name": "WasCast",
-          "line": 9501,
+          "line": 9525,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you cast it\" — zoneless cast check (unlike CastFromZone which requires a specific zone). CR 701.57a: Used by Discover ETB triggers. Negation (\"if it wasn't cast\") is expressed via `Not { Box::new(WasCast) }`.",
@@ -26676,7 +26694,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 9505,
+          "line": 9529,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -26687,7 +26705,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 9510,
+          "line": 9534,
           "kind": "struct",
           "field_names": [
             "source",
@@ -26703,7 +26721,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 9526,
+          "line": 9550,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -26713,7 +26731,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9532,
+          "line": 9556,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26728,7 +26746,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 9536,
+          "line": 9560,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -26739,7 +26757,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 9540,
+          "line": 9564,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -26750,7 +26768,7 @@
         },
         {
           "name": "WasType",
-          "line": 9545,
+          "line": 9569,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -26763,7 +26781,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 9548,
+          "line": 9572,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26775,7 +26793,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 9552,
+          "line": 9576,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26788,7 +26806,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 9556,
+          "line": 9580,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26800,7 +26818,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 9560,
+          "line": 9584,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -26810,7 +26828,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9563,
+          "line": 9587,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -26822,7 +26840,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 9567,
+          "line": 9591,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26834,7 +26852,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 9570,
+          "line": 9594,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26846,7 +26864,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9576,
+          "line": 9600,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -26856,7 +26874,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9579,
+          "line": 9603,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -26866,7 +26884,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 9582,
+          "line": 9606,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -26876,7 +26894,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9589,
+          "line": 9613,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26888,7 +26906,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9594,
+          "line": 9618,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26900,7 +26918,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9598,
+          "line": 9622,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -26910,7 +26928,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 9603,
+          "line": 9627,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -26922,7 +26940,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9609,
+          "line": 9633,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -26932,7 +26950,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 9614,
+          "line": 9638,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -26942,7 +26960,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 9617,
+          "line": 9641,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -26952,7 +26970,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 9620,
+          "line": 9644,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -26962,7 +26980,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 9622,
+          "line": 9646,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -26974,7 +26992,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 9625,
+          "line": 9649,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -26984,7 +27002,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 9629,
+          "line": 9653,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -26994,7 +27012,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 9633,
+          "line": 9657,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27007,7 +27025,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 9636,
+          "line": 9660,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -27017,7 +27035,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9640,
+          "line": 9664,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -27030,7 +27048,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9643,
+          "line": 9667,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -27043,7 +27061,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9645,
+          "line": 9669,
           "kind": "struct",
           "field_names": [
             "color",
@@ -27056,7 +27074,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 9647,
+          "line": 9671,
           "kind": "struct",
           "field_names": [
             "text"
@@ -27068,7 +27086,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 9649,
+          "line": 9673,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -27080,7 +27098,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 9653,
+          "line": 9677,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -27094,7 +27112,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 9655,
+          "line": 9679,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -27104,7 +27122,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 9660,
+          "line": 9684,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -27119,7 +27137,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9671,
+          "line": 9695,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -27135,7 +27153,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 9686,
+          "line": 9710,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -27147,7 +27165,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9689,
+          "line": 9713,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27160,7 +27178,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 9699,
+          "line": 9723,
           "kind": "struct",
           "field_names": [
             "label"
@@ -27174,7 +27192,7 @@
         },
         {
           "name": "AttackersDeclaredMin",
-          "line": 9712,
+          "line": 9736,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27190,7 +27208,7 @@
         },
         {
           "name": "NoneOfAttackersTargetedYou",
-          "line": 9717,
+          "line": 9741,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 603.4: Intervening-if \"if none of those creatures attacked you\". Reads the triggering `AttackersDeclared` event's per-attacker `AttackTarget` tuples (CR 508.1b) and returns true iff no attacker in the batch targeted the trigger's controller directly (`AttackTarget::Player(trigger_controller)`).",
@@ -27202,7 +27220,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9727,
+          "line": 9751,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -27214,7 +27232,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 9738,
+          "line": 9762,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -27226,7 +27244,7 @@
         },
         {
           "name": "And",
-          "line": 9742,
+          "line": 9766,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27236,7 +27254,7 @@
         },
         {
           "name": "Or",
-          "line": 9744,
+          "line": 9768,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27246,7 +27264,7 @@
         },
         {
           "name": "Not",
-          "line": 9754,
+          "line": 9778,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -27262,13 +27280,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9935,
+      "line": 9959,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 9937,
+          "line": 9961,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -27276,7 +27294,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 9939,
+          "line": 9963,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -27284,7 +27302,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 9941,
+          "line": 9965,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -27292,7 +27310,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 9946,
+          "line": 9970,
           "kind": "struct",
           "field_names": [
             "n",
@@ -27303,7 +27321,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 9953,
+          "line": 9977,
           "kind": "struct",
           "field_names": [
             "n"
@@ -27313,7 +27331,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 9955,
+          "line": 9979,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -27321,7 +27339,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 9959,
+          "line": 9983,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -27331,7 +27349,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 9961,
+          "line": 9985,
           "kind": "struct",
           "field_names": [
             "level"
@@ -27343,7 +27361,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 9964,
+          "line": 9988,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29588,7 +29606,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3614,
+      "line": 3638,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -29597,7 +29615,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 3616,
+          "line": 3640,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29605,7 +29623,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 3617,
+          "line": 3641,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29613,7 +29631,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 3618,
+          "line": 3642,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29623,7 +29641,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 3621,
+          "line": 3645,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29633,7 +29651,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 3633,
+          "line": 3657,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29722,7 +29740,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7112,
+      "line": 7136,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -29731,7 +29749,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 7115,
+          "line": 7139,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -29741,7 +29759,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 7119,
+          "line": 7143,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -29751,7 +29769,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 7127,
+          "line": 7151,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",


### PR DESCRIPTION
Add PlayerAttribute{relation, attr: Box<QuantityRef>, comparator, value: Box<QuantityExpr>}
— "each player satisfying relation whose scalar attribute <comparator> value",
where attr (HandSize / LifeTotal / GraveyardSize / PlayerCounter) is read PER
CANDIDATE PLAYER. Completes the bucket-3 player-count drive: alongside CHANGE 1's
ControlsCount (object-control predicates), this covers scalar player-attribute
thresholds.

The runtime helper candidate_player_scalar reads the candidate's own
p.hand/p.life/p.graveyard/p.player_counter directly (NOT controller-scoped), so
"opponents who have N or more poison counters" counts each opponent's own poison,
never the controller's. The threshold `value` is resolved once, controller-scoped.

Fixes Glissa's Retriever ("the number of opponents who have three or more poison
counters") and Wolfcaller's Howl ("the number of your opponents with four or more
cards in hand"); the shared parse_player_counter_kind delegation also covers
rad/experience/ticket thresholds for free. attr/value are Box'd to break the
QuantityRef <-> PlayerFilter recursive type cycle (mirroring ControlsCount.count).

CR 402.1 (hand), CR 119.1 (life), CR 122.1f (poison), CR 404.1 (graveyard).
