### PR TITLE
fix(engine+client): floor-aware X-cost max + live stack-entry cost display (supersedes #1036)

### DIFF
--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -47,6 +47,7 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
   const playerId = usePlayerId();
   const objects = useGameStore((s) => s.gameState?.objects);
   const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const pendingCast = useGameStore((s) => s.gameState?.pending_cast);
   const inspectObject = useUiStore((s) => s.inspectObject);
 
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
@@ -76,6 +77,10 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
   });
 
   const isSpell = entry.kind.type === "Spell";
+  const displayManaCost =
+    isSpell && pendingCast?.object_id === entry.source_id
+      ? pendingCast.cost
+      : sourceObj?.mana_cost;
   const isTriggered = entry.kind.type === "TriggeredAbility";
   // Triggered abilities show "Triggered — From <source>" so the player can
   // tell which permanent owns the trigger without hovering the card image.
@@ -180,8 +185,8 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
             draggable={false}
           />
         )}
-        {isSpell && sourceObj?.mana_cost && (
-          <ManaCostPips cost={sourceObj.mana_cost} size="sm" className="absolute right-[5%] top-[2.5%]" />
+        {isSpell && displayManaCost && (
+          <ManaCostPips cost={displayManaCost} size="sm" className="absolute right-[5%] top-[2.5%]" />
         )}
       </div>
 

--- a/client/src/components/stack/__tests__/StackEntry.test.tsx
+++ b/client/src/components/stack/__tests__/StackEntry.test.tsx
@@ -1,0 +1,153 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { StackEntry } from "../StackEntry.tsx";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import type { GameState, StackEntry as StackEntryType } from "../../../adapter/types.ts";
+
+vi.mock("../../../hooks/useCardImage.ts", () => ({
+  useCardImage: () => ({ src: "/test-card.png", isLoading: false }),
+}));
+
+function createGameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    turn_number: 1,
+    active_player: 0,
+    phase: "PreCombatMain",
+    players: [
+      { id: 0, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [], hand: [], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+      { id: 1, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [], hand: [], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+    ],
+    priority_player: 0,
+    objects: {},
+    next_object_id: 100,
+    battlefield: [],
+    stack: [],
+    exile: [],
+    rng_seed: 1,
+    combat: null,
+    waiting_for: { type: "Priority", data: { player: 0 } },
+    has_pending_cast: false,
+    lands_played_this_turn: 0,
+    max_lands_per_turn: 1,
+    priority_pass_count: 0,
+    pending_replacement: null,
+    layers_dirty: false,
+    next_timestamp: 1,
+    seat_order: [0, 1],
+    format_config: {
+      format: "Standard",
+      starting_life: 20,
+      min_players: 2,
+      max_players: 2,
+      deck_size: 60,
+      singleton: false,
+      command_zone: false,
+      commander_damage_threshold: null,
+      range_of_influence: null,
+      team_based: false,
+      uses_commander: false,
+      allow_debug_actions: false,
+    },
+    eliminated_players: [],
+    ...overrides,
+  };
+}
+
+describe("StackEntry", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the live pending_cast cost for an in-flight X spell instead of the printed base cost", () => {
+    const entry = {
+      id: 77,
+      source_id: 42,
+      controller: 0,
+      kind: {
+        type: "Spell",
+        card_id: 1,
+        ability: null,
+        casting_variant: { type: "Normal" },
+        actual_mana_spent: 0,
+      },
+    } as unknown as StackEntryType;
+
+    const gameState = createGameState({
+      objects: {
+        42: {
+          id: 42,
+          card_id: 1,
+          name: "Crackle with Power",
+          controller: 0,
+          owner: 0,
+          zone: "Stack",
+          mana_cost: { type: "Cost", shards: ["X", "Red", "Red"], generic: 2 },
+          tapped: false,
+          card_types: { core_types: ["Sorcery"], subtypes: [], supertypes: [] },
+          abilities: [],
+          colors: ["Red"],
+          counters: {},
+          damage: 0,
+          is_summon_sick: false,
+          attached_to: null,
+          cast_from_zone: null,
+          face_down: false,
+          is_commander: false,
+          is_attacking: null,
+          is_blocking: null,
+          mana_spent_to_cast: false,
+          colors_spent_to_cast: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
+        } as unknown as GameState["objects"][number],
+      },
+      stack: [entry] as unknown as GameState["stack"],
+      waiting_for: {
+        type: "ChooseXValue",
+        data: {
+          player: 0,
+          min: 0,
+          max: 3,
+          pending_cast: {
+            object_id: 42,
+            card_id: 1,
+            ability: {} as never,
+            cost: { type: "Cost", shards: ["X", "Red", "Red"], generic: 0 },
+          },
+        },
+      } as GameState["waiting_for"],
+      has_pending_cast: true,
+      pending_cast: {
+        object_id: 42,
+        card_id: 1,
+        ability: {} as never,
+        cost: { type: "Cost", shards: ["X", "Red", "Red"], generic: 0 },
+      } as GameState["pending_cast"],
+    });
+
+    act(() => {
+      useGameStore.setState({
+        gameState,
+        waitingFor: gameState.waiting_for,
+      });
+    });
+
+    render(
+      <StackEntry
+        entry={entry}
+        index={0}
+        isTop
+        isPending
+        cardSize={{ width: 120, height: 168 }}
+      />,
+    );
+
+    expect(screen.getByAltText("X")).toBeInTheDocument();
+    expect(screen.getAllByAltText("R")).toHaveLength(2);
+    expect(screen.queryByAltText("2")).not.toBeInTheDocument();
+  });
+});

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2734,7 +2734,7 @@ fn apply_all_cost_modifiers(
     // CR 601.2b + CR 601.2f: Cost-floor statics (Trinisphere class) — LAST, after
     // every additive/subtractive modifier so the floor sees the final mana
     // component. While the cost still contains `{X}`, X has mana value 0
-    // (CR 107.3b), so flooring now would over-count the spell once X is paid
+    // (CR 107.3g), so flooring now would over-count the spell once X is paid
     // (CR 601.2b locks in the chosen X *before* the "directly affect the total
     // cost" step of CR 601.2f). Defer the floor for `{X}` costs to
     // `apply_post_x_cost_floor`, run from the ChooseX handler once X is concrete.
@@ -3243,7 +3243,7 @@ fn apply_battlefield_cost_modifiers_inner(
 /// is below the floor, generic mana is added to bring the total to the floor —
 /// colored requirements are never modified, per the Trinisphere reminder text
 /// "Additional mana ... may be paid with any color of mana or colorless mana."
-fn apply_cost_floor(
+pub(super) fn apply_cost_floor(
     state: &GameState,
     caster: PlayerId,
     spell_id: ObjectId,
@@ -27435,6 +27435,71 @@ mod tests {
             },
             "floor must be deferred while X is symbolic — applying it now would wrongly add {{3}}"
         );
+    }
+
+    /// CR 601.2b + CR 601.2f + CR 601.2h: With a Trinisphere-class floor active,
+    /// the X-announce step must not offer an X whose floored, locked-in cost is
+    /// unpayable. An `{X}{1}` spell with pool = 2 under a `{3}` floor: the bare
+    /// arithmetic formula offers max X = `(2-1)/1 = 1`, but X=1 → `{1}{1}` = `{2}`
+    /// → floored to `{3}`, which a pool of 2 cannot pay. The floor-aware probe
+    /// finds no payable X (X=0 → `{1}` → `{3}` is likewise unpayable from 2), so
+    /// `ChooseXValue.max` must be 0, not 1.
+    ///
+    /// Drives the real cast pipeline via `apply_as_current` + `CastSpell`. This is
+    /// the discriminating test for the floor-aware `max_x_value_excluding` fix:
+    /// pre-fix it would report `max = 1` (and fail this assertion); post-fix it
+    /// reports `max = 0`.
+    #[test]
+    fn x_spell_under_trinisphere_does_not_offer_unpayable_x() {
+        let mut state = setup_game_at_main_phase();
+        add_trinisphere(&mut state, PlayerId(0)); // {3} floor, untapped
+        let spell = create_object(
+            &mut state,
+            CardId(950),
+            PlayerId(0),
+            "Synthetic X Sorcery".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Ref {
+                        qty: QuantityRef::Variable {
+                            name: "X".to_string(),
+                        },
+                    },
+                    target: TargetFilter::Controller,
+                },
+            ));
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::X],
+                generic: 1,
+            }; // {X}{1}
+        }
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 2); // pool = 2
+
+        let result = apply_as_current(
+            &mut state,
+            GameAction::CastSpell {
+                object_id: spell,
+                card_id: CardId(950),
+                targets: vec![],
+            },
+        )
+        .expect("cast enters ChooseXValue");
+
+        // Pre-fix: ChooseXValue.max == 1 (arithmetic offers an unpayable X=1).
+        // Post-fix: ChooseXValue.max == 0 (X=1's floored {3} is unpayable from pool 2).
+        match result.waiting_for {
+            WaitingFor::ChooseXValue { max, .. } => assert_eq!(
+                max, 0,
+                "floor-aware max must exclude X=1 (floors to {{3}}, unpayable from pool 2)"
+            ),
+            other => panic!("expected ChooseXValue, got {other:?}"),
+        }
     }
 
     /// CR 601.2b + CR 601.2f: Once X is concretized to a value that brings the

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4105,6 +4105,8 @@ pub(super) fn max_x_value_excluding(
     object_id: Option<ObjectId>,
     excluded_sources: &HashSet<ObjectId>,
 ) -> u32 {
+    use crate::types::statics::StaticMode;
+
     let ManaCost::Cost { shards, generic } = cost else {
         return 0;
     };
@@ -4179,8 +4181,57 @@ pub(super) fn max_x_value_excluding(
     // CR 107.1b: Each `ManaCostShard::X` in the cost contributes `value` generic,
     // so for `{X}{X}` each point of X costs 2 mana. Dividing by `x_count` yields
     // the largest X the caster can actually afford.
-    let remaining = (pool + capacity).saturating_sub(fixed_portion);
-    remaining / x_count
+    let available = pool + capacity;
+    let formula_max = available.saturating_sub(fixed_portion) / x_count;
+
+    // CR 601.2f: A Trinisphere-class cost floor ("this spell costs at least {N}")
+    // is an effect that "directly affect[s] the total cost" and is locked in
+    // after X is chosen (CR 601.2b announces X first; CR 107.3g means symbolic X
+    // has mana value 0, so the floor is deferred until X is concrete). The
+    // arithmetic `formula_max` ignores the floor entirely, so it can offer an X
+    // whose floored, locked-in total is unpayable. CR 601.2h: unpayable costs
+    // can't be paid, so such an X must never be offered. The floor only ever
+    // *increases* a cost (it tops generic mana up to the floor, never reduces),
+    // so `formula_max` is an upper bound on any payable X — the probe never needs
+    // to search above it.
+    //
+    // An object-less X cost (the `max_x_value` public path used by the
+    // resolution-time probe in `effects/pay.rs`) is never a cast-time spell, so
+    // no cast-time floor can apply: return the unfloored bound unchanged.
+    let Some(spell_id) = object_id else {
+        return formula_max;
+    };
+
+    // Fast path: only floor-affected casts pay for the probe. This is an
+    // *existence* check ("could any cost floor apply at all"), not the authoritative
+    // CR 604.1 condition gate — `battlefield_functioning_statics` deliberately does
+    // NOT evaluate `def.condition`, so a tapped/non-functional Trinisphere still
+    // passes this `.any()`. That is correct by design: `apply_cost_floor` (called
+    // inside the probe) re-evaluates each static's condition per CR 601.2f, so a
+    // non-functional floor is correctly skipped there, yielding `formula_max` for
+    // that candidate. The vast majority of games have zero `MinimumCost` statics,
+    // so the hot X-announce / legal-actions path pays only one short-circuiting scan.
+    let floor_active = super::functioning_abilities::battlefield_functioning_statics(state)
+        .any(|(_, def)| matches!(def.mode, StaticMode::MinimumCost { .. }));
+    if !floor_active {
+        return formula_max;
+    }
+
+    // CR 601.2b + CR 601.2f + CR 601.2h: descend from the arithmetic upper bound to
+    // the largest X whose floored, locked-in total is payable. Mirrors the
+    // resolution-time descending probe in `effects/pay.rs` (`max_resolution_mana_x_value`).
+    // The probe consults the single floor authority (`casting::apply_cost_floor`)
+    // rather than re-deriving floor logic; it runs the untargeted channel only,
+    // which is exact for the target-independent `MinimumCost` filters in use today.
+    (0..=formula_max)
+        .rev()
+        .find(|&x| {
+            let mut probe = cost.clone();
+            probe.concretize_x(x);
+            super::casting::apply_cost_floor(state, player, spell_id, &mut probe);
+            probe.mana_value() <= available
+        })
+        .unwrap_or(0)
 }
 
 /// Single authority for transitioning into the payment step of a cast.


### PR DESCRIPTION
## Summary

Supersedes #1036 (codex `jeremytboyer-magnus-x-fix`). Two related X-cost casting defects, fixed at the correct seams:

1. **Engine** — the maximum X offered for an X-cost spell ignored Trinisphere-class post-X cost **floors** (`StaticMode::MinimumCost`), so the engine could offer the player (or the AI) an X value that becomes unpayable once the floor raises the locked-in total.
2. **Client** — while an X-cost spell was mid-cast, its stack entry rendered the *printed* mana cost (`{X}{R}{R}`) instead of the live `pending_cast.cost` the player is actually paying.

Original bug discovery and the first implementation are @jeremytboyer's (#1036). The engine fix here is re-implemented fresh at the correct seam; the client fix is extracted verbatim from #1036 (co-authored).

## The engine bug

`max_x_value_excluding` (`crates/engine/src/game/casting_costs.rs`) computes the max payable X with a pure arithmetic formula `(pool + capacity − fixed_portion) / x_count`. That formula has no knowledge of the cost floor. Since `{X}` has mana value 0 while symbolic (CR 107.3g), `apply_all_cost_modifiers` **defers** the floor (`apply_cost_floor`) until *after* X is concretized. So for an `{X}{1}` spell with a `{3}` floor and a pool of 2, the formula offers max X = 1, but X=1 → `{1}{1}` = `{2}` → floored to `{3}`, which a pool of 2 cannot pay.

## Why #1036's seam was wrong (and this one is right)

The codex PR reached for an `apply_all_cost_modifiers_inner` refactor plus a `DYNAMIC_X_SEARCH_EXTRA_HEADROOM = 1024` magic constant. The actual seam is narrower and already singular: **`max_x_value_excluding` is the sole producer of `WaitingFor::ChooseXValue.max`**, which both the human slider and the AI candidate enumerator (`ai_support/candidates.rs`) read. Fixing it there fixes every consumer at once — no AI change, no frontend change, no new constant.

The fix makes `max_x_value_excluding` floor-aware:

- Compute `formula_max` exactly as today — it's a provable **upper bound** (the floor only ever *increases* cost).
- **Fast-path guard:** if `object_id` is `None` (resolution-time X, `effects/pay.rs`) or no `StaticMode::MinimumCost` static is active on the battlefield, return `formula_max` unchanged — **zero behavior change for >99% of casts**.
- Otherwise, descending-probe `(0..=formula_max).rev()` for the largest X whose floored cost (via the existing `apply_cost_floor` authority — *consulted, not duplicated*) is payable.

`MinimumCost` is provably the *only* post-X-deferred cost **increaser**: every other cost modifier (`ReduceCost`, `RaiseCost`/Thalia, affinity, pending reductions) is applied unconditionally *before* X is concretized and is therefore already baked into `fixed_portion`.

## The client fix (extracted from #1036)

`StackEntry` now selects `pending_cast.cost` when the entry is the in-flight pending cast, else the printed `mana_cost` — a pure display-layer choice between two engine-provided fields (no game state computed client-side).

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test -p engine` — **9815 passed, 0 failed**.
- New discriminating pipeline test `x_spell_under_trinisphere_does_not_offer_unpayable_x` (drives `apply_as_current` → `CastSpell` → `ChooseXValue`): **fails pre-fix** (`max == 1`), **passes post-fix** (`max == 0`). Independently reproduced by review (neuter the probe → fails; restore → passes).
- Existing `max_x_value_*`, `cost_floor_*`, `trinisphere` clusters all green (fast-path guard preserves behavior).
- Client: `tsc -b --noEmit` clean, ESLint 0 errors, new `StackEntry.test.tsx` passes (asserts the live `{X}{R}{R}` pips render and the printed-cost `{2}` pip does not).

## CR annotations (all grep-verified against `docs/MagicCompRules.txt`)

CR 107.3a, 107.3g, 118.6, 601.2b, 601.2f (cost floors "directly affect the total cost"), 601.2h, 604.1. Also migrates a pre-existing `CR 107.3b` → `CR 107.3g` mis-citation at the deferral site.

## Blast radius

`max_x_value_excluding` has one production caller (`enter_payment_step`); its public wrapper `max_x_value` feeds `effects/pay.rs` (resolution-time X, `object_id: None`) — the early-return makes that path byte-identical to pre-fix. AI reads the fixed `ChooseXValue.max`; no AI/frontend logic change.

Supersedes #1036.

Co-authored-by: jeremy <jeremytboyer@gmail.com>
