### PR TITLE
feat(engine): count opponents dealt combat damage by a filtered source (Estinien Varlineau)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -11544,6 +11544,7 @@ mod bloodthirst_runtime_tests {
             target_controller: PlayerId(1),
             amount: 1,
             is_combat: false,
+            ..Default::default()
         });
 
         let obj_id = spawn_bloodthirst_via_etb_pipeline(&mut state, &face, PlayerId(0));
@@ -11590,6 +11591,7 @@ mod bloodthirst_runtime_tests {
                 target_controller: PlayerId(1),
                 amount: 2,
                 is_combat: false,
+                ..Default::default()
             },
             DamageRecord {
                 source_id,
@@ -11598,6 +11600,7 @@ mod bloodthirst_runtime_tests {
                 target_controller: PlayerId(1),
                 amount: 3,
                 is_combat: true,
+                ..Default::default()
             },
             DamageRecord {
                 source_id,
@@ -11606,6 +11609,7 @@ mod bloodthirst_runtime_tests {
                 target_controller: PlayerId(0),
                 amount: 7,
                 is_combat: false,
+                ..Default::default()
             },
         ]);
 
@@ -11639,6 +11643,7 @@ mod bloodthirst_runtime_tests {
             target_controller: PlayerId(1),
             amount: 4,
             is_combat: true,
+            ..Default::default()
         });
         state.objects.remove(&source_id);
 
@@ -11677,6 +11682,7 @@ mod bloodthirst_runtime_tests {
             target_controller: PlayerId(1),
             amount: 4,
             is_combat: false,
+            ..Default::default()
         });
 
         let obj = state.objects.get(&obj_id).expect("object exists");
@@ -11719,6 +11725,7 @@ mod bloodthirst_runtime_tests {
             target_controller: third_player,
             amount: 2,
             is_combat: false,
+            ..Default::default()
         });
 
         let obj_id = spawn_bloodthirst_via_etb_pipeline(&mut state, &face, PlayerId(0));
@@ -11752,6 +11759,7 @@ mod bloodthirst_runtime_tests {
             target_controller: PlayerId(1),
             amount: 1,
             is_combat: true,
+            ..Default::default()
         });
 
         // Install Hardened Scales as a battlefield object.
