### PR TITLE
feat(engine): resolve "opponents who investigated this way" count (Wernog, Rider's Chaplain)

### DIFF
--- a/crates/engine/src/game/effects/investigate.rs
+++ b/crates/engine/src/game/effects/investigate.rs
@@ -1,5 +1,5 @@
 use crate::types::ability::{EffectError, PtValue, ResolvedAbility};
-use crate::types::events::GameEvent;
+use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::GameState;
 
 /// CR 701.16a: Investigate — create a Clue artifact token.
@@ -36,5 +36,18 @@ pub fn resolve(
         ability.source_id,
         ability.controller,
     );
-    super::token::resolve(state, &clue_ability, events)
+    super::token::resolve(state, &clue_ability, events)?;
+
+    // CR 608.2c + CR 109.5: Record the investigating player so downstream
+    // "the number of opponents who investigated this way" references resolve.
+    // During an `Effect`-level `player_scope: Opponent` fan-out the driver
+    // rebinds `ability.controller` to the scoped opponent (effects/mod.rs:2891),
+    // so each opponent's investigate records THAT opponent. The generic scan in
+    // effects/mod.rs inserts `(player_id, action)` into `player_actions_this_way`.
+    events.push(GameEvent::PlayerPerformedAction {
+        player_id: ability.controller,
+        action: PlayerActionKind::Investigate,
+    });
+
+    Ok(())
 }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -382,6 +382,20 @@ pub(crate) fn parse_quantity_ref_with_context(
                 return Some(QuantityRef::PlayerCount { filter });
             }
         }
+        // CR 608.2c + CR 109.5: "the number of [population] who [verb]ed … this
+        // way" — the count of players who performed the preceding optional
+        // action (Wernog's "the number of opponents who investigated this way").
+        // Shares the verb-dispatched combinator with the for-each path above, so
+        // search and investigate (and any future verb) stay one building block.
+        // Tried before the generic ObjectCount fall-through so the player
+        // population — not battlefield permanents — is counted.
+        if let Ok((remainder, (relation, action))) = parse_action_this_way(rest) {
+            if remainder.trim().is_empty() {
+                return Some(QuantityRef::PlayerCount {
+                    filter: PlayerFilter::PerformedActionThisWay { relation, action },
+                });
+            }
+        }
         let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
         // CR 109.1: `parse_type_phrase_with_ctx` always returns `TargetFilter::Typed`,
         // including the empty-shaped form (no `type_filters`, no `controller`, no
@@ -1666,19 +1680,50 @@ fn target_hand_card_filter(
     })
 }
 
-/// CR 608.2c + CR 109.5: Recognize "opponent who searched their library this
-/// way" as a player-action quantity. The runtime accumulator is keyed by
+/// CR 608.2c + CR 109.5: Recognize "[population] who [verb]ed [this way]" as a
+/// player-action quantity, returning the player relation and the action that
+/// keys the runtime accumulator. The runtime accumulator is keyed by
 /// `GameEvent::PlayerPerformedAction`, not by zone changes, so it still counts
-/// a player who searched and failed to find.
-fn parse_opponent_searched_library_this_way(
+/// a player who performed the action without an observable board result (e.g.
+/// searched and failed to find).
+///
+/// Nesting: the population word ("opponent(s)"/"player(s)") fixes the relation,
+/// then the shared `"who "` prefix dispatches on the verb arm. The search arm
+/// carries an object-noun ("searched their library"); the investigate arm is
+/// object-less ("investigated"). Composed entirely from `alt`/`value`/`tag` —
+/// no permutation enumeration.
+fn parse_action_this_way(
     input: &str,
-) -> nom::IResult<&str, (), OracleError<'_>> {
-    let (input, _) = tag("opponent who ").parse(input)?;
+) -> nom::IResult<&str, (PlayerRelation, PlayerActionKind), OracleError<'_>> {
+    let (input, relation) = alt((
+        value(PlayerRelation::Opponent, tag("opponents ")),
+        value(PlayerRelation::Opponent, tag("opponent ")),
+        value(PlayerRelation::All, tag("players ")),
+        value(PlayerRelation::All, tag("player ")),
+    ))
+    .parse(input)?;
+    let (input, _) = tag("who ").parse(input)?;
+    let (input, action) = alt((parse_searched_arm, parse_investigated_arm)).parse(input)?;
+    let (input, _) = tag(" this way").parse(input)?;
+    Ok((input, (relation, action)))
+}
+
+/// "searches/searched a/their library" → `SearchedLibrary` (Tempting Offer cycle).
+fn parse_searched_arm(input: &str) -> nom::IResult<&str, PlayerActionKind, OracleError<'_>> {
     let (input, _) = alt((tag("searches"), tag("searched"))).parse(input)?;
     let (input, _) = tag(" ").parse(input)?;
     let (input, _) = alt((tag("a "), tag("their "))).parse(input)?;
