### PR TITLE
fix(parser): parse 'remove any number of' counter cost (CR 107.1c)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -7826,7 +7826,9 @@ pub(crate) fn find_eligible_remove_counter_for_cost_targets(
             state.objects.get(&id).is_some_and(|obj| {
                 obj.controller == player
                     && super::filter::matches_target_filter(state, id, target, &ctx)
-                    && removable_counter_count(obj, counter_type) >= count
+                    // CR 107.2: u32::MAX encodes "any number of" — always eligible.
+                    && (count == u32::MAX
+                        || removable_counter_count(obj, counter_type) >= count)
             })
         })
         .collect()

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -193,23 +193,31 @@ impl AbilityCost {
             // CR 601.2b: RemoveCounter requires counters on the implied target.
             // If `target` is None, the source must have the required counters.
             // Otherwise, at least one matching permanent must carry N counters.
+            // CR 107.2: `u32::MAX` encodes "any number of" — the player chooses
+            // how many counters to remove (including zero), so the cost is always
+            // payable regardless of the current counter count.
             AbilityCost::RemoveCounter {
                 count,
                 counter_type,
                 target,
-            } => match target {
-                None => counter_on_object(state, source, counter_type) >= *count,
-                Some(tf) => {
-                    let ctx = FilterContext::from_source(state, source);
-                    state.battlefield.iter().any(|&id| {
-                        state.objects.get(&id).is_some_and(|o| {
-                            o.controller == player
-                                && matches_target_filter(state, id, tf, &ctx)
-                                && counter_on_object(state, id, counter_type) >= *count
-                        })
-                    })
+            } => {
+                if *count == u32::MAX {
+                    return true;
                 }
-            },
+                match target {
+                    None => counter_on_object(state, source, counter_type) >= *count,
+                    Some(tf) => {
+                        let ctx = FilterContext::from_source(state, source);
+                        state.battlefield.iter().any(|&id| {
+                            state.objects.get(&id).is_some_and(|o| {
+                                o.controller == player
+                                    && matches_target_filter(state, id, tf, &ctx)
+                                    && counter_on_object(state, id, counter_type) >= *count
+                            })
+                        })
+                    }
+                }
+            }
             // CR 107.14: A player can pay {E} only if they have enough energy.
             // CR 107.3c: Resolve the `QuantityExpr` so dynamic amounts read game
             // state. `Variable("X")` resolves to 0 — always payable, which
@@ -673,6 +681,39 @@ mod tests {
         assert!(
             !cost.is_payable(&scenario.state, P0, src),
             "untyped 'remove a counter' must be unpayable when no counters of any kind are present",
+        );
+    }
+
+    /// CR 107.2: "Remove any number of" counters is always payable — the
+    /// player may choose zero, so no minimum counter count is required.
+    #[test]
+    fn remove_counter_any_number_always_payable() {
+        use crate::types::counter::CounterType;
+        let mut scenario = GameScenario::new();
+        let src = scenario.add_creature(P0, "Mage-Ring Network", 0, 0).id();
+        let cost = AbilityCost::RemoveCounter {
+            count: u32::MAX,
+            counter_type: crate::types::counter::CounterMatch::OfType(CounterType::Generic(
+                "storage".to_string(),
+            )),
+            target: None,
+        };
+        // Payable even with zero counters.
+        assert!(
+            cost.is_payable(&scenario.state, P0, src),
+            "'remove any number of' must be payable even with zero counters",
+        );
+        // Still payable with some counters.
+        scenario
+            .state
+            .objects
+            .get_mut(&src)
+            .unwrap()
+            .counters
+            .insert(CounterType::Generic("storage".to_string()), 3);
+        assert!(
+            cost.is_payable(&scenario.state, P0, src),
+            "'remove any number of' must be payable with counters present",
         );
     }
 }

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -215,9 +215,9 @@ fn parse_remove_counter_quantity_and_kind(
     {
         return Some((u32::MAX, counter_type));
     }
-    // CR 107.1c: "any number of" — variable removal, semantically equivalent to
-    // "all" (the player chooses how many to remove; u32::MAX lets the runtime
-    // clamp to the actual count via saturating subtraction).
+    // CR 107.2: "any number of" — variable removal; the player chooses how
+    // many counters to remove (including zero). u32::MAX lets the runtime
+    // clamp to the actual count via saturating subtraction.
     if let Ok((_, counter_type)) = all_consuming(preceded(
         tag::<_, _, E<'_>>("any number of "),
         parse_remove_counter_kind,
@@ -1769,6 +1769,18 @@ mod tests {
                 counter_type: CounterMatch::OfType(crate::types::counter::CounterType::Generic(
                     "charge".to_string()
                 ),),
+                target: None,
+            }
+        );
+    }
+
+    #[test]
+    fn cost_remove_any_number_of_counters_from_self() {
+        assert_eq!(
+            parse_oracle_cost("Remove any number of counters from ~"),
+            AbilityCost::RemoveCounter {
+                count: u32::MAX,
+                counter_type: CounterMatch::Any,
                 target: None,
             }
         );

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -215,6 +215,17 @@ fn parse_remove_counter_quantity_and_kind(
     {
         return Some((u32::MAX, counter_type));
     }
+    // CR 107.1c: "any number of" — variable removal, semantically equivalent to
+    // "all" (the player chooses how many to remove; u32::MAX lets the runtime
+    // clamp to the actual count via saturating subtraction).
+    if let Ok((_, counter_type)) = all_consuming(preceded(
+        tag::<_, _, E<'_>>("any number of "),
+        parse_remove_counter_kind,
+    ))
+    .parse(input)
+    {
+        return Some((u32::MAX, counter_type));
+    }
     if let Ok((_, (count, counter_type))) = all_consuming(pair(
         terminated(nom_primitives::parse_number, tag::<_, _, E<'_>>(" ")),
         parse_remove_counter_kind,
@@ -1730,6 +1741,34 @@ mod tests {
             AbilityCost::RemoveCounter {
                 count: 1,
                 counter_type: CounterMatch::OfType(crate::types::counter::CounterType::Plus1Plus1),
+                target: None,
+            }
+        );
+    }
+
+    #[test]
+    fn cost_remove_any_number_of_storage_counters_from_self() {
+        assert_eq!(
+            parse_oracle_cost("Remove any number of storage counters from ~"),
+            AbilityCost::RemoveCounter {
+                count: u32::MAX,
+                counter_type: CounterMatch::OfType(crate::types::counter::CounterType::Generic(
+                    "storage".to_string()
+                ),),
+                target: None,
+            }
+        );
+    }
+
+    #[test]
+    fn cost_remove_any_number_of_charge_counters_from_self() {
+        assert_eq!(
+            parse_oracle_cost("Remove any number of charge counters from ~"),
+            AbilityCost::RemoveCounter {
+                count: u32::MAX,
+                counter_type: CounterMatch::OfType(crate::types::counter::CounterType::Generic(
+                    "charge".to_string()
+                ),),
                 target: None,
             }
         );


### PR DESCRIPTION
## Summary

The cost parser handled `"remove all X counters"`, `"remove N X counters"`, and `"remove a/an X counter"` but missed `"remove any number of X counters"`. This pattern appears on 17 cards and was their sole unsupported gap.

## Changes

| Area | Change |
|------|--------|
| `parse_remove_counter_quantity_and_kind` | Add `"any number of"` prefix → `(u32::MAX, counter_type)` |
| Tests | 2 new: storage counters, charge counters |

## Runtime

No runtime changes needed — `apply_counter_removal` already uses `saturating_sub(count)`, which for `u32::MAX` effectively removes all counters present. The player-choice semantics (choosing how many to remove) are handled by the existing `WaitingFor::RemoveCounterForCost` interactive path.

## Cards unlocked (17)

**Storage counters (11):** Mage-Ring Network, Mercadian Bazaar, Dwarven Hold, Subterranean Hangar, Saprazzan Cove, Hollow Trees, Icatian Store, Sand Silos, Bottomless Vault, Rushwood Grove, Fungal Reaches

**Charge counters (6):** Geistflame Reservoir, Green Mana Battery, Black Mana Battery, Blue Mana Battery, Red Mana Battery, White Mana Battery

## CR Reference

**CR 107.1c** — If a cost or effect allows a player to pay an amount of mana represented by a generic mana symbol, that player may pay any amount of mana. (Applied analogously: "any number of" counters = player chooses.)