@@ -11805,6 +11813,7 @@ mod bloodthirst_runtime_tests {
             target_controller: PlayerId(1),
             amount: 2,
             is_combat: true,
+            ..Default::default()
         });
 
         // Advance to the next turn via the real engine path that clears

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1168,7 +1168,7 @@ fn fmt_player_filter(pf: &PlayerFilter) -> String {
         PlayerFilter::DefendingPlayer => "defending player",
         PlayerFilter::OpponentLostLife => "each opponent who lost life this turn",
         PlayerFilter::OpponentGainedLife => "each opponent who gained life this turn",
-        PlayerFilter::OpponentDealtCombatDamage => {
+        PlayerFilter::OpponentDealtCombatDamage { .. } => {
             "each opponent who was dealt combat damage this turn"
         }
         PlayerFilter::OpponentAttackedThisTurn => "each opponent you attacked this turn",
@@ -5272,7 +5272,7 @@ fn player_filter_feature(scope: &PlayerFilter) -> (&'static str, FeatureSupport)
         PlayerFilter::DefendingPlayer => ("DefendingPlayer", Handled),
         PlayerFilter::OpponentLostLife => ("OpponentLostLife", Handled),
         PlayerFilter::OpponentGainedLife => ("OpponentGainedLife", Handled),
-        PlayerFilter::OpponentDealtCombatDamage => ("OpponentDealtCombatDamage", Handled),
+        PlayerFilter::OpponentDealtCombatDamage { .. } => ("OpponentDealtCombatDamage", Handled),
         PlayerFilter::OpponentAttackedThisTurn => ("OpponentAttackedThisTurn", Handled),
         PlayerFilter::HighestSpeed => ("HighestSpeed", Handled),
         // Previously emitted via Debug formatting; never appeared in the handled set.

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -473,14 +473,45 @@ pub(crate) fn apply_damage_after_replacement(
                 .map(|object| object.controller)
                 .unwrap_or(ctx.controller),
         };
-        state.damage_dealt_this_turn.push(DamageRecord {
+        // CR 608.2i + CR 608.2h: Snapshot the damage source's characteristics at
+        // damage time so look-back source-filter queries ("opponents who were
+        // dealt combat damage by ~ or a Dragon this turn") evaluate against the
+        // source as it was when the damage was dealt — the source may later
+        // change type, leave the battlefield (CR 113.7a LKI), or be removed.
+        let src = state.objects.get(&ctx.source_id);
+        let mut record = DamageRecord {
             source_id: ctx.source_id,
             source_controller: ctx.controller,
             target: t.clone(),
             target_controller,
             amount: actual_amount,
             is_combat,
-        });
+            source_name: String::new(),
+            source_core_types: Vec::new(),
+            source_subtypes: Vec::new(),
+            source_supertypes: Vec::new(),
+            source_keywords: Vec::new(),
+            source_power: None,
+            source_toughness: None,
+            source_colors: Vec::new(),
+            source_mana_value: 0,
+            source_controller_snapshot: ctx.controller,
+            source_owner: ctx.controller,
+        };
+        if let Some(obj) = src {
+            record.source_name = obj.name.clone();
+            record.source_core_types = obj.card_types.core_types.clone();
+            record.source_subtypes = obj.card_types.subtypes.clone();
+            record.source_supertypes = obj.card_types.supertypes.clone();
+            record.source_keywords = obj.keywords.clone();
+            record.source_power = obj.power;
+            record.source_toughness = obj.toughness;
+            record.source_colors = obj.color.clone();
+            record.source_mana_value = obj.mana_cost.mana_value();
+            record.source_controller_snapshot = obj.controller;
+            record.source_owner = obj.owner;
+        }
+        state.damage_dealt_this_turn.push(record);
     }
 
     // CR 702.15b / CR 120.3f: Lifelink — controller gains life equal to damage dealt.
@@ -855,14 +886,17 @@ fn collect_matching_players(
                     PlayerFilter::OpponentGainedLife => {
                         p.id != source_controller && p.life_gained_this_turn > 0
                     }
-                    // CR 120.1 + CR 510.1: Each opponent who was dealt combat
-                    // damage this turn (`damage_dealt_this_turn` ledger).
-                    PlayerFilter::OpponentDealtCombatDamage => {
-                        p.id != source_controller
-                            && state.damage_dealt_this_turn.iter().any(|r| {
-                                r.is_combat
-                                    && matches!(r.target, TargetRef::Player(pid) if pid == p.id)
-                            })
+                    // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
+                    // who was dealt combat damage this turn, optionally
+                    // restricted to a matching source.
+                    PlayerFilter::OpponentDealtCombatDamage { ref source } => {
+                        crate::game::quantity::opponent_dealt_combat_damage_matches(
+                            state,
+                            p.id,
+                            source_controller,
+                            source,
+                            source_id,
+                        )
                     }
                     // CR 508.6: opponent this player attacked this turn.
                     PlayerFilter::OpponentAttackedThisTurn => {
@@ -1023,14 +1057,17 @@ pub fn resolve_each_player(
                     PlayerFilter::OpponentGainedLife => {
                         p.id != ability.controller && p.life_gained_this_turn > 0
                     }
-                    // CR 120.1 + CR 510.1: Each opponent who was dealt combat
-                    // damage this turn (`damage_dealt_this_turn` ledger).
-                    PlayerFilter::OpponentDealtCombatDamage => {
-                        p.id != ability.controller
-                            && state.damage_dealt_this_turn.iter().any(|r| {
-                                r.is_combat
-                                    && matches!(r.target, TargetRef::Player(pid) if pid == p.id)
-                            })
+                    // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
+                    // who was dealt combat damage this turn, optionally
+                    // restricted to a matching source.
+                    PlayerFilter::OpponentDealtCombatDamage { source } => {
+                        crate::game::quantity::opponent_dealt_combat_damage_matches(
+                            state,
+                            p.id,
+                            ability.controller,
+                            source,
+                            ability.source_id,
+                        )
                     }
                     // CR 508.6: opponent this player attacked this turn.
                     PlayerFilter::OpponentAttackedThisTurn => {

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -217,14 +217,13 @@ pub(crate) fn matches_player_scope(
                     PlayerFilter::OpponentGainedLife => {
                         p.id != controller && p.life_gained_this_turn > 0
                     }
-                    // CR 120.1 + CR 510.1: Each opponent who was dealt combat
-                    // damage this turn (`damage_dealt_this_turn` ledger).
-                    PlayerFilter::OpponentDealtCombatDamage => {
-                        p.id != controller
-                            && state.damage_dealt_this_turn.iter().any(|r| {
-                                r.is_combat
-                                    && matches!(r.target, TargetRef::Player(pid) if pid == p.id)
-                            })
+                    // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
+                    // who was dealt combat damage this turn, optionally
+                    // restricted to a matching source.
+                    PlayerFilter::OpponentDealtCombatDamage { source } => {
+                        crate::game::quantity::opponent_dealt_combat_damage_matches(
+                            state, p.id, controller, source, source_id,
+                        )
                     }
                     // CR 508.6: opponent this player attacked this turn.
                     PlayerFilter::OpponentAttackedThisTurn => {
@@ -4629,7 +4628,7 @@ fn scoped_player_matches_filter(
         // `TriggerCondition::DuringPlayersTurn` fallthrough pattern at
         // game/triggers.rs:3703-3723).
         PlayerFilter::DefendingPlayer
-        | PlayerFilter::OpponentDealtCombatDamage
+        | PlayerFilter::OpponentDealtCombatDamage { .. }
         | PlayerFilter::OpponentAttackedThisTurn
         | PlayerFilter::HighestSpeed
         | PlayerFilter::ZoneChangedThisWay

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -48,21 +48,17 @@ fn players_for_filter(
             .filter(|player| player.id != controller && player.life_gained_this_turn > 0)
             .map(|player| player.id)
             .collect(),
-        // CR 120.1 + CR 510.1: Each opponent who was dealt combat damage this
-        // turn (`damage_dealt_this_turn` ledger).
-        PlayerFilter::OpponentDealtCombatDamage => state
+        // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent who was
+        // dealt combat damage this turn, optionally restricted to a matching
+        // source.
+        PlayerFilter::OpponentDealtCombatDamage { source } => state
             .players
             .iter()
             .filter(|player| !player.is_eliminated)
             .filter(|player| {
-                player.id != controller
-                    && state.damage_dealt_this_turn.iter().any(|r| {
-                        r.is_combat
-                            && matches!(
-                                r.target,
-                                crate::types::ability::TargetRef::Player(pid) if pid == player.id
-                            )
-                    })
+                crate::game::quantity::opponent_dealt_combat_damage_matches(
+                    state, player.id, controller, source, source_id,
+                )
             })
             .map(|player| player.id)
             .collect(),

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -18,7 +18,7 @@ use crate::types::ability::{
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterMatch;
 use crate::types::game_state::{
-    CounterAddedRecord, GameState, LKISnapshot, SpellCastRecord, ZoneChangeRecord,
+    CounterAddedRecord, DamageRecord, GameState, LKISnapshot, SpellCastRecord, ZoneChangeRecord,
 };
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::Keyword;
@@ -378,6 +378,48 @@ pub fn matches_target_filter_on_counter_added_record(
         state,
         &obj,
         record.object_id,
+        filter,
+        ctx.source_id,
+        ctx.source_controller,
+        ctx.ability,
+        ctx.recipient_id,
+    )
+}
+
+/// CR 120.9 + CR 608.2i + CR 608.2h: Check whether a per-turn combat-damage
+/// snapshot's *source* matches a target filter using the source's event-time
+/// characteristics. Look-back queries ("opponents who were dealt combat damage
+/// by ~ or a Dragon this turn", Estinien Varlineau) match against the source as
+/// it was when the damage was dealt (CR 608.2i — criteria need not still hold);
+/// the source may have since changed type, left the battlefield, or been
+/// removed. `SelfRef` matches iff the snapshot's source is the ability source.
+pub fn matches_target_filter_on_damage_record_source(
+    state: &GameState,
+    record: &DamageRecord,
+    filter: &TargetFilter,
+    ctx: &FilterContext<'_>,
+) -> bool {
+    let mut obj = GameObject::new(
+        record.source_id,
+        CardId(0),
+        record.source_owner,
+        record.source_name.clone(),
+        Zone::Battlefield,
+    );
+    obj.controller = record.source_controller_snapshot;
+    obj.power = record.source_power;
+    obj.toughness = record.source_toughness;
+    obj.card_types.core_types = record.source_core_types.clone();
+    obj.card_types.subtypes = record.source_subtypes.clone();
+    obj.card_types.supertypes = record.source_supertypes.clone();
+    obj.mana_cost = crate::types::mana::ManaCost::generic(record.source_mana_value);
+    obj.keywords = record.source_keywords.clone();
+    obj.color = record.source_colors.clone();
+
+    filter_inner_for_object(
+        state,
+        &obj,
+        record.source_id,
         filter,
         ctx.source_id,
         ctx.source_controller,
@@ -3494,6 +3536,7 @@ mod tests {
             target_controller: PlayerId(0),
             amount: 2,
             is_combat: true,
+            ..Default::default()
         });
         state.objects.get_mut(&creature).unwrap().damage_marked = 0;
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -9,8 +9,8 @@ use std::collections::{HashMap, HashSet};
 use crate::game::arithmetic::{u32_to_i32_saturating, usize_to_i32_saturating};
 use crate::game::filter::{
     matches_target_filter, matches_target_filter_on_counter_added_record,
-    matches_target_filter_on_zone_change_record, player_matches_target_filter,
-    spell_record_matches_filter, type_filter_matches, FilterContext,
+    matches_target_filter_on_damage_record_source, matches_target_filter_on_zone_change_record,
+    player_matches_target_filter, spell_record_matches_filter, type_filter_matches, FilterContext,
 };
 use crate::game::speed::effective_speed;
 use crate::types::ability::{
@@ -20,7 +20,7 @@ use crate::types::ability::{
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{DamageRecord, GameState};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{ManaColor, ManaCost};
 use crate::types::player::PlayerId;
@@ -1894,16 +1894,19 @@ fn counter_added_actor_matches(
     }
 }
 
+/// CR 120.9 + CR 608.2i + CR 608.2h: Match a damage record's source against
+/// `filter` using the source's snapshot captured at damage time (look-back —
+/// criteria need not still hold). `TargetFilter::Any` short-circuits.
 fn damage_record_source_matches(
     state: &GameState,
-    source_id: ObjectId,
+    record: &DamageRecord,
     filter: &TargetFilter,
     ctx: &FilterContext<'_>,
 ) -> bool {
     if matches!(filter, TargetFilter::Any) {
         return true;
     }
-    matches_target_filter(state, source_id, filter, ctx)
+    matches_target_filter_on_damage_record_source(state, record, filter, ctx)
 }
 
 /// CR 120.1 + CR 120.9 + CR 603.4: Resolver for `QuantityRef::DamageDealtThisTurn`.
@@ -1926,32 +1929,19 @@ fn resolve_damage_dealt_this_turn(
 ) -> i32 {
     use crate::types::ability::DamageGroupKey;
 
-    // CR 120.9: Apply the source filter's `controller` predicate (if any)
-    // against `record.source_controller` (LKI at time of damage), so a control
-    // change between damage and check still answers the rules-correct question.
-    // Pass the rest of the filter (controller stripped) through the live-source
-    // matcher for type/property predicates.
-    let (live_source_filter, lki_controller) = split_controller_filter(source);
-    let live_source_filter_ref: &TargetFilter = live_source_filter.as_ref().unwrap_or(source);
-
-    let source_matches = |record_source_id: ObjectId, record_source_controller: PlayerId| {
-        if let Some(expected) = lki_controller.as_ref() {
-            if !damage_source_controller_matches(
-                state,
-                record_source_controller,
-                controller,
-                ctx,
-                ability,
-                expected,
-            ) {
-                return false;
-            }
-        }
-        damage_record_source_matches(state, record_source_id, live_source_filter_ref, filter_ctx)
-    };
+    // CR 120.9 + CR 608.2i + CR 608.2h: Match the source filter (including any
+    // `controller` predicate) against each record's source snapshot captured at
+    // damage time, not the live object. The snapshot carries the source's
+    // event-time controller, type, and characteristics, so a control change,
+    // type change, or the source leaving the battlefield after damage still
+    // answers the rules-correct look-back question. The controller predicate is
+    // served by the snapshot's controller via the matcher's controller arm — no
+    // separate `split_controller_filter` lift is needed on the source side.
+    let source_matches =
+        |record: &DamageRecord| damage_record_source_matches(state, record, source, filter_ctx);
 
     let matching = state.damage_dealt_this_turn.iter().filter(|record| {
-        source_matches(record.source_id, record.source_controller)
+        source_matches(record)
             && damage_record_target_matches(
                 state, record, controller, ctx, ability, target, filter_ctx,
             )
@@ -2812,6 +2802,38 @@ pub(crate) fn compute_party_size(state: &GameState, player: PlayerId) -> i32 {
     best as i32
 }
 
+/// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Single authority for
+/// `PlayerFilter::OpponentDealtCombatDamage` matching. `player` was dealt combat
+/// damage this turn (relative to `controller`'s opponents) when a
+/// `damage_dealt_this_turn` record targets it with `is_combat = true` AND its
+/// source matches `source`. `source = None` accepts any source (Tymna the
+/// Weaver); `source = Some(Any)` short-circuits to true; otherwise (CR 120.9)
+/// the record's CR 608.2i look-back source snapshot is matched against the
+/// filter, so the source's qualities are evaluated as of damage time.
+pub(crate) fn opponent_dealt_combat_damage_matches(
+    state: &GameState,
+    player: PlayerId,
+    controller: PlayerId,
+    source: &Option<Box<TargetFilter>>,
+    ability_source_id: ObjectId,
+) -> bool {
+    if player == controller {
+        return false;
+    }
+    let ctx = FilterContext::from_source_with_controller(ability_source_id, controller);
+    state.damage_dealt_this_turn.iter().any(|r| {
+        r.is_combat
+            && matches!(r.target, TargetRef::Player(pid) if pid == player)
+            && match source {
+                None => true,
+                Some(f) => {
+                    matches!(**f, TargetFilter::Any)
+                        || matches_target_filter_on_damage_record_source(state, r, f, &ctx)
+                }
+            }
+    })
+}
+
 /// Count players matching a PlayerFilter relative to the controller.
 pub(crate) fn resolve_player_count(
     state: &GameState,
@@ -2845,16 +2867,13 @@ pub(crate) fn resolve_player_count(
                         PlayerFilter::OpponentGainedLife => {
                             p.id != controller && p.life_gained_this_turn > 0
                         }
-                        // CR 120.1 + CR 510.1: Each opponent who was dealt combat
-                        // damage this turn. Probes the `damage_dealt_this_turn`
-                        // ledger for any record targeting this player with
-                        // `is_combat = true`.
-                        PlayerFilter::OpponentDealtCombatDamage => {
-                            p.id != controller
-                                && state.damage_dealt_this_turn.iter().any(|r| {
-                                    r.is_combat
-                                        && matches!(r.target, TargetRef::Player(pid) if pid == p.id)
-                                })
+                        // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each
+                        // opponent who was dealt combat damage this turn,
+                        // optionally restricted to a matching source.
+                        PlayerFilter::OpponentDealtCombatDamage { source } => {
+                            opponent_dealt_combat_damage_matches(
+                                state, p.id, controller, source, source_id,
+                            )
                         }
                         // CR 508.6: opponent this player attacked this turn.
                         PlayerFilter::OpponentAttackedThisTurn => {
@@ -4166,6 +4185,7 @@ mod tests {
                 target_controller: PlayerId(1),
                 amount: 3,
                 is_combat: false,
+                ..Default::default()
             },
             DamageRecord {
                 source_id: p0_source,
@@ -4174,6 +4194,7 @@ mod tests {
                 target_controller: PlayerId(1),
                 amount: 2,
                 is_combat: false,
+                ..Default::default()
             },
             DamageRecord {
                 source_id: p0_other_source,
@@ -4182,6 +4203,7 @@ mod tests {
                 target_controller: PlayerId(1),
                 amount: 4,
                 is_combat: false,
+                ..Default::default()
             },
             DamageRecord {
                 source_id: p1_source,
@@ -4190,6 +4212,8 @@ mod tests {
                 target_controller: PlayerId(0),
                 amount: 9,
                 is_combat: false,
+                source_controller_snapshot: PlayerId(1),
+                ..Default::default()
             },
         ]);
 
@@ -4232,6 +4256,7 @@ mod tests {
                 target_controller: PlayerId(1),
                 amount: 1,
                 is_combat: true,
+                ..Default::default()
             },
             DamageRecord {
                 source_id: other_source,
@@ -4240,6 +4265,7 @@ mod tests {
                 target_controller: PlayerId(1),
                 amount: 1,
                 is_combat: true,
+                ..Default::default()
             },
         ]);
 
@@ -4280,6 +4306,8 @@ mod tests {
             target_controller: PlayerId(0),
             amount: 1,
             is_combat: false,
+            source_controller_snapshot: PlayerId(1),
+            ..Default::default()
         });
 
         let expr = QuantityExpr::Ref {
@@ -4339,6 +4367,7 @@ mod tests {
                 target_controller: PlayerId(1),
                 amount: 3,
                 is_combat: false,
+                ..Default::default()
             },
             DamageRecord {
                 source_id: p0_source,
@@ -4347,6 +4376,7 @@ mod tests {
                 target_controller: PlayerId(1),
                 amount: 2,
                 is_combat: false,
+                ..Default::default()
             },
             DamageRecord {
                 source_id: p0_other,
@@ -4355,6 +4385,7 @@ mod tests {
                 target_controller: PlayerId(1),
                 amount: 4,
                 is_combat: false,
+                ..Default::default()
             },
             DamageRecord {
                 source_id: p1_source,
@@ -4363,6 +4394,8 @@ mod tests {
                 target_controller: PlayerId(0),
                 amount: 9,
                 is_combat: false,
+                source_controller_snapshot: PlayerId(1),
+                ..Default::default()
             },
         ]);
 
@@ -4409,6 +4442,9 @@ mod tests {
             Zone::Battlefield,
         );
         // Damage was dealt while P0 controlled the source.
+        // CR 608.2i: the source-controller snapshot captures P0 at damage time;
+        // the source-side filter now matches against this snapshot, not the live
+        // object's controller (which changes below).
         state.damage_dealt_this_turn.push(DamageRecord {
             source_id: damage_source,
             source_controller: PlayerId(0),
@@ -4416,6 +4452,8 @@ mod tests {
             target_controller: PlayerId(1),
             amount: 4,
             is_combat: false,
+            source_controller_snapshot: PlayerId(0),
+            ..Default::default()
         });
         // Then control changed (e.g., Threaten); the live object now belongs to P1.
         state.objects.get_mut(&damage_source).unwrap().controller = PlayerId(1);
@@ -4467,6 +4505,7 @@ mod tests {
             target_controller: PlayerId(1),
             amount: 3,
             is_combat: false,
+            ..Default::default()
         });
         state.objects.get_mut(&target).unwrap().controller = PlayerId(0);
 
@@ -5390,6 +5429,7 @@ mod tests {
             target_controller: PlayerId(1),
             amount: 4,
             is_combat: true,
+            ..Default::default()
         });
         state.damage_dealt_this_turn.push(DamageRecord {
             source_id: ObjectId(99),
@@ -5398,6 +5438,7 @@ mod tests {
             target_controller: PlayerId(2),
             amount: 2,
             is_combat: false,
+            ..Default::default()
         });
         // Self-damage record must not count as an "opponent dealt combat damage".
         state.damage_dealt_this_turn.push(DamageRecord {
@@ -5407,11 +5448,12 @@ mod tests {
             target_controller: PlayerId(0),
             amount: 1,
             is_combat: true,
+            ..Default::default()
         });
 
         let expr = QuantityExpr::Ref {
             qty: QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage,
+                filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
             },
         };
         // Controller = player 0: only player 1 satisfies (combat + opponent).
@@ -5426,10 +5468,110 @@ mod tests {
         let state = GameState::new_two_player(42);
         let expr = QuantityExpr::Ref {
             qty: QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage,
+                filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
             },
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 0);
+    }
+
+    /// CR 608.2i (the whole point): a source-restricted `OpponentDealtCombatDamage`
+    /// must match against the record's damage-time source snapshot, NOT the live
+    /// object. Record combat damage from a Dragon to an opponent, then remove
+    /// the live Dragon from the battlefield. A resolve-now model would see no
+    /// Dragon and return 0; the snapshot model still counts the opponent (1).
+    #[test]
+    fn opponent_dealt_combat_damage_source_uses_damage_time_snapshot() {
+        let mut state = GameState::new_two_player(42);
+        let dragon = create_object(
+            &mut state,
+            CardId(1000),
+            PlayerId(0),
+            "Shivan Dragon".to_string(),
+            Zone::Battlefield,
+        );
+        // The live object's subtype at damage time IS Dragon; record the snapshot.
+        state.damage_dealt_this_turn.push(DamageRecord {
+            source_id: dragon,
+            source_controller: PlayerId(0),
+            target: TargetRef::Player(PlayerId(1)),
+            target_controller: PlayerId(1),
+            amount: 5,
+            is_combat: true,
+            source_subtypes: vec!["Dragon".to_string()],
+            source_core_types: vec![CoreType::Creature],
+            source_controller_snapshot: PlayerId(0),
+            source_owner: PlayerId(0),
+            ..Default::default()
+        });
+        // The live Dragon leaves the battlefield (or is transformed). A
+        // resolve-now matcher against the live object would now find nothing.
+        state.objects.remove(&dragon);
+
+        let dragon_filter =
+            TargetFilter::Typed(TypedFilter::default().subtype("Dragon".to_string()));
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::OpponentDealtCombatDamage {
+                    source: Some(Box::new(dragon_filter)),
+                },
+            },
+        };
+        // CR 608.2i: the opponent was dealt combat damage by a Dragon this turn,
+        // even though the Dragon no longer exists.
+        assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), dragon), 1);
+    }
+
+    /// CR 120.9 + CR 608.2i: source-filter discrimination — a Dragon-restricted
+    /// filter counts a Dragon-snapshot record but not a non-Dragon one; a
+    /// `SelfRef` filter matches only the record whose source is the ability source.
+    #[test]
+    fn opponent_dealt_combat_damage_source_filter_discriminates() {
+        let mut state = GameState::new_two_player(42);
+        let ability_source = ObjectId(50);
+        // Record 1: combat damage to opponent from a Dragon that IS the ability source.
+        state.damage_dealt_this_turn.push(DamageRecord {
+            source_id: ability_source,
+            source_controller: PlayerId(0),
+            target: TargetRef::Player(PlayerId(1)),
+            target_controller: PlayerId(1),
+            amount: 2,
+            is_combat: true,
+            source_subtypes: vec!["Dragon".to_string()],
+            source_core_types: vec![CoreType::Creature],
+            source_controller_snapshot: PlayerId(0),
+            source_owner: PlayerId(0),
+            ..Default::default()
+        });
+
+        let dragon = TargetFilter::Typed(TypedFilter::default().subtype("Dragon".to_string()));
+        let goblin = TargetFilter::Typed(TypedFilter::default().subtype("Goblin".to_string()));
+
+        let count = |source: TargetFilter| {
+            resolve_quantity(
+                &state,
+                &QuantityExpr::Ref {
+                    qty: QuantityRef::PlayerCount {
+                        filter: PlayerFilter::OpponentDealtCombatDamage {
+                            source: Some(Box::new(source)),
+                        },
+                    },
+                },
+                PlayerId(0),
+                ability_source,
+            )
+        };
+
+        assert_eq!(count(dragon), 1, "Dragon snapshot matches Dragon filter");
+        assert_eq!(
+            count(goblin),
+            0,
+            "Dragon snapshot does not match Goblin filter"
+        );
+        assert_eq!(
+            count(TargetFilter::SelfRef),
+            1,
+            "record source IS the ability source → SelfRef matches"
+        );
     }
 
     /// CR 119.3: `LifeLostThisTurn { Opponent { Sum } }` sums life lost across

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -11,7 +11,8 @@ use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
 
 use super::filter::{
-    matches_target_filter, matches_target_filter_on_battlefield_entry, FilterContext,
+    matches_target_filter, matches_target_filter_on_battlefield_entry,
+    matches_target_filter_on_damage_record_source, FilterContext,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, PendingReplacement, WaitingFor};
@@ -2468,8 +2469,11 @@ fn evaluate_replacement_condition(
             };
             let ctx = FilterContext::from_source(state, source_id);
             state.damage_dealt_this_turn.iter().any(|record| {
+                // CR 608.2i + CR 608.2h: match the damage source against its
+                // damage-time snapshot (look-back), consistent with
+                // DamageDealtThisTurn / OpponentDealtCombatDamage.
                 record.target == TargetRef::Object(affected_id)
-                    && matches_target_filter(state, record.source_id, source, &ctx)
+                    && matches_target_filter_on_damage_record_source(state, record, source, &ctx)
             })
         }
         ReplacementCondition::EventSourceControlledBy {
@@ -6006,6 +6010,7 @@ mod tests {
             target_controller: PlayerId(0),
             amount: 1,
             is_combat: false,
+            ..Default::default()
         });
 
         let cond = ReplacementCondition::DealtDamageThisTurnBySource {
@@ -6049,6 +6054,7 @@ mod tests {
             target_controller: PlayerId(1),
             amount: 1,
             is_combat: false,
+            ..Default::default()
         });
 
         assert!(evaluate_replacement_condition(
@@ -6097,6 +6103,7 @@ mod tests {
             target_controller: PlayerId(0),
             amount: 1,
             is_combat: false,
+            ..Default::default()
         });
 
         assert!(evaluate_replacement_condition(
@@ -6109,6 +6116,105 @@ mod tests {
             Some(ObjectId(30)),
             &dummy_begin_turn_event(),
         ));
+    }
+
+    /// CR 608.2i + CR 608.2h: `DealtDamageThisTurnBySource` matches the damage
+    /// source against its damage-time *snapshot*, not the live object. A Dragon
+    /// deals damage this turn and is then transformed into a non-Dragon (or
+    /// leaves the battlefield). A live-object source match would now read the
+    /// current characteristics and fail; the snapshot match still recognizes
+    /// the source was a Dragon when the damage was dealt. This is the
+    /// discriminating regression guard for the lookback unification — it would
+    /// FAIL under the previous `matches_target_filter(state, record.source_id,
+    /// ..)` live read.
+    #[test]
+    fn dealt_damage_by_source_uses_damage_time_snapshot() {
+        use crate::types::ability::{TargetFilter, TypedFilter};
+        use crate::types::card_type::CoreType;
+
+        let mut state = test_state_with_object(ObjectId(10), Zone::Battlefield, Vec::new());
+        let dragon_id = ObjectId(20);
+        let victim_id = ObjectId(30);
+
+        // The damage source: a Dragon creature controlled by PlayerId(0) at damage time.
+        let mut dragon = GameObject::new(
+            dragon_id,
+            CardId(2),
+            PlayerId(0),
+            "Shivan Dragon".to_string(),
+            Zone::Battlefield,
+        );
+        dragon.card_types.core_types.push(CoreType::Creature);
+        dragon.card_types.subtypes.push("Dragon".to_string());
+        state.objects.insert(dragon_id, dragon);
+        state.battlefield.push_back(dragon_id);
+
+        let victim = GameObject::new(
+            victim_id,
+            CardId(3),
+            PlayerId(0),
+            "Victim".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.insert(victim_id, victim);
+
+        // Record damage with the Dragon characteristics captured at damage time.
+        state.damage_dealt_this_turn.push(DamageRecord {
+            source_id: dragon_id,
+            source_controller: PlayerId(0),
+            target: TargetRef::Object(victim_id),
+            target_controller: PlayerId(0),
+            amount: 3,
+            is_combat: false,
+            source_subtypes: vec!["Dragon".to_string()],
+            source_core_types: vec![CoreType::Creature],
+            source_controller_snapshot: PlayerId(0),
+            source_owner: PlayerId(0),
+            ..Default::default()
+        });
+
+        // Now mutate the LIVE source: strip its Dragon subtype (transformed into
+        // a non-Dragon permanent). A live-object match would no longer see a Dragon.
+        let live = state.objects.get_mut(&dragon_id).unwrap();
+        live.card_types.subtypes.clear();
+        live.card_types.core_types.clear();
+
+        let dragon_filter =
+            TargetFilter::Typed(TypedFilter::default().subtype("Dragon".to_string()));
+        let cond = ReplacementCondition::DealtDamageThisTurnBySource {
+            source: dragon_filter,
+        };
+
+        // The snapshot says the source was a Dragon at damage time → matches.
+        assert!(
+            evaluate_replacement_condition(
+                &cond,
+                PlayerId(0),
+                ObjectId(10),
+                &state,
+                Some(victim_id),
+                &dummy_begin_turn_event(),
+            ),
+            "source matched its damage-time Dragon snapshot even after the live \
+             object lost the Dragon subtype (CR 608.2i lookback)"
+        );
+
+        // A non-matching filter (Goblin) must NOT match the Dragon snapshot —
+        // confirms the swap discriminates on snapshot characteristics, not Any.
+        let goblin_cond = ReplacementCondition::DealtDamageThisTurnBySource {
+            source: TargetFilter::Typed(TypedFilter::default().subtype("Goblin".to_string())),
+        };
+        assert!(
+            !evaluate_replacement_condition(
+                &goblin_cond,
+                PlayerId(0),
+                ObjectId(10),
+                &state,
+                Some(victim_id),
+                &dummy_begin_turn_event(),
+            ),
+            "Dragon snapshot must not satisfy a Goblin source filter"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3705,7 +3705,7 @@ pub(crate) fn check_trigger_condition(
             | PlayerFilter::OpponentGainedLife
             // CR 120.1 + CR 510.1: a set-valued combat-damaged-this-turn
             // predicate has no single-player "whose turn" semantic.
-            | PlayerFilter::OpponentDealtCombatDamage
+            | PlayerFilter::OpponentDealtCombatDamage { .. }
             // CR 508.6: a set-valued attacked-this-turn predicate has no
             // single-player "whose turn" semantic.
             | PlayerFilter::OpponentAttackedThisTurn
@@ -8698,6 +8698,7 @@ pub mod tests {
             target_controller: PlayerId(0),
             amount: 3,
             is_combat: false,
+            ..Default::default()
         });
 
         let condition = TriggerCondition::DealtDamageBySourceThisTurn;
@@ -8796,6 +8797,7 @@ pub mod tests {
             target_controller: PlayerId(0),
             amount: 2,
             is_combat: true,
+            ..Default::default()
         });
         assert!(!state.damage_dealt_this_turn.is_empty());
 

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -24,7 +24,8 @@ use super::oracle_nom::quantity as nom_quantity;
 use super::oracle_nom::target as nom_target;
 use crate::parser::oracle_effect::counter::normalize_counter_type;
 use crate::parser::oracle_effect::parse_controls_permanent_object;
-use crate::parser::oracle_target::{parse_type_phrase, parse_type_phrase_with_ctx};
+use crate::parser::oracle_target::{parse_target, parse_type_phrase, parse_type_phrase_with_ctx};
+use crate::parser::oracle_util::merge_or_filters;
 use crate::types::ability::{
     AggregateFunction, Comparator, ControllerRef, CountScope, DevotionColors, FilterProp,
     ObjectProperty, ObjectScope, PlayerFilter, PlayerRelation, PlayerScope, QuantityExpr,
@@ -318,9 +319,11 @@ pub(crate) fn parse_quantity_ref_with_context(
         // upstream callers may strip durations before this parser sees the
         // phrase. PlayerCount{OpponentDealtCombatDamage} is inherently scoped
         // to this turn through `state.damage_dealt_this_turn`.
-        if parse_opponent_dealt_combat_damage_clause(rest).is_ok() {
+        if let Ok((_, source)) = parse_opponent_dealt_combat_damage_clause(rest) {
             return Some(QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage,
+                filter: PlayerFilter::OpponentDealtCombatDamage {
+                    source: source.map(Box::new),
+                },
             });
         }
         // CR 508.6: "opponents you attacked [this turn]" (Militant Angel).
@@ -829,20 +832,64 @@ fn parse_counters_removed_phrase(input: &str) -> nom::IResult<&str, (), OracleEr
     Ok((input, ()))
 }
 
+/// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Parse "[your] opponents who were
+/// dealt combat damage [by <source>] [this turn]" into the optional source
+/// filter. Returns `Ok((_, None))` for the unfiltered class (Tymna the Weaver,
+/// Moonshae Pixie) and `Ok((_, Some(f)))` for a `by <source>` restriction
+/// (Estinien Varlineau: "by ~ or a Dragon" → `Or[SelfRef, Typed{Dragon}]`).
+/// `Err` means the clause did not match. The whole clause must be consumed
+/// (explicit `eof`) so trailing unrecognized text doesn't silently drop.
 fn parse_opponent_dealt_combat_damage_clause(
     input: &str,
-) -> nom::IResult<&str, (), OracleError<'_>> {
-    all_consuming((
-        alt((tag::<_, _, OracleError<'_>>("opponents"), tag("opponent"))),
-        tag(" "),
-        alt((tag("that"), tag("who"))),
-        tag(" "),
-        alt((tag("were"), tag("was"))),
-        tag(" dealt combat damage"),
-        opt(tag(" this turn")),
-    ))
-    .parse(input)
-    .map(|(rest, _)| (rest, ()))
+) -> OracleResult<'_, Option<TargetFilter>> {
+    let (input, _) = opt(tag("your ")).parse(input)?;
+    let (input, _) = alt((tag("opponents"), tag("opponent"))).parse(input)?;
+    let (input, _) = tag(" ").parse(input)?;
+    let (input, _) = alt((tag("that"), tag("who"))).parse(input)?;
+    let (input, _) = tag(" ").parse(input)?;
+    let (input, _) = alt((tag("were"), tag("was"))).parse(input)?;
+    let (input, _) = tag(" dealt combat damage").parse(input)?;
+    // CR 120.9: optional "by <source>" restriction. The source phrase is
+    // isolated from the optional trailing " this turn" with a combinator
+    // (`take_until` / `eof`), then parsed via the `parse_target` + " or " +
+    // `merge_or_filters` building block.
+    let (input, source) = opt(preceded(tag(" by "), parse_damage_source_chain)).parse(input)?;
+    let (input, _) = opt(tag(" this turn")).parse(input)?;
+    let (input, _) = eof.parse(input)?;
+    Ok((input, source))
+}
+
+/// CR 120.9 + CR 608.2i: Parse a damage-source phrase ("~", "a Dragon", "~ or a
+/// Dragon") into a `TargetFilter`, composing chained "or"-separated subjects via
+/// `parse_target` + `merge_or_filters`. The source phrase ends at the optional
+/// trailing " this turn" or at end-of-input. Isolating the phrase with
+/// `take_until`/`eof` (not `.split`/`.rfind`/`.contains`) lets `parse_target`
+/// consume the whole subject without swallowing the duration suffix.
+fn parse_damage_source_chain(input: &str) -> OracleResult<'_, TargetFilter> {
+    // Isolate the source phrase: everything up to " this turn", or the whole
+    // remainder if no duration suffix is present.
+    let (rest, phrase) = alt((take_until(" this turn"), nom::combinator::rest)).parse(input)?;
+    if phrase.is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+    let filter = parse_source_chain_phrase(phrase);
+    Ok((rest, filter))
+}
+
+/// Recursively parse "X or Y or ..." over a fully-isolated source phrase using
+/// `parse_target` (which maps "~" → `SelfRef` and "a Dragon" → `Typed{Dragon}`)
+/// and `merge_or_filters` to fold the disjunction.
+fn parse_source_chain_phrase(phrase: &str) -> TargetFilter {
+    let (first, rest) = parse_target(phrase);
+    let rest = rest.trim_start();
+    if let Ok((after, _)) = tag::<_, _, OracleError<'_>>("or ").parse(rest) {
+        let second = parse_source_chain_phrase(after);
+        return merge_or_filters(first, second);
+    }
+    first
 }
 
 /// CR 508.6: "opponents you attacked [this turn]". Trailing " this turn"
@@ -1758,9 +1805,11 @@ fn parse_for_each_clause_with_they_controller(
     // / "opponent who was dealt combat damage this turn". Mirrors the
     // lost-life / gained-life arms above, but consumes the full clause instead
     // of doing substring dispatch.
-    if parse_opponent_dealt_combat_damage_clause(clause).is_ok() {
+    if let Ok((_, source)) = parse_opponent_dealt_combat_damage_clause(clause) {
         return Some(QuantityRef::PlayerCount {
-            filter: PlayerFilter::OpponentDealtCombatDamage,
+            filter: PlayerFilter::OpponentDealtCombatDamage {
+                source: source.map(Box::new),
+            },
         });
     }
 
@@ -2330,7 +2379,7 @@ mod tests {
             assert_eq!(
                 parse_for_each_clause(phrase),
                 Some(QuantityRef::PlayerCount {
-                    filter: PlayerFilter::OpponentDealtCombatDamage,
+                    filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
                 }),
                 "phrase {phrase:?} must consume as OpponentDealtCombatDamage"
             );
@@ -2933,7 +2982,7 @@ mod tests {
             qty,
             QuantityExpr::Ref {
                 qty: QuantityRef::PlayerCount {
-                    filter: PlayerFilter::OpponentDealtCombatDamage,
+                    filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
                 }
             }
         );
@@ -2950,7 +2999,7 @@ mod tests {
             qty,
             QuantityExpr::Ref {
                 qty: QuantityRef::PlayerCount {
-                    filter: PlayerFilter::OpponentDealtCombatDamage,
+                    filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
                 }
             }
         );
@@ -2979,10 +3028,78 @@ mod tests {
                 qty,
                 QuantityExpr::Ref {
                     qty: QuantityRef::PlayerCount {
-                        filter: PlayerFilter::OpponentDealtCombatDamage,
+                        filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
                     }
                 },
                 "phrase {phrase:?} must route to OpponentDealtCombatDamage",
+            );
+        }
+    }
+
+    /// CR 120.9 + CR 608.2i: Estinien Varlineau — "the number of your opponents
+    /// who were dealt combat damage by ~ or a Dragon this turn" must parse the
+    /// `by <source>` restriction into `Some(Or[SelfRef, Typed{Dragon}])`. The
+    /// `your ` possessive head and the trailing ` this turn` duration are both
+    /// consumed by combinators; the source phrase folds via `parse_target` +
+    /// `merge_or_filters`. Previously this produced a bare `Variable("...")`
+    /// that resolved to 0 at runtime.
+    #[test]
+    fn opponent_dealt_combat_damage_by_self_or_dragon() {
+        let qty = parse_quantity_ref(
+            "the number of your opponents who were dealt combat damage by ~ or a Dragon this turn",
+        )
+        .expect("must parse to PlayerCount");
+        assert_eq!(
+            qty,
+            QuantityRef::PlayerCount {
+                filter: PlayerFilter::OpponentDealtCombatDamage {
+                    source: Some(Box::new(TargetFilter::Or {
+                        filters: vec![
+                            TargetFilter::SelfRef,
+                            TargetFilter::Typed(
+                                TypedFilter::default().subtype("Dragon".to_string())
+                            ),
+                        ],
+                    })),
+                },
+            }
+        );
+    }
+
+    /// CR 120.9 + CR 608.2i: a single-source `by ~` restriction parses to
+    /// `Some(SelfRef)` — the source filter is the ability source alone.
+    #[test]
+    fn opponent_dealt_combat_damage_by_self_only() {
+        let qty = parse_quantity_ref(
+            "the number of opponents who were dealt combat damage by ~ this turn",
+        )
+        .expect("must parse to PlayerCount");
+        assert_eq!(
+            qty,
+            QuantityRef::PlayerCount {
+                filter: PlayerFilter::OpponentDealtCombatDamage {
+                    source: Some(Box::new(TargetFilter::SelfRef)),
+                },
+            }
+        );
+    }
+
+    /// CR 120.1 + CR 510.1: the unfiltered class (Tymna the Weaver, Moonshae
+    /// Pixie) — no `by <source>` clause — must still parse to `source: None`,
+    /// including with the optional `your ` possessive head.
+    #[test]
+    fn opponent_dealt_combat_damage_unfiltered_is_none() {
+        for phrase in [
+            "the number of opponents who were dealt combat damage this turn",
+            "the number of your opponents who were dealt combat damage this turn",
+            "the number of opponents that were dealt combat damage",
+        ] {
+            assert_eq!(
+                parse_quantity_ref(phrase),
+                Some(QuantityRef::PlayerCount {
+                    filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
+                }),
+                "phrase {phrase:?} must parse to unfiltered OpponentDealtCombatDamage"
             );
         }
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -18699,7 +18699,7 @@ mod tests {
 
         let bound_qty = QuantityExpr::Ref {
             qty: QuantityRef::PlayerCount {
-                filter: PlayerFilter::OpponentDealtCombatDamage,
+                filter: PlayerFilter::OpponentDealtCombatDamage { source: None },
             },
         };
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3293,12 +3293,19 @@ pub enum PlayerFilter {
     OpponentLostLife,
     /// Each opponent who gained life this turn (life_gained_this_turn > 0).
     OpponentGainedLife,
-    /// CR 120.1 + CR 510.1: Each opponent who was dealt combat damage this turn.
-    /// Resolved against `state.damage_dealt_this_turn` records whose
-    /// `is_combat = true` and `target = Player(p.id)`. Used by partner-quality
-    /// "for each opponent that was dealt combat damage this turn" cards
-    /// (Tymna the Weaver).
-    OpponentDealtCombatDamage,
+    /// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent who was dealt
+    /// combat damage this turn, optionally restricted to damage from a source
+    /// matching `source`. Resolved against `state.damage_dealt_this_turn`
+    /// records whose `is_combat = true` and `target = Player(p.id)`. `source =
+    /// None` counts any combat-damage source (Tymna the Weaver); `source =
+    /// Some(f)` (CR 120.9) counts only opponents dealt combat damage by a source
+    /// matching `f` — matched against each record's CR 608.2i look-back source
+    /// snapshot, so the source's qualities are checked as they were at damage
+    /// time (Estinien Varlineau: "by ~ or a Dragon").
+    OpponentDealtCombatDamage {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<Box<TargetFilter>>,
+    },
     /// CR 508.6: A player has "attacked [a player]" if they declared one or more
     /// creatures attacking that player. Each opponent the controller attacked this
     /// turn, resolved against `state.attacked_defenders_this_turn[controller]`.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -509,6 +509,14 @@ pub struct ChosenDamageSource {
 }
 
 /// CR 120.1: Snapshot of a damage event for "was dealt damage by" queries.
+///
+/// CR 608.2i + CR 608.2h: source characteristics snapshot at damage time
+/// (look-back; criteria need not still hold). Queries such as "opponents who
+/// were dealt combat damage by ~ or a Dragon this turn" (Estinien Varlineau)
+/// must match the source's qualities *as they were when damage was dealt* — the
+/// source may have since changed type, left the battlefield, or been removed.
+/// The `source_*` snapshot fields mirror `CounterAddedRecord`'s event-time
+/// characteristic capture and feed `matches_target_filter_on_damage_record_source`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DamageRecord {
     pub source_id: ObjectId,
@@ -520,6 +528,59 @@ pub struct DamageRecord {
     pub amount: u32,
     #[serde(default)]
     pub is_combat: bool,
+    // CR 608.2i + CR 608.2h: source characteristics snapshot at damage time
+    // (look-back; criteria need not still hold).
+    #[serde(default)]
+    pub source_name: String,
+    #[serde(default)]
+    pub source_core_types: Vec<CoreType>,
+    #[serde(default)]
+    pub source_subtypes: Vec<String>,
+    #[serde(default)]
+    pub source_supertypes: Vec<Supertype>,
+    #[serde(default)]
+    pub source_keywords: Vec<Keyword>,
+    #[serde(default)]
+    pub source_power: Option<i32>,
+    #[serde(default)]
+    pub source_toughness: Option<i32>,
+    #[serde(default)]
+    pub source_colors: Vec<ManaColor>,
+    #[serde(default)]
+    pub source_mana_value: u32,
+    #[serde(default)]
+    pub source_controller_snapshot: PlayerId,
+    #[serde(default)]
+    pub source_owner: PlayerId,
+}
+
+impl Default for DamageRecord {
+    /// A non-combat, zero-amount record from/to player 0 with an empty source
+    /// snapshot. Production damage recording (`deal_damage.rs`) always fills
+    /// every field explicitly; this default exists so test and synthesis
+    /// fixtures that only care about a few fields can spread `..Default::default()`
+    /// for the CR 608.2i source-snapshot fields they don't exercise.
+    fn default() -> Self {
+        Self {
+            source_id: ObjectId(0),
+            source_controller: PlayerId(0),
+            target: TargetRef::Player(PlayerId(0)),
+            target_controller: PlayerId(0),
+            amount: 0,
+            is_combat: false,
+            source_name: String::new(),
+            source_core_types: Vec::new(),
+            source_subtypes: Vec::new(),
+            source_supertypes: Vec::new(),
+            source_keywords: Vec::new(),
+            source_power: None,
+            source_toughness: None,
+            source_colors: Vec::new(),
+            source_mana_value: 0,
+            source_controller_snapshot: PlayerId(0),
+            source_owner: PlayerId(0),
+        }
+    }
 }
 
 /// CR 122.1 + CR 122.6: Snapshot of counters put on an object this turn.

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -430,13 +430,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9019,
+      "line": 9026,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 9037,
+          "line": 9044,
           "kind": "struct",
           "field_names": [
             "source",
@@ -454,7 +454,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 9053,
+          "line": 9060,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -465,7 +465,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 9058,
+          "line": 9065,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -479,7 +479,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 9063,
+          "line": 9070,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -489,7 +489,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 9071,
+          "line": 9078,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -499,7 +499,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9074,
+          "line": 9081,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -511,7 +511,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9078,
+          "line": 9085,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -524,7 +524,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9081,
+          "line": 9088,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -537,7 +537,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9084,
+          "line": 9091,
           "kind": "struct",
           "field_names": [
             "color",
@@ -551,7 +551,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 9090,
+          "line": 9097,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -564,7 +564,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9098,
+          "line": 9105,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -575,7 +575,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9101,
+          "line": 9108,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -588,7 +588,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 9106,
+          "line": 9113,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -602,7 +602,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 9110,
+          "line": 9117,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -616,7 +616,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 9119,
+          "line": 9126,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -630,7 +630,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9124,
+          "line": 9131,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -640,7 +640,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9126,
+          "line": 9133,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -650,7 +650,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9129,
+          "line": 9136,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -660,7 +660,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 9133,
+          "line": 9140,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -672,7 +672,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 9138,
+          "line": 9145,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -686,7 +686,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9146,
+          "line": 9153,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -698,7 +698,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9151,
+          "line": 9158,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -714,7 +714,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 9163,
+          "line": 9170,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -727,7 +727,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 9167,
+          "line": 9174,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -740,7 +740,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 9171,
+          "line": 9178,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -750,7 +750,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9179,
+          "line": 9186,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -763,7 +763,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9184,
+          "line": 9191,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -776,7 +776,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9189,
+          "line": 9196,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -788,7 +788,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 9195,
+          "line": 9202,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -800,7 +800,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 9199,
+          "line": 9206,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -814,7 +814,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9202,
+          "line": 9209,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -824,7 +824,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 9211,
+          "line": 9218,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -837,7 +837,7 @@
         },
         {
           "name": "And",
-          "line": 9216,
+          "line": 9223,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -849,7 +849,7 @@
         },
         {
           "name": "Or",
-          "line": 9221,
+          "line": 9228,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -861,7 +861,7 @@
         },
         {
           "name": "Not",
-          "line": 9229,
+          "line": 9236,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -873,7 +873,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 9233,
+          "line": 9240,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -883,7 +883,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 9235,
+          "line": 9242,
           "kind": "struct",
           "field_names": [
             "state"
@@ -895,7 +895,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 9245,
+          "line": 9252,
           "kind": "struct",
           "field_names": [
             "n"
@@ -907,7 +907,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 9248,
+          "line": 9255,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -919,7 +919,7 @@
         },
         {
           "name": "ScopedPlayerMatches",
-          "line": 9268,
+          "line": 9275,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -945,13 +945,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4309,
+      "line": 4316,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 4310,
+          "line": 4317,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -961,7 +961,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 4319,
+          "line": 4326,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -974,7 +974,7 @@
         },
         {
           "name": "Tap",
-          "line": 4322,
+          "line": 4329,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -982,7 +982,7 @@
         },
         {
           "name": "Untap",
-          "line": 4323,
+          "line": 4330,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -990,7 +990,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 4324,
+          "line": 4331,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1000,7 +1000,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 4327,
+          "line": 4334,
           "kind": "struct",
           "field_names": [
             "target",
@@ -1011,7 +1011,7 @@
         },
         {
           "name": "PayLife",
-          "line": 4339,
+          "line": 4346,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1023,7 +1023,7 @@
         },
         {
           "name": "Discard",
-          "line": 4342,
+          "line": 4349,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1036,7 +1036,7 @@
         },
         {
           "name": "Exile",
-          "line": 4353,
+          "line": 4360,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1048,7 +1048,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 4362,
+          "line": 4369,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1061,7 +1061,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 4365,
+          "line": 4372,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1072,7 +1072,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 4376,
+          "line": 4383,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1087,7 +1087,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 4382,
+          "line": 4389,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1097,7 +1097,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4386,
+          "line": 4393,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1110,7 +1110,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4394,
+          "line": 4401,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1124,7 +1124,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4403,
+          "line": 4410,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1134,7 +1134,7 @@
         },
         {
           "name": "Mill",
-          "line": 4404,
+          "line": 4411,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1144,7 +1144,7 @@
         },
         {
           "name": "Exert",
-          "line": 4407,
+          "line": 4414,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1152,7 +1152,7 @@
         },
         {
           "name": "Blight",
-          "line": 4410,
+          "line": 4417,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1162,7 +1162,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4413,
+          "line": 4420,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1173,7 +1173,7 @@
         },
         {
           "name": "Behold",
-          "line": 4421,
+          "line": 4428,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1185,7 +1185,7 @@
         },
         {
           "name": "Composite",
-          "line": 4427,
+          "line": 4434,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1195,7 +1195,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4444,
+          "line": 4451,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1208,7 +1208,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4448,
+          "line": 4455,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1218,7 +1218,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4453,
+          "line": 4460,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1231,7 +1231,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4460,
+          "line": 4467,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1243,7 +1243,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4476,
+          "line": 4483,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1257,7 +1257,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4481,
+          "line": 4488,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1270,13 +1270,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8158,
+      "line": 8165,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 8160,
+          "line": 8167,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1284,7 +1284,7 @@
         },
         {
           "name": "Activated",
-          "line": 8161,
+          "line": 8168,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1292,7 +1292,7 @@
         },
         {
           "name": "Database",
-          "line": 8162,
+          "line": 8169,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1300,7 +1300,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 8165,
+          "line": 8172,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1308,7 +1308,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 8171,
+          "line": 8178,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1321,7 +1321,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8312,
+      "line": 8319,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1329,7 +1329,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 8314,
+          "line": 8321,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1339,7 +1339,7 @@
         },
         {
           "name": "Evolve",
-          "line": 8316,
+          "line": 8323,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1349,7 +1349,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 8318,
+          "line": 8325,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1359,7 +1359,7 @@
         },
         {
           "name": "Outlast",
-          "line": 8320,
+          "line": 8327,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1428,68 +1428,12 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8328,
+      "line": 8335,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8329,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AsInstant",
-          "line": 8330,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourTurn",
-          "line": 8331,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourUpkeep",
-          "line": 8332,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringCombat",
-          "line": 8333,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BeforeAttackersDeclared",
-          "line": 8334,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BeforeCombatDamage",
-          "line": 8335,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "OnlyOnceEachTurn",
           "line": 8336,
           "kind": "unit",
           "field_names": [],
@@ -1497,7 +1441,7 @@
           "cr_refs": []
         },
         {
-          "name": "OnlyOnce",
+          "name": "AsInstant",
           "line": 8337,
           "kind": "unit",
           "field_names": [],
@@ -1505,8 +1449,64 @@
           "cr_refs": []
         },
         {
-          "name": "MaxTimesEachTurn",
+          "name": "DuringYourTurn",
           "line": 8338,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringYourUpkeep",
+          "line": 8339,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DuringCombat",
+          "line": 8340,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeAttackersDeclared",
+          "line": 8341,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeCombatDamage",
+          "line": 8342,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "OnlyOnceEachTurn",
+          "line": 8343,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "OnlyOnce",
+          "line": 8344,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MaxTimesEachTurn",
+          "line": 8345,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1516,7 +1516,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8341,
+          "line": 8348,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1526,7 +1526,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 8345,
+          "line": 8352,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1536,7 +1536,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 8347,
+          "line": 8354,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1548,7 +1548,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 8352,
+          "line": 8359,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1562,7 +1562,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 8363,
+          "line": 8370,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1576,7 +1576,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 8376,
+          "line": 8383,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1589,13 +1589,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4685,
+      "line": 4692,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 4691,
+          "line": 4698,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1606,7 +1606,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4701,
+          "line": 4708,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1622,7 +1622,7 @@
         },
         {
           "name": "Choice",
-          "line": 4708,
+          "line": 4715,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1630,7 +1630,7 @@
         },
         {
           "name": "Required",
-          "line": 4710,
+          "line": 4717,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1641,7 +1641,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4719,
+      "line": 4726,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1649,7 +1649,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 4721,
+          "line": 4728,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1657,7 +1657,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4722,
+          "line": 4729,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1665,7 +1665,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 4723,
+          "line": 4730,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1745,7 +1745,7 @@
     },
     "AlternativeCastKeyword": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1439,
+      "line": 1500,
       "doc": "CR 118.9: Identifies which keyword ability granted an alternative casting cost so the `WaitingFor::AlternativeCastChoice` dispatcher can route to the keyword-specific post-payment handler. The four keywords share a single player decision shape (printed cost vs. alternative cost) but diverge in post-payment semantics — this enum keeps the prompt unified while preserving CR fidelity at resolution.  Adding a new alternative-cost keyword (e.g., Madness CR 702.35a, Spectacle CR 702.137a) is a compile error at every dispatch site until handled.",
       "cr_refs": [
         "CR 118.9",
@@ -1755,7 +1755,7 @@
       "variants": [
         {
           "name": "Warp",
-          "line": 1441,
+          "line": 1502,
           "kind": "unit",
           "field_names": [],
           "doc": "Custom Warp keyword — exile-at-end-step rider; no CR section.",
@@ -1763,7 +1763,7 @@
         },
         {
           "name": "Evoke",
-          "line": 1444,
+          "line": 1505,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: ETB + sacrifice trigger fires when the resolving permanent was cast for its evoke cost (CR 702.74b).",
@@ -1774,7 +1774,7 @@
         },
         {
           "name": "Overload",
-          "line": 1446,
+          "line": 1507,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a: Spell's text changes \"target\" to \"each\" (CR 702.96b-c).",
@@ -1785,7 +1785,7 @@
         },
         {
           "name": "Bestow",
-          "line": 1448,
+          "line": 1509,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a: Spell becomes an Aura with enchant creature (CR 702.103b).",
@@ -1796,7 +1796,7 @@
         },
         {
           "name": "Awaken",
-          "line": 1453,
+          "line": 1514,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: \"If this spell's awaken cost was paid, put N +1/+1 counters on target land you control. That land becomes a 0/0 Elemental creature with haste. It's still a land.\" Paying the awaken cost adds the land target (CR 702.113b); casting normally adds no target and no rider.",
@@ -1807,7 +1807,7 @@
         },
         {
           "name": "Cleave",
-          "line": 1456,
+          "line": 1517,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Paying the cleave cost removes every square-bracketed span from the spell's text (a text-changing effect).",
@@ -1921,13 +1921,13 @@
     },
     "AutoPassMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3259,
+      "line": 3320,
       "doc": "What the engine stores for auto-pass (includes captured state).",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3262,
+          "line": 3323,
           "kind": "struct",
           "field_names": [
             "initial_stack_len"
@@ -1937,7 +1937,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3266,
+          "line": 3327,
           "kind": "unit",
           "field_names": [],
           "doc": "Auto-pass through priority/combat stops until the flagged player's next turn starts. Interrupted by opponent stack activity (MTGA-style) or when the current phase matches the player's entry in `GameState::phase_stops`.",
@@ -1948,13 +1948,13 @@
     },
     "AutoPassRequest": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3251,
+      "line": 3312,
       "doc": "What the frontend requests for auto-pass (no internal state).  Phase stops that should interrupt `UntilEndOfTurn` are a separate per-player preference on `GameState::phase_stops`, managed via `GameAction::SetPhaseStops`. Keeping them out of the request preserves a single source of truth and lets the preference change mid-session without requiring a new auto-pass request.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3252,
+          "line": 3313,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1962,7 +1962,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3253,
+          "line": 3314,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2024,13 +2024,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4301,
+      "line": 4308,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 4302,
+          "line": 4309,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2038,7 +2038,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 4303,
+          "line": 4310,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2148,7 +2148,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5021,
+      "line": 5028,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2156,7 +2156,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 5024,
+          "line": 5031,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2164,7 +2164,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 5026,
+          "line": 5033,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2515,7 +2515,7 @@
     },
     "CastPaymentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 831,
+      "line": 892,
       "doc": "CR 601.2g-h: Whether the engine may auto-pay an unambiguous spell mana cost or must pause after announcement so the player can activate mana abilities manually before committing payment.",
       "cr_refs": [
         "CR 601.2g"
@@ -2523,7 +2523,7 @@
       "variants": [
         {
           "name": "Auto",
-          "line": 833,
+          "line": 894,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2531,7 +2531,7 @@
         },
         {
           "name": "Manual",
-          "line": 834,
+          "line": 895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2580,7 +2580,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4275,
+      "line": 4282,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -2589,7 +2589,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 4278,
+          "line": 4285,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -2600,7 +2600,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4237,
+      "line": 4244,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -2611,7 +2611,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4239,
+          "line": 4246,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -2622,7 +2622,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4242,
+          "line": 4249,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -2632,7 +2632,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4244,
+          "line": 4251,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -2642,7 +2642,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4246,
+          "line": 4253,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -2652,7 +2652,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4249,
+          "line": 4256,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -2662,7 +2662,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4255,
+          "line": 4262,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -2672,7 +2672,7 @@
         },
         {
           "name": "Escape",
-          "line": 4260,
+          "line": 4267,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -2683,7 +2683,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4263,
+          "line": 4270,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -2693,7 +2693,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4268,
+          "line": 4275,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -2887,68 +2887,12 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8384,
+      "line": 8391,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8385,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringCombat",
-          "line": 8386,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringOpponentsTurn",
-          "line": 8387,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourTurn",
-          "line": 8388,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourUpkeep",
-          "line": 8389,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringOpponentsUpkeep",
-          "line": 8390,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringAnyUpkeep",
-          "line": 8391,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourEndStep",
           "line": 8392,
           "kind": "unit",
           "field_names": [],
@@ -2956,7 +2900,7 @@
           "cr_refs": []
         },
         {
-          "name": "DuringOpponentsEndStep",
+          "name": "DuringCombat",
           "line": 8393,
           "kind": "unit",
           "field_names": [],
@@ -2964,7 +2908,7 @@
           "cr_refs": []
         },
         {
-          "name": "DeclareAttackersStep",
+          "name": "DuringOpponentsTurn",
           "line": 8394,
           "kind": "unit",
           "field_names": [],
@@ -2972,7 +2916,7 @@
           "cr_refs": []
         },
         {
-          "name": "DeclareBlockersStep",
+          "name": "DuringYourTurn",
           "line": 8395,
           "kind": "unit",
           "field_names": [],
@@ -2980,7 +2924,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeAttackersDeclared",
+          "name": "DuringYourUpkeep",
           "line": 8396,
           "kind": "unit",
           "field_names": [],
@@ -2988,7 +2932,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeBlockersDeclared",
+          "name": "DuringOpponentsUpkeep",
           "line": 8397,
           "kind": "unit",
           "field_names": [],
@@ -2996,7 +2940,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeCombatDamage",
+          "name": "DuringAnyUpkeep",
           "line": 8398,
           "kind": "unit",
           "field_names": [],
@@ -3004,7 +2948,7 @@
           "cr_refs": []
         },
         {
-          "name": "AfterCombat",
+          "name": "DuringYourEndStep",
           "line": 8399,
           "kind": "unit",
           "field_names": [],
@@ -3012,8 +2956,64 @@
           "cr_refs": []
         },
         {
-          "name": "RequiresCondition",
+          "name": "DuringOpponentsEndStep",
           "line": 8400,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DeclareAttackersStep",
+          "line": 8401,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DeclareBlockersStep",
+          "line": 8402,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeAttackersDeclared",
+          "line": 8403,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeBlockersDeclared",
+          "line": 8404,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeCombatDamage",
+          "line": 8405,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AfterCombat",
+          "line": 8406,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RequiresCondition",
+          "line": 8407,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3026,13 +3026,13 @@
     },
     "CastingVariant": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3344,
+      "line": 3405,
       "doc": "How a spell was cast — determines zone routing and post-resolution behavior. Replaces individual boolean flags (cast_as_adventure, cast_as_warp) with a single enum that captures the casting context.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Normal",
-          "line": 3347,
+          "line": 3408,
           "kind": "unit",
           "field_names": [],
           "doc": "Normal spell cast — no special resolution behavior.",
@@ -3040,7 +3040,7 @@
         },
         {
           "name": "Adventure",
-          "line": 3350,
+          "line": 3411,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.4: Cast as the Adventure half. On resolution, exiled with AdventureCreature permission and creature face restored.",
@@ -3050,7 +3050,7 @@
         },
         {
           "name": "Omen",
-          "line": 3353,
+          "line": 3414,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 720.3d / CR 720.4: Cast as the Omen half. On resolution, shuffled into its owner's library with normal characteristics restored.",
@@ -3061,7 +3061,7 @@
         },
         {
           "name": "Warp",
-          "line": 3356,
+          "line": 3417,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.185a: Cast via Warp alternative cost from hand. On resolution, creates a delayed trigger to exile at end step with WarpExile permission.",
@@ -3071,7 +3071,7 @@
         },
         {
           "name": "Escape",
-          "line": 3359,
+          "line": 3420,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138: Cast from graveyard via Escape. On resolution, goes to appropriate zone normally (unlike Flashback which exiles).",
@@ -3081,7 +3081,7 @@
         },
         {
           "name": "Retrace",
-          "line": 3362,
+          "line": 3423,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.81a: Cast from graveyard via Retrace by discarding a land card as an additional cost. Resolution uses normal spell routing.",
@@ -3091,7 +3091,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 3365,
+          "line": 3426,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.180a: Cast from graveyard for harmonize cost. On resolution, exiled instead of going anywhere else (unlike Escape which returns to graveyard).",
@@ -3101,7 +3101,7 @@
         },
         {
           "name": "Flashback",
-          "line": 3368,
+          "line": 3429,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34a: Cast from graveyard for flashback cost. On resolution (or whenever leaving the stack for any reason), exiled instead of going anywhere else.",
@@ -3111,7 +3111,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 3371,
+          "line": 3432,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Cast an aftermath half of a split card from a graveyard. If it was cast from a graveyard, exile it any time it leaves the stack.",
@@ -3121,7 +3121,7 @@
         },
         {
           "name": "GraveyardPermission",
-          "line": 3375,
+          "line": 3436,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3137,7 +3137,7 @@
         },
         {
           "name": "HandPermission",
-          "line": 3401,
+          "line": 3462,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3152,7 +3152,7 @@
         },
         {
           "name": "ExilePermission",
-          "line": 3417,
+          "line": 3478,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3168,7 +3168,7 @@
         },
         {
           "name": "Sneak",
-          "line": 3434,
+          "line": 3495,
           "kind": "struct",
           "field_names": [
             "returned_creature",
@@ -3182,7 +3182,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 3443,
+          "line": 3504,
           "kind": "struct",
           "field_names": [
             "returned_creature"
@@ -3194,7 +3194,7 @@
         },
         {
           "name": "Miracle",
-          "line": 3450,
+          "line": 3511,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94a: Cast from hand via Miracle's alternative cost after revealing the card as the first card drawn this turn. The granting keyword carries the miracle mana cost, which `prepare_spell_cast_with_variant_override` substitutes for the printed mana cost. The keyword's `ManaCost` payload is read at preparation time rather than stored here because `prepare_spell_cast` already reads `obj.keywords` for analogous paths.",
@@ -3204,7 +3204,7 @@
         },
         {
           "name": "Madness",
-          "line": 3453,
+          "line": 3514,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.35a: Cast from exile via Madness after the discard replacement exiled the card and its madness triggered ability resolved.",
@@ -3214,7 +3214,7 @@
         },
         {
           "name": "Evoke",
-          "line": 3457,
+          "line": 3518,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Cast from hand via Evoke's alternative cost. On resolution, the permanent enters tagged with `CastVariantPaid::Evoke`, which fires the synthesized intervening-if ETB sacrifice trigger.",
@@ -3224,7 +3224,7 @@
         },
         {
           "name": "Suspend",
-          "line": 3464,
+          "line": 3525,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast from exile via Suspend's \"play it without paying its mana cost\" trigger after the last time counter was removed. On resolution of the resulting permanent, the stack handler tags `CastVariantPaid::Suspend` and — for creature spells — installs a transient continuous \"has haste\" effect that lasts as long as the resolution-time controller still controls the permanent.",
@@ -3234,7 +3234,7 @@
         },
         {
           "name": "Plot",
-          "line": 3471,
+          "line": 3532,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.170d: Cast from exile via the Plot \"cast without paying its mana cost\" permission during the owner's main phase on a turn after the card was plotted. Detected at cast preparation when the exile-zone source has a `CastingPermission::Plotted { turn_plotted }` and the current turn is strictly greater than `turn_plotted`. Zeroes the mana cost and routes through the normal cast pipeline; no special resolution-time behavior.",
@@ -3244,7 +3244,7 @@
         },
         {
           "name": "Foretell",
-          "line": 3478,
+          "line": 3539,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143a-c: Cast from exile via a foretold card's foretell cost on a turn after it was foretold. Detected at cast preparation when the exile-zone source has a `CastingPermission::Foretold { .. }`. The permission supplies the alternative mana cost; stack finalization tags the source with `CastVariantPaid::Foretell` so \"if this spell was foretold\" clauses can evaluate while the spell resolves.",
@@ -3254,7 +3254,7 @@
         },
         {
           "name": "Overload",
-          "line": 3488,
+          "line": 3549,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a-c: Cast from hand via Overload's alternative cost. The printed mana cost is replaced by `Keyword::Overload(cost)` at cast preparation (mirrors `Evoke`/`Warp`). Per CR 702.96b, every \"target\" in the spell's text is replaced by \"each\" — applied as a cast-time transformation of the spell's ability tree (`Destroy`→`DestroyAll`, `Pump`→`PumpAll`, `DealDamage`→`DamageAll`, `Tap`→`TapAll`, `Bounce`→`ChangeZoneAll`). Per CR 702.96c, the resulting spell has no targets, so target selection is naturally skipped because the transformed effects carry no `TargetRef` slots.",
@@ -3266,7 +3266,7 @@
         },
         {
           "name": "Bestow",
-          "line": 3503,
+          "line": 3564,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a-b: Cast from hand via Bestow's alternative cost. The printed mana cost is replaced by `Keyword::Bestow(cost)` at cast preparation; the spell becomes an Aura with `enchant creature` while on the stack and as the resulting permanent (until it becomes unattached, per CR 702.103f). The type-changing mutation is applied directly to the stack object (mirroring `swap_to_alternative_spell_face` for Adventure/Omen) — Layers cannot be used here because they only apply to battlefield/hand objects, not stack objects.  Per CR 702.103e: if the target is illegal at resolution, the type-changing effect ends and the spell resolves as a creature spell. Per CR 702.103f: when a bestowed Aura becomes unattached on the battlefield, the type-changing effect ends — it remains as an enchantment creature (overrides CR 704.5m for bestow Auras).",
@@ -3279,7 +3279,7 @@
         },
         {
           "name": "Awaken",
-          "line": 3514,
+          "line": 3575,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: Cast from hand via Awaken's alternative cost. The printed mana cost is replaced by `Keyword::Awaken { cost }` at cast preparation (mirrors `Overload`). A resolution rider is appended to the tail of the spell's ability tree (`effects::awaken::append_awaken_rider`): the printed effect resolves first, then \"put N +1/+1 counters on target land you control; that land becomes a 0/0 Elemental creature with haste; it's still a land.\" Per CR 702.113b, the land target only exists on the awaken variant — a normal cast appends no rider and requests no land target. CR 702.113a: the spell goes to the graveyard normally, so this variant is deliberately absent from `exiles_when_leaving_stack_for_any_reason`.",
@@ -3290,7 +3290,7 @@
         },
         {
           "name": "Cleave",
-          "line": 3525,
+          "line": 3586,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Cast from hand via Cleave's alternative cost (CR 118.9). The printed mana cost is replaced by `Keyword::Cleave(cost)` at cast preparation (mirrors `Evoke`/`Overload`). Per CR 702.148a, paying the cleave cost is a text-changing effect (CR 612) that removes every square-bracketed span from the spell's rules text. The bracket-removed ability set is parsed at build time into `CardFace::cleave_variant` and swapped onto the stack object before preparation (mirroring the Bestow object-mutation-before-prepare seam). Resolution routing matches a normal spell — there is no on-resolve special behavior, so the spell goes to its owner's graveyard like any instant/sorcery.",
@@ -3804,7 +3804,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10091,
+      "line": 10098,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -3812,7 +3812,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 10092,
+          "line": 10099,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3820,7 +3820,7 @@
         },
         {
           "name": "Lost",
-          "line": 10093,
+          "line": 10100,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3831,13 +3831,13 @@
     },
     "CollectEvidenceResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 953,
+      "line": 1014,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Casting",
-          "line": 954,
+          "line": 1015,
           "kind": "struct",
           "field_names": [
             "pending_cast"
@@ -3847,7 +3847,7 @@
         },
         {
           "name": "Effect",
-          "line": 957,
+          "line": 1018,
           "kind": "struct",
           "field_names": [
             "pending_ability"
@@ -3860,7 +3860,7 @@
     },
     "CombatDamageAssignmentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2903,
+      "line": 2964,
       "doc": "CR 510.1c: Optional combat-damage assignment mode for attackers with text like \"you may have this creature assign its combat damage as though it weren't blocked.\"",
       "cr_refs": [
         "CR 510.1c"
@@ -3868,7 +3868,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 2905,
+          "line": 2966,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3876,7 +3876,7 @@
         },
         {
           "name": "AsThoughUnblocked",
-          "line": 2906,
+          "line": 2967,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3887,7 +3887,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10591,
+      "line": 10598,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -3895,7 +3895,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 10592,
+          "line": 10599,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3903,7 +3903,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 10593,
+          "line": 10600,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3958,7 +3958,7 @@
     },
     "CombatTaxContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1154,
+      "line": 1215,
       "doc": "CR 508.1d + CR 509.1c: Which combat step a `WaitingFor::CombatTaxPayment` belongs to.  Drives the resume branch after the tax decision — on accept, the engine submits the stored attacker / blocker declaration; on decline, the engine filters the taxed creatures out of that declaration and submits the remainder.",
       "cr_refs": [
         "CR 508.1d",
@@ -3967,7 +3967,7 @@
       "variants": [
         {
           "name": "Attacking",
-          "line": 1155,
+          "line": 1216,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3975,7 +3975,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1156,
+          "line": 1217,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3986,7 +3986,7 @@
     },
     "CombatTaxPending": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1164,
+      "line": 1225,
       "doc": "CR 508.1d + CR 509.1c: The declaration that is paused awaiting a combat-tax decision. Keyed by `CombatTaxContext` — the engine resumes the matching variant on `GameAction::PayCombatTax`.",
       "cr_refs": [
         "CR 508.1d",
@@ -3995,7 +3995,7 @@
       "variants": [
         {
           "name": "Attack",
-          "line": 1165,
+          "line": 1226,
           "kind": "struct",
           "field_names": [
             "attacks"
@@ -4005,7 +4005,7 @@
         },
         {
           "name": "Block",
-          "line": 1168,
+          "line": 1229,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -4018,7 +4018,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3678,
+      "line": 3685,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -4026,7 +4026,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 3681,
+          "line": 3688,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -4037,7 +4037,7 @@
         },
         {
           "name": "Any",
-          "line": 3685,
+          "line": 3692,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -4141,13 +4141,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3549,
+      "line": 3556,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 3550,
+          "line": 3557,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4155,7 +4155,7 @@
         },
         {
           "name": "LT",
-          "line": 3551,
+          "line": 3558,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4163,7 +4163,7 @@
         },
         {
           "name": "GE",
-          "line": 3552,
+          "line": 3559,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4171,7 +4171,7 @@
         },
         {
           "name": "LE",
-          "line": 3553,
+          "line": 3560,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4179,7 +4179,7 @@
         },
         {
           "name": "EQ",
-          "line": 3554,
+          "line": 3561,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4187,7 +4187,7 @@
         },
         {
           "name": "NE",
-          "line": 3555,
+          "line": 3562,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4198,13 +4198,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11007,
+      "line": 11014,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 11008,
+          "line": 11015,
           "kind": "struct",
           "field_names": [
             "values",
@@ -4215,7 +4215,7 @@
         },
         {
           "name": "SetName",
-          "line": 11023,
+          "line": 11030,
           "kind": "struct",
           "field_names": [
             "name"
@@ -4229,7 +4229,7 @@
         },
         {
           "name": "AddPower",
-          "line": 11026,
+          "line": 11033,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4239,7 +4239,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 11029,
+          "line": 11036,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4249,7 +4249,7 @@
         },
         {
           "name": "SetPower",
-          "line": 11032,
+          "line": 11039,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4259,7 +4259,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 11035,
+          "line": 11042,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4269,7 +4269,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 11038,
+          "line": 11045,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4279,7 +4279,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 11041,
+          "line": 11048,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4289,7 +4289,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 11044,
+          "line": 11051,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4299,7 +4299,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 11051,
+          "line": 11058,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -4311,7 +4311,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 11054,
+          "line": 11061,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4319,7 +4319,7 @@
         },
         {
           "name": "AddType",
-          "line": 11055,
+          "line": 11062,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4329,7 +4329,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 11058,
+          "line": 11065,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4339,7 +4339,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 11061,
+          "line": 11068,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4349,7 +4349,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 11064,
+          "line": 11071,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4359,7 +4359,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 11071,
+          "line": 11078,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4372,7 +4372,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 11077,
+          "line": 11084,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4385,7 +4385,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 11081,
+          "line": 11088,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4395,7 +4395,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 11085,
+          "line": 11092,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4405,7 +4405,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 11092,
+          "line": 11099,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4417,7 +4417,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 11097,
+          "line": 11104,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4429,7 +4429,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 11101,
+          "line": 11108,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4441,7 +4441,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 11105,
+          "line": 11112,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4453,7 +4453,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 11110,
+          "line": 11117,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4466,7 +4466,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 11116,
+          "line": 11123,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4474,7 +4474,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 11119,
+          "line": 11126,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4485,7 +4485,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 11122,
+          "line": 11129,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4495,7 +4495,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 11127,
+          "line": 11134,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4505,7 +4505,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 11134,
+          "line": 11141,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -4516,7 +4516,7 @@
         },
         {
           "name": "SetColor",
-          "line": 11135,
+          "line": 11142,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4526,7 +4526,7 @@
         },
         {
           "name": "AddColor",
-          "line": 11138,
+          "line": 11145,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4536,7 +4536,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 11143,
+          "line": 11150,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4546,7 +4546,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 11157,
+          "line": 11164,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4561,7 +4561,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 11161,
+          "line": 11168,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4571,7 +4571,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 11164,
+          "line": 11171,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -4581,7 +4581,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 11166,
+          "line": 11173,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -4591,7 +4591,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 11168,
+          "line": 11175,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -4601,7 +4601,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 11171,
+          "line": 11178,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -4611,7 +4611,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 11174,
+          "line": 11181,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -4623,7 +4623,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 11188,
+          "line": 11195,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -4635,7 +4635,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 11196,
+          "line": 11203,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4650,7 +4650,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 11205,
+          "line": 11212,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4665,7 +4665,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 11219,
+          "line": 11226,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -4827,7 +4827,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11298,
+      "line": 11305,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -4837,7 +4837,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 11301,
+          "line": 11308,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -4845,7 +4845,7 @@
         },
         {
           "name": "Finalized",
-          "line": 11303,
+          "line": 11310,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -4856,13 +4856,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4965,
+      "line": 4972,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 4966,
+          "line": 4973,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4873,7 +4873,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6933,
+      "line": 6940,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -4882,7 +4882,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 6935,
+          "line": 6942,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -4890,7 +4890,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 6937,
+          "line": 6944,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -5014,7 +5014,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4495,
+      "line": 4502,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -5022,62 +5022,6 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4496,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TapsSelf",
-          "line": 4497,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "UntapsSelf",
-          "line": 4498,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SacrificesPermanent",
-          "line": 4499,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysLife",
-          "line": 4500,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysLoyalty",
-          "line": 4501,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Discards",
-          "line": 4502,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ExilesCards",
           "line": 4503,
           "kind": "unit",
           "field_names": [],
@@ -5085,7 +5029,7 @@
           "cr_refs": []
         },
         {
-          "name": "TapsOtherCreatures",
+          "name": "TapsSelf",
           "line": 4504,
           "kind": "unit",
           "field_names": [],
@@ -5093,7 +5037,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemovesCounters",
+          "name": "UntapsSelf",
           "line": 4505,
           "kind": "unit",
           "field_names": [],
@@ -5101,7 +5045,7 @@
           "cr_refs": []
         },
         {
-          "name": "PaysEnergy",
+          "name": "SacrificesPermanent",
           "line": 4506,
           "kind": "unit",
           "field_names": [],
@@ -5109,7 +5053,7 @@
           "cr_refs": []
         },
         {
-          "name": "PaysSpeed",
+          "name": "PaysLife",
           "line": 4507,
           "kind": "unit",
           "field_names": [],
@@ -5117,7 +5061,7 @@
           "cr_refs": []
         },
         {
-          "name": "ReturnsToHand",
+          "name": "PaysLoyalty",
           "line": 4508,
           "kind": "unit",
           "field_names": [],
@@ -5125,7 +5069,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unattaches",
+          "name": "Discards",
           "line": 4509,
           "kind": "unit",
           "field_names": [],
@@ -5133,7 +5077,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mills",
+          "name": "ExilesCards",
           "line": 4510,
           "kind": "unit",
           "field_names": [],
@@ -5141,7 +5085,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutsCounters",
+          "name": "TapsOtherCreatures",
           "line": 4511,
           "kind": "unit",
           "field_names": [],
@@ -5149,7 +5093,7 @@
           "cr_refs": []
         },
         {
-          "name": "Reveals",
+          "name": "RemovesCounters",
           "line": 4512,
           "kind": "unit",
           "field_names": [],
@@ -5157,7 +5101,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exerts",
+          "name": "PaysEnergy",
           "line": 4513,
           "kind": "unit",
           "field_names": [],
@@ -5165,8 +5109,64 @@
           "cr_refs": []
         },
         {
-          "name": "KeywordCost",
+          "name": "PaysSpeed",
           "line": 4514,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ReturnsToHand",
+          "line": 4515,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unattaches",
+          "line": 4516,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Mills",
+          "line": 4517,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PutsCounters",
+          "line": 4518,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Reveals",
+          "line": 4519,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Exerts",
+          "line": 4520,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "KeywordCost",
+          "line": 4521,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5629,7 +5629,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10468,
+      "line": 10475,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -5637,7 +5637,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10470,
+          "line": 10477,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -5645,7 +5645,7 @@
         },
         {
           "name": "Triple",
-          "line": 10472,
+          "line": 10479,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -5653,7 +5653,7 @@
         },
         {
           "name": "Plus",
-          "line": 10474,
+          "line": 10481,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5663,7 +5663,7 @@
         },
         {
           "name": "Minus",
-          "line": 10481,
+          "line": 10488,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5676,7 +5676,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 10485,
+          "line": 10492,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -5686,7 +5686,7 @@
         },
         {
           "name": "SetTo",
-          "line": 10491,
+          "line": 10498,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5698,7 +5698,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 10497,
+          "line": 10504,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -5748,7 +5748,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4946,
+      "line": 4953,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -5756,7 +5756,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 4948,
+          "line": 4955,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -5764,7 +5764,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 4951,
+          "line": 4958,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -5778,7 +5778,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10579,
+      "line": 10586,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -5786,7 +5786,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 10581,
+          "line": 10588,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -5794,7 +5794,7 @@
         },
         {
           "name": "Player",
-          "line": 10583,
+          "line": 10590,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5804,7 +5804,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 10586,
+          "line": 10593,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5817,7 +5817,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10567,
+      "line": 10574,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -5825,7 +5825,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10568,
+          "line": 10575,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5833,7 +5833,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10569,
+          "line": 10576,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5841,7 +5841,7 @@
         },
         {
           "name": "Controller",
-          "line": 10572,
+          "line": 10579,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -5849,7 +5849,7 @@
         },
         {
           "name": "Specific",
-          "line": 10573,
+          "line": 10580,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6392,7 +6392,7 @@
     },
     "DistributionUnit": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2922,
+      "line": 2983,
       "doc": "CR 601.2d: What is being distributed (damage, counters, life).",
       "cr_refs": [
         "CR 601.2d"
@@ -6400,7 +6400,7 @@
       "variants": [
         {
           "name": "Damage",
-          "line": 2923,
+          "line": 2984,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6408,7 +6408,7 @@
         },
         {
           "name": "EvenSplitDamage",
-          "line": 2926,
+          "line": 2987,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2d: Even split — engine auto-computes `total / num_targets` (rounded down). No player choice needed; bypasses `WaitingFor::DistributeAmong`.",
@@ -6418,7 +6418,7 @@
         },
         {
           "name": "Counters",
-          "line": 2927,
+          "line": 2988,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6426,7 +6426,7 @@
         },
         {
           "name": "Life",
-          "line": 2928,
+          "line": 2989,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6631,13 +6631,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5047,
+      "line": 5054,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 5049,
+          "line": 5056,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -6649,7 +6649,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 5055,
+          "line": 5062,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -6664,7 +6664,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 5066,
+          "line": 5073,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6676,7 +6676,7 @@
         },
         {
           "name": "Draw",
-          "line": 5086,
+          "line": 5093,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6692,7 +6692,7 @@
         },
         {
           "name": "Pump",
-          "line": 5092,
+          "line": 5099,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6704,7 +6704,7 @@
         },
         {
           "name": "PairWith",
-          "line": 5103,
+          "line": 5110,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6717,7 +6717,7 @@
         },
         {
           "name": "Destroy",
-          "line": 5106,
+          "line": 5113,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6728,7 +6728,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 5114,
+          "line": 5121,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6740,7 +6740,7 @@
         },
         {
           "name": "Counter",
-          "line": 5118,
+          "line": 5125,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6751,7 +6751,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 5139,
+          "line": 5146,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6765,7 +6765,7 @@
         },
         {
           "name": "Token",
-          "line": 5143,
+          "line": 5150,
           "kind": "struct",
           "field_names": [
             "name",
@@ -6788,7 +6788,7 @@
         },
         {
           "name": "GainLife",
-          "line": 5181,
+          "line": 5188,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6799,7 +6799,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 5188,
+          "line": 5195,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6810,7 +6810,7 @@
         },
         {
           "name": "Tap",
-          "line": 5195,
+          "line": 5202,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6820,7 +6820,7 @@
         },
         {
           "name": "Untap",
-          "line": 5199,
+          "line": 5206,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6830,7 +6830,7 @@
         },
         {
           "name": "TapAll",
-          "line": 5204,
+          "line": 5211,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6842,7 +6842,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 5209,
+          "line": 5216,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6854,18 +6854,6 @@
         },
         {
           "name": "AddCounter",
-          "line": 5213,
-          "kind": "struct",
-          "field_names": [
-            "counter_type",
-            "count",
-            "target"
-          ],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RemoveCounter",
           "line": 5220,
           "kind": "struct",
           "field_names": [
@@ -6877,8 +6865,20 @@
           "cr_refs": []
         },
         {
+          "name": "RemoveCounter",
+          "line": 5227,
+          "kind": "struct",
+          "field_names": [
+            "counter_type",
+            "count",
+            "target"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Sacrifice",
-          "line": 5228,
+          "line": 5235,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6890,7 +6890,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 5249,
+          "line": 5256,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6901,7 +6901,7 @@
         },
         {
           "name": "Mill",
-          "line": 5255,
+          "line": 5262,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6913,7 +6913,7 @@
         },
         {
           "name": "Scry",
-          "line": 5272,
+          "line": 5279,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6928,7 +6928,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 5278,
+          "line": 5285,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6940,7 +6940,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 5292,
+          "line": 5299,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6957,7 +6957,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 5316,
+          "line": 5323,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6970,7 +6970,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 5320,
+          "line": 5327,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6981,7 +6981,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 5327,
+          "line": 5334,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7000,7 +7000,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 5378,
+          "line": 5385,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7013,7 +7013,7 @@
         },
         {
           "name": "Dig",
-          "line": 5391,
+          "line": 5398,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7033,7 +7033,7 @@
         },
         {
           "name": "GainControl",
-          "line": 5417,
+          "line": 5424,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7043,7 +7043,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 5421,
+          "line": 5428,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7054,7 +7054,7 @@
         },
         {
           "name": "Attach",
-          "line": 5427,
+          "line": 5434,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7065,7 +7065,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 5439,
+          "line": 5446,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7078,7 +7078,7 @@
         },
         {
           "name": "Surveil",
-          "line": 5451,
+          "line": 5458,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7093,7 +7093,7 @@
         },
         {
           "name": "Fight",
-          "line": 5457,
+          "line": 5464,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7104,7 +7104,7 @@
         },
         {
           "name": "Bounce",
-          "line": 5465,
+          "line": 5472,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7116,7 +7116,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 5484,
+          "line": 5491,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7131,7 +7131,7 @@
         },
         {
           "name": "Explore",
-          "line": 5492,
+          "line": 5499,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7139,7 +7139,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 5496,
+          "line": 5503,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7151,7 +7151,7 @@
         },
         {
           "name": "Investigate",
-          "line": 5501,
+          "line": 5508,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.136: Investigate — create a Clue artifact token.",
@@ -7161,7 +7161,7 @@
         },
         {
           "name": "Tribute",
-          "line": 5508,
+          "line": 5515,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7174,7 +7174,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 5514,
+          "line": 5521,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -7184,7 +7184,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 5516,
+          "line": 5523,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -7194,7 +7194,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 5517,
+          "line": 5524,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7202,7 +7202,7 @@
         },
         {
           "name": "Populate",
-          "line": 5519,
+          "line": 5526,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -7212,7 +7212,7 @@
         },
         {
           "name": "Clash",
-          "line": 5521,
+          "line": 5528,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -7222,7 +7222,7 @@
         },
         {
           "name": "Vote",
-          "line": 5536,
+          "line": 5543,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7238,7 +7238,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 5580,
+          "line": 5587,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -7258,7 +7258,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 5599,
+          "line": 5606,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7270,7 +7270,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 5603,
+          "line": 5610,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7281,7 +7281,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 5612,
+          "line": 5619,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7294,7 +7294,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 5623,
+          "line": 5630,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7314,7 +7314,7 @@
         },
         {
           "name": "Myriad",
-          "line": 5670,
+          "line": 5677,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -7324,7 +7324,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 5673,
+          "line": 5680,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7340,7 +7340,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 5683,
+          "line": 5690,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7351,7 +7351,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 5689,
+          "line": 5696,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7363,7 +7363,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 5697,
+          "line": 5704,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7377,7 +7377,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 5704,
+          "line": 5711,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7389,7 +7389,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 5712,
+          "line": 5719,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7402,7 +7402,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 5718,
+          "line": 5725,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7415,7 +7415,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 5726,
+          "line": 5733,
           "kind": "struct",
           "field_names": [
             "source",
@@ -7433,7 +7433,7 @@
         },
         {
           "name": "Animate",
-          "line": 5746,
+          "line": 5753,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7448,7 +7448,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 5780,
+          "line": 5787,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -7472,7 +7472,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 5796,
+          "line": 5803,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -7482,7 +7482,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 5800,
+          "line": 5807,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -7494,7 +7494,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 5808,
+          "line": 5815,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -7511,7 +7511,7 @@
         },
         {
           "name": "Mana",
-          "line": 5826,
+          "line": 5833,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -7525,7 +7525,7 @@
         },
         {
           "name": "Discard",
-          "line": 5849,
+          "line": 5856,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7539,7 +7539,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 5871,
+          "line": 5878,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7549,7 +7549,7 @@
         },
         {
           "name": "Transform",
-          "line": 5875,
+          "line": 5882,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7559,7 +7559,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 5881,
+          "line": 5888,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7574,7 +7574,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 5923,
+          "line": 5930,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7592,7 +7592,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 5934,
+          "line": 5941,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7606,7 +7606,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 5958,
+          "line": 5965,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7619,7 +7619,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5969,
+          "line": 5976,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7632,7 +7632,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 5974,
+          "line": 5981,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7645,7 +7645,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 5983,
+          "line": 5990,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7657,7 +7657,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 6006,
+          "line": 6013,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7667,7 +7667,7 @@
         },
         {
           "name": "Choose",
-          "line": 6012,
+          "line": 6019,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -7678,7 +7678,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 6023,
+          "line": 6030,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -7691,7 +7691,7 @@
         },
         {
           "name": "Suspect",
-          "line": 6028,
+          "line": 6035,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7703,7 +7703,7 @@
         },
         {
           "name": "Connive",
-          "line": 6035,
+          "line": 6042,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7717,7 +7717,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 6043,
+          "line": 6050,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7729,7 +7729,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 6050,
+          "line": 6057,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7741,7 +7741,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 6055,
+          "line": 6062,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7753,7 +7753,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 6060,
+          "line": 6067,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -7763,7 +7763,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 6067,
+          "line": 6074,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7775,7 +7775,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 6074,
+          "line": 6081,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7787,7 +7787,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 6079,
+          "line": 6086,
           "kind": "struct",
           "field_names": [
             "level"
@@ -7799,7 +7799,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 6084,
+          "line": 6091,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -7813,7 +7813,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 6114,
+          "line": 6121,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -7827,7 +7827,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 6120,
+          "line": 6127,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -7839,7 +7839,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 6125,
+          "line": 6132,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7852,7 +7852,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 6132,
+          "line": 6139,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -7865,7 +7865,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 6141,
+          "line": 6148,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7878,7 +7878,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 6149,
+          "line": 6156,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -7892,7 +7892,7 @@
         },
         {
           "name": "PayCost",
-          "line": 6159,
+          "line": 6166,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -7905,7 +7905,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 6170,
+          "line": 6177,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7923,7 +7923,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 6200,
+          "line": 6207,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7939,7 +7939,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 6239,
+          "line": 6246,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -7960,7 +7960,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 6269,
+          "line": 6276,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: A player who meets this effect's condition loses the game. The affected player is determined by resolution context (controller's opponent if untargeted, or explicit target if targeted).",
@@ -7970,7 +7970,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 6271,
+          "line": 6278,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: The controller wins the game — all opponents lose.",
@@ -7980,7 +7980,7 @@
         },
         {
           "name": "RollDie",
-          "line": 6276,
+          "line": 6283,
           "kind": "struct",
           "field_names": [
             "sides",
@@ -7995,7 +7995,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 6284,
+          "line": 6291,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -8008,7 +8008,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 6296,
+          "line": 6303,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8022,7 +8022,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 6305,
+          "line": 6312,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -8034,7 +8034,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 6310,
+          "line": 6317,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -8044,7 +8044,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 6313,
+          "line": 6320,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -8054,7 +8054,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 6315,
+          "line": 6322,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -8066,7 +8066,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 6320,
+          "line": 6327,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -8077,7 +8077,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 6323,
+          "line": 6330,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -8087,7 +8087,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 6326,
+          "line": 6333,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -8099,7 +8099,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 6343,
+          "line": 6350,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8118,7 +8118,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 6376,
+          "line": 6383,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8133,7 +8133,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 6389,
+          "line": 6396,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -8147,7 +8147,7 @@
         },
         {
           "name": "Exploit",
-          "line": 6398,
+          "line": 6405,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8159,7 +8159,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 6403,
+          "line": 6410,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8171,7 +8171,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 6408,
+          "line": 6415,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -8186,7 +8186,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 6420,
+          "line": 6427,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8198,7 +8198,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 6432,
+          "line": 6439,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8214,7 +8214,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 6443,
+          "line": 6450,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8232,7 +8232,7 @@
         },
         {
           "name": "Discover",
-          "line": 6477,
+          "line": 6484,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -8244,7 +8244,7 @@
         },
         {
           "name": "Cascade",
-          "line": 6489,
+          "line": 6496,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -8254,7 +8254,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 6493,
+          "line": 6500,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8266,7 +8266,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 6498,
+          "line": 6505,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8278,7 +8278,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 6511,
+          "line": 6518,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8290,7 +8290,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 6520,
+          "line": 6527,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8302,7 +8302,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 6529,
+          "line": 6536,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8312,7 +8312,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 6534,
+          "line": 6541,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -8322,7 +8322,7 @@
         },
         {
           "name": "Goad",
-          "line": 6540,
+          "line": 6547,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8334,7 +8334,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 6547,
+          "line": 6554,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8346,7 +8346,7 @@
         },
         {
           "name": "Detain",
-          "line": 6554,
+          "line": 6561,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8358,7 +8358,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 6565,
+          "line": 6572,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -8372,7 +8372,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 6576,
+          "line": 6583,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8386,7 +8386,7 @@
         },
         {
           "name": "Manifest",
-          "line": 6591,
+          "line": 6598,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8399,7 +8399,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 6597,
+          "line": 6604,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -8409,7 +8409,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 6601,
+          "line": 6608,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8421,7 +8421,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 6615,
+          "line": 6622,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8434,7 +8434,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 6626,
+          "line": 6633,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8447,7 +8447,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 6636,
+          "line": 6643,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8461,7 +8461,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 6648,
+          "line": 6655,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8477,7 +8477,7 @@
         },
         {
           "name": "Double",
-          "line": 6659,
+          "line": 6666,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -8491,7 +8491,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 6667,
+          "line": 6674,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -8503,7 +8503,7 @@
         },
         {
           "name": "Incubate",
-          "line": 6673,
+          "line": 6680,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8515,7 +8515,7 @@
         },
         {
           "name": "Amass",
-          "line": 6681,
+          "line": 6688,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -8528,7 +8528,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 6689,
+          "line": 6696,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8540,7 +8540,7 @@
         },
         {
           "name": "Renown",
-          "line": 6695,
+          "line": 6702,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8552,7 +8552,7 @@
         },
         {
           "name": "Bolster",
-          "line": 6701,
+          "line": 6708,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8564,7 +8564,7 @@
         },
         {
           "name": "Adapt",
-          "line": 6707,
+          "line": 6714,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8576,7 +8576,7 @@
         },
         {
           "name": "Learn",
-          "line": 6713,
+          "line": 6720,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -8586,7 +8586,7 @@
         },
         {
           "name": "Forage",
-          "line": 6715,
+          "line": 6722,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -8596,7 +8596,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6717,
+          "line": 6724,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8608,7 +8608,7 @@
         },
         {
           "name": "Endure",
-          "line": 6724,
+          "line": 6731,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8621,7 +8621,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 6729,
+          "line": 6736,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8633,7 +8633,7 @@
         },
         {
           "name": "Seek",
-          "line": 6734,
+          "line": 6741,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -8647,7 +8647,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 6751,
+          "line": 6758,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8660,7 +8660,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 6766,
+          "line": 6773,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8676,7 +8676,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 6773,
+          "line": 6780,
           "kind": "struct",
           "field_names": [
             "to"
@@ -8688,7 +8688,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 6778,
+          "line": 6785,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8701,7 +8701,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 6787,
+          "line": 6794,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8713,7 +8713,7 @@
         },
         {
           "name": "Conjure",
-          "line": 6794,
+          "line": 6801,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -8725,7 +8725,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 6815,
+          "line": 6822,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8739,7 +8739,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6826,
+          "line": 6833,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8834,13 +8834,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11686,
+      "line": 11693,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 11688,
+          "line": 11695,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8848,7 +8848,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 11690,
+          "line": 11697,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8856,7 +8856,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 11692,
+          "line": 11699,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8864,7 +8864,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 11694,
+          "line": 11701,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8872,7 +8872,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 11696,
+          "line": 11703,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8880,7 +8880,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 11698,
+          "line": 11705,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8891,68 +8891,12 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7800,
+      "line": 7807,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7801,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeSpeed",
-          "line": 7802,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DealDamage",
-          "line": 7803,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Draw",
-          "line": 7804,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Pump",
-          "line": 7805,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PairWith",
-          "line": 7806,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Destroy",
-          "line": 7807,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Counter",
           "line": 7808,
           "kind": "unit",
           "field_names": [],
@@ -8960,7 +8904,7 @@
           "cr_refs": []
         },
         {
-          "name": "CounterAll",
+          "name": "ChangeSpeed",
           "line": 7809,
           "kind": "unit",
           "field_names": [],
@@ -8968,7 +8912,7 @@
           "cr_refs": []
         },
         {
-          "name": "Token",
+          "name": "DealDamage",
           "line": 7810,
           "kind": "unit",
           "field_names": [],
@@ -8976,7 +8920,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainLife",
+          "name": "Draw",
           "line": 7811,
           "kind": "unit",
           "field_names": [],
@@ -8984,7 +8928,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseLife",
+          "name": "Pump",
           "line": 7812,
           "kind": "unit",
           "field_names": [],
@@ -8992,7 +8936,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tap",
+          "name": "PairWith",
           "line": 7813,
           "kind": "unit",
           "field_names": [],
@@ -9000,7 +8944,7 @@
           "cr_refs": []
         },
         {
-          "name": "Untap",
+          "name": "Destroy",
           "line": 7814,
           "kind": "unit",
           "field_names": [],
@@ -9008,7 +8952,7 @@
           "cr_refs": []
         },
         {
-          "name": "AddCounter",
+          "name": "Counter",
           "line": 7815,
           "kind": "unit",
           "field_names": [],
@@ -9016,7 +8960,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveCounter",
+          "name": "CounterAll",
           "line": 7816,
           "kind": "unit",
           "field_names": [],
@@ -9024,7 +8968,7 @@
           "cr_refs": []
         },
         {
-          "name": "Sacrifice",
+          "name": "Token",
           "line": 7817,
           "kind": "unit",
           "field_names": [],
@@ -9032,7 +8976,7 @@
           "cr_refs": []
         },
         {
-          "name": "DiscardCard",
+          "name": "GainLife",
           "line": 7818,
           "kind": "unit",
           "field_names": [],
@@ -9040,7 +8984,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mill",
+          "name": "LoseLife",
           "line": 7819,
           "kind": "unit",
           "field_names": [],
@@ -9048,7 +8992,7 @@
           "cr_refs": []
         },
         {
-          "name": "Scry",
+          "name": "Tap",
           "line": 7820,
           "kind": "unit",
           "field_names": [],
@@ -9056,7 +9000,7 @@
           "cr_refs": []
         },
         {
-          "name": "PumpAll",
+          "name": "Untap",
           "line": 7821,
           "kind": "unit",
           "field_names": [],
@@ -9064,7 +9008,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageAll",
+          "name": "AddCounter",
           "line": 7822,
           "kind": "unit",
           "field_names": [],
@@ -9072,7 +9016,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageEachPlayer",
+          "name": "RemoveCounter",
           "line": 7823,
           "kind": "unit",
           "field_names": [],
@@ -9080,7 +9024,7 @@
           "cr_refs": []
         },
         {
-          "name": "DestroyAll",
+          "name": "Sacrifice",
           "line": 7824,
           "kind": "unit",
           "field_names": [],
@@ -9088,7 +9032,7 @@
           "cr_refs": []
         },
         {
-          "name": "TapAll",
+          "name": "DiscardCard",
           "line": 7825,
           "kind": "unit",
           "field_names": [],
@@ -9096,7 +9040,7 @@
           "cr_refs": []
         },
         {
-          "name": "UntapAll",
+          "name": "Mill",
           "line": 7826,
           "kind": "unit",
           "field_names": [],
@@ -9104,7 +9048,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZone",
+          "name": "Scry",
           "line": 7827,
           "kind": "unit",
           "field_names": [],
@@ -9112,7 +9056,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZoneAll",
+          "name": "PumpAll",
           "line": 7828,
           "kind": "unit",
           "field_names": [],
@@ -9120,7 +9064,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dig",
+          "name": "DamageAll",
           "line": 7829,
           "kind": "unit",
           "field_names": [],
@@ -9128,7 +9072,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainControl",
+          "name": "DamageEachPlayer",
           "line": 7830,
           "kind": "unit",
           "field_names": [],
@@ -9136,7 +9080,7 @@
           "cr_refs": []
         },
         {
-          "name": "ControlNextTurn",
+          "name": "DestroyAll",
           "line": 7831,
           "kind": "unit",
           "field_names": [],
@@ -9144,7 +9088,7 @@
           "cr_refs": []
         },
         {
-          "name": "Attach",
+          "name": "TapAll",
           "line": 7832,
           "kind": "unit",
           "field_names": [],
@@ -9152,7 +9096,7 @@
           "cr_refs": []
         },
         {
-          "name": "AttachAll",
+          "name": "UntapAll",
           "line": 7833,
           "kind": "unit",
           "field_names": [],
@@ -9160,7 +9104,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnattachAll",
+          "name": "ChangeZone",
           "line": 7834,
           "kind": "unit",
           "field_names": [],
@@ -9168,7 +9112,7 @@
           "cr_refs": []
         },
         {
-          "name": "Surveil",
+          "name": "ChangeZoneAll",
           "line": 7835,
           "kind": "unit",
           "field_names": [],
@@ -9176,7 +9120,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fight",
+          "name": "Dig",
           "line": 7836,
           "kind": "unit",
           "field_names": [],
@@ -9184,7 +9128,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bounce",
+          "name": "GainControl",
           "line": 7837,
           "kind": "unit",
           "field_names": [],
@@ -9192,7 +9136,7 @@
           "cr_refs": []
         },
         {
-          "name": "BounceAll",
+          "name": "ControlNextTurn",
           "line": 7838,
           "kind": "unit",
           "field_names": [],
@@ -9200,7 +9144,7 @@
           "cr_refs": []
         },
         {
-          "name": "Explore",
+          "name": "Attach",
           "line": 7839,
           "kind": "unit",
           "field_names": [],
@@ -9208,7 +9152,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExploreAll",
+          "name": "AttachAll",
           "line": 7840,
           "kind": "unit",
           "field_names": [],
@@ -9216,7 +9160,7 @@
           "cr_refs": []
         },
         {
-          "name": "Investigate",
+          "name": "UnattachAll",
           "line": 7841,
           "kind": "unit",
           "field_names": [],
@@ -9224,7 +9168,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tribute",
+          "name": "Surveil",
           "line": 7842,
           "kind": "unit",
           "field_names": [],
@@ -9232,7 +9176,7 @@
           "cr_refs": []
         },
         {
-          "name": "TimeTravel",
+          "name": "Fight",
           "line": 7843,
           "kind": "unit",
           "field_names": [],
@@ -9240,7 +9184,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomeMonarch",
+          "name": "Bounce",
           "line": 7844,
           "kind": "unit",
           "field_names": [],
@@ -9248,7 +9192,7 @@
           "cr_refs": []
         },
         {
-          "name": "Proliferate",
+          "name": "BounceAll",
           "line": 7845,
           "kind": "unit",
           "field_names": [],
@@ -9256,7 +9200,7 @@
           "cr_refs": []
         },
         {
-          "name": "Populate",
+          "name": "Explore",
           "line": 7846,
           "kind": "unit",
           "field_names": [],
@@ -9264,7 +9208,7 @@
           "cr_refs": []
         },
         {
-          "name": "Clash",
+          "name": "ExploreAll",
           "line": 7847,
           "kind": "unit",
           "field_names": [],
@@ -9272,8 +9216,64 @@
           "cr_refs": []
         },
         {
-          "name": "Vote",
+          "name": "Investigate",
+          "line": 7848,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Tribute",
           "line": 7849,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TimeTravel",
+          "line": 7850,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomeMonarch",
+          "line": 7851,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Proliferate",
+          "line": 7852,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Populate",
+          "line": 7853,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Clash",
+          "line": 7854,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Vote",
+          "line": 7856,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -9283,7 +9283,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7851,
+          "line": 7858,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -9293,62 +9293,6 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7852,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopySpell",
-          "line": 7853,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastCopyOfCard",
-          "line": 7854,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopyTokenOf",
-          "line": 7855,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Myriad",
-          "line": 7856,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BecomeCopy",
-          "line": 7857,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseCard",
-          "line": 7858,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutCounter",
           "line": 7859,
           "kind": "unit",
           "field_names": [],
@@ -9356,7 +9300,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutCounterAll",
+          "name": "CopySpell",
           "line": 7860,
           "kind": "unit",
           "field_names": [],
@@ -9364,7 +9308,7 @@
           "cr_refs": []
         },
         {
-          "name": "MultiplyCounter",
+          "name": "CastCopyOfCard",
           "line": 7861,
           "kind": "unit",
           "field_names": [],
@@ -9372,7 +9316,7 @@
           "cr_refs": []
         },
         {
-          "name": "DoublePT",
+          "name": "CopyTokenOf",
           "line": 7862,
           "kind": "unit",
           "field_names": [],
@@ -9380,7 +9324,7 @@
           "cr_refs": []
         },
         {
-          "name": "DoublePTAll",
+          "name": "Myriad",
           "line": 7863,
           "kind": "unit",
           "field_names": [],
@@ -9388,7 +9332,7 @@
           "cr_refs": []
         },
         {
-          "name": "MoveCounters",
+          "name": "BecomeCopy",
           "line": 7864,
           "kind": "unit",
           "field_names": [],
@@ -9396,7 +9340,7 @@
           "cr_refs": []
         },
         {
-          "name": "Animate",
+          "name": "ChooseCard",
           "line": 7865,
           "kind": "unit",
           "field_names": [],
@@ -9404,7 +9348,7 @@
           "cr_refs": []
         },
         {
-          "name": "ReturnAsAura",
+          "name": "PutCounter",
           "line": 7866,
           "kind": "unit",
           "field_names": [],
@@ -9412,7 +9356,7 @@
           "cr_refs": []
         },
         {
-          "name": "RegisterBending",
+          "name": "PutCounterAll",
           "line": 7867,
           "kind": "unit",
           "field_names": [],
@@ -9420,7 +9364,7 @@
           "cr_refs": []
         },
         {
-          "name": "GenericEffect",
+          "name": "MultiplyCounter",
           "line": 7868,
           "kind": "unit",
           "field_names": [],
@@ -9428,7 +9372,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cleanup",
+          "name": "DoublePT",
           "line": 7869,
           "kind": "unit",
           "field_names": [],
@@ -9436,7 +9380,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mana",
+          "name": "DoublePTAll",
           "line": 7870,
           "kind": "unit",
           "field_names": [],
@@ -9444,7 +9388,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discard",
+          "name": "MoveCounters",
           "line": 7871,
           "kind": "unit",
           "field_names": [],
@@ -9452,7 +9396,7 @@
           "cr_refs": []
         },
         {
-          "name": "Shuffle",
+          "name": "Animate",
           "line": 7872,
           "kind": "unit",
           "field_names": [],
@@ -9460,7 +9404,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchLibrary",
+          "name": "ReturnAsAura",
           "line": 7873,
           "kind": "unit",
           "field_names": [],
@@ -9468,7 +9412,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchOutsideGame",
+          "name": "RegisterBending",
           "line": 7874,
           "kind": "unit",
           "field_names": [],
@@ -9476,7 +9420,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileTop",
+          "name": "GenericEffect",
           "line": 7875,
           "kind": "unit",
           "field_names": [],
@@ -9484,7 +9428,7 @@
           "cr_refs": []
         },
         {
-          "name": "TargetOnly",
+          "name": "Cleanup",
           "line": 7876,
           "kind": "unit",
           "field_names": [],
@@ -9492,7 +9436,7 @@
           "cr_refs": []
         },
         {
-          "name": "Choose",
+          "name": "Mana",
           "line": 7877,
           "kind": "unit",
           "field_names": [],
@@ -9500,7 +9444,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDamageSource",
+          "name": "Discard",
           "line": 7878,
           "kind": "unit",
           "field_names": [],
@@ -9508,7 +9452,7 @@
           "cr_refs": []
         },
         {
-          "name": "Suspect",
+          "name": "Shuffle",
           "line": 7879,
           "kind": "unit",
           "field_names": [],
@@ -9516,7 +9460,7 @@
           "cr_refs": []
         },
         {
-          "name": "Connive",
+          "name": "SearchLibrary",
           "line": 7880,
           "kind": "unit",
           "field_names": [],
@@ -9524,7 +9468,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseOut",
+          "name": "SearchOutsideGame",
           "line": 7881,
           "kind": "unit",
           "field_names": [],
@@ -9532,7 +9476,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseIn",
+          "name": "ExileTop",
           "line": 7882,
           "kind": "unit",
           "field_names": [],
@@ -9540,7 +9484,7 @@
           "cr_refs": []
         },
         {
-          "name": "ForceBlock",
+          "name": "TargetOnly",
           "line": 7883,
           "kind": "unit",
           "field_names": [],
@@ -9548,7 +9492,7 @@
           "cr_refs": []
         },
         {
-          "name": "SolveCase",
+          "name": "Choose",
           "line": 7884,
           "kind": "unit",
           "field_names": [],
@@ -9556,8 +9500,64 @@
           "cr_refs": []
         },
         {
-          "name": "BecomePrepared",
+          "name": "ChooseDamageSource",
+          "line": 7885,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Suspect",
           "line": 7886,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Connive",
+          "line": 7887,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseOut",
+          "line": 7888,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseIn",
+          "line": 7889,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ForceBlock",
+          "line": 7890,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SolveCase",
+          "line": 7891,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomePrepared",
+          "line": 7893,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -9567,7 +9567,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 7888,
+          "line": 7895,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -9577,62 +9577,6 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 7889,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDelayedTrigger",
-          "line": 7890,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddTargetReplacement",
-          "line": 7891,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddRestriction",
-          "line": 7892,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReduceNextSpellCost",
-          "line": 7893,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantNextSpellAbility",
-          "line": 7894,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddPendingETBCounters",
-          "line": 7895,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateEmblem",
           "line": 7896,
           "kind": "unit",
           "field_names": [],
@@ -9640,7 +9584,7 @@
           "cr_refs": []
         },
         {
-          "name": "PayCost",
+          "name": "CreateDelayedTrigger",
           "line": 7897,
           "kind": "unit",
           "field_names": [],
@@ -9648,7 +9592,7 @@
           "cr_refs": []
         },
         {
-          "name": "CastFromZone",
+          "name": "AddTargetReplacement",
           "line": 7898,
           "kind": "unit",
           "field_names": [],
@@ -9656,7 +9600,7 @@
           "cr_refs": []
         },
         {
-          "name": "PreventDamage",
+          "name": "AddRestriction",
           "line": 7899,
           "kind": "unit",
           "field_names": [],
@@ -9664,7 +9608,7 @@
           "cr_refs": []
         },
         {
-          "name": "CreateDamageReplacement",
+          "name": "ReduceNextSpellCost",
           "line": 7900,
           "kind": "unit",
           "field_names": [],
@@ -9672,7 +9616,7 @@
           "cr_refs": []
         },
         {
-          "name": "Regenerate",
+          "name": "GrantNextSpellAbility",
           "line": 7901,
           "kind": "unit",
           "field_names": [],
@@ -9680,7 +9624,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseTheGame",
+          "name": "AddPendingETBCounters",
           "line": 7902,
           "kind": "unit",
           "field_names": [],
@@ -9688,7 +9632,7 @@
           "cr_refs": []
         },
         {
-          "name": "WinTheGame",
+          "name": "CreateEmblem",
           "line": 7903,
           "kind": "unit",
           "field_names": [],
@@ -9696,7 +9640,7 @@
           "cr_refs": []
         },
         {
-          "name": "RollDie",
+          "name": "PayCost",
           "line": 7904,
           "kind": "unit",
           "field_names": [],
@@ -9704,7 +9648,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoin",
+          "name": "CastFromZone",
           "line": 7905,
           "kind": "unit",
           "field_names": [],
@@ -9712,7 +9656,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoins",
+          "name": "PreventDamage",
           "line": 7906,
           "kind": "unit",
           "field_names": [],
@@ -9720,7 +9664,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoinUntilLose",
+          "name": "CreateDamageReplacement",
           "line": 7907,
           "kind": "unit",
           "field_names": [],
@@ -9728,7 +9672,7 @@
           "cr_refs": []
         },
         {
-          "name": "RingTemptsYou",
+          "name": "Regenerate",
           "line": 7908,
           "kind": "unit",
           "field_names": [],
@@ -9736,7 +9680,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureIntoDungeon",
+          "name": "LoseTheGame",
           "line": 7909,
           "kind": "unit",
           "field_names": [],
@@ -9744,7 +9688,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureInto",
+          "name": "WinTheGame",
           "line": 7910,
           "kind": "unit",
           "field_names": [],
@@ -9752,7 +9696,7 @@
           "cr_refs": []
         },
         {
-          "name": "TakeTheInitiative",
+          "name": "RollDie",
           "line": 7911,
           "kind": "unit",
           "field_names": [],
@@ -9760,7 +9704,7 @@
           "cr_refs": []
         },
         {
-          "name": "ProcessRadCounters",
+          "name": "FlipCoin",
           "line": 7912,
           "kind": "unit",
           "field_names": [],
@@ -9768,7 +9712,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantCastingPermission",
+          "name": "FlipCoins",
           "line": 7913,
           "kind": "unit",
           "field_names": [],
@@ -9776,7 +9720,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseFromZone",
+          "name": "FlipCoinUntilLose",
           "line": 7914,
           "kind": "unit",
           "field_names": [],
@@ -9784,7 +9728,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseObjectsIntoTrackedSet",
+          "name": "RingTemptsYou",
           "line": 7915,
           "kind": "unit",
           "field_names": [],
@@ -9792,7 +9736,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseAndSacrificeRest",
+          "name": "VentureIntoDungeon",
           "line": 7916,
           "kind": "unit",
           "field_names": [],
@@ -9800,7 +9744,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exploit",
+          "name": "VentureInto",
           "line": 7917,
           "kind": "unit",
           "field_names": [],
@@ -9808,7 +9752,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainEnergy",
+          "name": "TakeTheInitiative",
           "line": 7918,
           "kind": "unit",
           "field_names": [],
@@ -9816,7 +9760,7 @@
           "cr_refs": []
         },
         {
-          "name": "GivePlayerCounter",
+          "name": "ProcessRadCounters",
           "line": 7919,
           "kind": "unit",
           "field_names": [],
@@ -9824,7 +9768,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseAllPlayerCounters",
+          "name": "GrantCastingPermission",
           "line": 7920,
           "kind": "unit",
           "field_names": [],
@@ -9832,7 +9776,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileFromTopUntil",
+          "name": "ChooseFromZone",
           "line": 7921,
           "kind": "unit",
           "field_names": [],
@@ -9840,7 +9784,7 @@
           "cr_refs": []
         },
         {
-          "name": "RevealUntil",
+          "name": "ChooseObjectsIntoTrackedSet",
           "line": 7922,
           "kind": "unit",
           "field_names": [],
@@ -9848,7 +9792,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discover",
+          "name": "ChooseAndSacrificeRest",
           "line": 7923,
           "kind": "unit",
           "field_names": [],
@@ -9856,7 +9800,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cascade",
+          "name": "Exploit",
           "line": 7924,
           "kind": "unit",
           "field_names": [],
@@ -9864,7 +9808,7 @@
           "cr_refs": []
         },
         {
-          "name": "MiracleCast",
+          "name": "GainEnergy",
           "line": 7925,
           "kind": "unit",
           "field_names": [],
@@ -9872,7 +9816,7 @@
           "cr_refs": []
         },
         {
-          "name": "MadnessCast",
+          "name": "GivePlayerCounter",
           "line": 7926,
           "kind": "unit",
           "field_names": [],
@@ -9880,7 +9824,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutAtLibraryPosition",
+          "name": "LoseAllPlayerCounters",
           "line": 7927,
           "kind": "unit",
           "field_names": [],
@@ -9888,7 +9832,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDrawnThisTurnPayOrTopdeck",
+          "name": "ExileFromTopUntil",
           "line": 7928,
           "kind": "unit",
           "field_names": [],
@@ -9896,7 +9840,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutOnTopOrBottom",
+          "name": "RevealUntil",
           "line": 7929,
           "kind": "unit",
           "field_names": [],
@@ -9904,7 +9848,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiftDelivery",
+          "name": "Discover",
           "line": 7930,
           "kind": "unit",
           "field_names": [],
@@ -9912,7 +9856,7 @@
           "cr_refs": []
         },
         {
-          "name": "Goad",
+          "name": "Cascade",
           "line": 7931,
           "kind": "unit",
           "field_names": [],
@@ -9920,7 +9864,7 @@
           "cr_refs": []
         },
         {
-          "name": "GoadAll",
+          "name": "MiracleCast",
           "line": 7932,
           "kind": "unit",
           "field_names": [],
@@ -9928,7 +9872,7 @@
           "cr_refs": []
         },
         {
-          "name": "Detain",
+          "name": "MadnessCast",
           "line": 7933,
           "kind": "unit",
           "field_names": [],
@@ -9936,7 +9880,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeControl",
+          "name": "PutAtLibraryPosition",
           "line": 7934,
           "kind": "unit",
           "field_names": [],
@@ -9944,7 +9888,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeTargets",
+          "name": "ChooseDrawnThisTurnPayOrTopdeck",
           "line": 7935,
           "kind": "unit",
           "field_names": [],
@@ -9952,7 +9896,7 @@
           "cr_refs": []
         },
         {
-          "name": "Incubate",
+          "name": "PutOnTopOrBottom",
           "line": 7936,
           "kind": "unit",
           "field_names": [],
@@ -9960,7 +9904,7 @@
           "cr_refs": []
         },
         {
-          "name": "Amass",
+          "name": "GiftDelivery",
           "line": 7937,
           "kind": "unit",
           "field_names": [],
@@ -9968,7 +9912,7 @@
           "cr_refs": []
         },
         {
-          "name": "Monstrosity",
+          "name": "Goad",
           "line": 7938,
           "kind": "unit",
           "field_names": [],
@@ -9976,7 +9920,7 @@
           "cr_refs": []
         },
         {
-          "name": "Renown",
+          "name": "GoadAll",
           "line": 7939,
           "kind": "unit",
           "field_names": [],
@@ -9984,7 +9928,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bolster",
+          "name": "Detain",
           "line": 7940,
           "kind": "unit",
           "field_names": [],
@@ -9992,7 +9936,7 @@
           "cr_refs": []
         },
         {
-          "name": "Adapt",
+          "name": "ExchangeControl",
           "line": 7941,
           "kind": "unit",
           "field_names": [],
@@ -10000,7 +9944,7 @@
           "cr_refs": []
         },
         {
-          "name": "Manifest",
+          "name": "ChangeTargets",
           "line": 7942,
           "kind": "unit",
           "field_names": [],
@@ -10008,7 +9952,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "Incubate",
           "line": 7943,
           "kind": "unit",
           "field_names": [],
@@ -10016,7 +9960,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExtraTurn",
+          "name": "Amass",
           "line": 7944,
           "kind": "unit",
           "field_names": [],
@@ -10024,7 +9968,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantExtraLoyaltyActivations",
+          "name": "Monstrosity",
           "line": 7945,
           "kind": "unit",
           "field_names": [],
@@ -10032,7 +9976,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextTurn",
+          "name": "Renown",
           "line": 7946,
           "kind": "unit",
           "field_names": [],
@@ -10040,7 +9984,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextStep",
+          "name": "Bolster",
           "line": 7947,
           "kind": "unit",
           "field_names": [],
@@ -10048,7 +9992,7 @@
           "cr_refs": []
         },
         {
-          "name": "AdditionalPhase",
+          "name": "Adapt",
           "line": 7948,
           "kind": "unit",
           "field_names": [],
@@ -10056,7 +10000,7 @@
           "cr_refs": []
         },
         {
-          "name": "Double",
+          "name": "Manifest",
           "line": 7949,
           "kind": "unit",
           "field_names": [],
@@ -10064,7 +10008,7 @@
           "cr_refs": []
         },
         {
-          "name": "RuntimeHandled",
+          "name": "ManifestDread",
           "line": 7950,
           "kind": "unit",
           "field_names": [],
@@ -10072,7 +10016,7 @@
           "cr_refs": []
         },
         {
-          "name": "Learn",
+          "name": "ExtraTurn",
           "line": 7951,
           "kind": "unit",
           "field_names": [],
@@ -10080,7 +10024,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "GrantExtraLoyaltyActivations",
           "line": 7952,
           "kind": "unit",
           "field_names": [],
@@ -10088,7 +10032,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "SkipNextTurn",
           "line": 7953,
           "kind": "unit",
           "field_names": [],
@@ -10096,7 +10040,7 @@
           "cr_refs": []
         },
         {
-          "name": "Endure",
+          "name": "SkipNextStep",
           "line": 7954,
           "kind": "unit",
           "field_names": [],
@@ -10104,7 +10048,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlightEffect",
+          "name": "AdditionalPhase",
           "line": 7955,
           "kind": "unit",
           "field_names": [],
@@ -10112,7 +10056,7 @@
           "cr_refs": []
         },
         {
-          "name": "Seek",
+          "name": "Double",
           "line": 7956,
           "kind": "unit",
           "field_names": [],
@@ -10120,7 +10064,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetLifeTotal",
+          "name": "RuntimeHandled",
           "line": 7957,
           "kind": "unit",
           "field_names": [],
@@ -10128,7 +10072,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeLifeWithStat",
+          "name": "Learn",
           "line": 7958,
           "kind": "unit",
           "field_names": [],
@@ -10136,7 +10080,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetDayNight",
+          "name": "Forage",
           "line": 7959,
           "kind": "unit",
           "field_names": [],
@@ -10144,7 +10088,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveControl",
+          "name": "CollectEvidence",
           "line": 7960,
           "kind": "unit",
           "field_names": [],
@@ -10152,7 +10096,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveFromCombat",
+          "name": "Endure",
           "line": 7961,
           "kind": "unit",
           "field_names": [],
@@ -10160,7 +10104,7 @@
           "cr_refs": []
         },
         {
-          "name": "Conjure",
+          "name": "BlightEffect",
           "line": 7962,
           "kind": "unit",
           "field_names": [],
@@ -10168,7 +10112,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseOneOf",
+          "name": "Seek",
           "line": 7963,
           "kind": "unit",
           "field_names": [],
@@ -10176,7 +10120,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unimplemented",
+          "name": "SetLifeTotal",
           "line": 7964,
           "kind": "unit",
           "field_names": [],
@@ -10184,8 +10128,64 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "ExchangeLifeWithStat",
+          "line": 7965,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetDayNight",
           "line": 7966,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GiveControl",
+          "line": 7967,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RemoveFromCombat",
+          "line": 7968,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Conjure",
+          "line": 7969,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseOneOf",
+          "line": 7970,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unimplemented",
+          "line": 7971,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 7973,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -10193,7 +10193,7 @@
         },
         {
           "name": "Crew",
-          "line": 7968,
+          "line": 7975,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -10203,7 +10203,7 @@
         },
         {
           "name": "Station",
-          "line": 7970,
+          "line": 7977,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -10213,7 +10213,7 @@
         },
         {
           "name": "Saddle",
-          "line": 7972,
+          "line": 7979,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -10223,7 +10223,7 @@
         },
         {
           "name": "Reveal",
-          "line": 7974,
+          "line": 7981,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -10231,7 +10231,7 @@
         },
         {
           "name": "Transform",
-          "line": 7975,
+          "line": 7982,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10239,7 +10239,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 7976,
+          "line": 7983,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10247,7 +10247,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 7977,
+          "line": 7984,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10347,13 +10347,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9003,
+      "line": 9010,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 9007,
+          "line": 9014,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -10364,7 +10364,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 9010,
+          "line": 9017,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -10536,7 +10536,7 @@
     },
     "ExileLinkKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 555,
+      "line": 616,
       "doc": "CR 607.2a + CR 406.6: Tracks the link between an exiling source and the exiled card. When the source leaves the battlefield, the exiled card returns (CR 610.3a).",
       "cr_refs": [
         "CR 406.6",
@@ -10546,7 +10546,7 @@
       "variants": [
         {
           "name": "UntilSourceLeaves",
-          "line": 557,
+          "line": 618,
           "kind": "struct",
           "field_names": [
             "return_zone"
@@ -10558,7 +10558,7 @@
         },
         {
           "name": "TrackedBySource",
-          "line": 559,
+          "line": 620,
           "kind": "unit",
           "field_names": [],
           "doc": "Track cards \"exiled with\" a source without creating an automatic return.",
@@ -10566,7 +10566,7 @@
         },
         {
           "name": "ParadigmSource",
-          "line": 568,
+          "line": 629,
           "kind": "struct",
           "field_names": [
             "player"
@@ -14148,7 +14148,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8797,
+      "line": 8804,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -14157,7 +14157,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 8800,
+          "line": 8807,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -15852,7 +15852,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11254,
+      "line": 11261,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -15861,7 +15861,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 11256,
+          "line": 11263,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -15874,7 +15874,7 @@
         },
         {
           "name": "Crew",
-          "line": 11262,
+          "line": 11269,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -15887,7 +15887,7 @@
         },
         {
           "name": "Saddle",
-          "line": 11268,
+          "line": 11275,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -15900,7 +15900,7 @@
         },
         {
           "name": "Station",
-          "line": 11276,
+          "line": 11283,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -17011,7 +17011,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9375,
+      "line": 9382,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -17021,7 +17021,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 9377,
+          "line": 9384,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -17031,7 +17031,7 @@
         },
         {
           "name": "Second",
-          "line": 9380,
+          "line": 9387,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -17280,13 +17280,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4932,
+      "line": 4939,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 4933,
+          "line": 4940,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17294,7 +17294,7 @@
         },
         {
           "name": "Bottom",
-          "line": 4934,
+          "line": 4941,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17302,7 +17302,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 4936,
+          "line": 4943,
           "kind": "struct",
           "field_names": [
             "n"
@@ -17537,13 +17537,13 @@
     },
     "ManaAbilityResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 963,
+      "line": 1024,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 964,
+          "line": 1025,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17551,7 +17551,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 965,
+          "line": 1026,
           "kind": "struct",
           "field_names": [
             "convoke_mode"
@@ -17561,7 +17561,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 969,
+          "line": 1030,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -17578,7 +17578,7 @@
     },
     "ManaChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1035,
+      "line": 1096,
       "doc": "CR 608.2d + CR 605.3b: Player's answer to a `ManaChoicePrompt`, carried by `GameAction::ChooseManaColor`. Shape mirrors the prompt variant.",
       "cr_refs": [
         "CR 605.3b",
@@ -17587,7 +17587,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1036,
+          "line": 1097,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17595,7 +17595,7 @@
         },
         {
           "name": "Combination",
-          "line": 1037,
+          "line": 1098,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17606,7 +17606,7 @@
     },
     "ManaChoiceContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1045,
+      "line": 1106,
       "doc": "CR 106.3 + CR 608.2d + CR 605.3b: What resumes after a mana-color choice. Mana abilities and resolving spell/ability effects share the same prompt and response action, but resume through different rules paths.",
       "cr_refs": [
         "CR 106.3",
@@ -17616,7 +17616,7 @@
       "variants": [
         {
           "name": "ManaAbility",
-          "line": 1046,
+          "line": 1107,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17624,7 +17624,7 @@
         },
         {
           "name": "ResolvingEffect",
-          "line": 1047,
+          "line": 1108,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17635,7 +17635,7 @@
     },
     "ManaChoicePrompt": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1018,
+      "line": 1079,
       "doc": "CR 608.2d + CR 605.3b: The shape of the prompt surfaced via `WaitingFor::ChooseManaColor`. Typed enum rather than a bool discriminator: the continuation logic is identical (validate choice → produce mana → resume), only the option set differs.",
       "cr_refs": [
         "CR 605.3b",
@@ -17644,7 +17644,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1021,
+          "line": 1082,
           "kind": "struct",
           "field_names": [
             "options"
@@ -17654,7 +17654,7 @@
         },
         {
           "name": "Combination",
-          "line": 1023,
+          "line": 1084,
           "kind": "struct",
           "field_names": [
             "options"
@@ -17664,7 +17664,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 1025,
+          "line": 1086,
           "kind": "struct",
           "field_names": [
             "count",
@@ -18179,7 +18179,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10538,
+      "line": 10545,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -18188,7 +18188,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 10541,
+          "line": 10548,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -18200,7 +18200,7 @@
         },
         {
           "name": "Multiply",
-          "line": 10544,
+          "line": 10551,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -18446,7 +18446,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10550,
+      "line": 10557,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -18455,7 +18455,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10553,
+          "line": 10560,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -18463,7 +18463,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 10555,
+          "line": 10562,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -18874,13 +18874,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8237,
+      "line": 8244,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 8239,
+          "line": 8246,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -18892,7 +18892,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8242,
+          "line": 8249,
           "kind": "struct",
           "field_names": [
             "source",
@@ -18911,13 +18911,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8217,
+      "line": 8224,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 8218,
+          "line": 8225,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18925,7 +18925,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 8221,
+          "line": 8228,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -18940,7 +18940,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 8228,
+          "line": 8235,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -18950,7 +18950,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 8231,
+          "line": 8238,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -19040,7 +19040,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4219,
+      "line": 4226,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -19050,7 +19050,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4221,
+          "line": 4228,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -19060,7 +19060,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4223,
+          "line": 4230,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -19180,7 +19180,7 @@
     },
     "OpeningHandBottomReason": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1320,
+      "line": 1381,
       "doc": "CR 103.5 / TL:R 906.6a: Why a player is bottoming cards from an opening hand before the normal mulligan-decision step.",
       "cr_refs": [
         "CR 103.5"
@@ -19188,7 +19188,7 @@
       "variants": [
         {
           "name": "TinyLeadersMultiCommander",
-          "line": 1321,
+          "line": 1382,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19218,7 +19218,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10023,
+      "line": 10030,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -19228,7 +19228,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10025,
+          "line": 10032,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -19236,7 +19236,7 @@
         },
         {
           "name": "Equals",
-          "line": 10027,
+          "line": 10034,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -19244,7 +19244,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 10030,
+          "line": 10037,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -19252,7 +19252,7 @@
         },
         {
           "name": "OneOf",
-          "line": 10032,
+          "line": 10039,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -19263,7 +19263,7 @@
     },
     "OutsideGameChoiceSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1270,
+      "line": 1331,
       "doc": "CR 400.11 + CR 406.3: A discriminated source for one outside-game selection. Sideboard entries (the wishboard pool) and face-up exile cards (the Karn / Coax wishboard return pool) are surfaced through one choice list so the caster picks across both pools in a single decision.  The size delta between the two variants (`Sideboard` carries a full `CardFace` so the UI can render the wishboard card without a sideboard lookup; `FaceUpExile` holds only an `ObjectId`) is intentional — `OutsideGameChoiceEntry` lists are short-lived (one entry per offered candidate while a single `WaitingFor::OutsideGameChoice` is active) and never collected by the million, so the asymmetry doesn't warrant boxing every CardFace through a heap indirection.",
       "cr_refs": [
         "CR 400.11",
@@ -19272,7 +19272,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 1272,
+          "line": 1333,
           "kind": "struct",
           "field_names": [
             "sideboard_index",
@@ -19285,7 +19285,7 @@
         },
         {
           "name": "FaceUpExile",
-          "line": 1277,
+          "line": 1338,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -19394,7 +19394,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3945,
+      "line": 3952,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -19403,7 +19403,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 3946,
+          "line": 3953,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -19413,7 +19413,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3950,
+          "line": 3957,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -19423,7 +19423,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 3951,
+          "line": 3958,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19431,7 +19431,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3953,
+          "line": 3960,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -19441,7 +19441,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 3954,
+          "line": 3961,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19451,7 +19451,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 3957,
+          "line": 3964,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -19462,7 +19462,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 3961,
+          "line": 3968,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -19472,7 +19472,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3965,
+          "line": 3972,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -19482,7 +19482,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 3967,
+          "line": 3974,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -19492,7 +19492,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 3968,
+          "line": 3975,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19500,7 +19500,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 3969,
+          "line": 3976,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -19510,7 +19510,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 3972,
+          "line": 3979,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -19520,7 +19520,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 3975,
+          "line": 3982,
           "kind": "struct",
           "field_names": [
             "color"
@@ -19530,7 +19530,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 3978,
+          "line": 3985,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19538,7 +19538,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 3979,
+          "line": 3986,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19546,7 +19546,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 3980,
+          "line": 3987,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19554,7 +19554,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 3981,
+          "line": 3988,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19565,7 +19565,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 3985,
+          "line": 3992,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19576,7 +19576,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 3989,
+          "line": 3996,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19588,7 +19588,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3994,
+          "line": 4001,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19598,7 +19598,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 3997,
+          "line": 4004,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19608,7 +19608,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 4000,
+          "line": 4007,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -19618,7 +19618,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 4005,
+          "line": 4012,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19630,7 +19630,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4014,
+          "line": 4021,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19645,7 +19645,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 4019,
+          "line": 4026,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19655,7 +19655,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 4022,
+          "line": 4029,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -19665,7 +19665,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 4025,
+          "line": 4032,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -19676,7 +19676,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 4029,
+          "line": 4036,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -19687,7 +19687,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 4033,
+          "line": 4040,
           "kind": "struct",
           "field_names": [
             "color",
@@ -19698,7 +19698,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 4037,
+          "line": 4044,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -19708,7 +19708,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 4040,
+          "line": 4047,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19716,7 +19716,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 4041,
+          "line": 4048,
           "kind": "struct",
           "field_names": [
             "name"
@@ -19726,7 +19726,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 4048,
+          "line": 4055,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -19739,7 +19739,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 4052,
+          "line": 4059,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19749,7 +19749,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 4055,
+          "line": 4062,
           "kind": "struct",
           "field_names": [
             "power",
@@ -19760,7 +19760,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 4059,
+          "line": 4066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19768,7 +19768,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 4060,
+          "line": 4067,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19778,7 +19778,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 4063,
+          "line": 4070,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19788,7 +19788,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 4066,
+          "line": 4073,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19798,7 +19798,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 4069,
+          "line": 4076,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19806,7 +19806,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 4070,
+          "line": 4077,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19814,7 +19814,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 4071,
+          "line": 4078,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19824,7 +19824,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 4077,
+          "line": 4084,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -19832,7 +19832,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 4080,
+          "line": 4087,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19845,7 +19845,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 4084,
+          "line": 4091,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19853,7 +19853,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 4085,
+          "line": 4092,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19863,7 +19863,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 4088,
+          "line": 4095,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19871,7 +19871,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 4089,
+          "line": 4096,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19879,7 +19879,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 4090,
+          "line": 4097,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19887,7 +19887,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 4091,
+          "line": 4098,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19895,7 +19895,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 4093,
+          "line": 4100,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -19905,7 +19905,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 4094,
+          "line": 4101,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19913,7 +19913,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 4095,
+          "line": 4102,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19921,7 +19921,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 4096,
+          "line": 4103,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19929,7 +19929,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 4097,
+          "line": 4104,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19940,7 +19940,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 4101,
+          "line": 4108,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19950,7 +19950,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 4106,
+          "line": 4113,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19963,7 +19963,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4111,
+          "line": 4118,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -19973,7 +19973,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 4119,
+          "line": 4126,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -19983,7 +19983,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 4132,
+          "line": 4139,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19997,7 +19997,7 @@
         },
         {
           "name": "And",
-          "line": 4140,
+          "line": 4147,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -20010,7 +20010,7 @@
         },
         {
           "name": "Or",
-          "line": 4146,
+          "line": 4153,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -20023,7 +20023,7 @@
         },
         {
           "name": "Not",
-          "line": 4153,
+          "line": 4160,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -20110,7 +20110,7 @@
     },
     "PayableResource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2936,
+      "line": 2997,
       "doc": "CR 107.14 + CR 118.8: Resource that can be paid in a \"pay any amount of X\" prompt. Typed so the same `WaitingFor::PayAmountChoice` variant generalizes to future classes (energy, life, mana) without re-introducing boolean flags.",
       "cr_refs": [
         "CR 107.14",
@@ -20119,7 +20119,7 @@
       "variants": [
         {
           "name": "Energy",
-          "line": 2938,
+          "line": 2999,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.",
@@ -20129,7 +20129,7 @@
         },
         {
           "name": "ManaGeneric",
-          "line": 2940,
+          "line": 3001,
           "kind": "struct",
           "field_names": [
             "per_x"
@@ -20183,7 +20183,7 @@
     },
     "PaymentCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4166,
+      "line": 4173,
       "doc": "CR 118.1: A cost paid as part of an effect's resolution. Distinct from AbilityCost (which gates activation before the colon).",
       "cr_refs": [
         "CR 118.1"
@@ -20191,7 +20191,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 4167,
+          "line": 4174,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20201,7 +20201,7 @@
         },
         {
           "name": "Life",
-          "line": 4175,
+          "line": 4182,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20214,7 +20214,7 @@
         },
         {
           "name": "Speed",
-          "line": 4179,
+          "line": 4186,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20227,7 +20227,7 @@
         },
         {
           "name": "Energy",
-          "line": 4184,
+          "line": 4191,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20239,7 +20239,7 @@
         },
         {
           "name": "AbilityCost",
-          "line": 4191,
+          "line": 4198,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20252,7 +20252,7 @@
         },
         {
           "name": "ScaledMana",
-          "line": 4201,
+          "line": 4208,
           "kind": "struct",
           "field_names": [
             "base",
@@ -20448,7 +20448,7 @@
     },
     "PileSide": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1407,
+      "line": 1468,
       "doc": "CR 700.3: Identifies one of the two piles produced by a `SeparateIntoPiles` partition. Typed rather than `bool` so the `GameAction::ChoosePile` payload and the engine handler share a self-documenting domain and the parser/AI cannot accidentally swap pile semantics. Pile A is the partitioner's chosen subset; pile B is `eligible \\ pile_a`.",
       "cr_refs": [
         "CR 700.3"
@@ -20456,7 +20456,7 @@
       "variants": [
         {
           "name": "A",
-          "line": 1408,
+          "line": 1469,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20464,7 +20464,7 @@
         },
         {
           "name": "B",
-          "line": 1409,
+          "line": 1470,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20630,18 +20630,22 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 3301,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "CR 120.1 + CR 510.1: Each opponent who was dealt combat damage this turn. Resolved against `state.damage_dealt_this_turn` records whose `is_combat = true` and `target = Player(p.id)`. Used by partner-quality \"for each opponent that was dealt combat damage this turn\" cards (Tymna the Weaver).",
+          "line": 3305,
+          "kind": "struct",
+          "field_names": [
+            "source"
+          ],
+          "doc": "CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent who was dealt combat damage this turn, optionally restricted to damage from a source matching `source`. Resolved against `state.damage_dealt_this_turn` records whose `is_combat = true` and `target = Player(p.id)`. `source = None` counts any combat-damage source (Tymna the Weaver); `source = Some(f)` (CR 120.9) counts only opponents dealt combat damage by a source matching `f` — matched against each record's CR 608.2i look-back source snapshot, so the source's qualities are checked as they were at damage time (Estinien Varlineau: \"by ~ or a Dragon\").",
           "cr_refs": [
             "CR 120.1",
-            "CR 510.1"
+            "CR 120.9",
+            "CR 510.1",
+            "CR 608.2i"
           ]
         },
         {
           "name": "OpponentAttackedThisTurn",
-          "line": 3307,
+          "line": 3314,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.6: A player has \"attacked [a player]\" if they declared one or more creatures attacking that player. Each opponent the controller attacked this turn, resolved against `state.attacked_defenders_this_turn[controller]`. Used by \"the number of opponents you attacked this turn\" (Militant Angel). (CR 508.1b: declare-attackers announcement; CR 506.2: active = attacking player.)",
@@ -20653,7 +20657,7 @@
         },
         {
           "name": "All",
-          "line": 3309,
+          "line": 3316,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -20661,7 +20665,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 3311,
+          "line": 3318,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -20671,7 +20675,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 3314,
+          "line": 3321,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -20679,7 +20683,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 3318,
+          "line": 3325,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20693,7 +20697,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 3324,
+          "line": 3331,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -20701,7 +20705,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3328,
+          "line": 3335,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -20712,7 +20716,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 3337,
+          "line": 3344,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -20723,7 +20727,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 3348,
+          "line": 3355,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -20736,7 +20740,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3360,
+          "line": 3367,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -20747,7 +20751,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 3381,
+          "line": 3388,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20763,7 +20767,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 3405,
+          "line": 3412,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20963,7 +20967,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10652,
+      "line": 10659,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -20972,7 +20976,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 10653,
+          "line": 10660,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20980,7 +20984,7 @@
         },
         {
           "name": "Resolved",
-          "line": 10654,
+          "line": 10661,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21045,7 +21049,7 @@
     },
     "ProductionOverride": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1001,
+      "line": 1062,
       "doc": "CR 605.3b + CR 106.1a: A pre-resolved choice that short-circuits the normal `ChooseManaColor` prompt. Auto-tap sets this when the cost-payment planner has already determined the exact mana to produce; manual activation leaves it `None` so the player is prompted.  Typed enum (never a bool): `SingleColor` covers the one-color-repeated variants (`AnyOneColor`, `ChoiceAmongExiledColors`), while `Combination` carries the full pre-chosen multi-mana sequence for fixed combinations (`ChoiceAmongCombinations`) and free per-slot choices (`AnyCombination`).",
       "cr_refs": [
         "CR 106.1a",
@@ -21054,7 +21058,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1005,
+          "line": 1066,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked a single color; every unit of mana the ability produces becomes this color (mirrors the pre-widening `Option<ManaType>` semantics).",
@@ -21062,7 +21066,7 @@
         },
         {
           "name": "Combination",
-          "line": 1008,
+          "line": 1069,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked one complete mana sequence; the ability produces exactly these mana types in order.",
@@ -21560,7 +21564,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3589,
+      "line": 3596,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -21568,7 +21572,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 3591,
+          "line": 3598,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -21578,7 +21582,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3593,
+          "line": 3600,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -21588,7 +21592,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 3595,
+          "line": 3602,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -21634,7 +21638,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3604,
+      "line": 3611,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -21643,7 +21647,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 3607,
+          "line": 3614,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -21653,7 +21657,7 @@
         },
         {
           "name": "Base",
-          "line": 3610,
+          "line": 3617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -21666,13 +21670,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3417,
+      "line": 3424,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 3419,
+          "line": 3426,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -21682,7 +21686,7 @@
         },
         {
           "name": "Fixed",
-          "line": 3421,
+          "line": 3428,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21692,7 +21696,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 3425,
+          "line": 3432,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21706,7 +21710,7 @@
         },
         {
           "name": "Offset",
-          "line": 3432,
+          "line": 3439,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21719,7 +21723,7 @@
         },
         {
           "name": "Multiply",
-          "line": 3437,
+          "line": 3444,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -21730,7 +21734,7 @@
         },
         {
           "name": "Sum",
-          "line": 3446,
+          "line": 3453,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -21740,7 +21744,7 @@
         },
         {
           "name": "UpTo",
-          "line": 3471,
+          "line": 3478,
           "kind": "struct",
           "field_names": [
             "max"
@@ -21753,7 +21757,7 @@
         },
         {
           "name": "Power",
-          "line": 3477,
+          "line": 3484,
           "kind": "struct",
           "field_names": [
             "base",
@@ -21766,7 +21770,7 @@
         },
         {
           "name": "Difference",
-          "line": 3492,
+          "line": 3499,
           "kind": "struct",
           "field_names": [
             "left",
@@ -21782,7 +21786,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10504,
+      "line": 10511,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -21790,7 +21794,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10506,
+          "line": 10513,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -21798,7 +21802,7 @@
         },
         {
           "name": "Plus",
-          "line": 10508,
+          "line": 10515,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21808,7 +21812,7 @@
         },
         {
           "name": "Minus",
-          "line": 10510,
+          "line": 10517,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21818,7 +21822,7 @@
         },
         {
           "name": "Prevent",
-          "line": 10530,
+          "line": 10537,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -22711,7 +22715,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8782,
+      "line": 8789,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -22720,7 +22724,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 8786,
+          "line": 8793,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -22733,13 +22737,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9811,
+      "line": 9818,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 9814,
+          "line": 9821,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -22751,7 +22755,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 9820,
+          "line": 9827,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22761,7 +22765,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 9827,
+          "line": 9834,
           "kind": "struct",
           "field_names": [
             "count",
@@ -22774,7 +22778,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 9832,
+          "line": 9839,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22786,7 +22790,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 9837,
+          "line": 9844,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -22799,7 +22803,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 9840,
+          "line": 9847,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -22811,7 +22815,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 9843,
+          "line": 9850,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -22821,7 +22825,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 9846,
+          "line": 9853,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -22832,7 +22836,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 9854,
+          "line": 9861,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22845,7 +22849,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 9868,
+          "line": 9875,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22858,7 +22862,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9877,
+          "line": 9884,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -22869,7 +22873,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 9880,
+          "line": 9887,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -22879,7 +22883,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9886,
+          "line": 9893,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -22891,7 +22895,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9891,
+          "line": 9898,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22903,7 +22907,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 9896,
+          "line": 9903,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -22914,7 +22918,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 9905,
+          "line": 9912,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -22926,7 +22930,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 9912,
+          "line": 9919,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -22940,7 +22944,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 9920,
+          "line": 9927,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -22950,7 +22954,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 9925,
+          "line": 9932,
           "kind": "struct",
           "field_names": [
             "source"
@@ -22964,7 +22968,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 9929,
+          "line": 9936,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -22977,7 +22981,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 9934,
+          "line": 9941,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -22988,7 +22992,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 9945,
+          "line": 9952,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -23001,7 +23005,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9956,
+          "line": 9963,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -23013,7 +23017,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 9964,
+          "line": 9971,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -23026,7 +23030,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9974,
+          "line": 9981,
           "kind": "struct",
           "field_names": [
             "level"
@@ -23038,7 +23042,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 9979,
+          "line": 9986,
           "kind": "struct",
           "field_names": [
             "text"
@@ -23442,13 +23446,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10618,
+      "line": 10625,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 10621,
+          "line": 10628,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -23456,7 +23460,7 @@
         },
         {
           "name": "Optional",
-          "line": 10623,
+          "line": 10630,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -23466,7 +23470,7 @@
         },
         {
           "name": "MayCost",
-          "line": 10630,
+          "line": 10637,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -23483,7 +23487,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10606,
+      "line": 10613,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 614.1a"
@@ -23491,7 +23495,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 10608,
+          "line": 10615,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source's controller.",
@@ -23499,7 +23503,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10610,
+          "line": 10617,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source's controller.",
@@ -23507,7 +23511,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 10612,
+          "line": 10619,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -23637,7 +23641,7 @@
     },
     "RetargetScope": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2953,
+      "line": 3014,
       "doc": "CR 115.7: Scope of retargeting — single target, all targets, or forced.",
       "cr_refs": [
         "CR 115.7"
@@ -23645,7 +23649,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 2954,
+          "line": 3015,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23653,7 +23657,7 @@
         },
         {
           "name": "All",
-          "line": 2955,
+          "line": 3016,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23661,7 +23665,7 @@
         },
         {
           "name": "ForcedTo",
-          "line": 2956,
+          "line": 3017,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -23699,7 +23703,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4295,
+      "line": 4302,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -23707,7 +23711,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 4297,
+          "line": 4304,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -23776,7 +23780,7 @@
     },
     "ShardChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1197,
+      "line": 1258,
       "doc": "CR 107.4f + CR 601.2f: The caster's resolved choice for one Phyrexian shard.",
       "cr_refs": [
         "CR 107.4f",
@@ -23785,7 +23789,7 @@
       "variants": [
         {
           "name": "PayMana",
-          "line": 1199,
+          "line": 1260,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay one mana of the shard's color (or either component color for hybrid-Phyrexian).",
@@ -23793,7 +23797,7 @@
         },
         {
           "name": "PayLife",
-          "line": 1201,
+          "line": 1262,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay 2 life.",
@@ -23804,7 +23808,7 @@
     },
     "ShardOptions": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1185,
+      "line": 1246,
       "doc": "CR 107.4f + CR 601.2h: Which legal payments a single Phyrexian shard offers to the caster. Computed from the mana pool state (Phyrexian color availability) combined with the caster's life total and CantLoseLife status (CR 118.3 + CR 119.8).  The engine pauses at `WaitingFor::PhyrexianPayment` whenever any shard would deduct life — both `ManaOrLife` (player explicitly picks mana vs life) and `LifeOnly` (life is the only remaining payment route; player confirms or cancels via `CancelCast`). Only `ManaOnly` shards auto-resolve without surfacing the prompt, since they have no life consequence (issue #704: silent life deduction violated CR 601.2h's right to refuse the cast).",
       "cr_refs": [
         "CR 107.4f",
@@ -23815,7 +23819,7 @@
       "variants": [
         {
           "name": "ManaOrLife",
-          "line": 1187,
+          "line": 1248,
           "kind": "unit",
           "field_names": [],
           "doc": "Both mana and 2 life are legal payments; player must choose.",
@@ -23823,7 +23827,7 @@
         },
         {
           "name": "ManaOnly",
-          "line": 1189,
+          "line": 1250,
           "kind": "unit",
           "field_names": [],
           "doc": "Only mana is legal (insufficient life or CR 119.8 CantLoseLife lock).",
@@ -23833,7 +23837,7 @@
         },
         {
           "name": "LifeOnly",
-          "line": 1191,
+          "line": 1252,
           "kind": "unit",
           "field_names": [],
           "doc": "Only 2 life is legal (no mana of the shard's color available, given restrictions).",
@@ -24061,7 +24065,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3617,
+      "line": 3624,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -24070,7 +24074,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 3619,
+          "line": 3626,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -24082,7 +24086,7 @@
         },
         {
           "name": "Text",
-          "line": 3625,
+          "line": 3632,
           "kind": "struct",
           "field_names": [
             "description"
@@ -24095,7 +24099,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4973,
+      "line": 4980,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -24103,7 +24107,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 4975,
+          "line": 4982,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -24113,7 +24117,7 @@
         },
         {
           "name": "Decrease",
-          "line": 4977,
+          "line": 4984,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -24126,13 +24130,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4782,
+      "line": 4789,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 4783,
+          "line": 4790,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24140,7 +24144,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 4784,
+          "line": 4791,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24148,7 +24152,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 4785,
+          "line": 4792,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24156,7 +24160,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 4787,
+          "line": 4794,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -24169,13 +24173,13 @@
     },
     "StackEntryKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3561,
+      "line": 3622,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 3562,
+          "line": 3623,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -24188,7 +24192,7 @@
         },
         {
           "name": "ActivatedAbility",
-          "line": 3576,
+          "line": 3637,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -24199,7 +24203,7 @@
         },
         {
           "name": "TriggeredAbility",
-          "line": 3580,
+          "line": 3641,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -24215,7 +24219,7 @@
         },
         {
           "name": "KeywordAction",
-          "line": 3616,
+          "line": 3677,
           "kind": "struct",
           "field_names": [
             "action"
@@ -24231,13 +24235,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3691,
+      "line": 3698,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 3692,
+          "line": 3699,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -24248,7 +24252,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 3696,
+          "line": 3703,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24258,7 +24262,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 3702,
+          "line": 3709,
           "kind": "struct",
           "field_names": [
             "color"
@@ -24268,7 +24272,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 3711,
+          "line": 3718,
           "kind": "struct",
           "field_names": [
             "label"
@@ -24281,7 +24285,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3717,
+          "line": 3724,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -24293,7 +24297,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 3723,
+          "line": 3730,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -24303,7 +24307,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 3725,
+          "line": 3732,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -24316,7 +24320,7 @@
         },
         {
           "name": "And",
-          "line": 3729,
+          "line": 3736,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24326,7 +24330,7 @@
         },
         {
           "name": "Or",
-          "line": 3733,
+          "line": 3740,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24336,7 +24340,7 @@
         },
         {
           "name": "Not",
-          "line": 3739,
+          "line": 3746,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -24346,7 +24350,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 3743,
+          "line": 3750,
           "kind": "struct",
           "field_names": [
             "state"
@@ -24358,7 +24362,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 3752,
+          "line": 3759,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24374,7 +24378,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 3763,
+          "line": 3770,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24389,7 +24393,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 3771,
+          "line": 3778,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24401,7 +24405,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 3778,
+          "line": 3785,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24413,7 +24417,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 3782,
+          "line": 3789,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -24423,7 +24427,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3786,
+          "line": 3793,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -24434,7 +24438,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 3790,
+          "line": 3797,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -24445,7 +24449,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3794,
+          "line": 3801,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -24455,7 +24459,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 3796,
+          "line": 3803,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -24465,7 +24469,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 3799,
+          "line": 3806,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -24475,7 +24479,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 3801,
+          "line": 3808,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -24485,7 +24489,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 3804,
+          "line": 3811,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -24495,7 +24499,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 3810,
+          "line": 3817,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -24507,7 +24511,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 3818,
+          "line": 3825,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -24519,7 +24523,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3822,
+          "line": 3829,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24531,7 +24535,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 3847,
+          "line": 3854,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -24549,7 +24553,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 3856,
+          "line": 3863,
           "kind": "struct",
           "field_names": [
             "text"
@@ -24559,7 +24563,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 3859,
+          "line": 3866,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24567,7 +24571,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3862,
+          "line": 3869,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -24577,7 +24581,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 3864,
+          "line": 3871,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -24587,7 +24591,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 3866,
+          "line": 3873,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24599,7 +24603,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 3872,
+          "line": 3879,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -24613,7 +24617,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 3877,
+          "line": 3884,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -24623,7 +24627,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 3884,
+          "line": 3891,
           "kind": "struct",
           "field_names": [
             "player"
@@ -24636,7 +24640,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 3889,
+          "line": 3896,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -24646,7 +24650,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 3893,
+          "line": 3900,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -24656,7 +24660,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 3897,
+          "line": 3904,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -24667,7 +24671,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 3901,
+          "line": 3908,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24679,7 +24683,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 3913,
+          "line": 3920,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24691,7 +24695,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 3917,
+          "line": 3924,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -24701,7 +24705,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 3920,
+          "line": 3927,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -24713,7 +24717,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 3926,
+          "line": 3933,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -24724,7 +24728,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 3931,
+          "line": 3938,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ReduceCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -24735,7 +24739,7 @@
         },
         {
           "name": "None",
-          "line": 3932,
+          "line": 3939,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25774,7 +25778,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4985,
+      "line": 4992,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -25783,7 +25787,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 4986,
+          "line": 4993,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25791,7 +25795,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 4987,
+          "line": 4994,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25802,7 +25806,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8747,
+      "line": 8754,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -25810,7 +25814,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 8755,
+          "line": 8762,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -25818,7 +25822,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 8760,
+          "line": 8767,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -25997,7 +26001,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8417,
+      "line": 8424,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -26007,7 +26011,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 8419,
+          "line": 8426,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26015,7 +26019,7 @@
         },
         {
           "name": "Resolution",
-          "line": 8420,
+          "line": 8427,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26432,13 +26436,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11236,
+      "line": 11243,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 11237,
+          "line": 11244,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26446,7 +26450,7 @@
         },
         {
           "name": "Player",
-          "line": 11238,
+          "line": 11245,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26457,13 +26461,13 @@
     },
     "TargetSelectionConstraint": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1141,
+      "line": 1202,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 1142,
+          "line": 1203,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26471,7 +26475,7 @@
         },
         {
           "name": "DifferentObjectControllers",
-          "line": 1144,
+          "line": 1205,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1 + CR 601.2c: Object targets must be controlled by different players.",
@@ -26602,13 +26606,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9507,
+      "line": 9514,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 9510,
+          "line": 9517,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26618,7 +26622,7 @@
         },
         {
           "name": "LostLife",
-          "line": 9512,
+          "line": 9519,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -26626,7 +26630,7 @@
         },
         {
           "name": "Descended",
-          "line": 9514,
+          "line": 9521,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -26634,7 +26638,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 9516,
+          "line": 9523,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26644,7 +26648,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 9518,
+          "line": 9525,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -26654,7 +26658,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 9520,
+          "line": 9527,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -26664,7 +26668,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 9530,
+          "line": 9537,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26677,7 +26681,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9533,
+          "line": 9540,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -26688,7 +26692,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 9536,
+          "line": 9543,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -26698,7 +26702,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 9540,
+          "line": 9547,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26710,7 +26714,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 9543,
+          "line": 9550,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -26720,7 +26724,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9546,
+          "line": 9553,
           "kind": "struct",
           "field_names": [
             "level"
@@ -26732,7 +26736,7 @@
         },
         {
           "name": "WasCast",
-          "line": 9551,
+          "line": 9558,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you cast it\" — zoneless cast check (unlike CastFromZone which requires a specific zone). CR 701.57a: Used by Discover ETB triggers. Negation (\"if it wasn't cast\") is expressed via `Not { Box::new(WasCast) }`.",
@@ -26742,7 +26746,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 9555,
+          "line": 9562,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -26753,7 +26757,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 9560,
+          "line": 9567,
           "kind": "struct",
           "field_names": [
             "source",
@@ -26769,7 +26773,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 9576,
+          "line": 9583,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -26779,7 +26783,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9582,
+          "line": 9589,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26794,7 +26798,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 9586,
+          "line": 9593,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -26805,7 +26809,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 9590,
+          "line": 9597,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -26816,7 +26820,7 @@
         },
         {
           "name": "WasType",
-          "line": 9595,
+          "line": 9602,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -26829,7 +26833,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 9598,
+          "line": 9605,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26841,7 +26845,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 9602,
+          "line": 9609,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26854,7 +26858,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 9606,
+          "line": 9613,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26866,7 +26870,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 9610,
+          "line": 9617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -26876,7 +26880,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9613,
+          "line": 9620,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -26888,7 +26892,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 9617,
+          "line": 9624,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26900,7 +26904,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 9620,
+          "line": 9627,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26912,7 +26916,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9626,
+          "line": 9633,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -26922,7 +26926,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9629,
+          "line": 9636,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -26932,7 +26936,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 9632,
+          "line": 9639,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -26942,7 +26946,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9639,
+          "line": 9646,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26954,7 +26958,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9644,
+          "line": 9651,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26966,7 +26970,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9648,
+          "line": 9655,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -26976,7 +26980,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 9653,
+          "line": 9660,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -26988,7 +26992,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9659,
+          "line": 9666,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -26998,7 +27002,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 9664,
+          "line": 9671,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -27008,7 +27012,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 9667,
+          "line": 9674,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -27018,7 +27022,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 9670,
+          "line": 9677,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -27028,7 +27032,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 9672,
+          "line": 9679,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -27040,7 +27044,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 9675,
+          "line": 9682,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -27050,7 +27054,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 9679,
+          "line": 9686,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -27060,7 +27064,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 9683,
+          "line": 9690,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27073,7 +27077,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 9686,
+          "line": 9693,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -27083,7 +27087,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9690,
+          "line": 9697,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -27096,7 +27100,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9693,
+          "line": 9700,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -27109,7 +27113,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9695,
+          "line": 9702,
           "kind": "struct",
           "field_names": [
             "color",
@@ -27122,7 +27126,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 9697,
+          "line": 9704,
           "kind": "struct",
           "field_names": [
             "text"
@@ -27134,7 +27138,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 9699,
+          "line": 9706,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -27146,7 +27150,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 9703,
+          "line": 9710,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -27160,7 +27164,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 9705,
+          "line": 9712,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -27170,7 +27174,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 9710,
+          "line": 9717,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -27185,7 +27189,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9721,
+          "line": 9728,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -27201,7 +27205,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 9736,
+          "line": 9743,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -27213,7 +27217,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9739,
+          "line": 9746,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27226,7 +27230,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 9749,
+          "line": 9756,
           "kind": "struct",
           "field_names": [
             "label"
@@ -27240,7 +27244,7 @@
         },
         {
           "name": "AttackersDeclaredMin",
-          "line": 9762,
+          "line": 9769,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27256,7 +27260,7 @@
         },
         {
           "name": "NoneOfAttackersTargetedYou",
-          "line": 9767,
+          "line": 9774,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 603.4: Intervening-if \"if none of those creatures attacked you\". Reads the triggering `AttackersDeclared` event's per-attacker `AttackTarget` tuples (CR 508.1b) and returns true iff no attacker in the batch targeted the trigger's controller directly (`AttackTarget::Player(trigger_controller)`).",
@@ -27268,7 +27272,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9777,
+          "line": 9784,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -27280,7 +27284,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 9788,
+          "line": 9795,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -27292,7 +27296,7 @@
         },
         {
           "name": "And",
-          "line": 9792,
+          "line": 9799,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27302,7 +27306,7 @@
         },
         {
           "name": "Or",
-          "line": 9794,
+          "line": 9801,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27312,7 +27316,7 @@
         },
         {
           "name": "Not",
-          "line": 9804,
+          "line": 9811,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -27328,13 +27332,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9985,
+      "line": 9992,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 9987,
+          "line": 9994,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -27342,7 +27346,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 9989,
+          "line": 9996,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -27350,7 +27354,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 9991,
+          "line": 9998,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -27358,7 +27362,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 9996,
+          "line": 10003,
           "kind": "struct",
           "field_names": [
             "n",
@@ -27369,7 +27373,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 10003,
+          "line": 10010,
           "kind": "struct",
           "field_names": [
             "n"
@@ -27379,7 +27383,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 10005,
+          "line": 10012,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -27387,7 +27391,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 10009,
+          "line": 10016,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -27397,7 +27401,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 10011,
+          "line": 10018,
           "kind": "struct",
           "field_names": [
             "level"
@@ -27409,7 +27413,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 10014,
+          "line": 10021,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29654,7 +29658,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3644,
+      "line": 3651,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -29663,7 +29667,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 3646,
+          "line": 3653,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29671,7 +29675,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 3647,
+          "line": 3654,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29679,7 +29683,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 3648,
+          "line": 3655,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29689,7 +29693,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 3651,
+          "line": 3658,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29699,7 +29703,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 3663,
+          "line": 3670,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29759,7 +29763,7 @@
     },
     "VoteActor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1382,
+      "line": 1443,
       "doc": "CR 101.4 + CR 608.2 (Battlebond friend-or-foe keyword action — no explicit CR section): The \"who acts\" semantic for a `WaitingFor::VoteChoice` step.  * `SubjectActs` — the player named by `player` casts the vote for   themselves. Classic Council's-dilemma (CR 701.38) is exclusively this   case: each voter acts on their own behalf and APNAP iteration changes   both subject and actor together. * `Delegated(actor)` — a fixed `actor` casts every vote on behalf of the   cycling subjects. The Battlebond friend-or-foe spell controller pins   themselves here so `player` cycles through every player in APNAP order   while authorization stays with the controller.  Stored on `WaitingFor::VoteChoice` instead of `Option<PlayerId>` so the \"is this delegated?\" discriminator is a named sum type with a meaningful pair of variant names, not a boolean-flavored optional. Callers route through [`VoteActor::resolve`] to get the authorized submitter without branching at every call site.",
       "cr_refs": [
         "CR 101.4",
@@ -29769,7 +29773,7 @@
       "variants": [
         {
           "name": "SubjectActs",
-          "line": 1383,
+          "line": 1444,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29777,7 +29781,7 @@
         },
         {
           "name": "Delegated",
-          "line": 1384,
+          "line": 1445,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -29788,7 +29792,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7142,
+      "line": 7149,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -29797,7 +29801,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 7145,
+          "line": 7152,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -29807,7 +29811,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 7149,
+          "line": 7156,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -29817,7 +29821,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 7157,
+          "line": 7164,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",
@@ -29831,13 +29835,13 @@
     },
     "WaitingFor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1470,
+      "line": 1531,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1471,
+          "line": 1532,
           "kind": "struct",
           "field_names": [
             "player"
@@ -29847,7 +29851,7 @@
         },
         {
           "name": "MulliganDecision",
-          "line": 1487,
+          "line": 1548,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -29862,7 +29866,7 @@
         },
         {
           "name": "MulliganBottomCards",
-          "line": 1500,
+          "line": 1561,
           "kind": "struct",
           "field_names": [
             "pending"
@@ -29874,7 +29878,7 @@
         },
         {
           "name": "OpeningHandBottomCards",
-          "line": 1506,
+          "line": 1567,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -29885,7 +29889,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1510,
+          "line": 1571,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29896,7 +29900,7 @@
         },
         {
           "name": "ChooseXValue",
-          "line": 1528,
+          "line": 1589,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29913,7 +29917,7 @@
         },
         {
           "name": "TargetSelection",
-          "line": 1537,
+          "line": 1598,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29926,7 +29930,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 1544,
+          "line": 1605,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29938,7 +29942,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 1550,
+          "line": 1611,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29951,7 +29955,7 @@
         },
         {
           "name": "UntapChoice",
-          "line": 1566,
+          "line": 1627,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29965,7 +29969,7 @@
         },
         {
           "name": "ExertChoice",
-          "line": 1578,
+          "line": 1639,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29980,7 +29984,7 @@
         },
         {
           "name": "GameOver",
-          "line": 1584,
+          "line": 1645,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -29990,7 +29994,7 @@
         },
         {
           "name": "ReplacementChoice",
-          "line": 1587,
+          "line": 1648,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30002,7 +30006,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 1600,
+          "line": 1661,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30017,7 +30021,7 @@
         },
         {
           "name": "CopyTargetChoice",
-          "line": 1606,
+          "line": 1667,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30032,7 +30036,7 @@
         },
         {
           "name": "ExploreChoice",
-          "line": 1616,
+          "line": 1677,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30048,7 +30052,7 @@
         },
         {
           "name": "ReturnAsAuraTarget",
-          "line": 1638,
+          "line": 1699,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30071,7 +30075,7 @@
         },
         {
           "name": "EquipTarget",
-          "line": 1655,
+          "line": 1716,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30083,7 +30087,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 1661,
+          "line": 1722,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30098,7 +30102,7 @@
         },
         {
           "name": "StationTarget",
-          "line": 1672,
+          "line": 1733,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30112,7 +30116,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 1680,
+          "line": 1741,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30127,7 +30131,7 @@
         },
         {
           "name": "ScryChoice",
-          "line": 1688,
+          "line": 1749,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30138,7 +30142,7 @@
         },
         {
           "name": "DigChoice",
-          "line": 1693,
+          "line": 1754,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30158,7 +30162,7 @@
         },
         {
           "name": "SurveilChoice",
-          "line": 1717,
+          "line": 1778,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30169,7 +30173,7 @@
         },
         {
           "name": "RevealChoice",
-          "line": 1721,
+          "line": 1782,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30183,7 +30187,7 @@
         },
         {
           "name": "SearchChoice",
-          "line": 1740,
+          "line": 1801,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30199,7 +30203,7 @@
         },
         {
           "name": "SearchPartitionChoice",
-          "line": 1774,
+          "line": 1835,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30218,7 +30222,7 @@
         },
         {
           "name": "OutsideGameChoice",
-          "line": 1787,
+          "line": 1848,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30237,7 +30241,7 @@
         },
         {
           "name": "ChooseFromZoneChoice",
-          "line": 1801,
+          "line": 1862,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30254,7 +30258,7 @@
         },
         {
           "name": "ChooseOneOfBranch",
-          "line": 1813,
+          "line": 1874,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30273,7 +30277,7 @@
         },
         {
           "name": "ConniveDiscard",
-          "line": 1831,
+          "line": 1892,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30289,7 +30293,7 @@
         },
         {
           "name": "DiscardChoice",
-          "line": 1840,
+          "line": 1901,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30307,7 +30311,7 @@
         },
         {
           "name": "EffectZoneChoice",
-          "line": 1856,
+          "line": 1917,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30334,7 +30338,7 @@
         },
         {
           "name": "DrawnThisTurnTopdeckChoice",
-          "line": 1909,
+          "line": 1970,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30349,7 +30353,7 @@
         },
         {
           "name": "LearnChoice",
-          "line": 1919,
+          "line": 1980,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30362,7 +30366,7 @@
         },
         {
           "name": "ManifestDreadChoice",
-          "line": 1925,
+          "line": 1986,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30375,7 +30379,7 @@
         },
         {
           "name": "TriggerTargetSelection",
-          "line": 1929,
+          "line": 1990,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30390,7 +30394,7 @@
         },
         {
           "name": "BetweenGamesSideboard",
-          "line": 1943,
+          "line": 2004,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30402,7 +30406,7 @@
         },
         {
           "name": "BetweenGamesChoosePlayDraw",
-          "line": 1948,
+          "line": 2009,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30414,7 +30418,7 @@
         },
         {
           "name": "NamedChoice",
-          "line": 1954,
+          "line": 2015,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30427,7 +30431,7 @@
         },
         {
           "name": "DamageSourceChoice",
-          "line": 1964,
+          "line": 2025,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30441,7 +30445,7 @@
         },
         {
           "name": "ModeChoice",
-          "line": 1970,
+          "line": 2031,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30453,7 +30457,7 @@
         },
         {
           "name": "DiscardToHandSize",
-          "line": 1976,
+          "line": 2037,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30465,7 +30469,7 @@
         },
         {
           "name": "OptionalCostChoice",
-          "line": 1984,
+          "line": 2045,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30478,7 +30482,7 @@
         },
         {
           "name": "DefilerPayment",
-          "line": 1996,
+          "line": 2057,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30493,7 +30497,7 @@
         },
         {
           "name": "AdventureCastChoice",
-          "line": 2006,
+          "line": 2067,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30508,7 +30512,7 @@
         },
         {
           "name": "ModalFaceChoice",
-          "line": 2023,
+          "line": 2084,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30524,7 +30528,7 @@
         },
         {
           "name": "AlternativeCastChoice",
-          "line": 2046,
+          "line": 2107,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30550,7 +30554,7 @@
         },
         {
           "name": "CastingVariantChoice",
-          "line": 2078,
+          "line": 2139,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30566,7 +30570,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 2090,
+          "line": 2151,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30583,7 +30587,7 @@
         },
         {
           "name": "MultiTargetSelection",
-          "line": 2101,
+          "line": 2162,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30599,7 +30603,7 @@
         },
         {
           "name": "AbilityModeChoice",
-          "line": 2112,
+          "line": 2173,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30616,7 +30620,7 @@
         },
         {
           "name": "OptionalEffectChoice",
-          "line": 2135,
+          "line": 2196,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30631,7 +30635,7 @@
         },
         {
           "name": "PairChoice",
-          "line": 2146,
+          "line": 2207,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30646,7 +30650,7 @@
         },
         {
           "name": "TributeChoice",
-          "line": 2157,
+          "line": 2218,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30661,7 +30665,7 @@
         },
         {
           "name": "MiracleReveal",
-          "line": 2169,
+          "line": 2230,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30676,7 +30680,7 @@
         },
         {
           "name": "MiracleCastOffer",
-          "line": 2179,
+          "line": 2240,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30691,7 +30695,7 @@
         },
         {
           "name": "MadnessCastOffer",
-          "line": 2188,
+          "line": 2249,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30705,7 +30709,7 @@
         },
         {
           "name": "OpponentMayChoice",
-          "line": 2195,
+          "line": 2256,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30721,7 +30725,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 2208,
+          "line": 2269,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30739,7 +30743,7 @@
         },
         {
           "name": "UnlessPaymentChooseCost",
-          "line": 2242,
+          "line": 2303,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30757,7 +30761,7 @@
         },
         {
           "name": "WardDiscardChoice",
-          "line": 2272,
+          "line": 2333,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30771,7 +30775,7 @@
         },
         {
           "name": "WardSacrificeChoice",
-          "line": 2280,
+          "line": 2341,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30786,7 +30790,7 @@
         },
         {
           "name": "UnlessBounceChoice",
-          "line": 2291,
+          "line": 2352,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30801,7 +30805,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 2299,
+          "line": 2360,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30814,7 +30818,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 2304,
+          "line": 2365,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30827,7 +30831,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 2309,
+          "line": 2370,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30842,7 +30846,7 @@
         },
         {
           "name": "DiscardForCost",
-          "line": 2317,
+          "line": 2378,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30857,7 +30861,7 @@
         },
         {
           "name": "SacrificeForCost",
-          "line": 2327,
+          "line": 2388,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30874,7 +30878,7 @@
         },
         {
           "name": "ReturnToHandForCost",
-          "line": 2340,
+          "line": 2401,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30890,7 +30894,7 @@
         },
         {
           "name": "ActivationCostOneOfChoice",
-          "line": 2350,
+          "line": 2411,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30904,7 +30908,7 @@
         },
         {
           "name": "RemoveCounterForCost",
-          "line": 2357,
+          "line": 2418,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30922,7 +30926,7 @@
         },
         {
           "name": "BlightChoice",
-          "line": 2367,
+          "line": 2428,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30935,7 +30939,7 @@
         },
         {
           "name": "TapCreaturesForSpellCost",
-          "line": 2378,
+          "line": 2439,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30951,7 +30955,7 @@
         },
         {
           "name": "BeholdForCost",
-          "line": 2386,
+          "line": 2447,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30965,7 +30969,7 @@
         },
         {
           "name": "TapCreaturesForManaAbility",
-          "line": 2394,
+          "line": 2455,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30981,7 +30985,7 @@
         },
         {
           "name": "DiscardForManaAbility",
-          "line": 2401,
+          "line": 2462,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30997,7 +31001,7 @@
         },
         {
           "name": "ExileForManaAbility",
-          "line": 2411,
+          "line": 2472,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31015,7 +31019,7 @@
         },
         {
           "name": "SacrificeForManaAbility",
-          "line": 2423,
+          "line": 2484,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31032,7 +31036,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 2439,
+          "line": 2500,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31048,7 +31052,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 2449,
+          "line": 2510,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31064,7 +31068,7 @@
         },
         {
           "name": "ExileForCost",
-          "line": 2462,
+          "line": 2523,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31083,7 +31087,7 @@
         },
         {
           "name": "CollectEvidenceChoice",
-          "line": 2477,
+          "line": 2538,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31099,7 +31103,7 @@
         },
         {
           "name": "HarmonizeTapChoice",
-          "line": 2486,
+          "line": 2547,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31116,7 +31120,7 @@
         },
         {
           "name": "DiscoverChoice",
-          "line": 2494,
+          "line": 2555,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31130,7 +31134,7 @@
         },
         {
           "name": "RevealUntilKeptChoice",
-          "line": 2506,
+          "line": 2567,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31151,7 +31155,7 @@
         },
         {
           "name": "RepeatDecision",
-          "line": 2527,
+          "line": 2588,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31165,7 +31169,7 @@
         },
         {
           "name": "CascadeChoice",
-          "line": 2537,
+          "line": 2598,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31180,7 +31184,7 @@
         },
         {
           "name": "TopOrBottomChoice",
-          "line": 2553,
+          "line": 2614,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31193,7 +31197,7 @@
         },
         {
           "name": "ParadigmCastOffer",
-          "line": 2562,
+          "line": 2623,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31206,7 +31210,7 @@
         },
         {
           "name": "PopulateChoice",
-          "line": 2567,
+          "line": 2628,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31220,7 +31224,7 @@
         },
         {
           "name": "ClashCardPlacement",
-          "line": 2575,
+          "line": 2636,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31234,7 +31238,7 @@
         },
         {
           "name": "VoteChoice",
-          "line": 2586,
+          "line": 2647,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31256,7 +31260,7 @@
         },
         {
           "name": "SeparatePilesPartition",
-          "line": 2645,
+          "line": 2706,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31277,7 +31281,7 @@
         },
         {
           "name": "SeparatePilesChoice",
-          "line": 2675,
+          "line": 2736,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31294,7 +31298,7 @@
         },
         {
           "name": "CompanionReveal",
-          "line": 2690,
+          "line": 2751,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31307,7 +31311,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 2697,
+          "line": 2758,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31321,7 +31325,7 @@
         },
         {
           "name": "CommanderZoneChoice",
-          "line": 2706,
+          "line": 2767,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31335,7 +31339,7 @@
         },
         {
           "name": "BattleProtectorChoice",
-          "line": 2717,
+          "line": 2778,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31351,7 +31355,7 @@
         },
         {
           "name": "ProliferateChoice",
-          "line": 2724,
+          "line": 2785,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31364,7 +31368,7 @@
         },
         {
           "name": "ChooseObjectsSelection",
-          "line": 2734,
+          "line": 2795,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31378,7 +31382,7 @@
         },
         {
           "name": "CategoryChoice",
-          "line": 2747,
+          "line": 2808,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31398,7 +31402,7 @@
         },
         {
           "name": "CopyRetarget",
-          "line": 2770,
+          "line": 2831,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31413,7 +31417,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 2780,
+          "line": 2841,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31435,7 +31439,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 2804,
+          "line": 2865,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31450,7 +31454,7 @@
         },
         {
           "name": "MoveCountersDistribution",
-          "line": 2812,
+          "line": 2873,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31468,7 +31472,7 @@
         },
         {
           "name": "PayAmountChoice",
-          "line": 2826,
+          "line": 2887,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31486,7 +31490,7 @@
         },
         {
           "name": "RetargetChoice",
-          "line": 2839,
+          "line": 2900,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31502,7 +31506,7 @@
         },
         {
           "name": "CombatTaxPayment",
-          "line": 2861,
+          "line": 2922,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31522,7 +31526,7 @@
         },
         {
           "name": "PhyrexianPayment",
-          "line": 2879,
+          "line": 2940,
           "kind": "struct",
           "field_names": [
             "player",


### PR DESCRIPTION
Parameterize PlayerFilter::OpponentDealtCombatDamage into
{ source: Option<Box<TargetFilter>> } so "the number of your opponents who were
dealt combat damage by ~ or a Dragon this turn" resolves correctly instead of
falling through to QuantityRef::Variable{name} (which resolved to 0). None
preserves the unfiltered reading (Tymna the Weaver, Moonshae Pixie); Some(filter)
gates the count on the damage source.

Strict CR 608.2i look-back: snapshot the damage source's characteristics into
DamageRecord at damage time (mirroring CounterAddedRecord) and match source
filters against that snapshot via a new matches_target_filter_on_damage_record_source.
A Dragon that dealt combat damage and then died or stopped being a Dragon still
counts. This unifies the look-back model across all three combat-damage
source-filter consumers -- PlayerFilter::OpponentDealtCombatDamage,
QuantityRef::DamageDealtThisTurn, and ReplacementCondition::DealtDamageThisTurnBySource
-- which each previously matched the source against the live object. The ad-hoc
source_controller controller-LKI workaround on DamageDealtThisTurn is now subsumed
by the snapshot's controller field.

Parser: parse_opponent_dealt_combat_damage_clause now returns
OracleResult<Option<TargetFilter>>, strips the "your " possessive, and parses an
optional "by <source>" tail via parse_target + merge_or_filters
("~ or a Dragon" -> Or[SelfRef, Typed{Dragon}]). A shared
opponent_dealt_combat_damage_matches resolver replaces five inline duplicates.

DamageRecord gains a Default impl so its many test fixtures spread
..Default::default() for the new snapshot fields; the single production push in
deal_damage.rs populates every field explicitly from the live source.

Regenerates the tracked engine-inventory.json.

CR 608.2i / 608.2h (look-back + last-known information); CR 510.1 / 510.2 (combat
damage); CR 120.1 / 120.9 (damage source).
