### PR TITLE
Add Plaguecrafter

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5134,6 +5134,10 @@ fn condition_feature(cond: &AbilityCondition) -> (&'static str, FeatureSupport) 
             ("CostPaidObjectMatchesFilter", Handled)
         }
         AbilityCondition::SourceLacksKeyword { .. } => ("SourceLacksKeyword", Handled),
+        // CR 101.3 + CR 109.5: per-iteration scoped-player filter check; handled by
+        // `evaluate_condition` (effects/mod.rs). Used by cross-scope decline-tail
+        // gates (Liliana, Waker of the Dead — parent `All`, decline `Opponent`).
+        AbilityCondition::ScopedPlayerMatches { .. } => ("ScopedPlayerMatches", Handled),
     }
 }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4585,7 +4585,17 @@ fn scoped_player_matches_filter(
     candidate: PlayerId,
     filter: &PlayerFilter,
 ) -> bool {
-    let controller = ability.controller;
+    // CR 109.5: During a `player_scope` iteration the driver rebinds
+    // `ability.controller = scoped_player` (effects/mod.rs:2884) so that
+    // body effects whose leaf target is `Controller` resolve to the
+    // iterated player. The decline-clause scope filter, however, evaluates
+    // "Opponent of whom" relative to the PRINTED controller — the canonical
+    // idiom used by `quantity.rs` (see `original_controller.unwrap_or(controller)`
+    // at quantity.rs:479,514,530,721). Without this fallback, `Opponent`
+    // here would evaluate `candidate != iterated_player` and short-circuit
+    // to false for every per-iteration call, silently dropping cross-scope
+    // bodies (e.g. Liliana, Waker of the Dead [+1]).
+    let controller = ability.original_controller.unwrap_or(ability.controller);
     match filter {
         PlayerFilter::Controller => candidate == controller,
         PlayerFilter::Opponent => candidate != controller,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1072,6 +1072,7 @@ fn should_resolve_subability_on_optional_decline(ability: &ResolvedAbility) -> b
             | AbilityCondition::DayNightIs { .. }
             | AbilityCondition::NthResolutionThisTurn { .. }
             | AbilityCondition::SourceLacksKeyword { .. }
+            | AbilityCondition::ScopedPlayerMatches { .. }
             | AbilityCondition::EffectOutcome {
                 signal: EffectOutcomeSignal::CurrentScopeSucceeded,
             },
@@ -4556,6 +4557,71 @@ pub(crate) fn evaluate_condition(
             .objects
             .get(&ability.source_id)
             .is_some_and(|obj| !obj.has_keyword(keyword)),
+        // CR 101.3 + CR 109.5 + CR 608.2c: per-iteration scoped-player filter.
+        // The decline-tail body for a cross-scope decline clause (parent
+        // iterates a wider set than the decline-clause `PlayerFilter`) fires
+        // only when the iterated player matches the decline scope. Outside a
+        // `player_scope` iteration `scoped_player` is `None` and we fall back
+        // to the ability's controller — the canonical
+        // `ScopedPlayer`/`Controller` fallback semantics.
+        AbilityCondition::ScopedPlayerMatches { filter } => {
+            let candidate = ability.scoped_player.unwrap_or(ability.controller);
+            scoped_player_matches_filter(state, ability, candidate, filter)
+        }
+    }
+}
+
+/// CR 101.3 + CR 109.5: Evaluate a `PlayerFilter` against a single per-iteration
+/// candidate player. Mirrors the per-candidate predicates in
+/// `quantity::resolve_player_count`, but applied to one already-bound iteration
+/// player rather than a fold over all players. Set-valued / event-context
+/// variants that have no single-player semantic outside an iteration loop fail
+/// closed — `ScopedPlayerMatches` is only emitted by the parser for `All` /
+/// `Opponent` / `Controller` today (the canonical decline-tail scopes), so the
+/// fall-through is defensive rather than load-bearing.
+fn scoped_player_matches_filter(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    candidate: PlayerId,
+    filter: &PlayerFilter,
+) -> bool {
+    let controller = ability.controller;
+    match filter {
+        PlayerFilter::Controller => candidate == controller,
+        PlayerFilter::Opponent => candidate != controller,
+        PlayerFilter::All => true,
+        PlayerFilter::OpponentLostLife => {
+            candidate != controller
+                && state
+                    .players
+                    .iter()
+                    .find(|p| p.id == candidate)
+                    .is_some_and(|p| p.life_lost_this_turn > 0)
+        }
+        PlayerFilter::OpponentGainedLife => {
+            candidate != controller
+                && state
+                    .players
+                    .iter()
+                    .find(|p| p.id == candidate)
+                    .is_some_and(|p| p.life_gained_this_turn > 0)
+        }
+        // Set-valued / event-context / aggregate variants: not used by
+        // decline-tail today. Fail closed (mirrors the
+        // `TriggerCondition::DuringPlayersTurn` fallthrough pattern at
+        // game/triggers.rs:3703-3723).
+        PlayerFilter::DefendingPlayer
+        | PlayerFilter::OpponentDealtCombatDamage
+        | PlayerFilter::HighestSpeed
+        | PlayerFilter::ZoneChangedThisWay
+        | PlayerFilter::PerformedActionThisWay { .. }
+        | PlayerFilter::OwnersOfCardsExiledBySource
+        | PlayerFilter::TriggeringPlayer
+        | PlayerFilter::OpponentOtherThanTriggering
+        | PlayerFilter::VotedFor { .. }
+        | PlayerFilter::ParentObjectTargetController
+        | PlayerFilter::ControlsCount { .. }
+        | PlayerFilter::PlayerAttribute { .. } => false,
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13223,15 +13223,25 @@ pub(crate) fn parse_effect_chain_ir(
             .or(implicit_player_scope)
             .or(carried_player_scope);
 
-        // CR 608.2e + CR 608.2c: "For each opponent who doesn't, <body>" is a
-        // separate-sentence decline-tail of a preceding "each opponent may
-        // <optional action>". Strip the prefix, then stamp `player_scope:
-        // Opponent` (the body iterates per opponent) + `condition: Not{IfYouDo}`
-        // (the body runs only for an opponent who did NOT perform the optional
-        // action). Retarget the preceding clause's trailing boundary to `Then`
-        // so this clause lowers as a within-action `ContinuationStep` — never a
-        // `SequentialSibling` that would resolve even when the opponent accepts.
-        let (text, condition, is_decline_head) =
+        // CR 608.2e + CR 608.2c + CR 101.3: A decline-tail strips one of four
+        // shapes (prepositional vs subject-only × optional `doesn't` vs
+        // mandatory `can't`) into a body that runs only when the parent's
+        // per-iteration action did NOT happen. Track which quadrant dispatched
+        // so the recipient-rebinding walker fires on the right axis:
+        //   - Prepositional ("for each opponent who …, <body>") rebinds via
+        //     `rebind_decline_body_recipients` (Controller → OriginalController).
+        //   - SubjectOnly ("each <scope> who can't, <body>") rebinds via
+        //     `rebind_subject_only_body_recipients` (Controller → ScopedPlayer).
+        // Both walkers run on every chunk while the sticky
+        // `decline_consequence_active` flag remains set, so only the kind
+        // (which walker) needs to be tracked — no head bit.
+        #[derive(Copy, Clone)]
+        enum DeclineDispatch {
+            None,
+            Prepositional,
+            SubjectOnly,
+        }
+        let (text, condition, decline_dispatch) =
             if let Some((body, decline_condition)) = strip_for_each_opponent_who_doesnt(&text) {
                 // CR 608.2e + CR 101.3: Do NOT stamp `player_scope` on the body
                 // — it inherits the parent's `player_scope: Opponent` iteration
@@ -13254,28 +13264,49 @@ pub(crate) fn parse_effect_chain_ir(
                     Some(AbilityCondition::Not {
                         condition: Box::new(decline_condition),
                     }),
-                    true,
+                    DeclineDispatch::Prepositional,
                 )
-            } else if let Some(body) = strip_for_each_opponent_who_cant(&text) {
-                player_scope = Some(PlayerFilter::Opponent);
+            } else if let Some((_scope, body)) = strip_each_scope_who_cant_subject(&text) {
+                // CR 608.2c + CR 101.3 + CR 118.12: subject-only
+                // mandatory-impossible decline-tail (Plaguecrafter:
+                // "each player sacrifices …. Each player who can't discards a
+                // card."). Retarget the preceding clause's Sentence boundary
+                // to Then so this clause lowers as a within-action
+                // ContinuationStep, then stamp the Not gate.
+                //
+                // Do NOT stamp `player_scope = Some(scope)` here — the body
+                // inherits the parent's per-player iteration by being
+                // attached as `sub_ability` inside the scoped clone. The
+                // parent's first-sentence parse already stamps the matching
+                // `player_scope` (e.g. `All` for "each player sacrifices …")
+                // via `strip_player_scope_subject`, so a second stamp here
+                // would start a nested per-player fan-out that resets
+                // `cost_payment_failed_flag` for each inner iteration —
+                // exactly the failure mode `_scope` is left unstamped to
+                // avoid. The bound is retained for documentation only.
+                // Parallel to `strip_for_each_opponent_who_doesnt` above.
+                if let Some(prev) = clauses.last_mut() {
+                    if prev.boundary == Some(ClauseBoundary::Sentence) {
+                        prev.boundary = Some(ClauseBoundary::Then);
+                    }
+                }
                 (
                     body,
-                    Some(AbilityCondition::QuantityCheck {
-                        lhs: QuantityExpr::Ref {
-                            qty: QuantityRef::EventContextAmount,
-                        },
-                        comparator: Comparator::LT,
-                        rhs: QuantityExpr::Fixed { value: 1 },
+                    Some(AbilityCondition::Not {
+                        condition: Box::new(AbilityCondition::current_scope_succeeded()),
                     }),
-                    true,
+                    DeclineDispatch::SubjectOnly,
                 )
             } else {
-                (text, condition, false)
+                (text, condition, DeclineDispatch::None)
             };
-        // Recipient rebinds apply to every chunk of the decline-consequence
-        // sentence; the `Not{IfYouDo}` condition and `player_scope` only to the
-        // head chunk that carried the "for each opponent who doesn't" prefix.
-        let is_decline_consequence = is_decline_head || decline_consequence_active;
+        // Recipient rebinds apply to every chunk of the prepositional
+        // decline-consequence sentence; the `Not{IfYouDo}` condition and
+        // `player_scope` only to the head chunk that carried the "for each
+        // opponent who doesn't" prefix. The subject-only quadrant rebinds
+        // independently below via its own walker — see Step 4 site.
+        let is_decline_consequence = matches!(decline_dispatch, DeclineDispatch::Prepositional)
+            || decline_consequence_active;
 
         let (text, mut unless_pay) = extract_resolution_unless_pay_modifier(&text);
 
@@ -13611,11 +13642,19 @@ pub(crate) fn parse_effect_chain_ir(
         // the resolver iterates all players and `Controller` reads the
         // rebound per-player controller.
         lift_each_player_exile_top_scope(&mut clause.effect, &mut player_scope);
-        // CR 109.5: For a "for each opponent who doesn't" decline body, rebind
-        // every recipient-bearing node so "that player" → ScopedPlayer and
-        // "you" → OriginalController resolve relative to the per-opponent
-        // iteration. The undirected `LoseLife { target: None }` shape is rebound
-        // to `Some(ScopedPlayer)` so the life loss hits the declining opponent.
+        // CR 109.5: Rebind recipient-bearing nodes inside a decline body so the
+        // body's "you"/"that player" anaphors resolve relative to the surrounding
+        // per-player iteration. The two walkers are parallel inverses:
+        //   - Prepositional ("for each opponent who …, you draw …"): rebinds
+        //     Controller → OriginalController so "you" stays the printed
+        //     controller inside the Opponent-scoped iteration; also covers the
+        //     sticky continuation chunks via `decline_consequence_active`.
+        //   - SubjectOnly ("each player who can't discards a card"): rebinds
+        //     Controller → ScopedPlayer so the body's implicit recipient binds
+        //     to the per-iteration player who couldn't perform the predicate.
+        if matches!(decline_dispatch, DeclineDispatch::SubjectOnly) {
+            rebind_subject_only_body_recipients(&mut clause);
+        }
         if is_decline_consequence {
             rebind_decline_body_recipients(&mut clause);
         }
@@ -15842,6 +15881,17 @@ fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, String) {
         tag("may only"),
         tag("may not"),
         tag("may cast"),
+        // CR 101.3 + CR 109.5: Reserve the relative-clause shape "who can't" /
+        // "who cannot" for the Plaguecrafter-class subject-only decline-tail
+        // dispatcher (`strip_each_scope_who_cant_subject` in
+        // `parse_effect_clause_inner`). The dispatcher runs AFTER this
+        // function returns, so we must return `(None, text)` for these
+        // shapes — otherwise we'd strip `each player ` and leave
+        // `who can't …` orphaned to be misclassified as a static
+        // restriction. This is load-bearing for the dispatch contract, not
+        // a defensive escape.
+        tag("who can't"),
+        tag("who cannot"),
     ))
     .parse(rest_lower.as_str())
     .is_ok()
@@ -15874,6 +15924,32 @@ fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, String) {
     // Deconjugate the verb: "discards" → "discard", "draws" → "draw"
     let deconjugated = subject::deconjugate_verb(rest);
     (Some(scope), deconjugated)
+}
+
+/// CR 101.3 + CR 118.12 + CR 109.5: Strip a leading "each <scope> who can't /
+/// cannot, <body>" subject-only mandatory-impossible decline-tail. Returns the
+/// player scope and the body text. The body's recipient (e.g. Discard.target)
+/// must be rewritten Controller → ScopedPlayer by the caller; the body's
+/// condition must be stamped Not { current_scope_succeeded() }; the preceding
+/// clause's boundary must be retargeted Sentence → Then. Caller responsibilities
+/// — this combinator only does subject + scope detection.
+///
+/// Parallel to `strip_for_each_opponent_who_doesnt` (prepositional + optional);
+/// fills the subject-only + mandatory-impossible quadrant of the 2×2 matrix.
+fn strip_each_scope_who_cant_subject(text: &str) -> Option<(PlayerFilter, String)> {
+    let lower = text.to_lowercase();
+    nom_on_lower(text, &lower, |i| {
+        let (i, scope) = alt((
+            value(PlayerFilter::Opponent, tag("each other player who ")),
+            value(PlayerFilter::Opponent, tag("each opponent who ")),
+            value(PlayerFilter::All, tag("each player who ")),
+        ))
+        .parse(i)?;
+        let (i, _) = alt((tag("can't"), tag("cannot"))).parse(i)?;
+        let (i, _) = preceded(opt(tag(",")), opt(multispace1)).parse(i)?;
+        Ok((i, scope))
+    })
+    .map(|(scope, rest)| (scope, rest.to_string()))
 }
 
 /// CR 608.2e + CR 608.2c + CR 101.3: Strip a leading "For each opponent who
@@ -15926,28 +16002,6 @@ fn strip_for_each_opponent_who_doesnt(text: &str) -> Option<(String, AbilityCond
     .map(|(cond, rest)| (rest.to_string(), cond))
 }
 
-/// CR 608.2c: Strip a leading "For each opponent who can't, " consequence
-/// prefix. This differs from "who doesn't": no optional decision exists. The
-/// body runs later as a separate per-opponent sibling, gated by that opponent's
-/// previous-effect count being zero.
-fn strip_for_each_opponent_who_cant(text: &str) -> Option<String> {
-    let lower = text.to_lowercase();
-    nom_on_lower(text, &lower, |i| {
-        value(
-            (),
-            preceded(
-                alt((
-                    tag("for each opponent who can't"),
-                    tag("for each opponent who cannot"),
-                )),
-                preceded(opt(tag(",")), opt(multispace1)),
-            ),
-        )
-        .parse(i)
-    })
-    .map(|((), rest)| rest.to_string())
-}
-
 /// CR 109.5 + CR 115.10: Within a "for each opponent who doesn't" decline body,
 /// "that player" is the scoped (per-iteration) opponent and "you" is the printed
 /// ability controller. Rewrite a recipient-bearing effect's recipient so it
@@ -15991,6 +16045,49 @@ fn rebind_decline_body_recipients(clause: &mut ParsedEffectClause) {
     let mut cursor = clause.sub_ability.as_deref_mut();
     while let Some(node) = cursor {
         rebind_decline_body_recipient(&mut node.effect);
+        cursor = node.sub_ability.as_deref_mut();
+    }
+}
+
+/// CR 109.5 + CR 101.3: Inside a subject-only "each <scope> who can't, <body>"
+/// decline-tail, the body's implicit recipient binds to the SCOPED player (the
+/// one who couldn't perform the predicate), not to the printed ability
+/// controller. Rewrite Controller → ScopedPlayer.
+///
+/// PARALLEL INVERSE to `rebind_decline_body_recipient`:
+///   - this:  Controller → ScopedPlayer  (subject-only "each X who can't")
+///   - that:  Controller → OriginalController  (prepositional "for each
+///            opponent who doesn't" — "you" stays "you" inside an Opponent-
+///            scoped iteration)
+/// Same five-variant surface: { LoseLife, Draw, Discard, Mill, Token }.
+/// Sacrifice is NOT covered (it carries its own target on the parent node).
+fn rebind_subject_only_body_recipient(effect: &mut Effect) {
+    fn rebind(filter: &mut TargetFilter) {
+        if matches!(filter, TargetFilter::Controller) {
+            *filter = TargetFilter::ScopedPlayer;
+        }
+    }
+    match effect {
+        Effect::LoseLife { target, .. } => match target {
+            Some(filter) => rebind(filter),
+            None => *target = Some(TargetFilter::ScopedPlayer),
+        },
+        Effect::Draw { target, .. }
+        | Effect::Discard { target, .. }
+        | Effect::Mill { target, .. } => rebind(target),
+        Effect::Token { owner, .. } => rebind(owner),
+        _ => {}
+    }
+}
+
+/// CR 109.5: Walk a subject-only decline body chain (`effect` + every
+/// `sub_ability` descendant) and rebind each recipient-bearing node so the
+/// body's implicit recipient binds to the per-iteration scoped player.
+fn rebind_subject_only_body_recipients(clause: &mut ParsedEffectClause) {
+    rebind_subject_only_body_recipient(&mut clause.effect);
+    let mut cursor = clause.sub_ability.as_deref_mut();
+    while let Some(node) = cursor {
+        rebind_subject_only_body_recipient(&mut node.effect);
         cursor = node.sub_ability.as_deref_mut();
     }
 }
@@ -31899,6 +31996,151 @@ mod tests {
         let (scope, result) = strip_each_player_subject("each other player also loses 2 life");
         assert_eq!(scope, Some(PlayerFilter::Opponent));
         assert_eq!(result, "lose 2 life");
+    }
+
+    /// CR 101.3 + CR 118.12 + CR 109.5: `strip_each_scope_who_cant_subject`
+    /// covers the full subject-only × scope × can't/cannot matrix
+    /// (Plaguecrafter: "each player who can't discards a card") and rejects
+    /// non-matching variants ("doesn't") and non-subject phrases
+    /// ("target opponent ...").
+    #[test]
+    fn strip_each_scope_who_cant_subject_matrix() {
+        // Each scope × can't / cannot.
+        let (scope, body) =
+            strip_each_scope_who_cant_subject("each player who can't, discards a card")
+                .expect("each player who can't");
+        assert_eq!(scope, PlayerFilter::All);
+        assert_eq!(body, "discards a card");
+
+        let (scope, body) = strip_each_scope_who_cant_subject("each player who cannot discards a card")
+            .expect("each player who cannot");
+        assert_eq!(scope, PlayerFilter::All);
+        assert_eq!(body, "discards a card");
+
+        let (scope, body) =
+            strip_each_scope_who_cant_subject("each opponent who can't, discards a card")
+                .expect("each opponent who can't");
+        assert_eq!(scope, PlayerFilter::Opponent);
+        assert_eq!(body, "discards a card");
+
+        let (scope, body) =
+            strip_each_scope_who_cant_subject("each opponent who cannot, discards a card")
+                .expect("each opponent who cannot");
+        assert_eq!(scope, PlayerFilter::Opponent);
+        assert_eq!(body, "discards a card");
+
+        let (scope, body) =
+            strip_each_scope_who_cant_subject("each other player who can't, discards a card")
+                .expect("each other player who can't");
+        assert_eq!(scope, PlayerFilter::Opponent);
+        assert_eq!(body, "discards a card");
+
+        let (scope, body) =
+            strip_each_scope_who_cant_subject("each other player who cannot discards a card")
+                .expect("each other player who cannot");
+        assert_eq!(scope, PlayerFilter::Opponent);
+        assert_eq!(body, "discards a card");
+
+        // Case insensitivity via the nom_on_lower bridge.
+        let (scope, body) =
+            strip_each_scope_who_cant_subject("Each Player Who Can't, discards a card")
+                .expect("case insensitivity");
+        assert_eq!(scope, PlayerFilter::All);
+        assert_eq!(body, "discards a card");
+    }
+
+    /// Negative cases — `strip_each_scope_who_cant_subject` MUST return None
+    /// for shapes outside the subject-only × can't quadrant:
+    /// - optional "doesn't" decline-tail is the other quadrant
+    ///   (`strip_for_each_opponent_who_doesnt`'s job).
+    /// - non-"each" subjects are not relative-clause decline-tails.
+    /// - target-phrased subjects belong to the imperative pipeline.
+    #[test]
+    fn strip_each_scope_who_cant_subject_rejects_non_matches() {
+        assert!(
+            strip_each_scope_who_cant_subject("each player who doesn't discards a card").is_none(),
+            "doesn't is the optional-decline arm, not subject-only mandatory-impossible"
+        );
+        assert!(
+            strip_each_scope_who_cant_subject("each player who does not discard a card").is_none(),
+            "does not is the optional-decline arm"
+        );
+        assert!(
+            strip_each_scope_who_cant_subject("target opponent discards a card").is_none(),
+            "target-phrased subject is not a relative-clause decline-tail"
+        );
+        assert!(
+            strip_each_scope_who_cant_subject("each player sacrifices a creature").is_none(),
+            "no who can't clause means this is a normal imperative subject"
+        );
+        assert!(
+            strip_each_scope_who_cant_subject("for each opponent who can't, you draw a card")
+                .is_none(),
+            "prepositional shape belongs to strip_for_each_opponent_who_doesnt"
+        );
+    }
+
+    /// CR 101.3 + CR 118.12 + CR 109.5: Plaguecrafter's ETB body — "each
+    /// player sacrifices a creature or planeswalker of their choice. Each
+    /// player who can't discards a card." — must lower into a two-clause chain
+    /// whose second clause is `Effect::Discard { target: ScopedPlayer }`,
+    /// gated by `Not{IfCurrentScopeSucceeded}`, and whose preceding clause's
+    /// boundary was retargeted from `Sentence` to `Then` so this lowers as a
+    /// within-action `ContinuationStep`.
+    ///
+    /// Mirrors the style of
+    /// `for_each_opponent_who_cant_lowers_to_if_current_scope_succeeded`.
+    #[test]
+    fn plaguecrafter_etb_lowers_subject_only_decline_tail() {
+        use crate::types::ability::SubAbilityLink;
+        let def = parse_effect_chain(
+            "each player sacrifices a creature or planeswalker of their choice. Each \
+             player who can't discards a card.",
+            AbilityKind::Spell,
+        );
+
+        // Root: each player sacrifices — player_scope: All (each player).
+        assert!(matches!(*def.effect, Effect::Sacrifice { .. }));
+        assert_eq!(
+            def.player_scope,
+            Some(PlayerFilter::All),
+            "the sacrifice iterates per player"
+        );
+
+        // Decline body: Discard, gated on Not{IfCurrentScopeSucceeded},
+        // recipient rewritten Controller → ScopedPlayer so the discard
+        // applies to the per-iteration player who couldn't sacrifice.
+        let discard = def
+            .sub_ability
+            .as_ref()
+            .expect("sacrifice should chain to the decline body");
+        assert_eq!(
+            discard.condition,
+            Some(AbilityCondition::Not {
+                condition: Box::new(AbilityCondition::current_scope_succeeded())
+            }),
+            "Plaguecrafter's discard body fires only for the per-iteration player whose mandatory sacrifice failed"
+        );
+        assert_eq!(
+            discard.sub_link,
+            SubAbilityLink::ContinuationStep,
+            "Sentence → Then retargeting makes this a within-action continuation"
+        );
+        assert_eq!(
+            discard.player_scope, None,
+            "the body inherits the parent's per-player iteration instead of stamping its own loop"
+        );
+        match &*discard.effect {
+            Effect::Discard { count, target, .. } => {
+                assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                assert_eq!(
+                    target,
+                    &TargetFilter::ScopedPlayer,
+                    "the body's implicit recipient binds to the per-iteration scoped player, not the printed controller"
+                );
+            }
+            other => panic!("expected Discard, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13227,14 +13227,16 @@ pub(crate) fn parse_effect_chain_ir(
         // shapes (prepositional vs subject-only × optional `doesn't` vs
         // mandatory `can't`) into a body that runs only when the parent's
         // per-iteration action did NOT happen. Track which quadrant dispatched
-        // so the recipient-rebinding walker fires on the right axis:
-        //   - Prepositional ("for each opponent who …, <body>") rebinds via
-        //     `rebind_decline_body_recipients` (Controller → OriginalController).
-        //   - SubjectOnly ("each <scope> who can't, <body>") rebinds via
-        //     `rebind_subject_only_body_recipients` (Controller → ScopedPlayer).
-        // Both walkers run on every chunk while the sticky
+        // so the recipient-rebinding walker fires on the right axis. Both
+        // paths share the single `rebind_clause_recipients_with` walker; the
+        // per-quadrant mapping is the leaf rebinder:
+        //   - Prepositional ("for each opponent who …, <body>") uses
+        //     `rebind_decline_body_recipient` (Controller → OriginalController).
+        //   - SubjectOnly ("each <scope> who can't, <body>") uses
+        //     `rebind_subject_only_body_recipient` (Controller → ScopedPlayer).
+        // Both leaf rebinders run on every chunk while the sticky
         // `decline_consequence_active` flag remains set, so only the kind
-        // (which walker) needs to be tracked — no head bit.
+        // (which leaf rebinder) needs to be tracked — no head bit.
         #[derive(Copy, Clone)]
         enum DeclineDispatch {
             None,
@@ -13266,13 +13268,13 @@ pub(crate) fn parse_effect_chain_ir(
                     }),
                     DeclineDispatch::Prepositional,
                 )
-            } else if let Some((_scope, body)) = strip_each_scope_who_cant_subject(&text) {
+            } else if let Some((scope, body)) = strip_each_scope_who_cant_subject(&text) {
                 // CR 608.2c + CR 101.3 + CR 118.12: subject-only
                 // mandatory-impossible decline-tail (Plaguecrafter:
                 // "each player sacrifices …. Each player who can't discards a
                 // card."). Retarget the preceding clause's Sentence boundary
                 // to Then so this clause lowers as a within-action
-                // ContinuationStep, then stamp the Not gate.
+                // ContinuationStep, then stamp the And-of-two-conjuncts gate.
                 //
                 // Do NOT stamp `player_scope = Some(scope)` here — the body
                 // inherits the parent's per-player iteration by being
@@ -13282,21 +13284,43 @@ pub(crate) fn parse_effect_chain_ir(
                 // via `strip_player_scope_subject`, so a second stamp here
                 // would start a nested per-player fan-out that resets
                 // `cost_payment_failed_flag` for each inner iteration —
-                // exactly the failure mode `_scope` is left unstamped to
-                // avoid. The bound is retained for documentation only.
-                // Parallel to `strip_for_each_opponent_who_doesnt` above.
+                // exactly the failure mode the second stamp is omitted to
+                // avoid. Parallel to `strip_for_each_opponent_who_doesnt`
+                // above.
+                //
+                // CR 101.3 + CR 109.5: The body's gate has TWO conjuncts:
+                //   (a) `Not{IfCurrentScopeSucceeded}` — fires only on
+                //       iterations whose mandatory parent action failed
+                //       (the canonical "who can't" filter from CR 101.3).
+                //   (b) `ScopedPlayerMatches { filter: scope }` — fires only
+                //       on iterations whose scoped player matches the
+                //       decline clause's OWN PlayerFilter, relative to the
+                //       ability controller.
+                //
+                // Conjunct (b) is the cross-scope fix (Liliana, Waker of the
+                // Dead: parent "each player discards a card" iterates `All`,
+                // decline clause "each opponent who can't loses 3 life"
+                // filters to `Opponent`; without (b) the controller would
+                // lose 3 life if they couldn't discard, violating CR 109.5).
+                // For same-scope cards (Plaguecrafter, Entropic Battlecruiser,
+                // Skull Storm, Momentum Breaker, Lurking Spinecrawler — parent
+                // and decline share the scope) the `ScopedPlayerMatches`
+                // conjunct is trivially true for every iteration and acts as
+                // a no-op, so this is uniformly safe for the whole class.
                 if let Some(prev) = clauses.last_mut() {
                     if prev.boundary == Some(ClauseBoundary::Sentence) {
                         prev.boundary = Some(ClauseBoundary::Then);
                     }
                 }
-                (
-                    body,
-                    Some(AbilityCondition::Not {
-                        condition: Box::new(AbilityCondition::current_scope_succeeded()),
-                    }),
-                    DeclineDispatch::SubjectOnly,
-                )
+                let condition = AbilityCondition::And {
+                    conditions: vec![
+                        AbilityCondition::Not {
+                            condition: Box::new(AbilityCondition::current_scope_succeeded()),
+                        },
+                        AbilityCondition::ScopedPlayerMatches { filter: scope },
+                    ],
+                };
+                (body, Some(condition), DeclineDispatch::SubjectOnly)
             } else {
                 (text, condition, DeclineDispatch::None)
             };
@@ -13653,10 +13677,10 @@ pub(crate) fn parse_effect_chain_ir(
         //     Controller → ScopedPlayer so the body's implicit recipient binds
         //     to the per-iteration player who couldn't perform the predicate.
         if matches!(decline_dispatch, DeclineDispatch::SubjectOnly) {
-            rebind_subject_only_body_recipients(&mut clause);
+            rebind_clause_recipients_with(&mut clause, rebind_subject_only_body_recipient);
         }
         if is_decline_consequence {
-            rebind_decline_body_recipients(&mut clause);
+            rebind_clause_recipients_with(&mut clause, rebind_decline_body_recipient);
         }
         if inherits_carried_targeted_player_subject {
             if let Some(subject) = carried_targeted_player_subject.as_ref() {
@@ -16037,14 +16061,24 @@ fn rebind_decline_body_recipient(effect: &mut Effect) {
     }
 }
 
-/// CR 109.5: Walk a decline-consequence body chain (`effect` + every
-/// `sub_ability` descendant) and rebind each recipient-bearing node so "that
-/// player"/"you" resolve relative to the per-opponent iteration.
-fn rebind_decline_body_recipients(clause: &mut ParsedEffectClause) {
-    rebind_decline_body_recipient(&mut clause.effect);
+/// CR 109.5: Walk a decline-body chain (`effect` + every `sub_ability`
+/// descendant) and apply `rebind` to each node's `effect`. Single shared
+/// walker; the per-quadrant mapping is supplied as the leaf rebinder.
+///
+/// Used by both the prepositional decline path
+/// (`rebind_decline_body_recipient`: `Controller → OriginalController`) and
+/// the subject-only decline path (`rebind_subject_only_body_recipient`:
+/// `Controller → ScopedPlayer`). Replaces the previous byte-for-byte
+/// duplicated `rebind_decline_body_recipients` / `rebind_subject_only_body_recipients`
+/// pair — the two walkers differed only in which leaf function they called.
+fn rebind_clause_recipients_with(
+    clause: &mut ParsedEffectClause,
+    rebind: impl Fn(&mut Effect),
+) {
+    rebind(&mut clause.effect);
     let mut cursor = clause.sub_ability.as_deref_mut();
     while let Some(node) = cursor {
-        rebind_decline_body_recipient(&mut node.effect);
+        rebind(&mut node.effect);
         cursor = node.sub_ability.as_deref_mut();
     }
 }
@@ -16078,18 +16112,6 @@ fn rebind_subject_only_body_recipient(effect: &mut Effect) {
         | Effect::Mill { target, .. } => rebind(target),
         Effect::Token { owner, .. } => rebind(owner),
         _ => {}
-    }
-}
-
-/// CR 109.5: Walk a subject-only decline body chain (`effect` + every
-/// `sub_ability` descendant) and rebind each recipient-bearing node so the
-/// body's implicit recipient binds to the per-iteration scoped player.
-fn rebind_subject_only_body_recipients(clause: &mut ParsedEffectClause) {
-    rebind_subject_only_body_recipient(&mut clause.effect);
-    let mut cursor = clause.sub_ability.as_deref_mut();
-    while let Some(node) = cursor {
-        rebind_subject_only_body_recipient(&mut node.effect);
-        cursor = node.sub_ability.as_deref_mut();
     }
 }
 
@@ -32109,19 +32131,35 @@ mod tests {
             "the sacrifice iterates per player"
         );
 
-        // Decline body: Discard, gated on Not{IfCurrentScopeSucceeded},
+        // Decline body: Discard, gated on
+        // `And { [Not{IfCurrentScopeSucceeded}, ScopedPlayerMatches(All)] }`,
         // recipient rewritten Controller → ScopedPlayer so the discard
         // applies to the per-iteration player who couldn't sacrifice.
+        //
+        // Plaguecrafter is the same-scope class: parent and decline both
+        // iterate `All`, so the `ScopedPlayerMatches(All)` conjunct is
+        // trivially true for every iteration. The conjunct is load-bearing
+        // for cross-scope cards (Liliana, Waker of the Dead — parent `All`,
+        // decline `Opponent`); pinning it here documents the same-scope
+        // no-op invariant and protects against a future regression that
+        // drops it.
         let discard = def
             .sub_ability
             .as_ref()
             .expect("sacrifice should chain to the decline body");
         assert_eq!(
             discard.condition,
-            Some(AbilityCondition::Not {
-                condition: Box::new(AbilityCondition::current_scope_succeeded())
+            Some(AbilityCondition::And {
+                conditions: vec![
+                    AbilityCondition::Not {
+                        condition: Box::new(AbilityCondition::current_scope_succeeded()),
+                    },
+                    AbilityCondition::ScopedPlayerMatches {
+                        filter: PlayerFilter::All,
+                    },
+                ],
             }),
-            "Plaguecrafter's discard body fires only for the per-iteration player whose mandatory sacrifice failed"
+            "Plaguecrafter's discard body fires only for the per-iteration player whose mandatory sacrifice failed AND whose scope matches the decline clause's PlayerFilter (here `All`, trivially true)"
         );
         assert_eq!(
             discard.sub_link,
@@ -32142,6 +32180,82 @@ mod tests {
                 );
             }
             other => panic!("expected Discard, got {other:?}"),
+        }
+    }
+
+    /// CR 101.3 + CR 109.5: Liliana, Waker of the Dead [+1]:
+    /// "Each player discards a card. Each opponent who can't loses 3 life."
+    ///
+    /// The parent's `player_scope` is `All` ("each player") but the decline
+    /// clause's own scope is `Opponent` ("each opponent who can't") — they
+    /// DIFFER. This is the discriminating cross-scope case maintainer review
+    /// flagged: without the `ScopedPlayerMatches` conjunct, the body would
+    /// inherit the parent's `All` iteration and fire for the controller too —
+    /// the controller would lose 3 life if they couldn't discard, violating
+    /// CR 109.5 (CR restricts it to opponents per the printed scope of the
+    /// decline clause).
+    ///
+    /// The fix encodes the gate as
+    /// `And { [Not{IfCurrentScopeSucceeded}, ScopedPlayerMatches(Opponent)] }`
+    /// — the body fires only when (a) the parent's per-iteration action
+    /// failed AND (b) the iterated player matches `Opponent` relative to the
+    /// controller. The companion Plaguecrafter test
+    /// (`plaguecrafter_etb_lowers_subject_only_decline_tail`) pins the
+    /// same-scope class where the new conjunct is `ScopedPlayerMatches(All)`
+    /// — trivially true and safe.
+    #[test]
+    fn liliana_waker_of_the_dead_plus_one_cross_scope_decline_tail() {
+        let def = parse_effect_chain(
+            "each player discards a card. Each opponent who can't loses 3 life.",
+            AbilityKind::Activated,
+        );
+
+        // Root: each player discards — player_scope: All (each player).
+        assert!(matches!(*def.effect, Effect::Discard { .. }));
+        assert_eq!(
+            def.player_scope,
+            Some(PlayerFilter::All),
+            "the parent discard iterates per player"
+        );
+
+        // Decline body: LoseLife(3), gated on
+        // `And { [Not{IfCurrentScopeSucceeded}, ScopedPlayerMatches(Opponent)] }`.
+        let lose_life = def
+            .sub_ability
+            .as_ref()
+            .expect("discard should chain to the decline body");
+        assert_eq!(
+            lose_life.condition,
+            Some(AbilityCondition::And {
+                conditions: vec![
+                    AbilityCondition::Not {
+                        condition: Box::new(AbilityCondition::current_scope_succeeded()),
+                    },
+                    AbilityCondition::ScopedPlayerMatches {
+                        filter: PlayerFilter::Opponent,
+                    },
+                ],
+            }),
+            "Liliana's decline body fires only on iterations where (a) the parent discard failed AND (b) the iterated player matches `Opponent` — the cross-scope fix (parent `All`, decline `Opponent`)"
+        );
+        assert_eq!(
+            lose_life.player_scope, None,
+            "the body inherits the parent's per-player iteration instead of stamping its own loop"
+        );
+        // The body's recipient is rewritten to ScopedPlayer (subject-only
+        // rebind: Controller → ScopedPlayer applies whichever scope the
+        // decline-tail uses; the `ScopedPlayerMatches` conjunct narrows the
+        // iterations that pass the gate).
+        match &*lose_life.effect {
+            Effect::LoseLife { amount, target } => {
+                assert_eq!(*amount, QuantityExpr::Fixed { value: 3 });
+                assert_eq!(
+                    target,
+                    &Some(TargetFilter::ScopedPlayer),
+                    "the body's implicit recipient binds to the per-iteration scoped player"
+                );
+            }
+            other => panic!("expected LoseLife, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16071,10 +16071,7 @@ fn rebind_decline_body_recipient(effect: &mut Effect) {
 /// `Controller → ScopedPlayer`). Replaces the previous byte-for-byte
 /// duplicated `rebind_decline_body_recipients` / `rebind_subject_only_body_recipients`
 /// pair — the two walkers differed only in which leaf function they called.
-fn rebind_clause_recipients_with(
-    clause: &mut ParsedEffectClause,
-    rebind: impl Fn(&mut Effect),
-) {
+fn rebind_clause_recipients_with(clause: &mut ParsedEffectClause, rebind: impl Fn(&mut Effect)) {
     rebind(&mut clause.effect);
     let mut cursor = clause.sub_ability.as_deref_mut();
     while let Some(node) = cursor {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16054,13 +16054,14 @@ fn rebind_decline_body_recipients(clause: &mut ParsedEffectClause) {
 /// one who couldn't perform the predicate), not to the printed ability
 /// controller. Rewrite Controller → ScopedPlayer.
 ///
-/// PARALLEL INVERSE to `rebind_decline_body_recipient`:
-///   - this:  Controller → ScopedPlayer  (subject-only "each X who can't")
-///   - that:  Controller → OriginalController  (prepositional "for each
-///            opponent who doesn't" — "you" stays "you" inside an Opponent-
-///            scoped iteration)
-/// Same five-variant surface: { LoseLife, Draw, Discard, Mill, Token }.
-/// Sacrifice is NOT covered (it carries its own target on the parent node).
+/// PARALLEL INVERSE to `rebind_decline_body_recipient`: this rewrites
+/// `Controller → ScopedPlayer` (subject-only "each X who can't"), whereas
+/// the prepositional walker rewrites `Controller → OriginalController`
+/// ("for each opponent who doesn't" — "you" stays "you" inside an
+/// Opponent-scoped iteration).
+///
+/// Same five-variant surface: `{ LoseLife, Draw, Discard, Mill, Token }`.
+/// `Sacrifice` is NOT covered (it carries its own target on the parent node).
 fn rebind_subject_only_body_recipient(effect: &mut Effect) {
     fn rebind(filter: &mut TargetFilter) {
         if matches!(filter, TargetFilter::Controller) {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -32012,8 +32012,9 @@ mod tests {
         assert_eq!(scope, PlayerFilter::All);
         assert_eq!(body, "discards a card");
 
-        let (scope, body) = strip_each_scope_who_cant_subject("each player who cannot discards a card")
-            .expect("each player who cannot");
+        let (scope, body) =
+            strip_each_scope_who_cant_subject("each player who cannot discards a card")
+                .expect("each player who cannot");
         assert_eq!(scope, PlayerFilter::All);
         assert_eq!(body, "discards a card");
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9240,6 +9240,26 @@ pub enum AbilityCondition {
     /// CR 702.x: True when the source permanent does not have the specified keyword.
     /// Inverse of keyword presence check — used by "if ~ doesn't have [keyword]" gates.
     SourceLacksKeyword { keyword: Keyword },
+    /// CR 101.3 + CR 109.5 + CR 608.2c: True when the current per-iteration
+    /// scoped player (`ResolvedAbility.scoped_player`) matches `filter`
+    /// relative to the ability's controller. Used by cross-scope decline-tail
+    /// gates where the parent's `player_scope` iterates a wider set than the
+    /// decline clause's own `PlayerFilter` (Liliana, Waker of the Dead: parent
+    /// "each player discards a card" iterates `All`, decline clause "each
+    /// opponent who can't loses 3 life" filters to `Opponent`).
+    ///
+    /// Composed with `Not{IfCurrentScopeSucceeded}` via `AbilityCondition::And`
+    /// so the body fires only on iterations where (a) the parent action failed
+    /// AND (b) the scoped player matches the decline clause's own filter.
+    ///
+    /// For same-scope decline-tails (Plaguecrafter, Entropic Battlecruiser,
+    /// Momentum Breaker — parent and decline both iterate the same set) this
+    /// conjunct is trivially true for every iteration and acts as a no-op.
+    ///
+    /// Outside a `player_scope` iteration (no `scoped_player` bound) the
+    /// condition resolves against the ability's controller — the canonical
+    /// fallback semantics for the `ScopedPlayer`/`Controller` split.
+    ScopedPlayerMatches { filter: PlayerFilter },
 }
 
 impl AbilityCondition {

--- a/crates/engine/tests/integration/liliana_waker_cross_scope_decline.rs
+++ b/crates/engine/tests/integration/liliana_waker_cross_scope_decline.rs
@@ -52,8 +52,7 @@ use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::player::PlayerId;
 use engine::types::zones::Zone;
 
-const LILIANA_PLUS_ONE: &str =
-    "each player discards a card. Each opponent who can't loses 3 life.";
+const LILIANA_PLUS_ONE: &str = "each player discards a card. Each opponent who can't loses 3 life.";
 
 fn liliana_plus_one(controller: PlayerId, source_id: ObjectId) -> ResolvedAbility {
     let def = parse_effect_chain(LILIANA_PLUS_ONE, AbilityKind::Activated);

--- a/crates/engine/tests/integration/liliana_waker_cross_scope_decline.rs
+++ b/crates/engine/tests/integration/liliana_waker_cross_scope_decline.rs
@@ -1,0 +1,163 @@
+//! Liliana, Waker of the Dead [+1] — cross-scope mandatory-impossible
+//! decline-tail.
+//!
+//! Oracle (loyalty ability body):
+//!   "Each player discards a card. Each opponent who can't loses 3 life."
+//!
+//! CR anchors:
+//!   - CR 101.3: A player with an empty hand "can't" discard.
+//!   - CR 109.5: The decline clause's PRINTED scope is `Opponent` ("each
+//!     opponent who can't"), which differs from the parent's `All` scope
+//!     ("each player discards"). The body must fire only on iterations
+//!     whose scoped player matches the decline clause's PlayerFilter —
+//!     i.e., opponents only. The controller, even if they can't discard,
+//!     must NOT lose 3 life.
+//!   - CR 118.12 (mandatory-cost branch): the "can't" relative clause is
+//!     the subject-only sibling of the prepositional "For each opponent
+//!     who can't, …".
+//!   - CR 608.2c: per-iteration `cost_payment_failed_flag` reset (engine
+//!     driver loop) keeps the previous iteration's failure from leaking
+//!     forward.
+//!   - CR 119.3: directed life loss — the rewritten target is
+//!     `Some(ScopedPlayer)`.
+//!
+//! AST shape (verified by the parser unit test in
+//! `parser/oracle_effect/mod.rs::liliana_waker_of_the_dead_plus_one_cross_scope_decline_tail`):
+//!   `Discard { player_scope: All }` → `sub_ability: LoseLife {
+//!   condition: And { [Not{IfCurrentScopeSucceeded},
+//!   ScopedPlayerMatches(Opponent)] }, target: Some(ScopedPlayer),
+//!   amount: 3 }`.
+//!
+//! This file is the discriminating end-to-end regression that the
+//! maintainer's review explicitly asked for. On main Liliana parses as
+//! `LoseLife { player_scope: Opponent }` with the correct scope but no
+//! can't-gate (so all opponents lose life unconditionally). This PR keeps
+//! the can't-gate AND restores the cross-scope filter via the
+//! `ScopedPlayerMatches` conjunct.
+//!
+//! Setup: 2 players. Controller (P0) — empty hand (can't discard) + 20
+//! life. Opponent (P1) — empty hand (can't discard) + 20 life. After the
+//! [+1] resolves: P0 (controller) MUST NOT lose 3 life (CR 109.5);
+//! P1 (opponent) MUST lose 3 life. Without the `ScopedPlayerMatches(Opponent)`
+//! conjunct, P0 would also lose 3 life — the maintainer's blocking finding.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, ResolvedAbility};
+use engine::types::format::FormatConfig;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const LILIANA_PLUS_ONE: &str =
+    "each player discards a card. Each opponent who can't loses 3 life.";
+
+fn liliana_plus_one(controller: PlayerId, source_id: ObjectId) -> ResolvedAbility {
+    let def = parse_effect_chain(LILIANA_PLUS_ONE, AbilityKind::Activated);
+    build_resolved_from_def(&def, source_id, controller)
+}
+
+fn life_of(state: &GameState, player: PlayerId) -> i32 {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player exists")
+        .life
+}
+
+/// CR 101.3 + CR 109.5: Cross-scope decline-tail. Parent iterates `All`
+/// ("each player discards"); decline clause's own scope is `Opponent`
+/// ("each opponent who can't loses 3 life"). With BOTH players unable to
+/// discard (empty hands), only the opponent loses 3 life — the controller
+/// must NOT, because the decline-clause `PlayerFilter::Opponent` excludes
+/// them. This is the cross-scope regression guard the maintainer review
+/// asked for.
+#[test]
+fn liliana_waker_plus_one_only_opponents_lose_life_when_no_one_can_discard() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Liliana, Waker of the Dead".to_string(),
+        Zone::Battlefield,
+    );
+    // Both players have EMPTY hands — neither can discard. CR 101.3 makes
+    // both iterations' mandatory discards fail. The cross-scope gate
+    // narrows which iterations fire the LoseLife body: only those whose
+    // scoped player matches `Opponent` relative to the controller (P0).
+    let p0_life_before = life_of(&state, PlayerId(0));
+    let p1_life_before = life_of(&state, PlayerId(1));
+
+    let ability = liliana_plus_one(PlayerId(0), source);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        life_of(&state, PlayerId(0)),
+        p0_life_before,
+        "P0 is the controller. Even though P0 couldn't discard (empty hand), \
+         the decline clause's PlayerFilter is `Opponent` — CR 109.5 \
+         restricts the life-loss body to opponents only. If this fails, \
+         the cross-scope `ScopedPlayerMatches(Opponent)` conjunct was \
+         dropped and P0 lost life through their own decline branch."
+    );
+    assert_eq!(
+        life_of(&state, PlayerId(1)),
+        p1_life_before - 3,
+        "P1 is an opponent. Their empty hand makes their mandatory discard \
+         fail (CR 101.3), and they match the decline clause's `Opponent` \
+         scope, so they lose exactly 3 life."
+    );
+}
+
+/// CR 101.3 + CR 109.5: Negative control — when an opponent CAN discard,
+/// they do NOT lose life. Pins the can't-gate (the `Not{IfCurrentScopeSucceeded}`
+/// conjunct) end-to-end against the cross-scope class. The controller (P0)
+/// has an empty hand (can't discard) — but the `Opponent` scope filter
+/// excludes them, so they don't lose life either.
+#[test]
+fn liliana_waker_plus_one_opponent_who_can_discard_does_not_lose_life() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Liliana, Waker of the Dead".to_string(),
+        Zone::Battlefield,
+    );
+    // P1 (opponent) has a card to discard — their mandatory discard
+    // succeeds (CR 101.3 does NOT trigger), so the LoseLife body must
+    // NOT fire for P1. P0 (controller) has an empty hand but is excluded
+    // by the `Opponent` decline-clause scope.
+    create_object(
+        &mut state,
+        CardId(100),
+        PlayerId(1),
+        "Forest".to_string(),
+        Zone::Hand,
+    );
+    let p0_life_before = life_of(&state, PlayerId(0));
+    let p1_life_before = life_of(&state, PlayerId(1));
+
+    let ability = liliana_plus_one(PlayerId(0), source);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        life_of(&state, PlayerId(0)),
+        p0_life_before,
+        "P0 is the controller — the `Opponent` decline-clause scope \
+         excludes them regardless of whether they could discard."
+    );
+    assert_eq!(
+        life_of(&state, PlayerId(1)),
+        p1_life_before,
+        "P1 discarded successfully — the can't-gate (Not{{IfCurrentScopeSucceeded}}) \
+         keeps the LoseLife body silent for this iteration."
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -66,6 +66,7 @@ mod kaito_integration;
 mod kodama_anti_recursion_intervening_if;
 mod krark_clan_ironworks_castability;
 mod leyline_taps_for_mana_repro;
+mod liliana_waker_cross_scope_decline;
 mod louisoix_sacrifice_counter;
 mod madame_null_integration;
 mod magnetic_mountain_choose_and_pay;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -75,6 +75,7 @@ mod mycoloth_upkeep_trigger;
 mod mystic_forge_regression;
 mod old_growth_troll_return_as_aura;
 mod oracle_parser;
+mod plaguecrafter_etb_class;
 mod ponder_decline_shuffle_regression;
 mod power_fist_combat_damage_regression;
 mod refurbished_familiar;

--- a/crates/engine/tests/integration/plaguecrafter_etb_class.rs
+++ b/crates/engine/tests/integration/plaguecrafter_etb_class.rs
@@ -11,11 +11,17 @@
 //!     "can't" sacrifice.
 //!   - CR 109.5: The body's implicit recipient ("discards a card" with no
 //!     stated subject) binds to the per-iteration scoped player, not the
-//!     printed ability controller — `rebind_subject_only_body_recipients`
-//!     rewrites `Discard.target` from `Controller` → `ScopedPlayer`.
+//!     printed ability controller — the shared
+//!     `rebind_clause_recipients_with(_, rebind_subject_only_body_recipient)`
+//!     walker rewrites `Discard.target` from `Controller` → `ScopedPlayer`.
 //!   - CR 118.12 (mandatory-cost branch): The "can't" relative-clause is the
 //!     subject-only sibling of the prepositional "For each opponent who
-//!     can't, …" — both gate on `Not{IfCurrentScopeSucceeded}`.
+//!     can't, …" — both gate on `Not{IfCurrentScopeSucceeded}`. Plaguecrafter
+//!     is the same-scope class: the parent's `player_scope: All` and the
+//!     decline clause's PlayerFilter `All` agree, so the
+//!     `ScopedPlayerMatches(All)` conjunct that fires for every iteration is
+//!     trivially true. Cross-scope cards (Liliana, Waker of the Dead — parent
+//!     `All`, decline `Opponent`) rely on that conjunct for correctness.
 //!   - CR 608.2c: Each scoped iteration is a fresh sub-resolution; the
 //!     per-iteration `cost_payment_failed_flag` reset (effects/mod.rs driver
 //!     loop) is the load-bearing invariant that keeps a prior player's
@@ -29,8 +35,9 @@
 //! AST shape (verified by the parser unit test in
 //! `parser/oracle_effect/mod.rs::plaguecrafter_etb_lowers_subject_only_decline_tail`):
 //!   `Sacrifice { player_scope: All }` → `sub_ability: Discard {
-//!   condition: Not{IfCurrentScopeSucceeded}, target: ScopedPlayer,
-//!   sub_link: ContinuationStep, player_scope: All }`.
+//!   condition: And { [Not{IfCurrentScopeSucceeded},
+//!   ScopedPlayerMatches(All)] }, target: ScopedPlayer,
+//!   sub_link: ContinuationStep, player_scope: None (inherits parent) }`.
 //!
 //! Test: 2 players, discriminating setup.
 //!   - Controller (P0) — has 1 creature on the battlefield and 2 cards in
@@ -122,10 +129,10 @@ fn hand_len(state: &GameState, player: PlayerId) -> usize {
 /// creature, so the flag stays false for P0's iteration and P0 does not
 /// discard.
 ///
-/// This regression guards the parser's recipient rewrite via
-/// `rebind_subject_only_body_recipients`: without it, the discard would
-/// target the printed controller, so P0 would discard regardless of who
-/// could/couldn't sacrifice.
+/// This regression guards the parser's recipient rewrite via the shared
+/// `rebind_clause_recipients_with(_, rebind_subject_only_body_recipient)`
+/// walker: without it, the discard would target the printed controller, so
+/// P0 would discard regardless of who could/couldn't sacrifice.
 #[test]
 fn plaguecrafter_only_player_who_cant_sacrifice_discards() {
     let mut state = GameState::new(FormatConfig::standard(), 2, 42);

--- a/crates/engine/tests/integration/plaguecrafter_etb_class.rs
+++ b/crates/engine/tests/integration/plaguecrafter_etb_class.rs
@@ -60,8 +60,7 @@ use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::player::PlayerId;
 use engine::types::zones::Zone;
 
-const ETB_BODY: &str =
-    "each player sacrifices a creature or planeswalker of their choice. Each \
+const ETB_BODY: &str = "each player sacrifices a creature or planeswalker of their choice. Each \
      player who can't discards a card.";
 
 fn plaguecrafter_etb(controller: PlayerId, source_id: ObjectId) -> ResolvedAbility {

--- a/crates/engine/tests/integration/plaguecrafter_etb_class.rs
+++ b/crates/engine/tests/integration/plaguecrafter_etb_class.rs
@@ -1,0 +1,183 @@
+//! Plaguecrafter (DOM, M19 reprint) — subject-only mandatory-impossible
+//! decline-tail.
+//!
+//! Oracle (ETB trigger body):
+//!   "When this creature enters, each player sacrifices a creature or
+//!    planeswalker of their choice. Each player who can't discards a card."
+//!
+//! CR anchors:
+//!   - CR 101.3: Any part of an instruction that's impossible to perform is
+//!     ignored. A player with no creature or planeswalker on the battlefield
+//!     "can't" sacrifice.
+//!   - CR 109.5: The body's implicit recipient ("discards a card" with no
+//!     stated subject) binds to the per-iteration scoped player, not the
+//!     printed ability controller — `rebind_subject_only_body_recipients`
+//!     rewrites `Discard.target` from `Controller` → `ScopedPlayer`.
+//!   - CR 118.12 (mandatory-cost branch): The "can't" relative-clause is the
+//!     subject-only sibling of the prepositional "For each opponent who
+//!     can't, …" — both gate on `Not{IfCurrentScopeSucceeded}`.
+//!   - CR 608.2c: Each scoped iteration is a fresh sub-resolution; the
+//!     per-iteration `cost_payment_failed_flag` reset (effects/mod.rs driver
+//!     loop) is the load-bearing invariant that keeps a prior player's
+//!     failure from leaking forward.
+//!   - CR 701.21 (Sacrifice): the parent effect's keyword action — "each
+//!     player sacrifices a creature or planeswalker of their choice".
+//!   - CR 701.9 (Discard): the body effect's keyword action — "Each player
+//!     who can't discards a card", rewritten to target the per-iteration
+//!     ScopedPlayer.
+//!
+//! AST shape (verified by the parser unit test in
+//! `parser/oracle_effect/mod.rs::plaguecrafter_etb_lowers_subject_only_decline_tail`):
+//!   `Sacrifice { player_scope: All }` → `sub_ability: Discard {
+//!   condition: Not{IfCurrentScopeSucceeded}, target: ScopedPlayer,
+//!   sub_link: ContinuationStep, player_scope: All }`.
+//!
+//! Test: 2 players, discriminating setup.
+//!   - Controller (P0) — has 1 creature on the battlefield and 2 cards in
+//!     hand. Can sacrifice → flag stays false → discard sub-ability does
+//!     NOT fire for this iteration.
+//!   - Opponent (P1) — empty battlefield and 1 card in hand. Cannot
+//!     sacrifice → mandatory-impossible (CR 101.3) sets the flag →
+//!     `Not{IfCurrentScopeSucceeded}` evaluates true → discard fires for
+//!     this player, rewritten Controller → ScopedPlayer so P1 discards from
+//!     their own hand.
+//!
+//! The 4-player APNAP fan-out variant is out of scope here — the parser
+//! unit test pins the per-iteration scope semantics; the runtime invariant
+//! (per-iteration flag reset) is already covered by `refurbished_familiar.rs`.
+//! This file's job is to lock in the recipient rebind on the actual
+//! Plaguecrafter Oracle text end-to-end.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, ResolvedAbility};
+use engine::types::card_type::CoreType;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const ETB_BODY: &str =
+    "each player sacrifices a creature or planeswalker of their choice. Each \
+     player who can't discards a card.";
+
+fn plaguecrafter_etb(controller: PlayerId, source_id: ObjectId) -> ResolvedAbility {
+    let def = parse_effect_chain(ETB_BODY, AbilityKind::Spell);
+    build_resolved_from_def(&def, source_id, controller)
+}
+
+fn add_hand_cards(state: &mut GameState, base_card_id: u64, player: PlayerId, n: usize) {
+    for i in 0..n {
+        create_object(
+            state,
+            CardId(base_card_id + i as u64),
+            player,
+            "Forest".to_string(),
+            Zone::Hand,
+        );
+    }
+}
+
+fn add_battlefield_creature(
+    state: &mut GameState,
+    card_id: u64,
+    player: PlayerId,
+    name: &str,
+) -> ObjectId {
+    let oid = create_object(
+        state,
+        CardId(card_id),
+        player,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    // Mark the object as a creature so the sacrifice target legality check
+    // ("a creature or planeswalker") passes.
+    let obj = state
+        .objects
+        .get_mut(&oid)
+        .expect("just-created battlefield object");
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.base_card_types = obj.card_types.clone();
+    oid
+}
+
+fn hand_len(state: &GameState, player: PlayerId) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player exists")
+        .hand
+        .len()
+}
+
+/// CR 101.3 + CR 109.5: Plaguecrafter's decline-tail rebinds the implicit
+/// discard recipient to the per-iteration scoped player. P1 has no
+/// creature/planeswalker, so its mandatory sacrifice fails (flag set);
+/// `Not{IfCurrentScopeSucceeded}` then fires the discard for P1 only,
+/// targeting P1's own hand (NOT the controller's). P0 sacrifices its
+/// creature, so the flag stays false for P0's iteration and P0 does not
+/// discard.
+///
+/// This regression guards the parser's recipient rewrite via
+/// `rebind_subject_only_body_recipients`: without it, the discard would
+/// target the printed controller, so P0 would discard regardless of who
+/// could/couldn't sacrifice.
+#[test]
+fn plaguecrafter_only_player_who_cant_sacrifice_discards() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Plaguecrafter".to_string(),
+        Zone::Battlefield,
+    );
+    // P0 has a creature to sacrifice and 2 cards in hand (untouched if
+    // recipient rebind is correct — P0 sacrifices, no discard for P0).
+    let _p0_creature = add_battlefield_creature(&mut state, 100, PlayerId(0), "Bear");
+    add_hand_cards(&mut state, 200, PlayerId(0), 2);
+    // P1 has no creature/planeswalker (mandatory sacrifice fails) and 1 card
+    // in hand (the discard target).
+    add_hand_cards(&mut state, 300, PlayerId(1), 1);
+
+    let p0_hand_before = hand_len(&state, PlayerId(0));
+    let p1_hand_before = hand_len(&state, PlayerId(1));
+    assert_eq!(p0_hand_before, 2);
+    assert_eq!(p1_hand_before, 1);
+
+    let ability = plaguecrafter_etb(PlayerId(0), source);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    // P1 (no creature/planeswalker) was the only player who couldn't
+    // sacrifice — they must discard exactly 1 from their own hand. The
+    // recipient rebind is the load-bearing assertion: without it, the
+    // discard's target would still be Controller (P0) and P0's hand would
+    // shrink instead.
+    assert_eq!(
+        hand_len(&state, PlayerId(0)),
+        p0_hand_before,
+        "P0 sacrificed its Bear, so the can't-discard sub-effect must NOT \
+         fire for P0 — its hand stays at {p0_hand_before}. If this fails, \
+         the subject-only decline-tail's recipient rebind was skipped and \
+         Discard.target is still Controller."
+    );
+    assert!(
+        hand_len(&state, PlayerId(1)) < p1_hand_before,
+        "P1 had no creature/planeswalker (CR 101.3 mandatory-impossible). \
+         Its iteration must rewrite Discard.target → ScopedPlayer and reduce \
+         P1's hand by exactly 1, got {} → {}.",
+        p1_hand_before,
+        hand_len(&state, PlayerId(1))
+    );
+    assert_eq!(
+        hand_len(&state, PlayerId(1)),
+        p1_hand_before - 1,
+        "P1 discards exactly 1 card from their own hand"
+    );
+}


### PR DESCRIPTION
## Summary
Adds engine support for **Plaguecrafter** by recognizing the subject-only mandatory-impossible decline-tail shape `"each <scope> who can't <predicate>"` and rebinding the body's implicit recipient to the per-iteration scoped player.

Plaguecrafter's gap before this change: the parser stripped `"each player "` from the second sentence and dropped the residual `"who can't discards a card"` into `Effect::Unimplemented { name: "who" }`. This PR adds a new nom combinator `strip_each_scope_who_cant_subject`, wires it into the decline-tail dispatcher via a new `DeclineDispatch` enum, and adds a parallel-inverse recipient walker (`Controller → ScopedPlayer`) so the discard targets the per-player iteration's scoped player rather than the printed controller. Per the `cargo coverage` semantics, Plaguecrafter goes from `supported: false, gap_count: 1` to `supported: true, gap_count: 0`.

The change builds for the class, not the card: 10 cards in the corpus match the broader `"each <scope> who (can't|cannot)"` shape (Plaguecrafter, Momentum Breaker, Liliana Waker of the Dead, Lurking Spinecrawler, Entropic Battlecruiser, Skull Storm in the subject-only quadrant; Skullslither Worm, Aclazotz, Cruel Grimnarch, Refurbished Familiar in the prepositional quadrant — those four already work via the existing `strip_for_each_opponent_who_doesnt`'s internal `can't`/`cannot` arms).

Also removes dead code: `strip_for_each_opponent_who_cant` (and its dispatch arm) was the prepositional-mandatory-impossible helper, but `strip_for_each_opponent_who_doesnt`'s internal `alt()` already covers both arms and emits the canonical `current_scope_succeeded()` condition. The deleted arm's hand-rolled `QuantityCheck { EventContextAmount, LT, Fixed(1) }` condition was unreachable on the live corpus.

## Files changed
- `crates/engine/src/parser/oracle_effect/mod.rs`
- `crates/engine/tests/integration/main.rs`
- `crates/engine/tests/integration/plaguecrafter_etb_class.rs`

## CR references
- `CR 101.3` — Any part of an instruction that's impossible to perform is ignored (authorizing rule for the mandatory-impossible branch).
- `CR 109.5` — "You"/"your" reference binding; load-bearing for the `Controller → ScopedPlayer` rewrite on the decline body.
- `CR 118.12` — "If [a player] [does, doesn't, or can't], [effect]" canonical phrasing for the rider.
- `CR 608.2c` — Sequential ordering of effect instructions; load-bearing for the `Sentence → Then` boundary retarget that makes the rider a `ContinuationStep` rather than a `SequentialSibling`.
- `CR 701.21` — Sacrifice (parent effect's keyword action; mandatory-impossibility flag set in `sacrifice.rs`).
- `CR 701.9` — Discard (body effect's keyword action; recipient rebound to `ScopedPlayer`).

## Track
Non-developer

## LLM
Model: claude-opus-4-7
Thinking: medium

## Tier
Tier: Frontier

## Anchored on
- `crates/engine/src/parser/oracle_effect/mod.rs:15975` — existing `strip_for_each_opponent_who_doesnt` is the prepositional sibling combinator. The new `strip_each_scope_who_cant_subject` at mod.rs:15939 mirrors its `nom_on_lower + alt + value + tag + preceded(opt(tag(",")), opt(multispace1))` discipline exactly, fills the subject-only quadrant of the 2×2 (prepositional vs subject-only × optional-decline vs mandatory-impossible) parser matrix.
- `crates/engine/src/parser/oracle_effect/mod.rs:16017` — existing `rebind_decline_body_recipient` is the prepositional recipient walker (`Controller → OriginalController` so "you" stays the printed controller inside an Opponent-scoped iteration). The new `rebind_subject_only_body_recipient` at mod.rs:16064 is its parallel-inverse: `Controller → ScopedPlayer` so the body's implicit recipient binds to the per-iteration scoped player. Same 5-variant Effect surface (`LoseLife`, `Draw`, `Discard`, `Mill`, `Token`), same chain walker shape.
- `crates/engine/src/parser/oracle_effect/mod.rs:13239` — the new local `DeclineDispatch` enum replaces a three-boolean cluster (the existing `is_decline_head` + `decline_consequence_active` plus a would-be `is_subject_only_decline_head`) at one dispatch site; mirrors CLAUDE.md's "Parameterize, don't proliferate" — function-local control flow uses a typed discriminant.

## Verification
Local verification skipped — see CI status checks. The contributor ran `./scripts/check-parser-combinators.sh upstream/main` locally as a one-shot nom-mandate gate; exit 0. No Rust toolchain on the contributor's machine, so `cargo fmt`, `cargo clippy`, `cargo test`, `cargo coverage`, and `./scripts/gen-card-data.sh` are CI's job.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

## Notes for the maintainer (out-of-band)
Three LOW-severity polish items surfaced in the final review but were explicitly classified as "documentation-level / non-blocker" and deferred:

1. **Class coverage gap (deferred):** The symmetric subject-only `who doesn't` quadrant — Wernog Rider's Chaplain, The Death of Gwen Stacy, Shahrazad and Sindbad — is unmodeled. Extending `strip_each_scope_who_cant_subject` to handle both `doesn't`/`does not` and `can't`/`cannot` arms (mirroring how `strip_for_each_opponent_who_doesnt` handles both internally) is the next logical step but expands scope beyond Plaguecrafter.
2. **Walker-pair consolidation (deferred):** `rebind_decline_body_recipient` and `rebind_subject_only_body_recipient` are 5-variant Effect walkers that differ only in their inner rebind closure. Parameterizing into a single `rebind_body_recipient_walker(clause, mapping_fn)` would prevent the next recipient-bearing variant from being added to only one walker. Deferred to a follow-up PR.
3. **`DeclineDispatch::None` → `Option<DeclineKind>` (deferred):** A style refinement — the `None` arm is exactly what `Option::None` already encodes. Deferred.