-    let (input, _) = tag("library this way").parse(input)?;
-    Ok((input, ()))
+    let (input, _) = tag("library").parse(input)?;
+    Ok((input, PlayerActionKind::SearchedLibrary))
+}
+
+/// "investigates/investigated" → `Investigate` (Wernog, Rider's Chaplain).
+fn parse_investigated_arm(input: &str) -> nom::IResult<&str, PlayerActionKind, OracleError<'_>> {
+    value(
+        PlayerActionKind::Investigate,
+        alt((tag("investigates"), tag("investigated"))),
+    )
+    .parse(input)
 }
 
 /// Parse the clause after "for each" into a QuantityRef.
@@ -1746,20 +1791,18 @@ fn parse_for_each_clause_with_they_controller(
         if lower == "1 damage prevented this way" || lower == "damage prevented this way" {
             return Some(QuantityRef::EventContextAmount);
         }
-        // CR 608.2c + CR 109.5: "opponent who searches/searched [a/their] library
-        // this way" — Tempting Offer cycle's bonus-tutor-per-accepting-opponent
-        // step. A single nom combinator handles all four (verb tense × article)
-        // permutations, returning a player-count quantity rather than the
-        // object-count `TrackedSetSize` fallback below. Must be tried before that
-        // fallback because every "opponent who … this way" clause does contain
-        // "this way".
-        if let Ok((rest, ())) = parse_opponent_searched_library_this_way(lower.as_str()) {
+        // CR 608.2c + CR 109.5: "[population] who [verb]ed … this way" — the
+        // Tempting Offer cycle's bonus-tutor-per-accepting-opponent step and
+        // Wernog's bonus-investigate-per-investigating-opponent step. A single
+        // verb-dispatched combinator handles every (population × verb tense ×
+        // article) permutation, returning a player-count quantity rather than
+        // the object-count `TrackedSetSize` fallback below. Must be tried before
+        // that fallback because every "[population] who … this way" clause does
+        // contain "this way".
+        if let Ok((rest, (relation, action))) = parse_action_this_way(lower.as_str()) {
             if rest.is_empty() {
                 return Some(QuantityRef::PlayerCount {
-                    filter: PlayerFilter::PerformedActionThisWay {
-                        relation: PlayerRelation::Opponent,
-                        action: PlayerActionKind::SearchedLibrary,
-                    },
+                    filter: PlayerFilter::PerformedActionThisWay { relation, action },
                 });
             }
         }
@@ -4094,6 +4137,50 @@ mod tests {
                 filter: PlayerFilter::PerformedActionThisWay {
                     relation: PlayerRelation::Opponent,
                     action: PlayerActionKind::SearchedLibrary,
+                },
+            }
+        );
+    }
+
+    /// CR 608.2c + CR 109.5 + CR 701.16a: Wernog, Rider's Chaplain — "the number
+    /// of opponents who investigated this way" must count the player population
+    /// that performed the optional `Investigate`, NOT battlefield objects. The
+    /// verb-dispatched combinator shared with the search-this-way path returns
+    /// `PerformedActionThisWay { Opponent, Investigate }`.
+    #[test]
+    fn the_number_of_opponents_who_investigated_this_way_is_player_count() {
+        let qty = parse_quantity_ref("the number of opponents who investigated this way").unwrap();
+        assert_eq!(
+            qty,
+            QuantityRef::PlayerCount {
+                filter: PlayerFilter::PerformedActionThisWay {
+                    relation: PlayerRelation::Opponent,
+                    action: PlayerActionKind::Investigate,
+                },
+            }
+        );
+    }
+
+    /// CR 604.3 + CR 609.3: Wernog's full repeat count "one plus the number of
+    /// opponents who investigated this way" composes the "N plus" Offset arm
+    /// over the inner player-action count. Before the inner resolved, the whole
+    /// phrase collapsed to an opaque `Variable`.
+    #[test]
+    fn one_plus_opponents_who_investigated_this_way_is_offset_player_count() {
+        let expr = parse_cda_quantity("one plus the number of opponents who investigated this way")
+            .unwrap();
+        let QuantityExpr::Offset { inner, offset } = expr else {
+            panic!("expected Offset, got {expr:?}");
+        };
+        assert_eq!(offset, 1);
+        assert_eq!(
+            *inner,
+            QuantityExpr::Ref {
+                qty: QuantityRef::PlayerCount {
+                    filter: PlayerFilter::PerformedActionThisWay {
+                        relation: PlayerRelation::Opponent,
+                        action: PlayerActionKind::Investigate,
+                    },
                 },
             }
         );

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5504,7 +5504,7 @@ pub enum Effect {
         #[serde(default = "default_target_filter_any")]
         filter: TargetFilter,
     },
-    /// CR 702.136: Investigate — create a Clue artifact token.
+    /// CR 701.16: Investigate — create a Clue token.
     Investigate,
     /// CR 702.104a: Tribute — "As this creature enters, an opponent of your choice may
     /// put N +1/+1 counters on it." The chosen opponent (persisted on the source as

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -87,6 +87,8 @@ pub enum PlayerActionKind {
     ShuffledLibrary,
     /// CR 701.34a: A player proliferated.
     Proliferate,
+    /// CR 701.16a: A player investigated (created a Clue token).
+    Investigate,
 }
 
 /// CR 701.30d: Result of a clash — whether the controller won, lost, or tied.

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -116,5 +116,6 @@ mod vigor_regression;
 mod virulent_emissary_trigger;
 mod volatile_fault_that_player_search;
 mod wedding_ring_etb_token_copy;
+mod wernog_riders_chaplain_investigate_count;
 mod wise_mothman_milled_trigger;
 mod yuriko_combat_damage;

--- a/crates/engine/tests/integration/wernog_riders_chaplain_investigate_count.rs
+++ b/crates/engine/tests/integration/wernog_riders_chaplain_investigate_count.rs
@@ -1,0 +1,237 @@
+//! Integration tests for Wernog, Rider's Chaplain's "you investigate X times,
+//! where X is one plus the number of opponents who investigated this way"
+//! clause (CR 608.2c + CR 109.5 + CR 701.16a).
+//!
+//! The third sub-ability already parses with
+//! `repeat_for: Variable("one plus the number of opponents who investigated
+//! this way")` because the inner player-action count did not resolve. Once the
+//! "[population] who investigated this way" combinator and the
+//! `PlayerActionKind::Investigate` ledger event are in place, the inner count
+//! resolves to `PlayerCount { PerformedActionThisWay { Opponent, Investigate } }`
+//! and the wrapping "one plus" produces `Offset(+1, …)`.
+//!
+//! This mirrors `tempt_with_discovery.rs` — the identical "each opponent may X,
+//! then you do X once per opponent who did" machinery, but for Investigate
+//! instead of SearchLibrary.
+//!
+//! OUT OF SCOPE: clause 2 ("each opponent who doesn't loses 1 life") currently
+//! parses unconditionally (no decline-gate linking it to clause 1's optional
+//! investigate), so every opponent loses 1 life regardless of whether they
+//! investigated. That is a separate pre-existing parser gap (the decline-gate),
+//! not part of this count fix, and these tests deliberately assert nothing
+//! about clause-2 life loss.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::engine::apply;
+use engine::types::ability::{Effect, ResolvedAbility};
+use engine::types::actions::GameAction;
+use engine::types::events::PlayerActionKind;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::player::PlayerId;
+
+const WERNOG_ORACLE: &str = "When Wernog, Rider's Chaplain enters or leaves the battlefield, \
+     each opponent may investigate. Each opponent who doesn't loses 1 life. \
+     You investigate X times, where X is one plus the number of opponents who \
+     investigated this way.";
+
+fn count_clues(state: &GameState) -> usize {
+    state.objects.values().filter(|o| o.name == "Clue").count()
+}
+
+/// Build a fresh `n`-player game and the resolved ETB trigger ability for
+/// Wernog (controller = P0). Returns the game state and the ability.
+fn make_game_and_ability(num_players: u8) -> (GameState, ResolvedAbility) {
+    let parsed = engine::parser::oracle::parse_oracle_text(
+        WERNOG_ORACLE,
+        "Wernog, Rider's Chaplain",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    // The enters-the-battlefield trigger is the first of the two zone-change
+    // triggers; both share the identical body.
+    let def = parsed.triggers[0]
+        .execute
+        .as_ref()
+        .expect("Wernog ETB trigger must have an execute body");
+    let ability = build_resolved_from_def(def, ObjectId(9000), PlayerId(0));
+    let state = GameState::new(FormatConfig::standard(), num_players, 42);
+    (state, ability)
+}
+
+/// CR 608.2c + CR 109.5 + CR 701.16a: With 2 opponents who both investigate,
+/// the clause-3 `repeat_for` count resolves to `1 + 2 = 3` — P0 investigates 3
+/// times. Total Clue tokens = P1(1) + P2(1) + P0(3) = 5.
+///
+/// This drives the real `player_scope: Opponent` fan-out through `apply()`:
+/// each opponent's `Effect::Investigate` emits
+/// `GameEvent::PlayerPerformedAction { Investigate }`, which the generic scan
+/// records into `player_actions_this_way` keyed by the *scoped opponent* (the
+/// driver rebinds `ability.controller` to each opponent). The clause-3 count
+/// then reads that ledger.
+#[test]
+fn wernog_clause3_count_is_one_plus_two_investigating_opponents() {
+    let (mut state, ability) = make_game_and_ability(3);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    // Clause 1 fans out over opponents (APNAP from P0 → P1 then P2). P1 is
+    // prompted first.
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::OptionalEffectChoice {
+                player: PlayerId(1),
+                ..
+            }
+        ),
+        "expected P1 to be prompted to investigate, got {:?}",
+        state.waiting_for
+    );
+
+    // P1 accepts — investigates. Ledger now records P1 (the scoped opponent).
+    apply(
+        &mut state,
+        PlayerId(1),
+        GameAction::DecideOptionalEffect { accept: true },
+    )
+    .unwrap();
+    assert!(
+        state
+            .player_actions_this_way
+            .contains(&(PlayerId(1), PlayerActionKind::Investigate)),
+        "P1's investigate must be recorded against P1 (the scoped opponent), \
+         got {:?}",
+        state.player_actions_this_way
+    );
+
+    // P2 accepts — investigates. This is the final clause-1 iteration; clause-2
+    // (LoseLife, out of scope) and clause-3 (the repeat_for self-investigate)
+    // then run inside the same top-level resolution, so the ledger is fully
+    // populated with both opponents BEFORE the clause-3 count resolves.
+    apply(
+        &mut state,
+        PlayerId(2),
+        GameAction::DecideOptionalEffect { accept: true },
+    )
+    .unwrap();
+
+    // Resolution completed — no further opponent prompts pending.
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "all clauses should have resolved, got {:?}",
+        state.waiting_for
+    );
+
+    // Both opponents recorded as having investigated this way.
+    assert!(
+        state
+            .player_actions_this_way
+            .contains(&(PlayerId(1), PlayerActionKind::Investigate)),
+        "P1 must remain recorded after full resolution"
+    );
+    assert!(
+        state
+            .player_actions_this_way
+            .contains(&(PlayerId(2), PlayerActionKind::Investigate)),
+        "P2 must be recorded after full resolution"
+    );
+
+    // X = 1 + 2 = 3 → P0 investigated 3 times (clause 3), so the controller
+    // also appears in the ledger.
+    assert!(
+        state
+            .player_actions_this_way
+            .contains(&(PlayerId(0), PlayerActionKind::Investigate)),
+        "controller P0 must have investigated via the clause-3 repeat_for"
+    );
+
+    // Total Clues = P1(1) + P2(1) + P0(X=3) = 5. If the inner count had stayed
+    // an opaque Variable (resolving to 0), the "one plus" Offset would give
+    // X=1 and the total would be 3, not 5.
+    assert_eq!(
+        count_clues(&state),
+        5,
+        "expected 5 Clue tokens: 1 per investigating opponent + (1 + 2) for P0; \
+         a wrong count means the clause-3 X did not resolve to 1 + investigating \
+         opponents"
+    );
+}
+
+/// CR 608.2c + CR 109.5: Boundary — when no opponent investigates, the clause-3
+/// count resolves to `1 + 0 = 1`, so P0 investigates exactly once. Total Clues
+/// = P0(1) = 1.
+#[test]
+fn wernog_clause3_count_is_one_when_no_opponent_investigates() {
+    let (mut state, ability) = make_game_and_ability(3);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    // Both opponents decline.
+    apply(
+        &mut state,
+        PlayerId(1),
+        GameAction::DecideOptionalEffect { accept: false },
+    )
+    .unwrap();
+    apply(
+        &mut state,
+        PlayerId(2),
+        GameAction::DecideOptionalEffect { accept: false },
+    )
+    .unwrap();
+
+    // No opponent recorded.
+    assert!(
+        !state
+            .player_actions_this_way
+            .contains(&(PlayerId(1), PlayerActionKind::Investigate)),
+        "P1 declined and must not be recorded"
+    );
+    assert!(
+        !state
+            .player_actions_this_way
+            .contains(&(PlayerId(2), PlayerActionKind::Investigate)),
+        "P2 declined and must not be recorded"
+    );
+
+    // X = 1 + 0 = 1 → exactly one Clue, created by P0's single clause-3
+    // investigate.
+    assert_eq!(
+        count_clues(&state),
+        1,
+        "with zero investigating opponents, X = 1 + 0 = 1, so exactly one Clue \
+         (P0's) should exist; got a different count"
+    );
+}
+
+/// CR 701.16a: A bare `Effect::Investigate` (no `player_scope`, no `repeat_for`)
+/// still creates exactly one Clue token. The new `PlayerPerformedAction`
+/// emission is unconditional in the resolver — the ledger entry it leaves is
+/// harmless for a standalone investigate.
+#[test]
+fn bare_investigate_creates_exactly_one_clue() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let ability = ResolvedAbility::new(Effect::Investigate, vec![], ObjectId(9000), PlayerId(0));
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        count_clues(&state),
+        1,
+        "a bare investigate must create exactly one Clue token"
+    );
+    // The harmless ledger entry is present but does not affect anything here.
+    assert!(
+        state
+            .player_actions_this_way
+            .contains(&(PlayerId(0), PlayerActionKind::Investigate)),
+        "the unconditional ledger emit records the investigating player"
+    );
+}

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -26,7 +26,7 @@
     "crates/engine/src/types/card_type.rs"
   ],
   "enum_count": 245,
