### PR TITLE
Partial: Inspirit, Flagship Vessel

### DIFF
--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -71,6 +71,8 @@ fn sync_derived_from_counters(obj: &mut GameObject, counter_type: &CounterType) 
 /// `layers_dirty` for these is defensive — the layer reset/re-derive path is
 /// idempotent when counters already match.
 pub(crate) fn counter_type_affects_layers(counter_type: &CounterType) -> bool {
+    // CR 613.1: Recompute the continuous-effect layer system whenever a
+    // counter change can alter condition-gated effects.
     counter_type.power_toughness_delta().is_some()
         || matches!(
             counter_type,

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -65,14 +65,19 @@ fn sync_derived_from_counters(obj: &mut GameObject, counter_type: &CounterType) 
 /// Mark layers dirty if this counter type projects into a derived characteristic
 /// computed by the layer system. P/T counters feed layer 7c (CR 613.4c);
 /// Loyalty/Defense are cached fields mirrored from the counter map; keyword
-/// counters grant abilities at layer 6 (CR 613.1f + CR 122.1b). Setting
+/// counters grant abilities at layer 6 (CR 613.1f + CR 122.1b); generic
+/// counters can gate static/trigger conditions (e.g. Spacecraft Station
+/// thresholds) whose effects are realized by layer recomputation. Setting
 /// `layers_dirty` for these is defensive — the layer reset/re-derive path is
 /// idempotent when counters already match.
 pub(crate) fn counter_type_affects_layers(counter_type: &CounterType) -> bool {
     counter_type.power_toughness_delta().is_some()
         || matches!(
             counter_type,
-            CounterType::Loyalty | CounterType::Defense | CounterType::Keyword(_)
+            CounterType::Loyalty
+                | CounterType::Defense
+                | CounterType::Keyword(_)
+                | CounterType::Generic(_)
         )
 }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -18705,8 +18705,11 @@ mod crew_tests {
 mod station_tests {
     use super::*;
     use crate::game::zones::create_object;
+    use crate::types::ability::{
+        ContinuousModification, StaticCondition, StaticDefinition, TargetFilter,
+    };
     use crate::types::card_type::CoreType;
-    use crate::types::counter::CounterType;
+    use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
     use crate::types::zones::Zone;
@@ -18984,6 +18987,102 @@ mod station_tests {
         assert_eq!(
             charge, 5,
             "CR 113.7a: snapshot_power applied even when tapped creature left battlefield"
+        );
+    }
+
+    #[test]
+    fn station_threshold_static_reapplies_and_spacecraft_becomes_creature() {
+        let (mut state, spacecraft_id, p5, _) = setup_station_scenario();
+
+        {
+            let spacecraft = state.objects.get_mut(&spacecraft_id).unwrap();
+            spacecraft.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SelfRef)
+                    .condition(StaticCondition::HasCounters {
+                        counters: CounterMatch::OfType(CounterType::Generic("charge".to_string())),
+                        minimum: 8,
+                        maximum: None,
+                    })
+                    .modifications(vec![
+                        ContinuousModification::AddType {
+                            core_type: CoreType::Creature,
+                        },
+                        ContinuousModification::SetPower { value: 5 },
+                        ContinuousModification::SetToughness { value: 5 },
+                    ])
+                    .description("CR 721.2b: Spacecraft is an artifact creature at 8+".to_string()),
+            );
+        }
+
+        // First station activation: 5 charge counters, below threshold.
+        apply_as_current(
+            &mut state,
+            GameAction::ActivateStation {
+                spacecraft_id,
+                creature_id: None,
+            },
+        )
+        .unwrap();
+        apply_as_current(
+            &mut state,
+            GameAction::ActivateStation {
+                spacecraft_id,
+                creature_id: Some(p5),
+            },
+        )
+        .unwrap();
+        apply(&mut state, PlayerId(0), GameAction::PassPriority).unwrap();
+        apply(&mut state, PlayerId(1), GameAction::PassPriority).unwrap();
+
+        assert!(
+            !state
+                .objects
+                .get(&spacecraft_id)
+                .unwrap()
+                .card_types
+                .core_types
+                .contains(&CoreType::Creature),
+            "spacecraft should still be noncreature below threshold"
+        );
+
+        // Simulate a later main phase where the same creature can station again.
+        state.objects.get_mut(&p5).unwrap().tapped = false;
+        state.phase = Phase::PreCombatMain;
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        // Second station activation: another 5 counters, crossing threshold.
+        apply_as_current(
+            &mut state,
+            GameAction::ActivateStation {
+                spacecraft_id,
+                creature_id: None,
+            },
+        )
+        .unwrap();
+        apply_as_current(
+            &mut state,
+            GameAction::ActivateStation {
+                spacecraft_id,
+                creature_id: Some(p5),
+            },
+        )
+        .unwrap();
+        apply(&mut state, PlayerId(0), GameAction::PassPriority).unwrap();
+        apply(&mut state, PlayerId(1), GameAction::PassPriority).unwrap();
+
+        assert!(
+            state
+                .objects
+                .get(&spacecraft_id)
+                .unwrap()
+                .card_types
+                .core_types
+                .contains(&CoreType::Creature),
+            "spacecraft should become a creature at 8+ charge counters"
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes station-threshold runtime behavior for **Inspirit, Flagship Vessel** by ensuring charge counters trigger layer recomputation, so threshold-gated Spacecraft effects (including becoming a creature at 8+) apply correctly.

## Files changed
- crates/engine/src/game/effects/counters.rs
- crates/engine/src/game/engine.rs

## CR references
- CR 613.1 / CR 613.4c (layer re-evaluation impact)
- CR 721.2b (Spacecraft becomes an artifact creature at threshold)

## Track
Developer

## LLM
Tier: Standard
Model: GPT-5.3-Codex
Thinking: medium

## Anchored on
- crates/engine/src/game/effects/counters.rs:158 � existing counter-add path marks layer recalculation through `counter_type_affects_layers`.
- crates/engine/src/game/effects/counters.rs:213 � existing counter-remove path mirrors the same layer-dirty pattern.
- crates/engine/src/game/engine.rs:18811 � existing station resolution test pattern (announce -> pass priority -> resolve -> assert counters/events).

## Gate A
```text
EXIT:0
```

## Verification
- `cargo fmt --all` � clean
- `./scripts/check-parser-combinators.sh` (run as `bash -lc`) � clean (`EXIT:0`)
- `cargo clippy-strict` � started, but local run did not complete due prolonged Windows test-binary build/link stall at `engine(test)` progress stage after extended wait
- `cargo test -p engine station_resolution_taps_creature_and_adds_counters_equal_to_power -- --exact` � started, but local run did not complete due prolonged Windows test-binary build/link stall at `engine(test)` progress stage after extended wait
- `./scripts/gen-card-data.sh` � not run in this session
- `cargo coverage` � not run in this session
- `cargo semantic-audit` � not run in this session

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
Local Developer-track verification was only partially completed in this Windows session:
- `cargo clippy-strict` and targeted `cargo test` repeatedly stalled during long test-binary build/link phase (`engine(test)`), despite extended waits.
- `./scripts/gen-card-data.sh`, `cargo coverage`, and `cargo semantic-audit` were not run locally in this session.
Please rely on PR CI for full verification.
