### PR TITLE
fix(parser): route SetLifeTotal RHS through the general quantity parser

### DIFF
--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -23,6 +23,7 @@ use super::super::oracle_nom::error::OracleResult;
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_nom::target::parse_event_context_ref;
+use super::super::oracle_quantity;
 use super::super::oracle_static::{
     classify_block_exception, parse_additive_type_clause_modifications,
     parse_chosen_qualifier_subject, parse_continuous_modifications, parse_static_line_multi,
@@ -1944,7 +1945,8 @@ fn parse_attack_if_able_duration(input: &str) -> OracleResult<'_, Duration> {
 
 /// CR 119.5: Parse "life total becomes N" into SetLifeTotal effect.
 /// Handles: "half that player's starting life total", numeric amounts,
-/// "their starting life total", and other quantity expressions.
+/// "their starting life total", and any other quantity the general quantity
+/// parser recognizes (e.g. "the highest/lowest life total among all players").
 fn try_parse_set_life_total(
     become_text: &str,
     application: &SubjectApplication,
@@ -1969,7 +1971,14 @@ fn try_parse_set_life_total(
         }
         QuantityExpr::Fixed { value: n as i32 }
     } else {
-        return None;
+        // CR 119.5: the new life total may be a dynamic quantity rather than a
+        // fixed number — e.g. "the highest/lowest life total among all players"
+        // (Repay in Kind, Arbiter of Knollridge, Mortal Flesh Is Weak). Route
+        // the whole RHS through the general quantity parser so every
+        // "life total becomes <quantity>" card composes. `parse_cda_quantity`
+        // returns `Some` only when it fully consumes the phrase, so an
+        // unrecognized trailer yields `None` here — no false positives.
+        oracle_quantity::parse_cda_quantity(&lower)?
     };
 
     // CR 119.5: Use the parsed target if targeted ("target player's life total"),
@@ -2883,6 +2892,62 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// CR 119.5: "<player>'s life total becomes <dynamic>" routes the RHS through
+    /// the general quantity parser, so a cross-player life extremum (CR 119.1 /
+    /// CR 102.1, parsed by `parse_cross_player_life_extremum`) resolves to a
+    /// dynamic `QuantityExpr::Ref(LifeTotal{..})` rather than collapsing to
+    /// `Effect::Unimplemented`. Covers the class shared by Repay in Kind,
+    /// Arbiter of Knollridge, and Mortal Flesh Is Weak.
+    #[test]
+    fn life_total_becomes_cross_player_extremum() {
+        use crate::types::ability::AggregateFunction;
+
+        for (text, expected_player) in [
+            (
+                "each player's life total becomes the highest life total among all players",
+                PlayerScope::AllPlayers {
+                    aggregate: AggregateFunction::Max,
+                    exclude: None,
+                },
+            ),
+            (
+                "each player's life total becomes the lowest life total among all players",
+                PlayerScope::AllPlayers {
+                    aggregate: AggregateFunction::Min,
+                    exclude: None,
+                },
+            ),
+            (
+                "each opponent's life total becomes the lowest life total among your opponents",
+                PlayerScope::Opponent {
+                    aggregate: AggregateFunction::Min,
+                },
+            ),
+        ] {
+            let mut ctx = ParseContext::default();
+            let ability = crate::parser::oracle_effect::parse_effect_chain_with_context(
+                text,
+                AbilityKind::Spell,
+                &mut ctx,
+            );
+            let Effect::SetLifeTotal { amount, .. } = &*ability.effect else {
+                panic!(
+                    "expected SetLifeTotal for {text:?}, got {:?}",
+                    ability.effect
+                );
+            };
+            assert_eq!(
+                amount,
+                &QuantityExpr::Ref {
+                    qty: QuantityRef::LifeTotal {
+                        player: expected_player,
+                    },
+                },
+                "wrong amount for {text:?}",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
The RHS of "<player>'s life total becomes <X>" only parsed "starting life
total" expressions and bare numbers; anything else fell through to
`return None`, collapsing the whole effect to `Effect::Unimplemented`.

Route the remaining RHS through `oracle_quantity::parse_cda_quantity`
before giving up, so any quantity the general parser recognizes composes.
The general parser already reaches `parse_cross_player_life_extremum`
(shipped in #1458), so "the highest/lowest life total among {all
players|players|your opponents}" now resolves to a dynamic
`QuantityExpr::Ref(QuantityRef::LifeTotal { .. })`. `parse_cda_quantity`
returns `Some` only when it fully consumes the phrase, so unrecognized
trailers still yield `None` — no false positives.

CR 119.5: setting a player's life total to a specific number gains/loses
the necessary life. The dynamic amount being a cross-player life extremum
is CR 119.1 (Life) + CR 102.1 (Players), already annotated on the reused
combinator.

Fixes (previously Unimplemented):
- Repay in Kind (sorcery) → SetLifeTotal { amount: LifeTotal{AllPlayers, Min} }
- Arbiter of Knollridge (ETB trigger) → LifeTotal{AllPlayers, Max}
- Mortal Flesh Is Weak (SetInMotion scheme) → LifeTotal{Opponent, Min}

Parser-only: no engine type, variant, or resolver change — SetLifeTotal
already carried a `QuantityExpr` amount and player-scope target.
