### PR TITLE
fix(client): let convoke/improvise/waterbend tap creatures during mana payment

### DIFF
--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -54,7 +54,18 @@ function isDialogVisibleFor(waitingFor: WaitingFor | null | undefined): boolean 
 
 function isClickThroughDialog(waitingFor: WaitingFor | null | undefined): boolean {
   if (!waitingFor) return false;
-  return CLICK_THROUGH_WAITING_FOR_TYPES.has(waitingFor.type);
+  if (CLICK_THROUGH_WAITING_FOR_TYPES.has(waitingFor.type)) return true;
+  // CR 702.51a (Convoke) / CR 701.67a (Waterbend) / CR 702.126a (Improvise):
+  // these tap-payment modes let the caster tap creatures/artifacts on the
+  // battlefield to pay generic/colored mana while the `ManaPaymentUI` panel
+  // (a self-anchored `fixed inset-x-0 bottom-0` strip) is open. The host must
+  // stay click-through for them so those board taps reach the cards —
+  // otherwise the `fixed inset-0 z-40` wrapper swallows the clicks and the
+  // player cannot tap creatures to pay (the creatures still get the mana-tap
+  // ring, but clicking them does nothing). Plain/hybrid/Phyrexian payment needs
+  // no board interaction (the panel's Pay button passes priority), so it stays
+  // wrapped — `convoke_mode` is the engine's signal that board taps are live.
+  return waitingFor.type === "ManaPayment" && waitingFor.data.convoke_mode != null;
 }
 
 export function DialogHost({ children }: { children: ReactNode }) {

--- a/client/src/components/modal/__tests__/DialogHost.test.tsx
+++ b/client/src/components/modal/__tests__/DialogHost.test.tsx
@@ -87,6 +87,41 @@ describe("DialogHost", () => {
     expect(wrapper?.className ?? "").not.toMatch(/fixed/);
   });
 
+  it("stays click-through (no viewport-blocking wrapper) during convoke mana payment (regression)", () => {
+    // CR 702.51a: a convoke spell enters `ManaPayment` with `convoke_mode` set,
+    // and the caster taps creatures on the battlefield to pay. If the host
+    // wrapped children in `fixed inset-0 z-40`, that overlay would swallow the
+    // board clicks and the player could not tap convoke creatures — the
+    // reported bug was "creatures are highlighted but clicking does nothing".
+    setWaitingFor({
+      type: "ManaPayment",
+      data: { player: 0, convoke_mode: "Convoke" },
+    } as never);
+    const { container } = render(
+      <DialogHost>
+        <div data-testid="child" />
+      </DialogHost>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    expect(wrapper?.className ?? "").not.toMatch(/fixed/);
+  });
+
+  it("keeps the viewport wrapper for plain mana payment without convoke", () => {
+    // Plain payment is committed via the panel's Pay button (no board taps), so
+    // the host wraps normally — only `convoke_mode` payments go click-through.
+    setWaitingFor({
+      type: "ManaPayment",
+      data: { player: 0 },
+    } as never);
+    const { container } = render(
+      <DialogHost>
+        <div data-testid="child" />
+      </DialogHost>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    expect(wrapper?.className ?? "").toMatch(/fixed/);
+  });
+
   it("resets peek to false when WaitingFor changes (regression)", () => {
     setWaitingFor({ type: "ModeChoice", data: { player: 0 } } as never);
     render(


### PR DESCRIPTION
Convoke routes through WaitingFor::ManaPayment with convoke_mode set, and ManaPaymentUI renders inside DialogHost. DialogHost wraps non-click-through dialogs in a full-viewport `fixed inset-0 z-40` overlay that swallowed board clicks, so convoke creatures got the mana-tap ring but clicking them did nothing.

Gate isClickThroughDialog on ManaPayment.convoke_mode so all three tap-payment modes (Convoke CR 702.51a, Waterbend CR 701.67a, Improvise CR 702.126a) stay click-through and board taps reach the cards. Plain/hybrid/Phyrexian payment stays wrapped (no board interaction needed).
