### PR TITLE
feat(engine): count opponents you attacked this turn (Militant Angel)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1171,6 +1171,7 @@ fn fmt_player_filter(pf: &PlayerFilter) -> String {
         PlayerFilter::OpponentDealtCombatDamage => {
             "each opponent who was dealt combat damage this turn"
         }
+        PlayerFilter::OpponentAttackedThisTurn => "each opponent you attacked this turn",
         PlayerFilter::All => "each player",
         PlayerFilter::HighestSpeed => "each player with the highest speed",
         PlayerFilter::ZoneChangedThisWay => "each player who changed a card this way",
@@ -5272,6 +5273,7 @@ fn player_filter_feature(scope: &PlayerFilter) -> (&'static str, FeatureSupport)
         PlayerFilter::OpponentLostLife => ("OpponentLostLife", Handled),
         PlayerFilter::OpponentGainedLife => ("OpponentGainedLife", Handled),
         PlayerFilter::OpponentDealtCombatDamage => ("OpponentDealtCombatDamage", Handled),
+        PlayerFilter::OpponentAttackedThisTurn => ("OpponentAttackedThisTurn", Handled),
         PlayerFilter::HighestSpeed => ("HighestSpeed", Handled),
         // Previously emitted via Debug formatting; never appeared in the handled set.
         PlayerFilter::Controller => ("Controller", Unhandled),

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -864,6 +864,14 @@ fn collect_matching_players(
                                     && matches!(r.target, TargetRef::Player(pid) if pid == p.id)
                             })
                     }
+                    // CR 508.6: opponent this player attacked this turn.
+                    PlayerFilter::OpponentAttackedThisTurn => {
+                        p.id != source_controller
+                            && state
+                                .attacked_defenders_this_turn
+                                .get(&source_controller)
+                                .is_some_and(|defenders| defenders.contains(&p.id))
+                    }
                     PlayerFilter::HighestSpeed => {
                         let highest_speed = state
                             .players
@@ -1023,6 +1031,14 @@ pub fn resolve_each_player(
                                 r.is_combat
                                     && matches!(r.target, TargetRef::Player(pid) if pid == p.id)
                             })
+                    }
+                    // CR 508.6: opponent this player attacked this turn.
+                    PlayerFilter::OpponentAttackedThisTurn => {
+                        p.id != ability.controller
+                            && state
+                                .attacked_defenders_this_turn
+                                .get(&ability.controller)
+                                .is_some_and(|defenders| defenders.contains(&p.id))
                     }
                     PlayerFilter::HighestSpeed => {
                         let highest_speed = state

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -226,6 +226,14 @@ pub(crate) fn matches_player_scope(
                                     && matches!(r.target, TargetRef::Player(pid) if pid == p.id)
                             })
                     }
+                    // CR 508.6: opponent this player attacked this turn.
+                    PlayerFilter::OpponentAttackedThisTurn => {
+                        p.id != controller
+                            && state
+                                .attacked_defenders_this_turn
+                                .get(&controller)
+                                .is_some_and(|defenders| defenders.contains(&p.id))
+                    }
                     PlayerFilter::HighestSpeed => {
                         let highest_speed = state
                             .players
@@ -4622,6 +4630,7 @@ fn scoped_player_matches_filter(
         // game/triggers.rs:3703-3723).
         PlayerFilter::DefendingPlayer
         | PlayerFilter::OpponentDealtCombatDamage
+        | PlayerFilter::OpponentAttackedThisTurn
         | PlayerFilter::HighestSpeed
         | PlayerFilter::ZoneChangedThisWay
         | PlayerFilter::PerformedActionThisWay { .. }

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -66,6 +66,20 @@ fn players_for_filter(
             })
             .map(|player| player.id)
             .collect(),
+        // CR 508.6: each opponent this player attacked this turn.
+        PlayerFilter::OpponentAttackedThisTurn => state
+            .players
+            .iter()
+            .filter(|player| !player.is_eliminated)
+            .filter(|player| {
+                player.id != controller
+                    && state
+                        .attacked_defenders_this_turn
+                        .get(&controller)
+                        .is_some_and(|defenders| defenders.contains(&player.id))
+            })
+            .map(|player| player.id)
+            .collect(),
         PlayerFilter::All => state
             .players
             .iter()

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2856,6 +2856,14 @@ pub(crate) fn resolve_player_count(
                                         && matches!(r.target, TargetRef::Player(pid) if pid == p.id)
                                 })
                         }
+                        // CR 508.6: opponent this player attacked this turn.
+                        PlayerFilter::OpponentAttackedThisTurn => {
+                            p.id != controller
+                                && state
+                                    .attacked_defenders_this_turn
+                                    .get(&controller)
+                                    .is_some_and(|defenders| defenders.contains(&p.id))
+                        }
                         PlayerFilter::All => true,
                         PlayerFilter::HighestSpeed => {
                             let highest_speed = state

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -233,6 +233,15 @@ pub fn record_attackers_declared(
         .attacking_creatures_this_turn
         .entry(state.active_player)
         .or_insert(0) += attacker_count as u32;
+
+    // CR 508.6 + CR 508.5: record the defending players attacked this declaration.
+    // `players_attacked_this_step` already holds this declaration's defenders.
+    let active = state.active_player;
+    state
+        .attacked_defenders_this_turn
+        .entry(active)
+        .or_default()
+        .extend(state.players_attacked_this_step.iter().copied());
 }
 
 pub fn record_discard(state: &mut crate::types::game_state::GameState, player: PlayerId) {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3706,6 +3706,9 @@ pub(crate) fn check_trigger_condition(
             // CR 120.1 + CR 510.1: a set-valued combat-damaged-this-turn
             // predicate has no single-player "whose turn" semantic.
             | PlayerFilter::OpponentDealtCombatDamage
+            // CR 508.6: a set-valued attacked-this-turn predicate has no
+            // single-player "whose turn" semantic.
+            | PlayerFilter::OpponentAttackedThisTurn
             | PlayerFilter::All
             | PlayerFilter::HighestSpeed
             | PlayerFilter::ZoneChangedThisWay

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -493,6 +493,7 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
     state.players_attacked_this_step.clear();
     state.players_attacked_this_turn.clear();
     state.attacking_creatures_this_turn.clear();
+    state.attacked_defenders_this_turn.clear();
     state.combat_phases_started_this_turn = 0;
     state.creatures_attacked_this_turn.clear();
     state.creatures_blocked_this_turn.clear();

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -323,6 +323,12 @@ pub(crate) fn parse_quantity_ref_with_context(
                 filter: PlayerFilter::OpponentDealtCombatDamage,
             });
         }
+        // CR 508.6: "opponents you attacked [this turn]" (Militant Angel).
+        if parse_opponents_attacked_clause(rest).is_ok() {
+            return Some(QuantityRef::PlayerCount {
+                filter: PlayerFilter::OpponentAttackedThisTurn,
+            });
+        }
         // CR 109.4 + CR 109.5: "opponents who control <filter>" / "opponents who
         // don't control <filter>" / "players who control more <type> than you" →
         // PlayerCount over the population satisfying the shared control predicate.
@@ -833,6 +839,20 @@ fn parse_opponent_dealt_combat_damage_clause(
         tag(" "),
         alt((tag("were"), tag("was"))),
         tag(" dealt combat damage"),
+        opt(tag(" this turn")),
+    ))
+    .parse(input)
+    .map(|(rest, _)| (rest, ()))
+}
+
+/// CR 508.6: "opponents you attacked [this turn]". Trailing " this turn"
+/// optional (durations may be stripped upstream). No collision with "creature
+/// you attacked WITH this turn" (`AttackedThisTurn`) — different subject word,
+/// no " with".
+fn parse_opponents_attacked_clause(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
+    all_consuming((
+        alt((tag::<_, _, OracleError<'_>>("opponents"), tag("opponent"))),
+        tag(" you attacked"),
         opt(tag(" this turn")),
     ))
     .parse(input)
@@ -1744,6 +1764,13 @@ fn parse_for_each_clause_with_they_controller(
         });
     }
 
+    // CR 508.6: "opponent you attacked this turn".
+    if parse_opponents_attacked_clause(clause).is_ok() {
+        return Some(QuantityRef::PlayerCount {
+            filter: PlayerFilter::OpponentAttackedThisTurn,
+        });
+    }
+
     // "opponent"
     if clause == "opponent" || clause == "opponent you have" {
         return Some(QuantityRef::PlayerCount {
@@ -2308,6 +2335,49 @@ mod tests {
                 "phrase {phrase:?} must consume as OpponentDealtCombatDamage"
             );
         }
+    }
+
+    /// CR 508.6: "the number of opponents you attacked [this turn]" (Militant
+    /// Angel) routes to the dedicated `PlayerCount { OpponentAttackedThisTurn }`.
+    /// The trailing " this turn" is optional (durations may be stripped
+    /// upstream), and the singular "opponent" form hits the same arm.
+    #[test]
+    fn quantity_ref_opponents_you_attacked_is_player_count() {
+        for phrase in [
+            "the number of opponents you attacked this turn",
+            "the number of opponents you attacked",
+            "the number of opponent you attacked this turn",
+        ] {
+            assert_eq!(
+                parse_quantity_ref(phrase),
+                Some(QuantityRef::PlayerCount {
+                    filter: PlayerFilter::OpponentAttackedThisTurn,
+                }),
+                "phrase {phrase:?} must route to OpponentAttackedThisTurn"
+            );
+        }
+    }
+
+    /// CR 508.6: the for-each clause form ("opponent you attacked this turn")
+    /// reaches the same `PlayerCount { OpponentAttackedThisTurn }`.
+    #[test]
+    fn for_each_opponent_you_attacked_is_player_count() {
+        assert_eq!(
+            parse_for_each_clause("opponent you attacked this turn"),
+            Some(QuantityRef::PlayerCount {
+                filter: PlayerFilter::OpponentAttackedThisTurn,
+            }),
+        );
+    }
+
+    /// Collision guard: "creature you attacked WITH this turn" (the source-
+    /// referential attacked-with form) must stay `QuantityRef::AttackedThisTurn`
+    /// — the " with" subject distinguishes it from the player-population
+    /// "opponents you attacked" phrase.
+    #[test]
+    fn creature_you_attacked_with_this_turn_stays_attacked_this_turn() {
+        let qty = parse_for_each_clause("creature you attacked with this turn").unwrap();
+        assert_eq!(qty, QuantityRef::AttackedThisTurn);
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3299,6 +3299,12 @@ pub enum PlayerFilter {
     /// "for each opponent that was dealt combat damage this turn" cards
     /// (Tymna the Weaver).
     OpponentDealtCombatDamage,
+    /// CR 508.6: A player has "attacked [a player]" if they declared one or more
+    /// creatures attacking that player. Each opponent the controller attacked this
+    /// turn, resolved against `state.attacked_defenders_this_turn[controller]`.
+    /// Used by "the number of opponents you attacked this turn" (Militant Angel).
+    /// (CR 508.1b: declare-attackers announcement; CR 506.2: active = attacking player.)
+    OpponentAttackedThisTurn,
     /// All players.
     All,
     /// CR 702.179f: Each player whose speed is tied for the highest speed among players.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4284,6 +4284,14 @@ pub struct GameState {
     pub players_attacked_this_turn: HashSet<PlayerId>,
     #[serde(default)]
     pub attacking_creatures_this_turn: HashMap<PlayerId, u32>,
+    /// CR 508.6 + CR 508.1b: For each attacking player, the set of defending
+    /// players they attacked this turn, accumulated across every combat's
+    /// declare-attackers step (CR 508.5 "defending player": planeswalker/battle
+    /// attacks resolve to controller/protector). Counted by
+    /// `PlayerFilter::OpponentAttackedThisTurn` for "opponents you attacked this
+    /// turn" (Militant Angel).
+    #[serde(default)]
+    pub attacked_defenders_this_turn: HashMap<PlayerId, HashSet<PlayerId>>,
     /// CR 500.8 + CR 506.1: Number of combat phases that have begun this turn.
     /// Used by intervening-if triggers that only fire during the first combat phase.
     #[serde(default, skip_serializing_if = "is_zero_u32")]
@@ -4956,6 +4964,7 @@ impl GameState {
             players_attacked_this_step: HashSet::new(),
             players_attacked_this_turn: HashSet::new(),
             attacking_creatures_this_turn: HashMap::new(),
+            attacked_defenders_this_turn: HashMap::new(),
             combat_phases_started_this_turn: 0,
             creatures_attacked_this_turn: HashSet::new(),
             creatures_blocked_this_turn: HashSet::new(),
@@ -5239,6 +5248,7 @@ impl PartialEq for GameState {
             && self.players_attacked_this_step == other.players_attacked_this_step
             && self.players_attacked_this_turn == other.players_attacked_this_turn
             && self.attacking_creatures_this_turn == other.attacking_creatures_this_turn
+            && self.attacked_defenders_this_turn == other.attacked_defenders_this_turn
             && self.combat_phases_started_this_turn == other.combat_phases_started_this_turn
             && self.creatures_attacked_this_turn == other.creatures_attacked_this_turn
             && self.creatures_blocked_this_turn == other.creatures_blocked_this_turn

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -72,6 +72,7 @@ mod madame_null_integration;
 mod magnetic_mountain_choose_and_pay;
 mod mana_drain_refund;
 mod master_of_ceremonies;
+mod militant_angel_attacked_opponents;
 mod mycoloth_upkeep_trigger;
 mod mystic_forge_regression;
 mod old_growth_troll_return_as_aura;

--- a/crates/engine/tests/integration/militant_angel_attacked_opponents.rs
+++ b/crates/engine/tests/integration/militant_angel_attacked_opponents.rs
@@ -1,0 +1,88 @@
+//! Runtime test for CR 508.6 — "the number of opponents you attacked this
+//! turn" (Militant Angel) must resolve against real declare-attackers state.
+//!
+//! Militant Angel reads:
+//!   "Whenever Militant Angel attacks, create a number of 1/1 white Soldier
+//!    creature tokens equal to the number of opponents you attacked this turn."
+//!
+//! The `PlayerCount { OpponentAttackedThisTurn }` filter resolves against
+//! `state.attacked_defenders_this_turn[controller]`, which is populated by
+//! `record_attackers_declared` during the real DeclareAttackers step (CR 508.5:
+//! the defending player is the player/planeswalker-controller/battle-protector
+//! the creature is attacking). This test drives the full pipeline through
+//! `apply` — it does NOT hand-insert into the substrate map (that would be a
+//! shape test). It then resolves the public `resolve_quantity` against the
+//! post-declare state and asserts the count reflects the opponent attacked.
+//!
+//! These tests use synthetic creatures (`add_creature`), so no card database is
+//! loaded and they run identically in CI and local Tilt.
+
+use engine::game::combat::AttackTarget;
+use engine::game::quantity::resolve_quantity;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{PlayerFilter, QuantityExpr, QuantityRef};
+use engine::types::actions::GameAction;
+use engine::types::phase::Phase;
+
+/// CR 508.6: after P0 declares a creature attacking P1, resolving
+/// `PlayerCount { OpponentAttackedThisTurn }` from P0's perspective counts the
+/// one opponent attacked this turn.
+#[test]
+fn opponents_attacked_this_turn_counts_declared_defender() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let attacker = scenario.add_creature(P0, "Soldier", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // Drive the real declare-attackers step so `record_attackers_declared`
+    // populates `attacked_defenders_this_turn` (no hand-insertion).
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+        })
+        .expect("DeclareAttackers should succeed");
+
+    let count = resolve_quantity(
+        runner.state(),
+        &QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::OpponentAttackedThisTurn,
+            },
+        },
+        P0,
+        attacker,
+    );
+
+    assert_eq!(
+        count, 1,
+        "P0 attacked exactly one opponent (P1) this turn (CR 508.6)"
+    );
+}
+
+/// Negative control: with no attackers declared, the substrate is empty and the
+/// count is 0 (CR 508.6 — a player has only "attacked" players against whom they
+/// declared attackers).
+#[test]
+fn opponents_attacked_this_turn_is_zero_without_combat() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let _attacker = scenario.add_creature(P0, "Soldier", 2, 2).id();
+    let runner = scenario.build();
+
+    let count = resolve_quantity(
+        runner.state(),
+        &QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::OpponentAttackedThisTurn,
+            },
+        },
+        P0,
+        _attacker,
+    );
+
+    assert_eq!(
+        count, 0,
+        "no attacks declared this turn means 0 opponents attacked (CR 508.6)"
+    );
+}

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -26,7 +26,7 @@
     "crates/engine/src/types/card_type.rs"
   ],
   "enum_count": 245,