-  "variant_count": 2774,
+  "variant_count": 2775,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -3769,7 +3769,7 @@
     },
     "ClashResult": {
       "file": "crates/engine/src/types/events.rs",
-      "line": 94,
+      "line": 96,
       "doc": "CR 701.30d: Result of a clash — whether the controller won, lost, or tied.",
       "cr_refs": [
         "CR 701.30d"
@@ -3777,7 +3777,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 95,
+          "line": 97,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3785,7 +3785,7 @@
         },
         {
           "name": "Lost",
-          "line": 96,
+          "line": 98,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3793,7 +3793,7 @@
         },
         {
           "name": "Tied",
-          "line": 97,
+          "line": 99,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7154,9 +7154,9 @@
           "line": 5508,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 702.136: Investigate — create a Clue artifact token.",
+          "doc": "CR 701.16: Investigate — create a Clue token.",
           "cr_refs": [
-            "CR 702.136"
+            "CR 701.16"
           ]
         },
         {
@@ -12616,13 +12616,13 @@
     },
     "GameEvent": {
       "file": "crates/engine/src/types/events.rs",
-      "line": 102,
+      "line": 104,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "GameStarted",
-          "line": 103,
+          "line": 105,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12630,7 +12630,7 @@
         },
         {
           "name": "TurnStarted",
-          "line": 104,
+          "line": 106,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12641,7 +12641,7 @@
         },
         {
           "name": "PhaseChanged",
-          "line": 108,
+          "line": 110,
           "kind": "struct",
           "field_names": [
             "phase"
@@ -12651,7 +12651,7 @@
         },
         {
           "name": "PriorityPassed",
-          "line": 111,
+          "line": 113,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12661,7 +12661,7 @@
         },
         {
           "name": "SpellCast",
-          "line": 114,
+          "line": 116,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -12673,7 +12673,7 @@
         },
         {
           "name": "SpellCopied",
-          "line": 123,
+          "line": 125,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -12688,7 +12688,7 @@
         },
         {
           "name": "XValueChosen",
-          "line": 131,
+          "line": 133,
           "kind": "struct",
           "field_names": [
             "player",
@@ -12703,7 +12703,7 @@
         },
         {
           "name": "AbilityActivated",
-          "line": 145,
+          "line": 147,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12717,7 +12717,7 @@
         },
         {
           "name": "ZoneChanged",
-          "line": 161,
+          "line": 163,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12733,7 +12733,7 @@
         },
         {
           "name": "LifeChanged",
-          "line": 170,
+          "line": 172,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12744,7 +12744,7 @@
         },
         {
           "name": "ManaAdded",
-          "line": 174,
+          "line": 176,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12757,7 +12757,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 190,
+          "line": 192,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12774,7 +12774,7 @@
         },
         {
           "name": "ManaPoolEmptied",
-          "line": 206,
+          "line": 208,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12790,7 +12790,7 @@
         },
         {
           "name": "ManaRecolored",
-          "line": 214,
+          "line": 216,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12805,7 +12805,7 @@
         },
         {
           "name": "PermanentTapped",
-          "line": 219,
+          "line": 221,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12816,7 +12816,7 @@
         },
         {
           "name": "CreatureExerted",
-          "line": 229,
+          "line": 231,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12829,7 +12829,7 @@
         },
         {
           "name": "PlayerLost",
-          "line": 232,
+          "line": 234,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12839,7 +12839,7 @@
         },
         {
           "name": "MulliganStarted",
-          "line": 235,
+          "line": 237,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12847,7 +12847,7 @@
         },
         {
           "name": "CardsDrawn",
-          "line": 236,
+          "line": 238,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12858,7 +12858,7 @@
         },
         {
           "name": "CardDrawn",
-          "line": 240,
+          "line": 242,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12871,7 +12871,7 @@
         },
         {
           "name": "PermanentUntapped",
-          "line": 257,
+          "line": 259,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12881,7 +12881,7 @@
         },
         {
           "name": "PermanentPhasedOut",
-          "line": 263,
+          "line": 265,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12895,7 +12895,7 @@
         },
         {
           "name": "PermanentPhasedIn",
-          "line": 269,
+          "line": 271,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12907,7 +12907,7 @@
         },
         {
           "name": "PlayerPhasedOut",
-          "line": 277,
+          "line": 279,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12919,7 +12919,7 @@
         },
         {
           "name": "PlayerPhasedIn",
-          "line": 282,
+          "line": 284,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12929,7 +12929,7 @@
         },
         {
           "name": "LandPlayed",
-          "line": 285,
+          "line": 287,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12941,7 +12941,7 @@
         },
         {
           "name": "StackPushed",
-          "line": 290,
+          "line": 292,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12951,7 +12951,7 @@
         },
         {
           "name": "StackResolved",
-          "line": 293,
+          "line": 295,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12961,7 +12961,7 @@
         },
         {
           "name": "Discarded",
-          "line": 296,
+          "line": 298,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -12972,7 +12972,7 @@
         },
         {
           "name": "DamageCleared",
-          "line": 300,
+          "line": 302,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -12982,7 +12982,7 @@
         },
         {
           "name": "GameOver",
-          "line": 303,
+          "line": 305,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -12992,7 +12992,7 @@
         },
         {
           "name": "DamageDealt",
-          "line": 306,
+          "line": 308,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13006,7 +13006,7 @@
         },
         {
           "name": "DamagePrevented",
-          "line": 317,
+          "line": 319,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13020,7 +13020,7 @@
         },
         {
           "name": "SpellCountered",
-          "line": 322,
+          "line": 324,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13031,7 +13031,7 @@
         },
         {
           "name": "CounterAdded",
-          "line": 326,
+          "line": 328,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13043,7 +13043,7 @@
         },
         {
           "name": "Evolved",
-          "line": 333,
+          "line": 335,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13055,7 +13055,7 @@
         },
         {
           "name": "CounterRemoved",
-          "line": 336,
+          "line": 338,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13067,7 +13067,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 341,
+          "line": 343,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13078,7 +13078,7 @@
         },
         {
           "name": "ObjectConjured",
-          "line": 346,
+          "line": 348,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13089,7 +13089,7 @@
         },
         {
           "name": "CreatureDestroyed",
-          "line": 350,
+          "line": 352,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13099,7 +13099,7 @@
         },
         {
           "name": "PermanentSacrificed",
-          "line": 353,
+          "line": 355,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13110,7 +13110,7 @@
         },
         {
           "name": "EffectResolved",
-          "line": 357,
+          "line": 359,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -13121,7 +13121,7 @@
         },
         {
           "name": "Unattached",
-          "line": 363,
+          "line": 365,
           "kind": "struct",
           "field_names": [
             "attachment_id",
@@ -13134,7 +13134,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 367,
+          "line": 369,
           "kind": "struct",
           "field_names": [
             "attacker_ids",
@@ -13146,7 +13146,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 374,
+          "line": 376,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -13156,7 +13156,7 @@
         },
         {
           "name": "CombatTaxPaid",
-          "line": 379,
+          "line": 381,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13170,7 +13170,7 @@
         },
         {
           "name": "CombatTaxDeclined",
-          "line": 385,
+          "line": 387,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13184,7 +13184,7 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 389,
+          "line": 391,
           "kind": "struct",
           "field_names": [
             "target",
@@ -13195,7 +13195,7 @@
         },
         {
           "name": "VehicleCrewed",
-          "line": 395,
+          "line": 397,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -13208,7 +13208,7 @@
         },
         {
           "name": "Stationed",
-          "line": 405,
+          "line": 407,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -13222,7 +13222,7 @@
         },
         {
           "name": "Saddled",
-          "line": 415,
+          "line": 417,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -13235,7 +13235,7 @@
         },
         {
           "name": "ReplacementApplied",
-          "line": 419,
+          "line": 421,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13246,7 +13246,7 @@
         },
         {
           "name": "Transformed",
-          "line": 423,
+          "line": 425,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13256,7 +13256,7 @@
         },
         {
           "name": "DayNightChanged",
-          "line": 426,
+          "line": 428,
           "kind": "struct",
           "field_names": [
             "new_state"
@@ -13266,7 +13266,7 @@
         },
         {
           "name": "TurnedFaceUp",
-          "line": 429,
+          "line": 431,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13276,7 +13276,7 @@
         },
         {
           "name": "CardsRevealed",
-          "line": 432,
+          "line": 434,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13288,7 +13288,7 @@
         },
         {
           "name": "CombatDamageDealtToPlayer",
-          "line": 438,
+          "line": 440,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13300,7 +13300,7 @@
         },
         {
           "name": "PlayerEliminated",
-          "line": 464,
+          "line": 466,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13310,7 +13310,7 @@
         },
         {
           "name": "CrimeCommitted",
-          "line": 467,
+          "line": 469,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13320,7 +13320,7 @@
         },
         {
           "name": "Cycled",
-          "line": 470,
+          "line": 472,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13331,7 +13331,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 474,
+          "line": 476,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13342,7 +13342,7 @@
         },
         {
           "name": "Regenerated",
-          "line": 479,
+          "line": 481,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13354,7 +13354,7 @@
         },
         {
           "name": "CreatureSuspected",
-          "line": 483,
+          "line": 485,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13366,7 +13366,7 @@
         },
         {
           "name": "Detained",
-          "line": 490,
+          "line": 492,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13378,7 +13378,7 @@
         },
         {
           "name": "BecamePrepared",
-          "line": 496,
+          "line": 498,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13390,7 +13390,7 @@
         },
         {
           "name": "BecameUnprepared",
-          "line": 502,
+          "line": 504,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13402,7 +13402,7 @@
         },
         {
           "name": "CaseSolved",
-          "line": 506,
+          "line": 508,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13414,7 +13414,7 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 510,
+          "line": 512,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13427,7 +13427,7 @@
         },
         {
           "name": "MonarchChanged",
-          "line": 515,
+          "line": 517,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13439,7 +13439,7 @@
         },
         {
           "name": "CityBlessingGained",
-          "line": 519,
+          "line": 521,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13451,7 +13451,7 @@
         },
         {
           "name": "DieRolled",
-          "line": 523,
+          "line": 525,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13465,7 +13465,7 @@
         },
         {
           "name": "CoinFlipped",
-          "line": 529,
+          "line": 531,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13478,7 +13478,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 534,
+          "line": 536,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13490,7 +13490,7 @@
         },
         {
           "name": "RoomEntered",
-          "line": 538,
+          "line": 540,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13505,7 +13505,7 @@
         },
         {
           "name": "RoomDoorUnlocked",
-          "line": 545,
+          "line": 547,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13520,7 +13520,7 @@
         },
         {
           "name": "BecomesPlotted",
-          "line": 552,
+          "line": 554,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13533,7 +13533,7 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 557,
+          "line": 559,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13546,7 +13546,7 @@
         },
         {
           "name": "InitiativeTaken",
-          "line": 562,
+          "line": 564,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13558,7 +13558,7 @@
         },
         {
           "name": "Firebend",
-          "line": 566,
+          "line": 568,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13569,7 +13569,7 @@
         },
         {
           "name": "Airbend",
-          "line": 571,
+          "line": 573,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13580,7 +13580,7 @@
         },
         {
           "name": "Earthbend",
-          "line": 576,
+          "line": 578,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13591,7 +13591,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 581,
+          "line": 583,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13602,7 +13602,7 @@
         },
         {
           "name": "CompanionRevealed",
-          "line": 586,
+          "line": 588,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13615,7 +13615,7 @@
         },
         {
           "name": "CompanionMovedToHand",
-          "line": 591,
+          "line": 593,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13628,7 +13628,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 598,
+          "line": 600,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13641,7 +13641,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 608,
+          "line": 610,
           "kind": "struct",
           "field_names": [
             "ability_tag",
@@ -13658,7 +13658,7 @@
         },
         {
           "name": "CreatureExploited",
-          "line": 616,
+          "line": 618,
           "kind": "struct",
           "field_names": [
             "exploiter",
@@ -13671,7 +13671,7 @@
         },
         {
           "name": "EnergyChanged",
-          "line": 621,
+          "line": 623,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13684,7 +13684,7 @@
         },
         {
           "name": "SpeedChanged",
-          "line": 626,
+          "line": 628,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13698,7 +13698,7 @@
         },
         {
           "name": "PlayerCounterChanged",
-          "line": 632,
+          "line": 634,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13712,7 +13712,7 @@
         },
         {
           "name": "ManaExpended",
-          "line": 638,
+          "line": 640,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13726,7 +13726,7 @@
         },
         {
           "name": "Clash",
-          "line": 644,
+          "line": 646,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -13742,7 +13742,7 @@
         },
         {
           "name": "VoteCast",
-          "line": 655,
+          "line": 657,
           "kind": "struct",
           "field_names": [
             "voter",
@@ -13756,7 +13756,7 @@
         },
         {
           "name": "VoteResolved",
-          "line": 663,
+          "line": 665,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13769,7 +13769,7 @@
         },
         {
           "name": "PowerToughnessChanged",
-          "line": 669,
+          "line": 671,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13783,7 +13783,7 @@
         },
         {
           "name": "CascadeMissed",
-          "line": 680,
+          "line": 682,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -13797,7 +13797,7 @@
         },
         {
           "name": "DebugActionUsed",
-          "line": 688,
+          "line": 690,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13808,7 +13808,7 @@
         },
         {
           "name": "DebugPermissionGranted",
-          "line": 694,
+          "line": 696,
           "kind": "struct",
           "field_names": [
             "host",
@@ -13819,7 +13819,7 @@
         },
         {
           "name": "DebugPermissionRevoked",
-          "line": 699,
+          "line": 701,
           "kind": "struct",
           "field_names": [
             "host",
@@ -20530,6 +20530,16 @@
           "doc": "CR 701.34a: A player proliferated.",
           "cr_refs": [
             "CR 701.34a"
+          ]
+        },
+        {
+          "name": "Investigate",
+          "line": 91,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.16a: A player investigated (created a Clue token).",
+          "cr_refs": [
+            "CR 701.16a"
           ]
         }
       ],


### PR DESCRIPTION
Wernog's "you investigate X times, where X is one plus the number of opponents
who investigated this way" already parsed the repeat via repeat_for, but the
inner quantity collapsed to an opaque Variable, so the Offset(+1, ...) wrapper
could not resolve and X stayed 0 (a single investigate). Resolve the inner count:

- Add PlayerActionKind::Investigate.
- investigate::resolve emits GameEvent::PlayerPerformedAction so the generic
  intra-resolution ledger scan records (player, Investigate) into
  player_actions_this_way. During the "each opponent may investigate" player-scope
  fan-out the resolver runs scoped to each opponent, so each records itself; the
  clause-3 "you investigate X times" then resolves
  Offset(1, PlayerCount{PerformedActionThisWay{Opponent, Investigate}}) after the
  fan-out completes (the ledger persists across the chain, cleared only at depth 0).
- Generalize the search-only parse_opponent_searched_library_this_way into a
  verb-dispatched parse_action_this_way returning (PlayerRelation, PlayerActionKind),
  and add a "the number of [opponents/players] who [verbed] this way" branch to the
  quantity dispatcher. The existing "searched their library this way" caller (Tempt
  with Discovery) is preserved.
- Fix a wrong CR annotation on Effect::Investigate (702.136 Riot -> 701.16 Investigate).

Reuses the existing repeat_for (CR 609.3), the PerformedActionThisWay ledger, and
the Offset arm -- no new effect parameterization. Regenerates engine-inventory.json.

Out of scope (separate pre-existing parser gap, untouched): Wernog's "each opponent
who doesn't investigate loses 1 life" lacks a decline-gate and currently applies to
every opponent unconditionally.

CR 701.16 / 701.16a (investigate); CR 608.2c (this-way intra-resolution scope);
CR 609.3 (repeat_for).
