### PR TITLE
refactor(engine): dedupe OpponentAttackedThisTurn lookup via GameState::has_attacked

### DIFF
--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -899,11 +899,7 @@ fn collect_matching_players(
                     }
                     // CR 508.6: opponent this player attacked this turn.
                     PlayerFilter::OpponentAttackedThisTurn => {
-                        p.id != source_controller
-                            && state
-                                .attacked_defenders_this_turn
-                                .get(&source_controller)
-                                .is_some_and(|defenders| defenders.contains(&p.id))
+                        p.id != source_controller && state.has_attacked(source_controller, p.id)
                     }
                     PlayerFilter::HighestSpeed => {
                         let highest_speed = state
@@ -1070,11 +1066,7 @@ pub fn resolve_each_player(
                     }
                     // CR 508.6: opponent this player attacked this turn.
                     PlayerFilter::OpponentAttackedThisTurn => {
-                        p.id != ability.controller
-                            && state
-                                .attacked_defenders_this_turn
-                                .get(&ability.controller)
-                                .is_some_and(|defenders| defenders.contains(&p.id))
+                        p.id != ability.controller && state.has_attacked(ability.controller, p.id)
                     }
                     PlayerFilter::HighestSpeed => {
                         let highest_speed = state

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -227,11 +227,7 @@ pub(crate) fn matches_player_scope(
                     }
                     // CR 508.6: opponent this player attacked this turn.
                     PlayerFilter::OpponentAttackedThisTurn => {
-                        p.id != controller
-                            && state
-                                .attacked_defenders_this_turn
-                                .get(&controller)
-                                .is_some_and(|defenders| defenders.contains(&p.id))
+                        p.id != controller && state.has_attacked(controller, p.id)
                     }
                     PlayerFilter::HighestSpeed => {
                         let highest_speed = state

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -67,13 +67,7 @@ fn players_for_filter(
             .players
             .iter()
             .filter(|player| !player.is_eliminated)
-            .filter(|player| {
-                player.id != controller
-                    && state
-                        .attacked_defenders_this_turn
-                        .get(&controller)
-                        .is_some_and(|defenders| defenders.contains(&player.id))
-            })
+            .filter(|player| player.id != controller && state.has_attacked(controller, player.id))
             .map(|player| player.id)
             .collect(),
         PlayerFilter::All => state

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2878,11 +2878,7 @@ pub(crate) fn resolve_player_count(
                         }
                         // CR 508.6: opponent this player attacked this turn.
                         PlayerFilter::OpponentAttackedThisTurn => {
-                            p.id != controller
-                                && state
-                                    .attacked_defenders_this_turn
-                                    .get(&controller)
-                                    .is_some_and(|defenders| defenders.contains(&p.id))
+                            p.id != controller && state.has_attacked(controller, p.id)
                         }
                         PlayerFilter::All => true,
                         PlayerFilter::HighestSpeed => {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4923,6 +4923,14 @@ impl GameState {
             .collect()
     }
 
+    /// CR 508.6: True if `attacker` declared one or more creatures attacking
+    /// `defender` this turn (reads the per-turn attacked-defenders ledger).
+    pub fn has_attacked(&self, attacker: PlayerId, defender: PlayerId) -> bool {
+        self.attacked_defenders_this_turn
+            .get(&attacker)
+            .is_some_and(|defenders| defenders.contains(&defender))
+    }
+
     /// Create a new game with the given format configuration and player count.
     pub fn new(config: FormatConfig, player_count: u8, seed: u64) -> Self {
         let players: Vec<Player> = (0..player_count)

--- a/crates/engine/tests/integration/militant_angel_attacked_opponents.rs
+++ b/crates/engine/tests/integration/militant_angel_attacked_opponents.rs
@@ -23,6 +23,11 @@ use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::ability::{PlayerFilter, QuantityExpr, QuantityRef};
 use engine::types::actions::GameAction;
 use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+/// Convenience constant for the third player (no `P2` const in the scenario
+/// module).
+const P2: PlayerId = PlayerId(2);
 
 /// CR 508.6: after P0 declares a creature attacking P1, resolving
 /// `PlayerCount { OpponentAttackedThisTurn }` from P0's perspective counts the
@@ -84,5 +89,112 @@ fn opponents_attacked_this_turn_is_zero_without_combat() {
     assert_eq!(
         count, 0,
         "no attacks declared this turn means 0 opponents attacked (CR 508.6)"
+    );
+}
+
+/// CR 508.6: in a 3-player game, when P0 declares creatures attacking BOTH P1
+/// and P2, resolving `PlayerCount { OpponentAttackedThisTurn }` from P0 counts
+/// both attacked opponents (Gemini-specified multi-opponent coverage for
+/// Militant Angel's token fan-out).
+#[test]
+fn opponents_attacked_this_turn_counts_multiple_defenders() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let attacker_vs_p1 = scenario.add_creature(P0, "Soldier", 2, 2).id();
+    let attacker_vs_p2 = scenario.add_creature(P0, "Soldier", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // Pass priority for every player (3-player game) until the active player
+    // reaches the declare-attackers step, then declare both attackers in one
+    // step so `record_attackers_declared` records both defenders (no
+    // hand-insertion into the substrate).
+    for _ in 0..12 {
+        if runner.waiting_for_kind() == "DeclareAttackers" {
+            break;
+        }
+        let _ = runner.act(GameAction::PassPriority);
+    }
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![
+                (attacker_vs_p1, AttackTarget::Player(P1)),
+                (attacker_vs_p2, AttackTarget::Player(P2)),
+            ],
+        })
+        .expect("DeclareAttackers should succeed");
+
+    let count = resolve_quantity(
+        runner.state(),
+        &QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::OpponentAttackedThisTurn,
+            },
+        },
+        P0,
+        attacker_vs_p1,
+    );
+
+    assert_eq!(
+        count, 2,
+        "P0 attacked both opponents (P1 and P2) this turn (CR 508.6)"
+    );
+}
+
+/// CR 102.3 + CR 800.4a: an opponent is a player still in the game, and a
+/// player who has left the game (`is_eliminated`) no longer participates, so a
+/// defender P0 attacked this turn but who has since left the game must NOT be
+/// counted by `PlayerCount { OpponentAttackedThisTurn }`. Discriminating test
+/// for the `!p.is_eliminated` guard on the resolving arm: with both defenders
+/// attacked the count is 2 (see the multi-defender test); eliminating one
+/// attacked opponent drops it to 1.
+#[test]
+fn opponents_attacked_this_turn_excludes_eliminated_defender() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let attacker_vs_p1 = scenario.add_creature(P0, "Soldier", 2, 2).id();
+    let attacker_vs_p2 = scenario.add_creature(P0, "Soldier", 2, 2).id();
+    let mut runner = scenario.build();
+
+    for _ in 0..12 {
+        if runner.waiting_for_kind() == "DeclareAttackers" {
+            break;
+        }
+        let _ = runner.act(GameAction::PassPriority);
+    }
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![
+                (attacker_vs_p1, AttackTarget::Player(P1)),
+                (attacker_vs_p2, AttackTarget::Player(P2)),
+            ],
+        })
+        .expect("DeclareAttackers should succeed");
+
+    // CR 800.4a + CR 102.3: P2 has left the game and is no longer an opponent.
+    // The attacked-defenders ledger still records the declaration, but the
+    // resolving arm must filter eliminated players so the count reflects only
+    // opponents still in the game.
+    runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P2)
+        .expect("P2 exists")
+        .is_eliminated = true;
+
+    let count = resolve_quantity(
+        runner.state(),
+        &QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::OpponentAttackedThisTurn,
+            },
+        },
+        P0,
+        attacker_vs_p1,
+    );
+
+    assert_eq!(
+        count, 1,
+        "eliminating attacked opponent P2 drops the count to 1 (only P1 remains)"
     );
 }


### PR DESCRIPTION
Route the five OpponentAttackedThisTurn resolver arms (resolve_player_count,
matches_player_scope, deal_damage x2, speed_effects players_for_filter) through a
new GameState::has_attacked(attacker, defender) helper, replacing the duplicated
attacked_defenders_this_turn lookup. Behavior-preserving: each site keeps its
`p.id != controller` opponent predicate and its pre-existing !is_eliminated guard.

Add two integration tests for the multiplayer cases #1482 did not cover: counting
multiple attacked opponents, and excluding an attacked opponent who has since left
the game. The eliminated-exclusion test is a regression guard -- the !is_eliminated
filter already existed (it rides the resolver loop's shared guard, consistent with
the OpponentLostLife/OpponentDealtCombatDamage sibling cluster); the test fails if
it is ever removed.

Addresses code-review feedback on #1482 (the duplicated-lookup and missing
multi-opponent-coverage findings; the "missing eliminated guard" finding was a
false positive -- the guard rides the loop-level filter the suggestion overlooked).

CR 508.6 (a player has "attacked [a player]").
