### PR TITLE
fix(keywords): wire Recover deserialization — keyword_from_tagged

### DIFF
--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -2170,6 +2170,8 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         // CR 702.173a: Freerunning alternative cost.
         "Freerunning" => Ok(Keyword::Freerunning(mana(data)?)),
         "Surge" => Ok(Keyword::Surge(mana(data)?)),
+        // CR 702.59a: Recover {cost}
+        "Recover" => Ok(Keyword::Recover(mana(data)?)),
         "Encore" => Ok(Keyword::Encore(mana(data)?)),
         "Buyback" => {
             // Accept both legacy ManaCost format and new BuybackCost tagged format.
@@ -3155,6 +3157,45 @@ mod tests {
                 }
             })
         );
+    }
+
+    /// CR 702.59a: Recover keyword FromStr parsing.
+    #[test]
+    fn recover_from_str_parses_cost() {
+        let parsed = Keyword::from_str("recover:{2}{B}").unwrap();
+        let expected_cost = parse_keyword_mana_cost("{2}{B}");
+        match parsed {
+            Keyword::Recover(cost) => {
+                assert_eq!(cost, expected_cost, "Recover cost mismatch");
+            }
+            other => panic!("expected Keyword::Recover, got {other:?}"),
+        }
+    }
+
+    /// CR 702.59a: Recover keyword discriminant and serde round-trip.
+    #[test]
+    fn recover_kind_and_round_trip() {
+        let kw = Keyword::Recover(parse_keyword_mana_cost("{2}{B}"));
+        assert_eq!(kw.kind(), KeywordKind::Recover);
+        let json = serde_json::to_value(&kw).unwrap();
+        let deserialized: Keyword = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(kw, deserialized, "round-trip failed for {json}");
+    }
+
+    /// CR 702.59a: Recover keyword_from_tagged deserialization.
+    #[test]
+    fn recover_keyword_from_tagged() {
+        let data = serde_json::json!({
+            "type": "Cost",
+            "shards": ["Black"],
+            "generic": 2
+        });
+        let kw = keyword_from_tagged("Recover", &data).unwrap();
+        assert_eq!(kw.kind(), KeywordKind::Recover);
+        match kw {
+            Keyword::Recover(_) => {} // cost shape validated by ManaCost deser
+            other => panic!("expected Keyword::Recover, got {other:?}"),
+        }
     }
 
     /// CR 702.173a: Freerunning keyword FromStr parsing.


### PR DESCRIPTION
## Summary

`keyword_from_tagged` was missing a `"Recover"` arm. When card-data.json is loaded, the Recover keyword fell through to `Keyword::Unknown(...)`, causing 9 Coldsnap/CSP cards to show as unsupported in coverage.

`FromStr` already handled lowercase `"recover"` (line 1659), but the JSON tagged-enum deserialization path was missing.

## Changes

| Area | Change |
|------|--------|
| `keyword_from_tagged` | Add `"Recover" => Ok(Keyword::Recover(mana(data)?))` |
| Tests | 3 tests: FromStr, serde round-trip, keyword_from_tagged |

## Cards unlocked (9)

Grim Harvest, Icefall, Krovikan Rot, Resize, Controvert, Sun's Bounty, Garza's Assassin, A-Circle of the Land Druid, Circle of the Land Druid

## CR Reference

**CR 702.59a** — Recover {cost} is a triggered ability that functions while the card is in a player's graveyard. "Recover [cost]" means "When a creature is put into your graveyard from the battlefield, you may pay [cost]. If you do, return this card from your graveyard to your hand. Otherwise, exile this card."