-  "variant_count": 2770,
+  "variant_count": 2774,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -430,13 +430,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9013,
+      "line": 9019,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 9031,
+          "line": 9037,
           "kind": "struct",
           "field_names": [
             "source",
@@ -454,7 +454,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 9047,
+          "line": 9053,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -465,7 +465,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 9052,
+          "line": 9058,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -479,7 +479,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 9057,
+          "line": 9063,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -489,7 +489,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 9065,
+          "line": 9071,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -499,7 +499,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9068,
+          "line": 9074,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -511,7 +511,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9072,
+          "line": 9078,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -524,7 +524,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9075,
+          "line": 9081,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -537,7 +537,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9078,
+          "line": 9084,
           "kind": "struct",
           "field_names": [
             "color",
@@ -551,7 +551,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 9084,
+          "line": 9090,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -564,7 +564,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9092,
+          "line": 9098,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -575,7 +575,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9095,
+          "line": 9101,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -588,7 +588,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 9100,
+          "line": 9106,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -602,7 +602,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 9104,
+          "line": 9110,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -616,7 +616,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 9113,
+          "line": 9119,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -630,7 +630,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9118,
+          "line": 9124,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -640,7 +640,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9120,
+          "line": 9126,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -650,7 +650,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9123,
+          "line": 9129,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -660,7 +660,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 9127,
+          "line": 9133,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -672,7 +672,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 9132,
+          "line": 9138,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -686,7 +686,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9140,
+          "line": 9146,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -698,7 +698,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9145,
+          "line": 9151,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -714,7 +714,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 9157,
+          "line": 9163,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -727,7 +727,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 9161,
+          "line": 9167,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -740,7 +740,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 9165,
+          "line": 9171,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -750,7 +750,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9173,
+          "line": 9179,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -763,7 +763,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9178,
+          "line": 9184,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -776,7 +776,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9183,
+          "line": 9189,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -788,7 +788,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 9189,
+          "line": 9195,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -800,7 +800,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 9193,
+          "line": 9199,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -814,7 +814,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9196,
+          "line": 9202,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -824,7 +824,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 9205,
+          "line": 9211,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -837,7 +837,7 @@
         },
         {
           "name": "And",
-          "line": 9210,
+          "line": 9216,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -849,7 +849,7 @@
         },
         {
           "name": "Or",
-          "line": 9215,
+          "line": 9221,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -861,7 +861,7 @@
         },
         {
           "name": "Not",
-          "line": 9223,
+          "line": 9229,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -873,7 +873,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 9227,
+          "line": 9233,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -883,7 +883,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 9229,
+          "line": 9235,
           "kind": "struct",
           "field_names": [
             "state"
@@ -895,7 +895,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 9239,
+          "line": 9245,
           "kind": "struct",
           "field_names": [
             "n"
@@ -907,7 +907,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 9242,
+          "line": 9248,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -915,6 +915,20 @@
           "doc": "CR 702.x: True when the source permanent does not have the specified keyword. Inverse of keyword presence check — used by \"if ~ doesn't have [keyword]\" gates.",
           "cr_refs": [
             "CR 702"
+          ]
+        },
+        {
+          "name": "ScopedPlayerMatches",
+          "line": 9268,
+          "kind": "struct",
+          "field_names": [
+            "filter"
+          ],
+          "doc": "CR 101.3 + CR 109.5 + CR 608.2c: True when the current per-iteration scoped player (`ResolvedAbility.scoped_player`) matches `filter` relative to the ability's controller. Used by cross-scope decline-tail gates where the parent's `player_scope` iterates a wider set than the decline clause's own `PlayerFilter` (Liliana, Waker of the Dead: parent \"each player discards a card\" iterates `All`, decline clause \"each opponent who can't loses 3 life\" filters to `Opponent`).  Composed with `Not{IfCurrentScopeSucceeded}` via `AbilityCondition::And` so the body fires only on iterations where (a) the parent action failed AND (b) the scoped player matches the decline clause's own filter.  For same-scope decline-tails (Plaguecrafter, Entropic Battlecruiser, Momentum Breaker — parent and decline both iterate the same set) this conjunct is trivially true for every iteration and acts as a no-op.  Outside a `player_scope` iteration (no `scoped_player` bound) the condition resolves against the ability's controller — the canonical fallback semantics for the `ScopedPlayer`/`Controller` split.",
+          "cr_refs": [
+            "CR 101.3",
+            "CR 109.5",
+            "CR 608.2c"
           ]
         }
       ],
@@ -931,13 +945,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4303,
+      "line": 4309,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 4304,
+          "line": 4310,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -947,7 +961,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 4313,
+          "line": 4319,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -960,7 +974,7 @@
         },
         {
           "name": "Tap",
-          "line": 4316,
+          "line": 4322,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -968,7 +982,7 @@
         },
         {
           "name": "Untap",
-          "line": 4317,
+          "line": 4323,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -976,7 +990,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 4318,
+          "line": 4324,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -986,7 +1000,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 4321,
+          "line": 4327,
           "kind": "struct",
           "field_names": [
             "target",
@@ -997,7 +1011,7 @@
         },
         {
           "name": "PayLife",
-          "line": 4333,
+          "line": 4339,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1009,7 +1023,7 @@
         },
         {
           "name": "Discard",
-          "line": 4336,
+          "line": 4342,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1022,7 +1036,7 @@
         },
         {
           "name": "Exile",
-          "line": 4347,
+          "line": 4353,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1034,7 +1048,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 4356,
+          "line": 4362,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1047,7 +1061,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 4359,
+          "line": 4365,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1058,7 +1072,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 4370,
+          "line": 4376,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1073,7 +1087,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 4376,
+          "line": 4382,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1083,7 +1097,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4380,
+          "line": 4386,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1096,7 +1110,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4388,
+          "line": 4394,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1110,7 +1124,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4397,
+          "line": 4403,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1120,7 +1134,7 @@
         },
         {
           "name": "Mill",
-          "line": 4398,
+          "line": 4404,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1130,7 +1144,7 @@
         },
         {
           "name": "Exert",
-          "line": 4401,
+          "line": 4407,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1138,7 +1152,7 @@
         },
         {
           "name": "Blight",
-          "line": 4404,
+          "line": 4410,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1148,7 +1162,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4407,
+          "line": 4413,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1159,7 +1173,7 @@
         },
         {
           "name": "Behold",
-          "line": 4415,
+          "line": 4421,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1171,7 +1185,7 @@
         },
         {
           "name": "Composite",
-          "line": 4421,
+          "line": 4427,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1181,7 +1195,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4438,
+          "line": 4444,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1194,7 +1208,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4442,
+          "line": 4448,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1204,7 +1218,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4447,
+          "line": 4453,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1217,7 +1231,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4454,
+          "line": 4460,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1229,7 +1243,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4470,
+          "line": 4476,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1243,7 +1257,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4475,
+          "line": 4481,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1256,13 +1270,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8152,
+      "line": 8158,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 8154,
+          "line": 8160,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1270,7 +1284,7 @@
         },
         {
           "name": "Activated",
-          "line": 8155,
+          "line": 8161,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1278,7 +1292,7 @@
         },
         {
           "name": "Database",
-          "line": 8156,
+          "line": 8162,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1286,7 +1300,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 8159,
+          "line": 8165,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1294,7 +1308,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 8165,
+          "line": 8171,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1307,7 +1321,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8306,
+      "line": 8312,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1315,7 +1329,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 8308,
+          "line": 8314,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1325,7 +1339,7 @@
         },
         {
           "name": "Evolve",
-          "line": 8310,
+          "line": 8316,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1335,7 +1349,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 8312,
+          "line": 8318,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1345,7 +1359,7 @@
         },
         {
           "name": "Outlast",
-          "line": 8314,
+          "line": 8320,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1414,60 +1428,12 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8322,
+      "line": 8328,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8323,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AsInstant",
-          "line": 8324,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourTurn",
-          "line": 8325,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourUpkeep",
-          "line": 8326,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringCombat",
-          "line": 8327,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BeforeAttackersDeclared",
-          "line": 8328,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BeforeCombatDamage",
           "line": 8329,
           "kind": "unit",
           "field_names": [],
@@ -1475,7 +1441,7 @@
           "cr_refs": []
         },
         {
-          "name": "OnlyOnceEachTurn",
+          "name": "AsInstant",
           "line": 8330,
           "kind": "unit",
           "field_names": [],
@@ -1483,7 +1449,7 @@
           "cr_refs": []
         },
         {
-          "name": "OnlyOnce",
+          "name": "DuringYourTurn",
           "line": 8331,
           "kind": "unit",
           "field_names": [],
@@ -1491,8 +1457,56 @@
           "cr_refs": []
         },
         {
-          "name": "MaxTimesEachTurn",
+          "name": "DuringYourUpkeep",
           "line": 8332,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringCombat",
+          "line": 8333,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeAttackersDeclared",
+          "line": 8334,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeCombatDamage",
+          "line": 8335,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "OnlyOnceEachTurn",
+          "line": 8336,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "OnlyOnce",
+          "line": 8337,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MaxTimesEachTurn",
+          "line": 8338,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1502,7 +1516,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8335,
+          "line": 8341,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1512,7 +1526,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 8339,
+          "line": 8345,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1522,7 +1536,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 8341,
+          "line": 8347,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1534,7 +1548,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 8346,
+          "line": 8352,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1548,7 +1562,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 8357,
+          "line": 8363,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1562,7 +1576,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 8370,
+          "line": 8376,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1575,13 +1589,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4679,
+      "line": 4685,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 4685,
+          "line": 4691,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1592,7 +1606,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4695,
+          "line": 4701,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1608,7 +1622,7 @@
         },
         {
           "name": "Choice",
-          "line": 4702,
+          "line": 4708,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1616,7 +1630,7 @@
         },
         {
           "name": "Required",
-          "line": 4704,
+          "line": 4710,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1627,7 +1641,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4713,
+      "line": 4719,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1635,7 +1649,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 4715,
+          "line": 4721,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1643,7 +1657,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4716,
+          "line": 4722,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1651,7 +1665,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 4717,
+          "line": 4723,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1731,7 +1745,7 @@
     },
     "AlternativeCastKeyword": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1424,
+      "line": 1439,
       "doc": "CR 118.9: Identifies which keyword ability granted an alternative casting cost so the `WaitingFor::AlternativeCastChoice` dispatcher can route to the keyword-specific post-payment handler. The four keywords share a single player decision shape (printed cost vs. alternative cost) but diverge in post-payment semantics — this enum keeps the prompt unified while preserving CR fidelity at resolution.  Adding a new alternative-cost keyword (e.g., Madness CR 702.35a, Spectacle CR 702.137a) is a compile error at every dispatch site until handled.",
       "cr_refs": [
         "CR 118.9",
@@ -1741,7 +1755,7 @@
       "variants": [
         {
           "name": "Warp",
-          "line": 1426,
+          "line": 1441,
           "kind": "unit",
           "field_names": [],
           "doc": "Custom Warp keyword — exile-at-end-step rider; no CR section.",
@@ -1749,7 +1763,7 @@
         },
         {
           "name": "Evoke",
-          "line": 1429,
+          "line": 1444,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: ETB + sacrifice trigger fires when the resolving permanent was cast for its evoke cost (CR 702.74b).",
@@ -1760,7 +1774,7 @@
         },
         {
           "name": "Overload",
-          "line": 1431,
+          "line": 1446,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a: Spell's text changes \"target\" to \"each\" (CR 702.96b-c).",
@@ -1771,7 +1785,7 @@
         },
         {
           "name": "Bestow",
-          "line": 1433,
+          "line": 1448,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a: Spell becomes an Aura with enchant creature (CR 702.103b).",
@@ -1781,8 +1795,19 @@
           ]
         },
         {
+          "name": "Awaken",
+          "line": 1453,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.113a: \"If this spell's awaken cost was paid, put N +1/+1 counters on target land you control. That land becomes a 0/0 Elemental creature with haste. It's still a land.\" Paying the awaken cost adds the land target (CR 702.113b); casting normally adds no target and no rider.",
+          "cr_refs": [
+            "CR 702.113a",
+            "CR 702.113b"
+          ]
+        },
+        {
           "name": "Cleave",
-          "line": 1436,
+          "line": 1456,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Paying the cleave cost removes every square-bracketed span from the spell's text (a text-changing effect).",
@@ -1871,13 +1896,13 @@
     },
     "AutoMayChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 461,
+      "line": 476,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Accept",
-          "line": 462,
+          "line": 477,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1885,7 +1910,7 @@
         },
         {
           "name": "Decline",
-          "line": 463,
+          "line": 478,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1896,13 +1921,13 @@
     },
     "AutoPassMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3236,
+      "line": 3259,
       "doc": "What the engine stores for auto-pass (includes captured state).",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3239,
+          "line": 3262,
           "kind": "struct",
           "field_names": [
             "initial_stack_len"
@@ -1912,7 +1937,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3243,
+          "line": 3266,
           "kind": "unit",
           "field_names": [],
           "doc": "Auto-pass through priority/combat stops until the flagged player's next turn starts. Interrupted by opponent stack activity (MTGA-style) or when the current phase matches the player's entry in `GameState::phase_stops`.",
@@ -1923,13 +1948,13 @@
     },
     "AutoPassRequest": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3228,
+      "line": 3251,
       "doc": "What the frontend requests for auto-pass (no internal state).  Phase stops that should interrupt `UntilEndOfTurn` are a separate per-player preference on `GameState::phase_stops`, managed via `GameAction::SetPhaseStops`. Keeping them out of the request preserves a single source of truth and lets the preference change mid-session without requiring a new auto-pass request.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3229,
+          "line": 3252,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1937,7 +1962,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3230,
+          "line": 3253,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1999,13 +2024,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4295,
+      "line": 4301,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 4296,
+          "line": 4302,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2013,7 +2038,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 4297,
+          "line": 4303,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2123,7 +2148,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5015,
+      "line": 5021,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2131,7 +2156,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 5018,
+          "line": 5024,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2139,7 +2164,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 5020,
+          "line": 5026,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2490,7 +2515,7 @@
     },
     "CastPaymentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 816,
+      "line": 831,
       "doc": "CR 601.2g-h: Whether the engine may auto-pay an unambiguous spell mana cost or must pause after announcement so the player can activate mana abilities manually before committing payment.",
       "cr_refs": [
         "CR 601.2g"
@@ -2498,7 +2523,7 @@
       "variants": [
         {
           "name": "Auto",
-          "line": 818,
+          "line": 833,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2506,7 +2531,7 @@
         },
         {
           "name": "Manual",
-          "line": 819,
+          "line": 834,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2555,7 +2580,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4269,
+      "line": 4275,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -2564,7 +2589,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 4272,
+          "line": 4278,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -2575,7 +2600,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4231,
+      "line": 4237,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -2586,7 +2611,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4233,
+          "line": 4239,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -2597,7 +2622,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4236,
+          "line": 4242,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -2607,7 +2632,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4238,
+          "line": 4244,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -2617,7 +2642,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4240,
+          "line": 4246,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -2627,7 +2652,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4243,
+          "line": 4249,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -2637,7 +2662,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4249,
+          "line": 4255,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -2647,7 +2672,7 @@
         },
         {
           "name": "Escape",
-          "line": 4254,
+          "line": 4260,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -2658,7 +2683,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4257,
+          "line": 4263,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -2668,7 +2693,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4262,
+          "line": 4268,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -2862,60 +2887,12 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8378,
+      "line": 8384,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8379,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringCombat",
-          "line": 8380,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringOpponentsTurn",
-          "line": 8381,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourTurn",
-          "line": 8382,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourUpkeep",
-          "line": 8383,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringOpponentsUpkeep",
-          "line": 8384,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringAnyUpkeep",
           "line": 8385,
           "kind": "unit",
           "field_names": [],
@@ -2923,7 +2900,7 @@
           "cr_refs": []
         },
         {
-          "name": "DuringYourEndStep",
+          "name": "DuringCombat",
           "line": 8386,
           "kind": "unit",
           "field_names": [],
@@ -2931,7 +2908,7 @@
           "cr_refs": []
         },
         {
-          "name": "DuringOpponentsEndStep",
+          "name": "DuringOpponentsTurn",
           "line": 8387,
           "kind": "unit",
           "field_names": [],
@@ -2939,7 +2916,7 @@
           "cr_refs": []
         },
         {
-          "name": "DeclareAttackersStep",
+          "name": "DuringYourTurn",
           "line": 8388,
           "kind": "unit",
           "field_names": [],
@@ -2947,7 +2924,7 @@
           "cr_refs": []
         },
         {
-          "name": "DeclareBlockersStep",
+          "name": "DuringYourUpkeep",
           "line": 8389,
           "kind": "unit",
           "field_names": [],
@@ -2955,7 +2932,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeAttackersDeclared",
+          "name": "DuringOpponentsUpkeep",
           "line": 8390,
           "kind": "unit",
           "field_names": [],
@@ -2963,7 +2940,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeBlockersDeclared",
+          "name": "DuringAnyUpkeep",
           "line": 8391,
           "kind": "unit",
           "field_names": [],
@@ -2971,7 +2948,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeCombatDamage",
+          "name": "DuringYourEndStep",
           "line": 8392,
           "kind": "unit",
           "field_names": [],
@@ -2979,7 +2956,7 @@
           "cr_refs": []
         },
         {
-          "name": "AfterCombat",
+          "name": "DuringOpponentsEndStep",
           "line": 8393,
           "kind": "unit",
           "field_names": [],
@@ -2987,8 +2964,56 @@
           "cr_refs": []
         },
         {
-          "name": "RequiresCondition",
+          "name": "DeclareAttackersStep",
           "line": 8394,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DeclareBlockersStep",
+          "line": 8395,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeAttackersDeclared",
+          "line": 8396,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeBlockersDeclared",
+          "line": 8397,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeCombatDamage",
+          "line": 8398,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AfterCombat",
+          "line": 8399,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RequiresCondition",
+          "line": 8400,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3001,13 +3026,13 @@
     },
     "CastingVariant": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3321,
+      "line": 3344,
       "doc": "How a spell was cast — determines zone routing and post-resolution behavior. Replaces individual boolean flags (cast_as_adventure, cast_as_warp) with a single enum that captures the casting context.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Normal",
-          "line": 3324,
+          "line": 3347,
           "kind": "unit",
           "field_names": [],
           "doc": "Normal spell cast — no special resolution behavior.",
@@ -3015,7 +3040,7 @@
         },
         {
           "name": "Adventure",
-          "line": 3327,
+          "line": 3350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.4: Cast as the Adventure half. On resolution, exiled with AdventureCreature permission and creature face restored.",
@@ -3025,7 +3050,7 @@
         },
         {
           "name": "Omen",
-          "line": 3330,
+          "line": 3353,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 720.3d / CR 720.4: Cast as the Omen half. On resolution, shuffled into its owner's library with normal characteristics restored.",
@@ -3036,7 +3061,7 @@
         },
         {
           "name": "Warp",
-          "line": 3333,
+          "line": 3356,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.185a: Cast via Warp alternative cost from hand. On resolution, creates a delayed trigger to exile at end step with WarpExile permission.",
@@ -3046,7 +3071,7 @@
         },
         {
           "name": "Escape",
-          "line": 3336,
+          "line": 3359,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138: Cast from graveyard via Escape. On resolution, goes to appropriate zone normally (unlike Flashback which exiles).",
@@ -3056,7 +3081,7 @@
         },
         {
           "name": "Retrace",
-          "line": 3339,
+          "line": 3362,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.81a: Cast from graveyard via Retrace by discarding a land card as an additional cost. Resolution uses normal spell routing.",
@@ -3066,7 +3091,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 3342,
+          "line": 3365,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.180a: Cast from graveyard for harmonize cost. On resolution, exiled instead of going anywhere else (unlike Escape which returns to graveyard).",
@@ -3076,7 +3101,7 @@
         },
         {
           "name": "Flashback",
-          "line": 3345,
+          "line": 3368,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34a: Cast from graveyard for flashback cost. On resolution (or whenever leaving the stack for any reason), exiled instead of going anywhere else.",
@@ -3086,7 +3111,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 3348,
+          "line": 3371,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Cast an aftermath half of a split card from a graveyard. If it was cast from a graveyard, exile it any time it leaves the stack.",
@@ -3096,7 +3121,7 @@
         },
         {
           "name": "GraveyardPermission",
-          "line": 3352,
+          "line": 3375,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3112,7 +3137,7 @@
         },
         {
           "name": "HandPermission",
-          "line": 3378,
+          "line": 3401,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3127,7 +3152,7 @@
         },
         {
           "name": "ExilePermission",
-          "line": 3394,
+          "line": 3417,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3143,7 +3168,7 @@
         },
         {
           "name": "Sneak",
-          "line": 3411,
+          "line": 3434,
           "kind": "struct",
           "field_names": [
             "returned_creature",
@@ -3157,7 +3182,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 3420,
+          "line": 3443,
           "kind": "struct",
           "field_names": [
             "returned_creature"
@@ -3169,7 +3194,7 @@
         },
         {
           "name": "Miracle",
-          "line": 3427,
+          "line": 3450,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94a: Cast from hand via Miracle's alternative cost after revealing the card as the first card drawn this turn. The granting keyword carries the miracle mana cost, which `prepare_spell_cast_with_variant_override` substitutes for the printed mana cost. The keyword's `ManaCost` payload is read at preparation time rather than stored here because `prepare_spell_cast` already reads `obj.keywords` for analogous paths.",
@@ -3179,7 +3204,7 @@
         },
         {
           "name": "Madness",
-          "line": 3430,
+          "line": 3453,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.35a: Cast from exile via Madness after the discard replacement exiled the card and its madness triggered ability resolved.",
@@ -3189,7 +3214,7 @@
         },
         {
           "name": "Evoke",
-          "line": 3434,
+          "line": 3457,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Cast from hand via Evoke's alternative cost. On resolution, the permanent enters tagged with `CastVariantPaid::Evoke`, which fires the synthesized intervening-if ETB sacrifice trigger.",
@@ -3199,7 +3224,7 @@
         },
         {
           "name": "Suspend",
-          "line": 3441,
+          "line": 3464,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast from exile via Suspend's \"play it without paying its mana cost\" trigger after the last time counter was removed. On resolution of the resulting permanent, the stack handler tags `CastVariantPaid::Suspend` and — for creature spells — installs a transient continuous \"has haste\" effect that lasts as long as the resolution-time controller still controls the permanent.",
@@ -3209,7 +3234,7 @@
         },
         {
           "name": "Plot",
-          "line": 3448,
+          "line": 3471,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.170d: Cast from exile via the Plot \"cast without paying its mana cost\" permission during the owner's main phase on a turn after the card was plotted. Detected at cast preparation when the exile-zone source has a `CastingPermission::Plotted { turn_plotted }` and the current turn is strictly greater than `turn_plotted`. Zeroes the mana cost and routes through the normal cast pipeline; no special resolution-time behavior.",
@@ -3219,7 +3244,7 @@
         },
         {
           "name": "Foretell",
-          "line": 3455,
+          "line": 3478,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143a-c: Cast from exile via a foretold card's foretell cost on a turn after it was foretold. Detected at cast preparation when the exile-zone source has a `CastingPermission::Foretold { .. }`. The permission supplies the alternative mana cost; stack finalization tags the source with `CastVariantPaid::Foretell` so \"if this spell was foretold\" clauses can evaluate while the spell resolves.",
@@ -3229,7 +3254,7 @@
         },
         {
           "name": "Overload",
-          "line": 3465,
+          "line": 3488,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a-c: Cast from hand via Overload's alternative cost. The printed mana cost is replaced by `Keyword::Overload(cost)` at cast preparation (mirrors `Evoke`/`Warp`). Per CR 702.96b, every \"target\" in the spell's text is replaced by \"each\" — applied as a cast-time transformation of the spell's ability tree (`Destroy`→`DestroyAll`, `Pump`→`PumpAll`, `DealDamage`→`DamageAll`, `Tap`→`TapAll`, `Bounce`→`ChangeZoneAll`). Per CR 702.96c, the resulting spell has no targets, so target selection is naturally skipped because the transformed effects carry no `TargetRef` slots.",
@@ -3241,7 +3266,7 @@
         },
         {
           "name": "Bestow",
-          "line": 3480,
+          "line": 3503,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a-b: Cast from hand via Bestow's alternative cost. The printed mana cost is replaced by `Keyword::Bestow(cost)` at cast preparation; the spell becomes an Aura with `enchant creature` while on the stack and as the resulting permanent (until it becomes unattached, per CR 702.103f). The type-changing mutation is applied directly to the stack object (mirroring `swap_to_alternative_spell_face` for Adventure/Omen) — Layers cannot be used here because they only apply to battlefield/hand objects, not stack objects.  Per CR 702.103e: if the target is illegal at resolution, the type-changing effect ends and the spell resolves as a creature spell. Per CR 702.103f: when a bestowed Aura becomes unattached on the battlefield, the type-changing effect ends — it remains as an enchantment creature (overrides CR 704.5m for bestow Auras).",
@@ -3253,8 +3278,19 @@
           ]
         },
         {
+          "name": "Awaken",
+          "line": 3514,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.113a: Cast from hand via Awaken's alternative cost. The printed mana cost is replaced by `Keyword::Awaken { cost }` at cast preparation (mirrors `Overload`). A resolution rider is appended to the tail of the spell's ability tree (`effects::awaken::append_awaken_rider`): the printed effect resolves first, then \"put N +1/+1 counters on target land you control; that land becomes a 0/0 Elemental creature with haste; it's still a land.\" Per CR 702.113b, the land target only exists on the awaken variant — a normal cast appends no rider and requests no land target. CR 702.113a: the spell goes to the graveyard normally, so this variant is deliberately absent from `exiles_when_leaving_stack_for_any_reason`.",
+          "cr_refs": [
+            "CR 702.113a",
+            "CR 702.113b"
+          ]
+        },
+        {
           "name": "Cleave",
-          "line": 3491,
+          "line": 3525,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Cast from hand via Cleave's alternative cost (CR 118.9). The printed mana cost is replaced by `Keyword::Cleave(cost)` at cast preparation (mirrors `Evoke`/`Overload`). Per CR 702.148a, paying the cleave cost is a text-changing effect (CR 612) that removes every square-bracketed span from the spell's rules text. The bracket-removed ability set is parsed at build time into `CardFace::cleave_variant` and swapped onto the stack object before preparation (mirroring the Bestow object-mutation-before-prepare seam). Resolution routing matches a normal spell — there is no on-resolve special behavior, so the spell goes to its owner's graveyard like any instant/sorcery.",
@@ -3768,7 +3804,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10065,
+      "line": 10091,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -3776,7 +3812,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 10066,
+          "line": 10092,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3784,7 +3820,7 @@
         },
         {
           "name": "Lost",
-          "line": 10067,
+          "line": 10093,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3795,13 +3831,13 @@
     },
     "CollectEvidenceResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 938,
+      "line": 953,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Casting",
-          "line": 939,
+          "line": 954,
           "kind": "struct",
           "field_names": [
             "pending_cast"
@@ -3811,7 +3847,7 @@
         },
         {
           "name": "Effect",
-          "line": 942,
+          "line": 957,
           "kind": "struct",
           "field_names": [
             "pending_ability"
@@ -3824,7 +3860,7 @@
     },
     "CombatDamageAssignmentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2880,
+      "line": 2903,
       "doc": "CR 510.1c: Optional combat-damage assignment mode for attackers with text like \"you may have this creature assign its combat damage as though it weren't blocked.\"",
       "cr_refs": [
         "CR 510.1c"
@@ -3832,7 +3868,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 2882,
+          "line": 2905,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3840,7 +3876,7 @@
         },
         {
           "name": "AsThoughUnblocked",
-          "line": 2883,
+          "line": 2906,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3851,7 +3887,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10565,
+      "line": 10591,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -3859,7 +3895,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 10566,
+          "line": 10592,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3867,7 +3903,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 10567,
+          "line": 10593,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3922,7 +3958,7 @@
     },
     "CombatTaxContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1139,
+      "line": 1154,
       "doc": "CR 508.1d + CR 509.1c: Which combat step a `WaitingFor::CombatTaxPayment` belongs to.  Drives the resume branch after the tax decision — on accept, the engine submits the stored attacker / blocker declaration; on decline, the engine filters the taxed creatures out of that declaration and submits the remainder.",
       "cr_refs": [
         "CR 508.1d",
@@ -3931,7 +3967,7 @@
       "variants": [
         {
           "name": "Attacking",
-          "line": 1140,
+          "line": 1155,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3939,7 +3975,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1141,
+          "line": 1156,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3950,7 +3986,7 @@
     },
     "CombatTaxPending": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1149,
+      "line": 1164,
       "doc": "CR 508.1d + CR 509.1c: The declaration that is paused awaiting a combat-tax decision. Keyed by `CombatTaxContext` — the engine resumes the matching variant on `GameAction::PayCombatTax`.",
       "cr_refs": [
         "CR 508.1d",
@@ -3959,7 +3995,7 @@
       "variants": [
         {
           "name": "Attack",
-          "line": 1150,
+          "line": 1165,
           "kind": "struct",
           "field_names": [
             "attacks"
@@ -3969,7 +4005,7 @@
         },
         {
           "name": "Block",
-          "line": 1153,
+          "line": 1168,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -3982,7 +4018,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3672,
+      "line": 3678,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -3990,7 +4026,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 3675,
+          "line": 3681,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -4001,7 +4037,7 @@
         },
         {
           "name": "Any",
-          "line": 3679,
+          "line": 3685,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -4105,13 +4141,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3543,
+      "line": 3549,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 3544,
+          "line": 3550,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4119,7 +4155,7 @@
         },
         {
           "name": "LT",
-          "line": 3545,
+          "line": 3551,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4127,7 +4163,7 @@
         },
         {
           "name": "GE",
-          "line": 3546,
+          "line": 3552,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4135,7 +4171,7 @@
         },
         {
           "name": "LE",
-          "line": 3547,
+          "line": 3553,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4143,7 +4179,7 @@
         },
         {
           "name": "EQ",
-          "line": 3548,
+          "line": 3554,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4151,7 +4187,7 @@
         },
         {
           "name": "NE",
-          "line": 3549,
+          "line": 3555,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4162,13 +4198,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10981,
+      "line": 11007,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 10982,
+          "line": 11008,
           "kind": "struct",
           "field_names": [
             "values",
@@ -4179,7 +4215,7 @@
         },
         {
           "name": "SetName",
-          "line": 10997,
+          "line": 11023,
           "kind": "struct",
           "field_names": [
             "name"
@@ -4193,7 +4229,7 @@
         },
         {
           "name": "AddPower",
-          "line": 11000,
+          "line": 11026,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4203,7 +4239,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 11003,
+          "line": 11029,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4213,7 +4249,7 @@
         },
         {
           "name": "SetPower",
-          "line": 11006,
+          "line": 11032,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4223,7 +4259,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 11009,
+          "line": 11035,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4233,7 +4269,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 11012,
+          "line": 11038,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4243,7 +4279,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 11015,
+          "line": 11041,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4253,7 +4289,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 11018,
+          "line": 11044,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4263,7 +4299,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 11025,
+          "line": 11051,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -4275,7 +4311,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 11028,
+          "line": 11054,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4283,7 +4319,7 @@
         },
         {
           "name": "AddType",
-          "line": 11029,
+          "line": 11055,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4293,7 +4329,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 11032,
+          "line": 11058,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4303,7 +4339,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 11035,
+          "line": 11061,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4313,7 +4349,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 11038,
+          "line": 11064,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4323,7 +4359,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 11045,
+          "line": 11071,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4336,7 +4372,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 11051,
+          "line": 11077,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4349,7 +4385,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 11055,
+          "line": 11081,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4359,7 +4395,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 11059,
+          "line": 11085,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4369,7 +4405,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 11066,
+          "line": 11092,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4381,7 +4417,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 11071,
+          "line": 11097,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4393,7 +4429,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 11075,
+          "line": 11101,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4405,7 +4441,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 11079,
+          "line": 11105,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4417,7 +4453,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 11084,
+          "line": 11110,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4430,7 +4466,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 11090,
+          "line": 11116,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4438,7 +4474,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 11093,
+          "line": 11119,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4449,7 +4485,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 11096,
+          "line": 11122,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4459,7 +4495,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 11101,
+          "line": 11127,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4469,7 +4505,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 11108,
+          "line": 11134,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -4480,7 +4516,7 @@
         },
         {
           "name": "SetColor",
-          "line": 11109,
+          "line": 11135,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4490,7 +4526,7 @@
         },
         {
           "name": "AddColor",
-          "line": 11112,
+          "line": 11138,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4500,7 +4536,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 11117,
+          "line": 11143,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4510,7 +4546,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 11131,
+          "line": 11157,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4525,7 +4561,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 11135,
+          "line": 11161,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4535,7 +4571,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 11138,
+          "line": 11164,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -4545,7 +4581,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 11140,
+          "line": 11166,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -4555,7 +4591,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 11142,
+          "line": 11168,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -4565,7 +4601,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 11145,
+          "line": 11171,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -4575,7 +4611,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 11148,
+          "line": 11174,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -4587,7 +4623,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 11162,
+          "line": 11188,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -4599,7 +4635,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 11170,
+          "line": 11196,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4614,7 +4650,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 11179,
+          "line": 11205,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4629,7 +4665,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 11193,
+          "line": 11219,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -4791,7 +4827,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11272,
+      "line": 11298,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -4801,7 +4837,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 11275,
+          "line": 11301,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -4809,7 +4845,7 @@
         },
         {
           "name": "Finalized",
-          "line": 11277,
+          "line": 11303,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -4820,13 +4856,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4959,
+      "line": 4965,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 4960,
+          "line": 4966,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4837,7 +4873,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6927,
+      "line": 6933,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -4846,7 +4882,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 6929,
+          "line": 6935,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -4854,7 +4890,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 6931,
+          "line": 6937,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -4978,7 +5014,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4489,
+      "line": 4495,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -4986,54 +5022,6 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4490,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TapsSelf",
-          "line": 4491,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "UntapsSelf",
-          "line": 4492,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SacrificesPermanent",
-          "line": 4493,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysLife",
-          "line": 4494,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysLoyalty",
-          "line": 4495,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Discards",
           "line": 4496,
           "kind": "unit",
           "field_names": [],
@@ -5041,7 +5029,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExilesCards",
+          "name": "TapsSelf",
           "line": 4497,
           "kind": "unit",
           "field_names": [],
@@ -5049,7 +5037,7 @@
           "cr_refs": []
         },
         {
-          "name": "TapsOtherCreatures",
+          "name": "UntapsSelf",
           "line": 4498,
           "kind": "unit",
           "field_names": [],
@@ -5057,7 +5045,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemovesCounters",
+          "name": "SacrificesPermanent",
           "line": 4499,
           "kind": "unit",
           "field_names": [],
@@ -5065,7 +5053,7 @@
           "cr_refs": []
         },
         {
-          "name": "PaysEnergy",
+          "name": "PaysLife",
           "line": 4500,
           "kind": "unit",
           "field_names": [],
@@ -5073,7 +5061,7 @@
           "cr_refs": []
         },
         {
-          "name": "PaysSpeed",
+          "name": "PaysLoyalty",
           "line": 4501,
           "kind": "unit",
           "field_names": [],
@@ -5081,7 +5069,7 @@
           "cr_refs": []
         },
         {
-          "name": "ReturnsToHand",
+          "name": "Discards",
           "line": 4502,
           "kind": "unit",
           "field_names": [],
@@ -5089,7 +5077,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unattaches",
+          "name": "ExilesCards",
           "line": 4503,
           "kind": "unit",
           "field_names": [],
@@ -5097,7 +5085,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mills",
+          "name": "TapsOtherCreatures",
           "line": 4504,
           "kind": "unit",
           "field_names": [],
@@ -5105,7 +5093,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutsCounters",
+          "name": "RemovesCounters",
           "line": 4505,
           "kind": "unit",
           "field_names": [],
@@ -5113,7 +5101,7 @@
           "cr_refs": []
         },
         {
-          "name": "Reveals",
+          "name": "PaysEnergy",
           "line": 4506,
           "kind": "unit",
           "field_names": [],
@@ -5121,7 +5109,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exerts",
+          "name": "PaysSpeed",
           "line": 4507,
           "kind": "unit",
           "field_names": [],
@@ -5129,8 +5117,56 @@
           "cr_refs": []
         },
         {
-          "name": "KeywordCost",
+          "name": "ReturnsToHand",
           "line": 4508,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unattaches",
+          "line": 4509,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Mills",
+          "line": 4510,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PutsCounters",
+          "line": 4511,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Reveals",
+          "line": 4512,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Exerts",
+          "line": 4513,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "KeywordCost",
+          "line": 4514,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5593,7 +5629,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10442,
+      "line": 10468,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -5601,7 +5637,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10444,
+          "line": 10470,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -5609,7 +5645,7 @@
         },
         {
           "name": "Triple",
-          "line": 10446,
+          "line": 10472,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -5617,7 +5653,7 @@
         },
         {
           "name": "Plus",
-          "line": 10448,
+          "line": 10474,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5627,7 +5663,7 @@
         },
         {
           "name": "Minus",
-          "line": 10455,
+          "line": 10481,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5640,7 +5676,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 10459,
+          "line": 10485,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -5650,7 +5686,7 @@
         },
         {
           "name": "SetTo",
-          "line": 10465,
+          "line": 10491,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5662,7 +5698,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 10471,
+          "line": 10497,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -5712,7 +5748,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4940,
+      "line": 4946,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -5720,7 +5756,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 4942,
+          "line": 4948,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -5728,7 +5764,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 4945,
+          "line": 4951,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -5742,7 +5778,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10553,
+      "line": 10579,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -5750,7 +5786,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 10555,
+          "line": 10581,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -5758,7 +5794,7 @@
         },
         {
           "name": "Player",
-          "line": 10557,
+          "line": 10583,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5768,7 +5804,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 10560,
+          "line": 10586,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5781,7 +5817,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10541,
+      "line": 10567,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -5789,7 +5825,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10542,
+          "line": 10568,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5797,7 +5833,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10543,
+          "line": 10569,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5805,7 +5841,7 @@
         },
         {
           "name": "Controller",
-          "line": 10546,
+          "line": 10572,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -5813,7 +5849,7 @@
         },
         {
           "name": "Specific",
-          "line": 10547,
+          "line": 10573,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6356,7 +6392,7 @@
     },
     "DistributionUnit": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2899,
+      "line": 2922,
       "doc": "CR 601.2d: What is being distributed (damage, counters, life).",
       "cr_refs": [
         "CR 601.2d"
@@ -6364,7 +6400,7 @@
       "variants": [
         {
           "name": "Damage",
-          "line": 2900,
+          "line": 2923,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6372,7 +6408,7 @@
         },
         {
           "name": "EvenSplitDamage",
-          "line": 2903,
+          "line": 2926,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2d: Even split — engine auto-computes `total / num_targets` (rounded down). No player choice needed; bypasses `WaitingFor::DistributeAmong`.",
@@ -6382,7 +6418,7 @@
         },
         {
           "name": "Counters",
-          "line": 2904,
+          "line": 2927,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6390,7 +6426,7 @@
         },
         {
           "name": "Life",
-          "line": 2905,
+          "line": 2928,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6595,13 +6631,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5041,
+      "line": 5047,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 5043,
+          "line": 5049,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -6613,7 +6649,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 5049,
+          "line": 5055,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -6628,7 +6664,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 5060,
+          "line": 5066,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6640,7 +6676,7 @@
         },
         {
           "name": "Draw",
-          "line": 5080,
+          "line": 5086,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6656,7 +6692,7 @@
         },
         {
           "name": "Pump",
-          "line": 5086,
+          "line": 5092,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6668,7 +6704,7 @@
         },
         {
           "name": "PairWith",
-          "line": 5097,
+          "line": 5103,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6681,7 +6717,7 @@
         },
         {
           "name": "Destroy",
-          "line": 5100,
+          "line": 5106,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6692,7 +6728,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 5108,
+          "line": 5114,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6704,7 +6740,7 @@
         },
         {
           "name": "Counter",
-          "line": 5112,
+          "line": 5118,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6715,7 +6751,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 5133,
+          "line": 5139,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6729,7 +6765,7 @@
         },
         {
           "name": "Token",
-          "line": 5137,
+          "line": 5143,
           "kind": "struct",
           "field_names": [
             "name",
@@ -6752,7 +6788,7 @@
         },
         {
           "name": "GainLife",
-          "line": 5175,
+          "line": 5181,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6763,7 +6799,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 5182,
+          "line": 5188,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6774,7 +6810,7 @@
         },
         {
           "name": "Tap",
-          "line": 5189,
+          "line": 5195,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6784,7 +6820,7 @@
         },
         {
           "name": "Untap",
-          "line": 5193,
+          "line": 5199,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6794,7 +6830,7 @@
         },
         {
           "name": "TapAll",
-          "line": 5198,
+          "line": 5204,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6806,7 +6842,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 5203,
+          "line": 5209,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6818,7 +6854,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 5207,
+          "line": 5213,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6830,7 +6866,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 5214,
+          "line": 5220,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6842,7 +6878,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5222,
+          "line": 5228,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6854,7 +6890,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 5243,
+          "line": 5249,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6865,7 +6901,7 @@
         },
         {
           "name": "Mill",
-          "line": 5249,
+          "line": 5255,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6877,7 +6913,7 @@
         },
         {
           "name": "Scry",
-          "line": 5266,
+          "line": 5272,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6892,7 +6928,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 5272,
+          "line": 5278,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6904,7 +6940,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 5286,
+          "line": 5292,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6921,7 +6957,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 5310,
+          "line": 5316,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6934,7 +6970,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 5314,
+          "line": 5320,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6945,7 +6981,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 5321,
+          "line": 5327,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6964,7 +7000,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 5372,
+          "line": 5378,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -6977,7 +7013,7 @@
         },
         {
           "name": "Dig",
-          "line": 5385,
+          "line": 5391,
           "kind": "struct",
           "field_names": [
             "player",
@@ -6997,7 +7033,7 @@
         },
         {
           "name": "GainControl",
-          "line": 5411,
+          "line": 5417,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7007,7 +7043,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 5415,
+          "line": 5421,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7018,7 +7054,7 @@
         },
         {
           "name": "Attach",
-          "line": 5421,
+          "line": 5427,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7029,7 +7065,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 5433,
+          "line": 5439,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7042,7 +7078,7 @@
         },
         {
           "name": "Surveil",
-          "line": 5445,
+          "line": 5451,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7057,7 +7093,7 @@
         },
         {
           "name": "Fight",
-          "line": 5451,
+          "line": 5457,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7068,7 +7104,7 @@
         },
         {
           "name": "Bounce",
-          "line": 5459,
+          "line": 5465,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7080,7 +7116,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 5478,
+          "line": 5484,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7095,7 +7131,7 @@
         },
         {
           "name": "Explore",
-          "line": 5486,
+          "line": 5492,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7103,7 +7139,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 5490,
+          "line": 5496,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7115,7 +7151,7 @@
         },
         {
           "name": "Investigate",
-          "line": 5495,
+          "line": 5501,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.136: Investigate — create a Clue artifact token.",
@@ -7125,7 +7161,7 @@
         },
         {
           "name": "Tribute",
-          "line": 5502,
+          "line": 5508,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7138,7 +7174,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 5508,
+          "line": 5514,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -7148,7 +7184,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 5510,
+          "line": 5516,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -7158,7 +7194,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 5511,
+          "line": 5517,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7166,7 +7202,7 @@
         },
         {
           "name": "Populate",
-          "line": 5513,
+          "line": 5519,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -7176,7 +7212,7 @@
         },
         {
           "name": "Clash",
-          "line": 5515,
+          "line": 5521,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -7186,7 +7222,7 @@
         },
         {
           "name": "Vote",
-          "line": 5530,
+          "line": 5536,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7202,7 +7238,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 5574,
+          "line": 5580,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -7222,7 +7258,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 5593,
+          "line": 5599,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7234,7 +7270,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 5597,
+          "line": 5603,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7245,7 +7281,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 5606,
+          "line": 5612,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7258,7 +7294,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 5617,
+          "line": 5623,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7278,7 +7314,7 @@
         },
         {
           "name": "Myriad",
-          "line": 5664,
+          "line": 5670,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -7288,7 +7324,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 5667,
+          "line": 5673,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7304,7 +7340,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 5677,
+          "line": 5683,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7315,7 +7351,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 5683,
+          "line": 5689,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7327,7 +7363,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 5691,
+          "line": 5697,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7341,7 +7377,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 5698,
+          "line": 5704,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7353,7 +7389,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 5706,
+          "line": 5712,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7366,7 +7402,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 5712,
+          "line": 5718,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7379,7 +7415,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 5720,
+          "line": 5726,
           "kind": "struct",
           "field_names": [
             "source",
@@ -7397,7 +7433,7 @@
         },
         {
           "name": "Animate",
-          "line": 5740,
+          "line": 5746,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7412,7 +7448,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 5774,
+          "line": 5780,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -7436,7 +7472,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 5790,
+          "line": 5796,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -7446,7 +7482,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 5794,
+          "line": 5800,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -7458,7 +7494,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 5802,
+          "line": 5808,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -7475,7 +7511,7 @@
         },
         {
           "name": "Mana",
-          "line": 5820,
+          "line": 5826,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -7489,7 +7525,7 @@
         },
         {
           "name": "Discard",
-          "line": 5843,
+          "line": 5849,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7503,7 +7539,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 5865,
+          "line": 5871,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7513,7 +7549,7 @@
         },
         {
           "name": "Transform",
-          "line": 5869,
+          "line": 5875,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7523,7 +7559,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 5875,
+          "line": 5881,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7538,7 +7574,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 5917,
+          "line": 5923,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7556,7 +7592,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 5928,
+          "line": 5934,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7570,7 +7606,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 5952,
+          "line": 5958,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7583,7 +7619,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5963,
+          "line": 5969,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7596,7 +7632,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 5968,
+          "line": 5974,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7609,7 +7645,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 5977,
+          "line": 5983,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7621,7 +7657,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 6000,
+          "line": 6006,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7631,7 +7667,7 @@
         },
         {
           "name": "Choose",
-          "line": 6006,
+          "line": 6012,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -7642,7 +7678,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 6017,
+          "line": 6023,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -7655,7 +7691,7 @@
         },
         {
           "name": "Suspect",
-          "line": 6022,
+          "line": 6028,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7667,7 +7703,7 @@
         },
         {
           "name": "Connive",
-          "line": 6029,
+          "line": 6035,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7681,7 +7717,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 6037,
+          "line": 6043,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7693,7 +7729,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 6044,
+          "line": 6050,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7705,7 +7741,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 6049,
+          "line": 6055,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7717,7 +7753,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 6054,
+          "line": 6060,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -7727,7 +7763,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 6061,
+          "line": 6067,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7739,7 +7775,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 6068,
+          "line": 6074,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7751,7 +7787,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 6073,
+          "line": 6079,
           "kind": "struct",
           "field_names": [
             "level"
@@ -7763,7 +7799,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 6078,
+          "line": 6084,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -7777,7 +7813,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 6108,
+          "line": 6114,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -7791,7 +7827,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 6114,
+          "line": 6120,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -7803,7 +7839,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 6119,
+          "line": 6125,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7816,7 +7852,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 6126,
+          "line": 6132,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -7829,7 +7865,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 6135,
+          "line": 6141,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7842,7 +7878,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 6143,
+          "line": 6149,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -7856,7 +7892,7 @@
         },
         {
           "name": "PayCost",
-          "line": 6153,
+          "line": 6159,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -7869,7 +7905,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 6164,
+          "line": 6170,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7887,7 +7923,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 6194,
+          "line": 6200,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7903,7 +7939,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 6233,
+          "line": 6239,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -7924,7 +7960,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 6263,
+          "line": 6269,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: A player who meets this effect's condition loses the game. The affected player is determined by resolution context (controller's opponent if untargeted, or explicit target if targeted).",
@@ -7934,7 +7970,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 6265,
+          "line": 6271,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: The controller wins the game — all opponents lose.",
@@ -7944,7 +7980,7 @@
         },
         {
           "name": "RollDie",
-          "line": 6270,
+          "line": 6276,
           "kind": "struct",
           "field_names": [
             "sides",
@@ -7959,7 +7995,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 6278,
+          "line": 6284,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -7972,7 +8008,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 6290,
+          "line": 6296,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7986,7 +8022,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 6299,
+          "line": 6305,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -7998,7 +8034,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 6304,
+          "line": 6310,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -8008,7 +8044,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 6307,
+          "line": 6313,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -8018,7 +8054,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 6309,
+          "line": 6315,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -8030,7 +8066,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 6314,
+          "line": 6320,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -8041,7 +8077,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 6317,
+          "line": 6323,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -8051,7 +8087,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 6320,
+          "line": 6326,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -8063,7 +8099,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 6337,
+          "line": 6343,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8082,7 +8118,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 6370,
+          "line": 6376,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8097,7 +8133,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 6383,
+          "line": 6389,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -8111,7 +8147,7 @@
         },
         {
           "name": "Exploit",
-          "line": 6392,
+          "line": 6398,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8123,7 +8159,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 6397,
+          "line": 6403,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8135,7 +8171,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 6402,
+          "line": 6408,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -8150,7 +8186,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 6414,
+          "line": 6420,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8162,7 +8198,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 6426,
+          "line": 6432,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8178,7 +8214,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 6437,
+          "line": 6443,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8196,7 +8232,7 @@
         },
         {
           "name": "Discover",
-          "line": 6471,
+          "line": 6477,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -8208,7 +8244,7 @@
         },
         {
           "name": "Cascade",
-          "line": 6483,
+          "line": 6489,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -8218,7 +8254,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 6487,
+          "line": 6493,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8230,7 +8266,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 6492,
+          "line": 6498,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8242,7 +8278,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 6505,
+          "line": 6511,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8254,7 +8290,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 6514,
+          "line": 6520,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8266,7 +8302,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 6523,
+          "line": 6529,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8276,7 +8312,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 6528,
+          "line": 6534,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -8286,7 +8322,7 @@
         },
         {
           "name": "Goad",
-          "line": 6534,
+          "line": 6540,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8298,7 +8334,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 6541,
+          "line": 6547,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8310,7 +8346,7 @@
         },
         {
           "name": "Detain",
-          "line": 6548,
+          "line": 6554,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8322,7 +8358,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 6559,
+          "line": 6565,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -8336,7 +8372,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 6570,
+          "line": 6576,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8350,7 +8386,7 @@
         },
         {
           "name": "Manifest",
-          "line": 6585,
+          "line": 6591,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8363,7 +8399,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 6591,
+          "line": 6597,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -8373,7 +8409,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 6595,
+          "line": 6601,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8385,7 +8421,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 6609,
+          "line": 6615,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8398,7 +8434,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 6620,
+          "line": 6626,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8411,7 +8447,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 6630,
+          "line": 6636,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8425,7 +8461,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 6642,
+          "line": 6648,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8441,7 +8477,7 @@
         },
         {
           "name": "Double",
-          "line": 6653,
+          "line": 6659,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -8455,7 +8491,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 6661,
+          "line": 6667,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -8467,7 +8503,7 @@
         },
         {
           "name": "Incubate",
-          "line": 6667,
+          "line": 6673,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8479,7 +8515,7 @@
         },
         {
           "name": "Amass",
-          "line": 6675,
+          "line": 6681,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -8492,7 +8528,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 6683,
+          "line": 6689,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8504,7 +8540,7 @@
         },
         {
           "name": "Renown",
-          "line": 6689,
+          "line": 6695,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8516,7 +8552,7 @@
         },
         {
           "name": "Bolster",
-          "line": 6695,
+          "line": 6701,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8528,7 +8564,7 @@
         },
         {
           "name": "Adapt",
-          "line": 6701,
+          "line": 6707,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8540,7 +8576,7 @@
         },
         {
           "name": "Learn",
-          "line": 6707,
+          "line": 6713,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -8550,7 +8586,7 @@
         },
         {
           "name": "Forage",
-          "line": 6709,
+          "line": 6715,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -8560,7 +8596,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6711,
+          "line": 6717,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8572,7 +8608,7 @@
         },
         {
           "name": "Endure",
-          "line": 6718,
+          "line": 6724,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8585,7 +8621,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 6723,
+          "line": 6729,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8597,7 +8633,7 @@
         },
         {
           "name": "Seek",
-          "line": 6728,
+          "line": 6734,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -8611,7 +8647,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 6745,
+          "line": 6751,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8624,7 +8660,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 6760,
+          "line": 6766,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8640,7 +8676,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 6767,
+          "line": 6773,
           "kind": "struct",
           "field_names": [
             "to"
@@ -8652,7 +8688,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 6772,
+          "line": 6778,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8665,7 +8701,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 6781,
+          "line": 6787,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8677,7 +8713,7 @@
         },
         {
           "name": "Conjure",
-          "line": 6788,
+          "line": 6794,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -8689,7 +8725,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 6809,
+          "line": 6815,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8703,7 +8739,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6820,
+          "line": 6826,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8798,13 +8834,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11660,
+      "line": 11686,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 11662,
+          "line": 11688,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8812,7 +8848,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 11664,
+          "line": 11690,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8820,7 +8856,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 11666,
+          "line": 11692,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8828,7 +8864,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 11668,
+          "line": 11694,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8836,7 +8872,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 11670,
+          "line": 11696,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8844,7 +8880,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 11672,
+          "line": 11698,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8855,60 +8891,12 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7794,
+      "line": 7800,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7795,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeSpeed",
-          "line": 7796,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DealDamage",
-          "line": 7797,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Draw",
-          "line": 7798,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Pump",
-          "line": 7799,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PairWith",
-          "line": 7800,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Destroy",
           "line": 7801,
           "kind": "unit",
           "field_names": [],
@@ -8916,7 +8904,7 @@
           "cr_refs": []
         },
         {
-          "name": "Counter",
+          "name": "ChangeSpeed",
           "line": 7802,
           "kind": "unit",
           "field_names": [],
@@ -8924,7 +8912,7 @@
           "cr_refs": []
         },
         {
-          "name": "CounterAll",
+          "name": "DealDamage",
           "line": 7803,
           "kind": "unit",
           "field_names": [],
@@ -8932,7 +8920,7 @@
           "cr_refs": []
         },
         {
-          "name": "Token",
+          "name": "Draw",
           "line": 7804,
           "kind": "unit",
           "field_names": [],
@@ -8940,7 +8928,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainLife",
+          "name": "Pump",
           "line": 7805,
           "kind": "unit",
           "field_names": [],
@@ -8948,7 +8936,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseLife",
+          "name": "PairWith",
           "line": 7806,
           "kind": "unit",
           "field_names": [],
@@ -8956,7 +8944,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tap",
+          "name": "Destroy",
           "line": 7807,
           "kind": "unit",
           "field_names": [],
@@ -8964,7 +8952,7 @@
           "cr_refs": []
         },
         {
-          "name": "Untap",
+          "name": "Counter",
           "line": 7808,
           "kind": "unit",
           "field_names": [],
@@ -8972,7 +8960,7 @@
           "cr_refs": []
         },
         {
-          "name": "AddCounter",
+          "name": "CounterAll",
           "line": 7809,
           "kind": "unit",
           "field_names": [],
@@ -8980,7 +8968,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveCounter",
+          "name": "Token",
           "line": 7810,
           "kind": "unit",
           "field_names": [],
@@ -8988,7 +8976,7 @@
           "cr_refs": []
         },
         {
-          "name": "Sacrifice",
+          "name": "GainLife",
           "line": 7811,
           "kind": "unit",
           "field_names": [],
@@ -8996,7 +8984,7 @@
           "cr_refs": []
         },
         {
-          "name": "DiscardCard",
+          "name": "LoseLife",
           "line": 7812,
           "kind": "unit",
           "field_names": [],
@@ -9004,7 +8992,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mill",
+          "name": "Tap",
           "line": 7813,
           "kind": "unit",
           "field_names": [],
@@ -9012,7 +9000,7 @@
           "cr_refs": []
         },
         {
-          "name": "Scry",
+          "name": "Untap",
           "line": 7814,
           "kind": "unit",
           "field_names": [],
@@ -9020,7 +9008,7 @@
           "cr_refs": []
         },
         {
-          "name": "PumpAll",
+          "name": "AddCounter",
           "line": 7815,
           "kind": "unit",
           "field_names": [],
@@ -9028,7 +9016,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageAll",
+          "name": "RemoveCounter",
           "line": 7816,
           "kind": "unit",
           "field_names": [],
@@ -9036,7 +9024,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageEachPlayer",
+          "name": "Sacrifice",
           "line": 7817,
           "kind": "unit",
           "field_names": [],
@@ -9044,7 +9032,7 @@
           "cr_refs": []
         },
         {
-          "name": "DestroyAll",
+          "name": "DiscardCard",
           "line": 7818,
           "kind": "unit",
           "field_names": [],
@@ -9052,7 +9040,7 @@
           "cr_refs": []
         },
         {
-          "name": "TapAll",
+          "name": "Mill",
           "line": 7819,
           "kind": "unit",
           "field_names": [],
@@ -9060,7 +9048,7 @@
           "cr_refs": []
         },
         {
-          "name": "UntapAll",
+          "name": "Scry",
           "line": 7820,
           "kind": "unit",
           "field_names": [],
@@ -9068,7 +9056,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZone",
+          "name": "PumpAll",
           "line": 7821,
           "kind": "unit",
           "field_names": [],
@@ -9076,7 +9064,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZoneAll",
+          "name": "DamageAll",
           "line": 7822,
           "kind": "unit",
           "field_names": [],
@@ -9084,7 +9072,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dig",
+          "name": "DamageEachPlayer",
           "line": 7823,
           "kind": "unit",
           "field_names": [],
@@ -9092,7 +9080,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainControl",
+          "name": "DestroyAll",
           "line": 7824,
           "kind": "unit",
           "field_names": [],
@@ -9100,7 +9088,7 @@
           "cr_refs": []
         },
         {
-          "name": "ControlNextTurn",
+          "name": "TapAll",
           "line": 7825,
           "kind": "unit",
           "field_names": [],
@@ -9108,7 +9096,7 @@
           "cr_refs": []
         },
         {
-          "name": "Attach",
+          "name": "UntapAll",
           "line": 7826,
           "kind": "unit",
           "field_names": [],
@@ -9116,7 +9104,7 @@
           "cr_refs": []
         },
         {
-          "name": "AttachAll",
+          "name": "ChangeZone",
           "line": 7827,
           "kind": "unit",
           "field_names": [],
@@ -9124,7 +9112,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnattachAll",
+          "name": "ChangeZoneAll",
           "line": 7828,
           "kind": "unit",
           "field_names": [],
@@ -9132,7 +9120,7 @@
           "cr_refs": []
         },
         {
-          "name": "Surveil",
+          "name": "Dig",
           "line": 7829,
           "kind": "unit",
           "field_names": [],
@@ -9140,7 +9128,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fight",
+          "name": "GainControl",
           "line": 7830,
           "kind": "unit",
           "field_names": [],
@@ -9148,7 +9136,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bounce",
+          "name": "ControlNextTurn",
           "line": 7831,
           "kind": "unit",
           "field_names": [],
@@ -9156,7 +9144,7 @@
           "cr_refs": []
         },
         {
-          "name": "BounceAll",
+          "name": "Attach",
           "line": 7832,
           "kind": "unit",
           "field_names": [],
@@ -9164,7 +9152,7 @@
           "cr_refs": []
         },
         {
-          "name": "Explore",
+          "name": "AttachAll",
           "line": 7833,
           "kind": "unit",
           "field_names": [],
@@ -9172,7 +9160,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExploreAll",
+          "name": "UnattachAll",
           "line": 7834,
           "kind": "unit",
           "field_names": [],
@@ -9180,7 +9168,7 @@
           "cr_refs": []
         },
         {
-          "name": "Investigate",
+          "name": "Surveil",
           "line": 7835,
           "kind": "unit",
           "field_names": [],
@@ -9188,7 +9176,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tribute",
+          "name": "Fight",
           "line": 7836,
           "kind": "unit",
           "field_names": [],
@@ -9196,7 +9184,7 @@
           "cr_refs": []
         },
         {
-          "name": "TimeTravel",
+          "name": "Bounce",
           "line": 7837,
           "kind": "unit",
           "field_names": [],
@@ -9204,7 +9192,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomeMonarch",
+          "name": "BounceAll",
           "line": 7838,
           "kind": "unit",
           "field_names": [],
@@ -9212,7 +9200,7 @@
           "cr_refs": []
         },
         {
-          "name": "Proliferate",
+          "name": "Explore",
           "line": 7839,
           "kind": "unit",
           "field_names": [],
@@ -9220,7 +9208,7 @@
           "cr_refs": []
         },
         {
-          "name": "Populate",
+          "name": "ExploreAll",
           "line": 7840,
           "kind": "unit",
           "field_names": [],
@@ -9228,7 +9216,7 @@
           "cr_refs": []
         },
         {
-          "name": "Clash",
+          "name": "Investigate",
           "line": 7841,
           "kind": "unit",
           "field_names": [],
@@ -9236,8 +9224,56 @@
           "cr_refs": []
         },
         {
-          "name": "Vote",
+          "name": "Tribute",
+          "line": 7842,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TimeTravel",
           "line": 7843,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomeMonarch",
+          "line": 7844,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Proliferate",
+          "line": 7845,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Populate",
+          "line": 7846,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Clash",
+          "line": 7847,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Vote",
+          "line": 7849,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -9247,7 +9283,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7845,
+          "line": 7851,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -9257,54 +9293,6 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7846,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopySpell",
-          "line": 7847,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastCopyOfCard",
-          "line": 7848,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopyTokenOf",
-          "line": 7849,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Myriad",
-          "line": 7850,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BecomeCopy",
-          "line": 7851,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseCard",
           "line": 7852,
           "kind": "unit",
           "field_names": [],
@@ -9312,7 +9300,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutCounter",
+          "name": "CopySpell",
           "line": 7853,
           "kind": "unit",
           "field_names": [],
@@ -9320,7 +9308,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutCounterAll",
+          "name": "CastCopyOfCard",
           "line": 7854,
           "kind": "unit",
           "field_names": [],
@@ -9328,7 +9316,7 @@
           "cr_refs": []
         },
         {
-          "name": "MultiplyCounter",
+          "name": "CopyTokenOf",
           "line": 7855,
           "kind": "unit",
           "field_names": [],
@@ -9336,7 +9324,7 @@
           "cr_refs": []
         },
         {
-          "name": "DoublePT",
+          "name": "Myriad",
           "line": 7856,
           "kind": "unit",
           "field_names": [],
@@ -9344,7 +9332,7 @@
           "cr_refs": []
         },
         {
-          "name": "DoublePTAll",
+          "name": "BecomeCopy",
           "line": 7857,
           "kind": "unit",
           "field_names": [],
@@ -9352,7 +9340,7 @@
           "cr_refs": []
         },
         {
-          "name": "MoveCounters",
+          "name": "ChooseCard",
           "line": 7858,
           "kind": "unit",
           "field_names": [],
@@ -9360,7 +9348,7 @@
           "cr_refs": []
         },
         {
-          "name": "Animate",
+          "name": "PutCounter",
           "line": 7859,
           "kind": "unit",
           "field_names": [],
@@ -9368,7 +9356,7 @@
           "cr_refs": []
         },
         {
-          "name": "ReturnAsAura",
+          "name": "PutCounterAll",
           "line": 7860,
           "kind": "unit",
           "field_names": [],
@@ -9376,7 +9364,7 @@
           "cr_refs": []
         },
         {
-          "name": "RegisterBending",
+          "name": "MultiplyCounter",
           "line": 7861,
           "kind": "unit",
           "field_names": [],
@@ -9384,7 +9372,7 @@
           "cr_refs": []
         },
         {
-          "name": "GenericEffect",
+          "name": "DoublePT",
           "line": 7862,
           "kind": "unit",
           "field_names": [],
@@ -9392,7 +9380,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cleanup",
+          "name": "DoublePTAll",
           "line": 7863,
           "kind": "unit",
           "field_names": [],
@@ -9400,7 +9388,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mana",
+          "name": "MoveCounters",
           "line": 7864,
           "kind": "unit",
           "field_names": [],
@@ -9408,7 +9396,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discard",
+          "name": "Animate",
           "line": 7865,
           "kind": "unit",
           "field_names": [],
@@ -9416,7 +9404,7 @@
           "cr_refs": []
         },
         {
-          "name": "Shuffle",
+          "name": "ReturnAsAura",
           "line": 7866,
           "kind": "unit",
           "field_names": [],
@@ -9424,7 +9412,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchLibrary",
+          "name": "RegisterBending",
           "line": 7867,
           "kind": "unit",
           "field_names": [],
@@ -9432,7 +9420,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchOutsideGame",
+          "name": "GenericEffect",
           "line": 7868,
           "kind": "unit",
           "field_names": [],
@@ -9440,7 +9428,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileTop",
+          "name": "Cleanup",
           "line": 7869,
           "kind": "unit",
           "field_names": [],
@@ -9448,7 +9436,7 @@
           "cr_refs": []
         },
         {
-          "name": "TargetOnly",
+          "name": "Mana",
           "line": 7870,
           "kind": "unit",
           "field_names": [],
@@ -9456,7 +9444,7 @@
           "cr_refs": []
         },
         {
-          "name": "Choose",
+          "name": "Discard",
           "line": 7871,
           "kind": "unit",
           "field_names": [],
@@ -9464,7 +9452,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDamageSource",
+          "name": "Shuffle",
           "line": 7872,
           "kind": "unit",
           "field_names": [],
@@ -9472,7 +9460,7 @@
           "cr_refs": []
         },
         {
-          "name": "Suspect",
+          "name": "SearchLibrary",
           "line": 7873,
           "kind": "unit",
           "field_names": [],
@@ -9480,7 +9468,7 @@
           "cr_refs": []
         },
         {
-          "name": "Connive",
+          "name": "SearchOutsideGame",
           "line": 7874,
           "kind": "unit",
           "field_names": [],
@@ -9488,7 +9476,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseOut",
+          "name": "ExileTop",
           "line": 7875,
           "kind": "unit",
           "field_names": [],
@@ -9496,7 +9484,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseIn",
+          "name": "TargetOnly",
           "line": 7876,
           "kind": "unit",
           "field_names": [],
@@ -9504,7 +9492,7 @@
           "cr_refs": []
         },
         {
-          "name": "ForceBlock",
+          "name": "Choose",
           "line": 7877,
           "kind": "unit",
           "field_names": [],
@@ -9512,7 +9500,7 @@
           "cr_refs": []
         },
         {
-          "name": "SolveCase",
+          "name": "ChooseDamageSource",
           "line": 7878,
           "kind": "unit",
           "field_names": [],
@@ -9520,8 +9508,56 @@
           "cr_refs": []
         },
         {
-          "name": "BecomePrepared",
+          "name": "Suspect",
+          "line": 7879,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Connive",
           "line": 7880,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseOut",
+          "line": 7881,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseIn",
+          "line": 7882,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ForceBlock",
+          "line": 7883,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SolveCase",
+          "line": 7884,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomePrepared",
+          "line": 7886,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -9531,7 +9567,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 7882,
+          "line": 7888,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -9541,54 +9577,6 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 7883,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDelayedTrigger",
-          "line": 7884,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddTargetReplacement",
-          "line": 7885,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddRestriction",
-          "line": 7886,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReduceNextSpellCost",
-          "line": 7887,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantNextSpellAbility",
-          "line": 7888,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddPendingETBCounters",
           "line": 7889,
           "kind": "unit",
           "field_names": [],
@@ -9596,7 +9584,7 @@
           "cr_refs": []
         },
         {
-          "name": "CreateEmblem",
+          "name": "CreateDelayedTrigger",
           "line": 7890,
           "kind": "unit",
           "field_names": [],
@@ -9604,7 +9592,7 @@
           "cr_refs": []
         },
         {
-          "name": "PayCost",
+          "name": "AddTargetReplacement",
           "line": 7891,
           "kind": "unit",
           "field_names": [],
@@ -9612,7 +9600,7 @@
           "cr_refs": []
         },
         {
-          "name": "CastFromZone",
+          "name": "AddRestriction",
           "line": 7892,
           "kind": "unit",
           "field_names": [],
@@ -9620,7 +9608,7 @@
           "cr_refs": []
         },
         {
-          "name": "PreventDamage",
+          "name": "ReduceNextSpellCost",
           "line": 7893,
           "kind": "unit",
           "field_names": [],
@@ -9628,7 +9616,7 @@
           "cr_refs": []
         },
         {
-          "name": "CreateDamageReplacement",
+          "name": "GrantNextSpellAbility",
           "line": 7894,
           "kind": "unit",
           "field_names": [],
@@ -9636,7 +9624,7 @@
           "cr_refs": []
         },
         {
-          "name": "Regenerate",
+          "name": "AddPendingETBCounters",
           "line": 7895,
           "kind": "unit",
           "field_names": [],
@@ -9644,7 +9632,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseTheGame",
+          "name": "CreateEmblem",
           "line": 7896,
           "kind": "unit",
           "field_names": [],
@@ -9652,7 +9640,7 @@
           "cr_refs": []
         },
         {
-          "name": "WinTheGame",
+          "name": "PayCost",
           "line": 7897,
           "kind": "unit",
           "field_names": [],
@@ -9660,7 +9648,7 @@
           "cr_refs": []
         },
         {
-          "name": "RollDie",
+          "name": "CastFromZone",
           "line": 7898,
           "kind": "unit",
           "field_names": [],
@@ -9668,7 +9656,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoin",
+          "name": "PreventDamage",
           "line": 7899,
           "kind": "unit",
           "field_names": [],
@@ -9676,7 +9664,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoins",
+          "name": "CreateDamageReplacement",
           "line": 7900,
           "kind": "unit",
           "field_names": [],
@@ -9684,7 +9672,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoinUntilLose",
+          "name": "Regenerate",
           "line": 7901,
           "kind": "unit",
           "field_names": [],
@@ -9692,7 +9680,7 @@
           "cr_refs": []
         },
         {
-          "name": "RingTemptsYou",
+          "name": "LoseTheGame",
           "line": 7902,
           "kind": "unit",
           "field_names": [],
@@ -9700,7 +9688,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureIntoDungeon",
+          "name": "WinTheGame",
           "line": 7903,
           "kind": "unit",
           "field_names": [],
@@ -9708,7 +9696,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureInto",
+          "name": "RollDie",
           "line": 7904,
           "kind": "unit",
           "field_names": [],
@@ -9716,7 +9704,7 @@
           "cr_refs": []
         },
         {
-          "name": "TakeTheInitiative",
+          "name": "FlipCoin",
           "line": 7905,
           "kind": "unit",
           "field_names": [],
@@ -9724,7 +9712,7 @@
           "cr_refs": []
         },
         {
-          "name": "ProcessRadCounters",
+          "name": "FlipCoins",
           "line": 7906,
           "kind": "unit",
           "field_names": [],
@@ -9732,7 +9720,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantCastingPermission",
+          "name": "FlipCoinUntilLose",
           "line": 7907,
           "kind": "unit",
           "field_names": [],
@@ -9740,7 +9728,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseFromZone",
+          "name": "RingTemptsYou",
           "line": 7908,
           "kind": "unit",
           "field_names": [],
@@ -9748,7 +9736,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseObjectsIntoTrackedSet",
+          "name": "VentureIntoDungeon",
           "line": 7909,
           "kind": "unit",
           "field_names": [],
@@ -9756,7 +9744,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseAndSacrificeRest",
+          "name": "VentureInto",
           "line": 7910,
           "kind": "unit",
           "field_names": [],
@@ -9764,7 +9752,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exploit",
+          "name": "TakeTheInitiative",
           "line": 7911,
           "kind": "unit",
           "field_names": [],
@@ -9772,7 +9760,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainEnergy",
+          "name": "ProcessRadCounters",
           "line": 7912,
           "kind": "unit",
           "field_names": [],
@@ -9780,7 +9768,7 @@
           "cr_refs": []
         },
         {
-          "name": "GivePlayerCounter",
+          "name": "GrantCastingPermission",
           "line": 7913,
           "kind": "unit",
           "field_names": [],
@@ -9788,7 +9776,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseAllPlayerCounters",
+          "name": "ChooseFromZone",
           "line": 7914,
           "kind": "unit",
           "field_names": [],
@@ -9796,7 +9784,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileFromTopUntil",
+          "name": "ChooseObjectsIntoTrackedSet",
           "line": 7915,
           "kind": "unit",
           "field_names": [],
@@ -9804,7 +9792,7 @@
           "cr_refs": []
         },
         {
-          "name": "RevealUntil",
+          "name": "ChooseAndSacrificeRest",
           "line": 7916,
           "kind": "unit",
           "field_names": [],
@@ -9812,7 +9800,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discover",
+          "name": "Exploit",
           "line": 7917,
           "kind": "unit",
           "field_names": [],
@@ -9820,7 +9808,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cascade",
+          "name": "GainEnergy",
           "line": 7918,
           "kind": "unit",
           "field_names": [],
@@ -9828,7 +9816,7 @@
           "cr_refs": []
         },
         {
-          "name": "MiracleCast",
+          "name": "GivePlayerCounter",
           "line": 7919,
           "kind": "unit",
           "field_names": [],
@@ -9836,7 +9824,7 @@
           "cr_refs": []
         },
         {
-          "name": "MadnessCast",
+          "name": "LoseAllPlayerCounters",
           "line": 7920,
           "kind": "unit",
           "field_names": [],
@@ -9844,7 +9832,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutAtLibraryPosition",
+          "name": "ExileFromTopUntil",
           "line": 7921,
           "kind": "unit",
           "field_names": [],
@@ -9852,7 +9840,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDrawnThisTurnPayOrTopdeck",
+          "name": "RevealUntil",
           "line": 7922,
           "kind": "unit",
           "field_names": [],
@@ -9860,7 +9848,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutOnTopOrBottom",
+          "name": "Discover",
           "line": 7923,
           "kind": "unit",
           "field_names": [],
@@ -9868,7 +9856,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiftDelivery",
+          "name": "Cascade",
           "line": 7924,
           "kind": "unit",
           "field_names": [],
@@ -9876,7 +9864,7 @@
           "cr_refs": []
         },
         {
-          "name": "Goad",
+          "name": "MiracleCast",
           "line": 7925,
           "kind": "unit",
           "field_names": [],
@@ -9884,7 +9872,7 @@
           "cr_refs": []
         },
         {
-          "name": "GoadAll",
+          "name": "MadnessCast",
           "line": 7926,
           "kind": "unit",
           "field_names": [],
@@ -9892,7 +9880,7 @@
           "cr_refs": []
         },
         {
-          "name": "Detain",
+          "name": "PutAtLibraryPosition",
           "line": 7927,
           "kind": "unit",
           "field_names": [],
@@ -9900,7 +9888,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeControl",
+          "name": "ChooseDrawnThisTurnPayOrTopdeck",
           "line": 7928,
           "kind": "unit",
           "field_names": [],
@@ -9908,7 +9896,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeTargets",
+          "name": "PutOnTopOrBottom",
           "line": 7929,
           "kind": "unit",
           "field_names": [],
@@ -9916,7 +9904,7 @@
           "cr_refs": []
         },
         {
-          "name": "Incubate",
+          "name": "GiftDelivery",
           "line": 7930,
           "kind": "unit",
           "field_names": [],
@@ -9924,7 +9912,7 @@
           "cr_refs": []
         },
         {
-          "name": "Amass",
+          "name": "Goad",
           "line": 7931,
           "kind": "unit",
           "field_names": [],
@@ -9932,7 +9920,7 @@
           "cr_refs": []
         },
         {
-          "name": "Monstrosity",
+          "name": "GoadAll",
           "line": 7932,
           "kind": "unit",
           "field_names": [],
@@ -9940,7 +9928,7 @@
           "cr_refs": []
         },
         {
-          "name": "Renown",
+          "name": "Detain",
           "line": 7933,
           "kind": "unit",
           "field_names": [],
@@ -9948,7 +9936,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bolster",
+          "name": "ExchangeControl",
           "line": 7934,
           "kind": "unit",
           "field_names": [],
@@ -9956,7 +9944,7 @@
           "cr_refs": []
         },
         {
-          "name": "Adapt",
+          "name": "ChangeTargets",
           "line": 7935,
           "kind": "unit",
           "field_names": [],
@@ -9964,7 +9952,7 @@
           "cr_refs": []
         },
         {
-          "name": "Manifest",
+          "name": "Incubate",
           "line": 7936,
           "kind": "unit",
           "field_names": [],
@@ -9972,7 +9960,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "Amass",
           "line": 7937,
           "kind": "unit",
           "field_names": [],
@@ -9980,7 +9968,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExtraTurn",
+          "name": "Monstrosity",
           "line": 7938,
           "kind": "unit",
           "field_names": [],
@@ -9988,7 +9976,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantExtraLoyaltyActivations",
+          "name": "Renown",
           "line": 7939,
           "kind": "unit",
           "field_names": [],
@@ -9996,7 +9984,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextTurn",
+          "name": "Bolster",
           "line": 7940,
           "kind": "unit",
           "field_names": [],
@@ -10004,7 +9992,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextStep",
+          "name": "Adapt",
           "line": 7941,
           "kind": "unit",
           "field_names": [],
@@ -10012,7 +10000,7 @@
           "cr_refs": []
         },
         {
-          "name": "AdditionalPhase",
+          "name": "Manifest",
           "line": 7942,
           "kind": "unit",
           "field_names": [],
@@ -10020,7 +10008,7 @@
           "cr_refs": []
         },
         {
-          "name": "Double",
+          "name": "ManifestDread",
           "line": 7943,
           "kind": "unit",
           "field_names": [],
@@ -10028,7 +10016,7 @@
           "cr_refs": []
         },
         {
-          "name": "RuntimeHandled",
+          "name": "ExtraTurn",
           "line": 7944,
           "kind": "unit",
           "field_names": [],
@@ -10036,7 +10024,7 @@
           "cr_refs": []
         },
         {
-          "name": "Learn",
+          "name": "GrantExtraLoyaltyActivations",
           "line": 7945,
           "kind": "unit",
           "field_names": [],
@@ -10044,7 +10032,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "SkipNextTurn",
           "line": 7946,
           "kind": "unit",
           "field_names": [],
@@ -10052,7 +10040,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "SkipNextStep",
           "line": 7947,
           "kind": "unit",
           "field_names": [],
@@ -10060,7 +10048,7 @@
           "cr_refs": []
         },
         {
-          "name": "Endure",
+          "name": "AdditionalPhase",
           "line": 7948,
           "kind": "unit",
           "field_names": [],
@@ -10068,7 +10056,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlightEffect",
+          "name": "Double",
           "line": 7949,
           "kind": "unit",
           "field_names": [],
@@ -10076,7 +10064,7 @@
           "cr_refs": []
         },
         {
-          "name": "Seek",
+          "name": "RuntimeHandled",
           "line": 7950,
           "kind": "unit",
           "field_names": [],
@@ -10084,7 +10072,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetLifeTotal",
+          "name": "Learn",
           "line": 7951,
           "kind": "unit",
           "field_names": [],
@@ -10092,7 +10080,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeLifeWithStat",
+          "name": "Forage",
           "line": 7952,
           "kind": "unit",
           "field_names": [],
@@ -10100,7 +10088,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetDayNight",
+          "name": "CollectEvidence",
           "line": 7953,
           "kind": "unit",
           "field_names": [],
@@ -10108,7 +10096,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveControl",
+          "name": "Endure",
           "line": 7954,
           "kind": "unit",
           "field_names": [],
@@ -10116,7 +10104,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveFromCombat",
+          "name": "BlightEffect",
           "line": 7955,
           "kind": "unit",
           "field_names": [],
@@ -10124,7 +10112,7 @@
           "cr_refs": []
         },
         {
-          "name": "Conjure",
+          "name": "Seek",
           "line": 7956,
           "kind": "unit",
           "field_names": [],
@@ -10132,7 +10120,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseOneOf",
+          "name": "SetLifeTotal",
           "line": 7957,
           "kind": "unit",
           "field_names": [],
@@ -10140,7 +10128,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unimplemented",
+          "name": "ExchangeLifeWithStat",
           "line": 7958,
           "kind": "unit",
           "field_names": [],
@@ -10148,8 +10136,56 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "SetDayNight",
+          "line": 7959,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GiveControl",
           "line": 7960,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RemoveFromCombat",
+          "line": 7961,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Conjure",
+          "line": 7962,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseOneOf",
+          "line": 7963,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unimplemented",
+          "line": 7964,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 7966,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -10157,7 +10193,7 @@
         },
         {
           "name": "Crew",
-          "line": 7962,
+          "line": 7968,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -10167,7 +10203,7 @@
         },
         {
           "name": "Station",
-          "line": 7964,
+          "line": 7970,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -10177,7 +10213,7 @@
         },
         {
           "name": "Saddle",
-          "line": 7966,
+          "line": 7972,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -10187,7 +10223,7 @@
         },
         {
           "name": "Reveal",
-          "line": 7968,
+          "line": 7974,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -10195,7 +10231,7 @@
         },
         {
           "name": "Transform",
-          "line": 7969,
+          "line": 7975,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10203,7 +10239,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 7970,
+          "line": 7976,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10211,7 +10247,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 7971,
+          "line": 7977,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10311,13 +10347,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8997,
+      "line": 9003,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 9001,
+          "line": 9007,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -10328,7 +10364,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 9004,
+          "line": 9010,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -10500,7 +10536,7 @@
     },
     "ExileLinkKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 540,
+      "line": 555,
       "doc": "CR 607.2a + CR 406.6: Tracks the link between an exiling source and the exiled card. When the source leaves the battlefield, the exiled card returns (CR 610.3a).",
       "cr_refs": [
         "CR 406.6",
@@ -10510,7 +10546,7 @@
       "variants": [
         {
           "name": "UntilSourceLeaves",
-          "line": 542,
+          "line": 557,
           "kind": "struct",
           "field_names": [
             "return_zone"
@@ -10522,7 +10558,7 @@
         },
         {
           "name": "TrackedBySource",
-          "line": 544,
+          "line": 559,
           "kind": "unit",
           "field_names": [],
           "doc": "Track cards \"exiled with\" a source without creating an automatic return.",
@@ -10530,7 +10566,7 @@
         },
         {
           "name": "ParadigmSource",
-          "line": 553,
+          "line": 568,
           "kind": "struct",
           "field_names": [
             "player"
@@ -14112,7 +14148,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8791,
+      "line": 8797,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -14121,7 +14157,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 8794,
+          "line": 8800,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -15816,7 +15852,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11228,
+      "line": 11254,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -15825,7 +15861,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 11230,
+          "line": 11256,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -15838,7 +15874,7 @@
         },
         {
           "name": "Crew",
-          "line": 11236,
+          "line": 11262,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -15851,7 +15887,7 @@
         },
         {
           "name": "Saddle",
-          "line": 11242,
+          "line": 11268,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -15864,7 +15900,7 @@
         },
         {
           "name": "Station",
-          "line": 11250,
+          "line": 11276,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -16975,7 +17011,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9349,
+      "line": 9375,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -16985,7 +17021,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 9351,
+          "line": 9377,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -16995,7 +17031,7 @@
         },
         {
           "name": "Second",
-          "line": 9354,
+          "line": 9380,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -17244,13 +17280,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4926,
+      "line": 4932,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 4927,
+          "line": 4933,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17258,7 +17294,7 @@
         },
         {
           "name": "Bottom",
-          "line": 4928,
+          "line": 4934,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17266,7 +17302,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 4930,
+          "line": 4936,
           "kind": "struct",
           "field_names": [
             "n"
@@ -17501,13 +17537,13 @@
     },
     "ManaAbilityResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 948,
+      "line": 963,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 949,
+          "line": 964,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17515,7 +17551,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 950,
+          "line": 965,
           "kind": "struct",
           "field_names": [
             "convoke_mode"
@@ -17525,7 +17561,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 954,
+          "line": 969,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -17542,7 +17578,7 @@
     },
     "ManaChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1020,
+      "line": 1035,
       "doc": "CR 608.2d + CR 605.3b: Player's answer to a `ManaChoicePrompt`, carried by `GameAction::ChooseManaColor`. Shape mirrors the prompt variant.",
       "cr_refs": [
         "CR 605.3b",
@@ -17551,7 +17587,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1021,
+          "line": 1036,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17559,7 +17595,7 @@
         },
         {
           "name": "Combination",
-          "line": 1022,
+          "line": 1037,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17570,7 +17606,7 @@
     },
     "ManaChoiceContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1030,
+      "line": 1045,
       "doc": "CR 106.3 + CR 608.2d + CR 605.3b: What resumes after a mana-color choice. Mana abilities and resolving spell/ability effects share the same prompt and response action, but resume through different rules paths.",
       "cr_refs": [
         "CR 106.3",
@@ -17580,7 +17616,7 @@
       "variants": [
         {
           "name": "ManaAbility",
-          "line": 1031,
+          "line": 1046,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17588,7 +17624,7 @@
         },
         {
           "name": "ResolvingEffect",
-          "line": 1032,
+          "line": 1047,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17599,7 +17635,7 @@
     },
     "ManaChoicePrompt": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1003,
+      "line": 1018,
       "doc": "CR 608.2d + CR 605.3b: The shape of the prompt surfaced via `WaitingFor::ChooseManaColor`. Typed enum rather than a bool discriminator: the continuation logic is identical (validate choice → produce mana → resume), only the option set differs.",
       "cr_refs": [
         "CR 605.3b",
@@ -17608,7 +17644,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1006,
+          "line": 1021,
           "kind": "struct",
           "field_names": [
             "options"
@@ -17618,7 +17654,7 @@
         },
         {
           "name": "Combination",
-          "line": 1008,
+          "line": 1023,
           "kind": "struct",
           "field_names": [
             "options"
@@ -17628,7 +17664,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 1010,
+          "line": 1025,
           "kind": "struct",
           "field_names": [
             "count",
@@ -18143,7 +18179,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10512,
+      "line": 10538,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -18152,7 +18188,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 10515,
+          "line": 10541,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -18164,7 +18200,7 @@
         },
         {
           "name": "Multiply",
-          "line": 10518,
+          "line": 10544,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -18410,7 +18446,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10524,
+      "line": 10550,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -18419,7 +18455,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10527,
+          "line": 10553,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -18427,7 +18463,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 10529,
+          "line": 10555,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -18809,13 +18845,13 @@
     },
     "MayTriggerOrigin": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 468,
+      "line": 483,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Printed",
-          "line": 469,
+          "line": 484,
           "kind": "struct",
           "field_names": [
             "trigger_index"
@@ -18825,7 +18861,7 @@
         },
         {
           "name": "Keyword",
-          "line": 470,
+          "line": 485,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -18838,13 +18874,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8231,
+      "line": 8237,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 8233,
+          "line": 8239,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -18856,7 +18892,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8236,
+          "line": 8242,
           "kind": "struct",
           "field_names": [
             "source",
@@ -18875,13 +18911,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8211,
+      "line": 8217,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 8212,
+          "line": 8218,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18889,7 +18925,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 8215,
+          "line": 8221,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -18904,7 +18940,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 8222,
+          "line": 8228,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -18914,7 +18950,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 8225,
+          "line": 8231,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -19004,7 +19040,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4213,
+      "line": 4219,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -19014,7 +19050,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4215,
+          "line": 4221,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -19024,7 +19060,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4217,
+          "line": 4223,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -19144,7 +19180,7 @@
     },
     "OpeningHandBottomReason": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1305,
+      "line": 1320,
       "doc": "CR 103.5 / TL:R 906.6a: Why a player is bottoming cards from an opening hand before the normal mulligan-decision step.",
       "cr_refs": [
         "CR 103.5"
@@ -19152,7 +19188,7 @@
       "variants": [
         {
           "name": "TinyLeadersMultiCommander",
-          "line": 1306,
+          "line": 1321,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19182,7 +19218,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9997,
+      "line": 10023,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -19192,7 +19228,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 9999,
+          "line": 10025,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -19200,7 +19236,7 @@
         },
         {
           "name": "Equals",
-          "line": 10001,
+          "line": 10027,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -19208,7 +19244,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 10004,
+          "line": 10030,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -19216,7 +19252,7 @@
         },
         {
           "name": "OneOf",
-          "line": 10006,
+          "line": 10032,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -19227,7 +19263,7 @@
     },
     "OutsideGameChoiceSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1255,
+      "line": 1270,
       "doc": "CR 400.11 + CR 406.3: A discriminated source for one outside-game selection. Sideboard entries (the wishboard pool) and face-up exile cards (the Karn / Coax wishboard return pool) are surfaced through one choice list so the caster picks across both pools in a single decision.  The size delta between the two variants (`Sideboard` carries a full `CardFace` so the UI can render the wishboard card without a sideboard lookup; `FaceUpExile` holds only an `ObjectId`) is intentional — `OutsideGameChoiceEntry` lists are short-lived (one entry per offered candidate while a single `WaitingFor::OutsideGameChoice` is active) and never collected by the million, so the asymmetry doesn't warrant boxing every CardFace through a heap indirection.",
       "cr_refs": [
         "CR 400.11",
@@ -19236,7 +19272,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 1257,
+          "line": 1272,
           "kind": "struct",
           "field_names": [
             "sideboard_index",
@@ -19249,7 +19285,7 @@
         },
         {
           "name": "FaceUpExile",
-          "line": 1262,
+          "line": 1277,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -19358,7 +19394,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3939,
+      "line": 3945,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -19367,7 +19403,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 3940,
+          "line": 3946,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -19377,7 +19413,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3944,
+          "line": 3950,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -19387,7 +19423,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 3945,
+          "line": 3951,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19395,7 +19431,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3947,
+          "line": 3953,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -19405,7 +19441,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 3948,
+          "line": 3954,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19415,7 +19451,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 3951,
+          "line": 3957,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -19426,7 +19462,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 3955,
+          "line": 3961,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -19436,7 +19472,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3959,
+          "line": 3965,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -19446,7 +19482,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 3961,
+          "line": 3967,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -19456,7 +19492,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 3962,
+          "line": 3968,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19464,7 +19500,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 3963,
+          "line": 3969,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -19474,7 +19510,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 3966,
+          "line": 3972,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -19484,7 +19520,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 3969,
+          "line": 3975,
           "kind": "struct",
           "field_names": [
             "color"
@@ -19494,7 +19530,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 3972,
+          "line": 3978,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19502,7 +19538,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 3973,
+          "line": 3979,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19510,7 +19546,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 3974,
+          "line": 3980,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19518,7 +19554,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 3975,
+          "line": 3981,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19529,7 +19565,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 3979,
+          "line": 3985,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19540,7 +19576,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 3983,
+          "line": 3989,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19552,7 +19588,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3988,
+          "line": 3994,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19562,7 +19598,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 3991,
+          "line": 3997,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19572,7 +19608,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 3994,
+          "line": 4000,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -19582,7 +19618,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 3999,
+          "line": 4005,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19594,7 +19630,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4008,
+          "line": 4014,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19609,7 +19645,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 4013,
+          "line": 4019,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19619,7 +19655,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 4016,
+          "line": 4022,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -19629,7 +19665,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 4019,
+          "line": 4025,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -19640,7 +19676,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 4023,
+          "line": 4029,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -19651,7 +19687,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 4027,
+          "line": 4033,
           "kind": "struct",
           "field_names": [
             "color",
@@ -19662,7 +19698,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 4031,
+          "line": 4037,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -19672,7 +19708,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 4034,
+          "line": 4040,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19680,7 +19716,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 4035,
+          "line": 4041,
           "kind": "struct",
           "field_names": [
             "name"
@@ -19690,7 +19726,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 4042,
+          "line": 4048,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -19703,7 +19739,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 4046,
+          "line": 4052,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19713,7 +19749,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 4049,
+          "line": 4055,
           "kind": "struct",
           "field_names": [
             "power",
@@ -19724,7 +19760,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 4053,
+          "line": 4059,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19732,26 +19768,6 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 4054,
-          "kind": "struct",
-          "field_names": [
-            "count"
-          ],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 4057,
-          "kind": "struct",
-          "field_names": [
-            "count"
-          ],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "YouControlLandsWithSameNameAtLeast",
           "line": 4060,
           "kind": "struct",
           "field_names": [
@@ -19761,8 +19777,28 @@
           "cr_refs": []
         },
         {
-          "name": "YouControlNoCreatures",
+          "name": "YouControlDifferentPowerCreatureCountAtLeast",
           "line": 4063,
+          "kind": "struct",
+          "field_names": [
+            "count"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "YouControlLandsWithSameNameAtLeast",
+          "line": 4066,
+          "kind": "struct",
+          "field_names": [
+            "count"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "YouControlNoCreatures",
+          "line": 4069,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19770,7 +19806,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 4064,
+          "line": 4070,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19778,7 +19814,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 4065,
+          "line": 4071,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19788,7 +19824,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 4071,
+          "line": 4077,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -19796,7 +19832,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 4074,
+          "line": 4080,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19809,7 +19845,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 4078,
+          "line": 4084,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19817,7 +19853,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 4079,
+          "line": 4085,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19827,7 +19863,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 4082,
+          "line": 4088,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19835,7 +19871,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 4083,
+          "line": 4089,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19843,7 +19879,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 4084,
+          "line": 4090,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19851,7 +19887,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 4085,
+          "line": 4091,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19859,7 +19895,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 4087,
+          "line": 4093,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -19869,7 +19905,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 4088,
+          "line": 4094,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19877,7 +19913,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 4089,
+          "line": 4095,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19885,7 +19921,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 4090,
+          "line": 4096,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19893,7 +19929,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 4091,
+          "line": 4097,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19904,7 +19940,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 4095,
+          "line": 4101,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19914,7 +19950,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 4100,
+          "line": 4106,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19927,7 +19963,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4105,
+          "line": 4111,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -19937,7 +19973,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 4113,
+          "line": 4119,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -19947,7 +19983,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 4126,
+          "line": 4132,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19961,7 +19997,7 @@
         },
         {
           "name": "And",
-          "line": 4134,
+          "line": 4140,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -19974,7 +20010,7 @@
         },
         {
           "name": "Or",
-          "line": 4140,
+          "line": 4146,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -19987,7 +20023,7 @@
         },
         {
           "name": "Not",
-          "line": 4147,
+          "line": 4153,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -20074,7 +20110,7 @@
     },
     "PayableResource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2913,
+      "line": 2936,
       "doc": "CR 107.14 + CR 118.8: Resource that can be paid in a \"pay any amount of X\" prompt. Typed so the same `WaitingFor::PayAmountChoice` variant generalizes to future classes (energy, life, mana) without re-introducing boolean flags.",
       "cr_refs": [
         "CR 107.14",
@@ -20083,7 +20119,7 @@
       "variants": [
         {
           "name": "Energy",
-          "line": 2915,
+          "line": 2938,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.",
@@ -20093,7 +20129,7 @@
         },
         {
           "name": "ManaGeneric",
-          "line": 2917,
+          "line": 2940,
           "kind": "struct",
           "field_names": [
             "per_x"
@@ -20147,7 +20183,7 @@
     },
     "PaymentCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4160,
+      "line": 4166,
       "doc": "CR 118.1: A cost paid as part of an effect's resolution. Distinct from AbilityCost (which gates activation before the colon).",
       "cr_refs": [
         "CR 118.1"
@@ -20155,7 +20191,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 4161,
+          "line": 4167,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20165,7 +20201,7 @@
         },
         {
           "name": "Life",
-          "line": 4169,
+          "line": 4175,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20178,7 +20214,7 @@
         },
         {
           "name": "Speed",
-          "line": 4173,
+          "line": 4179,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20191,7 +20227,7 @@
         },
         {
           "name": "Energy",
-          "line": 4178,
+          "line": 4184,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20203,7 +20239,7 @@
         },
         {
           "name": "AbilityCost",
-          "line": 4185,
+          "line": 4191,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20216,7 +20252,7 @@
         },
         {
           "name": "ScaledMana",
-          "line": 4195,
+          "line": 4201,
           "kind": "struct",
           "field_names": [
             "base",
@@ -20412,7 +20448,7 @@
     },
     "PileSide": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1392,
+      "line": 1407,
       "doc": "CR 700.3: Identifies one of the two piles produced by a `SeparateIntoPiles` partition. Typed rather than `bool` so the `GameAction::ChoosePile` payload and the engine handler share a self-documenting domain and the parser/AI cannot accidentally swap pile semantics. Pile A is the partitioner's chosen subset; pile B is `eligible \\ pile_a`.",
       "cr_refs": [
         "CR 700.3"
@@ -20420,7 +20456,7 @@
       "variants": [
         {
           "name": "A",
-          "line": 1393,
+          "line": 1408,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20428,7 +20464,7 @@
         },
         {
           "name": "B",
-          "line": 1394,
+          "line": 1409,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20604,8 +20640,20 @@
           ]
         },
         {
+          "name": "OpponentAttackedThisTurn",
+          "line": 3307,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 508.6: A player has \"attacked [a player]\" if they declared one or more creatures attacking that player. Each opponent the controller attacked this turn, resolved against `state.attacked_defenders_this_turn[controller]`. Used by \"the number of opponents you attacked this turn\" (Militant Angel). (CR 508.1b: declare-attackers announcement; CR 506.2: active = attacking player.)",
+          "cr_refs": [
+            "CR 506.2",
+            "CR 508.1b",
+            "CR 508.6"
+          ]
+        },
+        {
           "name": "All",
-          "line": 3303,
+          "line": 3309,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -20613,7 +20661,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 3305,
+          "line": 3311,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -20623,7 +20671,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 3308,
+          "line": 3314,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -20631,7 +20679,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 3312,
+          "line": 3318,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20645,7 +20693,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 3318,
+          "line": 3324,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -20653,7 +20701,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3322,
+          "line": 3328,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -20664,7 +20712,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 3331,
+          "line": 3337,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -20675,7 +20723,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 3342,
+          "line": 3348,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -20688,7 +20736,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3354,
+          "line": 3360,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -20699,7 +20747,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 3375,
+          "line": 3381,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20715,7 +20763,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 3399,
+          "line": 3405,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20915,7 +20963,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10626,
+      "line": 10652,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -20924,7 +20972,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 10627,
+          "line": 10653,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20932,7 +20980,7 @@
         },
         {
           "name": "Resolved",
-          "line": 10628,
+          "line": 10654,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20997,7 +21045,7 @@
     },
     "ProductionOverride": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 986,
+      "line": 1001,
       "doc": "CR 605.3b + CR 106.1a: A pre-resolved choice that short-circuits the normal `ChooseManaColor` prompt. Auto-tap sets this when the cost-payment planner has already determined the exact mana to produce; manual activation leaves it `None` so the player is prompted.  Typed enum (never a bool): `SingleColor` covers the one-color-repeated variants (`AnyOneColor`, `ChoiceAmongExiledColors`), while `Combination` carries the full pre-chosen multi-mana sequence for fixed combinations (`ChoiceAmongCombinations`) and free per-slot choices (`AnyCombination`).",
       "cr_refs": [
         "CR 106.1a",
@@ -21006,7 +21054,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 990,
+          "line": 1005,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked a single color; every unit of mana the ability produces becomes this color (mirrors the pre-widening `Option<ManaType>` semantics).",
@@ -21014,7 +21062,7 @@
         },
         {
           "name": "Combination",
-          "line": 993,
+          "line": 1008,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked one complete mana sequence; the ability produces exactly these mana types in order.",
@@ -21512,7 +21560,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3583,
+      "line": 3589,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -21520,7 +21568,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 3585,
+          "line": 3591,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -21530,7 +21578,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3587,
+          "line": 3593,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -21540,7 +21588,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 3589,
+          "line": 3595,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -21586,7 +21634,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3598,
+      "line": 3604,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -21595,7 +21643,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 3601,
+          "line": 3607,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -21605,7 +21653,7 @@
         },
         {
           "name": "Base",
-          "line": 3604,
+          "line": 3610,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -21618,13 +21666,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3411,
+      "line": 3417,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 3413,
+          "line": 3419,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -21634,7 +21682,7 @@
         },
         {
           "name": "Fixed",
-          "line": 3415,
+          "line": 3421,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21644,7 +21692,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 3419,
+          "line": 3425,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21658,7 +21706,7 @@
         },
         {
           "name": "Offset",
-          "line": 3426,
+          "line": 3432,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21671,7 +21719,7 @@
         },
         {
           "name": "Multiply",
-          "line": 3431,
+          "line": 3437,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -21682,7 +21730,7 @@
         },
         {
           "name": "Sum",
-          "line": 3440,
+          "line": 3446,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -21692,7 +21740,7 @@
         },
         {
           "name": "UpTo",
-          "line": 3465,
+          "line": 3471,
           "kind": "struct",
           "field_names": [
             "max"
@@ -21705,7 +21753,7 @@
         },
         {
           "name": "Power",
-          "line": 3471,
+          "line": 3477,
           "kind": "struct",
           "field_names": [
             "base",
@@ -21718,7 +21766,7 @@
         },
         {
           "name": "Difference",
-          "line": 3486,
+          "line": 3492,
           "kind": "struct",
           "field_names": [
             "left",
@@ -21734,7 +21782,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10478,
+      "line": 10504,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -21742,7 +21790,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10480,
+          "line": 10506,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -21750,7 +21798,7 @@
         },
         {
           "name": "Plus",
-          "line": 10482,
+          "line": 10508,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21760,7 +21808,7 @@
         },
         {
           "name": "Minus",
-          "line": 10484,
+          "line": 10510,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21770,7 +21818,7 @@
         },
         {
           "name": "Prevent",
-          "line": 10504,
+          "line": 10530,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -22663,7 +22711,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8776,
+      "line": 8782,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -22672,7 +22720,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 8780,
+          "line": 8786,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -22685,13 +22733,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9785,
+      "line": 9811,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 9788,
+          "line": 9814,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -22703,7 +22751,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 9794,
+          "line": 9820,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22713,7 +22761,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 9801,
+          "line": 9827,
           "kind": "struct",
           "field_names": [
             "count",
@@ -22726,7 +22774,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 9806,
+          "line": 9832,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22738,7 +22786,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 9811,
+          "line": 9837,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -22751,7 +22799,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 9814,
+          "line": 9840,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -22763,7 +22811,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 9817,
+          "line": 9843,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -22773,7 +22821,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 9820,
+          "line": 9846,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -22784,7 +22832,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 9828,
+          "line": 9854,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22797,7 +22845,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 9842,
+          "line": 9868,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22810,7 +22858,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9851,
+          "line": 9877,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -22821,7 +22869,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 9854,
+          "line": 9880,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -22831,7 +22879,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9860,
+          "line": 9886,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -22843,7 +22891,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9865,
+          "line": 9891,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22855,7 +22903,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 9870,
+          "line": 9896,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -22866,7 +22914,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 9879,
+          "line": 9905,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -22878,7 +22926,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 9886,
+          "line": 9912,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -22892,7 +22940,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 9894,
+          "line": 9920,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -22902,7 +22950,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 9899,
+          "line": 9925,
           "kind": "struct",
           "field_names": [
             "source"
@@ -22916,7 +22964,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 9903,
+          "line": 9929,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -22929,7 +22977,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 9908,
+          "line": 9934,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -22940,7 +22988,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 9919,
+          "line": 9945,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22953,7 +23001,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9930,
+          "line": 9956,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -22965,7 +23013,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 9938,
+          "line": 9964,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -22978,7 +23026,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9948,
+          "line": 9974,
           "kind": "struct",
           "field_names": [
             "level"
@@ -22990,7 +23038,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 9953,
+          "line": 9979,
           "kind": "struct",
           "field_names": [
             "text"
@@ -23394,13 +23442,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10592,
+      "line": 10618,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 10595,
+          "line": 10621,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -23408,7 +23456,7 @@
         },
         {
           "name": "Optional",
-          "line": 10597,
+          "line": 10623,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -23418,7 +23466,7 @@
         },
         {
           "name": "MayCost",
-          "line": 10604,
+          "line": 10630,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -23435,7 +23483,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10580,
+      "line": 10606,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 614.1a"
@@ -23443,7 +23491,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 10582,
+          "line": 10608,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source's controller.",
@@ -23451,7 +23499,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10584,
+          "line": 10610,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source's controller.",
@@ -23459,7 +23507,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 10586,
+          "line": 10612,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -23589,7 +23637,7 @@
     },
     "RetargetScope": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2930,
+      "line": 2953,
       "doc": "CR 115.7: Scope of retargeting — single target, all targets, or forced.",
       "cr_refs": [
         "CR 115.7"
@@ -23597,7 +23645,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 2931,
+          "line": 2954,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23605,7 +23653,7 @@
         },
         {
           "name": "All",
-          "line": 2932,
+          "line": 2955,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23613,7 +23661,7 @@
         },
         {
           "name": "ForcedTo",
-          "line": 2933,
+          "line": 2956,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -23651,7 +23699,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4289,
+      "line": 4295,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -23659,7 +23707,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 4291,
+          "line": 4297,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -23728,7 +23776,7 @@
     },
     "ShardChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1182,
+      "line": 1197,
       "doc": "CR 107.4f + CR 601.2f: The caster's resolved choice for one Phyrexian shard.",
       "cr_refs": [
         "CR 107.4f",
@@ -23737,7 +23785,7 @@
       "variants": [
         {
           "name": "PayMana",
-          "line": 1184,
+          "line": 1199,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay one mana of the shard's color (or either component color for hybrid-Phyrexian).",
@@ -23745,7 +23793,7 @@
         },
         {
           "name": "PayLife",
-          "line": 1186,
+          "line": 1201,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay 2 life.",
@@ -23756,7 +23804,7 @@
     },
     "ShardOptions": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1170,
+      "line": 1185,
       "doc": "CR 107.4f + CR 601.2h: Which legal payments a single Phyrexian shard offers to the caster. Computed from the mana pool state (Phyrexian color availability) combined with the caster's life total and CantLoseLife status (CR 118.3 + CR 119.8).  The engine pauses at `WaitingFor::PhyrexianPayment` whenever any shard would deduct life — both `ManaOrLife` (player explicitly picks mana vs life) and `LifeOnly` (life is the only remaining payment route; player confirms or cancels via `CancelCast`). Only `ManaOnly` shards auto-resolve without surfacing the prompt, since they have no life consequence (issue #704: silent life deduction violated CR 601.2h's right to refuse the cast).",
       "cr_refs": [
         "CR 107.4f",
@@ -23767,7 +23815,7 @@
       "variants": [
         {
           "name": "ManaOrLife",
-          "line": 1172,
+          "line": 1187,
           "kind": "unit",
           "field_names": [],
           "doc": "Both mana and 2 life are legal payments; player must choose.",
@@ -23775,7 +23823,7 @@
         },
         {
           "name": "ManaOnly",
-          "line": 1174,
+          "line": 1189,
           "kind": "unit",
           "field_names": [],
           "doc": "Only mana is legal (insufficient life or CR 119.8 CantLoseLife lock).",
@@ -23785,7 +23833,7 @@
         },
         {
           "name": "LifeOnly",
-          "line": 1176,
+          "line": 1191,
           "kind": "unit",
           "field_names": [],
           "doc": "Only 2 life is legal (no mana of the shard's color available, given restrictions).",
@@ -24013,7 +24061,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3611,
+      "line": 3617,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -24022,7 +24070,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 3613,
+          "line": 3619,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -24034,7 +24082,7 @@
         },
         {
           "name": "Text",
-          "line": 3619,
+          "line": 3625,
           "kind": "struct",
           "field_names": [
             "description"
@@ -24047,7 +24095,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4967,
+      "line": 4973,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -24055,7 +24103,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 4969,
+          "line": 4975,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -24065,7 +24113,7 @@
         },
         {
           "name": "Decrease",
-          "line": 4971,
+          "line": 4977,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -24078,13 +24126,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4776,
+      "line": 4782,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 4777,
+          "line": 4783,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24092,7 +24140,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 4778,
+          "line": 4784,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24100,7 +24148,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 4779,
+          "line": 4785,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24108,7 +24156,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 4781,
+          "line": 4787,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -24121,13 +24169,13 @@
     },
     "StackEntryKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3527,
+      "line": 3561,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 3528,
+          "line": 3562,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -24140,7 +24188,7 @@
         },
         {
           "name": "ActivatedAbility",
-          "line": 3542,
+          "line": 3576,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -24151,7 +24199,7 @@
         },
         {
           "name": "TriggeredAbility",
-          "line": 3546,
+          "line": 3580,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -24167,7 +24215,7 @@
         },
         {
           "name": "KeywordAction",
-          "line": 3582,
+          "line": 3616,
           "kind": "struct",
           "field_names": [
             "action"
@@ -24183,13 +24231,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3685,
+      "line": 3691,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 3686,
+          "line": 3692,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -24200,7 +24248,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 3690,
+          "line": 3696,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24210,7 +24258,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 3696,
+          "line": 3702,
           "kind": "struct",
           "field_names": [
             "color"
@@ -24220,7 +24268,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 3705,
+          "line": 3711,
           "kind": "struct",
           "field_names": [
             "label"
@@ -24233,7 +24281,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3711,
+          "line": 3717,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -24245,7 +24293,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 3717,
+          "line": 3723,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -24255,7 +24303,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 3719,
+          "line": 3725,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -24268,7 +24316,7 @@
         },
         {
           "name": "And",
-          "line": 3723,
+          "line": 3729,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24278,7 +24326,7 @@
         },
         {
           "name": "Or",
-          "line": 3727,
+          "line": 3733,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24288,7 +24336,7 @@
         },
         {
           "name": "Not",
-          "line": 3733,
+          "line": 3739,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -24298,7 +24346,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 3737,
+          "line": 3743,
           "kind": "struct",
           "field_names": [
             "state"
@@ -24310,7 +24358,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 3746,
+          "line": 3752,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24326,7 +24374,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 3757,
+          "line": 3763,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24341,7 +24389,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 3765,
+          "line": 3771,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24353,7 +24401,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 3772,
+          "line": 3778,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24365,7 +24413,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 3776,
+          "line": 3782,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -24375,7 +24423,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3780,
+          "line": 3786,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -24386,7 +24434,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 3784,
+          "line": 3790,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -24397,7 +24445,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3788,
+          "line": 3794,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -24407,7 +24455,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 3790,
+          "line": 3796,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -24417,7 +24465,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 3793,
+          "line": 3799,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -24427,7 +24475,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 3795,
+          "line": 3801,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -24437,7 +24485,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 3798,
+          "line": 3804,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -24447,7 +24495,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 3804,
+          "line": 3810,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -24459,7 +24507,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 3812,
+          "line": 3818,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -24471,7 +24519,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3816,
+          "line": 3822,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24483,7 +24531,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 3841,
+          "line": 3847,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -24501,7 +24549,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 3850,
+          "line": 3856,
           "kind": "struct",
           "field_names": [
             "text"
@@ -24511,7 +24559,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 3853,
+          "line": 3859,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24519,7 +24567,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3856,
+          "line": 3862,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -24529,7 +24577,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 3858,
+          "line": 3864,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -24539,7 +24587,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 3860,
+          "line": 3866,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24551,7 +24599,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 3866,
+          "line": 3872,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -24565,7 +24613,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 3871,
+          "line": 3877,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -24575,7 +24623,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 3878,
+          "line": 3884,
           "kind": "struct",
           "field_names": [
             "player"
@@ -24588,7 +24636,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 3883,
+          "line": 3889,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -24598,7 +24646,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 3887,
+          "line": 3893,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -24608,7 +24656,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 3891,
+          "line": 3897,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -24619,7 +24667,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 3895,
+          "line": 3901,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24631,7 +24679,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 3907,
+          "line": 3913,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24643,7 +24691,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 3911,
+          "line": 3917,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -24653,7 +24701,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 3914,
+          "line": 3920,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -24665,7 +24713,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 3920,
+          "line": 3926,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -24676,7 +24724,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 3925,
+          "line": 3931,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ReduceCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -24687,7 +24735,7 @@
         },
         {
           "name": "None",
-          "line": 3926,
+          "line": 3932,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25726,7 +25774,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4979,
+      "line": 4985,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -25735,7 +25783,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 4980,
+          "line": 4986,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25743,7 +25791,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 4981,
+          "line": 4987,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25754,7 +25802,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8741,
+      "line": 8747,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -25762,7 +25810,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 8749,
+          "line": 8755,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -25770,7 +25818,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 8754,
+          "line": 8760,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -25949,7 +25997,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8411,
+      "line": 8417,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -25959,7 +26007,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 8413,
+          "line": 8419,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25967,7 +26015,7 @@
         },
         {
           "name": "Resolution",
-          "line": 8414,
+          "line": 8420,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26384,13 +26432,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11210,
+      "line": 11236,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 11211,
+          "line": 11237,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26398,7 +26446,7 @@
         },
         {
           "name": "Player",
-          "line": 11212,
+          "line": 11238,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26409,13 +26457,13 @@
     },
     "TargetSelectionConstraint": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1126,
+      "line": 1141,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 1127,
+          "line": 1142,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26423,7 +26471,7 @@
         },
         {
           "name": "DifferentObjectControllers",
-          "line": 1129,
+          "line": 1144,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1 + CR 601.2c: Object targets must be controlled by different players.",
@@ -26554,13 +26602,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9481,
+      "line": 9507,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 9484,
+          "line": 9510,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26570,7 +26618,7 @@
         },
         {
           "name": "LostLife",
-          "line": 9486,
+          "line": 9512,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -26578,7 +26626,7 @@
         },
         {
           "name": "Descended",
-          "line": 9488,
+          "line": 9514,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -26586,7 +26634,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 9490,
+          "line": 9516,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26596,7 +26644,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 9492,
+          "line": 9518,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -26606,7 +26654,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 9494,
+          "line": 9520,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -26616,7 +26664,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 9504,
+          "line": 9530,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26629,7 +26677,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9507,
+          "line": 9533,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -26640,7 +26688,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 9510,
+          "line": 9536,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -26650,7 +26698,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 9514,
+          "line": 9540,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26662,7 +26710,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 9517,
+          "line": 9543,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -26672,7 +26720,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9520,
+          "line": 9546,
           "kind": "struct",
           "field_names": [
             "level"
@@ -26684,7 +26732,7 @@
         },
         {
           "name": "WasCast",
-          "line": 9525,
+          "line": 9551,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you cast it\" — zoneless cast check (unlike CastFromZone which requires a specific zone). CR 701.57a: Used by Discover ETB triggers. Negation (\"if it wasn't cast\") is expressed via `Not { Box::new(WasCast) }`.",
@@ -26694,7 +26742,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 9529,
+          "line": 9555,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -26705,7 +26753,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 9534,
+          "line": 9560,
           "kind": "struct",
           "field_names": [
             "source",
@@ -26721,7 +26769,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 9550,
+          "line": 9576,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -26731,7 +26779,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9556,
+          "line": 9582,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26746,7 +26794,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 9560,
+          "line": 9586,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -26757,7 +26805,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 9564,
+          "line": 9590,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -26768,7 +26816,7 @@
         },
         {
           "name": "WasType",
-          "line": 9569,
+          "line": 9595,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -26781,7 +26829,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 9572,
+          "line": 9598,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26793,7 +26841,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 9576,
+          "line": 9602,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26806,7 +26854,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 9580,
+          "line": 9606,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26818,7 +26866,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 9584,
+          "line": 9610,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -26828,7 +26876,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9587,
+          "line": 9613,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -26840,7 +26888,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 9591,
+          "line": 9617,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26852,7 +26900,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 9594,
+          "line": 9620,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26864,7 +26912,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9600,
+          "line": 9626,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -26874,7 +26922,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9603,
+          "line": 9629,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -26884,7 +26932,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 9606,
+          "line": 9632,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -26894,7 +26942,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9613,
+          "line": 9639,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26906,7 +26954,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9618,
+          "line": 9644,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26918,7 +26966,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9622,
+          "line": 9648,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -26928,7 +26976,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 9627,
+          "line": 9653,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -26940,7 +26988,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9633,
+          "line": 9659,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -26950,7 +26998,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 9638,
+          "line": 9664,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -26960,7 +27008,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 9641,
+          "line": 9667,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -26970,7 +27018,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 9644,
+          "line": 9670,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -26980,7 +27028,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 9646,
+          "line": 9672,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -26992,7 +27040,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 9649,
+          "line": 9675,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -27002,7 +27050,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 9653,
+          "line": 9679,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -27012,7 +27060,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 9657,
+          "line": 9683,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27025,7 +27073,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 9660,
+          "line": 9686,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -27035,7 +27083,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9664,
+          "line": 9690,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -27048,7 +27096,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9667,
+          "line": 9693,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -27061,7 +27109,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9669,
+          "line": 9695,
           "kind": "struct",
           "field_names": [
             "color",
@@ -27074,7 +27122,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 9671,
+          "line": 9697,
           "kind": "struct",
           "field_names": [
             "text"
@@ -27086,7 +27134,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 9673,
+          "line": 9699,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -27098,7 +27146,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 9677,
+          "line": 9703,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -27112,7 +27160,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 9679,
+          "line": 9705,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -27122,7 +27170,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 9684,
+          "line": 9710,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -27137,7 +27185,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9695,
+          "line": 9721,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -27153,7 +27201,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 9710,
+          "line": 9736,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -27165,7 +27213,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9713,
+          "line": 9739,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27178,7 +27226,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 9723,
+          "line": 9749,
           "kind": "struct",
           "field_names": [
             "label"
@@ -27192,7 +27240,7 @@
         },
         {
           "name": "AttackersDeclaredMin",
-          "line": 9736,
+          "line": 9762,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27208,7 +27256,7 @@
         },
         {
           "name": "NoneOfAttackersTargetedYou",
-          "line": 9741,
+          "line": 9767,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 603.4: Intervening-if \"if none of those creatures attacked you\". Reads the triggering `AttackersDeclared` event's per-attacker `AttackTarget` tuples (CR 508.1b) and returns true iff no attacker in the batch targeted the trigger's controller directly (`AttackTarget::Player(trigger_controller)`).",
@@ -27220,7 +27268,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9751,
+          "line": 9777,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -27232,7 +27280,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 9762,
+          "line": 9788,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -27244,7 +27292,7 @@
         },
         {
           "name": "And",
-          "line": 9766,
+          "line": 9792,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27254,7 +27302,7 @@
         },
         {
           "name": "Or",
-          "line": 9768,
+          "line": 9794,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27264,7 +27312,7 @@
         },
         {
           "name": "Not",
-          "line": 9778,
+          "line": 9804,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -27280,13 +27328,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9959,
+      "line": 9985,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 9961,
+          "line": 9987,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -27294,7 +27342,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 9963,
+          "line": 9989,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -27302,7 +27350,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 9965,
+          "line": 9991,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -27310,7 +27358,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 9970,
+          "line": 9996,
           "kind": "struct",
           "field_names": [
             "n",
@@ -27321,7 +27369,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 9977,
+          "line": 10003,
           "kind": "struct",
           "field_names": [
             "n"
@@ -27331,7 +27379,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 9979,
+          "line": 10005,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -27339,7 +27387,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 9983,
+          "line": 10009,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -27349,7 +27397,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 9985,
+          "line": 10011,
           "kind": "struct",
           "field_names": [
             "level"
@@ -27361,7 +27409,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 9988,
+          "line": 10014,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29606,7 +29654,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3638,
+      "line": 3644,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -29615,7 +29663,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 3640,
+          "line": 3646,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29623,7 +29671,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 3641,
+          "line": 3647,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29631,7 +29679,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 3642,
+          "line": 3648,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29641,7 +29689,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 3645,
+          "line": 3651,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29651,7 +29699,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 3657,
+          "line": 3663,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29711,7 +29759,7 @@
     },
     "VoteActor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1367,
+      "line": 1382,
       "doc": "CR 101.4 + CR 608.2 (Battlebond friend-or-foe keyword action — no explicit CR section): The \"who acts\" semantic for a `WaitingFor::VoteChoice` step.  * `SubjectActs` — the player named by `player` casts the vote for   themselves. Classic Council's-dilemma (CR 701.38) is exclusively this   case: each voter acts on their own behalf and APNAP iteration changes   both subject and actor together. * `Delegated(actor)` — a fixed `actor` casts every vote on behalf of the   cycling subjects. The Battlebond friend-or-foe spell controller pins   themselves here so `player` cycles through every player in APNAP order   while authorization stays with the controller.  Stored on `WaitingFor::VoteChoice` instead of `Option<PlayerId>` so the \"is this delegated?\" discriminator is a named sum type with a meaningful pair of variant names, not a boolean-flavored optional. Callers route through [`VoteActor::resolve`] to get the authorized submitter without branching at every call site.",
       "cr_refs": [
         "CR 101.4",
@@ -29721,7 +29769,7 @@
       "variants": [
         {
           "name": "SubjectActs",
-          "line": 1368,
+          "line": 1383,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29729,7 +29777,7 @@
         },
         {
           "name": "Delegated",
-          "line": 1369,
+          "line": 1384,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -29740,7 +29788,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7136,
+      "line": 7142,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -29749,7 +29797,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 7139,
+          "line": 7145,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -29759,7 +29807,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 7143,
+          "line": 7149,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -29769,7 +29817,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 7151,
+          "line": 7157,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",
@@ -29783,13 +29831,13 @@
     },
     "WaitingFor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1450,
+      "line": 1470,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1451,
+          "line": 1471,
           "kind": "struct",
           "field_names": [
             "player"
@@ -29799,7 +29847,7 @@
         },
         {
           "name": "MulliganDecision",
-          "line": 1467,
+          "line": 1487,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -29814,7 +29862,7 @@
         },
         {
           "name": "MulliganBottomCards",
-          "line": 1480,
+          "line": 1500,
           "kind": "struct",
           "field_names": [
             "pending"
@@ -29826,7 +29874,7 @@
         },
         {
           "name": "OpeningHandBottomCards",
-          "line": 1486,
+          "line": 1506,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -29837,7 +29885,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1490,
+          "line": 1510,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29848,7 +29896,7 @@
         },
         {
           "name": "ChooseXValue",
-          "line": 1508,
+          "line": 1528,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29865,7 +29913,7 @@
         },
         {
           "name": "TargetSelection",
-          "line": 1517,
+          "line": 1537,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29878,7 +29926,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 1524,
+          "line": 1544,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29890,7 +29938,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 1530,
+          "line": 1550,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29903,7 +29951,7 @@
         },
         {
           "name": "UntapChoice",
-          "line": 1546,
+          "line": 1566,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29917,7 +29965,7 @@
         },
         {
           "name": "ExertChoice",
-          "line": 1558,
+          "line": 1578,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29932,7 +29980,7 @@
         },
         {
           "name": "GameOver",
-          "line": 1564,
+          "line": 1584,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -29942,7 +29990,7 @@
         },
         {
           "name": "ReplacementChoice",
-          "line": 1567,
+          "line": 1587,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29954,7 +30002,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 1580,
+          "line": 1600,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29969,7 +30017,7 @@
         },
         {
           "name": "CopyTargetChoice",
-          "line": 1586,
+          "line": 1606,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29984,7 +30032,7 @@
         },
         {
           "name": "ExploreChoice",
-          "line": 1596,
+          "line": 1616,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30000,7 +30048,7 @@
         },
         {
           "name": "ReturnAsAuraTarget",
-          "line": 1618,
+          "line": 1638,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30023,7 +30071,7 @@
         },
         {
           "name": "EquipTarget",
-          "line": 1635,
+          "line": 1655,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30035,7 +30083,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 1641,
+          "line": 1661,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30050,7 +30098,7 @@
         },
         {
           "name": "StationTarget",
-          "line": 1652,
+          "line": 1672,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30064,7 +30112,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 1660,
+          "line": 1680,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30079,7 +30127,7 @@
         },
         {
           "name": "ScryChoice",
-          "line": 1668,
+          "line": 1688,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30090,7 +30138,7 @@
         },
         {
           "name": "DigChoice",
-          "line": 1673,
+          "line": 1693,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30110,7 +30158,7 @@
         },
         {
           "name": "SurveilChoice",
-          "line": 1697,
+          "line": 1717,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30121,7 +30169,7 @@
         },
         {
           "name": "RevealChoice",
-          "line": 1701,
+          "line": 1721,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30135,7 +30183,7 @@
         },
         {
           "name": "SearchChoice",
-          "line": 1720,
+          "line": 1740,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30151,7 +30199,7 @@
         },
         {
           "name": "SearchPartitionChoice",
-          "line": 1754,
+          "line": 1774,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30170,7 +30218,7 @@
         },
         {
           "name": "OutsideGameChoice",
-          "line": 1767,
+          "line": 1787,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30189,7 +30237,7 @@
         },
         {
           "name": "ChooseFromZoneChoice",
-          "line": 1781,
+          "line": 1801,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30206,7 +30254,7 @@
         },
         {
           "name": "ChooseOneOfBranch",
-          "line": 1793,
+          "line": 1813,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30225,7 +30273,7 @@
         },
         {
           "name": "ConniveDiscard",
-          "line": 1811,
+          "line": 1831,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30241,7 +30289,7 @@
         },
         {
           "name": "DiscardChoice",
-          "line": 1820,
+          "line": 1840,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30259,7 +30307,7 @@
         },
         {
           "name": "EffectZoneChoice",
-          "line": 1836,
+          "line": 1856,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30286,7 +30334,7 @@
         },
         {
           "name": "DrawnThisTurnTopdeckChoice",
-          "line": 1889,
+          "line": 1909,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30301,7 +30349,7 @@
         },
         {
           "name": "LearnChoice",
-          "line": 1899,
+          "line": 1919,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30314,7 +30362,7 @@
         },
         {
           "name": "ManifestDreadChoice",
-          "line": 1905,
+          "line": 1925,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30327,7 +30375,7 @@
         },
         {
           "name": "TriggerTargetSelection",
-          "line": 1909,
+          "line": 1929,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30342,7 +30390,7 @@
         },
         {
           "name": "BetweenGamesSideboard",
-          "line": 1923,
+          "line": 1943,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30354,7 +30402,7 @@
         },
         {
           "name": "BetweenGamesChoosePlayDraw",
-          "line": 1928,
+          "line": 1948,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30366,7 +30414,7 @@
         },
         {
           "name": "NamedChoice",
-          "line": 1934,
+          "line": 1954,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30379,7 +30427,7 @@
         },
         {
           "name": "DamageSourceChoice",
-          "line": 1944,
+          "line": 1964,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30393,7 +30441,7 @@
         },
         {
           "name": "ModeChoice",
-          "line": 1950,
+          "line": 1970,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30405,7 +30453,7 @@
         },
         {
           "name": "DiscardToHandSize",
-          "line": 1956,
+          "line": 1976,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30417,7 +30465,7 @@
         },
         {
           "name": "OptionalCostChoice",
-          "line": 1964,
+          "line": 1984,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30430,7 +30478,7 @@
         },
         {
           "name": "DefilerPayment",
-          "line": 1976,
+          "line": 1996,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30445,7 +30493,7 @@
         },
         {
           "name": "AdventureCastChoice",
-          "line": 1986,
+          "line": 2006,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30460,7 +30508,7 @@
         },
         {
           "name": "ModalFaceChoice",
-          "line": 2003,
+          "line": 2023,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30476,7 +30524,7 @@
         },
         {
           "name": "AlternativeCastChoice",
-          "line": 2026,
+          "line": 2046,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30502,7 +30550,7 @@
         },
         {
           "name": "CastingVariantChoice",
-          "line": 2058,
+          "line": 2078,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30518,7 +30566,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 2070,
+          "line": 2090,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30535,7 +30583,7 @@
         },
         {
           "name": "MultiTargetSelection",
-          "line": 2081,
+          "line": 2101,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30551,7 +30599,7 @@
         },
         {
           "name": "AbilityModeChoice",
-          "line": 2092,
+          "line": 2112,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30568,7 +30616,7 @@
         },
         {
           "name": "OptionalEffectChoice",
-          "line": 2115,
+          "line": 2135,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30583,7 +30631,7 @@
         },
         {
           "name": "PairChoice",
-          "line": 2126,
+          "line": 2146,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30598,7 +30646,7 @@
         },
         {
           "name": "TributeChoice",
-          "line": 2137,
+          "line": 2157,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30613,7 +30661,7 @@
         },
         {
           "name": "MiracleReveal",
-          "line": 2149,
+          "line": 2169,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30628,7 +30676,7 @@
         },
         {
           "name": "MiracleCastOffer",
-          "line": 2159,
+          "line": 2179,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30643,7 +30691,7 @@
         },
         {
           "name": "MadnessCastOffer",
-          "line": 2168,
+          "line": 2188,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30657,7 +30705,7 @@
         },
         {
           "name": "OpponentMayChoice",
-          "line": 2175,
+          "line": 2195,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30673,7 +30721,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 2188,
+          "line": 2208,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30691,7 +30739,7 @@
         },
         {
           "name": "UnlessPaymentChooseCost",
-          "line": 2222,
+          "line": 2242,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30709,7 +30757,7 @@
         },
         {
           "name": "WardDiscardChoice",
-          "line": 2252,
+          "line": 2272,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30723,7 +30771,7 @@
         },
         {
           "name": "WardSacrificeChoice",
-          "line": 2260,
+          "line": 2280,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30738,7 +30786,7 @@
         },
         {
           "name": "UnlessBounceChoice",
-          "line": 2271,
+          "line": 2291,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30753,7 +30801,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 2279,
+          "line": 2299,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30766,7 +30814,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 2284,
+          "line": 2304,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30779,7 +30827,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 2289,
+          "line": 2309,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30794,7 +30842,7 @@
         },
         {
           "name": "DiscardForCost",
-          "line": 2297,
+          "line": 2317,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30809,11 +30857,12 @@
         },
         {
           "name": "SacrificeForCost",
-          "line": 2307,
+          "line": 2327,
           "kind": "struct",
           "field_names": [
             "player",
             "count",
+            "min_count",
             "permanents",
             "pending_cast"
           ],
@@ -30825,7 +30874,7 @@
         },
         {
           "name": "ReturnToHandForCost",
-          "line": 2317,
+          "line": 2340,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30841,7 +30890,7 @@
         },
         {
           "name": "ActivationCostOneOfChoice",
-          "line": 2327,
+          "line": 2350,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30855,7 +30904,7 @@
         },
         {
           "name": "RemoveCounterForCost",
-          "line": 2334,
+          "line": 2357,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30873,7 +30922,7 @@
         },
         {
           "name": "BlightChoice",
-          "line": 2344,
+          "line": 2367,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30886,7 +30935,7 @@
         },
         {
           "name": "TapCreaturesForSpellCost",
-          "line": 2355,
+          "line": 2378,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30902,7 +30951,7 @@
         },
         {
           "name": "BeholdForCost",
-          "line": 2363,
+          "line": 2386,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30916,7 +30965,7 @@
         },
         {
           "name": "TapCreaturesForManaAbility",
-          "line": 2371,
+          "line": 2394,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30932,7 +30981,7 @@
         },
         {
           "name": "DiscardForManaAbility",
-          "line": 2378,
+          "line": 2401,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30948,7 +30997,7 @@
         },
         {
           "name": "ExileForManaAbility",
-          "line": 2388,
+          "line": 2411,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30966,7 +31015,7 @@
         },
         {
           "name": "SacrificeForManaAbility",
-          "line": 2400,
+          "line": 2423,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30983,7 +31032,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 2416,
+          "line": 2439,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30999,7 +31048,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 2426,
+          "line": 2449,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31015,7 +31064,7 @@
         },
         {
           "name": "ExileForCost",
-          "line": 2439,
+          "line": 2462,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31034,7 +31083,7 @@
         },
         {
           "name": "CollectEvidenceChoice",
-          "line": 2454,
+          "line": 2477,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31050,7 +31099,7 @@
         },
         {
           "name": "HarmonizeTapChoice",
-          "line": 2463,
+          "line": 2486,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31067,7 +31116,7 @@
         },
         {
           "name": "DiscoverChoice",
-          "line": 2471,
+          "line": 2494,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31081,7 +31130,7 @@
         },
         {
           "name": "RevealUntilKeptChoice",
-          "line": 2483,
+          "line": 2506,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31102,7 +31151,7 @@
         },
         {
           "name": "RepeatDecision",
-          "line": 2504,
+          "line": 2527,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31116,7 +31165,7 @@
         },
         {
           "name": "CascadeChoice",
-          "line": 2514,
+          "line": 2537,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31131,7 +31180,7 @@
         },
         {
           "name": "TopOrBottomChoice",
-          "line": 2530,
+          "line": 2553,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31144,7 +31193,7 @@
         },
         {
           "name": "ParadigmCastOffer",
-          "line": 2539,
+          "line": 2562,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31157,7 +31206,7 @@
         },
         {
           "name": "PopulateChoice",
-          "line": 2544,
+          "line": 2567,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31171,7 +31220,7 @@
         },
         {
           "name": "ClashCardPlacement",
-          "line": 2552,
+          "line": 2575,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31185,7 +31234,7 @@
         },
         {
           "name": "VoteChoice",
-          "line": 2563,
+          "line": 2586,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31207,7 +31256,7 @@
         },
         {
           "name": "SeparatePilesPartition",
-          "line": 2622,
+          "line": 2645,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31228,7 +31277,7 @@
         },
         {
           "name": "SeparatePilesChoice",
-          "line": 2652,
+          "line": 2675,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31245,7 +31294,7 @@
         },
         {
           "name": "CompanionReveal",
-          "line": 2667,
+          "line": 2690,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31258,7 +31307,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 2674,
+          "line": 2697,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31272,7 +31321,7 @@
         },
         {
           "name": "CommanderZoneChoice",
-          "line": 2683,
+          "line": 2706,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31286,7 +31335,7 @@
         },
         {
           "name": "BattleProtectorChoice",
-          "line": 2694,
+          "line": 2717,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31302,7 +31351,7 @@
         },
         {
           "name": "ProliferateChoice",
-          "line": 2701,
+          "line": 2724,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31315,7 +31364,7 @@
         },
         {
           "name": "ChooseObjectsSelection",
-          "line": 2711,
+          "line": 2734,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31329,7 +31378,7 @@
         },
         {
           "name": "CategoryChoice",
-          "line": 2724,
+          "line": 2747,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31349,7 +31398,7 @@
         },
         {
           "name": "CopyRetarget",
-          "line": 2747,
+          "line": 2770,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31364,7 +31413,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 2757,
+          "line": 2780,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31386,7 +31435,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 2781,
+          "line": 2804,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31401,7 +31450,7 @@
         },
         {
           "name": "MoveCountersDistribution",
-          "line": 2789,
+          "line": 2812,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31419,7 +31468,7 @@
         },
         {
           "name": "PayAmountChoice",
-          "line": 2803,
+          "line": 2826,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31437,7 +31486,7 @@
         },
         {
           "name": "RetargetChoice",
-          "line": 2816,
+          "line": 2839,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31453,7 +31502,7 @@
         },
         {
           "name": "CombatTaxPayment",
-          "line": 2838,
+          "line": 2861,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31473,7 +31522,7 @@
         },
         {
           "name": "PhyrexianPayment",
-          "line": 2856,
+          "line": 2879,
           "kind": "struct",
           "field_names": [
             "player",


### PR DESCRIPTION
Add PlayerFilter::OpponentAttackedThisTurn so "the number of opponents you
attacked this turn" resolves to the count of distinct defending players the
controller declared attackers against this turn. Previously the count fell
through to QuantityRef::Variable{name} and silently resolved to 0, so Militant
Angel created zero Knight tokens.

New turn-scoped substrate GameState.attacked_defenders_this_turn:
HashMap<PlayerId, HashSet<PlayerId>>, keyed by attacking player -> the set of
defending players attacked, accumulated across every combat's declare-attackers
step and cleared at turn start. Populated in record_attackers_declared from the
already-computed players_attacked_this_step (CR 508.5: planeswalker -> controller,
battle -> protector), so the count is exact even when the source enters on an
opponent's turn (the controller's entry is empty unless the controller declared
attackers).

Parser: new nom combinator parse_opponents_attacked_clause wired into both the
quantity-ref and for-each dispatch paths; no collision with "creature you
attacked WITH this turn" (AttackedThisTurn). Resolver plus all eight sibling
exhaustive PlayerFilter match sites updated in lockstep.

Parameterize-don't-proliferate: added as a sibling rather than folding into the
OpponentLostLife/GainedLife/DealtCombatDamage cluster, which spans CR 119 / CR
510 / CR 508 (distinct rule sections, distinct runtime ledgers) -- a
categorical-boundary that forbids the cross-section lift.

Regenerates the tracked engine-inventory.json.

Out of scope (separate pre-existing parser defect, untouched): the "with
vigilance" token keyword is dropped from Militant Angel's Token effect.

CR 508.6 (a player has "attacked [a player]"); CR 508.1b / 508.5 / 506.2.
