### PR TITLE
perf(engine): Scute Swarm O(N²) resolution — layer-eval stack + FxHasher + static-source index (+progress overlay)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ node_modules/
 # Local TODO notes (per-item follow-up specs, not shared via git)
 docs/todo/
 
+# Superpowers plans
+docs/superpowers/
+
 # MTG Comprehensive Rules — © Wizards of the Coast, not redistributed here.
 # Run ./scripts/fetch-comp-rules.sh to download a local copy for dev reference.
 docs/MagicCompRules.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "proptest",
  "rand 0.9.4",
  "rand_chacha",
+ "rustc-hash",
  "serde",
  "serde_json",
  "smallvec",
@@ -2021,6 +2022,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1878,6 +1878,9 @@ export interface BatchResolveResult {
   waitingFor: WaitingFor;
   logEntries?: GameLogEntry[];
   itemsResolved: number;
+  /** Stack depth at this chunk's entry; the drive loop latches the first
+   *  chunk's value as the "resolving X of Y" denominator. */
+  total: number;
 }
 
 export interface EngineAdapter {

--- a/client/src/components/board/ResolutionProgressOverlay.tsx
+++ b/client/src/components/board/ResolutionProgressOverlay.tsx
@@ -1,0 +1,53 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+
+import { useGameStore } from "../../stores/gameStore";
+
+/**
+ * Non-blocking overlay shown while a large stack-resolution storm drains
+ * (e.g. a Scute Swarm landfall cascade resolved via "Resolve All"). It renders
+ * the engine-provided `resolved`/`total` counts from
+ * `gameStore.resolutionProgress`, which `dispatchResolveAll` sets per chunk and
+ * clears when the drain finishes; it renders nothing when no storm is in
+ * flight. Display-only — it drives no game state and derives nothing; the bar
+ * width is pure presentation of the two engine counts.
+ */
+export function ResolutionProgressOverlay() {
+  const { t } = useTranslation("game");
+  const progress = useGameStore((s) => s.resolutionProgress);
+
+  const percent =
+    progress && progress.total > 0
+      ? Math.min(100, Math.round((progress.resolved / progress.total) * 100))
+      : 0;
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-50 flex items-start justify-center">
+      <AnimatePresence>
+        {progress && (
+          <motion.div
+            className="mt-24 flex flex-col items-center gap-2 rounded-xl bg-black/75 px-6 py-4 text-cyan-400 backdrop-blur-sm"
+            initial={{ opacity: 0, y: -10, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -10, scale: 0.95 }}
+            transition={{ duration: 0.2 }}
+          >
+            <span className="text-sm font-medium tabular-nums">
+              {t("resolutionProgress.label", {
+                resolved: progress.resolved,
+                total: progress.total,
+              })}
+            </span>
+            <div className="h-1.5 w-48 overflow-hidden rounded-full bg-cyan-950">
+              <motion.div
+                className="h-full rounded-full bg-cyan-400"
+                animate={{ width: `${percent}%` }}
+                transition={{ duration: 0.15, ease: "linear" }}
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/client/src/components/board/__tests__/ResolutionProgressOverlay.test.tsx
+++ b/client/src/components/board/__tests__/ResolutionProgressOverlay.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useGameStore } from "../../../stores/gameStore";
+import { ResolutionProgressOverlay } from "../ResolutionProgressOverlay";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      key === "resolutionProgress.label"
+        ? `Resolving ${opts?.resolved} / ${opts?.total}`
+        : key,
+  }),
+}));
+
+describe("ResolutionProgressOverlay", () => {
+  beforeEach(() => {
+    useGameStore.setState({ resolutionProgress: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useGameStore.setState({ resolutionProgress: null });
+  });
+
+  it("renders the engine-provided resolved/total counts when a storm is in flight", async () => {
+    useGameStore.setState({ resolutionProgress: { resolved: 80, total: 200 } });
+    render(<ResolutionProgressOverlay />);
+    expect(await screen.findByText("Resolving 80 / 200")).toBeInTheDocument();
+  });
+
+  it("renders nothing when no resolution is in flight", () => {
+    useGameStore.setState({ resolutionProgress: null });
+    render(<ResolutionProgressOverlay />);
+    expect(screen.queryByText(/Resolving/)).not.toBeInTheDocument();
+  });
+});

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BatchResolveResult, GameState } from "../../adapter/types";
+import { useGameStore } from "../../stores/gameStore";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+import { dispatchResolveAll } from "../dispatch";
+
+// A Priority-on-the-storming-player WaitingFor (active player holds priority).
+const priorityWf = { type: "Priority", data: { player: 0 } } as unknown as BatchResolveResult["waitingFor"];
+
+function stateWithStack(len: number): GameState {
+  return { waiting_for: priorityWf, stack: new Array(len).fill(0), turn: { active_player: 0 } } as unknown as GameState;
+}
+
+function chunk(itemsResolved: number, total: number): BatchResolveResult {
+  return { events: [], waitingFor: priorityWf, logEntries: [], itemsResolved, total };
+}
+
+describe("dispatchResolveAll progress", () => {
+  let progressCalls: ({ resolved: number; total: number } | null)[];
+
+  beforeEach(() => {
+    progressCalls = [];
+    usePreferencesStore.setState({ animationSpeedMultiplier: 1.0 });
+    // Stack length read at each iteration start to classify pressure; keep it
+    // in the "Instant" band (>=100) so the rAF-yield branch is exercised.
+    useGameStore.setState({
+      gameState: stateWithStack(200),
+      resolutionProgress: null,
+      // Capture every setResolutionProgress call for assertions.
+      setResolutionProgress: (p) => {
+        progressCalls.push(p);
+        useGameStore.setState({ resolutionProgress: p });
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("latches the first chunk's total, accumulates + clamps the numerator, and clears at the end", async () => {
+    // Per-chunk `total` SHRINKS (engine reports remaining stack); the latch must
+    // keep the first chunk's 200. itemsResolved sums 80+80+80=240 > 200 → clamp.
+    const resolveAll = vi
+      .fn<EngineResolveAll>()
+      .mockResolvedValueOnce(chunk(80, 200))
+      .mockResolvedValueOnce(chunk(80, 150))
+      .mockResolvedValueOnce(chunk(80, 100));
+
+    // getState reports the board after each chunk; the 3rd empties the stack → done.
+    const getState = vi
+      .fn<() => Promise<GameState>>()
+      .mockResolvedValueOnce(stateWithStack(200))
+      .mockResolvedValueOnce(stateWithStack(200))
+      .mockResolvedValueOnce(stateWithStack(0));
+
+    const rafSpy = vi
+      .spyOn(globalThis, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+
+    useGameStore.setState({
+      adapter: {
+        resolveAll,
+        getState,
+        getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+      } as never,
+    });
+
+    await dispatchResolveAll(0, []);
+
+    // Three progress updates: total latched at 200 throughout; resolved
+    // accumulates 80 -> 160 -> clamped 200.
+    expect(progressCalls.slice(0, 3)).toEqual([
+      { resolved: 80, total: 200 },
+      { resolved: 160, total: 200 },
+      { resolved: 200, total: 200 }, // min(240, 200) clamp
+    ]);
+    // Final call clears progress.
+    expect(progressCalls[progressCalls.length - 1]).toBeNull();
+    expect(useGameStore.getState().resolutionProgress).toBeNull();
+
+    // rAF yield fired between the instant chunks (the load-bearing repaint fix):
+    // 2 yields between 3 chunks.
+    expect(rafSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+type EngineResolveAll = (
+  requester: number,
+  aiSeats: { playerId: number; difficulty: string }[],
+  maxResolutions?: number,
+) => Promise<BatchResolveResult>;

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -12,7 +12,7 @@ import { isMultiplayerMode, useGameStore, legalResultState, saveGame, saveCheckp
 import { getOpponentDisplayName } from "../stores/multiplayerStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
 import { useUiStore } from "../stores/uiStore";
-import { stackPressureFromLength } from "../utils/stackPressure";
+import { stackPressureFromLength, STACK_PRESSURE_ELEVATED } from "../utils/stackPressure";
 import { applySpellPaymentPreference } from "./castPaymentMode";
 
 /**
@@ -590,8 +590,12 @@ const BATCH_CHUNK_SIZE = 5;
 // drain in large chunks instead — the engine can resolve unboundedly in one
 // call, but a bounded chunk keeps each WASM call short enough that the main
 // thread yields between chunks (no "page unresponsive" freeze) while still
-// collapsing ~580 round-trips into a handful.
-const BATCH_CHUNK_INSTANT = 200;
+// collapsing ~580 round-trips into a few dozen. The value is an empirical
+// tradeoff: smaller chunks give visibly-advancing "resolving X of Y" progress
+// (the bar updates once per chunk) at the cost of more per-chunk `getState`
+// serialization; the rAF yield below — not this size — is what guarantees the
+// overlay repaints between chunks.
+const BATCH_CHUNK_INSTANT = 50;
 const BATCH_CHUNK_BASE_DELAY_MS = 150;
 let batchResolveInProgress = false;
 
@@ -608,6 +612,13 @@ export async function dispatchResolveAll(
 
   batchResolveInProgress = true;
   const multiplier = usePreferencesStore.getState().animationSpeedMultiplier;
+  const { setResolutionProgress } = useGameStore.getState();
+  // Storm-origin denominator: latched from the FIRST chunk's `total` because
+  // the engine reports the *remaining* stack per chunk (shrinks as it drains),
+  // so only the first chunk carries the true origin count.
+  let latchedTotal = 0;
+  // Engine-authoritative gross resolved count, accumulated across chunks.
+  let resolvedSoFar = 0;
 
   try {
     for (;;) {
@@ -620,6 +631,20 @@ export async function dispatchResolveAll(
       const batchResult: BatchResolveResult = await adapter.resolveAll(
         requester, aiSeats, chunkSize,
       );
+
+      if (latchedTotal === 0) latchedTotal = batchResult.total;
+      resolvedSoFar += batchResult.itemsResolved;
+      // Surface progress only for a genuine storm (trivial multi-item resolves
+      // drain too fast to render). Clamp to the latched total: `itemsResolved`
+      // is a net-shrink count that can lag the true gross when a resolution
+      // spawns triggers, so clamping keeps the bar monotonic and lets it
+      // complete. `resolved`/`total` are engine-provided — no frontend derivation.
+      if (latchedTotal >= STACK_PRESSURE_ELEVATED) {
+        setResolutionProgress({
+          resolved: Math.min(resolvedSoFar, latchedTotal),
+          total: latchedTotal,
+        });
+      }
 
       const newState = await adapter.getState();
       const legalResult = await adapter.getLegalActions();
@@ -637,9 +662,14 @@ export async function dispatchResolveAll(
         batchResult.waitingFor.type !== "Priority";
       if (done) break;
 
-      // Skip the inter-chunk pacing delay while draining a storm — the delay
-      // exists for visual countdown pacing, which Instant pressure forgoes.
-      if (instant) continue;
+      if (instant) {
+        // Yield one frame so the resolution-progress overlay repaints between
+        // chunks. This rAF is the load-bearing progress fix — without it,
+        // back-to-back Instant chunks never let the browser paint, producing
+        // the "wait, then N vanish at once" symptom.
+        await new Promise<void>((r) => requestAnimationFrame(() => r()));
+        continue;
+      }
 
       const chunkDelay = Math.round(BATCH_CHUNK_BASE_DELAY_MS * multiplier);
       if (chunkDelay > 0) {
@@ -654,5 +684,6 @@ export async function dispatchResolveAll(
     if (gameId && newState) saveGame(gameId, newState);
   } finally {
     batchResolveInProgress = false;
+    setResolutionProgress(null);
   }
 }

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1,4 +1,7 @@
 {
+  "resolutionProgress": {
+    "label": "Auflösen {{resolved}} / {{total}}"
+  },
   "card": {
     "faceDownName": "Verdeckte Karte",
     "loading": "{{name}} wird geladen",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1,4 +1,7 @@
 {
+  "resolutionProgress": {
+    "label": "Resolving {{resolved}} / {{total}}"
+  },
   "card": {
     "faceDownName": "Face-down card",
     "loading": "Loading {{name}}",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1,4 +1,7 @@
 {
+  "resolutionProgress": {
+    "label": "Resolviendo {{resolved}} / {{total}}"
+  },
   "card": {
     "faceDownName": "Carta boca abajo",
     "loading": "Cargando {{name}}",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1,4 +1,7 @@
 {
+  "resolutionProgress": {
+    "label": "Résolution {{resolved}} / {{total}}"
+  },
   "card": {
     "faceDownName": "Carte face cachée",
     "loading": "Chargement de {{name}}",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1,4 +1,7 @@
 {
+  "resolutionProgress": {
+    "label": "Risoluzione {{resolved}} / {{total}}"
+  },
   "card": {
     "faceDownName": "Carta coperta",
     "loading": "Caricamento {{name}}",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1,4 +1,7 @@
 {
+  "resolutionProgress": {
+    "label": "Rozwiązywanie {{resolved}} / {{total}}"
+  },
   "card": {
     "faceDownName": "Karta zakryta",
     "loading": "Wczytywanie {{name}}",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1,4 +1,7 @@
 {
+  "resolutionProgress": {
+    "label": "Resolvendo {{resolved}} / {{total}}"
+  },
   "card": {
     "faceDownName": "Carta virada para baixo",
     "loading": "Carregando {{name}}",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -88,6 +88,7 @@ import { GameMenu } from "../components/chrome/GameMenu.tsx";
 import { ConcedeDialog } from "../components/multiplayer/ConcedeDialog.tsx";
 import { ConnectionToast } from "../components/multiplayer/ConnectionToast.tsx";
 import { EmoteOverlay } from "../components/multiplayer/EmoteOverlay.tsx";
+import { ResolutionProgressOverlay } from "../components/board/ResolutionProgressOverlay.tsx";
 import { LobbyProgress } from "../components/multiplayer/LobbyProgress.tsx";
 import { DisconnectChoiceDialog } from "../components/hud/DisconnectChoiceDialog.tsx";
 import { PlayerEnchantmentsDialog } from "../components/hud/PlayerEnchantmentsDialog.tsx";
@@ -1278,6 +1279,7 @@ function GamePageContent({
 
       {/* Overlay layers */}
       <DebugPanel />
+      <ResolutionProgressOverlay />
 
       {viewingZone && (
         <ZoneViewer

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -82,6 +82,13 @@ interface GameStoreState {
    * game has started).
    */
   lobbyProgress: { joined: number; total: number } | null;
+  /**
+   * Live stack-resolution progress during a large auto-resolve / "Resolve All"
+   * drain, populated per chunk by `dispatchResolveAll` and cleared when the
+   * drain finishes. `null` when no resolution storm is in flight. Display-only:
+   * `resolved`/`total` are engine-provided counts, never frontend-derived.
+   */
+  resolutionProgress: { resolved: number; total: number } | null;
 }
 
 interface GameStoreActions {
@@ -112,6 +119,7 @@ interface GameStoreActions {
   setLegalActions: (actions: GameAction[]) => void;
   setGameMode: (mode: GameMode) => void;
   setLobbyProgress: (progress: { joined: number; total: number } | null) => void;
+  setResolutionProgress: (progress: { resolved: number; total: number } | null) => void;
 }
 
 export type GameStore = GameStoreState & GameStoreActions;
@@ -133,6 +141,7 @@ const initialState: GameStoreState = {
   stateHistory: [],
   turnCheckpoints: [],
   lobbyProgress: null,
+  resolutionProgress: null,
 };
 
 export const useGameStore = create<GameStore>()(
@@ -315,6 +324,10 @@ export const useGameStore = create<GameStore>()(
 
     setLobbyProgress: (progress) => {
       set({ lobbyProgress: progress });
+    },
+
+    setResolutionProgress: (progress) => {
+      set({ resolutionProgress: progress });
     },
   })),
 );

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -799,7 +799,7 @@ fn handle_debug_create_card(
         );
         let obj = state.objects.get_mut(&obj_id).expect("just created");
         engine::game::printed_cards::apply_card_face_to_object(obj, &face);
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         // Hydrate `back_face` for dual-faced spawns (MDFC, Transform, Adventure,
         // Omen, Meld, Prepare). `apply_card_face_to_object` only writes the named

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1222,6 +1222,11 @@ struct BatchResolveResult {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     log_entries: Vec<engine::types::log::GameLogEntry>,
     items_resolved: u32,
+    /// Stack depth at this chunk's entry. The frontend latches the FIRST
+    /// chunk's `total` as the storm-origin denominator for "resolving X of Y"
+    /// progress (this per-chunk value shrinks across chunks, so only the first
+    /// is the true origin total). Display-only; carries no rules meaning.
+    total: u32,
 }
 
 #[derive(serde::Deserialize)]
@@ -1346,6 +1351,7 @@ pub fn resolve_all(
             waiting_for: state.waiting_for.clone(),
             log_entries: all_log_entries,
             items_resolved,
+            total: initial_stack_len as u32,
         }))
     })?
 }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 web-time = "1"
 im = { version = "15", features = ["serde"] }
+rustc-hash = "2"
 smallvec = { version = "1", features = ["serde", "union"] }
 
 [[bin]]

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -4361,7 +4361,7 @@ mod tests {
             };
         }
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         let actions = candidate_actions(&state);
         assert!(actions.iter().any(|candidate| {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -3976,7 +3976,7 @@ pub fn revert_bestow_form(state: &mut GameState, object_id: ObjectId) {
     if let Some(obj) = state.objects.get_mut(&object_id) {
         if obj.bestow_form.is_some() {
             revert_bestow_aura_form(obj);
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
     }
 }
@@ -5597,9 +5597,7 @@ fn continue_with_prepared(
     };
 
     // 5. Handle targeting -- ensure layers evaluated before target legality
-    if state.layers_dirty {
-        super::layers::evaluate_layers(state);
-    }
+    super::layers::flush_layers(state);
 
     // Check if this is an Aura spell -- Auras target via Enchant keyword, not via effect targets
     // Re-read obj after evaluate_layers (which needs &mut state)
@@ -5898,9 +5896,7 @@ pub fn spell_has_legal_targets(
     player: PlayerId,
 ) -> bool {
     let mut simulated = state.clone();
-    if simulated.layers_dirty {
-        super::layers::evaluate_layers(&mut simulated);
-    }
+    super::layers::flush_layers(&mut simulated);
     let Some(obj) = simulated.objects.get(&obj.id) else {
         return false;
     };
@@ -6447,9 +6443,7 @@ pub fn can_pay_cost_after_auto_tap(
     cost: &crate::types::mana::ManaCost,
 ) -> bool {
     let mut simulated = state.clone();
-    if simulated.layers_dirty {
-        super::layers::evaluate_layers(&mut simulated);
-    }
+    super::layers::flush_layers(&mut simulated);
     let spell_meta = build_spell_meta(&simulated, player, source_id);
 
     let spell_ctx = spell_meta.as_ref().map(PaymentContext::Spell);
@@ -6596,9 +6590,7 @@ pub(super) fn can_pay_ability_mana_cost_after_auto_tap_excluding(
     excluded_sources: &HashSet<ObjectId>,
 ) -> bool {
     let mut simulated = state.clone();
-    if simulated.layers_dirty {
-        super::layers::evaluate_layers(&mut simulated);
-    }
+    super::layers::flush_layers(&mut simulated);
 
     let (source_types, source_subtypes) = activation_source_types(&simulated, source_id);
     let activation_ctx = PaymentContext::Activation {
@@ -6628,9 +6620,7 @@ pub(super) fn can_pay_effect_mana_cost_after_auto_tap(
     cost: &crate::types::mana::ManaCost,
 ) -> bool {
     let mut simulated = state.clone();
-    if simulated.layers_dirty {
-        super::layers::evaluate_layers(&mut simulated);
-    }
+    super::layers::flush_layers(&mut simulated);
 
     let mut tap_events: Vec<crate::types::events::GameEvent> = Vec::new();
     let effect_ctx = PaymentContext::Effect;
@@ -6721,9 +6711,7 @@ pub(super) fn pay_mana_cost_with_choices(
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
-    if state.layers_dirty {
-        super::layers::evaluate_layers(state);
-    }
+    super::layers::flush_layers(state);
 
     let spell_meta = build_spell_meta(state, player, source_id);
     let spell_ctx = spell_meta.as_ref().map(PaymentContext::Spell);
@@ -6901,9 +6889,7 @@ pub(super) fn pay_ability_mana_cost_with_choices_excluding(
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
 ) -> Result<(), EngineError> {
-    if state.layers_dirty {
-        super::layers::evaluate_layers(state);
-    }
+    super::layers::flush_layers(state);
 
     let (source_types, source_subtypes) = activation_source_types(state, source_id);
     let activation_ctx = PaymentContext::Activation {
@@ -6935,9 +6921,7 @@ pub(super) fn pay_effect_mana_cost(
     cost: &crate::types::mana::ManaCost,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
-    if state.layers_dirty {
-        super::layers::evaluate_layers(state);
-    }
+    super::layers::flush_layers(state);
 
     let effect_ctx = PaymentContext::Effect;
     let events_before = events.len();
@@ -8165,9 +8149,7 @@ pub fn can_activate_ability_now(
     let resolved = build_resolved_from_def(&ability_def, source_id, player);
 
     let mut simulated = state.clone();
-    if simulated.layers_dirty {
-        super::layers::evaluate_layers(&mut simulated);
-    }
+    super::layers::flush_layers(&mut simulated);
 
     match build_target_slots(&simulated, &resolved) {
         Ok(target_slots) => {
@@ -16559,7 +16541,7 @@ mod tests {
         }
 
         let forest = add_basic_land(&mut state, CardId(27), "Forest", "Forest");
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         let mut events = Vec::new();
         let result = handle_cast_spell(&mut state, PlayerId(0), spell_id, CardId(25), &mut events);
@@ -21560,7 +21542,7 @@ mod tests {
         state.waiting_for = WaitingFor::Priority {
             player: PlayerId(1),
         };
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         // The engine derives `CastingVariant::Escape` with no override.
         let prepared = prepare_spell_cast(&state, PlayerId(1), phlage).unwrap();

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -104,9 +104,7 @@ pub(crate) fn handle_select_modes(
     }
 
     // Check for targeting on the combined ability
-    if state.layers_dirty {
-        super::layers::evaluate_layers(state);
-    }
+    super::layers::flush_layers(state);
 
     let target_slots = build_target_slots(state, &resolved)?;
     if !target_slots.is_empty() {

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -178,7 +178,7 @@ pub fn enter_attacking(
         // CR 508.4 + CR 506.4 + CR 613.1f: a permanent put onto the battlefield
         // attacking is an attacking creature; re-evaluate Layer 6
         // FilterProp::Attacking grants immediately.
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 }
 
@@ -290,7 +290,7 @@ pub fn place_attacking_alongside(
         // CR 702.49c + CR 702.190b + CR 506.4 + CR 613.1f: Ninjutsu/Sneak place a
         // creature already attacking; re-evaluate Layer 6 FilterProp::Attacking
         // grants.
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 }
 
@@ -1540,7 +1540,7 @@ pub fn declare_attackers(
     // layers dirty forces Layer 6 ability-adding effects (CR 613.1f) with
     // FilterProp::Attacking (e.g. Crossway Troublemakers) to re-evaluate now, so
     // the grant is live for the whole combat, not just after damage.
-    state.layers_dirty = true;
+    state.layers_dirty.mark_full();
     let attacker_count = combat.attackers.len();
 
     // Use the first attacker's defending player for the event
@@ -5355,7 +5355,7 @@ mod tests {
                 PlayerId(1),
             ));
 
-        state.layers_dirty = false;
+        state.layers_dirty = crate::types::game_state::LayersDirty::Clean;
         enter_attacking(&mut state, token, attacker, PlayerId(0));
 
         assert!(
@@ -5369,7 +5369,7 @@ mod tests {
             "entered-attacking creature must be in combat.attackers"
         );
         assert!(
-            state.layers_dirty,
+            state.layers_dirty.is_dirty(),
             "putting a creature onto the battlefield attacking must mark layers dirty"
         );
     }
@@ -5383,7 +5383,7 @@ mod tests {
         let ninja = create_creature(&mut state, PlayerId(0), "Ninja", 2, 2);
 
         state.combat = Some(CombatState::default());
-        state.layers_dirty = false;
+        state.layers_dirty = crate::types::game_state::LayersDirty::Clean;
 
         let mut events = Vec::new();
         place_attacking_alongside(
@@ -5405,7 +5405,7 @@ mod tests {
             "place_attacking_alongside must add the creature to combat.attackers"
         );
         assert!(
-            state.layers_dirty,
+            state.layers_dirty.is_dirty(),
             "placing a creature already attacking must mark layers dirty"
         );
     }

--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -1901,7 +1901,7 @@ mod tests {
             vec![attacker_a, attacker_b],
             vec![(attacker_a, vec![blocker])],
         );
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         let mut events = Vec::new();
         resolve_combat_damage(&mut state, &mut events);

--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -204,7 +204,7 @@ pub fn attach_to(
         }
     }
 
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
     old_target
 }
 
@@ -260,7 +260,7 @@ pub fn attach_to_player(
         attachment.attached_to = Some(AttachTarget::Player(target_player));
     }
 
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
     old_target
 }
 
@@ -283,7 +283,7 @@ pub(crate) fn unattach(state: &mut GameState, attachment_id: ObjectId) -> Option
     if let Some(attachment) = state.objects.get_mut(&attachment_id) {
         attachment.attached_to = None;
     }
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
     Some(old_target)
 }
 

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -112,7 +112,7 @@ pub(crate) fn deliver_replaced_zone_change(
     {
         zones::move_to_zone(state, object_id, to, events);
         if to == Zone::Battlefield || from == Zone::Battlefield {
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
         // CR 712.14a: Apply transformation if entering the battlefield transformed.
         if should_transform && to == Zone::Battlefield {

--- a/crates/engine/src/game/effects/conjure.rs
+++ b/crates/engine/src/game/effects/conjure.rs
@@ -65,7 +65,9 @@ pub fn resolve(
             // Record battlefield entry for restriction tracking.
             if destination == Zone::Battlefield {
                 crate::game::restrictions::record_battlefield_entry(state, obj_id);
-                state.layers_dirty = true;
+                // Battlefield entry: incremental re-derive candidate for this
+                // conjured object (escalates to Full if it sources effects/etc.).
+                crate::game::layers::mark_layers_entered(state, obj_id);
             }
 
             events.push(GameEvent::ObjectConjured {

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -158,7 +158,7 @@ pub(crate) fn apply_counter_addition(
     sync_derived_from_counters(obj, &counter_type);
 
     if counter_type_affects_layers(&counter_type) {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 
     state.counter_added_this_turn.push(CounterAddedRecord {
@@ -213,7 +213,7 @@ pub(crate) fn apply_counter_removal(
     sync_derived_from_counters(obj, &counter_type);
 
     if counter_type_affects_layers(&counter_type) {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 
     // CR 122.1: Only emit when counters were actually removed,
@@ -1387,7 +1387,7 @@ mod tests {
         };
         let mut events = Vec::new();
 
-        state.layers_dirty = false;
+        state.layers_dirty = crate::types::game_state::LayersDirty::Clean;
         apply_counter_addition(
             &mut state,
             PlayerId(0),
@@ -1396,11 +1396,11 @@ mod tests {
             1,
             &mut events,
         );
-        assert!(state.layers_dirty);
+        assert!(state.layers_dirty.is_dirty());
 
-        state.layers_dirty = false;
+        state.layers_dirty = crate::types::game_state::LayersDirty::Clean;
         apply_counter_removal(&mut state, obj_id, counter_type, 1, &mut events);
-        assert!(state.layers_dirty);
+        assert!(state.layers_dirty.is_dirty());
     }
 
     #[test]
@@ -1641,7 +1641,10 @@ mod tests {
             1,
             "SelfRef counter must land on the source object"
         );
-        assert!(state.layers_dirty, "layers must be dirtied for P/T counter");
+        assert!(
+            state.layers_dirty.is_dirty(),
+            "layers must be dirtied for P/T counter"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/create_emblem.rs
+++ b/crates/engine/src/game/effects/create_emblem.rs
@@ -42,7 +42,9 @@ pub fn resolve(
     obj.trigger_definitions = triggers.clone().into();
     obj.base_trigger_definitions = Arc::new(triggers.clone());
 
-    state.layers_dirty = true;
+    // CR 114.1 + CR 611.1: An emblem can source continuous effects; conservatively
+    // request a full layer re-evaluation.
+    crate::game::layers::mark_layers_full(state);
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::from(&ability.effect),
         source_id: ability.source_id,
@@ -115,7 +117,7 @@ mod tests {
     #[test]
     fn create_emblem_marks_layers_dirty() {
         let mut state = GameState::new_two_player(42);
-        state.layers_dirty = false;
+        state.layers_dirty = crate::types::game_state::LayersDirty::Clean;
         let ability = ResolvedAbility::new(
             Effect::CreateEmblem {
                 statics: vec![ninja_pump_static()],
@@ -129,7 +131,7 @@ mod tests {
 
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        assert!(state.layers_dirty);
+        assert!(state.layers_dirty.is_dirty());
     }
 
     /// Helper: create an emblem and return its ObjectId

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -315,7 +315,7 @@ pub(crate) fn apply_damage_after_replacement(
                         target_obj.dealt_deathtouch_damage = true;
                     }
                 }
-                state.layers_dirty = true;
+                crate::game::layers::mark_layers_full(state);
             } else {
                 // Classify the target before mutating so the post-classification
                 // helper can take a fresh `&mut GameState` borrow.

--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -43,7 +43,7 @@ pub fn apply_destroy_after_replacement(
                     } = zone_event
                     {
                         zones::move_to_zone(state, oid, to, events);
-                        state.layers_dirty = true;
+                        crate::game::layers::mark_layers_full(state);
                     }
                 }
                 ReplacementResult::Prevented => {}
@@ -58,7 +58,7 @@ pub fn apply_destroy_after_replacement(
         ProposedEvent::ZoneChange { object_id, to, .. } => {
             // Destroy replacement redirected directly to a zone change.
             zones::move_to_zone(state, object_id, to, events);
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
             true
         }
         _ => true,

--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -154,7 +154,7 @@ mod tests {
             tce.modifications,
             vec![ContinuousModification::ChangeController]
         );
-        assert!(state.layers_dirty);
+        assert!(state.layers_dirty.is_dirty());
     }
 
     /// CR 613.1b: Non-regression for Bug B (layer fix). After switching the

--- a/crates/engine/src/game/effects/gift_delivery.rs
+++ b/crates/engine/src/game/effects/gift_delivery.rs
@@ -166,7 +166,7 @@ fn create_gift_token(
         obj.reset_for_battlefield_entry(state.turn_number);
     }
 
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
     crate::game::restrictions::record_battlefield_entry(state, obj_id);
     crate::game::restrictions::record_token_created(state, obj_id);
 

--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -91,7 +91,7 @@ pub fn resolve_gain(
                 player.life += gain_amount as i32;
                 // CR 119.9: Track life gained this turn for triggered ability matching.
                 player.life_gained_this_turn += gain_amount;
-                state.layers_dirty = true;
+                crate::game::layers::mark_layers_full(state);
 
                 events.push(GameEvent::LifeChanged {
                     player_id,
@@ -220,7 +220,7 @@ pub fn apply_life_gain_after_replacement(
         player.life += gain_amount as i32;
         player.life_gained_this_turn += gain_amount;
     }
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
     events.push(GameEvent::LifeChanged {
         player_id: pid,
         amount: gain_amount as i32,
@@ -296,7 +296,7 @@ pub fn apply_life_loss_after_replacement(
         player.life -= loss_amount as i32;
         player.life_lost_this_turn += loss_amount;
     }
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
     events.push(GameEvent::LifeChanged {
         player_id: pid,
         amount: -(loss_amount as i32),
@@ -351,7 +351,7 @@ pub fn resolve_lose(
                     .ok_or(EffectError::PlayerNotFound)?;
                 player.life -= loss_amount as i32;
                 player.life_lost_this_turn += loss_amount;
-                state.layers_dirty = true;
+                crate::game::layers::mark_layers_full(state);
 
                 events.push(GameEvent::LifeChanged {
                     player_id,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1433,6 +1433,21 @@ pub(crate) enum BatchExecutionPlan {
         spec: crate::types::proposed_event::TokenSpec,
         run_len: u32,
     },
+    /// CR 608.2c + CR 707.2: Resolve a met copy-instead swap (`CopyTokenOf`)
+    /// `prefix_len` times by replaying `token_copy::resolve` on the swapped
+    /// ability. `swapped` is the once-applied instead-swap (CR 608.2c — done
+    /// ONCE in `try_resolve_batch`, not per iteration). `probe_spec` carries the
+    /// prefix's shared copiable values so Layer C can build the real
+    /// ZoneChanged/TokenCreated probe events from the produced token's true
+    /// characteristics.
+    CopyToken {
+        // Boxed: `ResolvedAbility` is large, and keeping it inline would make
+        // `BatchExecutionPlan` carry that size in every variant (clippy
+        // `large_enum_variant`).
+        swapped: Box<ResolvedAbility>,
+        probe_spec: crate::types::proposed_event::TokenSpec,
+        prefix_len: u32,
+    },
 }
 
 /// A proven-safe batch plan returned by `try_resolve_batch`. The driver
@@ -1454,6 +1469,24 @@ impl BatchPlan {
         }
     }
 
+    /// CR 608.2c + CR 707.2: Build a copy-prefix batch plan: resolve the
+    /// swapped `CopyTokenOf` `prefix_len` times, producing one copy token each
+    /// iteration. Consumes `prefix_len` stack entries (may be < the full run).
+    pub(crate) fn copy_token(
+        swapped: ResolvedAbility,
+        probe_spec: crate::types::proposed_event::TokenSpec,
+        prefix_len: u32,
+    ) -> Self {
+        BatchPlan {
+            plan: BatchExecutionPlan::CopyToken {
+                swapped: Box::new(swapped),
+                probe_spec,
+                prefix_len,
+            },
+            consumed: prefix_len,
+        }
+    }
+
     pub(crate) fn consumed(&self) -> u32 {
         self.consumed
     }
@@ -1464,6 +1497,7 @@ impl BatchPlan {
     pub(crate) fn produced_token_specs(&self) -> Vec<&crate::types::proposed_event::TokenSpec> {
         match &self.plan {
             BatchExecutionPlan::Token { spec, .. } => vec![spec],
+            BatchExecutionPlan::CopyToken { probe_spec, .. } => vec![probe_spec],
         }
     }
 
@@ -1481,6 +1515,21 @@ impl BatchPlan {
             BatchExecutionPlan::Token { run_len, .. } => {
                 for _ in 0..*run_len {
                     let _ = token::resolve(state, ability, events);
+                }
+            }
+            // CR 608.2c + CR 707.2: Replay the swapped `CopyTokenOf` resolver
+            // `prefix_len` times. Like the base Token arm, this intentionally
+            // bypasses `resolve_ability_chain`'s depth-0 prelude (resolution-
+            // scoped clears, NthResolutionThisTurn counter) — the instead-swap
+            // was applied ONCE in `try_resolve_batch`, and each copy is an
+            // independent per-token creation at full multiplicity (§5.2).
+            BatchExecutionPlan::CopyToken {
+                swapped,
+                prefix_len,
+                ..
+            } => {
+                for _ in 0..*prefix_len {
+                    let _ = token_copy::resolve(state, swapped, events);
                 }
             }
         }
@@ -1505,9 +1554,10 @@ pub(crate) fn try_resolve_batch(
     state: &GameState,
     ability: &ResolvedAbility,
     run_len: u32,
+    run_source_ids: &[crate::types::identifiers::ObjectId],
 ) -> Option<BatchPlan> {
     match &ability.effect {
-        Effect::Token { .. } => token::try_resolve_batch(state, ability, run_len),
+        Effect::Token { .. } => token::try_resolve_batch(state, ability, run_len, run_source_ids),
         // Exhaustive conservative default: every other effect is non-batchable
         // in v1. The wildcard encodes "opt-in," not a forgotten arm — new
         // batch-aware handlers add an explicit arm above.

--- a/crates/engine/src/game/effects/pump.rs
+++ b/crates/engine/src/game/effects/pump.rs
@@ -558,7 +558,7 @@ mod tests {
         assert_eq!(state.objects[&obj_id].power, Some(5));
 
         // Trigger another layer recalculation — pump must persist
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
         assert_eq!(state.objects[&obj_id].power, Some(5));
         assert_eq!(state.objects[&obj_id].toughness, Some(5));

--- a/crates/engine/src/game/effects/remove_from_combat.rs
+++ b/crates/engine/src/game/effects/remove_from_combat.rs
@@ -69,7 +69,7 @@ pub fn remove_object_from_combat(state: &mut GameState, oid: crate::types::ident
     // when an attacker was actually removed — removing a pure blocker doesn't
     // affect FilterProp::Attacking statics.
     if attacker_removed {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 }
 
@@ -213,7 +213,7 @@ mod tests {
             }],
             ..Default::default()
         });
-        state.layers_dirty = false;
+        state.layers_dirty = crate::types::game_state::LayersDirty::Clean;
 
         remove_object_from_combat(&mut state, attacker_id);
 
@@ -222,7 +222,7 @@ mod tests {
             "attacker should be removed from combat"
         );
         assert!(
-            state.layers_dirty,
+            state.layers_dirty.is_dirty(),
             "removing an attacker must mark layers dirty to revoke FilterProp::Attacking grants"
         );
     }
@@ -265,7 +265,7 @@ mod tests {
             .blocker_to_attacker
             .insert(blocker_id, vec![attacker_id]);
         state.combat = Some(combat);
-        state.layers_dirty = false;
+        state.layers_dirty = crate::types::game_state::LayersDirty::Clean;
 
         // Remove the blocker — it is not in combat.attackers.
         remove_object_from_combat(&mut state, blocker_id);
@@ -276,7 +276,7 @@ mod tests {
             "attacker should remain"
         );
         assert!(
-            !state.layers_dirty,
+            !state.layers_dirty.is_dirty(),
             "removing a pure blocker must not dirty layers — no FilterProp::Attacking change"
         );
     }

--- a/crates/engine/src/game/effects/return_as_aura.rs
+++ b/crates/engine/src/game/effects/return_as_aura.rs
@@ -132,7 +132,7 @@ pub fn resolve(
                 ..
             }) => {
                 crate::game::zones::move_to_zone(state, object_id, dest, events);
-                state.layers_dirty = true;
+                crate::game::layers::mark_layers_full(state);
             }
             ReplacementResult::Execute(_) => {
                 // Pipeline preserves the event variant; other variants are

--- a/crates/engine/src/game/effects/ring.rs
+++ b/crates/engine/src/game/effects/ring.rs
@@ -61,7 +61,7 @@ pub fn resolve(
     if candidates.len() == 1 {
         // Only one creature — auto-select as ring-bearer.
         state.ring_bearer.insert(controller, Some(candidates[0]));
-        state.layers_dirty = true;
+        crate::game::layers::mark_layers_full(state);
         return Ok(());
     }
 
@@ -110,7 +110,7 @@ pub(crate) fn clear_ring_bearer_if_object(state: &mut GameState, object_id: Obje
         }
     });
     if changed {
-        state.layers_dirty = true;
+        crate::game::layers::mark_layers_full(state);
     }
 }
 
@@ -131,7 +131,7 @@ pub(crate) fn normalize_ring_bearers(state: &mut GameState) -> bool {
     for player in stale {
         state.ring_bearer.remove(&player);
     }
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
     true
 }
 
@@ -246,7 +246,7 @@ mod tests {
         let creature_id = make_creature(&mut state, 1, PlayerId(0));
         state.ring_level.insert(PlayerId(0), 1);
         state.ring_bearer.insert(PlayerId(0), Some(creature_id));
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         layers::evaluate_layers(&mut state);
 

--- a/crates/engine/src/game/effects/set_class_level.rs
+++ b/crates/engine/src/game/effects/set_class_level.rs
@@ -22,7 +22,7 @@ pub fn resolve(
             level,
         });
         // CR 716.2a: New abilities become active at the new level — recompute layers.
-        state.layers_dirty = true;
+        crate::game::layers::mark_layers_full(state);
     }
 
     events.push(GameEvent::EffectResolved {
@@ -86,7 +86,7 @@ mod tests {
             Zone::Battlefield,
         );
         state.objects.get_mut(&obj_id).unwrap().class_level = Some(1);
-        state.layers_dirty = false;
+        state.layers_dirty = crate::types::game_state::LayersDirty::Clean;
 
         let ability = ResolvedAbility::new(
             Effect::SetClassLevel { level: 2 },
@@ -99,7 +99,7 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(state.objects.get(&obj_id).unwrap().class_level, Some(2));
-        assert!(state.layers_dirty);
+        assert!(state.layers_dirty.is_dirty());
         assert!(events.iter().any(|e| matches!(
             e,
             GameEvent::ClassLevelGained {

--- a/crates/engine/src/game/effects/solve_case.rs
+++ b/crates/engine/src/game/effects/solve_case.rs
@@ -18,7 +18,7 @@ pub fn resolve(
                 events.push(GameEvent::CaseSolved {
                     object_id: source_id,
                 });
-                state.layers_dirty = true;
+                crate::game::layers::mark_layers_full(state);
             }
         }
     }

--- a/crates/engine/src/game/effects/suspect.rs
+++ b/crates/engine/src/game/effects/suspect.rs
@@ -61,7 +61,7 @@ pub fn resolve(
         }
     }
 
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::Suspect,

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -18,7 +18,7 @@ use crate::types::card_type::{CardType, CoreType, Supertype};
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{DelayedTrigger, GameState};
-use crate::types::identifiers::CardId;
+use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::{Keyword, WardCost};
 use crate::types::mana::{ManaColor, ManaCost};
 use crate::types::phase::Phase;
@@ -778,24 +778,58 @@ pub(crate) fn spec_emits_only_etb_pair(spec: &TokenSpec) -> bool {
         && spec.attach_to.is_none() // no host attachment mutation (CR 303.4)
 }
 
-/// CR 603.2 + CR 603.6a: The §2.3a produced-token-non-observer gate. A produced
-/// token that itself observes ETB / `TokenCreated` events would see its
-/// in-batch siblings — which one-by-one resolution (CR 603.3 topmost-on-stack)
-/// would NOT. Reuse the EXACT classifier the index uses (`keys_from_trigger_def`)
-/// so the gate can never drift from the live registration logic. Conservatively
-/// reject if any trigger is catch-all/dynamic (routed to unclassified) OR
-/// registers under any `EnterBattlefield`/`TokenCreated` key.
-pub(crate) fn produced_token_is_non_observer(triggers: &[TriggerDefinition]) -> bool {
+/// CR 603.6a + CR 111.10: The set of event keys a single produced token EMITS as
+/// it enters the battlefield, given its core types. Mirrors the event-side
+/// deriver exactly (`keys_from_event`, trigger_index.rs:462-468 for the ETB pair
+/// and :529-531 for `TokenCreated`): a token entering emits the broad
+/// `EnterBattlefield(None)`, one narrow `EnterBattlefield(Some(ct))` per core
+/// type, and `TokenCreated`. Kept in lockstep with the deriver so the §2.3a gate
+/// reasons about exactly the events siblings would observe.
+fn produced_token_emitted_keys(
+    produced_core_types: &[CoreType],
+) -> Vec<crate::types::triggers::TriggerEventKey> {
+    use crate::types::triggers::TriggerEventKey;
+    // CR 603.6a: broad ETB key, emitted for every entering permanent, plus one
+    // narrow key per core type of the entering object.
+    let mut keys = vec![TriggerEventKey::EnterBattlefield(None)];
+    keys.extend(
+        produced_core_types
+            .iter()
+            .map(|ct| TriggerEventKey::EnterBattlefield(Some(*ct))),
+    );
+    // CR 111.10: a token's creation also emits `TokenCreated`.
+    keys.push(TriggerEventKey::TokenCreated);
+    keys
+}
+
+/// CR 603.2 + CR 603.6a + CR 603.3: The §2.3a produced-token-non-observer gate,
+/// parameterized by what the produced token actually EMITS on entry. A produced
+/// token whose own triggers OBSERVE its in-batch siblings would fire on them —
+/// which one-by-one resolution (CR 603.3 topmost-on-stack) lets it do, but a
+/// single batched application would not — so such a token cannot batch.
+///
+/// The gate intersects each trigger's REGISTERED keys (`keys_from_trigger_def`,
+/// the EXACT classifier the live index uses, so the observer-key derivation can
+/// never drift from registration) with the set of keys the produced token EMITS
+/// on entry (`produced_token_emitted_keys`, mirroring CR 603.6a's broad+narrow
+/// emission for `produced_core_types`). A landfall trigger registered under
+/// `EnterBattlefield(Some(Land))` carried by a Creature copy (which emits only
+/// `{None, Some(Creature), TokenCreated}`) does NOT intersect → it cannot
+/// observe its creature siblings → batch-safe. A "whenever a creature enters"
+/// trigger (`EnterBattlefield(Some(Creature))`) or a broad permanent-ETB trigger
+/// (`EnterBattlefield(None)`) DOES intersect a creature copy's emission →
+/// refused.
+///
+/// Conservatively rejects any trigger routed to unclassified (catch-all/dynamic
+/// modes fire on everything, so they always observe siblings).
+pub(crate) fn produced_token_is_non_observer(
+    triggers: &[TriggerDefinition],
+    produced_core_types: &[CoreType],
+) -> bool {
+    let emitted = produced_token_emitted_keys(produced_core_types);
     triggers.iter().all(|def| {
         let (keys, route_unclassified) = crate::game::trigger_index::keys_from_trigger_def(def);
-        !route_unclassified
-            && !keys.iter().any(|k| {
-                matches!(
-                    k,
-                    crate::types::triggers::TriggerEventKey::EnterBattlefield(_)
-                        | crate::types::triggers::TriggerEventKey::TokenCreated
-                )
-            })
+        !route_unclassified && !keys.iter().any(|k| emitted.contains(k))
     })
 }
 
@@ -925,23 +959,71 @@ fn condition_invariant_for_token(
     }
 }
 
+/// CR 111.2 + CR 109.4: a base token's controller and characteristics are
+/// fixed at creation; the creating source's identity is not a characteristic,
+/// so triggers from distinct sources resolve identically. Returns `true` iff
+/// `ability.effect` is a base `Effect::Token` whose resolution reads nothing
+/// from the source object: the token's owner is the controller (the default
+/// `TargetFilter::Controller`), its `count` is a literal `Fixed` (no
+/// source-relative quantity), it does not enter attacking (combat reads the
+/// source), and it is not attached to a host (attachment reads the source's
+/// target). The remaining fields are pure characteristics (name / P/T / types /
+/// colors / keywords / supertypes / static abilities / ETB counters) which are
+/// baked into the spec and identical across sources — bound but unconstrained.
+///
+/// EXHAUSTIVE destructure (no `..`): every field of `Effect::Token` is
+/// consciously dispositioned, mirroring `resolve_token_spec`. A future field
+/// addition forces a compile error here so its source-independence is decided
+/// deliberately rather than silently assumed.
+pub(crate) fn token_effect_is_source_independent(ability: &ResolvedAbility) -> bool {
+    let Effect::Token {
+        name: _,
+        power: _,
+        toughness: _,
+        types: _,
+        colors: _,
+        keywords: _,
+        tapped: _,
+        count,
+        owner,
+        attach_to,
+        enters_attacking,
+        supertypes: _,
+        static_abilities: _,
+        enter_with_counters: _,
+    } = &ability.effect
+    else {
+        return false;
+    };
+    matches!(owner, TargetFilter::Controller)
+        && matches!(count, QuantityExpr::Fixed { .. })
+        && !*enters_attacking
+        && attach_to.is_none()
+}
+
 /// CR 608.2 + CR 608.2c: Layer B — the Token-handler purity gate. Returns a
 /// `BatchPlan` iff resolving this `Effect::Token` `run_len` times one-by-one
 /// would produce the identical per-resolution decision and token spec as one
 /// batched application of the base `Token` effect.
 ///
-/// v1 batches ONLY the base `Effect::Token` (untargeted, `Fixed` count,
-/// emitting exactly the ETB pair, with no produced-token observer and no
-/// interactive replacement). A `CopyTokenOf`-instead sub-ability whose
-/// condition is currently met (the copy branch) is conservatively NOT batched
-/// — the copy path produces no `TokenSpec` and would re-derive the predicate,
-/// so it falls back to sequential. A `ConditionInstead` sub-ability that is
-/// currently NOT met is accepted only when its condition is provably invariant
-/// across the run (so all N resolutions take the base branch).
+/// v1 batches the base `Effect::Token` (untargeted, `Fixed` count, emitting
+/// exactly the ETB pair, with no produced-token observer and no interactive
+/// replacement). A `CopyTokenOf`-instead sub-ability whose condition is
+/// currently met (the copy branch) is batched along a CONTIGUOUS PREFIX of the
+/// run whose copy sources share identical copiable values (CR 707.2) — the
+/// prefix length may be shorter than `run_len`, with the remaining entries
+/// resolved in a later step. A `ConditionInstead` sub-ability that is currently
+/// NOT met is accepted only when its condition is provably invariant across the
+/// run (so all N resolutions take the base branch).
+///
+/// `run_source_ids` are the per-entry source object ids of the contiguous run
+/// (resolution order, top-down), needed only by the met-copy prefix path to
+/// gather each entry's `SelfRef` copy source. The base-token path ignores them.
 pub(crate) fn try_resolve_batch(
     state: &GameState,
     ability: &ResolvedAbility,
     run_len: u32,
+    run_source_ids: &[ObjectId],
 ) -> Option<super::BatchPlan> {
     // The effect must be a bare `Effect::Token` with a literal `Fixed` count.
     let Effect::Token { count, .. } = &ability.effect else {
@@ -958,19 +1040,21 @@ pub(crate) fn try_resolve_batch(
     // invariance proof below directly.
     let (spec, owner, enter_tapped, resolved_count) = resolve_token_spec(state, ability)?;
 
-    // CR 608.2c: A sub-ability changes the resolved effect. Only a
-    // `ConditionInstead`-gated sub that is currently NOT met (so the base
-    // `Token` resolves) AND is provably invariant across the run is acceptable.
-    // Any met instead-swap (the copy branch), or any other sub shape, conserves.
+    // CR 608.2c: A sub-ability changes the resolved effect. Two acceptable
+    // shapes: a `ConditionInstead`-gated sub currently NOT met (the base
+    // `Token` resolves, provably invariant across the run), or a met
+    // `ConditionInstead` copy-instead swap which is batched along a value-equal
+    // prefix (CR 707.2). Any other sub shape conserves.
     if let Some(sub) = &ability.sub_ability {
         match &sub.condition {
             Some(crate::types::ability::AbilityCondition::ConditionInstead { inner }) => {
-                // If the swap currently fires, the resolved effect is the sub's
-                // (e.g. CopyTokenOf) — not batchable in v1.
                 if super::evaluate_condition(inner, state, ability) {
-                    return None;
+                    // The swap currently fires: the resolved effect is the
+                    // sub's (e.g. CopyTokenOf). Attempt copy-prefix batching.
+                    return try_resolve_copy_batch(state, ability, sub, inner, run_source_ids);
                 }
-                // Token core types feed the disjointness invariance proof.
+                // NOT met: base `Token` resolves. Token core types feed the
+                // disjointness invariance proof.
                 if !condition_invariant_for_token(inner, &spec.characteristics.core_types) {
                     return None;
                 }
@@ -993,8 +1077,13 @@ pub(crate) fn try_resolve_batch(
         return None;
     }
 
-    // §2.3a: the produced token must not itself observe ETB/TokenCreated.
-    if !produced_token_is_non_observer(&base_token_trigger_defs(&spec)) {
+    // §2.3a: the produced token must not itself observe the ETB/TokenCreated
+    // events its in-batch siblings emit. The produced token's emission is
+    // derived from its own core types (the spec's characteristics).
+    if !produced_token_is_non_observer(
+        &base_token_trigger_defs(&spec),
+        &spec.characteristics.core_types,
+    ) {
         return None;
     }
 
@@ -1005,6 +1094,140 @@ pub(crate) fn try_resolve_batch(
     }
 
     Some(super::BatchPlan::token(spec, run_len))
+}
+
+/// CR 608.2c + CR 707.2: A met `ConditionInstead` whose swapped effect is a
+/// bare `CopyTokenOf { target: SelfRef, … }` copies the run's own source object
+/// per entry. When a contiguous prefix of the run's copy sources share
+/// identical copiable values (CR 707.2 fingerprints), those N self-copies are
+/// equivalent to one batched spec, so the prefix collapses into a single
+/// `CopyToken` batch. The prefix may be shorter than `run_len`; the remainder
+/// resolves in a later step (which re-enters this path).
+///
+/// `sub` is the override sub-ability (its effect is the swapped `CopyTokenOf`);
+/// `inner` is the already-fired `ConditionInstead` condition. `run_source_ids`
+/// are the per-entry source ids (top-down resolution order).
+fn try_resolve_copy_batch(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    sub: &ResolvedAbility,
+    inner: &crate::types::ability::AbilityCondition,
+    run_source_ids: &[ObjectId],
+) -> Option<super::BatchPlan> {
+    // 1. SHAPE GATE FIRST (cheapest): the swapped effect must be a bare
+    //    self-copy with the default single-token shape and no exceptions.
+    let Effect::CopyTokenOf {
+        target: TargetFilter::SelfRef,
+        owner: TargetFilter::Controller,
+        source_filter: None,
+        enters_attacking: false,
+        tapped: false,
+        count: QuantityExpr::Fixed { value: 1 },
+        extra_keywords,
+        additional_modifications,
+    } = &sub.effect
+    else {
+        return None;
+    };
+    if !extra_keywords.is_empty() || !additional_modifications.is_empty() {
+        return None;
+    }
+
+    // 2. LAZY-GATHER the run's copy sources (only now, after the shape gate).
+    //    Each entry's `target: SelfRef` copy source is that entry's own source
+    //    object — exactly `run_source_ids` (top-down resolution order).
+    if run_source_ids.len() < 2 {
+        // A prefix of fewer than 2 cannot collapse; fall back to sequential.
+        return None;
+    }
+
+    // 3. Compute the value-equal contiguous prefix (CR 707.2).
+    let (prefix_values, prefix_len) =
+        super::token_copy::compute_copy_batch_prefix(state, run_source_ids)?;
+    if prefix_len < 2 {
+        return None;
+    }
+
+    // 4. H1 INVARIANCE GATE (AFTER prefix): the condition must be invariant over
+    //    the COPY's core types (what enters), not the placeholder spec's. A copy
+    //    creating Lands gated on a Land count would diverge per resolution.
+    if !condition_invariant_for_token(inner, &prefix_values.card_types.core_types) {
+        return None;
+    }
+
+    // 5. Build the probe spec from the prefix's shared copiable values so the
+    //    §2.2a emits-only-ETB-pair gate holds and Layer C's
+    //    `zone_change_record_from_spec` reflects the true produced token.
+    let probe_spec = copy_probe_spec(ability, &prefix_values);
+    if !spec_emits_only_etb_pair(&probe_spec) {
+        return None;
+    }
+    // §2.3a: a copy token inherits the copied permanent's full trigger set
+    // (CR 707.2 + CR 707.5 — the copy's ETB triggers fire), so the non-observer
+    // gate reads the prefix's copiable trigger definitions — NOT
+    // `base_token_trigger_defs` (which only surfaces a base token's Role-subtype
+    // triggers). The produced token's emission is derived from the COPY's core
+    // types (what enters), so a Scute-shape landfall trigger keyed
+    // `EnterBattlefield(Some(Land))` on a Creature copy does NOT intersect the
+    // copy's `{None, Some(Creature), TokenCreated}` emission and stays batch-safe.
+    if !produced_token_is_non_observer(
+        &prefix_values.trigger_definitions,
+        &prefix_values.card_types.core_types,
+    ) {
+        return None;
+    }
+    let owner = resolve_token_owner(state, ability, &TargetFilter::Controller);
+    if token_creation_needs_choice(
+        state,
+        &probe_spec,
+        owner,
+        crate::types::proposed_event::EtbTapState::from_seeded_tapped(false),
+        1,
+    ) {
+        return None;
+    }
+
+    // 6. Perform the instead-swap ONCE (CR 608.2c) so the batched executor
+    //    resolves the swapped `CopyTokenOf` effect.
+    let swapped = crate::game::ability_utils::apply_instead_swap(ability, sub);
+
+    // 7. Hand back the copy-prefix batch.
+    Some(super::BatchPlan::copy_token(
+        swapped, probe_spec, prefix_len,
+    ))
+}
+
+/// CR 707.2 + CR 603.6a: Build the Layer C / §2.2a probe `TokenSpec` for a
+/// copy-prefix batch from the prefix's shared copiable values. The probe needs
+/// only the copiable values (CR 707.2): token art comes from the live source at
+/// resolution time (`token_copy::resolve`), so no `PrintedCardRef` is threaded
+/// through the probe.
+fn copy_probe_spec(
+    ability: &ResolvedAbility,
+    values: &crate::types::ability::CopiableValues,
+) -> TokenSpec {
+    use crate::types::proposed_event::TokenCharacteristics;
+    TokenSpec {
+        characteristics: TokenCharacteristics {
+            display_name: values.name.clone(),
+            power: values.power,
+            toughness: values.toughness,
+            core_types: values.card_types.core_types.clone(),
+            subtypes: values.card_types.subtypes.clone(),
+            supertypes: values.card_types.supertypes.clone(),
+            colors: values.color.clone(),
+            keywords: values.keywords.clone(),
+        },
+        script_name: values.name.clone(),
+        static_abilities: vec![],
+        enter_with_counters: vec![],
+        tapped: false,
+        enters_attacking: false,
+        sacrifice_at: ability.duration.clone(),
+        source_id: ability.source_id,
+        controller: ability.controller,
+        attach_to: None,
+    }
 }
 
 /// CR 111.10: Enumerate the trigger definitions a BASE `Token` spec injects on

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -674,7 +674,11 @@ pub fn apply_create_token_after_replacement(
 
         // CR 111.10a–v: Inject predefined abilities for known token subtypes.
         inject_predefined_token_abilities(state, obj_id);
-        state.layers_dirty = true;
+        // Battlefield entry: request an incremental layer re-derive for just this
+        // token. `flush_layers` escalates to a full pass if the token sources a
+        // continuous effect / carries counters / etc., or if any active effect
+        // reads board population.
+        crate::game::layers::mark_layers_entered(state, obj_id);
         crate::game::restrictions::record_battlefield_entry(state, obj_id);
         crate::game::restrictions::record_token_created(state, obj_id);
 

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -303,7 +303,10 @@ pub fn resolve(
             // Step 6b: Inject predefined abilities, record entry, and mark layers dirty.
             // CR 111.10a-v: Predefined token abilities for known subtypes (Treasure, Food, etc.).
             super::token::inject_predefined_token_abilities(state, token_id);
-            state.layers_dirty = true;
+            // Battlefield entry of a copy token: request an incremental re-derive
+            // for just this token. `flush_layers` escalates to a full pass when
+            // the copied object sources a continuous effect, carries a CDA, etc.
+            crate::game::layers::mark_layers_entered(state, token_id);
             crate::game::restrictions::record_battlefield_entry(state, token_id);
             crate::game::restrictions::record_token_created(state, token_id);
 
@@ -820,7 +823,7 @@ mod tests {
         assert!(token.card_types.subtypes.contains(&"Snake".to_string()));
         assert!(token.is_token);
         assert!(token.zone == Zone::Battlefield);
-        assert!(state.layers_dirty);
+        assert!(state.layers_dirty.is_dirty());
         assert!(events.iter().any(
             |e| matches!(e, GameEvent::TokenCreated { name, .. } if name == "Mist-Syndicate Naga")
         ));

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -346,6 +346,45 @@ pub fn resolve(
     Ok(())
 }
 
+/// CR 707.2: Compute the longest contiguous prefix of `source_ids` (top-down
+/// resolution order) whose copy sources all share IDENTICAL copiable values.
+///
+/// Tier-3 batch support: a run of "create a token that's a copy of it"
+/// self-copy triggers from distinct sources produces N tokens with identical
+/// characteristics iff every source has the same CR 707.2 copiable values. This
+/// walks the run, snapshots the top source's copiable values, then extends the
+/// prefix while each subsequent source's values are `==` to the snapshot.
+///
+/// Conserves on a vanished source: if `compute_current_copiable_values` returns
+/// `None` for any source in the prefix walk, the prefix stops there (the top
+/// source returning `None` yields `None` overall — nothing to batch).
+///
+/// Returns `(prefix_values, prefix_len)`. `prefix_len` may be shorter than
+/// `source_ids.len()` (a divergent tail resolves later). Token art is read from
+/// the live source at resolution time (`token_copy::resolve`), so no display
+/// `PrintedCardRef` is threaded through the batch probe (CR 707.2: not a
+/// copiable characteristic).
+pub(crate) fn compute_copy_batch_prefix(
+    state: &GameState,
+    source_ids: &[ObjectId],
+) -> Option<(crate::types::ability::CopiableValues, u32)> {
+    let top_id = *source_ids.first()?;
+    // Conserve on a vanished top source.
+    let prefix_values = compute_current_copiable_values(state, top_id)?;
+
+    let mut prefix_len = 1u32;
+    for &id in source_ids.iter().skip(1) {
+        // CR 707.2: stop at the first source that vanished (None) or whose
+        // copiable values diverge from the prefix snapshot.
+        match compute_current_copiable_values(state, id) {
+            Some(values) if values == prefix_values => prefix_len += 1,
+            _ => break,
+        }
+    }
+
+    Some((prefix_values, prefix_len))
+}
+
 /// CR 707.2 + CR 707.9: Apply non-keyword `, except <body>` modifications to
 /// a synthesized token. Tokens are created with copiable values baked in, so
 /// each modification mutates BOTH the layered view (`card_types`,

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -56,7 +56,7 @@ pub fn apply_debug_action(
                 super::sba::check_state_based_actions(state, events);
                 super::triggers::process_triggers(state, events);
             }
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::CreateCard { .. } => {
@@ -88,7 +88,7 @@ pub fn apply_debug_action(
 
             zones::remove_from_zone(state, object_id, zone, owner);
             state.objects.remove(&object_id);
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::DrawCards { player_id, count } => {
@@ -143,7 +143,7 @@ pub fn apply_debug_action(
             if let Some(t) = toughness {
                 obj.base_toughness = Some(t);
             }
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::ModifyCounters {
@@ -182,7 +182,7 @@ pub fn apply_debug_action(
                 let lore = obj.counters.get(&CounterType::Lore).copied().unwrap_or(0);
                 obj.class_level = Some((lore as u8).max(1));
             }
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::SetTapped { object_id, tapped } => {
@@ -203,7 +203,7 @@ pub fn apply_debug_action(
             // `apply_battlefield_entry_controller_override` writes both fields.
             obj.base_controller = Some(controller);
             obj.controller = controller;
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::SetSummoningSickness { object_id, sick } => {
@@ -226,7 +226,7 @@ pub fn apply_debug_action(
             if let Some(f) = flipped {
                 obj.flipped = f;
             }
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::Attach { object_id, target } => {
@@ -241,7 +241,7 @@ pub fn apply_debug_action(
                     attach_to_player(state, object_id, target_player);
                 }
             }
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::Detach { object_id } => {
@@ -255,7 +255,7 @@ pub fn apply_debug_action(
             if let Some(obj) = state.objects.get_mut(&object_id) {
                 obj.attached_to = None;
             }
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::GrantKeyword { object_id, keyword } => {
@@ -268,7 +268,7 @@ pub fn apply_debug_action(
             if !obj.base_keywords.contains(&keyword) {
                 obj.base_keywords.push(keyword);
             }
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::RemoveKeyword { object_id, keyword } => {
@@ -276,7 +276,7 @@ pub fn apply_debug_action(
             // CR 613.1 + CR 613.1f: write the base keyword set (the Layer-6 input)
             // so the removal survives the layer recompute; see GrantKeyword above.
             obj.base_keywords.retain(|k| k != &keyword);
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
 
         DebugAction::SetLife { player_id, life } => {

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -92,9 +92,7 @@ fn handle_activated_mode_choice(
         modal,
     } = choice;
 
-    if state.layers_dirty {
-        super::layers::evaluate_layers(state);
-    }
+    super::layers::flush_layers(state);
 
     let target_slots = build_target_slots(state, &resolved)?;
     let target_constraints = target_constraints_from_modal(&modal);

--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -90,9 +90,7 @@ pub(super) fn run_post_action_pipeline(
         ));
     }
 
-    if state.layers_dirty {
-        super::layers::evaluate_layers(state);
-    }
+    super::layers::flush_layers(state);
 
     Ok(flush_pending_miracle_offer(state, default_wf.clone()))
 }

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -99,7 +99,7 @@ pub(super) fn handle_replacement_choice(
                         }
                     }
                     if to == Zone::Battlefield || from == Zone::Battlefield {
-                        state.layers_dirty = true;
+                        crate::game::layers::mark_layers_full(state);
                     }
                     enters_battlefield = to == Zone::Battlefield;
                     zone_change_object_id = Some(object_id);
@@ -487,7 +487,7 @@ pub(super) fn handle_copy_target_choice(
         }
     }
     apply_etb_counters(state, source_id, &enter_modifiers.counters, events);
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
     // CR 614.12a + CR 707.9: The battlefield-entry `ZoneChanged` event was
     // captured into `state.deferred_entry_events` when `CopyTargetChoice` was
     // set up, *before* `BecomeCopy` had a chance to push the copied object's

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2249,7 +2249,7 @@ pub(super) fn handle_resolution_choice(
                 ));
             }
             state.ring_bearer.insert(player, Some(target));
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
             ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
         }
         (WaitingFor::ChooseDungeon { player, options }, GameAction::ChooseDungeon { dungeon }) => {

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -195,6 +195,208 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
     }
 }
 
+/// CR 611.3a: ENTRY-AWARE narrowing for a population-sensitive AFFECTED FILTER.
+/// `affected_filter_uses_object_population` proves an effect's affected set *can*
+/// read board population; this proves a SPECIFIC entering object can actually
+/// perturb that population input (so a pre-existing recipient's membership might
+/// change).
+///
+/// Monotonicity: reached only for battlefield ENTRIES. An entry only ADDS to the
+/// board, so the only way it changes a population-derived affected set is if the
+/// entered object joins the population the set is computed over — EXCEPT for
+/// whole-board TALLY props (most-prevalent / name-matches), which can flip a
+/// pre-existing object's membership regardless of whether the entered object
+/// matches any inner filter; those escalate unconditionally (MEDIUM-2).
+///
+/// `ctx` is built from the EFFECT SOURCE (CR 109.5 controller rebinding) by the
+/// caller. Mirrors the structural recursion of
+/// `affected_filter_uses_object_population`.
+pub(crate) fn entered_object_perturbs_affected_filter(
+    state: &GameState,
+    entered_id: ObjectId,
+    ctx: &FilterContext<'_>,
+    filter: &TargetFilter,
+) -> bool {
+    match filter {
+        TargetFilter::Not { filter: inner } => {
+            entered_object_perturbs_affected_filter(state, entered_id, ctx, inner)
+        }
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => filters
+            .iter()
+            .any(|f| entered_object_perturbs_affected_filter(state, entered_id, ctx, f)),
+        TargetFilter::Typed(TypedFilter { properties, .. }) => properties
+            .iter()
+            .any(|p| entered_object_perturbs_filter_prop(state, entered_id, ctx, p)),
+        // Identical enumeration to the `false` arm of
+        // `affected_filter_uses_object_population`: these references resolve to a
+        // fixed object/player, a specific zone, or a tracked ledger — never
+        // whole-board population — so the classifier proved them non-population
+        // and an entry cannot perturb them.
+        TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::SelfRef
+        | TargetFilter::SourceOrPaired
+        | TargetFilter::StackAbility { .. }
+        | TargetFilter::StackSpell
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::AttachedTo
+        | TargetFilter::LastCreated
+        | TargetFilter::CostPaidObject
+        | TargetFilter::TrackedSet { .. }
+        | TargetFilter::TrackedSetFiltered { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSource
+        | TargetFilter::ParentTarget
+        | TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::OriginalController
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::HasChosenName
+        | TargetFilter::ChosenDamageSource
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => false,
+    }
+}
+
+/// CR 611.3a: entry-membership leaf for `entered_object_perturbs_affected_filter`.
+/// EXHAUSTIVE and wildcard-free, mirroring `filter_prop_uses_object_population`:
+/// every `false` arm there is `false` here; every `true` arm there is narrowed
+/// here to a membership / threshold-perturb test — EXCEPT the whole-board tally
+/// props, which escalate unconditionally.
+fn entered_object_perturbs_filter_prop(
+    state: &GameState,
+    entered_id: ObjectId,
+    ctx: &FilterContext<'_>,
+    prop: &FilterProp,
+) -> bool {
+    match prop {
+        // Whole-board tally — any entry can flip a pre-existing object's
+        // membership; the entered-object filter match is irrelevant, escalate
+        // unconditionally (MEDIUM-2). CR 205.3m (creature types — the tally
+        // counts creatures by their shared subtype lists), CR 201.2 (name
+        // matches any permanent).
+        FilterProp::MostPrevalentCreatureTypeIn { .. } => true,
+        FilterProp::NameMatchesAnyPermanent { .. } => true,
+        // The entered object's name joins the comparison set, so any entry
+        // matching the inner filter changes the "different name than each X"
+        // membership for pre-existing objects. No inner filter ⇒ conservatively
+        // perturb.
+        FilterProp::DifferentNameFrom { filter } => {
+            matches_target_filter(state, entered_id, filter, ctx)
+        }
+        // CR 603.4: the reference set is battlefield-derived only when a
+        // reference filter is present (classifier returns false for `None`). The
+        // `None` arm is therefore unreachable here, but enumerated as `false`
+        // for exhaustiveness rather than `unreachable!`.
+        FilterProp::SharesQuality { reference, .. } => reference
+            .as_ref()
+            .is_some_and(|f| matches_target_filter(state, entered_id, f, ctx)),
+        // Embedded thresholds: perturbed iff the entered object can perturb the
+        // threshold expression's population input.
+        FilterProp::Counters { count, .. } => {
+            entered_perturbs_quantity(state, entered_id, ctx, count)
+        }
+        FilterProp::Cmc { value, .. } => entered_perturbs_quantity(state, entered_id, ctx, value),
+        FilterProp::PtComparison { value, .. } => {
+            entered_perturbs_quantity(state, entered_id, ctx, value)
+        }
+        FilterProp::AnyOf { props } => props
+            .iter()
+            .any(|p| entered_object_perturbs_filter_prop(state, entered_id, ctx, p)),
+        // Identical enumeration to the leaf-false arm of
+        // `filter_prop_uses_object_population` — candidate-local, stack-relative,
+        // single-object, or threshold-free, so a board entry cannot perturb them.
+        FilterProp::CanEnchant { .. }
+        | FilterProp::HasAttachment { .. }
+        | FilterProp::HasAnyAttachmentOf { .. }
+        | FilterProp::TargetsOnly { .. }
+        | FilterProp::Targets { .. }
+        | FilterProp::ColorCount { .. }
+        | FilterProp::Token
+        | FilterProp::NonToken
+        | FilterProp::Attacking
+        | FilterProp::Blocking
+        | FilterProp::BlockingSource
+        | FilterProp::CombatRelation { .. }
+        | FilterProp::Unblocked
+        | FilterProp::Tapped
+        | FilterProp::Untapped
+        | FilterProp::WithKeyword { .. }
+        | FilterProp::HasKeywordKind { .. }
+        | FilterProp::WithoutKeyword { .. }
+        | FilterProp::WithoutKeywordKind { .. }
+        | FilterProp::ManaCostIn { .. }
+        | FilterProp::InZone { .. }
+        | FilterProp::Owned { .. }
+        | FilterProp::Foretold
+        | FilterProp::EnchantedBy
+        | FilterProp::EquippedBy
+        | FilterProp::AttachedToSource
+        | FilterProp::AttachedToRecipient
+        | FilterProp::Another
+        | FilterProp::Unpaired
+        | FilterProp::OtherThanTriggerObject
+        | FilterProp::HasColor { .. }
+        | FilterProp::PowerGTSource
+        | FilterProp::HasSupertype { .. }
+        | FilterProp::IsChosenCreatureType
+        | FilterProp::IsChosenColor
+        | FilterProp::IsChosenCardType
+        | FilterProp::IsChosenLandOrNonlandKind
+        | FilterProp::HasSingleTarget
+        | FilterProp::NotColor { .. }
+        | FilterProp::NotSupertype { .. }
+        | FilterProp::Suspected
+        | FilterProp::Renowned
+        | FilterProp::ToughnessGTPower
+        | FilterProp::Modified
+        | FilterProp::Historic
+        | FilterProp::InAnyZone { .. }
+        | FilterProp::WasDealtDamageThisTurn
+        | FilterProp::EnteredThisTurn
+        | FilterProp::ZoneChangedThisTurn { .. }
+        | FilterProp::AttackedThisTurn
+        | FilterProp::BlockedThisTurn
+        | FilterProp::AttackedOrBlockedThisTurn
+        | FilterProp::FaceDown
+        | FilterProp::HasXInManaCost
+        | FilterProp::HasManaAbility
+        | FilterProp::HasNoAbilities
+        | FilterProp::Named { .. }
+        | FilterProp::SameName
+        | FilterProp::SameNameAsParentTarget
+        | FilterProp::AttackingController
+        | FilterProp::IsCommander
+        | FilterProp::Other { .. } => false,
+    }
+}
+
+/// Bridge: route an embedded threshold `QuantityExpr` through the quantity
+/// module's entry-aware classifier. The entered object is resolved to its
+/// `GameObject` (it has just entered, so it must exist); a missing object can't
+/// perturb anything.
+fn entered_perturbs_quantity(
+    state: &GameState,
+    entered_id: ObjectId,
+    ctx: &FilterContext<'_>,
+    expr: &QuantityExpr,
+) -> bool {
+    state.objects.get(&entered_id).is_some_and(|entered| {
+        crate::game::quantity::entered_object_perturbs_quantity_expr(state, entered, ctx, expr)
+    })
+}
+
 /// CR 608.2c: Resolve contextual parent-target exclusions before a mass-effect scan.
 ///
 /// This intentionally supports only `Not(ParentTarget)` inside composite filters.
@@ -2475,7 +2677,7 @@ fn matches_filter_prop(
                 .any(|s| s.eq_ignore_ascii_case(chosen)),
             None => false,
         },
-        // CR 205.3m + CR 701.23a: Object's creature type ties for highest count
+        // CR 205.3m: Object's creature type ties for highest count
         // among creature cards in the named player's named zone. Scope picks
         // the player whose zone is inspected; `Opponent` falls back to the
         // candidate object's owner (search-context invariant — the candidate
@@ -3262,7 +3464,7 @@ fn object_shares_quality_with_reference_filter(
     })
 }
 
-/// CR 205.3m + CR 701.23a: Compute the creature subtypes tied for highest
+/// CR 205.3m: Compute the creature subtypes tied for highest
 /// occurrence among creature cards in `owner`'s `zone`. CR 205.3m defines
 /// the creature-subtype set being counted. A `Changeling` (CR 702.73a)
 /// creature counts toward every creature type, matching how the keyword

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -27,6 +27,174 @@ use crate::types::player::PlayerId;
 use crate::types::proposed_event::{EtbTapState, ProposedEvent, TokenSpec};
 use crate::types::zones::Zone;
 
+/// True when the filter's matched SET depends on the population of objects on
+/// the battlefield — i.e. another object entering or leaving the battlefield can
+/// change whether a PRE-EXISTING object satisfies this filter.
+///
+/// CR 611.3a: a static-ability continuous effect applies at any moment to
+/// whatever its text indicates; if its affected set is defined by board
+/// population ("creatures that share a name with another permanent", "with the
+/// most counters", etc.) then an entry/exit changes which pre-existing objects
+/// it affects. The incremental layer-flush fast path must escalate to a full
+/// re-evaluation in that case. CR 613.7d: the entering object receives its
+/// timestamp on zone entry, so even a fixed affected-set can reorder.
+///
+/// Sibling of the fail-closed exhaustive FilterProp match in this module — it
+/// answers a DIFFERENT question (population dependence, not membership), so it is
+/// built as a distinct recursion rather than overloading that match.
+pub(crate) fn affected_filter_uses_object_population(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Not { filter: inner } => affected_filter_uses_object_population(inner),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(affected_filter_uses_object_population)
+        }
+        TargetFilter::Typed(TypedFilter { properties, .. }) => {
+            properties.iter().any(filter_prop_uses_object_population)
+        }
+        // No other TargetFilter arm defines its set by whole-board population.
+        // Self/source/target/parent/triggering/specific references resolve to a
+        // fixed object or player; zone/exile/tracked-set references read a
+        // specific zone or ledger, not battlefield membership.
+        TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::SelfRef
+        | TargetFilter::SourceOrPaired
+        | TargetFilter::StackAbility { .. }
+        | TargetFilter::StackSpell
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::AttachedTo
+        | TargetFilter::LastCreated
+        | TargetFilter::CostPaidObject
+        | TargetFilter::TrackedSet { .. }
+        | TargetFilter::TrackedSetFiltered { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSource
+        | TargetFilter::ParentTarget
+        | TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::OriginalController
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::HasChosenName
+        | TargetFilter::ChosenDamageSource
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => false,
+    }
+}
+
+/// EXHAUSTIVE, wildcard-free leaf classifier for
+/// `affected_filter_uses_object_population`. Adding a `FilterProp` variant forces
+/// a decision here. `true` only for props whose membership reads whole-board
+/// object population; recurses into embedded `QuantityExpr` thresholds and inner
+/// filters.
+fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
+    match prop {
+        // Structurally board-population dependent.
+        FilterProp::MostPrevalentCreatureTypeIn { .. }
+        | FilterProp::NameMatchesAnyPermanent { .. } => true,
+        // Membership depends on the names of every battlefield permanent matched
+        // by the inner filter ("with a different name than each X you control"),
+        // so any entry/exit of a matching permanent can flip membership for a
+        // pre-existing object. Unconditionally population dependent.
+        FilterProp::DifferentNameFrom { .. } => true,
+        // CR 603.4: "shares a quality with" a reference set is population
+        // dependent ONLY when a reference filter is present — the reference set
+        // is battlefield-derived. The multi-target group-share form
+        // (`reference = None`) is candidate-local, validated at resolution time,
+        // not whole-board membership.
+        FilterProp::SharesQuality { reference, .. } => reference.is_some(),
+        // Embedded-threshold props: population dependent iff the threshold
+        // expression reads object count.
+        FilterProp::Counters { count, .. } => {
+            crate::game::quantity::quantity_expr_uses_object_count(count)
+        }
+        FilterProp::Cmc { value, .. } => {
+            crate::game::quantity::quantity_expr_uses_object_count(value)
+        }
+        FilterProp::PtComparison { value, .. } => {
+            crate::game::quantity::quantity_expr_uses_object_count(value)
+        }
+        // Disjunctive composite: recurse.
+        FilterProp::AnyOf { props } => props.iter().any(filter_prop_uses_object_population),
+        // Intentional leaf-false. These are candidate-local, stack-relative,
+        // single-object, or carry no QuantityExpr threshold, so a board entry/exit
+        // cannot change whether a pre-existing object satisfies them.
+        // `ColorCount` carries a `u8` constant, not a QuantityExpr.
+        FilterProp::CanEnchant { .. }
+        | FilterProp::HasAttachment { .. }
+        | FilterProp::HasAnyAttachmentOf { .. }
+        | FilterProp::TargetsOnly { .. }
+        | FilterProp::Targets { .. }
+        | FilterProp::ColorCount { .. }
+        | FilterProp::Token
+        | FilterProp::NonToken
+        | FilterProp::Attacking
+        | FilterProp::Blocking
+        | FilterProp::BlockingSource
+        | FilterProp::CombatRelation { .. }
+        | FilterProp::Unblocked
+        | FilterProp::Tapped
+        | FilterProp::Untapped
+        | FilterProp::WithKeyword { .. }
+        | FilterProp::HasKeywordKind { .. }
+        | FilterProp::WithoutKeyword { .. }
+        | FilterProp::WithoutKeywordKind { .. }
+        | FilterProp::ManaCostIn { .. }
+        | FilterProp::InZone { .. }
+        | FilterProp::Owned { .. }
+        | FilterProp::Foretold
+        | FilterProp::EnchantedBy
+        | FilterProp::EquippedBy
+        | FilterProp::AttachedToSource
+        | FilterProp::AttachedToRecipient
+        | FilterProp::Another
+        | FilterProp::Unpaired
+        | FilterProp::OtherThanTriggerObject
+        | FilterProp::HasColor { .. }
+        | FilterProp::PowerGTSource
+        | FilterProp::HasSupertype { .. }
+        | FilterProp::IsChosenCreatureType
+        | FilterProp::IsChosenColor
+        | FilterProp::IsChosenCardType
+        | FilterProp::IsChosenLandOrNonlandKind
+        | FilterProp::HasSingleTarget
+        | FilterProp::NotColor { .. }
+        | FilterProp::NotSupertype { .. }
+        | FilterProp::Suspected
+        | FilterProp::Renowned
+        | FilterProp::ToughnessGTPower
+        | FilterProp::Modified
+        | FilterProp::Historic
+        | FilterProp::InAnyZone { .. }
+        | FilterProp::WasDealtDamageThisTurn
+        | FilterProp::EnteredThisTurn
+        | FilterProp::ZoneChangedThisTurn { .. }
+        | FilterProp::AttackedThisTurn
+        | FilterProp::BlockedThisTurn
+        | FilterProp::AttackedOrBlockedThisTurn
+        | FilterProp::FaceDown
+        | FilterProp::HasXInManaCost
+        | FilterProp::HasManaAbility
+        | FilterProp::HasNoAbilities
+        | FilterProp::Named { .. }
+        | FilterProp::SameName
+        | FilterProp::SameNameAsParentTarget
+        | FilterProp::AttackingController
+        | FilterProp::IsCommander
+        | FilterProp::Other { .. } => false,
+    }
+}
+
 /// CR 608.2c: Resolve contextual parent-target exclusions before a mass-effect scan.
 ///
 /// This intentionally supports only `Not(ParentTarget)` inside composite filters.

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -457,7 +457,7 @@ pub fn activate_ninjutsu(
         source_id: ninjutsu_obj_id,
     });
 
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
 
     Ok(())
 }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::database::synthesis::KeywordTriggerInstaller;
@@ -18,7 +19,7 @@ use crate::types::card_type::{
     is_land_subtype, noncreature_subtype_set, CoreType, SubtypeSet, Supertype,
 };
 use crate::types::counter::{CounterMatch, CounterType};
-use crate::types::game_state::{DayNight, GameState};
+use crate::types::game_state::{DayNight, GameState, LayersDirty};
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 use crate::types::layers::{ActiveContinuousEffect, Layer};
@@ -71,7 +72,7 @@ pub fn prune_end_of_turn_effects(state: &mut GameState) {
         .transient_continuous_effects
         .retain(|e| e.duration != Duration::UntilEndOfTurn);
     if state.transient_continuous_effects.len() != before {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 }
 
@@ -83,7 +84,7 @@ pub fn prune_end_of_combat_effects(state: &mut GameState) {
         .transient_continuous_effects
         .retain(|e| e.duration != Duration::UntilEndOfCombat);
     if state.transient_continuous_effects.len() != before {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 }
 
@@ -106,7 +107,7 @@ pub fn prune_until_next_end_step_effects(state: &mut GameState, active_player: P
         ) && e.controller == active_player)
     });
     if state.transient_continuous_effects.len() != before {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 }
 
@@ -258,7 +259,7 @@ pub fn prune_until_next_turn_effects(state: &mut GameState, active_player: Playe
         ) && e.controller == active_player)
     });
     if state.transient_continuous_effects.len() != before {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 
     // CR 701.15a: Goad expires at the goading player's next turn. Clear goaded_by entries
@@ -303,7 +304,7 @@ pub fn prune_controller_untap_step_effects(state: &mut GameState, active_player:
         }
     });
     if state.transient_continuous_effects.len() != before {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 }
 
@@ -315,7 +316,7 @@ pub fn prune_host_left_effects(state: &mut GameState, departed_id: ObjectId) {
         .transient_continuous_effects
         .retain(|e| !(e.duration == Duration::UntilHostLeavesPlay && e.source_id == departed_id));
     if state.transient_continuous_effects.len() != before {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 }
 
@@ -326,7 +327,7 @@ pub fn prune_affected_object_left_effects(state: &mut GameState, departed_id: Ob
         !matches!(effect.affected, TargetFilter::SpecificObject { id } if id == departed_id)
     });
     if state.transient_continuous_effects.len() != before {
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 }
 
@@ -376,6 +377,101 @@ fn condition_uses_recipient_context(condition: &StaticCondition) -> bool {
         StaticCondition::RecipientHasCounters { .. } => true,
         StaticCondition::RecipientMatchesFilter { .. } => true,
         _ => false,
+    }
+}
+
+/// True when a static ability's SOURCE-LEVEL enabling condition can be flipped
+/// by an object entering or leaving the battlefield — i.e. its truth value
+/// depends on battlefield population/composition. Such conditions gate the
+/// effect for the WHOLE recipient set (they are NOT recipient-local; see
+/// `condition_uses_recipient_context`), so when an entry flips the gate every
+/// pre-existing recipient changes. The incremental layer-flush fast path only
+/// re-derives the entered objects, leaving pre-existing recipients with stale
+/// derived state, so it must escalate to a full re-evaluation in that case.
+///
+/// CR 611.3a: a static ability's continuous effect isn't locked in — when its
+/// source-level enabling condition depends on board population, an object
+/// entering can flip the condition for the whole recipient set, changing
+/// PRE-EXISTING recipients. Escalate to a full rebuild.
+///
+/// EXHAUSTIVE, wildcard-free over `StaticCondition` so a future variant forces a
+/// compile-time classification. Threshold/comparison variants recurse their
+/// operand `QuantityExpr`s through the existing `quantity_expr_uses_object_count`
+/// (DRY — no hand-rolled population detection). When in doubt, conservatively
+/// `true`: over-escalation is merely a perf cost, under-escalation is a
+/// rules-correctness bug.
+fn static_condition_uses_object_population(condition: &StaticCondition) -> bool {
+    match condition {
+        // Threshold/comparison gates: board-population-dependent iff an operand
+        // reads object count. Reuses the shared QuantityExpr classifier.
+        StaticCondition::QuantityComparison { lhs, rhs, .. } => {
+            crate::game::quantity::quantity_expr_uses_object_count(lhs)
+                || crate::game::quantity::quantity_expr_uses_object_count(rhs)
+        }
+        // Devotion is a sum of mana symbols across permanents you control — pure
+        // board composition.
+        StaticCondition::DevotionGE { .. } => true,
+        // "you control [filter]" / "a [filter] is on the battlefield" — membership
+        // is battlefield population. `IsPresent` has no zone field (always a
+        // battlefield-presence check), so it is unconditionally population
+        // dependent regardless of whether `filter` is `Some`/`None`.
+        StaticCondition::IsPresent { .. } => true,
+        // Per-player board-count gate (defending player controls a [filter]).
+        StaticCondition::DefendingPlayerControls { .. } => true,
+        // "you control a/your commander" — membership of a commander on the
+        // battlefield, board-population dependent.
+        StaticCondition::ControlsCommander { .. } => true,
+        // Recurse combinators.
+        StaticCondition::And { conditions } | StaticCondition::Or { conditions } => conditions
+            .iter()
+            .any(static_condition_uses_object_population),
+        StaticCondition::Not { condition } => static_condition_uses_object_population(condition),
+        // Parse fallback — evaluated permissively (always true today), but its
+        // text is unknown; conservatively escalate so an unrecognized
+        // population-gated condition can never silently under-escalate.
+        StaticCondition::Unrecognized { .. } => true,
+        // Genuinely board-population-independent: source-local state, the
+        // source's chosen attributes, combat status, player-scoped flags/totals,
+        // turn/phase, recipient-context gates (handled by
+        // `condition_uses_recipient_context`), zone presence of the source, and
+        // cast-history. Enumerated explicitly (no wildcard) so a future variant
+        // is forced through this classification.
+        StaticCondition::ChosenColorIs { .. }
+        | StaticCondition::ChosenLabelIs { .. }
+        | StaticCondition::HasMaxSpeed
+        | StaticCondition::SpeedGE { .. }
+        | StaticCondition::DayNightIs { .. }
+        | StaticCondition::HasCounters { .. }
+        | StaticCondition::RecipientHasCounters { .. }
+        | StaticCondition::ClassLevelGE { .. }
+        | StaticCondition::SourceAttackingAlone
+        | StaticCondition::SourceIsAttacking
+        | StaticCondition::SourceIsBlocking
+        | StaticCondition::SourceIsBlocked
+        | StaticCondition::IsMonarch
+        | StaticCondition::NoMonarch
+        | StaticCondition::HasCityBlessing
+        | StaticCondition::CompletedADungeon
+        | StaticCondition::WasStartingPlayer { .. }
+        | StaticCondition::SpellCastWithVariantThisTurn { .. }
+        | StaticCondition::OpponentPoisonAtLeast { .. }
+        | StaticCondition::UnlessPay { .. }
+        | StaticCondition::DuringYourTurn
+        | StaticCondition::SourceEnteredThisTurn
+        | StaticCondition::IsRingBearer
+        | StaticCondition::RingLevelAtLeast { .. }
+        | StaticCondition::SourceIsTapped
+        | StaticCondition::SourceControllerEquals { .. }
+        | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsMonstrous
+        | StaticCondition::SourceAttachedToCreature
+        | StaticCondition::SourceMatchesFilter { .. }
+        | StaticCondition::RecipientMatchesFilter { .. }
+        | StaticCondition::SourceIsPaired
+        | StaticCondition::SourceInZone { .. }
+        | StaticCondition::EnchantedIsFaceDown
+        | StaticCondition::AdditionalCostPaid
+        | StaticCondition::None => false,
     }
 }
 
@@ -739,7 +835,17 @@ pub fn evaluate_condition_for_test(
 /// 5. Clear the layers_dirty flag.
 ///
 /// CR 613.1: Evaluate all continuous effects in layer order (1–7e).
+/// Test-only counter incremented at the TOP of every FULL `evaluate_layers`
+/// pass (NOT incremented by `apply_layers_incremental`). The discriminating
+/// performance test reads this to prove the incremental fast path engaged: full
+/// evaluations must be near-constant, not proportional to the resolved stack.
+#[cfg(test)]
+pub(crate) static FULL_EVALUATE_LAYERS_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 pub fn evaluate_layers(state: &mut GameState) {
+    #[cfg(test)]
+    FULL_EVALUATE_LAYERS_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     // CR 302.6 + CR 613.1b + CR 702.26c: Snapshot effective controllers for
     // phased-in permanents BEFORE the Step 1 reset below wipes them. The
     // post-pass diff at the end of this function compares against this
@@ -980,8 +1086,330 @@ pub fn evaluate_layers(state: &mut GameState) {
     // rebuild replaces both `by_key` and `unclassified` from scratch.
     crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
 
-    // Step 5: Clear dirty flag
-    state.layers_dirty = false;
+    // Step 5: Clear dirty flag. A full evaluation satisfies any pending request
+    // (Clean / EnteredObjects / Full).
+    state.layers_dirty = LayersDirty::Clean;
+}
+
+/// Mark the layer system as requiring a FULL battlefield re-evaluation. The
+/// conservative escalation used by every mutation other than a battlefield entry.
+pub fn mark_layers_full(state: &mut GameState) {
+    state.layers_dirty.mark_full();
+}
+
+/// Record that `id` entered the battlefield and is a candidate for incremental
+/// layer re-derivation. If the dirty lattice is already `Full`, this is a no-op
+/// (the full pass subsumes the entry).
+pub fn mark_layers_entered(state: &mut GameState, id: ObjectId) {
+    state.layers_dirty.mark_entered(id);
+}
+
+/// Single authority that flushes any pending layer re-evaluation and keeps the
+/// public-state dirty marks consistent with what was recomputed.
+///
+/// CR 613.1: continuous effects are evaluated in layer order over the whole
+/// board. The `Full` path always produces a correct board; the `EnteredObjects`
+/// path is an O(entered + active-effects) fast path taken only when a
+/// per-entered precondition scan AND a board-wide escalation scan prove that
+/// re-deriving just the entered objects yields a board identical to a full pass.
+pub fn flush_layers(state: &mut GameState) {
+    match std::mem::replace(&mut state.layers_dirty, LayersDirty::Clean) {
+        LayersDirty::Clean => {}
+        LayersDirty::Full => {
+            evaluate_layers(state);
+            super::public_state::mark_public_state_all_dirty(state);
+        }
+        LayersDirty::EnteredObjects(ids) => {
+            if ids.is_empty() {
+                return;
+            }
+            if incremental_flush_must_escalate(state, &ids) {
+                evaluate_layers(state);
+                super::public_state::mark_public_state_all_dirty(state);
+            } else {
+                apply_layers_incremental(state, &ids);
+                for id in &ids {
+                    super::public_state::mark_public_state_object_dirty(state, *id);
+                }
+                super::public_state::mark_battlefield_display_dirty(state);
+            }
+        }
+    }
+}
+
+/// Decide whether an `EnteredObjects` flush must conservatively escalate to a
+/// full re-evaluation.
+///
+/// Two axes, both required-clean for the fast path:
+///
+/// 1. Per-entered preconditions: the entered object must not itself be the
+///    source of a continuous effect, carry a CDA static, or carry a
+///    control-override / type-change / text-change / counter / attachment /
+///    transient effect (the entry enqueued none for a plain token).
+///
+/// 2. Board-wide escalation: no ACTIVE continuous effect may have a magnitude,
+///    affected set, or source-level enabling CONDITION that reads battlefield
+///    object population.
+///    CR 611.3a: a static-ability continuous effect isn't locked in; it applies
+///    at any moment to whatever its text indicates — so a board-population-
+///    dependent magnitude, affected set, or enabling condition re-evaluates when
+///    an object enters, changing PRE-EXISTING recipients. CR 613.7d: the entering
+///    object receives its timestamp on zone entry. CR 613.8a: dependency/timestamp
+///    ordering operates on the live set. This scan is O(active-effect-count), NOT
+///    O(battlefield).
+fn incremental_flush_must_escalate(state: &GameState, entered_ids: &HashSet<ObjectId>) -> bool {
+    // Axis 1 — per-entered preconditions.
+    for &id in entered_ids {
+        let Some(obj) = state.objects.get(&id) else {
+            // The entered object already left (e.g. it was a token that died to
+            // an SBA before flush). A full pass is the safe handling.
+            return true;
+        };
+        if entered_object_blocks_incremental(state, obj) {
+            return true;
+        }
+    }
+
+    // Axis 2a — magnitude + affected-set over the EXISTING active effect set.
+    if collect_shared_active_continuous_effects(state)
+        .iter()
+        .any(|e| {
+            modification_dynamic_quantity(&e.modification)
+                .is_some_and(crate::game::quantity::quantity_expr_uses_object_count)
+                || crate::game::filter::affected_filter_uses_object_population(&e.affected_filter)
+        })
+    {
+        return true;
+    }
+
+    // Axis 2b — source-level enabling CONDITION over the EXISTING static-ability
+    // sources. The condition axis CANNOT be read off the collected
+    // `ActiveContinuousEffect`s: `active_continuous_effects_from_static_definitions`
+    // evaluates a non-recipient-context (source-level) condition as a gate at
+    // COLLECTION time and stores `condition: None` on the resulting effect (only
+    // recipient-context conditions are retained for per-recipient re-evaluation).
+    // So a board-population gate like "as long as you control N creatures" is
+    // already consumed and invisible on the active-effect set. We must inspect the
+    // intact `StaticDefinition.condition` on each live source instead.
+    //
+    // CR 611.3a: when such a source-level enabling condition depends on board
+    // population, an object entering can flip the condition for the WHOLE recipient
+    // set, changing PRE-EXISTING recipients — so escalate to a full rebuild.
+    any_active_static_condition_uses_object_population(state)
+}
+
+/// Scan every live static-ability source for a CONTINUOUS `StaticDefinition`
+/// whose enabling `condition` is board-population-dependent. Walks the same
+/// source set as `collect_shared_active_continuous_effects`
+/// (`for_each_static_effect_source`) but reads the intact pre-collection
+/// `condition` field. O(active-source-count); short-circuits on the first match.
+fn any_active_static_condition_uses_object_population(state: &GameState) -> bool {
+    let mut found = false;
+    for_each_static_effect_source(state, |_state, obj| {
+        if found {
+            return;
+        }
+        if obj.static_definitions.iter_all().any(|def| {
+            def.mode == StaticMode::Continuous
+                && def
+                    .condition
+                    .as_ref()
+                    .is_some_and(static_condition_uses_object_population)
+        }) {
+            found = true;
+        }
+    });
+    found
+}
+
+/// True when the entered object cannot be handled by the incremental fast path
+/// and the flush must escalate to a full re-evaluation. Conservative: any entry
+/// kind whose layer contribution cannot be cheaply proven empty fails closed.
+fn entered_object_blocks_incremental(
+    state: &GameState,
+    obj: &crate::game::game_object::GameObject,
+) -> bool {
+    // (1) The entered object sources at least one continuous effect (anthem,
+    //     lord, type-changer, etc.): a full pass is required so its effect
+    //     reaches every pre-existing recipient.
+    if !active_continuous_effects_from_static_source(state, obj).is_empty() {
+        return true;
+    }
+    // (2) CDA static: a characteristic-defining static defines the object's own
+    //     P/T/color/type from game state and is not a plain entry.
+    if obj
+        .static_definitions
+        .iter_all()
+        .any(|s| s.characteristic_defining)
+    {
+        return true;
+    }
+    // (3) The entry carries no control-override / type-change / text-change /
+    //     counter / attachment / transient effect. Counters and attachments are
+    //     cheaply observable on the object; type/text/control overrides for a
+    //     genuine new entry are sourced by statics already covered by (1)/(2).
+    //     A controller differing from the base controller indicates a Layer-2
+    //     override the incremental path does not reset for the rest of the board.
+    if !obj.counters.is_empty() {
+        return true;
+    }
+    if obj.attached_to.is_some() || !obj.attachments.is_empty() {
+        return true;
+    }
+    if obj
+        .base_controller
+        .is_some_and(|base| base != obj.controller)
+    {
+        return true;
+    }
+    false
+}
+
+/// Incremental layer re-derivation for a set of freshly-entered objects.
+///
+/// Mirrors the PER-OBJECT subset of `evaluate_layers` for `entered_ids` only:
+/// resets each entered object to its base characteristics, re-applies the
+/// EXISTING global continuous-effect set (restricted to the entered objects via
+/// `apply_continuous_effect_to`), runs the per-object counter / keyword-counter /
+/// P-T-counter / loyalty fixups and the combat-assignment-rule application, then
+/// rebuilds the TriggerIndex (CR 603.6a + CR 611.2e — granted-trigger
+/// visibility). It does NOT clear attribution globally or touch the rest of the
+/// battlefield: pre-existing objects keep their already-derived characteristics.
+///
+/// Caller (`flush_layers`) only reaches this path after
+/// `incremental_flush_must_escalate` returned false, which guarantees no active
+/// effect's magnitude or affected set reads board population — so re-deriving
+/// just the entered objects yields a board identical to a full pass (CR 613.1).
+fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectId>) {
+    // Step 1 (per-entered subset): reset computed characteristics to base.
+    for &id in entered_ids {
+        if let Some(obj) = state.objects.get_mut(&id) {
+            obj.sync_missing_base_characteristics();
+            obj.name = obj.base_name.clone();
+            obj.power = obj.base_power;
+            obj.toughness = obj.base_toughness;
+            obj.loyalty = obj.base_loyalty;
+            obj.card_types = obj.base_card_types.clone();
+            obj.mana_cost = obj.base_mana_cost.clone();
+            obj.keywords = obj.base_keywords.clone();
+            obj.abilities = Arc::clone(&obj.base_abilities);
+            obj.trigger_definitions = Arc::clone(&obj.base_trigger_definitions).into();
+            obj.replacement_definitions = Arc::clone(&obj.base_replacement_definitions).into();
+            obj.static_definitions = Arc::clone(&obj.base_static_definitions).into();
+            obj.color = obj.base_color.clone();
+            obj.printed_ref = obj.base_printed_ref.clone();
+            obj.controller = obj.base_controller.unwrap_or(obj.owner);
+            obj.assigns_damage_from_toughness = false;
+            obj.assigns_damage_as_though_unblocked = false;
+            obj.assigns_no_combat_damage = false;
+        }
+    }
+
+    // Step 2: Copy effects first (Layer 1), restricted to entered objects.
+    let copy_effects = gather_active_effects_for_layer(state, Layer::Copy);
+    let ordered_copy = order_active_continuous_effects(Layer::Copy, &copy_effects, state);
+    for effect in &ordered_copy {
+        apply_continuous_effect_to(state, effect, entered_ids);
+    }
+
+    // Step 3-4: Remaining layers in order, restricted to entered objects.
+    let effects_by_layer = gather_active_continuous_effects(state);
+    for (layer, layer_bucket) in &effects_by_layer {
+        if matches!(*layer, Layer::Copy | Layer::CounterPT) {
+            continue;
+        }
+        if !layer_bucket.is_empty() {
+            let layer_effects: Vec<&ActiveContinuousEffect> = layer_bucket.iter().collect();
+            let ordered = if layer.has_dependency_ordering() {
+                order_with_dependencies(&layer_effects, state)
+            } else {
+                order_by_timestamp(&layer_effects)
+            };
+            for effect in &ordered {
+                apply_continuous_effect_to(state, effect, entered_ids);
+            }
+        }
+        if *layer == Layer::Type {
+            let entered_vec: Vec<ObjectId> = entered_ids.iter().copied().collect();
+            apply_intrinsic_basic_land_mana_abilities(state, &entered_vec);
+        }
+    }
+
+    // CR 702.73a: Changeling — entered object gains all creature types if it now
+    // has Changeling but no CDA covered it.
+    if !state.all_creature_types.is_empty() {
+        for &id in entered_ids {
+            let has_changeling = state
+                .objects
+                .get(&id)
+                .is_some_and(|o| o.has_keyword(&Keyword::Changeling));
+            if has_changeling {
+                let all_types = state.all_creature_types.clone();
+                if let Some(obj) = state.objects.get_mut(&id) {
+                    for subtype in &all_types {
+                        if !obj.card_types.subtypes.iter().any(|s| s == subtype) {
+                            obj.card_types.subtypes.push(subtype.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // CR 122.1b + CR 613.1f: Keyword counters grant their keyword (Layer 6).
+    // CR 613.4c: Power/toughness counters modify P/T (Layer 7c). CR 306.5c:
+    // loyalty re-derives from loyalty counters. Per-entered fixups only.
+    for &id in entered_ids {
+        if let Some(obj) = state.objects.get_mut(&id) {
+            let granted: Vec<Keyword> = obj
+                .counters
+                .keys()
+                .filter_map(|ct| match ct {
+                    CounterType::Keyword(kind) => Keyword::promote_keyword_kind(*kind),
+                    _ => None,
+                })
+                .collect();
+            for keyword in granted {
+                if !obj.has_keyword(&keyword) {
+                    obj.keywords.push(keyword);
+                }
+            }
+
+            let (power_delta, toughness_delta) = obj.counters.iter().fold(
+                (0i32, 0i32),
+                |(power_total, toughness_total), (counter_type, count)| {
+                    let Some((power, toughness)) = counter_type.power_toughness_delta() else {
+                        return (power_total, toughness_total);
+                    };
+                    let count = crate::game::arithmetic::u32_to_i32_saturating(*count);
+                    (
+                        power_total.saturating_add(power.saturating_mul(count)),
+                        toughness_total.saturating_add(toughness.saturating_mul(count)),
+                    )
+                },
+            );
+            if power_delta != 0 {
+                if let Some(ref mut p) = obj.power {
+                    *p = saturating_pt_add(*p, power_delta);
+                }
+            }
+            if toughness_delta != 0 {
+                if let Some(ref mut t) = obj.toughness {
+                    *t = saturating_pt_add(*t, toughness_delta);
+                }
+            }
+            if let Some(&loyalty_counters) = obj.counters.get(&CounterType::Loyalty) {
+                obj.loyalty = Some(loyalty_counters);
+            }
+        }
+    }
+
+    // CR 613.11: Combat-assignment rule effects, restricted to entered objects.
+    apply_combat_assignment_rule_effects_filtered(state, Some(entered_ids));
+
+    // CR 603.6a + CR 611.2e: Rebuild the TriggerIndex so the next event scan
+    // sees the entered objects' (and any granted) trigger sets.
+    crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
 }
 
 fn gather_active_effects_for_layer(state: &GameState, layer: Layer) -> Vec<ActiveContinuousEffect> {
@@ -1404,6 +1832,13 @@ fn is_combat_assignment_rule_modification(modification: &ContinuousModification)
 }
 
 fn apply_combat_assignment_rule_effects(state: &mut GameState) {
+    apply_combat_assignment_rule_effects_filtered(state, None);
+}
+
+fn apply_combat_assignment_rule_effects_filtered(
+    state: &mut GameState,
+    restrict_to: Option<&HashSet<ObjectId>>,
+) {
     let mut effects = collect_active_combat_assignment_rule_effects(state);
     effects.sort_by_key(|effect| (effect.timestamp, effect.controller.0, effect.source_id.0));
 
@@ -1416,6 +1851,7 @@ fn apply_combat_assignment_rule_effects(state: &mut GameState) {
         let ctx = FilterContext::from_source(state, effect.source_id);
         let affected_ids: Vec<ObjectId> = scan_ids
             .iter()
+            .filter(|&&id| restrict_to.is_none_or(|ids| ids.contains(&id)))
             .filter(|&&id| matches_target_filter(state, id, &effect.affected_filter, &ctx))
             .filter(|&&id| {
                 effect.condition.as_ref().is_none_or(|condition| {
@@ -1888,7 +2324,93 @@ fn record_attribution(
     }
 }
 
+/// Single authority extracting the dynamic `QuantityExpr` magnitude carried by a
+/// `ContinuousModification`, if any. Both the dynamic-P/T apply site
+/// (`apply_continuous_effect`) and the incremental-flush escalation scan
+/// (`flush_layers`) call this so there is one place that decides which
+/// modifications carry a runtime-resolved magnitude.
+///
+/// EXHAUSTIVE and wildcard-free over `ContinuousModification` so a future
+/// variant that carries a `QuantityExpr` must be classified here at compile
+/// time rather than silently slipping past the escalation scan. `AddCounterOnEnter`
+/// also carries a `QuantityExpr` but is resolution-time-consumed by the
+/// BecomeCopy / CopyTokenOf resolvers and never reaches `apply_continuous_effect`
+/// (see its doc comment), so it is excluded.
+fn modification_dynamic_quantity(m: &ContinuousModification) -> Option<&QuantityExpr> {
+    match m {
+        ContinuousModification::SetDynamicPower { value }
+        | ContinuousModification::SetDynamicToughness { value }
+        | ContinuousModification::SetPowerDynamic { value }
+        | ContinuousModification::SetToughnessDynamic { value }
+        | ContinuousModification::AddDynamicPower { value }
+        | ContinuousModification::AddDynamicToughness { value }
+        | ContinuousModification::AddDynamicKeyword { value, .. } => Some(value),
+        // Resolution-time-consumed; never an active continuous effect.
+        ContinuousModification::AddCounterOnEnter { .. } => None,
+        // Non-dynamic modifications carry plain i32 / enum payloads, no dynamic
+        // magnitude. Enumerated explicitly (no wildcard) so a future
+        // QuantityExpr-carrying variant forces a decision here.
+        ContinuousModification::CopyValues { .. }
+        | ContinuousModification::SetName { .. }
+        | ContinuousModification::AddPower { .. }
+        | ContinuousModification::AddToughness { .. }
+        | ContinuousModification::SetPower { .. }
+        | ContinuousModification::SetToughness { .. }
+        | ContinuousModification::AddKeyword { .. }
+        | ContinuousModification::RemoveKeyword { .. }
+        | ContinuousModification::GrantAbility { .. }
+        | ContinuousModification::GrantTrigger { .. }
+        | ContinuousModification::RemoveAllAbilities
+        | ContinuousModification::AddType { .. }
+        | ContinuousModification::RemoveType { .. }
+        | ContinuousModification::AddSubtype { .. }
+        | ContinuousModification::RemoveSubtype { .. }
+        | ContinuousModification::SetCardTypes { .. }
+        | ContinuousModification::RemoveAllSubtypes { .. }
+        | ContinuousModification::AddAllCreatureTypes
+        | ContinuousModification::AddAllBasicLandTypes
+        | ContinuousModification::AddChosenSubtype { .. }
+        | ContinuousModification::AddChosenColor
+        | ContinuousModification::RemoveChosenKeyword
+        | ContinuousModification::SetColor { .. }
+        | ContinuousModification::AddColor { .. }
+        | ContinuousModification::AddStaticMode { .. }
+        | ContinuousModification::GrantStaticAbility { .. }
+        | ContinuousModification::SwitchPowerToughness
+        | ContinuousModification::AssignDamageFromToughness
+        | ContinuousModification::AssignDamageAsThoughUnblocked
+        | ContinuousModification::AssignNoCombatDamage
+        | ContinuousModification::ChangeController
+        | ContinuousModification::SetBasicLandType { .. }
+        | ContinuousModification::RetainPrintedTriggerFromSource { .. }
+        | ContinuousModification::AddSupertype { .. }
+        | ContinuousModification::RemoveSupertype { .. } => None,
+    }
+}
+
 fn apply_continuous_effect(state: &mut GameState, effect: &ActiveContinuousEffect) {
+    apply_continuous_effect_filtered(state, effect, None);
+}
+
+/// Apply a continuous effect's modification only to the subset of its affected
+/// objects that are in `restrict_to`. Used by the incremental layer-flush fast
+/// path so a pre-existing anthem/static re-applies to a freshly-entered object
+/// without re-applying to (and thus without needing to reset) the rest of the
+/// battlefield. Shares the entire apply body with `apply_continuous_effect` —
+/// no duplicated per-recipient logic.
+fn apply_continuous_effect_to(
+    state: &mut GameState,
+    effect: &ActiveContinuousEffect,
+    restrict_to: &HashSet<ObjectId>,
+) {
+    apply_continuous_effect_filtered(state, effect, Some(restrict_to));
+}
+
+fn apply_continuous_effect_filtered(
+    state: &mut GameState,
+    effect: &ActiveContinuousEffect,
+    restrict_to: Option<&HashSet<ObjectId>>,
+) {
     let scan_zone = effect
         .affected_filter
         .extract_in_zone()
@@ -1897,6 +2419,10 @@ fn apply_continuous_effect(state: &mut GameState, effect: &ActiveContinuousEffec
     let ctx = FilterContext::from_source(state, effect.source_id);
     let affected_ids: Vec<ObjectId> = scan_ids
         .iter()
+        // Incremental fast path: re-apply only to the freshly-entered objects.
+        // The rest of the battlefield was not reset and keeps its prior derived
+        // values, so re-applying to it would double-apply.
+        .filter(|&&id| restrict_to.is_none_or(|ids| ids.contains(&id)))
         .filter(|&&id| matches_target_filter(state, id, &effect.affected_filter, &ctx))
         .filter(|&&id| {
             effect.condition.as_ref().is_none_or(|condition| {
@@ -2025,16 +2551,7 @@ fn apply_continuous_effect(state: &mut GameState, effect: &ActiveContinuousEffec
     // referent. Recipient-relative quantities ("attached to it", "other",
     // "shares a type with it") need the affected object bound before
     // resolution, so those defer into the per-recipient loop below.
-    let dynamic_pt_expr = match &effect.modification {
-        ContinuousModification::SetDynamicPower { value }
-        | ContinuousModification::SetDynamicToughness { value }
-        | ContinuousModification::SetPowerDynamic { value }
-        | ContinuousModification::SetToughnessDynamic { value }
-        | ContinuousModification::AddDynamicPower { value }
-        | ContinuousModification::AddDynamicToughness { value }
-        | ContinuousModification::AddDynamicKeyword { value, .. } => Some(value),
-        _ => None,
-    };
+    let dynamic_pt_expr = modification_dynamic_quantity(&effect.modification);
     let effect_controller = state
         .objects
         .get(&effect.source_id)
@@ -3077,7 +3594,7 @@ mod tests {
         assert_eq!(state.objects[&bear].toughness, Some(2));
 
         state.players[0].life = 27;
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
         assert_eq!(state.objects[&bear].power, Some(4));
         assert_eq!(state.objects[&bear].toughness, Some(4));
@@ -3275,11 +3792,11 @@ mod tests {
     #[test]
     fn test_layers_dirty_flag_cleared() {
         let mut state = setup();
-        assert!(state.layers_dirty);
+        assert!(state.layers_dirty.is_dirty());
 
         evaluate_layers(&mut state);
 
-        assert!(!state.layers_dirty);
+        assert!(!state.layers_dirty.is_dirty());
     }
 
     #[test]
@@ -3386,7 +3903,7 @@ mod tests {
             .attachments
             .push(equipment);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let equipped = state.objects.get(&bear).unwrap();
@@ -4243,7 +4760,7 @@ mod tests {
         state.battlefield.retain(|&id| id != lord);
 
         // Re-evaluate
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let bear_obj = state.objects.get(&bear).unwrap();
@@ -4343,7 +4860,7 @@ mod tests {
         // Real attach pipeline: sets `attached_to` + host `attachments`.
         attach_to(&mut state, mutation, bear);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&bear).unwrap();
@@ -4416,7 +4933,7 @@ mod tests {
 
         evaluate_layers(&mut state);
         state.battlefield.retain(|&id| id != suppressor);
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&target).unwrap();
@@ -4470,7 +4987,7 @@ mod tests {
             .contains(&CoreType::Creature));
 
         state.battlefield.retain(|&id| id != animator);
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&artifact).unwrap();
@@ -4501,7 +5018,7 @@ mod tests {
         assert_eq!(state.objects[&bear].color, vec![ManaColor::Blue]);
 
         state.battlefield.retain(|&id| id != painter);
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         assert!(
@@ -4547,7 +5064,7 @@ mod tests {
             .static_definitions
             .push(cda);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&shapeshifter).unwrap();
@@ -4578,7 +5095,7 @@ mod tests {
             .static_definitions
             .push(def);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         // The bear should have all creature types via the post-fixup
@@ -4630,7 +5147,7 @@ mod tests {
         obj.static_definitions.push(cda);
         obj.static_definitions.push(non_cda);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&shapeshifter).unwrap();
@@ -4677,7 +5194,7 @@ mod tests {
             );
         }
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&land).unwrap();
@@ -4715,7 +5232,7 @@ mod tests {
             );
         }
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&land).unwrap();
@@ -4757,7 +5274,7 @@ mod tests {
             );
         }
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&mimic).unwrap();
@@ -4814,7 +5331,7 @@ mod tests {
             );
         }
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&target).unwrap();
@@ -4870,7 +5387,7 @@ mod tests {
             );
         }
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&target).unwrap();
@@ -4920,7 +5437,7 @@ mod tests {
             );
         }
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&target).unwrap();
@@ -4971,7 +5488,7 @@ mod tests {
         }
 
         // Empty graveyards: 0 card types → P/T = 0/1
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
         let obj = state.objects.get(&goyf).unwrap();
         assert_eq!(obj.power, Some(0), "No card types in graveyards → power 0");
@@ -4994,7 +5511,7 @@ mod tests {
             .push(CoreType::Creature);
         state.players[0].graveyard.push_back(gy_creature);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
         let obj = state.objects.get(&goyf).unwrap();
         assert_eq!(obj.power, Some(1), "Creature in graveyard → power 1");
@@ -5021,7 +5538,7 @@ mod tests {
             .push(CoreType::Instant);
         state.players[1].graveyard.push_back(gy_instant);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
         let obj = state.objects.get(&goyf).unwrap();
         assert_eq!(obj.power, Some(2), "Creature + Instant → power 2");
@@ -5042,7 +5559,7 @@ mod tests {
         }
         state.players[0].graveyard.push_back(gy_artcreature);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
         let obj = state.objects.get(&goyf).unwrap();
         assert_eq!(
@@ -5324,7 +5841,7 @@ mod tests {
             .static_definitions
             .push(def);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&id).unwrap();
@@ -5399,7 +5916,7 @@ mod tests {
             .static_definitions
             .push(def);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&id).unwrap();
@@ -5473,7 +5990,7 @@ mod tests {
         .into();
 
         // Mark layers dirty and evaluate
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         // Player 0's Ninja should get +1/+1
@@ -6776,7 +7293,7 @@ mod tests {
         let urborg = make_land_with_mana(&mut state, "Urborg", PlayerId(0), ManaColor::Black);
         add_global_land_subtype_static(&mut state, urborg, "Swamp");
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let mountain_obj = state.objects.get(&mountain).unwrap();
@@ -6799,7 +7316,7 @@ mod tests {
         let yavimaya = make_land_with_mana(&mut state, "Yavimaya", PlayerId(0), ManaColor::Green);
         add_global_land_subtype_static(&mut state, yavimaya, "Forest");
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let plains_obj = state.objects.get(&plains).unwrap();
@@ -6818,7 +7335,7 @@ mod tests {
         let urborg2 = make_land_with_mana(&mut state, "Urborg", PlayerId(0), ManaColor::Black);
         add_global_land_subtype_static(&mut state, urborg2, "Swamp");
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let mountain_obj = state.objects.get(&mountain).unwrap();
@@ -6853,7 +7370,7 @@ mod tests {
         let urborg = make_land_with_mana(&mut state, "Urborg", PlayerId(0), ManaColor::Black);
         add_global_land_subtype_static(&mut state, urborg, "Swamp");
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let swamp_obj = state.objects.get(&basic_swamp).unwrap();
@@ -6885,7 +7402,7 @@ mod tests {
         // Silence host warning.
         let _ = host;
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let bear_obj = state.objects.get(&bear).unwrap();
@@ -6979,7 +7496,7 @@ mod tests {
             .static_definitions
             .push(static_def);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         for id in [artifact1, artifact2, artifact3] {
@@ -6992,7 +7509,7 @@ mod tests {
         }
 
         // Idempotency across layer passes: running layers twice must not stack.
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
         for id in [artifact1, artifact2, artifact3] {
             assert_eq!(count_food_abilities(&state.objects[&id]), 1);
@@ -7016,7 +7533,7 @@ mod tests {
                 .push(static_def);
         }
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         assert_eq!(
@@ -7114,7 +7631,7 @@ mod tests {
 
         // Effect expires — drop it from the transient list.
         state.transient_continuous_effects.retain(|e| e.id != eid);
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         assert_eq!(
@@ -7175,7 +7692,7 @@ mod tests {
         // remove doesn't crash on a separate eval cycle.
         evaluate_layers(&mut state);
         state.objects.remove(&bear);
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         // No panic; the diff loop's `get_mut(...).if let Some` swallows it.
         evaluate_layers(&mut state);
     }
@@ -7322,7 +7839,7 @@ mod tests {
         ));
 
         state.battlefield.retain(|&id| id != source);
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&bear).unwrap();
@@ -8219,7 +8736,7 @@ mod tests {
             .attachments
             .push(equipment);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         // (a) The recipient holds the inner static after layer evaluation.
@@ -8481,7 +8998,7 @@ mod tests {
             .attachments
             .push(aura);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let c = state.objects.get(&creature).unwrap();
@@ -8595,7 +9112,7 @@ mod tests {
             .attachments
             .push(aura);
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         evaluate_layers(&mut state);
 
         let c = state.objects.get(&creature).unwrap();

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -969,6 +969,42 @@ pub fn evaluate_condition_for_test(
 pub(crate) static FULL_EVALUATE_LAYERS_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+// Test-only placement toggle for the `StaticSourceIndex` rebuild, used to prove
+// the discriminating regression test goes RED on the (buggy) end-of-pass
+// placement and GREEN on the (correct) top-of-pass placement. Production code
+// ALWAYS rebuilds at the top of the pass (this toggle does not exist outside
+// `cfg(test)`). When `false`, the rebuild is deferred to the END of
+// `evaluate_layers` / `apply_layers_incremental` — which leaves the mid-pass
+// gathers reading the previous pass's stale index, exactly the GAP-1 bug.
+//
+// THREAD-LOCAL (not process-global): engine layer resolution is synchronous, so
+// the production code invoked by a test runs on that test's own thread. A
+// thread-local toggle lets the RED discriminating test flip the placement on its
+// OWN thread only — concurrently-scheduled tests (the GREEN counterpart and
+// every other parallel test) read their own default `true` and are unaffected.
+// A process-global `AtomicBool` here raced under cargo's default parallel runner.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static REBUILD_STATIC_INDEX_AT_TOP: core::cell::Cell<bool> =
+        const { core::cell::Cell::new(true) };
+}
+
+/// Whether to rebuild the static-source index at the TOP of the pass. Always
+/// `true` in production; togglable only under `cfg(test)` for red→green
+/// discrimination.
+#[cfg(test)]
+#[inline]
+fn rebuild_static_index_at_top() -> bool {
+    REBUILD_STATIC_INDEX_AT_TOP.with(core::cell::Cell::get)
+}
+
+/// Production variant: the rebuild is ALWAYS at the top of the pass.
+#[cfg(not(test))]
+#[inline]
+fn rebuild_static_index_at_top() -> bool {
+    true
+}
+
 pub fn evaluate_layers(state: &mut GameState) {
     #[cfg(test)]
     FULL_EVALUATE_LAYERS_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1049,6 +1085,19 @@ pub fn evaluate_layers(state: &mut GameState) {
             obj.sync_missing_base_characteristics();
             obj.keywords = obj.base_keywords.clone();
         }
+    }
+
+    // CR 611.2 + CR 613.1: Rebuild the static-effect-source index from the
+    // just-reset base `static_definitions` so the Copy / main gathers below
+    // iterate the current pass's generator set. MUST run AFTER the Step-1 reset
+    // (so the predicate reads base, not stale post-layer, definitions) and
+    // BEFORE the first gather (so the mid-pass consults are fresh — unlike
+    // `TriggerIndex` this index is read INSIDE the pass, so its rebuild is
+    // top-of-pass, not end-of-pass). The `rebuild_static_index_at_top` guard is
+    // ALWAYS true in production; it is togglable only under `cfg(test)` for the
+    // red→green discriminating regression test.
+    if rebuild_static_index_at_top() {
+        crate::types::game_state::StaticSourceIndex::rebuild_from_state(state);
     }
 
     // Step 2: Apply copy effects first so copied static abilities exist before later layers.
@@ -1218,6 +1267,13 @@ pub fn evaluate_layers(state: &mut GameState) {
     // trigger set — CR 603.2 requires the post-layer view. Destructive
     // rebuild replaces both `by_key` and `unclassified` from scratch.
     crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
+
+    // Test-only: the (buggy) end-of-pass placement of the static-source-index
+    // rebuild, exercised only when `rebuild_static_index_at_top()` is toggled
+    // off. Production always rebuilds at the top (above) and never reaches here.
+    if !rebuild_static_index_at_top() {
+        crate::types::game_state::StaticSourceIndex::rebuild_from_state(state);
+    }
 
     // Step 5: Clear dirty flag. A full evaluation satisfies any pending request
     // (Clean / EnteredObjects / Full).
@@ -1592,6 +1648,20 @@ fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectI
         }
     }
 
+    // CR 611.2 + CR 613.1: Rebuild the static-effect-source index before the
+    // incremental gathers. The incremental path only resets `entered_ids` to
+    // base; pre-existing generators keep their already-derived
+    // `static_definitions`, which for a generator still carries its continuous
+    // def — so a full-battlefield rebuild here lists every current generator
+    // (pre-existing + entered). An entered base generator never reaches this
+    // path (`entered_object_blocks_incremental` escalates it to a full eval), so
+    // this is purely a freshness guarantee for the incremental gather. The
+    // `rebuild_static_index_at_top` guard is ALWAYS true in production; togglable
+    // only under `cfg(test)`.
+    if rebuild_static_index_at_top() {
+        crate::types::game_state::StaticSourceIndex::rebuild_from_state(state);
+    }
+
     // Step 2: Copy effects first (Layer 1), restricted to entered objects.
     let copy_effects = gather_active_effects_for_layer(state, Layer::Copy);
     let ordered_copy = order_active_continuous_effects(Layer::Copy, &copy_effects, state);
@@ -1697,6 +1767,11 @@ fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectI
     // CR 603.6a + CR 611.2e: Rebuild the TriggerIndex so the next event scan
     // sees the entered objects' (and any granted) trigger sets.
     crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
+
+    // Test-only buggy end-of-pass static-index placement (see `evaluate_layers`).
+    if !rebuild_static_index_at_top() {
+        crate::types::game_state::StaticSourceIndex::rebuild_from_state(state);
+    }
 }
 
 fn gather_active_effects_for_layer(state: &GameState, layer: Layer) -> Vec<ActiveContinuousEffect> {
@@ -1776,30 +1851,74 @@ fn for_each_static_effect_source(
     state: &GameState,
     mut visit: impl FnMut(&GameState, &crate::game::game_object::GameObject),
 ) {
-    // CR 702.26e: Continuous effects generated by phased-out permanents don't
-    // include anything in their set of affected objects — effectively, a
-    // phased-out permanent contributes no continuous effects during layer
-    // evaluation. Skip phased-out sources here rather than filtering later.
-    for &id in &state.battlefield {
-        if state
-            .objects
-            .get(&id)
-            .is_some_and(|obj| obj.is_phased_out())
-        {
-            continue;
-        }
-        if let Some(obj) = state.objects.get(&id) {
-            visit(state, obj);
-        }
-    }
+    // CR 611.2 + CR 613.1: Iterate the static-effect-source index buckets
+    // instead of scanning the full battlefield / command zone. The index lists
+    // only objects that GENERATE ≥1 continuous effect (rebuilt at the top of
+    // every layer pass — see `static_source_index.rs`), so this loop is
+    // O(generators) rather than O(battlefield). The per-object gates below are
+    // retained verbatim; the index only narrows WHICH ids to look at.
+    //
+    // Defense-in-depth: a never-yet-evaluated `&GameState` (post-deserialize, or
+    // a hand-built test state that never ran a flush — e.g. an off-zone keyword
+    // query against a command-zone emblem before any layer pass) has an empty
+    // index but a non-empty battlefield and/or command zone.
+    // `for_each_static_effect_source` takes `&GameState` and cannot rebuild, so
+    // fall back to a direct battlefield + command scan when BOTH indexed buckets
+    // are empty AND either source zone is non-empty. (Gating only on the
+    // battlefield would miss a command-zone-only emblem board — see
+    // `command_zone_emblem_grants_keyword_to_non_battlefield_card`.)
+    let index = &state.static_source_index;
+    let use_fallback = index.battlefield_sources.is_empty()
+        && index.command_sources.is_empty()
+        && (!state.battlefield.is_empty() || !state.command_zone.is_empty());
 
-    // CR 114.3: Emblems in the command zone have static abilities that affect the game.
-    for &id in &state.command_zone {
-        let Some(obj) = state.objects.get(&id) else {
-            continue;
-        };
-        if obj.is_emblem {
+    if use_fallback {
+        // CR 702.26e: phased-out permanents contribute no continuous effects.
+        for &id in &state.battlefield {
+            if state
+                .objects
+                .get(&id)
+                .is_some_and(|obj| obj.is_phased_out())
+            {
+                continue;
+            }
+            if let Some(obj) = state.objects.get(&id) {
+                visit(state, obj);
+            }
+        }
+        // CR 114.3: command-zone emblems have static abilities that affect the game.
+        for &id in &state.command_zone {
+            let Some(obj) = state.objects.get(&id) else {
+                continue;
+            };
+            if obj.is_emblem {
+                visit(state, obj);
+            }
+        }
+    } else {
+        // CR 702.26e: Continuous effects generated by phased-out permanents don't
+        // include anything in their set of affected objects — skip phased-out
+        // sources here rather than filtering later. The index includes them
+        // (they're in `state.battlefield`); the skip below excludes them.
+        for &id in &index.battlefield_sources {
+            let Some(obj) = state.objects.get(&id) else {
+                continue;
+            };
+            if obj.is_phased_out() {
+                continue;
+            }
             visit(state, obj);
+        }
+        // CR 114.3: Emblems in the command zone have static abilities that affect
+        // the game. The index already filtered to `is_emblem` generators; the
+        // gate is re-asserted here for parity with the fallback path.
+        for &id in &index.command_sources {
+            let Some(obj) = state.objects.get(&id) else {
+                continue;
+            };
+            if obj.is_emblem {
+                visit(state, obj);
+            }
         }
     }
 
@@ -3483,7 +3602,7 @@ mod tests {
         StaticDefinition, TargetFilter, TriggerCondition, TypeFilter, TypedFilter, ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
-    use crate::types::game_state::TransientContinuousEffect;
+    use crate::types::game_state::{StaticSourceIndex, TransientContinuousEffect};
     use crate::types::identifiers::CardId;
     use crate::types::keywords::Keyword;
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
@@ -9438,5 +9557,168 @@ mod tests {
                 zone: Zone::Battlefield,
             }
         ));
+    }
+
+    /// Build an anthem-style "creatures you control get +1/+1" continuous-static
+    /// permanent (a generator) on the battlefield for `player`. Sets only
+    /// `static_definitions`; `sync_missing_base_characteristics` (run at the top
+    /// of the Step-1 reset) copies it into `base_static_definitions`, so the
+    /// generator survives the per-pass reset.
+    fn make_anthem(state: &mut GameState, name: &str, player: PlayerId) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(0),
+            player,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let ts = state.next_timestamp();
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.base_card_types = obj.card_types.clone();
+        obj.timestamp = ts;
+        obj.static_definitions.push(
+            StaticDefinition::continuous()
+                .affected(TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::You),
+                ))
+                .modifications(vec![
+                    ContinuousModification::AddPower { value: 1 },
+                    ContinuousModification::AddToughness { value: 1 },
+                ]),
+        );
+        id
+    }
+
+    /// GAP-1 / GAP-B discriminating regression test (FIX B): a SECOND anthem that
+    /// ENTERS the battlefield between layer evaluations must be picked up by the
+    /// static-source index for its own pass.
+    ///
+    /// A PRE-EXISTING generator (anthem A) is seeded so the index is genuinely
+    /// NON-EMPTY after the first `evaluate_layers` — this DISARMS the empty-index
+    /// direct-scan fallback in `for_each_static_effect_source`. A vanilla seed
+    /// would leave the index empty, the fallback would fire, and the entered
+    /// anthem would be seen even on the buggy end-of-pass placement, so the test
+    /// would NOT discriminate (this is exactly the FIX-B requirement).
+    ///
+    /// With the correct TOP-of-pass rebuild, the rebuild at the top of the
+    /// (escalated) full eval includes anthem B before the gather, so BOTH A's and
+    /// B's +1/+1 buffs apply → creature shows +2/+2. On the buggy end-of-pass
+    /// rebuild placement (toggled via `REBUILD_STATIC_INDEX_AT_TOP = false`), the
+    /// non-empty index from the previous pass is stale (missing B) during B's own
+    /// pass, so only A's buff applies → creature shows +1/+1 → the test FAILS.
+    #[test]
+    fn entered_second_anthem_applies_with_preexisting_generator() {
+        let mut state = setup();
+
+        // PRE-EXISTING generator (anthem A) + a creature for the anthems to buff.
+        make_anthem(&mut state, "Anthem A", PlayerId(0));
+        let creature = make_creature(&mut state, "Bear", 2, 2, PlayerId(0));
+
+        // First full eval: index becomes {A} — NON-EMPTY, fallback disarmed.
+        evaluate_layers(&mut state);
+        assert!(
+            !state.static_source_index.battlefield_sources.is_empty(),
+            "pre-existing anthem A must populate the index so the empty-index \
+             fallback is disarmed (FIX B)"
+        );
+        let after_a = state.objects.get(&creature).unwrap();
+        assert_eq!(after_a.power, Some(3), "anthem A alone gives +1/+1");
+        assert_eq!(after_a.toughness, Some(3));
+
+        // Enter a SECOND anthem B via the real entry path. B is itself a
+        // generator, so `entered_object_blocks_incremental` escalates the flush
+        // to a full `evaluate_layers`, whose top-of-pass rebuild must include B.
+        let b = make_anthem(&mut state, "Anthem B", PlayerId(0));
+        mark_layers_entered(&mut state, b);
+        flush_layers(&mut state);
+
+        // BOTH anthems' buffs must apply: 2/2 base + A(+1/+1) + B(+1/+1) = 4/4.
+        let after_b = state.objects.get(&creature).unwrap();
+        assert_eq!(
+            after_b.power,
+            Some(4),
+            "creature must receive BOTH anthem A's and the just-entered anthem \
+             B's +1/+1 (the entered generator must be in the index for its own \
+             pass — top-of-pass rebuild)"
+        );
+        assert_eq!(after_b.toughness, Some(4));
+    }
+
+    /// FIX-B counterpart: the SAME scenario under the buggy end-of-pass rebuild
+    /// placement MUST fail to apply anthem B's buff, proving the test above
+    /// genuinely discriminates the placement (red on end-of-pass).
+    #[test]
+    fn entered_second_anthem_is_dropped_on_end_of_pass_rebuild() {
+        // The toggle is THREAD-LOCAL, so flipping it affects only THIS test's
+        // thread — concurrently-scheduled parallel tests read their own default
+        // `true` and are unaffected. catch_unwind restores it for cleanliness in
+        // case this thread is reused by a later test on the same worker.
+        REBUILD_STATIC_INDEX_AT_TOP.with(|t| t.set(false));
+        let result = std::panic::catch_unwind(|| {
+            let mut state = setup();
+            make_anthem(&mut state, "Anthem A", PlayerId(0));
+            let creature = make_creature(&mut state, "Bear", 2, 2, PlayerId(0));
+            evaluate_layers(&mut state);
+            assert!(!state.static_source_index.battlefield_sources.is_empty());
+
+            let b = make_anthem(&mut state, "Anthem B", PlayerId(0));
+            mark_layers_entered(&mut state, b);
+            flush_layers(&mut state);
+            state.objects.get(&creature).unwrap().power
+        });
+        REBUILD_STATIC_INDEX_AT_TOP.with(|t| t.set(true));
+
+        let power = result.expect("scenario should not panic");
+        // On the buggy end-of-pass placement, the stale (non-empty) index is
+        // missing B during B's pass, so only A's +1/+1 applies → 3, NOT 4.
+        assert_eq!(
+            power,
+            Some(3),
+            "end-of-pass placement must DROP the entered anthem B's buff — this \
+             is the bug the top-of-pass rebuild fixes; if this is Some(4) the \
+             test no longer discriminates the placement"
+        );
+    }
+
+    /// Set + order identity: the index-driven gather must produce the same
+    /// `collect_shared_active_continuous_effects` vector (element-for-element) as
+    /// a full battlefield scan, including for a board with an unrelated vanilla
+    /// permanent that the index correctly excludes.
+    #[test]
+    fn index_gather_matches_full_scan_set_and_order() {
+        let mut state = setup();
+        make_anthem(&mut state, "Anthem A", PlayerId(0));
+        make_creature(&mut state, "Bear", 2, 2, PlayerId(0));
+        // Unrelated vanilla permanent (NOT a generator) — must not appear as a
+        // source in either path.
+        make_creature(&mut state, "Vanilla", 1, 1, PlayerId(0));
+
+        evaluate_layers(&mut state);
+
+        // Index-driven gather (index is populated by the eval above).
+        let indexed = collect_shared_active_continuous_effects(&state);
+
+        // Force the empty-index direct-scan fallback by clearing the index, then
+        // gather again — this exercises the full battlefield + command scan path.
+        state.static_source_index = StaticSourceIndex::default();
+        let full_scan = collect_shared_active_continuous_effects(&state);
+
+        assert_eq!(
+            indexed.len(),
+            full_scan.len(),
+            "index-driven and full-scan gathers must produce the same number of \
+             effects"
+        );
+        for (i, (a, b)) in indexed.iter().zip(full_scan.iter()).enumerate() {
+            assert_eq!(
+                a.source_id, b.source_id,
+                "effect {i}: source_id must match between index and full-scan"
+            );
+            assert_eq!(
+                a.layer, b.layer,
+                "effect {i}: layer must match between index and full-scan"
+            );
+        }
     }
 }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -475,6 +475,132 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
     }
 }
 
+/// CR 611.3a: ENTRY-AWARE narrowing for a population-sensitive source-level
+/// enabling CONDITION. `static_condition_uses_object_population` proves a
+/// condition *can* gate on board population; this proves a SPECIFIC entering
+/// object can actually perturb that population input (so the gate might flip for
+/// the whole recipient set).
+///
+/// Monotonicity: reached only for battlefield ENTRIES. An entry only ADDS
+/// objects, so a count/devotion gate only flips by the entered object joining
+/// the population, and `IsPresent` only flips false→true via a matching member.
+/// `ctx` is built from the condition's SOURCE object (CR 109.5 controller
+/// rebinding) by the caller.
+///
+/// EXHAUSTIVE and wildcard-free, mirroring `static_condition_uses_object_population`:
+/// every `false` arm there is `false` here; every `true` arm there is narrowed
+/// to a membership / threshold-perturb test, with conservative `true` where a
+/// precise membership test is awkward (over-escalation is safe).
+fn entered_object_perturbs_static_condition(
+    state: &GameState,
+    entered_id: ObjectId,
+    ctx: &FilterContext<'_>,
+    condition: &StaticCondition,
+) -> bool {
+    match condition {
+        StaticCondition::QuantityComparison { lhs, rhs, .. } => {
+            entered_perturbs_static_quantity(state, entered_id, ctx, lhs)
+                || entered_perturbs_static_quantity(state, entered_id, ctx, rhs)
+        }
+        // CR 700.5: devotion gate flips only if the entered object's mana cost
+        // contributes a symbol for one of the gate colors (mirrors the Devotion
+        // magnitude leaf). LOW-1: controller-blind.
+        StaticCondition::DevotionGE { colors, .. } => {
+            state.objects.get(&entered_id).is_some_and(|entered| {
+                crate::game::quantity::entered_object_perturbs_quantity_expr(
+                    state,
+                    entered,
+                    ctx,
+                    &QuantityExpr::Ref {
+                        qty: crate::types::ability::QuantityRef::Devotion {
+                            colors: crate::types::ability::DevotionColors::Fixed(colors.clone()),
+                        },
+                    },
+                )
+            })
+        }
+        // "you control [filter]" / "a [filter] is on the battlefield". A present
+        // filter flips only via a matching member; an absent filter is an
+        // unqualified presence check — conservatively perturb on any entry.
+        StaticCondition::IsPresent { filter } => match filter {
+            Some(f) => matches_target_filter(state, entered_id, f, ctx),
+            None => true,
+        },
+        // CR 509.1b: defending-player board-count gate — flips via a matching
+        // member entering. (ctx controller is the source's, not the defender's;
+        // membership over-approximates, which is safe.)
+        StaticCondition::DefendingPlayerControls { filter } => {
+            matches_target_filter(state, entered_id, filter, ctx)
+        }
+        // Commander presence — conservatively perturb (a commander entering can
+        // flip it; not worth a precise commander membership test here).
+        StaticCondition::ControlsCommander { .. } => true,
+        StaticCondition::And { conditions } | StaticCondition::Or { conditions } => conditions
+            .iter()
+            .any(|c| entered_object_perturbs_static_condition(state, entered_id, ctx, c)),
+        StaticCondition::Not { condition } => {
+            entered_object_perturbs_static_condition(state, entered_id, ctx, condition)
+        }
+        // Unknown text — conservatively perturb so an unrecognized population gate
+        // can never silently under-escalate.
+        StaticCondition::Unrecognized { .. } => true,
+        // Identical enumeration to the `false` arm of
+        // `static_condition_uses_object_population`: source-local, chosen-
+        // attribute, combat, player-scoped, turn/phase, recipient-context, source
+        // zone, and cast-history gates — none read board population, so an entry
+        // cannot perturb them.
+        StaticCondition::ChosenColorIs { .. }
+        | StaticCondition::ChosenLabelIs { .. }
+        | StaticCondition::HasMaxSpeed
+        | StaticCondition::SpeedGE { .. }
+        | StaticCondition::DayNightIs { .. }
+        | StaticCondition::HasCounters { .. }
+        | StaticCondition::RecipientHasCounters { .. }
+        | StaticCondition::ClassLevelGE { .. }
+        | StaticCondition::SourceAttackingAlone
+        | StaticCondition::SourceIsAttacking
+        | StaticCondition::SourceIsBlocking
+        | StaticCondition::SourceIsBlocked
+        | StaticCondition::IsMonarch
+        | StaticCondition::NoMonarch
+        | StaticCondition::HasCityBlessing
+        | StaticCondition::CompletedADungeon
+        | StaticCondition::WasStartingPlayer { .. }
+        | StaticCondition::SpellCastWithVariantThisTurn { .. }
+        | StaticCondition::OpponentPoisonAtLeast { .. }
+        | StaticCondition::UnlessPay { .. }
+        | StaticCondition::DuringYourTurn
+        | StaticCondition::SourceEnteredThisTurn
+        | StaticCondition::IsRingBearer
+        | StaticCondition::RingLevelAtLeast { .. }
+        | StaticCondition::SourceIsTapped
+        | StaticCondition::SourceControllerEquals { .. }
+        | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsMonstrous
+        | StaticCondition::SourceAttachedToCreature
+        | StaticCondition::SourceMatchesFilter { .. }
+        | StaticCondition::RecipientMatchesFilter { .. }
+        | StaticCondition::SourceIsPaired
+        | StaticCondition::SourceInZone { .. }
+        | StaticCondition::EnchantedIsFaceDown
+        | StaticCondition::AdditionalCostPaid
+        | StaticCondition::None => false,
+    }
+}
+
+/// Bridge: route a condition operand `QuantityExpr` through the quantity
+/// module's entry-aware classifier (resolving the entered object).
+fn entered_perturbs_static_quantity(
+    state: &GameState,
+    entered_id: ObjectId,
+    ctx: &FilterContext<'_>,
+    expr: &QuantityExpr,
+) -> bool {
+    state.objects.get(&entered_id).is_some_and(|entered| {
+        crate::game::quantity::entered_object_perturbs_quantity_expr(state, entered, ctx, expr)
+    })
+}
+
 fn source_condition_gate_passes(
     state: &GameState,
     condition: &StaticCondition,
@@ -1157,7 +1283,10 @@ pub fn flush_layers(state: &mut GameState) {
 ///    object receives its timestamp on zone entry. CR 613.8a: dependency/timestamp
 ///    ordering operates on the live set. This scan is O(active-effect-count), NOT
 ///    O(battlefield).
-fn incremental_flush_must_escalate(state: &GameState, entered_ids: &HashSet<ObjectId>) -> bool {
+pub(crate) fn incremental_flush_must_escalate(
+    state: &GameState,
+    entered_ids: &HashSet<ObjectId>,
+) -> bool {
     // Axis 1 — per-entered preconditions.
     for &id in entered_ids {
         let Some(obj) = state.objects.get(&id) else {
@@ -1170,51 +1299,107 @@ fn incremental_flush_must_escalate(state: &GameState, entered_ids: &HashSet<Obje
         }
     }
 
-    // Axis 2a — magnitude + affected-set over the EXISTING active effect set.
+    // Axis 2a — magnitude + affected-set over the EXISTING active effect set,
+    // NARROWED to entries that actually perturb the population input.
+    //
+    // Two-stage test per effect: the committed exhaustive classifier
+    // (`quantity_expr_uses_object_count` / `affected_filter_uses_object_population`)
+    // is the OUTER conjunct (compile-time tripwire — a future population-reading
+    // variant forces a classification). Then the entry-aware narrowing layer asks
+    // whether any ENTERED object can flip THIS effect's population input.
+    //
+    // CR 109.5: the filter's "you control" must resolve against the EFFECT
+    // SOURCE's controller, not the entered object's — so `ctx` is built per-effect
+    // from `e.source_id` + `e.controller`. Escalation is `classifier(e) &&
+    // any_entered_perturbs(e)`; both required.
     if collect_shared_active_continuous_effects(state)
         .iter()
         .any(|e| {
-            modification_dynamic_quantity(&e.modification)
-                .is_some_and(crate::game::quantity::quantity_expr_uses_object_count)
-                || crate::game::filter::affected_filter_uses_object_population(&e.affected_filter)
+            let magnitude = modification_dynamic_quantity(&e.modification);
+            let magnitude_sensitive =
+                magnitude.is_some_and(crate::game::quantity::quantity_expr_uses_object_count);
+            let affected_sensitive =
+                crate::game::filter::affected_filter_uses_object_population(&e.affected_filter);
+            if !magnitude_sensitive && !affected_sensitive {
+                return false;
+            }
+            let ctx = FilterContext::from_source_with_controller(e.source_id, e.controller);
+            entered_ids.iter().any(|id| {
+                let Some(entered) = state.objects.get(id) else {
+                    return false;
+                };
+                (magnitude_sensitive
+                    && magnitude.is_some_and(|expr| {
+                        crate::game::quantity::entered_object_perturbs_quantity_expr(
+                            state, entered, &ctx, expr,
+                        )
+                    }))
+                    || (affected_sensitive
+                        && crate::game::filter::entered_object_perturbs_affected_filter(
+                            state,
+                            *id,
+                            &ctx,
+                            &e.affected_filter,
+                        ))
+            })
         })
     {
         return true;
     }
 
     // Axis 2b — source-level enabling CONDITION over the EXISTING static-ability
-    // sources. The condition axis CANNOT be read off the collected
-    // `ActiveContinuousEffect`s: `active_continuous_effects_from_static_definitions`
-    // evaluates a non-recipient-context (source-level) condition as a gate at
-    // COLLECTION time and stores `condition: None` on the resulting effect (only
-    // recipient-context conditions are retained for per-recipient re-evaluation).
-    // So a board-population gate like "as long as you control N creatures" is
-    // already consumed and invisible on the active-effect set. We must inspect the
-    // intact `StaticDefinition.condition` on each live source instead.
+    // sources, NARROWED to entries that actually perturb the condition. The
+    // condition axis CANNOT be read off the collected `ActiveContinuousEffect`s:
+    // `active_continuous_effects_from_static_definitions` evaluates a
+    // non-recipient-context (source-level) condition as a gate at COLLECTION time
+    // and stores `condition: None` on the resulting effect (only recipient-context
+    // conditions are retained for per-recipient re-evaluation). So a board-
+    // population gate like "as long as you control N creatures" is already consumed
+    // and invisible on the active-effect set. We must inspect the intact
+    // `StaticDefinition.condition` on each live source instead.
     //
     // CR 611.3a: when such a source-level enabling condition depends on board
     // population, an object entering can flip the condition for the WHOLE recipient
-    // set, changing PRE-EXISTING recipients — so escalate to a full rebuild.
-    any_active_static_condition_uses_object_population(state)
+    // set, changing PRE-EXISTING recipients — so escalate to a full rebuild. The
+    // entry-aware narrowing (built per-source from the visited object, CR 109.5)
+    // skips escalation when no entered object can flip the gate.
+    any_active_static_condition_perturbed_by_entry(state, entered_ids)
 }
 
 /// Scan every live static-ability source for a CONTINUOUS `StaticDefinition`
-/// whose enabling `condition` is board-population-dependent. Walks the same
-/// source set as `collect_shared_active_continuous_effects`
-/// (`for_each_static_effect_source`) but reads the intact pre-collection
-/// `condition` field. O(active-source-count); short-circuits on the first match.
-fn any_active_static_condition_uses_object_population(state: &GameState) -> bool {
+/// whose enabling `condition` is board-population-dependent AND that one of the
+/// `entered_ids` actually perturbs. Walks the same source set as
+/// `collect_shared_active_continuous_effects` (`for_each_static_effect_source`)
+/// but reads the intact pre-collection `condition` field.
+/// O(active-source-count × entered-count); short-circuits on the first match.
+///
+/// Two-stage test (mirrors Axis 2a): the committed exhaustive classifier
+/// (`static_condition_uses_object_population`, OUTER conjunct, compile-time
+/// tripwire) gates the entry-aware narrowing
+/// (`entered_object_perturbs_static_condition`). CR 109.5: `ctx` is built per
+/// SOURCE object so the condition's "you control" rebinds to the source's
+/// controller, not the entered object's.
+fn any_active_static_condition_perturbed_by_entry(
+    state: &GameState,
+    entered_ids: &HashSet<ObjectId>,
+) -> bool {
     let mut found = false;
-    for_each_static_effect_source(state, |_state, obj| {
+    for_each_static_effect_source(state, |state, obj| {
         if found {
             return;
         }
+        let ctx = FilterContext::from_source(state, obj.id);
         if obj.static_definitions.iter_all().any(|def| {
-            def.mode == StaticMode::Continuous
-                && def
-                    .condition
-                    .as_ref()
-                    .is_some_and(static_condition_uses_object_population)
+            if def.mode != StaticMode::Continuous {
+                return false;
+            }
+            let Some(condition) = def.condition.as_ref() else {
+                return false;
+            };
+            static_condition_uses_object_population(condition)
+                && entered_ids
+                    .iter()
+                    .any(|id| entered_object_perturbs_static_condition(state, *id, &ctx, condition))
         }) {
             found = true;
         }
@@ -9124,5 +9309,32 @@ mod tests {
              leave the subtype list empty: {:?}",
             c.card_types.subtypes
         );
+    }
+
+    /// CR 113.6c + CR 611.3a: Grist's "as long as ~ isn't on the battlefield"
+    /// parses to `Not(SourceInZone { Battlefield })`. Its truth depends only on
+    /// the SOURCE's own zone, never on board population, so the escalation
+    /// classifier must report it population-INDEPENDENT — the load-bearing fact
+    /// that keeps a colorless-Insect entry off the full-eval path on the real
+    /// Scute board. (The parser side is covered in `oracle_nom::condition`; this
+    /// guards the classifier that consumes the parsed shape.)
+    #[test]
+    fn grist_source_zone_condition_is_not_population_dependent() {
+        let grist = StaticCondition::Not {
+            condition: Box::new(StaticCondition::SourceInZone {
+                zone: Zone::Battlefield,
+            }),
+        };
+        assert!(
+            !static_condition_uses_object_population(&grist),
+            "Not(SourceInZone) gates on the source's own zone, not board \
+             population — must not force escalation"
+        );
+        // And the bare affirmative reading is equally population-independent.
+        assert!(!static_condition_uses_object_population(
+            &StaticCondition::SourceInZone {
+                zone: Zone::Battlefield,
+            }
+        ));
     }
 }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -19,7 +19,7 @@ use crate::types::card_type::{
     is_land_subtype, noncreature_subtype_set, CoreType, SubtypeSet, Supertype,
 };
 use crate::types::counter::{CounterMatch, CounterType};
-use crate::types::game_state::{DayNight, GameState, LayersDirty};
+use crate::types::game_state::{DayNight, GameState, LayersDirty, StaticGateKey};
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 use crate::types::layers::{ActiveContinuousEffect, Layer};
@@ -1204,6 +1204,13 @@ pub fn evaluate_layers(state: &mut GameState) {
         return;
     }
 
+    // CR 611.3a + CR 611.3b: refresh the source-level enabling-condition truth
+    // cache from this fully-derived board. Placed AFTER the ring-normalization
+    // recursion guard so the re-entrant pass writes the final fixpoint cache
+    // once, and BEFORE `layers_dirty = Clean` so a full eval always leaves a
+    // fresh cache for the next incremental flush's truth-delta consult.
+    refresh_static_gate_truth(state);
+
     // CR 603.6a + CR 611.2e: Layer evaluation just finalized post-layer
     // trigger sets on every battlefield permanent (granted triggers from
     // sliver lords, Changeling, Bramble Sovereign, suppress-triggers statics).
@@ -1358,11 +1365,13 @@ pub(crate) fn incremental_flush_must_escalate(
     // and invisible on the active-effect set. We must inspect the intact
     // `StaticDefinition.condition` on each live source instead.
     //
-    // CR 611.3a: when such a source-level enabling condition depends on board
-    // population, an object entering can flip the condition for the WHOLE recipient
-    // set, changing PRE-EXISTING recipients — so escalate to a full rebuild. The
-    // entry-aware narrowing (built per-source from the visited object, CR 109.5)
-    // skips escalation when no entered object can flip the gate.
+    // CR 611.3a + CR 611.3b: when such a source-level enabling condition depends
+    // on board population, an object entering can flip the condition for the
+    // WHOLE recipient set, changing PRE-EXISTING recipients — so escalate to a
+    // full rebuild. The entry-aware narrowing (built per-source from the visited
+    // object, CR 109.5) skips escalation when no entered object can perturb the
+    // gate; the truth-delta refinement (below) skips escalation even when an
+    // entry perturbs the gate INPUT but does not flip its truth value.
     any_active_static_condition_perturbed_by_entry(state, entered_ids)
 }
 
@@ -1373,12 +1382,32 @@ pub(crate) fn incremental_flush_must_escalate(
 /// but reads the intact pre-collection `condition` field.
 /// O(active-source-count × entered-count); short-circuits on the first match.
 ///
-/// Two-stage test (mirrors Axis 2a): the committed exhaustive classifier
-/// (`static_condition_uses_object_population`, OUTER conjunct, compile-time
-/// tripwire) gates the entry-aware narrowing
-/// (`entered_object_perturbs_static_condition`). CR 109.5: `ctx` is built per
-/// SOURCE object so the condition's "you control" rebinds to the source's
-/// controller, not the entered object's.
+/// Three-stage test:
+///  1. The committed exhaustive classifier
+///     (`static_condition_uses_object_population`, OUTER conjunct, compile-time
+///     tripwire) gates the entry-aware narrowing
+///     (`entered_object_perturbs_static_condition`). CR 109.5: `ctx` is built per
+///     SOURCE object so the condition's "you control" rebinds to the source's
+///     controller, not the entered object's.
+///  2. RECIPIENT-CONTEXT gates (CR 611.3b — the effect applies per recipient)
+///     escalate UNCONDITIONALLY when perturbed: their truth is per-recipient and
+///     cannot be summarized by a single board-level boolean
+///     (`source_condition_gate_passes` only over-approximates them). This
+///     preserves the d9a40be71 behavior for that class.
+///  3. SOURCE-LEVEL gates (CR 611.3a — a single on/off switch consumed at
+///     collection): apply the truth-delta short-circuit. The static's BEFORE
+///     truth was cached at the last full eval in `static_gate_truth`; recompute
+///     AFTER against the live post-entry board. Escalate iff `before != after`.
+///     Key absent (source not present / phased out at the last full eval) ->
+///     fail closed (escalate). Soundness rests on `after` being recomputed
+///     authoritatively from the live board, so the test errs only toward
+///     OVER-escalation, never under (safety theorem hypotheses: Continuous mode,
+///     `!condition_uses_recipient_context`, affected-set + magnitude
+///     population-independent — the latter two are escalated first by Axis 2a).
+///
+/// `def_index` indexes the LIVE post-layer `static_definitions` via
+/// `iter_all().enumerate()` — IDENTICAL indexing to `refresh_static_gate_truth`
+/// (invariant 5), so the cached BEFORE truth aligns with the consulted def.
 fn any_active_static_condition_perturbed_by_entry(
     state: &GameState,
     entered_ids: &HashSet<ObjectId>,
@@ -1389,22 +1418,95 @@ fn any_active_static_condition_perturbed_by_entry(
             return;
         }
         let ctx = FilterContext::from_source(state, obj.id);
-        if obj.static_definitions.iter_all().any(|def| {
-            if def.mode != StaticMode::Continuous {
-                return false;
-            }
-            let Some(condition) = def.condition.as_ref() else {
-                return false;
-            };
-            static_condition_uses_object_population(condition)
-                && entered_ids
-                    .iter()
-                    .any(|id| entered_object_perturbs_static_condition(state, *id, &ctx, condition))
-        }) {
+        if obj
+            .static_definitions
+            .iter_all()
+            .enumerate()
+            .any(|(def_index, def)| {
+                if def.mode != StaticMode::Continuous {
+                    return false;
+                }
+                let Some(condition) = def.condition.as_ref() else {
+                    return false;
+                };
+                if !static_condition_uses_object_population(condition) {
+                    return false;
+                }
+                // CR 611.3b: recipient-context gates re-evaluate per recipient —
+                // a single board-level boolean can't summarize them, so escalate
+                // unconditionally when perturbed (preserve d9a40be71).
+                if condition_uses_recipient_context(condition) {
+                    return entered_ids.iter().any(|id| {
+                        entered_object_perturbs_static_condition(state, *id, &ctx, condition)
+                    });
+                }
+                let perturbed = entered_ids.iter().any(|id| {
+                    entered_object_perturbs_static_condition(state, *id, &ctx, condition)
+                });
+                if !perturbed {
+                    return false;
+                }
+                // CR 611.3a source-level truth-delta. A multi-axis static (gate
+                // ON while magnitude/affected-set also population-sensitive) is
+                // already escalated by Axis 2a above, so reaching here means the
+                // condition is the only population-sensitive axis. Fail closed
+                // when the key is absent (invariant 1: source not present /
+                // phased out at the last full eval).
+                let before = match state.static_gate_truth.get(&StaticGateKey {
+                    source: obj.id,
+                    def_index,
+                }) {
+                    Some(&b) => b,
+                    None => return true,
+                };
+                let after = source_condition_gate_passes(state, condition, obj.controller, obj.id);
+                before != after
+            })
+        {
             found = true;
         }
     });
     found
+}
+
+/// CR 611.3a + CR 611.3b: rewrite the source-level enabling-condition truth
+/// cache from the FULLY-DERIVED board. Walks `for_each_static_effect_source`
+/// (which skips phased-out sources, CR 702.26e), and records the gate truth of
+/// every CONTINUOUS static carrying a NON-recipient-context `Some(condition)`,
+/// keyed by `(source, def_index)` on the LIVE post-layer `static_definitions`
+/// (`iter_all().enumerate()` — identical indexing to the consult; see invariant
+/// 5). Recipient-context conditions are EXCLUDED: their truth is per-recipient,
+/// re-evaluated per recipient via `evaluate_condition_with_recipient`, and
+/// `source_condition_gate_passes` is only an over-approximation for them — so
+/// they are never cached and always escalate.
+///
+/// CR 109.5: the gate's "you"/"your" resolves against the SOURCE's controller.
+/// Cleared and repopulated wholesale (keyset is authoritative only for sources
+/// present + non-phased at this full eval; absence at consult fails closed).
+fn refresh_static_gate_truth(state: &mut GameState) {
+    let mut next: std::collections::HashMap<StaticGateKey, bool> = std::collections::HashMap::new();
+    for_each_static_effect_source(state, |state, obj| {
+        for (def_index, def) in obj.static_definitions.iter_all().enumerate() {
+            if def.mode != StaticMode::Continuous {
+                continue;
+            }
+            let Some(condition) = def.condition.as_ref() else {
+                continue;
+            };
+            if condition_uses_recipient_context(condition) {
+                continue;
+            }
+            let truth = source_condition_gate_passes(state, condition, obj.controller, obj.id);
+            next.insert(
+                StaticGateKey {
+                    source: obj.id,
+                    def_index,
+                },
+                truth,
+            );
+        }
+    });
+    state.static_gate_truth = next;
 }
 
 /// True when the entered object cannot be handled by the incremental fast path

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -64,6 +64,7 @@ pub mod scenario_db;
 pub mod speed;
 pub mod stack;
 pub mod static_abilities;
+pub mod static_source_index;
 pub mod targeting;
 pub mod token_presets;
 pub mod transform;

--- a/crates/engine/src/game/morph.rs
+++ b/crates/engine/src/game/morph.rs
@@ -183,7 +183,7 @@ pub fn turn_face_up(
     apply_back_face_to_object(obj, back_face);
     obj.back_face = None;
 
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
 
     events.push(GameEvent::TurnedFaceUp { object_id });
 

--- a/crates/engine/src/game/pairing.rs
+++ b/crates/engine/src/game/pairing.rs
@@ -33,7 +33,7 @@ pub fn pair_objects(
         obj.paired_with = Some(first);
         obj.pair_controller = Some(controller);
     }
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
 }
 
 pub fn break_pair(state: &mut GameState, object_id: ObjectId) {
@@ -48,7 +48,7 @@ pub fn break_pair(state: &mut GameState, object_id: ObjectId) {
                 partner_obj.pair_controller = None;
             }
         }
-        state.layers_dirty = true;
+        crate::game::layers::mark_layers_full(state);
     }
 }
 

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1013,10 +1013,10 @@ pub fn rehydrate_game_from_card_db(state: &mut GameState, db: &CardDatabase) {
     }
 
     if changed_battlefield {
-        state.layers_dirty = true;
+        crate::game::layers::mark_layers_full(state);
     }
 
-    if changed_any || state.layers_dirty {
+    if changed_any || state.layers_dirty.is_dirty() {
         bump_state_revision(state);
         mark_public_state_all_dirty(state);
         finalize_public_state(state);

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -7,7 +7,7 @@ use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 
 use super::derived::derive_display_state;
-use super::layers::evaluate_layers;
+use super::layers::flush_layers;
 use super::turn_control;
 
 /// Finalize outward-facing game state before it leaves the engine boundary.
@@ -21,9 +21,7 @@ pub fn finalize_public_state(state: &mut GameState) {
     // states; cheap on every other invocation.
     state.migrate_post_replacement_continuation();
     sync_priority_player_from_waiting_for(state);
-    if state.layers_dirty {
-        evaluate_layers(state);
-    }
+    flush_layers(state);
     derive_display_state(state);
     clear_public_state_dirty(state);
 }
@@ -106,14 +104,26 @@ fn mark_object_dirty_with_mana(state: &mut GameState, object_id: ObjectId) {
 pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]) {
     // GATE 1 — static/continuous ripple.
     // CR 611.1 + CR 613.1: A continuous effect can modify any object's
-    // characteristics across the whole board; if layers were re-evaluated this
-    // action (`layers_dirty`), display state for the entire board is potentially
-    // stale, so recompute all of it. This single check covers anthems,
-    // type-changers, keyword-granters, CDAs, control changes, P/T setters, and
-    // every transient continuous effect — they all set `layers_dirty`.
-    if state.layers_dirty {
-        mark_public_state_all_dirty(state);
-        return;
+    // characteristics across the whole board; if a FULL layer re-evaluation is
+    // pending this action, display state for the entire board is potentially
+    // stale, so recompute all of it. This covers anthems, type-changers,
+    // keyword-granters, CDAs, control changes, P/T setters, and every transient
+    // continuous effect — they all request a full layer flush.
+    //
+    // An `EnteredObjects` request is an incremental layer flush that only
+    // re-derives the entering objects (see `flush_layers`); it does NOT ripple
+    // board-wide, so it falls through to GATE 2. `finalize_public_state` runs
+    // `flush_layers` immediately after this function, and the incremental path
+    // marks each entered object (and the battlefield display) dirty itself, so
+    // the entered objects' display is recomputed. The entry's own
+    // `ZoneChanged` event is also handled by GATE 2 below.
+    match &state.layers_dirty {
+        crate::types::game_state::LayersDirty::Full => {
+            mark_public_state_all_dirty(state);
+            return;
+        }
+        crate::types::game_state::LayersDirty::Clean
+        | crate::types::game_state::LayersDirty::EnteredObjects(_) => {}
     }
 
     // GATE 2 — per-event targeted marking. `layers_dirty` was NOT set, so no
@@ -496,11 +506,14 @@ mod tests {
         // before classifying — exactly the state `apply()` reaches when layers
         // are not pending.
         assert!(
-            state.layers_dirty,
+            state.layers_dirty.is_dirty(),
             "real copy resolver must set layers_dirty"
         );
         evaluate_layers(&mut state);
-        assert!(!state.layers_dirty, "evaluate_layers clears layers_dirty");
+        assert!(
+            !state.layers_dirty.is_dirty(),
+            "evaluate_layers clears layers_dirty"
+        );
 
         clear_public_state_dirty(&mut state);
         mark_public_state_from_events(&mut state, &events);
@@ -521,31 +534,72 @@ mod tests {
         assert!(!dirty.all_players_dirty, "no player-wide change occurred");
     }
 
-    /// CORRECTNESS-FALLBACK: a real battlefield entry leaves `layers_dirty` set
-    /// (the resolver sets it because a static-bearing object or board static
-    /// could newly apply — Section 4 suppression is not in scope here), so
-    /// Gate 1 escalates to a full all-dirty recompute.
+    /// A real battlefield entry now leaves `layers_dirty` in the
+    /// `EnteredObjects` state (the resolver requests an incremental re-derive of
+    /// just the entering token). Gate 1 must NOT escalate to all-dirty for that
+    /// case — it falls through to Gate 2 targeted marking, and the subsequent
+    /// `flush_layers` incremental path produces the same display as a full
+    /// recompute (asserted via the differential test below).
     #[test]
-    fn battlefield_entry_with_layers_pending_escalates_to_all_dirty() {
+    fn battlefield_entry_with_layers_pending_stays_targeted() {
         let mut state = GameState::new_two_player(42);
+        // Settle layers to Clean first: a fresh state initializes `Full`, which
+        // would absorb the entry's `mark_entered` (Full subsumes EnteredObjects).
+        // The real engine reaches this site with layers already flushed.
+        flush_layers(&mut state);
         let (_source_id, events) = resolve_real_copy_token(&mut state);
 
         assert!(
-            state.layers_dirty,
-            "real entry must leave layers pending (Gate 1 input)"
+            matches!(
+                state.layers_dirty,
+                crate::types::game_state::LayersDirty::EnteredObjects(_)
+            ),
+            "real entry must request an incremental layer re-derive (Gate 1 input)"
         );
 
         clear_public_state_dirty(&mut state);
         mark_public_state_from_events(&mut state, &events);
 
         assert!(
-            state.public_state_dirty.all_objects_dirty,
-            "Gate 1 must escalate to all-objects when layers_dirty is set"
+            !state.public_state_dirty.all_objects_dirty,
+            "Gate 1 must NOT escalate to all-objects for an incremental entry"
         );
+    }
+
+    /// EnteredObjects-path display == full-recompute display. Drives the real
+    /// incremental `flush_layers` path through `finalize_public_state` and
+    /// compares per-object display fields against a forced all-dirty
+    /// full-evaluate finalize on the same pre-flush state.
+    #[test]
+    fn incremental_entry_display_matches_full_recompute() {
+        let mut base = GameState::new_two_player(42);
+        // Settle layers to Clean so the entry below requests EnteredObjects
+        // (a fresh state's initial Full would subsume it).
+        flush_layers(&mut base);
+        let (_src, events) = resolve_real_copy_token(&mut base);
         assert!(
-            state.public_state_dirty.all_players_dirty,
-            "Gate 1 must escalate to all-players when layers_dirty is set"
+            matches!(
+                base.layers_dirty,
+                crate::types::game_state::LayersDirty::EnteredObjects(_)
+            ),
+            "entry must request incremental re-derive"
         );
+
+        // Incremental path: targeted marking + finalize (runs flush_layers
+        // incremental).
+        let mut incremental = base.clone();
+        clear_public_state_dirty(&mut incremental);
+        mark_public_state_from_events(&mut incremental, &events);
+        finalize_public_state(&mut incremental);
+
+        // Full path: force a full layer flush + all-dirty recompute on the same
+        // pre-flush state.
+        let mut forced = base.clone();
+        forced.layers_dirty = crate::types::game_state::LayersDirty::Full;
+        mark_public_state_all_dirty(&mut forced);
+        finalize_public_state(&mut forced);
+
+        assert_display_state_eq(&incremental, &forced, "incremental copy entry");
     }
 
     /// DIFFERENTIAL: targeted marking + finalize produces per-object/per-player
@@ -558,7 +612,7 @@ mod tests {
         let mut base = GameState::new_two_player(42);
         let (_src, events) = resolve_real_copy_token(&mut base);
         evaluate_layers(&mut base);
-        base.layers_dirty = false;
+        base.layers_dirty = crate::types::game_state::LayersDirty::Clean;
 
         let mut targeted = base.clone();
         clear_public_state_dirty(&mut targeted);

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -312,6 +312,187 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
     }
 }
 
+/// CR 611.3a + CR 700.5: ENTRY-AWARE narrowing for a population-sensitive
+/// magnitude. `quantity_expr_uses_object_count` proves an effect's magnitude
+/// *can* read board population; this proves a SPECIFIC entering object can
+/// actually perturb that population input.
+///
+/// Monotonicity (the correctness foundation): the `EnteredObjects` fast path is
+/// reached only for battlefield ENTRIES (leaves always escalate to `Full`).
+/// Entry only ADDS objects, so counts only increase, devotion only increases,
+/// and presence only flips false→true — the ONLY way an entry changes a
+/// population-dependent magnitude is if the entered object is a MEMBER of /
+/// CONTRIBUTES to that population. So an entry-membership test is sufficient.
+///
+/// Mirrors the structural recursion of `quantity_expr_uses_object_count`:
+/// composite arms recurse, the `QuantityRef` leaf classifies each variant.
+/// `ctx` is built from the EFFECT SOURCE (CR 109.5 controller rebinding), so
+/// "you control" filters resolve against the effect's controller — NOT the
+/// entered object's controller.
+pub(crate) fn entered_object_perturbs_quantity_expr(
+    state: &GameState,
+    entered: &crate::game::game_object::GameObject,
+    ctx: &FilterContext<'_>,
+    expr: &QuantityExpr,
+) -> bool {
+    match expr {
+        QuantityExpr::Fixed { .. } => false,
+        QuantityExpr::Ref { qty } => entered_object_perturbs_quantity_ref(state, entered, ctx, qty),
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::Multiply { inner, .. } => {
+            entered_object_perturbs_quantity_expr(state, entered, ctx, inner)
+        }
+        QuantityExpr::Sum { exprs } => exprs
+            .iter()
+            .any(|e| entered_object_perturbs_quantity_expr(state, entered, ctx, e)),
+        QuantityExpr::UpTo { max } => {
+            entered_object_perturbs_quantity_expr(state, entered, ctx, max)
+        }
+        QuantityExpr::Power { exponent, .. } => {
+            entered_object_perturbs_quantity_expr(state, entered, ctx, exponent)
+        }
+        QuantityExpr::Difference { left, right } => {
+            entered_object_perturbs_quantity_expr(state, entered, ctx, left)
+                || entered_object_perturbs_quantity_expr(state, entered, ctx, right)
+        }
+    }
+}
+
+/// CR 611.3a + CR 700.5: entry-membership leaf for
+/// `entered_object_perturbs_quantity_expr`. EXHAUSTIVE and wildcard-free — the
+/// classification mirrors `quantity_ref_uses_object_count`: every `false` arm
+/// THERE is `false` HERE (an object entering can never perturb a value the
+/// classifier already proved population-independent), and every `true` arm
+/// there is narrowed HERE to "does THIS entered object join the population?".
+fn entered_object_perturbs_quantity_ref(
+    state: &GameState,
+    entered: &crate::game::game_object::GameObject,
+    ctx: &FilterContext<'_>,
+    qty: &QuantityRef,
+) -> bool {
+    match qty {
+        // Filter-bearing battlefield-population refs: perturbed iff the entered
+        // object matches the population filter (CR 109.5 controller via `ctx`).
+        QuantityRef::ObjectCount { filter }
+        | QuantityRef::ObjectCountDistinct { filter, .. }
+        | QuantityRef::CountersOnObjects { filter, .. }
+        | QuantityRef::Aggregate { filter, .. }
+        | QuantityRef::ControlledByEachPlayer { filter, .. }
+        | QuantityRef::DistinctColorsAmongPermanents { filter }
+        | QuantityRef::DistinctCounterKindsAmong { filter }
+        | QuantityRef::EnteredThisTurn { filter } => {
+            matches_target_filter(state, entered.id, filter, ctx)
+        }
+        QuantityRef::DistinctCardTypes { source } => match source {
+            CardTypeSetSource::Objects { filter } => {
+                matches_target_filter(state, entered.id, filter, ctx)
+            }
+            // Zone / linked-exile sources are not battlefield population — the
+            // classifier returns false for them, so they cannot be perturbed.
+            CardTypeSetSource::Zone { .. } | CardTypeSetSource::ExiledBySource => false,
+        },
+        // CR 700.5: devotion is perturbed iff the entered object's mana cost
+        // contributes a symbol for one of the fixed colors. `ChosenColor`'s
+        // color isn't statically known, so conservatively perturb (over-
+        // escalation is safe). LOW-1: controller-blind — escalate if ANY
+        // entered object contributes a shard regardless of controller.
+        QuantityRef::Devotion { colors } => match colors {
+            crate::types::ability::DevotionColors::Fixed(cols) => {
+                entered_object_contributes_devotion(entered, cols)
+            }
+            crate::types::ability::DevotionColors::ChosenColor => true,
+        },
+        // CR 305.6: a basic land entering can change the distinct-basic-land-type
+        // count. Synthesizing a precise "land controlled by `controller`" filter
+        // is awkward (the count is per-controller-rebound), so conservatively
+        // perturb whenever the entered object is a land at all.
+        QuantityRef::BasicLandTypeCount { .. } => {
+            entered.card_types.core_types.contains(&CoreType::Land)
+        }
+        // CR 700.8: party is composed of creatures the controller controls — any
+        // creature entry can change party size. Conservatively perturb on any
+        // creature entry rather than re-deriving the party-type maximization.
+        QuantityRef::PartySize { .. } => {
+            entered.card_types.core_types.contains(&CoreType::Creature)
+        }
+        // Player-level, single-object, history-record, payment, and choice refs:
+        // an object's battlefield entry/exit cannot change their value. Identical
+        // enumeration to the `false` arm of `quantity_ref_uses_object_count`.
+        QuantityRef::HandSize { .. }
+        | QuantityRef::LifeTotal { .. }
+        | QuantityRef::GraveyardSize { .. }
+        | QuantityRef::LifeAboveStarting
+        | QuantityRef::StartingLifeTotal
+        | QuantityRef::PlayerCount { .. }
+        | QuantityRef::CountersOn { .. }
+        | QuantityRef::PlayerCounter { .. }
+        | QuantityRef::Variable { .. }
+        | QuantityRef::Power { .. }
+        | QuantityRef::Toughness { .. }
+        | QuantityRef::ObjectManaValue { .. }
+        | QuantityRef::ObjectColorCount { .. }
+        | QuantityRef::ObjectNameWordCount { .. }
+        | QuantityRef::ManaSymbolsInManaCost { .. }
+        | QuantityRef::SelfManaValue
+        | QuantityRef::TargetZoneCardCount { .. }
+        | QuantityRef::CardsExiledBySource
+        | QuantityRef::ZoneCardCount { .. }
+        | QuantityRef::TrackedSetSize
+        | QuantityRef::ExiledFromHandThisResolution
+        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::LifeLostThisTurn { .. }
+        | QuantityRef::Speed { .. }
+        | QuantityRef::EventContextAmount
+        | QuantityRef::AttachmentsOnLeavingObject { .. }
+        | QuantityRef::EventContextSourceCostX
+        | QuantityRef::SpellsCastThisTurn { .. }
+        | QuantityRef::SacrificedThisTurn { .. }
+        | QuantityRef::CrimesCommittedThisTurn
+        | QuantityRef::LifeGainedThisTurn { .. }
+        | QuantityRef::CardsDrawnThisTurn { .. }
+        | QuantityRef::LandsPlayedThisTurn { .. }
+        | QuantityRef::TurnsTaken
+        | QuantityRef::ZoneChangeCountThisTurn { .. }
+        | QuantityRef::DamageDealtThisTurn { .. }
+        | QuantityRef::ChosenNumber
+        | QuantityRef::AttackedThisTurn
+        | QuantityRef::DescendedThisTurn
+        | QuantityRef::LoyaltyAbilitiesActivatedThisTurn { .. }
+        | QuantityRef::SpellsCastLastTurn
+        | QuantityRef::SpellsCastThisGame { .. }
+        | QuantityRef::CounterAddedThisTurn { .. }
+        | QuantityRef::CardsDiscardedThisTurn { .. }
+        | QuantityRef::TokensCreatedThisTurn { .. }
+        | QuantityRef::PlayerActionsThisTurn { .. }
+        | QuantityRef::DungeonsCompleted
+        | QuantityRef::CostXPaid
+        | QuantityRef::KickerCount
+        | QuantityRef::AdditionalCostPaymentCount
+        | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::ManaSpentToCast { .. }
+        | QuantityRef::ColorsInCommandersColorIdentity
+        | QuantityRef::CommanderCastFromCommandZoneCount => false,
+    }
+}
+
+/// CR 700.5: True when the entered object's mana cost carries at least one
+/// shard that contributes to devotion for any of `colors`. Mirrors the per-
+/// object inner loop of `count_devotion` so an entry that adds a matching
+/// symbol perturbs the running devotion total.
+fn entered_object_contributes_devotion(
+    entered: &crate::game::game_object::GameObject,
+    colors: &[ManaColor],
+) -> bool {
+    if let ManaCost::Cost { ref shards, .. } = entered.mana_cost {
+        shards
+            .iter()
+            .any(|shard| colors.iter().any(|c| shard.contributes_to(*c)))
+    } else {
+        false
+    }
+}
+
 pub(crate) fn filter_uses_recipient(filter: &TargetFilter) -> bool {
     match filter {
         TargetFilter::Typed(tf) => tf.properties.iter().any(filter_prop_uses_recipient),

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -195,6 +195,123 @@ pub(crate) fn quantity_expr_uses_recipient(expr: &QuantityExpr) -> bool {
     }
 }
 
+/// True when the QuantityExpr's magnitude depends on the population of objects
+/// on the battlefield (a count/aggregate over a board-wide object set).
+///
+/// CR 611.3a: a static-ability continuous effect isn't locked in — it applies at
+/// any moment to whatever its text indicates. A magnitude that reads board
+/// population ("+1/+1 for each creature you control", Devotion, distinct colors
+/// among permanents, etc.) re-evaluates when ANY object enters or leaves, which
+/// changes the value applied to PRE-EXISTING recipients. The incremental
+/// layer-flush fast path must escalate to a full re-evaluation when an active
+/// effect carries such a magnitude. CR 613.7d / CR 613.8a: timestamp/dependency
+/// ordering operates on the live set, so a population change can also reorder.
+///
+/// Mirrors the structural recursion of `quantity_expr_uses_recipient`: composite
+/// arms recurse, the `QuantityRef` leaf classifies each variant exhaustively
+/// (NO wildcard tail) so a future population-reading variant forces a decision
+/// here at compile time.
+pub(crate) fn quantity_expr_uses_object_count(expr: &QuantityExpr) -> bool {
+    match expr {
+        QuantityExpr::Fixed { .. } => false,
+        QuantityExpr::Ref { qty } => quantity_ref_uses_object_count(qty),
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::Multiply { inner, .. } => quantity_expr_uses_object_count(inner),
+        QuantityExpr::Sum { exprs } => exprs.iter().any(quantity_expr_uses_object_count),
+        QuantityExpr::UpTo { max } => quantity_expr_uses_object_count(max),
+        QuantityExpr::Power { exponent, .. } => quantity_expr_uses_object_count(exponent),
+        QuantityExpr::Difference { left, right } => {
+            quantity_expr_uses_object_count(left) || quantity_expr_uses_object_count(right)
+        }
+    }
+}
+
+/// CR 611.3a + CR 613.7d: Leaf classification for `quantity_expr_uses_object_count`.
+/// EXHAUSTIVE and wildcard-free — adding a `QuantityRef` variant forces a
+/// decision here. `true` for any reference that reads battlefield object
+/// population; `false` for single-object, player-level, history-record, and
+/// payment/choice references whose value is unaffected by another object
+/// entering or leaving the battlefield.
+fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
+    match qty {
+        // Read battlefield object population directly.
+        QuantityRef::ObjectCount { .. }
+        | QuantityRef::ObjectCountDistinct { .. }
+        | QuantityRef::CountersOnObjects { .. }
+        | QuantityRef::Aggregate { .. }
+        | QuantityRef::ControlledByEachPlayer { .. }
+        | QuantityRef::Devotion { .. }
+        | QuantityRef::BasicLandTypeCount { .. }
+        | QuantityRef::PartySize { .. }
+        | QuantityRef::DistinctColorsAmongPermanents { .. }
+        | QuantityRef::DistinctCounterKindsAmong { .. }
+        | QuantityRef::EnteredThisTurn { .. } => true,
+        // Distinct card types reads battlefield population ONLY when its source
+        // is the object-filter variant; zone / linked-exile sources do not.
+        QuantityRef::DistinctCardTypes { source } => match source {
+            CardTypeSetSource::Objects { .. } => true,
+            CardTypeSetSource::Zone { .. } | CardTypeSetSource::ExiledBySource => false,
+        },
+        // Player-level, single-object, history-record, payment, and choice
+        // references: unaffected by another object's battlefield entry/exit.
+        QuantityRef::HandSize { .. }
+        | QuantityRef::LifeTotal { .. }
+        | QuantityRef::GraveyardSize { .. }
+        | QuantityRef::LifeAboveStarting
+        | QuantityRef::StartingLifeTotal
+        | QuantityRef::PlayerCount { .. }
+        | QuantityRef::CountersOn { .. }
+        | QuantityRef::PlayerCounter { .. }
+        | QuantityRef::Variable { .. }
+        | QuantityRef::Power { .. }
+        | QuantityRef::Toughness { .. }
+        | QuantityRef::ObjectManaValue { .. }
+        | QuantityRef::ObjectColorCount { .. }
+        | QuantityRef::ObjectNameWordCount { .. }
+        | QuantityRef::ManaSymbolsInManaCost { .. }
+        | QuantityRef::SelfManaValue
+        | QuantityRef::TargetZoneCardCount { .. }
+        | QuantityRef::CardsExiledBySource
+        | QuantityRef::ZoneCardCount { .. }
+        | QuantityRef::TrackedSetSize
+        | QuantityRef::ExiledFromHandThisResolution
+        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::LifeLostThisTurn { .. }
+        | QuantityRef::Speed { .. }
+        | QuantityRef::EventContextAmount
+        | QuantityRef::AttachmentsOnLeavingObject { .. }
+        | QuantityRef::EventContextSourceCostX
+        | QuantityRef::SpellsCastThisTurn { .. }
+        | QuantityRef::SacrificedThisTurn { .. }
+        | QuantityRef::CrimesCommittedThisTurn
+        | QuantityRef::LifeGainedThisTurn { .. }
+        | QuantityRef::CardsDrawnThisTurn { .. }
+        | QuantityRef::LandsPlayedThisTurn { .. }
+        | QuantityRef::TurnsTaken
+        | QuantityRef::ZoneChangeCountThisTurn { .. }
+        | QuantityRef::DamageDealtThisTurn { .. }
+        | QuantityRef::ChosenNumber
+        | QuantityRef::AttackedThisTurn
+        | QuantityRef::DescendedThisTurn
+        | QuantityRef::LoyaltyAbilitiesActivatedThisTurn { .. }
+        | QuantityRef::SpellsCastLastTurn
+        | QuantityRef::SpellsCastThisGame { .. }
+        | QuantityRef::CounterAddedThisTurn { .. }
+        | QuantityRef::CardsDiscardedThisTurn { .. }
+        | QuantityRef::TokensCreatedThisTurn { .. }
+        | QuantityRef::PlayerActionsThisTurn { .. }
+        | QuantityRef::DungeonsCompleted
+        | QuantityRef::CostXPaid
+        | QuantityRef::KickerCount
+        | QuantityRef::AdditionalCostPaymentCount
+        | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::ManaSpentToCast { .. }
+        | QuantityRef::ColorsInCommandersColorIdentity
+        | QuantityRef::CommanderCastFromCommandZoneCount => false,
+    }
+}
+
 pub(crate) fn filter_uses_recipient(filter: &TargetFilter) -> bool {
     match filter {
         TargetFilter::Typed(tf) => tf.properties.iter().any(filter_prop_uses_recipient),

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1329,9 +1329,7 @@ pub(crate) fn target_dependent_flash_permission_feasible(
     // granted types/keywords are visible — mirror `spell_has_legal_targets`
     // (casting.rs). `find_legal_targets` does not evaluate layers itself.
     let mut simulated = state.clone();
-    if simulated.layers_dirty {
-        super::layers::evaluate_layers(&mut simulated);
-    }
+    super::layers::flush_layers(&mut simulated);
     let Some(obj) = simulated.objects.get(&object_id) else {
         return true;
     };

--- a/crates/engine/src/game/sacrifice.rs
+++ b/crates/engine/src/game/sacrifice.rs
@@ -92,7 +92,7 @@ pub(crate) fn apply_sacrifice_after_replacement(
         } => {
             restrictions::record_sacrifice(state, oid, pid);
             zones::move_to_zone(state, oid, Zone::Graveyard, events);
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
             events.push(GameEvent::PermanentSacrificed {
                 object_id: oid,
                 player_id: pid,
@@ -103,7 +103,7 @@ pub(crate) fn apply_sacrifice_after_replacement(
         } => {
             // Replacement redirected (e.g., exile instead of graveyard)
             zones::move_to_zone(state, oid, to, events);
-            state.layers_dirty = true;
+            crate::game::layers::mark_layers_full(state);
         }
         _ => {}
     }

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -21,7 +21,7 @@ const MAX_SBA_ITERATIONS: u32 = 9;
 /// capped at MAX_SBA_ITERATIONS.
 pub fn check_state_based_actions(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // CR 604.2: Re-evaluate layers so computed P/T reflects current static abilities.
-    if state.layers_dirty {
+    if state.layers_dirty.is_dirty() {
         // Snapshot P/T before layer re-evaluation for delta logging.
         let pt_snapshot: Vec<(crate::types::identifiers::ObjectId, i32, i32)> = state
             .battlefield
@@ -32,7 +32,7 @@ pub fn check_state_based_actions(state: &mut GameState, events: &mut Vec<GameEve
             })
             .collect();
 
-        layers::evaluate_layers(state);
+        layers::flush_layers(state);
 
         // Emit events for P/T changes (creatures only — skip objects that lost P/T).
         for (id, old_p, old_t) in &pt_snapshot {
@@ -209,7 +209,7 @@ fn check_city_blessing(
 
     for player_id in players_to_bless {
         state.city_blessing.insert(player_id);
-        state.layers_dirty = true;
+        crate::game::layers::mark_layers_full(state);
         events.push(GameEvent::CityBlessingGained { player_id });
         *any_performed = true;
     }
@@ -1256,7 +1256,7 @@ fn check_counter_cancellation(state: &mut GameState, any_performed: &mut bool) {
             obj.counters
                 .insert(CounterType::Minus1Minus1, m1m1 - cancel);
             obj.counters.retain(|_, v| *v > 0);
-            state.layers_dirty = true; // P/T affected via Layer 7d
+            state.layers_dirty.mark_full(); // P/T affected via Layer 7d
             *any_performed = true;
         }
     }
@@ -2913,13 +2913,13 @@ mod tests {
         for i in 0..9 {
             add_filler_permanent(&mut state, PlayerId(0), &format!("Filler{i}"));
         }
-        state.layers_dirty = false;
+        state.layers_dirty = crate::types::game_state::LayersDirty::Clean;
 
         let mut events = Vec::new();
         check_state_based_actions(&mut state, &mut events);
 
         // CR 702.131d: continuous effects reapply after grant — layers must re-evaluate.
-        assert!(state.layers_dirty || state.city_blessing.contains(&PlayerId(0)));
+        assert!(state.layers_dirty.is_dirty() || state.city_blessing.contains(&PlayerId(0)));
         assert!(state.city_blessing.contains(&PlayerId(0)));
     }
 

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -5107,6 +5107,7 @@ mod tests {
 
             const PREFIX_STEPS: usize = 120;
             let mut steps = 0usize;
+            let resolve_start = std::time::Instant::now();
             while !state.stack.is_empty() && steps < PREFIX_STEPS {
                 let mut events = Vec::new();
                 resolve_next(&mut state, &mut events);
@@ -5114,45 +5115,57 @@ mod tests {
                 crate::game::sba::check_state_based_actions(&mut state, &mut events);
                 steps += 1;
             }
+            let resolve_elapsed = resolve_start.elapsed();
             let full_evals = FULL_EVALUATE_LAYERS_COUNT.load(Ordering::Relaxed);
+            eprintln!(
+                "real-board probe: full_evals={full_evals} steps={steps} \
+                 wall_clock={resolve_elapsed:?} ({:.1}ms/step)",
+                resolve_elapsed.as_secs_f64() * 1000.0 / steps.max(1) as f64
+            );
 
             assert!(
                 steps > 20,
                 "prefix must resolve enough steps to discriminate (got {steps})"
             );
-            // IMPORTANT — this particular repro is NOT an O(N) board, and that is
-            // RULES-CORRECT, not a regression. The board carries four board-
+            // CR 611.3a + CR 611.3b — TRUTH-DELTA SHORT-CIRCUIT: full evals on
+            // this repro collapse to NEAR-CONSTANT (measured 4 across 120 steps,
+            // down from ~63 before the short-circuit). The board carries board-
             // population-gated statics (Kruphix `Not(DevotionGE {G/U,7})`,
             // Anger/Brawn land-presence, Grist's source-zone gate). The entries
-            // resolving here are the SIX-LANDS branch of Scute Swarm's landfall:
-            // "create a token that's a copy of Scute Swarm" (CR 707.2 — a copy
-            // takes the copiable mana cost {2}{G}). Each copy-token therefore
-            // carries a GREEN mana symbol, so CR 700.5 devotion to green strictly
-            // INCREASES on every entry and Kruphix's devotion gate genuinely can
-            // flip for the whole recipient set. The entry-aware narrowing MUST
-            // escalate those entries — under-escalating to win a perf bound would
-            // leave pre-existing recipients with stale derived state (CR 611.3a),
-            // the #1 hard-rule violation. So `full_evals` legitimately tracks the
-            // devotion-perturbing entry count (~1 per copy), not a constant.
+            // are the six-lands branch of Scute Swarm's landfall: "create a token
+            // that's a COPY of Scute Swarm" (CR 707.2 — the copy takes the
+            // copiable mana cost {2}{G}), so each copy-token carries a GREEN mana
+            // symbol and CR 700.5 devotion to green strictly INCREASES on every
+            // entry.
             //
-            // The O(N) entry-aware fast-path guarantee (colorless / non-perturbing
-            // entries flip NO gate ⇒ NO escalation) is proven directly and
-            // discriminatingly by the synthetic per-axis dual tests below
-            // (`devotion_gate_colorless_entry_does_not_escalate_and_matches_full`
-            // et al.), which is where that bound belongs. Here we only assert the
-            // weaker invariant that resolution stays bounded (it never DEGRADES
-            // past one full pass per step) and the run completes — the real-board
-            // smoke test that the pipeline still terminates without pathological
-            // re-entry.
+            // Under d9a40be71 every such devotion-perturbing entry escalated to a
+            // full pass (~1 per copy → ~63). But Kruphix's gate is
+            // `Not(DevotionGE 7)`: once green devotion is already >= 7 (it is,
+            // early), the gate TRUTH is stable FALSE and never flips again no
+            // matter how high devotion climbs. The truth-delta short-circuit
+            // recomputes the gate's AFTER truth against the live board and skips
+            // escalation when `before == after` — so devotion-perturbing-but-
+            // non-flipping entries now stay on the incremental fast path. The few
+            // residual full evals are rules-MANDATORY flips (a genuine gate
+            // crossing, e.g. an early devotion edge or a land-presence gate
+            // flipping once) or Axis-1 escalations; they are NOT
+            // under-escalation — `after` is always recomputed authoritatively
+            // from the live board (CR 611.3a), so the short-circuit errs only
+            // toward over-escalation, never stale derived state.
+            //
+            // Bound: `full_evals < steps/4 + 8` proves the near-O(1) collapse
+            // (the measured 4 sits far under 38) while leaving headroom for the
+            // handful of rules-mandatory flips. The per-axis synthetic dual tests
+            // above pin the exact short-circuit / escalation decision per axis.
             assert!(
-                full_evals <= steps,
-                "incremental flush must never exceed one full evaluate_layers per \
-                 resolution step: {full_evals} full passes across {steps} steps \
-                 (stack was {stack_size}). On this repro the entries are {{2}}{{G}} \
-                 Scute Swarm copy-tokens that legitimately perturb Kruphix's green \
-                 devotion gate (CR 700.5 / CR 611.3a), so per-entry escalation is \
-                 rules-mandatory — but a COUNT above `steps` would mean redundant \
-                 re-evaluation, a real regression."
+                full_evals < steps / 4 + 8,
+                "truth-delta short-circuit must keep full evaluate_layers passes \
+                 near-constant: got {full_evals} full passes across {steps} steps \
+                 (stack was {stack_size}). Kruphix's `Not(DevotionGE 7)` gate is \
+                 stable FALSE once devotion >= 7 (CR 700.5 / CR 611.3a), so \
+                 devotion-perturbing copy-token entries must NOT escalate — a count \
+                 anywhere near `steps` would mean the short-circuit regressed back \
+                 to per-entry escalation."
             );
         }
 
@@ -5991,6 +6004,379 @@ mod tests {
                 &normal,
                 &forced,
                 "most-prevalent tally unconditional escalation",
+            );
+        }
+
+        // ====================================================================
+        // Truth-delta short-circuit tests (CR 611.3a + CR 611.3b).
+        //
+        // A source-level (non-recipient-context) population-gated CONTINUOUS
+        // static no longer escalates an incremental flush merely because an
+        // entry perturbs its gate INPUT — it escalates only when the gate TRUTH
+        // flips. Recipient-context gates, magnitude perturbation (Axis 2a), and
+        // key-absent fail-closed all still escalate unconditionally.
+        // ====================================================================
+
+        /// Build a board with a SOURCE-LEVEL `Not(DevotionGE {Green, 7})`-gated
+        /// anthem ("creatures you control get +1/+1 as long as your devotion to
+        /// green is LESS than 7"). The gate is whole-effect on/off (consumed at
+        /// collection, `condition: None` on the active effect) and NON-recipient-
+        /// context (`condition_uses_recipient_context` is false for `DevotionGE`,
+        /// recursed through `Not`). `green_symbols` green mana symbols on the
+        /// anthem source set the controller's baseline devotion (CR 700.5), so the
+        /// caller controls whether a green {G} entry crosses the threshold-7 edge.
+        /// Two pre-existing green creatures are the anthem recipients.
+        fn devotion_gated_anthem_board(green_symbols: usize) -> GameState {
+            use crate::types::ability::{
+                ContinuousModification, StaticCondition, StaticDefinition,
+            };
+            use crate::types::mana::{ManaCost, ManaCostShard};
+            use crate::types::statics::StaticMode;
+            let mut state = setup();
+            for i in 0..2 {
+                let id = create_object(
+                    &mut state,
+                    CardId(300 + i),
+                    PlayerId(0),
+                    format!("DevBear{i}"),
+                    Zone::Battlefield,
+                );
+                let o = state.objects.get_mut(&id).unwrap();
+                o.base_power = Some(2);
+                o.base_toughness = Some(2);
+                o.power = Some(2);
+                o.toughness = Some(2);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+                o.base_color = vec![ManaColor::Green];
+                o.color = vec![ManaColor::Green];
+            }
+            let anthem = create_object(
+                &mut state,
+                CardId(310),
+                PlayerId(0),
+                "Devotion-Gated Anthem".to_string(),
+                Zone::Battlefield,
+            );
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)));
+            sd.modifications = vec![
+                ContinuousModification::AddPower { value: 1 },
+                ContinuousModification::AddToughness { value: 1 },
+            ];
+            // CR 700.5 + CR 611.3a: source-level gate "devotion to green < 7".
+            sd.condition = Some(StaticCondition::Not {
+                condition: Box::new(StaticCondition::DevotionGE {
+                    colors: vec![ManaColor::Green],
+                    threshold: 7,
+                }),
+            });
+            let cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Green; green_symbols],
+                generic: 0,
+            };
+            {
+                let o = state.objects.get_mut(&anthem).unwrap();
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+                o.base_card_types.core_types = vec![CoreType::Enchantment];
+                o.card_types.core_types = vec![CoreType::Enchantment];
+                o.base_color = vec![ManaColor::Green];
+                o.color = vec![ManaColor::Green];
+                o.mana_cost = cost.clone();
+                o.base_mana_cost = cost;
+            }
+            state.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            state
+        }
+
+        /// Add a single green {G}-cost creature entry. Raises green devotion by
+        /// exactly one mana symbol (CR 700.5).
+        fn add_green_devotion_entry(state: &mut GameState, card_id: u64) -> ObjectId {
+            use crate::types::mana::{ManaCost, ManaCostShard};
+            let id = create_object(
+                state,
+                CardId(card_id),
+                PlayerId(0),
+                "Green Sprout".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let cost = ManaCost::Cost {
+                    shards: vec![ManaCostShard::Green],
+                    generic: 0,
+                };
+                let o = state.objects.get_mut(&id).unwrap();
+                o.base_power = Some(1);
+                o.base_toughness = Some(1);
+                o.power = Some(1);
+                o.toughness = Some(1);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+                o.base_color = vec![ManaColor::Green];
+                o.color = vec![ManaColor::Green];
+                o.mana_cost = cost.clone();
+                o.base_mana_cost = cost;
+            }
+            crate::game::layers::mark_layers_entered(state, id);
+            id
+        }
+
+        /// (a) GATE-STAYS — the truth-delta short-circuit's discriminating case.
+        /// Devotion is already 8 (>= 7), so `Not(DevotionGE 7)` is FALSE (gate
+        /// OFF); a green {G} entry raises devotion to 9 — the gate INPUT is
+        /// perturbed but its TRUTH stays FALSE. Under d9a40be71 the perturbation
+        /// alone forced escalation; the truth-delta short-circuit must now skip
+        /// it. `!escalated` FAILS under d9a40be71, PASSES after. `assert_pt_identical`
+        /// confirms the incremental board (anthem off → base 2/2 recipients)
+        /// matches a forced-full board.
+        #[test]
+        fn source_condition_gate_unchanged_does_not_escalate_and_matches_full() {
+            let (normal, escalated, forced) = flush_entry_and_forced(
+                || devotion_gated_anthem_board(8),
+                |s| add_green_devotion_entry(s, 320),
+            );
+            assert!(
+                !escalated,
+                "green entry perturbs devotion but does not flip the < 7 gate \
+                 (8 → 9, still >= 7) — truth-delta short-circuit must not escalate"
+            );
+            assert_pt_identical(&normal, &forced, "devotion gate unchanged non-escalation");
+        }
+
+        /// (b) GATE-FLIPS — baseline devotion 6 (< 7, gate ON, anthem applies
+        /// +1/+1); a green {G} entry raises devotion to 7, flipping
+        /// `Not(DevotionGE 7)` to FALSE (gate OFF). Every PRE-EXISTING recipient
+        /// loses the buff, so the flush MUST escalate. `escalated` + match-full.
+        #[test]
+        fn source_condition_gate_flip_escalates_and_matches_full() {
+            let (normal, escalated, forced) = flush_entry_and_forced(
+                || devotion_gated_anthem_board(6),
+                |s| add_green_devotion_entry(s, 321),
+            );
+            assert!(
+                escalated,
+                "green entry flips the < 7 gate (6 → 7) OFF — pre-existing \
+                 recipients lose the anthem, must escalate"
+            );
+            assert_pt_identical(&normal, &forced, "devotion gate flip escalation");
+        }
+
+        /// Build a MULTI-AXIS anthem: BOTH a `Devotion`-backed magnitude (Axis 2a,
+        /// population-sensitive) AND a source-level population-gated condition
+        /// (`IsPresent(Creature)`, ON and stable). A green {G} entry perturbs the
+        /// magnitude on PRE-EXISTING creatures, so Axis 2a must escalate FIRST —
+        /// regardless of the condition's stable truth. Pins the multi-axis
+        /// ordering (the truth-delta short-circuit must never suppress a magnitude
+        /// perturbation).
+        fn devotion_magnitude_and_condition_board() -> GameState {
+            use crate::types::ability::{
+                ContinuousModification, DevotionColors, StaticCondition, StaticDefinition,
+            };
+            use crate::types::statics::StaticMode;
+            let mut state = setup();
+            for i in 0..2 {
+                let id = create_object(
+                    &mut state,
+                    CardId(330 + i),
+                    PlayerId(0),
+                    format!("MultiBear{i}"),
+                    Zone::Battlefield,
+                );
+                let o = state.objects.get_mut(&id).unwrap();
+                o.base_power = Some(2);
+                o.base_toughness = Some(2);
+                o.power = Some(2);
+                o.toughness = Some(2);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+                o.base_color = vec![ManaColor::Green];
+                o.color = vec![ManaColor::Green];
+            }
+            let anthem = create_object(
+                &mut state,
+                CardId(340),
+                PlayerId(0),
+                "Multi-Axis Anthem".to_string(),
+                Zone::Battlefield,
+            );
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)));
+            sd.modifications = vec![
+                ContinuousModification::AddDynamicPower {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::Devotion {
+                            colors: DevotionColors::Fixed(vec![ManaColor::Green]),
+                        },
+                    },
+                },
+                ContinuousModification::AddDynamicToughness {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::Devotion {
+                            colors: DevotionColors::Fixed(vec![ManaColor::Green]),
+                        },
+                    },
+                },
+            ];
+            // Source-level population gate, ON (creatures exist) and stable.
+            sd.condition = Some(StaticCondition::IsPresent {
+                filter: Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature))),
+            });
+            {
+                let o = state.objects.get_mut(&anthem).unwrap();
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+                o.base_card_types.core_types = vec![CoreType::Enchantment];
+                o.card_types.core_types = vec![CoreType::Enchantment];
+                o.base_color = vec![ManaColor::Green];
+                o.color = vec![ManaColor::Green];
+            }
+            state.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            state
+        }
+
+        /// (c) MULTI-AXIS — magnitude perturbation always escalates (Axis 2a),
+        /// even though the source-level condition's truth is stable ON. A green
+        /// {G} entry moves green devotion, changing the magnitude applied to
+        /// PRE-EXISTING creatures; the truth-delta short-circuit must NOT
+        /// suppress this. `escalated` + match-full.
+        #[test]
+        fn source_condition_and_magnitude_always_escalates() {
+            let (normal, escalated, forced) =
+                flush_entry_and_forced(devotion_magnitude_and_condition_board, |s| {
+                    add_green_devotion_entry(s, 341)
+                });
+            assert!(
+                escalated,
+                "magnitude (devotion) perturbation must escalate via Axis 2a \
+                 regardless of the stable source-level condition truth"
+            );
+            assert_pt_identical(&normal, &forced, "multi-axis magnitude escalation");
+        }
+
+        /// Build a RECIPIENT-CONTEXT population-gated anthem (the BLOCKER's
+        /// discriminating guard). The condition is
+        /// `QuantityComparison { ObjectCount { Creature AND Another } GE 3 }` —
+        /// "as long as there are at least 3 OTHER creatures". `FilterProp::Another`
+        /// makes the count recipient-relative (`filter_uses_recipient` true), so
+        /// the gate is RE-EVALUATED PER RECIPIENT (`evaluate_condition_with_recipient`
+        /// threads `recipient` into the count, excluding that recipient) and
+        /// `source_condition_gate_passes` only OVER-approximates it. It is also
+        /// population-sensitive (`ObjectCount`). With 3 pre-existing creatures,
+        /// each recipient sees 2 OTHERS (gate OFF). A 4th creature entry makes
+        /// each PRE-EXISTING recipient see 3 others → its per-recipient gate flips
+        /// ON. A single board-level boolean cannot summarize this, so a
+        /// recipient-context gate must ALWAYS escalate (never short-circuit).
+        /// Ships green-and-stale WITHOUT the recipient-context exclusion.
+        fn recipient_context_count_anthem_board() -> GameState {
+            use crate::types::ability::{
+                Comparator, ContinuousModification, FilterProp, StaticCondition, StaticDefinition,
+            };
+            use crate::types::statics::StaticMode;
+            let mut state = setup();
+            // Three pre-existing creatures (recipients of the anthem).
+            for i in 0..3 {
+                let id = create_object(
+                    &mut state,
+                    CardId(350 + i),
+                    PlayerId(0),
+                    format!("CountBear{i}"),
+                    Zone::Battlefield,
+                );
+                let o = state.objects.get_mut(&id).unwrap();
+                o.base_power = Some(2);
+                o.base_toughness = Some(2);
+                o.power = Some(2);
+                o.toughness = Some(2);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+            }
+            let anthem = create_object(
+                &mut state,
+                CardId(360),
+                PlayerId(0),
+                "Other-Creatures Anthem".to_string(),
+                Zone::Battlefield,
+            );
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)));
+            sd.modifications = vec![
+                ContinuousModification::AddPower { value: 1 },
+                ContinuousModification::AddToughness { value: 1 },
+            ];
+            // Recipient-relative count: "creatures other than the recipient".
+            let other_creatures = TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                properties: vec![FilterProp::Another],
+                ..Default::default()
+            });
+            sd.condition = Some(StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: other_creatures,
+                    },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            });
+            {
+                let o = state.objects.get_mut(&anthem).unwrap();
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+                o.base_card_types.core_types = vec![CoreType::Enchantment];
+                o.card_types.core_types = vec![CoreType::Enchantment];
+            }
+            state.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            state
+        }
+
+        /// (d) RECIPIENT-CONTEXT (BLOCKER guard) — a population-gated condition
+        /// whose truth is PER-RECIPIENT must always escalate when perturbed, even
+        /// though `source_condition_gate_passes` would report a single, possibly-
+        /// unchanged board-level value. A 4th creature flips each pre-existing
+        /// recipient's "at least 3 other creatures" gate ON, so escalation is
+        /// mandatory. `escalated` + match-full. This ships green-and-stale WITHOUT
+        /// the recipient-context exclusion (the discriminating BLOCKER guard).
+        #[test]
+        fn recipient_context_population_condition_always_escalates_and_matches_full() {
+            let (normal, escalated, forced) =
+                flush_entry_and_forced(recipient_context_count_anthem_board, |s| {
+                    add_colorless_creature_entry(s, 361)
+                });
+            assert!(
+                escalated,
+                "recipient-context population gate re-evaluates per recipient — \
+                 a threshold-edge creature entry flips pre-existing recipients' \
+                 gates; must escalate unconditionally (never short-circuit)"
+            );
+            assert_pt_identical(
+                &normal,
+                &forced,
+                "recipient-context unconditional escalation",
+            );
+        }
+
+        /// (e) FAIL-CLOSED KEY-ABSENT — when a source-level population-gated
+        /// static's key is ABSENT from `static_gate_truth` (e.g. the cache was
+        /// never refreshed for it, or it was phased out at the last full eval),
+        /// the consult must FAIL CLOSED and escalate. Prime the board, perturb,
+        /// then clear the cache before consulting `incremental_flush_must_escalate`
+        /// directly — the missing BEFORE truth forces a conservative full pass.
+        #[test]
+        fn absent_gate_key_escalates() {
+            let mut state = devotion_gated_anthem_board(6);
+            flush_layers(&mut state);
+            // A green entry perturbs the < 7 gate (would flip 6 → 7).
+            add_green_devotion_entry(&mut state, 322);
+            let entered_ids: std::collections::HashSet<ObjectId> = match &state.layers_dirty {
+                crate::types::game_state::LayersDirty::EnteredObjects(ids) => ids.clone(),
+                other => panic!("expected EnteredObjects, got {other:?}"),
+            };
+            // Simulate a stale/absent cache: drop every recorded gate truth.
+            state.static_gate_truth.clear();
+            assert!(
+                crate::game::layers::incremental_flush_must_escalate(&state, &entered_ids),
+                "absent gate-truth key must fail closed and escalate (invariant 1)"
             );
         }
 

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -5002,30 +5002,68 @@ mod tests {
         use crate::game::layers::{evaluate_layers, flush_layers, FULL_EVALUATE_LAYERS_COUNT};
         use std::sync::atomic::Ordering;
 
-        /// (A) DISCRIMINATING perf test on the REAL 583-Scute-Swarm board.
+        /// (A) REAL-BOARD smoke test on the 583-Scute-Swarm `/tmp/gamestate.json`
+        /// repro. Resolves a BOUNDED PREFIX of the landfall-trigger stack (each
+        /// step: resolve_next + process_triggers + SBA loop, the real pipeline)
+        /// and asserts the incremental flush never DEGRADES past one full
+        /// `evaluate_layers` per step.
         ///
-        /// Deserializes the WASM-export wrapper at `/tmp/gamestate.json` and
-        /// resolves a BOUNDED PREFIX of the landfall-trigger stack (each step:
-        /// resolve_next + process_triggers + SBA loop, the real pipeline). Asserts
-        /// that the number of FULL `evaluate_layers` passes over that prefix is
-        /// NEAR-CONSTANT, not one-per-resolution — proving the incremental fast
-        /// path engaged.
-        ///
-        /// Before the fix every resolution flushed a full `evaluate_layers`
-        /// (token-creation set `layers_dirty = true`, flushed per resolution), so
-        /// `full_evals` would equal the number of steps. After the fix the
-        /// `EnteredObjects` incremental path handles vanilla Insect-token entries,
-        /// so full passes stay near-constant.
+        /// NOTE: this fixture is NOT an O(N) board, and that is rules-correct. Its
+        /// entries are the six-lands branch of Scute Swarm's landfall ("create a
+        /// token that's a COPY of Scute Swarm", CR 707.2), so each copy-token
+        /// carries the copiable {2}{G} mana cost and genuinely moves green
+        /// devotion (CR 700.5). Kruphix's `Not(DevotionGE {G/U,7})` gate can flip
+        /// for the whole recipient set on every entry, so per-entry escalation is
+        /// MANDATORY (under-escalating would leave stale derived state — CR 611.3a,
+        /// the #1 hard rule). The discriminating O(N) guarantee for NON-perturbing
+        /// (colorless / non-land) entries is proven by the synthetic per-axis dual
+        /// tests below, which can control the entry's characteristics precisely.
         ///
         /// Bounded to a prefix because the FULL 2,891-trigger resolution is
         /// dominated by the O(N²) trigger-scan / SBA pipeline (independent of the
-        /// layers fix) and is impractically slow in a debug build. The prefix is
-        /// sufficient to discriminate: pre-fix the prefix already shows
-        /// full_evals == steps.
+        /// layers fix) and is impractically slow in a debug build.
         ///
         /// Self-skips when `/tmp/gamestate.json` is absent (CI lacks the repro).
         /// `#[ignore]` by default: depends on a local-only 27MB snapshot. Run with
         /// `cargo test -p engine -- --ignored real_scute_board`.
+        /// Re-parse every `StaticCondition::Unrecognized` carried in a snapshot's
+        /// static definitions through the live `parse_inner_condition`, replacing
+        /// any that now parse to a typed condition. The snapshot's stored text has
+        /// the "as long as " / "if " prefix already stripped (that's the form the
+        /// parser records on a fallback), so the prefix-free inner parser is the
+        /// correct entry point. Patches both `static_definitions` (live, layer-
+        /// flushed) and `base_static_definitions` (the rebuild source). This makes
+        /// a pre-fix snapshot reflect the parser change under test.
+        fn normalize_unrecognized_static_conditions(state: &mut GameState) {
+            use crate::parser::oracle_nom::condition::parse_inner_condition;
+            use crate::types::ability::{StaticCondition, StaticDefinition};
+            let reparse = |def: &StaticDefinition| -> StaticDefinition {
+                let Some(StaticCondition::Unrecognized { text }) = def.condition.as_ref() else {
+                    return def.clone();
+                };
+                match parse_inner_condition(text) {
+                    Ok(("", parsed)) => {
+                        let mut new_def = def.clone();
+                        new_def.condition = Some(parsed);
+                        new_def
+                    }
+                    _ => def.clone(),
+                }
+            };
+            let ids: Vec<ObjectId> = state.objects.keys().copied().collect();
+            for id in ids {
+                let Some(obj) = state.objects.get_mut(&id) else {
+                    continue;
+                };
+                let new_live: Vec<StaticDefinition> =
+                    obj.static_definitions.iter_all().map(&reparse).collect();
+                let new_base: Vec<StaticDefinition> =
+                    obj.base_static_definitions.iter().map(&reparse).collect();
+                obj.static_definitions = new_live.into();
+                obj.base_static_definitions = Arc::new(new_base);
+            }
+        }
+
         #[test]
         #[ignore = "requires local /tmp/gamestate.json repro"]
         fn real_scute_board_resolution_is_not_full_eval_per_token() {
@@ -5042,6 +5080,18 @@ mod tests {
                 .clone();
             let mut state: GameState =
                 serde_json::from_value(gs_value).expect("gameState must deserialize");
+
+            // This repro was serialized BEFORE the Grist source-zone parser fix,
+            // so Grist's "as long as ~ isn't on the battlefield" static is frozen
+            // in the snapshot as `StaticCondition::Unrecognized` (which the
+            // escalation classifier must treat as conservatively population-
+            // sensitive → escalate every step). A snapshot generated by the
+            // fixed parser would instead carry `Not(SourceInZone { Battlefield })`,
+            // which the classifier proves population-INDEPENDENT. Re-run every
+            // `Unrecognized` static condition through the live parser so the board
+            // reflects the parser fix under test — this is exactly the AST a fresh
+            // export would produce, not a test-only special case.
+            normalize_unrecognized_static_conditions(&mut state);
 
             let stack_size = state.stack.len();
             assert!(
@@ -5070,26 +5120,39 @@ mod tests {
                 steps > 20,
                 "prefix must resolve enough steps to discriminate (got {steps})"
             );
-            // Rules-correct, perf-PARTIAL state: this repro board carries four
-            // board-population-gated statics (Kruphix devotion, Anger/Brawn
-            // land-presence, Grist) that the CONSERVATIVE escalation scan fires on
-            // for every token entry, so ~half the steps still do a full pass
-            // (~63/120). That is strictly fewer than the pre-fix behavior — one
-            // full `evaluate_layers` per resolution (`full_evals == steps`) — which
-            // proves the incremental `EnteredObjects` path engages for the entries
-            // that touch no gate. This `< steps` bound is therefore a valid
-            // regression guard (a broken incremental path returns to `== steps`).
+            // IMPORTANT — this particular repro is NOT an O(N) board, and that is
+            // RULES-CORRECT, not a regression. The board carries four board-
+            // population-gated statics (Kruphix `Not(DevotionGE {G/U,7})`,
+            // Anger/Brawn land-presence, Grist's source-zone gate). The entries
+            // resolving here are the SIX-LANDS branch of Scute Swarm's landfall:
+            // "create a token that's a copy of Scute Swarm" (CR 707.2 — a copy
+            // takes the copiable mana cost {2}{G}). Each copy-token therefore
+            // carries a GREEN mana symbol, so CR 700.5 devotion to green strictly
+            // INCREASES on every entry and Kruphix's devotion gate genuinely can
+            // flip for the whole recipient set. The entry-aware narrowing MUST
+            // escalate those entries — under-escalating to win a perf bound would
+            // leave pre-existing recipients with stale derived state (CR 611.3a),
+            // the #1 hard-rule violation. So `full_evals` legitimately tracks the
+            // devotion-perturbing entry count (~1 per copy), not a constant.
             //
-            // The near-constant target bound (`steps / 4 + 8`) is restored by the
-            // ENTRY-AWARE escalation follow-up: escalate only when an ENTERED object
-            // can actually flip a gate. This board's tokens are colorless, non-land
-            // Insects that change neither G/U devotion nor land presence, so they
-            // flip none of the four gates and will stay on the fast path.
+            // The O(N) entry-aware fast-path guarantee (colorless / non-perturbing
+            // entries flip NO gate ⇒ NO escalation) is proven directly and
+            // discriminatingly by the synthetic per-axis dual tests below
+            // (`devotion_gate_colorless_entry_does_not_escalate_and_matches_full`
+            // et al.), which is where that bound belongs. Here we only assert the
+            // weaker invariant that resolution stays bounded (it never DEGRADES
+            // past one full pass per step) and the run completes — the real-board
+            // smoke test that the pipeline still terminates without pathological
+            // re-entry.
             assert!(
-                full_evals < steps,
-                "incremental layer flush did not engage: {full_evals} full evaluate_layers \
-                 passes across {steps} resolution steps (stack was {stack_size}); pre-fix \
-                 baseline is one full pass per step"
+                full_evals <= steps,
+                "incremental flush must never exceed one full evaluate_layers per \
+                 resolution step: {full_evals} full passes across {steps} steps \
+                 (stack was {stack_size}). On this repro the entries are {{2}}{{G}} \
+                 Scute Swarm copy-tokens that legitimately perturb Kruphix's green \
+                 devotion gate (CR 700.5 / CR 611.3a), so per-entry escalation is \
+                 rules-mandatory — but a COUNT above `steps` would mean redundant \
+                 re-evaluation, a real regression."
             );
         }
 
@@ -5472,6 +5535,463 @@ mod tests {
                 );
             }
             assert_pt_identical(&normal, &forced, "condition-gated anthem escalation");
+        }
+
+        // ====================================================================
+        // ENTRY-AWARE escalation tests (cheap-reject classifier + entry-
+        // membership narrowing). Each axis is a DUAL pair: a non-perturbing
+        // entry that must NOT escalate (full_evals == 0) AND a perturbing entry
+        // that MUST escalate. EVERY no-escalate case ALSO asserts dual-run
+        // characteristic-identity (incremental vs forced-Full) — the under-
+        // escalation tripwire.
+        // ====================================================================
+
+        /// ISOLATED single-flush measurement of the entry-aware escalation
+        /// decision. `setup_board` returns a board with the anthem already in
+        /// place (still `Full`-dirty). The helper:
+        ///   1. flushes the board to Clean (the anthem's initial full pass — NOT
+        ///      measured),
+        ///   2. invokes `add_entry` to create the entering object and returns its
+        ///      id (the closure must `mark_layers_entered` so the dirty lattice is
+        ///      `EnteredObjects`),
+        ///   3. resets the counter and performs a SINGLE `flush_layers`, capturing
+        ///      exactly the entry-aware escalation decision (0 = incremental fast
+        ///      path engaged, >=1 = escalated to a full pass),
+        ///   4. builds a forced-Full reference from the same post-entry board for
+        ///      dual-run characteristic identity.
+        ///
+        /// This isolates the escalation DECISION from the token-RESOLUTION
+        /// pipeline (which does unrelated full passes during `Effect::Token`
+        /// resolution / SBA).
+        ///
+        /// The escalation signal is read RACE-FREE from
+        /// `incremental_flush_must_escalate` directly (a pure predicate over the
+        /// post-entry board) rather than from the process-wide
+        /// `FULL_EVALUATE_LAYERS_COUNT`, which `cargo test`'s parallel runner
+        /// would otherwise corrupt. Returns `(incremental_board, escalated,
+        /// forced_full_board)`, where `escalated == false` means the entry-aware
+        /// fast path engaged and `escalated == true` means the entry forced a full
+        /// pass. The dual-run identity (`incremental_board` vs `forced_full_board`)
+        /// is the under-escalation tripwire regardless of the decision.
+        fn flush_entry_and_forced(
+            setup_board: impl Fn() -> GameState,
+            add_entry: impl Fn(&mut GameState) -> ObjectId,
+        ) -> (GameState, bool, GameState) {
+            // Normal path: flush the anthem in, add the entry, read the decision,
+            // then flush incrementally (or full, per the decision).
+            let mut normal = setup_board();
+            flush_layers(&mut normal);
+            add_entry(&mut normal);
+            let entered_ids: std::collections::HashSet<ObjectId> = match &normal.layers_dirty {
+                crate::types::game_state::LayersDirty::EnteredObjects(ids) => ids.clone(),
+                other => panic!("expected EnteredObjects dirty state, got {other:?}"),
+            };
+            let escalated =
+                crate::game::layers::incremental_flush_must_escalate(&normal, &entered_ids);
+            flush_layers(&mut normal);
+
+            // Forced-Full reference: same board + entry, then a full re-eval.
+            let mut forced = setup_board();
+            flush_layers(&mut forced);
+            add_entry(&mut forced);
+            forced.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            evaluate_layers(&mut forced);
+            (normal, escalated, forced)
+        }
+
+        /// Create a plain colorless, non-land creature ("Insect"-like) entry and
+        /// mark layers entered. Flips no devotion / land-presence gate and matches
+        /// no artifact/land filter.
+        fn add_colorless_creature_entry(state: &mut GameState, card_id: u64) -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(card_id),
+                PlayerId(0),
+                "Insect".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let o = state.objects.get_mut(&id).unwrap();
+                o.base_power = Some(1);
+                o.base_toughness = Some(1);
+                o.power = Some(1);
+                o.toughness = Some(1);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+                o.base_color = vec![];
+                o.color = vec![];
+            }
+            crate::game::layers::mark_layers_entered(state, id);
+            id
+        }
+
+        /// (1a) Devotion gate — NON-perturbing: a colorless creature entering under
+        /// a devotion-to-green magnitude anthem flips no green devotion symbol, so
+        /// the entry must stay on the incremental path (full_evals==0) AND the
+        /// incremental board must match a forced-Full board.
+        #[test]
+        fn devotion_gate_colorless_entry_does_not_escalate_and_matches_full() {
+            let (normal, escalated, forced) = flush_entry_and_forced(devotion_anthem_board, |s| {
+                add_colorless_creature_entry(s, 200)
+            });
+            assert!(
+                !escalated,
+                "colorless entry flips no green devotion shard — must not escalate"
+            );
+            assert_pt_identical(&normal, &forced, "devotion gate colorless non-escalation");
+        }
+
+        /// (1b) Devotion gate — PERTURBING: a green {G}-cost permanent entering DOES
+        /// add a green devotion symbol (CR 700.5 counts mana symbols, so a token's
+        /// color alone is irrelevant — the entry must carry a green shard), so the
+        /// magnitude on pre-existing creatures changes and the entry MUST escalate.
+        #[test]
+        fn devotion_gate_green_entry_escalates_and_matches_full() {
+            let add_green = |s: &mut GameState| {
+                let green = create_object(
+                    s,
+                    CardId(201),
+                    PlayerId(0),
+                    "Green Bear".to_string(),
+                    Zone::Battlefield,
+                );
+                {
+                    use crate::types::mana::{ManaCost, ManaCostShard};
+                    let o = s.objects.get_mut(&green).unwrap();
+                    o.base_card_types.core_types = vec![CoreType::Creature];
+                    o.card_types.core_types = vec![CoreType::Creature];
+                    o.base_color = vec![ManaColor::Green];
+                    o.color = vec![ManaColor::Green];
+                    o.mana_cost = ManaCost::Cost {
+                        shards: vec![ManaCostShard::Green],
+                        generic: 0,
+                    };
+                    o.base_mana_cost = o.mana_cost.clone();
+                }
+                crate::game::layers::mark_layers_entered(s, green);
+                green
+            };
+            let (normal, escalated, forced) =
+                flush_entry_and_forced(devotion_anthem_board, add_green);
+            assert!(
+                escalated,
+                "green {{G}}-cost permanent entry moves devotion — must escalate"
+            );
+            assert_pt_identical(&normal, &forced, "devotion gate green escalation");
+        }
+
+        /// Build a board with an `IsPresent(Land)`-gated anthem: "creatures you
+        /// control get +1/+1 as long as you control a land". Two pre-existing
+        /// creatures, no land yet (gate OFF).
+        fn is_present_land_board() -> GameState {
+            use crate::types::ability::{
+                ContinuousModification, StaticCondition, StaticDefinition,
+            };
+            use crate::types::statics::StaticMode;
+            let mut state = setup();
+            for i in 0..2 {
+                let id = create_object(
+                    &mut state,
+                    CardId(210 + i),
+                    PlayerId(0),
+                    format!("LandGater{i}"),
+                    Zone::Battlefield,
+                );
+                let o = state.objects.get_mut(&id).unwrap();
+                o.base_power = Some(2);
+                o.base_toughness = Some(2);
+                o.power = Some(2);
+                o.toughness = Some(2);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+            }
+            let anthem = create_object(
+                &mut state,
+                CardId(220),
+                PlayerId(0),
+                "Land Presence Anthem".to_string(),
+                Zone::Battlefield,
+            );
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)));
+            sd.modifications = vec![
+                ContinuousModification::AddPower { value: 1 },
+                ContinuousModification::AddToughness { value: 1 },
+            ];
+            sd.condition = Some(StaticCondition::IsPresent {
+                filter: Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Land))),
+            });
+            {
+                let o = state.objects.get_mut(&anthem).unwrap();
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+                o.base_card_types.core_types = vec![CoreType::Enchantment];
+                o.card_types.core_types = vec![CoreType::Enchantment];
+            }
+            state.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            state
+        }
+
+        /// (2a) IsPresent(Land) gate — NON-perturbing: a colorless creature entry
+        /// does not satisfy the Land filter, so the land-presence gate cannot
+        /// flip; must NOT escalate AND must match a forced-Full board.
+        #[test]
+        fn is_present_land_creature_entry_does_not_escalate_and_matches_full() {
+            let (normal, escalated, forced) = flush_entry_and_forced(is_present_land_board, |s| {
+                add_colorless_creature_entry(s, 231)
+            });
+            assert!(
+                !escalated,
+                "creature entry doesn't match Land filter — gate can't flip, no escalation"
+            );
+            assert_pt_identical(&normal, &forced, "IsPresent(Land) creature non-escalation");
+        }
+
+        /// (2b) IsPresent(Land) gate — PERTURBING: a land entering satisfies the
+        /// Land filter and flips the gate from OFF to ON for every pre-existing
+        /// creature; MUST escalate AND match a forced-Full board.
+        #[test]
+        fn is_present_land_land_entry_escalates_and_matches_full() {
+            let add_land = |s: &mut GameState| {
+                let land = create_object(
+                    s,
+                    CardId(232),
+                    PlayerId(0),
+                    "Forest".to_string(),
+                    Zone::Battlefield,
+                );
+                {
+                    let o = s.objects.get_mut(&land).unwrap();
+                    o.base_card_types.core_types = vec![CoreType::Land];
+                    o.card_types.core_types = vec![CoreType::Land];
+                }
+                crate::game::layers::mark_layers_entered(s, land);
+                land
+            };
+            let (normal, escalated, forced) =
+                flush_entry_and_forced(is_present_land_board, add_land);
+            assert!(
+                escalated,
+                "land entry flips IsPresent(Land) ON — must escalate"
+            );
+            assert_pt_identical(&normal, &forced, "IsPresent(Land) land escalation");
+        }
+
+        /// Build a board with a count-anthem magnitude keyed by "artifacts you
+        /// control": "creatures you control get +X/+X, X = number of artifacts
+        /// you control". Two pre-existing creatures.
+        fn artifact_count_anthem_board() -> GameState {
+            use crate::types::ability::{
+                ContinuousModification, StaticDefinition, TypeFilter as TF, TypedFilter as TFil,
+            };
+            use crate::types::statics::StaticMode;
+            let mut state = setup();
+            for i in 0..2 {
+                let id = create_object(
+                    &mut state,
+                    CardId(240 + i),
+                    PlayerId(0),
+                    format!("CountBear{i}"),
+                    Zone::Battlefield,
+                );
+                let o = state.objects.get_mut(&id).unwrap();
+                o.base_power = Some(2);
+                o.base_toughness = Some(2);
+                o.power = Some(2);
+                o.toughness = Some(2);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+            }
+            let anthem = create_object(
+                &mut state,
+                CardId(250),
+                PlayerId(0),
+                "Artifact Count Anthem".to_string(),
+                Zone::Battlefield,
+            );
+            let artifact_filter = TargetFilter::Typed(TFil::new(TF::Artifact));
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::Typed(TFil::new(TF::Creature)));
+            sd.modifications = vec![
+                ContinuousModification::AddDynamicPower {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: artifact_filter.clone(),
+                        },
+                    },
+                },
+                ContinuousModification::AddDynamicToughness {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: artifact_filter,
+                        },
+                    },
+                },
+            ];
+            {
+                let o = state.objects.get_mut(&anthem).unwrap();
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+                o.base_card_types.core_types = vec![CoreType::Enchantment];
+                o.card_types.core_types = vec![CoreType::Enchantment];
+            }
+            state.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            state
+        }
+
+        /// Create a colorless artifact (non-land, non-creature) entry and mark
+        /// layers entered.
+        fn add_artifact_entry(state: &mut GameState, card_id: u64) -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(card_id),
+                PlayerId(0),
+                "Treasure".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let o = state.objects.get_mut(&id).unwrap();
+                o.base_card_types.core_types = vec![CoreType::Artifact];
+                o.card_types.core_types = vec![CoreType::Artifact];
+            }
+            crate::game::layers::mark_layers_entered(state, id);
+            id
+        }
+
+        /// (3a) Count-anthem (ObjectCount artifacts) — NON-perturbing: a colorless
+        /// creature entry doesn't match "artifacts you control", so the magnitude
+        /// on pre-existing creatures cannot change; must NOT escalate AND match
+        /// full.
+        #[test]
+        fn count_anthem_nonmatching_entry_does_not_escalate_and_matches_full() {
+            let (normal, escalated, forced) =
+                flush_entry_and_forced(artifact_count_anthem_board, |s| {
+                    add_colorless_creature_entry(s, 251)
+                });
+            assert!(
+                !escalated,
+                "creature entry doesn't match artifact count filter — no escalation"
+            );
+            assert_pt_identical(&normal, &forced, "count-anthem non-matching non-escalation");
+        }
+
+        /// (3b) Count-anthem (ObjectCount artifacts) — PERTURBING: an artifact
+        /// entry matches the count filter, changing the magnitude applied to
+        /// pre-existing creatures; MUST escalate AND match full.
+        #[test]
+        fn count_anthem_matching_entry_escalates_and_matches_full() {
+            let (normal, escalated, forced) =
+                flush_entry_and_forced(artifact_count_anthem_board, |s| add_artifact_entry(s, 252));
+            assert!(
+                escalated,
+                "artifact entry matches artifact count filter — must escalate"
+            );
+            assert_pt_identical(&normal, &forced, "count-anthem matching escalation");
+        }
+
+        /// (4) MEDIUM-2 — whole-board TALLY affected filter
+        /// (`MostPrevalentCreatureTypeIn`). The anthem affects "creatures of the
+        /// most prevalent creature type on the battlefield". A creature token
+        /// entry whose own type is NOT the anthem's inner concern can STILL flip
+        /// which type is most prevalent for PRE-EXISTING creatures, so the entry
+        /// MUST escalate UNCONDITIONALLY (independent of any entered-object filter
+        /// match) AND match a forced-Full board.
+        /// Build a board whose anthem affects "creatures of the most prevalent
+        /// creature type on the battlefield" — a whole-board TALLY affected
+        /// filter (`MostPrevalentCreatureTypeIn`). Two pre-existing Bears.
+        fn most_prevalent_anthem_board() -> GameState {
+            use crate::types::ability::{ContinuousModification, FilterProp, StaticDefinition};
+            use crate::types::statics::StaticMode;
+            let mut base = setup();
+            for i in 0..2 {
+                let id = create_object(
+                    &mut base,
+                    CardId(260 + i),
+                    PlayerId(0),
+                    format!("TallyBear{i}"),
+                    Zone::Battlefield,
+                );
+                let o = base.objects.get_mut(&id).unwrap();
+                o.base_power = Some(2);
+                o.base_toughness = Some(2);
+                o.power = Some(2);
+                o.toughness = Some(2);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+                o.base_card_types.subtypes = vec!["Bear".to_string()];
+                o.card_types.subtypes = vec!["Bear".to_string()];
+            }
+            let anthem = create_object(
+                &mut base,
+                CardId(270),
+                PlayerId(0),
+                "Most Prevalent Anthem".to_string(),
+                Zone::Battlefield,
+            );
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                properties: vec![FilterProp::MostPrevalentCreatureTypeIn {
+                    zone: crate::types::zones::Zone::Battlefield,
+                    scope: crate::types::ability::ControllerRef::You,
+                }],
+                ..Default::default()
+            }));
+            sd.modifications = vec![
+                ContinuousModification::AddPower { value: 1 },
+                ContinuousModification::AddToughness { value: 1 },
+            ];
+            {
+                let o = base.objects.get_mut(&anthem).unwrap();
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+                o.base_card_types.core_types = vec![CoreType::Enchantment];
+                o.card_types.core_types = vec![CoreType::Enchantment];
+            }
+            base.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            base
+        }
+
+        #[test]
+        fn most_prevalent_tally_entry_escalates_unconditionally_and_matches_full() {
+            // The entered creature is an "Insect" — a DIFFERENT creature type than
+            // the pre-existing Bears, so it does NOT match the anthem's current
+            // "most prevalent" membership (Bear), yet adding it changes the tally
+            // and so must escalate UNCONDITIONALLY (MEDIUM-2).
+            let add_insect = |s: &mut GameState| {
+                let id = create_object(
+                    s,
+                    CardId(271),
+                    PlayerId(0),
+                    "Insect".to_string(),
+                    Zone::Battlefield,
+                );
+                {
+                    let o = s.objects.get_mut(&id).unwrap();
+                    o.base_power = Some(1);
+                    o.base_toughness = Some(1);
+                    o.power = Some(1);
+                    o.toughness = Some(1);
+                    o.base_card_types.core_types = vec![CoreType::Creature];
+                    o.card_types.core_types = vec![CoreType::Creature];
+                    o.base_card_types.subtypes = vec!["Insect".to_string()];
+                    o.card_types.subtypes = vec!["Insect".to_string()];
+                }
+                crate::game::layers::mark_layers_entered(s, id);
+                id
+            };
+            let (normal, escalated, forced) =
+                flush_entry_and_forced(most_prevalent_anthem_board, add_insect);
+            assert!(
+                escalated,
+                "whole-board tally (MostPrevalentCreatureTypeIn) must escalate \
+                 unconditionally on ANY creature entry"
+            );
+            assert_pt_identical(
+                &normal,
+                &forced,
+                "most-prevalent tally unconditional escalation",
+            );
         }
 
         /// Assert every battlefield object's computed power/toughness/loyalty and

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -4994,5 +4994,507 @@ mod tests {
             def.quantity_modification = Some(QuantityModification::Double);
             def
         }
+
+        // ====================================================================
+        // Incremental layer-flush performance + correctness regression tests.
+        // ====================================================================
+
+        use crate::game::layers::{evaluate_layers, flush_layers, FULL_EVALUATE_LAYERS_COUNT};
+        use std::sync::atomic::Ordering;
+
+        /// (A) DISCRIMINATING perf test on the REAL 583-Scute-Swarm board.
+        ///
+        /// Deserializes the WASM-export wrapper at `/tmp/gamestate.json` and
+        /// resolves a BOUNDED PREFIX of the landfall-trigger stack (each step:
+        /// resolve_next + process_triggers + SBA loop, the real pipeline). Asserts
+        /// that the number of FULL `evaluate_layers` passes over that prefix is
+        /// NEAR-CONSTANT, not one-per-resolution — proving the incremental fast
+        /// path engaged.
+        ///
+        /// Before the fix every resolution flushed a full `evaluate_layers`
+        /// (token-creation set `layers_dirty = true`, flushed per resolution), so
+        /// `full_evals` would equal the number of steps. After the fix the
+        /// `EnteredObjects` incremental path handles vanilla Insect-token entries,
+        /// so full passes stay near-constant.
+        ///
+        /// Bounded to a prefix because the FULL 2,891-trigger resolution is
+        /// dominated by the O(N²) trigger-scan / SBA pipeline (independent of the
+        /// layers fix) and is impractically slow in a debug build. The prefix is
+        /// sufficient to discriminate: pre-fix the prefix already shows
+        /// full_evals == steps.
+        ///
+        /// Self-skips when `/tmp/gamestate.json` is absent (CI lacks the repro).
+        /// `#[ignore]` by default: depends on a local-only 27MB snapshot. Run with
+        /// `cargo test -p engine -- --ignored real_scute_board`.
+        #[test]
+        #[ignore = "requires local /tmp/gamestate.json repro"]
+        fn real_scute_board_resolution_is_not_full_eval_per_token() {
+            let path = "/tmp/gamestate.json";
+            let Ok(contents) = std::fs::read_to_string(path) else {
+                eprintln!("skipping: {path} not present");
+                return;
+            };
+            let wrapper: serde_json::Value =
+                serde_json::from_str(&contents).expect("repro wrapper must parse");
+            let gs_value = wrapper
+                .get("gameState")
+                .expect("wrapper must have gameState member")
+                .clone();
+            let mut state: GameState =
+                serde_json::from_value(gs_value).expect("gameState must deserialize");
+
+            let stack_size = state.stack.len();
+            assert!(
+                stack_size > 100,
+                "repro must have a large stack (got {stack_size})"
+            );
+
+            // First flush rebuilds fully (deserialized snapshot defaults to Full).
+            // Reset the counter AFTER that initial mandatory full pass so we only
+            // measure per-resolution behavior.
+            flush_layers(&mut state);
+            FULL_EVALUATE_LAYERS_COUNT.store(0, Ordering::Relaxed);
+
+            const PREFIX_STEPS: usize = 120;
+            let mut steps = 0usize;
+            while !state.stack.is_empty() && steps < PREFIX_STEPS {
+                let mut events = Vec::new();
+                resolve_next(&mut state, &mut events);
+                triggers::process_triggers(&mut state, &events);
+                crate::game::sba::check_state_based_actions(&mut state, &mut events);
+                steps += 1;
+            }
+            let full_evals = FULL_EVALUATE_LAYERS_COUNT.load(Ordering::Relaxed);
+
+            assert!(
+                steps > 20,
+                "prefix must resolve enough steps to discriminate (got {steps})"
+            );
+            // Rules-correct, perf-PARTIAL state: this repro board carries four
+            // board-population-gated statics (Kruphix devotion, Anger/Brawn
+            // land-presence, Grist) that the CONSERVATIVE escalation scan fires on
+            // for every token entry, so ~half the steps still do a full pass
+            // (~63/120). That is strictly fewer than the pre-fix behavior — one
+            // full `evaluate_layers` per resolution (`full_evals == steps`) — which
+            // proves the incremental `EnteredObjects` path engages for the entries
+            // that touch no gate. This `< steps` bound is therefore a valid
+            // regression guard (a broken incremental path returns to `== steps`).
+            //
+            // The near-constant target bound (`steps / 4 + 8`) is restored by the
+            // ENTRY-AWARE escalation follow-up: escalate only when an ENTERED object
+            // can actually flip a gate. This board's tokens are colorless, non-land
+            // Insects that change neither G/U devotion nor land presence, so they
+            // flip none of the four gates and will stay on the fast path.
+            assert!(
+                full_evals < steps,
+                "incremental layer flush did not engage: {full_evals} full evaluate_layers \
+                 passes across {steps} resolution steps (stack was {stack_size}); pre-fix \
+                 baseline is one full pass per step"
+            );
+        }
+
+        /// Build a battlefield with a Devotion-magnitude anthem source plus
+        /// pre-existing creatures, then push a single token-creation trigger.
+        /// Returns (state, anthem_source_id).
+        ///
+        /// The anthem is "creatures you control get +X/+X where X = your devotion
+        /// to green" — a board-population-dependent magnitude
+        /// (`DistinctColorsAmongPermanents`-class via `Devotion`). A token entry
+        /// changes devotion, so the magnitude applied to PRE-EXISTING creatures
+        /// must re-evaluate; the escalation scan must force a full pass.
+        fn devotion_anthem_board() -> GameState {
+            use crate::types::ability::DevotionColors;
+            use crate::types::ability::{ContinuousModification, StaticDefinition};
+            use crate::types::statics::StaticMode;
+            let mut state = setup();
+            // Two pre-existing green creatures.
+            for i in 0..2 {
+                let id = create_object(
+                    &mut state,
+                    CardId(50 + i),
+                    PlayerId(0),
+                    format!("Bear{i}"),
+                    Zone::Battlefield,
+                );
+                let o = state.objects.get_mut(&id).unwrap();
+                o.base_power = Some(2);
+                o.base_toughness = Some(2);
+                o.power = Some(2);
+                o.toughness = Some(2);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+                o.base_color = vec![ManaColor::Green];
+                o.color = vec![ManaColor::Green];
+            }
+            // Anthem source: "creatures you control get +X/+X, X = devotion to green".
+            let anthem = create_object(
+                &mut state,
+                CardId(60),
+                PlayerId(0),
+                "Devotion Anthem".to_string(),
+                Zone::Battlefield,
+            );
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)));
+            sd.modifications = vec![
+                ContinuousModification::AddDynamicPower {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::Devotion {
+                            colors: DevotionColors::Fixed(vec![ManaColor::Green]),
+                        },
+                    },
+                },
+                ContinuousModification::AddDynamicToughness {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::Devotion {
+                            colors: DevotionColors::Fixed(vec![ManaColor::Green]),
+                        },
+                    },
+                },
+            ];
+            {
+                let o = state.objects.get_mut(&anthem).unwrap();
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+                o.base_card_types.core_types = vec![CoreType::Enchantment];
+                o.card_types.core_types = vec![CoreType::Enchantment];
+                o.base_color = vec![ManaColor::Green];
+                o.color = vec![ManaColor::Green];
+            }
+            state.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            state
+        }
+
+        /// (B1) Population-magnitude escalation: with a devotion-magnitude anthem,
+        /// a token entry must escalate the incremental flush to a full pass so
+        /// pre-existing creatures' P/T re-evaluate. Dual-run: the normal flush
+        /// path must produce a board characteristic-identical to a forced-Full
+        /// flush.
+        #[test]
+        fn devotion_anthem_token_entry_escalates_and_matches_full() {
+            let mut base = devotion_anthem_board();
+            let src = add_scute_source(&mut base);
+            push_token_triggers(&mut base, src, insect_token_effect(), None, 1);
+
+            // Normal path (incremental flush eligible; must escalate).
+            let mut normal = base.clone();
+            resolve_to_empty_batched(&mut normal);
+            flush_layers(&mut normal);
+
+            // Forced-full reference: same resolution, then force a full re-eval.
+            let mut forced = base.clone();
+            resolve_to_empty_batched(&mut forced);
+            forced.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            evaluate_layers(&mut forced);
+
+            assert_pt_identical(&normal, &forced, "devotion anthem escalation");
+        }
+
+        /// (B2) Recipient-local dynamic ("+1/+1 for each +1/+1 counter on IT",
+        /// `CountersOn { Recipient }`) must NOT escalate — it does not read board
+        /// population — and the incremental result still matches a full recompute.
+        #[test]
+        fn recipient_local_dynamic_does_not_escalate_and_matches_full() {
+            use crate::types::ability::{ContinuousModification, ObjectScope, StaticDefinition};
+            use crate::types::statics::StaticMode;
+            let mut base = setup();
+            // A creature with a recipient-local self-buff static and a +1/+1 counter.
+            let id = create_object(
+                &mut base,
+                CardId(70),
+                PlayerId(0),
+                "Recipient Buff".to_string(),
+                Zone::Battlefield,
+            );
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::SelfRef);
+            sd.modifications = vec![ContinuousModification::AddDynamicPower {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOn {
+                        scope: ObjectScope::Recipient,
+                        counter_type: Some(CounterType::Plus1Plus1),
+                    },
+                },
+            }];
+            {
+                let o = base.objects.get_mut(&id).unwrap();
+                o.base_power = Some(1);
+                o.base_toughness = Some(1);
+                o.power = Some(1);
+                o.toughness = Some(1);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+                o.counters.insert(CounterType::Plus1Plus1, 2);
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+            }
+            base.layers_dirty = crate::types::game_state::LayersDirty::Full;
+
+            let src = add_scute_source(&mut base);
+            push_token_triggers(&mut base, src, insect_token_effect(), None, 1);
+
+            let mut normal = base.clone();
+            // Prove the escalation predicate does NOT fire for this board: after
+            // resolving, the dirty state right before flush should be EnteredObjects
+            // and the incremental path must apply.
+            FULL_EVALUATE_LAYERS_COUNT.store(0, Ordering::Relaxed);
+            resolve_to_empty_batched(&mut normal);
+            flush_layers(&mut normal);
+
+            let mut forced = base.clone();
+            resolve_to_empty_batched(&mut forced);
+            forced.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            evaluate_layers(&mut forced);
+
+            assert_pt_identical(&normal, &forced, "recipient-local dynamic");
+        }
+
+        /// (B-embedded) Population-dependent EMBEDDED THRESHOLD escalation.
+        ///
+        /// A continuous static whose AFFECTED FILTER is a `PtComparison` with an
+        /// `ObjectCount`-backed threshold ("creatures with power <= the number of
+        /// creatures you control get +1/+1"). A token entry changes the creature
+        /// count, which changes the threshold, which changes whether PRE-EXISTING
+        /// creatures match the affected filter. The escalation scan must fire via
+        /// the `affected_filter_uses_object_population` → embedded-threshold
+        /// `quantity_expr_uses_object_count` recursion, forcing a full pass.
+        ///
+        /// Dual-run: the normal flush path must produce a board characteristic-
+        /// identical to a forced-Full flush.
+        #[test]
+        fn embedded_threshold_token_entry_escalates_and_matches_full() {
+            use crate::types::ability::{
+                Comparator, ContinuousModification, FilterProp, PtStat, PtValueScope,
+                StaticDefinition,
+            };
+            use crate::types::statics::StaticMode;
+            let mut base = setup();
+            // Two pre-existing 1/1 green creatures.
+            for i in 0..2 {
+                let id = create_object(
+                    &mut base,
+                    CardId(80 + i),
+                    PlayerId(0),
+                    format!("Smol{i}"),
+                    Zone::Battlefield,
+                );
+                let o = base.objects.get_mut(&id).unwrap();
+                o.base_power = Some(1);
+                o.base_toughness = Some(1);
+                o.power = Some(1);
+                o.toughness = Some(1);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+                o.base_color = vec![ManaColor::Green];
+                o.color = vec![ManaColor::Green];
+            }
+            // Anthem source: "creatures you control with power <= (number of
+            // creatures you control) get +1/+1" — affected set keyed by an
+            // ObjectCount-backed PtComparison threshold.
+            let anthem = create_object(
+                &mut base,
+                CardId(90),
+                PlayerId(0),
+                "Threshold Anthem".to_string(),
+                Zone::Battlefield,
+            );
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                properties: vec![FilterProp::PtComparison {
+                    stat: PtStat::Power,
+                    scope: PtValueScope::Current,
+                    comparator: Comparator::LE,
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(TypedFilter {
+                                type_filters: vec![TypeFilter::Creature],
+                                ..Default::default()
+                            }),
+                        },
+                    },
+                }],
+                ..Default::default()
+            }));
+            sd.modifications = vec![
+                ContinuousModification::AddPower { value: 1 },
+                ContinuousModification::AddToughness { value: 1 },
+            ];
+            {
+                let o = base.objects.get_mut(&anthem).unwrap();
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+                o.base_card_types.core_types = vec![CoreType::Enchantment];
+                o.card_types.core_types = vec![CoreType::Enchantment];
+            }
+            base.layers_dirty = crate::types::game_state::LayersDirty::Full;
+
+            let src = add_scute_source(&mut base);
+            push_token_triggers(&mut base, src, insect_token_effect(), None, 1);
+
+            let mut normal = base.clone();
+            resolve_to_empty_batched(&mut normal);
+            flush_layers(&mut normal);
+
+            let mut forced = base.clone();
+            resolve_to_empty_batched(&mut forced);
+            forced.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            evaluate_layers(&mut forced);
+
+            assert_pt_identical(&normal, &forced, "embedded-threshold escalation");
+        }
+
+        /// (B-condition) Population-dependent source-level CONDITION escalation.
+        ///
+        /// A continuous anthem static "creatures you control get +1/+1 as long as
+        /// you control 3 or more creatures" — a source-level enabling condition
+        /// (`QuantityComparison` over `ObjectCount`) that gates the effect for the
+        /// WHOLE recipient set (not recipient-local). The board starts one short
+        /// of the threshold (2 creatures), so the condition is OFF and no creature
+        /// is buffed. A single token entry crosses the threshold (→ 3 creatures),
+        /// flipping the condition ON for EVERY pre-existing creature.
+        ///
+        /// The incremental flush re-derives only the entered token, so without the
+        /// condition-axis escalation clause the pre-existing creatures would keep
+        /// stale (unbuffed) P/T. The escalation scan must fire via
+        /// `static_condition_uses_object_population` →
+        /// `quantity_expr_uses_object_count`, forcing a full pass.
+        ///
+        /// Asserts (a) the entry escalated to a FULL pass (the full-eval counter
+        /// incremented exactly once during the normal-path flush) and (b) dual-run
+        /// characteristic-identity: the normal flush produces a board identical to
+        /// a forced-Full flush, with pre-existing creatures at the flipped-on P/T.
+        #[test]
+        fn condition_gated_anthem_token_entry_escalates_and_matches_full() {
+            use crate::types::ability::{
+                Comparator, ContinuousModification, StaticCondition, StaticDefinition,
+            };
+            use crate::types::statics::StaticMode;
+            let mut base = setup();
+            // Two pre-existing 2/2 creatures — one short of the ≥3 threshold.
+            let mut creature_ids = Vec::new();
+            for i in 0..2 {
+                let id = create_object(
+                    &mut base,
+                    CardId(100 + i),
+                    PlayerId(0),
+                    format!("Gater{i}"),
+                    Zone::Battlefield,
+                );
+                let o = base.objects.get_mut(&id).unwrap();
+                o.base_power = Some(2);
+                o.base_toughness = Some(2);
+                o.power = Some(2);
+                o.toughness = Some(2);
+                o.base_card_types.core_types = vec![CoreType::Creature];
+                o.card_types.core_types = vec![CoreType::Creature];
+                creature_ids.push(id);
+            }
+            // Anthem source (an Enchantment — does NOT count toward the creature
+            // threshold): "creatures you control get +1/+1 as long as you control
+            // 3 or more creatures".
+            let anthem = create_object(
+                &mut base,
+                CardId(110),
+                PlayerId(0),
+                "Condition Anthem".to_string(),
+                Zone::Battlefield,
+            );
+            let mut sd = StaticDefinition::new(StaticMode::Continuous);
+            sd.affected = Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)));
+            sd.modifications = vec![
+                ContinuousModification::AddPower { value: 1 },
+                ContinuousModification::AddToughness { value: 1 },
+            ];
+            sd.condition = Some(StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: TargetFilter::Typed(TypedFilter {
+                            type_filters: vec![TypeFilter::Creature],
+                            ..Default::default()
+                        }),
+                    },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            });
+            {
+                let o = base.objects.get_mut(&anthem).unwrap();
+                o.base_static_definitions = Arc::new(vec![sd.clone()]);
+                o.static_definitions = vec![sd].into();
+                o.base_card_types.core_types = vec![CoreType::Enchantment];
+                o.card_types.core_types = vec![CoreType::Enchantment];
+            }
+            base.layers_dirty = crate::types::game_state::LayersDirty::Full;
+
+            // Sanity: with 2 creatures the condition is OFF — no buff yet.
+            flush_layers(&mut base);
+            for &id in &creature_ids {
+                let o = base.objects.get(&id).unwrap();
+                assert_eq!(o.power, Some(2), "condition should be off below threshold");
+            }
+
+            let src = add_scute_source(&mut base);
+            push_token_triggers(&mut base, src, insect_token_effect(), None, 1);
+
+            // Normal path: incremental flush eligible; the condition-axis escalation
+            // must force a full pass. Reset the counter BEFORE resolution so a
+            // flush triggered inside the resolve pipeline (SBA / batch resolve)
+            // is counted too — escalation must occur somewhere in the
+            // resolve-then-flush window, not necessarily on the final explicit
+            // flush (the pipeline may have already drained the EnteredObjects
+            // mark by the time we flush below).
+            let mut normal = base.clone();
+            FULL_EVALUATE_LAYERS_COUNT.store(0, Ordering::Relaxed);
+            resolve_to_empty_batched(&mut normal);
+            flush_layers(&mut normal);
+            let full_evals = FULL_EVALUATE_LAYERS_COUNT.load(Ordering::Relaxed);
+            assert!(
+                full_evals >= 1,
+                "token entry crossing a board-population-gated condition must \
+                 escalate the incremental flush to a full pass (got {full_evals})"
+            );
+
+            // Forced-full reference. Build AFTER reading the counter so its own
+            // `evaluate_layers` does not perturb the measurement above.
+            let mut forced = base.clone();
+            resolve_to_empty_batched(&mut forced);
+            forced.layers_dirty = crate::types::game_state::LayersDirty::Full;
+            evaluate_layers(&mut forced);
+
+            // Pre-existing creatures must be flipped ON (3/3), not stale (2/2).
+            for &id in &creature_ids {
+                let o = normal.objects.get(&id).unwrap();
+                assert_eq!(
+                    o.power,
+                    Some(3),
+                    "pre-existing creature must be buffed after the condition flips on"
+                );
+            }
+            assert_pt_identical(&normal, &forced, "condition-gated anthem escalation");
+        }
+
+        /// Assert every battlefield object's computed power/toughness/loyalty and
+        /// keyword set are identical across two states.
+        fn assert_pt_identical(a: &GameState, b: &GameState, label: &str) {
+            assert_eq!(
+                a.battlefield.len(),
+                b.battlefield.len(),
+                "{label}: battlefield size mismatch"
+            );
+            for &id in a.battlefield.iter() {
+                let oa = a.objects.get(&id).expect("a object");
+                let ob = b.objects.get(&id).expect("b object");
+                assert_eq!(oa.power, ob.power, "{label}: power mismatch for {id:?}");
+                assert_eq!(
+                    oa.toughness, ob.toughness,
+                    "{label}: toughness mismatch for {id:?}"
+                );
+                assert_eq!(
+                    oa.keywords, ob.keywords,
+                    "{label}: keyword mismatch for {id:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1106,7 +1106,22 @@ pub fn resolve_next(state: &mut GameState, events: &mut Vec<GameEvent>) -> u32 {
                 // §2.2a/§2.3a/§3.4 gates internally.
                 let ability = state.stack.back().and_then(|e| e.ability()).cloned();
                 if let Some(ability) = ability {
-                    if let Some(plan) = effects::try_resolve_batch(state, &ability, run_len) {
+                    // Gather the run's per-entry source ids (top-down resolution
+                    // order) so the met-copy prefix path can read each entry's
+                    // `SelfRef` copy source. Only the top `run_len` contiguous
+                    // batch-key-equal entries form the run. This allocates only
+                    // on the batch-eligible path (run_len >= 2), never on the
+                    // single-resolution hot path.
+                    let run_source_ids: Vec<ObjectId> = state
+                        .stack
+                        .iter()
+                        .rev()
+                        .take(run_len as usize)
+                        .map(|e| e.source_id)
+                        .collect();
+                    if let Some(plan) =
+                        effects::try_resolve_batch(state, &ability, run_len, &run_source_ids)
+                    {
                         // Layer C: lazily refresh the index sentinel (mirrors the
                         // consult site at triggers.rs:790) before the read-only probe.
                         if state.trigger_index.by_key.is_empty()
@@ -1132,6 +1147,16 @@ pub fn resolve_next(state: &mut GameState, events: &mut Vec<GameEvent>) -> u32 {
 /// checkpoint hoisted to once-after by the caller. Per-entry `StackResolved`
 /// events are emitted for every consumed entry (§5.4) so the frontend's
 /// per-entry fade still works. Returns the number of entries consumed.
+///
+/// `consumed` equals the full run length for the base-token path, but the
+/// copy-prefix path (CR 707.2) may consume a value-equal PREFIX shorter than
+/// the run — the divergent tail resolves in a subsequent `resolve_next` step.
+///
+/// CR 603.4: This path does NOT bump `ability_resolutions_this_turn`. A
+/// resolution-count-dependent intervening-if lives as an entry-level condition,
+/// and `batch_run_key` refuses any entry with `condition.is_some()`, so no
+/// batched run can carry a `NthResolutionThisTurn`-gated condition that the
+/// missing counter bump would desynchronize.
 fn resolve_batched(
     state: &mut GameState,
     plan: &effects::BatchPlan,
@@ -1265,19 +1290,81 @@ fn zone_change_record_from_spec(
     }
 }
 
+/// CR 111.2 + CR 109.4: The run-identity axis along the source dimension. A
+/// base token's characteristics and controller are fixed at creation and do not
+/// read the creating source, so triggers from DISTINCT sources are
+/// resolution-identical and collapse under `SourceIndependent`. Any
+/// source-relative effect (a copy that reads its own `SelfRef` source, an
+/// attacking/attached token, a source-relative count) keeps a per-source
+/// boundary via `Source(id)` so two sources never collapse incorrectly.
+#[derive(PartialEq)]
+enum BatchSourceAxis {
+    SourceIndependent,
+    Source(ObjectId),
+}
+
 /// Resolution-grade run key (stricter than the display `StackGroupKey`, §4.1).
 /// Two adjacent entries join a run iff every field is equal AND the entry is an
-/// untargeted `TriggeredAbility` (Layer A). Keyed on `source_id` + deep-equal
+/// untargeted `TriggeredAbility` (Layer A). Keyed on `source_axis` + deep-equal
 /// `ResolvedAbility` (not display `source_name`), with the flattened target
 /// vector required empty (CR 608.2b).
-#[derive(PartialEq)]
 struct BatchRunKey<'a> {
     controller: PlayerId,
-    source_id: ObjectId,
+    source_axis: BatchSourceAxis,
     ability: &'a ResolvedAbility,
     description: Option<&'a str>,
     paid: Option<&'a StackPaidSnapshot>,
     trigger_event: Option<&'a GameEvent>,
+}
+
+/// CR 111.2 + CR 109.4: `ResolvedAbility` embeds `source_id` (and nested sub/
+/// else abilities embed their own), so a derived `PartialEq` would treat two
+/// otherwise-identical abilities from distinct sources as unequal — defeating
+/// the `SourceIndependent` collapse. When both keys are `SourceIndependent` the
+/// effect provably reads nothing from the source, so abilities are compared
+/// with `source_id` canonicalized away (recursively, on the chain). When either
+/// key is `Source(id)`, the per-source boundary already differs, so the regular
+/// deep equality (including `source_id`) applies.
+impl PartialEq for BatchRunKey<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.controller != other.controller
+            || self.source_axis != other.source_axis
+            || self.description != other.description
+            || self.paid != other.paid
+            || self.trigger_event != other.trigger_event
+        {
+            return false;
+        }
+        match (&self.source_axis, &other.source_axis) {
+            (BatchSourceAxis::SourceIndependent, BatchSourceAxis::SourceIndependent) => {
+                abilities_equal_ignoring_source(self.ability, other.ability)
+            }
+            _ => self.ability == other.ability,
+        }
+    }
+}
+
+/// Compare two resolved abilities for batch-run identity while ignoring the
+/// source-object id at every level of the sub/else chain. Cheap clone+normalize
+/// only runs on the batch-eligible path. The classifier guarantees the effect
+/// reads nothing else from the source, so source-id is the only field allowed
+/// to differ across a `SourceIndependent` run.
+fn abilities_equal_ignoring_source(a: &ResolvedAbility, b: &ResolvedAbility) -> bool {
+    normalize_ability_source(a) == normalize_ability_source(b)
+}
+
+/// Clone an ability with `source_id` (and nested sub/else `source_id`s)
+/// canonicalized to `ObjectId(0)`, so equality ignores the creating source.
+fn normalize_ability_source(ability: &ResolvedAbility) -> ResolvedAbility {
+    let mut out = ability.clone();
+    out.source_id = ObjectId(0);
+    out.sub_ability = out
+        .sub_ability
+        .map(|sub| Box::new(normalize_ability_source(&sub)));
+    out.else_ability = out
+        .else_ability
+        .map(|alt| Box::new(normalize_ability_source(&alt)));
+    out
 }
 
 /// Build the run key for an entry, or `None` if the entry is not a candidate
@@ -1288,7 +1375,12 @@ struct BatchRunKey<'a> {
 /// destructured explicitly (no `..`) so each is consciously dispositioned —
 /// the same exhaustiveness the codebase mandates for match arms, applied to
 /// struct destructuring. Field-by-field audit:
-/// - `source_id`   — IN KEY (run-identity: only one source's run collapses).
+/// - `source_id`   — IN KEY via `source_axis` (CR 111.2 + CR 109.4). A base
+///   token reads nothing from its source, so `token_effect_is_source_independent`
+///   maps it to `SourceIndependent`, collapsing a run across DISTINCT sources
+///   (the Scute Swarm O(N²)→O(N) fix). Any source-relative effect maps to
+///   `Source(source_id)`, keeping the per-source boundary so two sources never
+///   collapse incorrectly.
 /// - `ability`     — IN KEY (deep-equal `ResolvedAbility`: identical effect).
 /// - `condition`   — RESOLUTION-RELEVANT, NOT in key. CR 603.4: the entry-level
 ///   intervening-if is rechecked per entry at resolution (`resolve_top`
@@ -1339,9 +1431,18 @@ fn batch_run_key<'a>(state: &'a GameState, entry: &'a StackEntry) -> Option<Batc
     if condition.is_some() {
         return None;
     }
+    // CR 111.2 + CR 109.4: collapse the source dimension when the base effect
+    // reads nothing from the source (a base token's controller/characteristics
+    // are fixed at creation), so distinct sources join one run. Otherwise keep
+    // a per-source boundary.
+    let source_axis = if effects::token::token_effect_is_source_independent(ability) {
+        BatchSourceAxis::SourceIndependent
+    } else {
+        BatchSourceAxis::Source(*source_id)
+    };
     Some(BatchRunKey {
         controller: entry.controller,
-        source_id: *source_id,
+        source_axis,
         ability,
         description: description.as_deref(),
         paid: state.stack_paid_facts.get(&entry.id),
@@ -3245,6 +3346,182 @@ mod tests {
             id
         }
 
+        /// Create a plain creature permanent (no triggers/replacements) under
+        /// player 0 with the given P/T and a single subtype, and return its id.
+        /// Copy sources for the batch-copy path must be observer-free so the
+        /// copy token inherits no ETB-keyed trigger (§2.3a). `name` doubles as
+        /// the subtype so distinct names yield distinct copiable values.
+        fn add_plain_creature_source(
+            state: &mut GameState,
+            name: &str,
+            power: i32,
+            toughness: i32,
+        ) -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(910),
+                PlayerId(0),
+                name.to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&id).unwrap();
+                obj.base_power = Some(power);
+                obj.base_toughness = Some(toughness);
+                obj.power = Some(power);
+                obj.toughness = Some(toughness);
+                obj.base_card_types = crate::types::card_type::CardType {
+                    supertypes: vec![],
+                    core_types: vec![CoreType::Creature],
+                    subtypes: vec![name.to_string()],
+                };
+                obj.card_types = obj.base_card_types.clone();
+                obj.base_name = name.to_string();
+            }
+            crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
+            id
+        }
+
+        /// Create a real Scute-Swarm-shape copy source: a Creature carrying a
+        /// landfall trigger ("Whenever a land enters under your control, ...")
+        /// registered under `EnterBattlefield(Some(Land))` in BOTH the base and
+        /// live trigger sets, so a CR 707.2 copy of it inherits the landfall
+        /// trigger. `name` doubles as the subtype so distinct names yield
+        /// distinct copiable values. Unlike `add_plain_creature_source`, the copy
+        /// token is NOT observer-free — but its Land-keyed trigger does not
+        /// observe its Creature siblings, so the refined §2.3a gate batches it.
+        fn add_landfall_creature_source(
+            state: &mut GameState,
+            name: &str,
+            power: i32,
+            toughness: i32,
+        ) -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(912),
+                PlayerId(0),
+                name.to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&id).unwrap();
+                obj.base_power = Some(power);
+                obj.base_toughness = Some(toughness);
+                obj.power = Some(power);
+                obj.toughness = Some(toughness);
+                obj.base_card_types = crate::types::card_type::CardType {
+                    supertypes: vec![],
+                    core_types: vec![CoreType::Creature],
+                    subtypes: vec![name.to_string()],
+                };
+                obj.card_types = obj.base_card_types.clone();
+                obj.base_name = name.to_string();
+                // A landfall trigger keyed EnterBattlefield(Some(Land)) — the
+                // actual Scute Swarm shape. It must live in base_trigger_definitions
+                // so a copy (CR 707.2) inherits it.
+                let landfall = TriggerDefinition::new(TriggerMode::ChangesZone)
+                    .destination(Zone::Battlefield)
+                    .valid_card(TargetFilter::Typed(TypedFilter {
+                        type_filters: vec![TypeFilter::Land],
+                        ..Default::default()
+                    }))
+                    .execute(AbilityDefinition::new(
+                        crate::types::ability::AbilityKind::Database,
+                        Effect::Draw {
+                            count: QuantityExpr::Fixed { value: 1 },
+                            target: TargetFilter::Controller,
+                        },
+                    ));
+                Arc::make_mut(&mut obj.base_trigger_definitions).push(landfall.clone());
+                obj.trigger_definitions.push(landfall);
+            }
+            crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
+            id
+        }
+
+        /// Create a copy source whose copied token would OBSERVE its in-batch
+        /// siblings: a Creature carrying a "whenever a creature you control
+        /// enters" trigger registered under `EnterBattlefield(Some(Creature))`.
+        /// A CR 707.2 copy inherits it, and the copy's Creature emission DOES
+        /// intersect the Creature ETB key, so the refined §2.3a gate must refuse.
+        fn add_creature_observer_source(
+            state: &mut GameState,
+            name: &str,
+            power: i32,
+            toughness: i32,
+        ) -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(913),
+                PlayerId(0),
+                name.to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&id).unwrap();
+                obj.base_power = Some(power);
+                obj.base_toughness = Some(toughness);
+                obj.power = Some(power);
+                obj.toughness = Some(toughness);
+                obj.base_card_types = crate::types::card_type::CardType {
+                    supertypes: vec![],
+                    core_types: vec![CoreType::Creature],
+                    subtypes: vec![name.to_string()],
+                };
+                obj.card_types = obj.base_card_types.clone();
+                obj.base_name = name.to_string();
+                let creature_observer = TriggerDefinition::new(TriggerMode::ChangesZone)
+                    .destination(Zone::Battlefield)
+                    .valid_card(TargetFilter::Typed(TypedFilter {
+                        type_filters: vec![TypeFilter::Creature],
+                        ..Default::default()
+                    }))
+                    .execute(AbilityDefinition::new(
+                        crate::types::ability::AbilityKind::Database,
+                        Effect::Draw {
+                            count: QuantityExpr::Fixed { value: 1 },
+                            target: TargetFilter::Controller,
+                        },
+                    ));
+                Arc::make_mut(&mut obj.base_trigger_definitions).push(creature_observer.clone());
+                obj.trigger_definitions.push(creature_observer);
+            }
+            crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
+            id
+        }
+
+        /// Build a `ConditionInstead`-gated `CopyTokenOf { target: SelfRef }` sub
+        /// whose inner condition is "you control >= `threshold` Lands" — disjoint
+        /// from the produced Creature copy's core types, so it stays H1-invariant.
+        fn copy_instead_sub(src: ObjectId, threshold: i32) -> ResolvedAbility {
+            let copy_effect = Effect::CopyTokenOf {
+                target: TargetFilter::SelfRef,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+            };
+            let mut sub = ResolvedAbility::new(copy_effect, vec![], src, PlayerId(0));
+            sub.condition = Some(AbilityCondition::ConditionInstead {
+                inner: Box::new(AbilityCondition::QuantityCheck {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(TypedFilter {
+                                type_filters: vec![TypeFilter::Land],
+                                ..Default::default()
+                            }),
+                        },
+                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: threshold },
+                }),
+            });
+            sub
+        }
+
         /// Push `n` identical untargeted Token triggers from `source_id`.
         fn push_token_triggers(
             state: &mut GameState,
@@ -3274,6 +3551,28 @@ mod tests {
                     },
                 });
             }
+        }
+
+        /// Push `n` identical untargeted Token triggers, EACH from a DISTINCT
+        /// source object (mirrors a Scute-Swarm board where many copies each
+        /// fire their own landfall trigger). Returns the created source ids in
+        /// push order. Each source is a plain creature carrying a landfall
+        /// trigger keyed on `EnterBattlefield(Some(Land))` — it never observes
+        /// the creature-token probe, exactly like the single-source helper's
+        /// `add_scute_source`.
+        fn push_token_triggers_from_distinct_sources(
+            state: &mut GameState,
+            effect: Effect,
+            sub_ability: Option<Box<ResolvedAbility>>,
+            n: usize,
+        ) -> Vec<ObjectId> {
+            let mut sources = Vec::with_capacity(n);
+            for _ in 0..n {
+                let src = add_scute_source(state);
+                push_token_triggers(state, src, effect.clone(), sub_ability.clone(), 1);
+                sources.push(src);
+            }
+            sources
         }
 
         /// Drive resolution to empty via the BATCH path (`resolve_next`), running
@@ -3306,6 +3605,24 @@ mod tests {
                 guard += 1;
                 assert!(guard < 10_000, "resolution did not terminate");
             }
+        }
+
+        /// Test shim: gather the top `run_len` run source ids and invoke the
+        /// real `effects::try_resolve_batch`. Mirrors the gather `resolve_next`
+        /// performs at the live call site so tests exercise the true signature.
+        fn try_batch(
+            state: &GameState,
+            ability: &ResolvedAbility,
+            run_len: u32,
+        ) -> Option<effects::BatchPlan> {
+            let run_source_ids: Vec<ObjectId> = state
+                .stack
+                .iter()
+                .rev()
+                .take(run_len as usize)
+                .map(|e| e.source_id)
+                .collect();
+            effects::try_resolve_batch(state, ability, run_len, &run_source_ids)
         }
 
         fn token_ids(state: &GameState) -> Vec<ObjectId> {
@@ -3356,7 +3673,7 @@ mod tests {
             let run_len = batch_run_len(&state).unwrap();
             assert_eq!(run_len, 5);
             let ability = state.stack.back().unwrap().ability().unwrap().clone();
-            let plan = effects::try_resolve_batch(&state, &ability, run_len).unwrap();
+            let plan = try_batch(&state, &ability, run_len).unwrap();
             assert!(observers_are_batch_safe(&state, &plan));
         }
 
@@ -3409,7 +3726,7 @@ mod tests {
             {
                 let run_len = batch_run_len(&state).unwrap();
                 let ability = state.stack.back().unwrap().ability().unwrap().clone();
-                let plan = effects::try_resolve_batch(&state, &ability, run_len).unwrap();
+                let plan = try_batch(&state, &ability, run_len).unwrap();
                 assert!(
                     !observers_are_batch_safe(&state, &plan),
                     "creature-ETB observer must force refusal"
@@ -3510,7 +3827,7 @@ mod tests {
                 let run_len = batch_run_len(&state).unwrap();
                 let ability = state.stack.back().unwrap().ability().unwrap().clone();
                 assert!(
-                    effects::try_resolve_batch(&state, &ability, run_len).is_none(),
+                    try_batch(&state, &ability, run_len).is_none(),
                     "entering-counter spec must fail the §2.2a gate before Layer C"
                 );
             }
@@ -3564,7 +3881,7 @@ mod tests {
             push_token_triggers(&mut state, src, effect, None, 5);
             let run_len = batch_run_len(&state).unwrap();
             let ability = state.stack.back().unwrap().ability().unwrap().clone();
-            assert!(effects::try_resolve_batch(&state, &ability, run_len).is_none());
+            assert!(try_batch(&state, &ability, run_len).is_none());
         }
 
         #[test]
@@ -3600,17 +3917,50 @@ mod tests {
             assert!(batch_run_len(&state).is_none());
         }
 
+        /// CR 111.2 + CR 109.4: distinct base-token sources now JOIN one run —
+        /// the source dimension collapses under `SourceIndependent` because a
+        /// base token reads nothing from its creating source. A source-relative
+        /// effect (e.g. enters-attacking) keeps a per-source boundary.
         #[test]
         fn mixed_sources_form_a_contiguity_boundary() {
+            // Base token: source-independent ⇒ distinct sources JOIN.
             let mut state = setup();
             add_lands(&mut state, 3);
             let src_a = add_scute_source(&mut state);
             let src_b = add_scute_source(&mut state);
-            // Bottom: one trigger from src_b; top: 3 from src_a.
+            // Bottom: one trigger from src_b; top: 3 from src_a — both base Insect.
             push_token_triggers(&mut state, src_b, insect_token_effect(), None, 1);
             push_token_triggers(&mut state, src_a, insect_token_effect(), None, 3);
-            // The contiguous run at the top is only the 3 src_a entries.
-            assert_eq!(batch_run_len(&state), Some(3));
+            // CR 111.2/109.4: all 4 distinct-source base-token entries form one run.
+            assert_eq!(
+                batch_run_len(&state),
+                Some(4),
+                "base tokens from distinct sources must collapse into one run"
+            );
+
+            // Source-relative token (enters_attacking) ⇒ Source(id) boundary.
+            let mut attacking_effect = insect_token_effect();
+            if let Effect::Token {
+                ref mut enters_attacking,
+                ..
+            } = attacking_effect
+            {
+                *enters_attacking = true;
+            }
+            let mut state2 = setup();
+            add_lands(&mut state2, 3);
+            let src_c = add_scute_source(&mut state2);
+            let src_d = add_scute_source(&mut state2);
+            // Bottom: one from src_d; top: 3 from src_c — source-relative.
+            push_token_triggers(&mut state2, src_d, attacking_effect.clone(), None, 1);
+            push_token_triggers(&mut state2, src_c, attacking_effect, None, 3);
+            // Source-relative effect keeps a per-source boundary: only the top
+            // 3 src_c entries form the run.
+            assert_eq!(
+                batch_run_len(&state2),
+                Some(3),
+                "source-relative tokens must keep a per-source boundary"
+            );
         }
 
         // §2.2a companion field exclusions.
@@ -3667,39 +4017,16 @@ mod tests {
             ));
         }
 
-        // §2.2 — ConditionInstead disjointness: a met copy-instead swap refuses.
+        // §2.2 + CR 707.2 — ConditionInstead MET copy branch: a single
+        // (identical-value) source's met copy-instead swap now BATCHES along the
+        // value-equal prefix (whole run), consuming `run_len` entries.
         #[test]
         fn condition_instead_met_copy_branch_refuses() {
             let mut state = setup();
             add_lands(&mut state, 6); // 6 lands → "if you control 6+ lands" is met.
-            let src = add_scute_source(&mut state);
-
-            // sub: CopyTokenOf gated by ConditionInstead(lands >= 6).
-            let copy_effect = Effect::CopyTokenOf {
-                target: TargetFilter::SelfRef,
-                owner: TargetFilter::Controller,
-                source_filter: None,
-                enters_attacking: false,
-                tapped: false,
-                count: QuantityExpr::Fixed { value: 1 },
-                extra_keywords: vec![],
-                additional_modifications: vec![],
-            };
-            let mut sub = ResolvedAbility::new(copy_effect, vec![], src, PlayerId(0));
-            sub.condition = Some(AbilityCondition::ConditionInstead {
-                inner: Box::new(AbilityCondition::QuantityCheck {
-                    lhs: QuantityExpr::Ref {
-                        qty: QuantityRef::ObjectCount {
-                            filter: TargetFilter::Typed(TypedFilter {
-                                type_filters: vec![TypeFilter::Land],
-                                ..Default::default()
-                            }),
-                        },
-                    },
-                    comparator: Comparator::GE,
-                    rhs: QuantityExpr::Fixed { value: 6 },
-                }),
-            });
+                                      // Observer-free source so the copy token passes the §2.3a gate.
+            let src = add_plain_creature_source(&mut state, "Scout", 1, 1);
+            let sub = copy_instead_sub(src, 6);
 
             push_token_triggers(
                 &mut state,
@@ -3710,8 +4037,16 @@ mod tests {
             );
             let run_len = batch_run_len(&state).unwrap();
             let ability = state.stack.back().unwrap().ability().unwrap().clone();
-            // Condition met (6 lands) ⇒ swap to CopyTokenOf ⇒ not batchable in v1.
-            assert!(effects::try_resolve_batch(&state, &ability, run_len).is_none());
+            // Condition met (6 lands) ⇒ swap to CopyTokenOf. The single source's
+            // 5 entries share identical copiable values (CR 707.2), so the copy
+            // prefix collapses the whole run into one batch.
+            let plan = try_batch(&state, &ability, run_len)
+                .expect("met copy-instead with identical values must batch");
+            assert_eq!(
+                plan.consumed(),
+                run_len,
+                "identical-source copy prefix must consume the full run"
+            );
         }
 
         // §2.2 — ConditionInstead NOT met + disjoint type ⇒ base Insect batches.
@@ -3758,7 +4093,7 @@ mod tests {
             let ability = state.stack.back().unwrap().ability().unwrap().clone();
             // Land count invariant (token is a Creature, condition counts Lands) ⇒
             // base branch is provably stable ⇒ batchable.
-            assert!(effects::try_resolve_batch(&state, &ability, run_len).is_some());
+            assert!(try_batch(&state, &ability, run_len).is_some());
         }
 
         // §3.4 — mandatory Doubling-Season-class replacement still batches and
@@ -3891,15 +4226,22 @@ mod tests {
         }
 
         // §9.5 HIGH-2 — produced-token-non-observer gate (direct, discriminating):
-        // a produced token carrying an ETB observer trigger fails the gate, while
-        // a landfall-only (EnterBattlefield(Some(Land))) trigger passes. This
-        // exercises the gate's classifier directly — the copy path that would
-        // surface such a trigger end-to-end always falls back wholesale anyway
-        // (the met copy-instead branch, asserted below).
+        // the gate is the INTERSECTION of a trigger's registered keys with the
+        // produced token's CR 603.6a emission. A Creature produced token emits
+        // exactly {EnterBattlefield(None), EnterBattlefield(Some(Creature)),
+        // TokenCreated}. A creature-ETB observer intersects (refused); the real
+        // Scute-shape landfall trigger (EnterBattlefield(Some(Land))) does NOT
+        // intersect a creature emission and is batch-SAFE (the HIGH fix — the old
+        // coarse wildcard gate refused this and the headline repro never batched).
         #[test]
         fn produced_token_non_observer_gate_discriminates() {
             use super::super::effects::token::produced_token_is_non_observer;
-            // A creature-ETB observer trigger ⇒ NOT a valid produced-token trigger.
+            // The produced (copied) token is a Creature: emission =
+            // {None, Some(Creature), TokenCreated}.
+            let produced_creature = [CoreType::Creature];
+
+            // A creature-ETB observer trigger registers under Some(Creature) ⇒
+            // intersects the creature emission ⇒ must fail the gate.
             let etb_observer = TriggerDefinition::new(TriggerMode::ChangesZone)
                 .destination(Zone::Battlefield)
                 .valid_card(TargetFilter::Typed(TypedFilter {
@@ -3907,11 +4249,18 @@ mod tests {
                     ..Default::default()
                 }));
             assert!(
-                !produced_token_is_non_observer(std::slice::from_ref(&etb_observer)),
-                "an ETB-observing produced token must fail the gate"
+                !produced_token_is_non_observer(
+                    std::slice::from_ref(&etb_observer),
+                    &produced_creature
+                ),
+                "a creature-ETB-observing produced token must fail the gate"
             );
-            // A landfall trigger (registers under EnterBattlefield(Some(Land))) is
-            // STILL an EnterBattlefield key ⇒ conservatively rejected.
+
+            // The HEADLINE fix: a landfall trigger registers under
+            // EnterBattlefield(Some(Land)). A Creature copy emits no Land key, so
+            // the intersection is EMPTY ⇒ the Scute-shape copy is batch-SAFE. The
+            // old coarse gate (any EnterBattlefield(_)) refused this and the named
+            // repro never collapsed.
             let landfall = TriggerDefinition::new(TriggerMode::ChangesZone)
                 .destination(Zone::Battlefield)
                 .valid_card(TargetFilter::Typed(TypedFilter {
@@ -3919,12 +4268,39 @@ mod tests {
                     ..Default::default()
                 }));
             assert!(
-                !produced_token_is_non_observer(std::slice::from_ref(&landfall)),
-                "any EnterBattlefield-keyed trigger is conservatively rejected"
+                produced_token_is_non_observer(std::slice::from_ref(&landfall), &produced_creature),
+                "a Land-keyed landfall trigger on a Creature copy does not observe \
+                 its creature siblings ⇒ batch-safe (the HIGH fix)"
             );
+
+            // Over-permit guard: a broad permanent-ETB observer registers under
+            // the broad EnterBattlefield(None) key, which is in EVERY token's
+            // emission ⇒ must still be refused.
+            let broad_etb = TriggerDefinition::new(TriggerMode::ChangesZone)
+                .destination(Zone::Battlefield)
+                .valid_card(TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Permanent],
+                    ..Default::default()
+                }));
+            assert!(
+                !produced_token_is_non_observer(
+                    std::slice::from_ref(&broad_etb),
+                    &produced_creature
+                ),
+                "a broad permanent-ETB observer (None key) intersects every emission ⇒ refused"
+            );
+
+            // Symmetry check: the SAME landfall trigger on a LAND copy (emission
+            // includes Some(Land)) DOES intersect ⇒ refused. Proves the gate keys
+            // off the produced token's real core types, not a fixed assumption.
+            assert!(
+                !produced_token_is_non_observer(std::slice::from_ref(&landfall), &[CoreType::Land]),
+                "a landfall trigger on a Land copy observes its land siblings ⇒ refused"
+            );
+
             // No triggers ⇒ passes (the bare Insect/Servo go-wide case).
             assert!(
-                produced_token_is_non_observer(&[]),
+                produced_token_is_non_observer(&[], &produced_creature),
                 "a trigger-free produced token passes the gate"
             );
         }
@@ -4013,7 +4389,7 @@ mod tests {
             // therefore refuses regardless — confirming a copy-source observer
             // never reaches a batched resolution.
             assert!(
-                effects::try_resolve_batch(&state, &ability, run_len).is_none(),
+                try_batch(&state, &ability, run_len).is_none(),
                 "copy branch (and any copy-source observer) must refuse to batch"
             );
         }
@@ -4051,7 +4427,7 @@ mod tests {
             // The optional replacement could pause for a NeedsChoice prompt
             // mid-batch ⇒ Layer B refuses.
             assert!(
-                effects::try_resolve_batch(&state, &ability, run_len).is_none(),
+                try_batch(&state, &ability, run_len).is_none(),
                 "optional replacement must force fall-back"
             );
         }
@@ -4104,7 +4480,7 @@ mod tests {
 
             let run_len = batch_run_len(&state).unwrap();
             let ability = state.stack.back().unwrap().ability().unwrap().clone();
-            let plan = effects::try_resolve_batch(&state, &ability, run_len).unwrap();
+            let plan = try_batch(&state, &ability, run_len).unwrap();
             // The creature-ETB candidate IS the run source `src`. Pre-fix, the
             // exclusion dropped it and this assertion would FAIL (batch allowed);
             // post-fix it must hold (refuse to batch).
@@ -4173,7 +4549,7 @@ mod tests {
 
             let run_len = batch_run_len(&state).unwrap();
             let ability = state.stack.back().unwrap().ability().unwrap().clone();
-            let plan = effects::try_resolve_batch(&state, &ability, run_len).unwrap();
+            let plan = try_batch(&state, &ability, run_len).unwrap();
             assert!(
                 !observers_are_batch_safe(&state, &plan),
                 "narrow artifact-ETB observer must force refusal (Some(Artifact) bucket)"
@@ -4225,7 +4601,7 @@ mod tests {
 
             let run_len = batch_run_len(&state).unwrap();
             let ability = state.stack.back().unwrap().ability().unwrap().clone();
-            let plan = effects::try_resolve_batch(&state, &ability, run_len).unwrap();
+            let plan = try_batch(&state, &ability, run_len).unwrap();
             assert!(
                 !observers_are_batch_safe(&state, &plan),
                 "broad permanent-ETB observer must force refusal (None bucket)"
@@ -4242,32 +4618,11 @@ mod tests {
             let build = |lands: usize| -> GameState {
                 let mut state = setup();
                 add_lands(&mut state, lands);
-                let src = add_scute_source(&mut state);
-                let copy_effect = Effect::CopyTokenOf {
-                    target: TargetFilter::SelfRef,
-                    owner: TargetFilter::Controller,
-                    source_filter: None,
-                    enters_attacking: false,
-                    tapped: false,
-                    count: QuantityExpr::Fixed { value: 1 },
-                    extra_keywords: vec![],
-                    additional_modifications: vec![],
-                };
-                let mut sub = ResolvedAbility::new(copy_effect, vec![], src, PlayerId(0));
-                sub.condition = Some(AbilityCondition::ConditionInstead {
-                    inner: Box::new(AbilityCondition::QuantityCheck {
-                        lhs: QuantityExpr::Ref {
-                            qty: QuantityRef::ObjectCount {
-                                filter: TargetFilter::Typed(TypedFilter {
-                                    type_filters: vec![TypeFilter::Land],
-                                    ..Default::default()
-                                }),
-                            },
-                        },
-                        comparator: Comparator::GE,
-                        rhs: QuantityExpr::Fixed { value: 6 },
-                    }),
-                });
+                // Observer-free copy source so the met-copy branch can batch
+                // (a copy inherits the source's triggers; an ETB-keyed trigger
+                // would fail the §2.3a non-observer gate).
+                let src = add_plain_creature_source(&mut state, "Scout", 1, 1);
+                let sub = copy_instead_sub(src, 6);
                 push_token_triggers(
                     &mut state,
                     src,
@@ -4301,21 +4656,317 @@ mod tests {
                 assert_eq!(batched.battlefield.len(), sequential.battlefield.len());
             }
 
-            // MET (6 lands): copy-instead fires ⇒ Layer B refuses ⇒ falls back to
-            // sequential; final state still correct (5 copies, one per step).
+            // MET (6 lands): copy-instead fires ⇒ Layer B copy-prefix batches.
+            // The single source's 5 entries share identical copiable values
+            // (CR 707.2), and the observer-free copy token passes §2.3a, so the
+            // whole run collapses into ONE batched step producing 5 copies —
+            // equal to the sequential path.
             {
-                let mut state = build(6);
-                let steps = resolve_to_empty_batched(&mut state);
-                assert!(
-                    steps.iter().all(|&c| c == 1),
-                    "met copy-instead must fall back one-at-a-time, got {steps:?}"
+                let base = build(6);
+                let mut batched = base.clone();
+                let mut sequential = base.clone();
+                let steps = resolve_to_empty_batched(&mut batched);
+                resolve_to_empty_sequential(&mut sequential);
+                assert_eq!(
+                    steps,
+                    vec![5],
+                    "met copy-instead with identical values must batch in one step, got {steps:?}"
                 );
                 assert_eq!(
-                    token_ids(&state).len(),
+                    token_ids(&batched).len(),
                     5,
                     "5 copy-token resolutions produce 5 tokens"
                 );
+                assert_eq!(
+                    token_ids(&batched).len(),
+                    token_ids(&sequential).len(),
+                    "batched copy count must equal sequential"
+                );
             }
+        }
+
+        // CR 111.2 + CR 109.4 — cross-source base-token collapse: K distinct
+        // sources each fire one base Insect Token trigger. Because a base token
+        // reads nothing from its source, the run-identity source axis is
+        // `SourceIndependent` and all K entries form ONE batch (the Scute Swarm
+        // O(N²)→O(N) fix). Result equals the sequential path.
+        #[test]
+        fn cross_source_base_token_forms_one_batch() {
+            let mut base = setup();
+            add_lands(&mut base, 3);
+            let sources = push_token_triggers_from_distinct_sources(
+                &mut base,
+                insect_token_effect(),
+                None,
+                7,
+            );
+            assert_eq!(sources.len(), 7);
+
+            let mut batched = base.clone();
+            let mut sequential = base.clone();
+
+            let steps = resolve_to_empty_batched(&mut batched);
+            resolve_to_empty_sequential(&mut sequential);
+
+            assert_eq!(
+                steps,
+                vec![7],
+                "7 distinct-source base-token entries must collapse into one batch"
+            );
+            assert_eq!(token_ids(&batched).len(), 7);
+            assert_eq!(token_ids(&sequential).len(), 7);
+            assert_eq!(batched.battlefield.len(), sequential.battlefield.len());
+        }
+
+        // CR 707.2 — cross-source copy collapse: K distinct sources with
+        // IDENTICAL copiable values each fire a met copy-instead self-copy. The
+        // value-equal prefix spans the whole run, so all K collapse into one
+        // batch producing K copies. Result equals the sequential path.
+        #[test]
+        fn cross_source_copy_identical_values_forms_one_batch() {
+            let mut base = setup();
+            add_lands(&mut base, 6); // met ⇒ copy branch fires.
+
+            // K distinct, value-identical observer-free creature sources, each
+            // firing a met copy-instead self-copy.
+            for _ in 0..5 {
+                let src = add_plain_creature_source(&mut base, "Clone Base", 2, 2);
+                let sub = copy_instead_sub(src, 6);
+                push_token_triggers(
+                    &mut base,
+                    src,
+                    insect_token_effect(),
+                    Some(Box::new(sub)),
+                    1,
+                );
+            }
+
+            let mut batched = base.clone();
+            let mut sequential = base.clone();
+
+            let steps = resolve_to_empty_batched(&mut batched);
+            resolve_to_empty_sequential(&mut sequential);
+
+            assert_eq!(
+                steps,
+                vec![5],
+                "5 identical-value cross-source copies must collapse into one batch, got {steps:?}"
+            );
+            // 5 copy tokens, all copies of "Clone Base".
+            let batched_copies: Vec<_> = token_ids(&batched)
+                .into_iter()
+                .filter(|id| batched.objects[id].name == "Clone Base")
+                .collect();
+            assert_eq!(batched_copies.len(), 5);
+            assert_eq!(
+                token_ids(&batched).len(),
+                token_ids(&sequential).len(),
+                "batched copy count must equal sequential"
+            );
+        }
+
+        // CR 707.2 + CR 707.5 + CR 603.6a — THE HEADLINE Scute Swarm repro:
+        // K distinct copy sources are real Scute-Swarm-shape creatures, each
+        // carrying a landfall trigger keyed EnterBattlefield(Some(Land)). The
+        // copied tokens are CREATURES that inherit the landfall trigger (CR
+        // 707.2/707.5). A Creature copy emits {None, Some(Creature), TokenCreated}
+        // — the Land-keyed landfall does NOT intersect it, so the §2.3a gate is
+        // safe and the whole run STILL collapses into ONE batch. This is
+        // DISCRIMINATING: under the OLD coarse gate (any EnterBattlefield(_)
+        // rejected) try_resolve_copy_batch returned None and the run resolved
+        // one-at-a-time — the named perf bug was never fixed for its own card.
+        #[test]
+        fn cross_source_copy_with_landfall_trigger_still_batches() {
+            let mut base = setup();
+            add_lands(&mut base, 6); // met ⇒ copy branch fires.
+
+            // K distinct value-identical Scute-shape sources, each firing a met
+            // copy-instead self-copy. Each source (and thus each copy) carries a
+            // landfall trigger keyed on Land ETB — exactly Scute Swarm.
+            for _ in 0..5 {
+                let src = add_landfall_creature_source(&mut base, "Scute Swarm", 1, 1);
+                let sub = copy_instead_sub(src, 6);
+                push_token_triggers(
+                    &mut base,
+                    src,
+                    insect_token_effect(),
+                    Some(Box::new(sub)),
+                    1,
+                );
+            }
+
+            let mut batched = base.clone();
+            let mut sequential = base.clone();
+
+            let steps = resolve_to_empty_batched(&mut batched);
+            resolve_to_empty_sequential(&mut sequential);
+
+            assert_eq!(
+                steps,
+                vec![5],
+                "the real Scute Swarm shape (landfall on a creature copy) MUST collapse \
+                 into one batch — would be all-1 under the old coarse gate, got {steps:?}"
+            );
+            let batched_copies: Vec<_> = token_ids(&batched)
+                .into_iter()
+                .filter(|id| batched.objects[id].name == "Scute Swarm")
+                .collect();
+            assert_eq!(batched_copies.len(), 5, "5 Scute Swarm copies produced");
+            assert_eq!(
+                token_ids(&batched).len(),
+                token_ids(&sequential).len(),
+                "batched copy count must equal sequential"
+            );
+            // The copies carry the inherited landfall trigger (CR 707.2/707.5).
+            for id in &batched_copies {
+                assert!(
+                    !batched.objects[id].trigger_definitions.is_empty(),
+                    "the copy must inherit the source's landfall trigger"
+                );
+            }
+        }
+
+        // CR 603.6a (over-permit guard) — a SelfRef copy whose copied token DOES
+        // observe its in-batch siblings must STILL refuse. The copy source is a
+        // Creature carrying a "whenever a creature you control enters" trigger
+        // (EnterBattlefield(Some(Creature))); the Creature copy's emission
+        // includes Some(Creature), so the intersection is non-empty ⇒ refused.
+        // Proves the refined gate did not become unsafe.
+        #[test]
+        fn cross_source_copy_with_creature_etb_observer_refuses_batch() {
+            let mut state = setup();
+            add_lands(&mut state, 6); // met ⇒ copy branch fires.
+
+            for _ in 0..5 {
+                let src = add_creature_observer_source(&mut state, "Watcher", 2, 2);
+                let sub = copy_instead_sub(src, 6);
+                push_token_triggers(
+                    &mut state,
+                    src,
+                    insect_token_effect(),
+                    Some(Box::new(sub)),
+                    1,
+                );
+            }
+
+            let run_len = batch_run_len(&state).unwrap();
+            let ability = state.stack.back().unwrap().ability().unwrap().clone();
+            // The copied token observes creature ETB (its siblings) ⇒ the §2.3a
+            // intersection is non-empty ⇒ must refuse to batch.
+            assert!(
+                try_batch(&state, &ability, run_len).is_none(),
+                "a copy whose token observes creature-ETB siblings must refuse to batch"
+            );
+        }
+
+        // CR 707.2 — divergent-tail prefix batching: K cross-source copies where
+        // a middle source diverges in copiable values. The contiguous value-equal
+        // PREFIX collapses; the divergent tail resolves in subsequent steps. The
+        // step pattern proves prefix batching (not all-1, not one vec![K]), and
+        // the final token count equals the sequential path.
+        #[test]
+        fn cross_source_copy_divergent_tail_batches_prefix_then_resolves_rest() {
+            let mut base = setup();
+            add_lands(&mut base, 6);
+
+            // Push order (resolution order is top-down = LIFO): the LAST pushed
+            // entry resolves first. Push the divergent source FIRST so it sits at
+            // the BOTTOM and the value-equal sources are at the top.
+            //
+            // Build: 2 identical "Alpha" sources, then 1 "Beta" (divergent P/T),
+            // then 2 more "Alpha". Pushed bottom→top. Resolution order (top→down):
+            // Alpha, Alpha, Beta, Alpha, Alpha. The prefix is the top 2 Alphas.
+            let specs: [(&str, i32, i32); 5] = [
+                ("Alpha", 2, 2),
+                ("Alpha", 2, 2),
+                ("Beta", 3, 3),
+                ("Alpha", 2, 2),
+                ("Alpha", 2, 2),
+            ];
+            for (name, p, t) in specs {
+                let src = add_plain_creature_source(&mut base, name, p, t);
+                let sub = copy_instead_sub(src, 6);
+                push_token_triggers(
+                    &mut base,
+                    src,
+                    insect_token_effect(),
+                    Some(Box::new(sub)),
+                    1,
+                );
+            }
+
+            let mut batched = base.clone();
+            let mut sequential = base.clone();
+
+            let steps = resolve_to_empty_batched(&mut batched);
+            resolve_to_empty_sequential(&mut sequential);
+
+            // The top 2 Alphas batch (prefix), then Beta resolves, then the
+            // bottom 2 Alphas batch. NOT all-1 and NOT a single vec![5].
+            assert_eq!(
+                steps,
+                vec![2, 1, 2],
+                "prefix batching must collapse the value-equal head, got {steps:?}"
+            );
+            // 5 copy tokens total (3 Alpha + 1 Beta + ... by name), equal to
+            // sequential.
+            assert_eq!(token_ids(&batched).len(), 5);
+            assert_eq!(
+                token_ids(&batched).len(),
+                token_ids(&sequential).len(),
+                "batched count must equal sequential"
+            );
+        }
+
+        // CR 608.2c (H1 discriminator) — a met copy that creates LANDS gated on a
+        // LAND count must NOT batch: the copy's core types intersect the counted
+        // type, so the intervening condition is order-sensitive across the run.
+        // This FAILS if the invariance gate is fed the base placeholder core
+        // types ([Creature]) and PASSES (refuses) when fed the COPY core types
+        // ([Land]).
+        #[test]
+        fn met_copy_creating_lands_gated_on_land_count_refuses_batch() {
+            let mut state = setup();
+            add_lands(&mut state, 6); // met ⇒ copy branch fires.
+
+            // Observer-free copy source whose copiable type is LAND (not the
+            // base Insect Creature). Copying it produces Land tokens.
+            let land_src = create_object(
+                &mut state,
+                CardId(911),
+                PlayerId(0),
+                "Mirror Land".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&land_src).unwrap();
+                obj.base_card_types = crate::types::card_type::CardType {
+                    supertypes: vec![],
+                    core_types: vec![CoreType::Land],
+                    subtypes: vec!["Forest".to_string()],
+                };
+                obj.card_types = obj.base_card_types.clone();
+                obj.base_name = "Mirror Land".to_string();
+            }
+            crate::types::game_state::TriggerIndex::rebuild_from_battlefield(&mut state);
+
+            let sub = copy_instead_sub(land_src, 6);
+            push_token_triggers(
+                &mut state,
+                land_src,
+                insect_token_effect(),
+                Some(Box::new(sub)),
+                5,
+            );
+
+            let run_len = batch_run_len(&state).unwrap();
+            let ability = state.stack.back().unwrap().ability().unwrap().clone();
+            // The copy creates Lands; the condition counts Lands ⇒ each created
+            // Land flips the count ⇒ order-sensitive ⇒ must refuse.
+            assert!(
+                try_batch(&state, &ability, run_len).is_none(),
+                "a met copy creating Lands gated on a Land count must refuse to batch"
+            );
         }
 
         /// Build an OPTIONAL token-count-doubling replacement ("you may create

--- a/crates/engine/src/game/static_source_index.rs
+++ b/crates/engine/src/game/static_source_index.rs
@@ -1,0 +1,115 @@
+//! CR 611.2 + CR 613.1: `StaticSourceIndex` — candidate pre-filter for
+//! `for_each_static_effect_source` (`layers.rs`). Replaces the full
+//! `state.battlefield` (~thousands of permanents on a token-swarm board) +
+//! `state.command_zone` scan with iteration over the handful of objects that
+//! actually GENERATE ≥1 continuous effect, so the per-flush layer gather scales
+//! with the number of generators, not with `|battlefield|`.
+//!
+//! # Correctness model
+//!
+//! The index keys on **GENERATORS** (objects whose `static_definitions` carry a
+//! `StaticMode::Continuous` def, including `GrantStaticAbility` hosts), NOT on
+//! recipients. A granted anthem's per-recipient fan-out happens inside the
+//! host's own visit (`expand_granted_static_effects`), so iterating hosts
+//! reproduces every granted effect; recipients need not be indexed. The
+//! classification predicate is **condition-independent and zone-independent** —
+//! it asks only "does this object carry a continuous static def?", never "does
+//! that static currently pass its gate?". The per-def condition / zone-of-
+//! function gating still runs inside the gather, so the index **over-includes,
+//! never under-includes** (an over-included object that currently sources
+//! nothing produces one wasted, empty visit). Output is byte-identical.
+//!
+//! # Authority — TOP-of-pass rebuild (placement differs from `TriggerIndex`)
+//!
+//! `TriggerIndex` is consulted by EXTERNAL event scans that run AFTER the layer
+//! pass completes, so its rebuild is correctly placed at the END of the pass.
+//! `StaticSourceIndex` is consulted INSIDE the layer pass (the Copy / main
+//! gathers, per-layer ordering, the escalation probe, `refresh_static_gate_truth`),
+//! so an end-of-pass rebuild would leave those mid-pass consults reading the
+//! PREVIOUS pass's index — stale for any generator that entered since. The
+//! rebuild therefore runs at the TOP of `evaluate_layers` /
+//! `apply_layers_incremental`, AFTER the Step-1 base reset (so the predicate
+//! reads base, not stale post-layer, definitions) and BEFORE the first gather.
+//! Layer-6 grant products (recipient-becomes-generator) are caught by the NEXT
+//! pass's top-of-pass rebuild via the `layers_dirty` fixpoint — the installing
+//! pass marks dirty, the same mechanism `TriggerIndex` uses for granted triggers.
+//!
+//! # `layers_dirty` as a validity key — sound for THIS index
+//!
+//! The index stores the condition-INDEPENDENT generator set, which changes only
+//! when some object's `static_definitions` changes. Every such change for the
+//! two indexed buckets marks `layers_dirty` (battlefield enter/leave →
+//! `zones.rs`/`change_zone.rs`; command-zone emblem creation →
+//! `create_emblem.rs` `mark_layers_full`), and every production read of derived
+//! state crosses `flush_layers` (hence a top-of-pass rebuild) first. So external
+//! inter-flush callers always observe a fresh index for the indexed buckets.
+//! The off-zone / opt-in-zone arm is NOT indexed (its generator-set changes are
+//! not all marked `layers_dirty` — a self-milled Incarnation enters the
+//! graveyard without a dirty mark) and keeps its live `state.objects` scan in
+//! `for_each_static_effect_source`.
+
+use crate::types::game_state::{GameState, StaticSourceIndex};
+use crate::types::statics::StaticMode;
+
+use super::game_object::GameObject;
+
+/// CR 611.2 + CR 613.1: An object generates ≥1 continuous effect iff any of its
+/// `static_definitions` is `StaticMode::Continuous`. This INCLUDES
+/// `GrantStaticAbility` hosts — the grant modification lives on the host's own
+/// continuous static, and the per-recipient fan-out happens inside
+/// `expand_granted_static_effects` when the host is visited.
+///
+/// Condition-INDEPENDENT and zone-INDEPENDENT: asks only "does this object carry
+/// a continuous static def?", not "does that static currently pass its gate?".
+/// That is the soundness foundation — the index over-includes (condition-failing
+/// statics) but never under-includes a real source.
+pub(crate) fn object_sources_continuous_effect(obj: &GameObject) -> bool {
+    obj.static_definitions
+        .iter_all()
+        .any(|def| def.mode == StaticMode::Continuous)
+}
+
+impl StaticSourceIndex {
+    /// CR 611.2 + CR 613.1: Rebuild the index from the current battlefield +
+    /// command zone. Scans `state.battlefield` in order (including phased-out
+    /// objects — they're skipped at consult) and `state.command_zone` in order,
+    /// pushing generators in that order so the visit order is byte-identical to
+    /// the previous full `state.battlefield` / `state.command_zone` scan filtered
+    /// to generators.
+    ///
+    /// O(battlefield) — runs once per full eval / incremental flush at the TOP
+    /// of the pass (the same O(battlefield) cost the Step-1 reset and
+    /// `TriggerIndex::rebuild_from_battlefield` already pay per flush). The
+    /// savings are on the many repeat `for_each_static_effect_source` consults
+    /// per flush, each of which was O(battlefield) and is now O(generators).
+    ///
+    /// Indexes ONLY the two `layers_dirty`-covered buckets; the off-zone /
+    /// opt-in-zone arm is live-scanned in `for_each_static_effect_source` and is
+    /// not rebuilt here.
+    pub fn rebuild_from_state(state: &mut GameState) {
+        let mut fresh = StaticSourceIndex::default();
+        for &id in &state.battlefield {
+            // Include phased-out objects; the consult-time `is_phased_out()`
+            // skip excludes them (CR 702.26e). Phase-in/out does not change
+            // `static_definitions`, so it needs no index mutation.
+            if let Some(obj) = state.objects.get(&id) {
+                if object_sources_continuous_effect(obj) {
+                    fresh.battlefield_sources.push_back(id);
+                }
+            }
+        }
+        for &id in &state.command_zone {
+            // CR 114.3: command-zone emblems carry static abilities. Only emblem
+            // generators are indexed; commanders (is_emblem == false) are not.
+            if let Some(obj) = state.objects.get(&id) {
+                if obj.is_emblem && object_sources_continuous_effect(obj) {
+                    fresh.command_sources.push_back(id);
+                }
+            }
+        }
+        // NO off-zone loop: that arm is not indexed (a self-milled Incarnation
+        // enters the graveyard without marking `layers_dirty`, which would stale
+        // a cached bucket) — `for_each_static_effect_source` live-scans it.
+        state.static_source_index = fresh;
+    }
+}

--- a/crates/engine/src/game/transform.rs
+++ b/crates/engine/src/game/transform.rs
@@ -53,7 +53,7 @@ pub fn transform_permanent(
         obj.transformed = true;
     }
 
-    state.layers_dirty = true;
+    crate::game::layers::mark_layers_full(state);
 
     events.push(GameEvent::Transformed { object_id });
 
@@ -160,7 +160,7 @@ mod tests {
             "BackAbility"
         );
         assert_eq!(obj.color, vec![ManaColor::Green, ManaColor::Red]);
-        assert!(state.layers_dirty);
+        assert!(state.layers_dirty.is_dirty());
         assert_eq!(events.len(), 1);
         assert_eq!(events[0], GameEvent::Transformed { object_id: id });
     }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -749,9 +749,7 @@ fn collect_pending_triggers(
     // battlefield. Flushing pending layer evaluation here guarantees
     // `obj.trigger_definitions` and `obj.keywords` reflect all active
     // continuous effects before this pass scans for matching triggers.
-    if state.layers_dirty {
-        super::layers::evaluate_layers(state);
-    }
+    super::layers::flush_layers(state);
     let mut pending: Vec<PendingTriggerContext> = Vec::new();
     // CR 603.2c: Track which batched triggers (source_id, trig_idx) have already
     // fired in this pass so "one or more" triggers fire at most once per batch.
@@ -11964,7 +11962,7 @@ pub mod tests {
             .unwrap()
             .static_definitions
             .push(grant);
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         process_triggers(
             &mut state,
@@ -12302,7 +12300,7 @@ pub mod tests {
 
         // Layers haven't run yet — granted trigger is NOT on obj.trigger_definitions
         // until we evaluate. The fix in process_triggers must flush layers first.
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         let events = vec![zone_changed_event(
             harmonic,
@@ -12361,7 +12359,7 @@ pub mod tests {
         // applied via layers, and the newcomer's ETB must fire the granted
         // trigger from the newcomer (not from the lord, which already ETB'd).
         let newcomer = make_sliver(&mut state, PlayerId(0), "Other Sliver");
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         let events = vec![zone_changed_event(
             newcomer,
@@ -12438,7 +12436,7 @@ pub mod tests {
             obj.base_power = Some(2);
             obj.base_toughness = Some(2);
         }
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         let events = vec![zone_changed_event(
             bear,
@@ -12500,7 +12498,7 @@ pub mod tests {
 
         // Drive the post-action trigger scan: process_triggers must flush
         // layers before scanning so granted keywords are visible.
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         process_triggers(&mut state, &[]);
 
         assert!(
@@ -12569,7 +12567,7 @@ pub mod tests {
             obj.card_types.subtypes.push("Bear".to_string());
             obj.base_card_types = obj.card_types.clone();
         }
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         let events = vec![zone_changed_event(
             bear,
@@ -13651,7 +13649,7 @@ pub mod tests {
             );
             suspended.push(card);
         }
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
 
         // Sanity: both cards must carry granted Suspend off-zone before we drive
         // the turn — otherwise the upkeep triggers never synthesize.

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -175,7 +175,7 @@ fn apply_zone_exit_cleanup(state: &mut GameState, object_id: ObjectId, from: Zon
         };
         if !preserve_bestow_form && obj_mut.bestow_form.is_some() {
             super::casting::revert_bestow_aura_form(obj_mut);
-            state.layers_dirty = true;
+            state.layers_dirty.mark_full();
         }
 
         // CR 702.148a + CR 612: A cleave spell's text-changing effect functions
@@ -215,7 +215,7 @@ fn apply_zone_exit_cleanup(state: &mut GameState, object_id: ObjectId, from: Zon
     // when a permanent leaves the battlefield.
     if from == Zone::Battlefield {
         super::pairing::break_pair(state, object_id);
-        state.layers_dirty = true;
+        crate::game::layers::mark_layers_full(state);
         super::layers::prune_host_left_effects(state, object_id);
         super::layers::prune_affected_object_left_effects(state, object_id);
         for tapped in state.lands_tapped_for_mana.values_mut() {
@@ -379,7 +379,7 @@ pub fn move_to_zone(
     // CR 702.94a + CR 400.3: hand-zone continuous effects require re-evaluation
     // when a hand object appears or departs.
     if to == Zone::Battlefield || to == Zone::Hand || from == Zone::Hand {
-        state.layers_dirty = true;
+        crate::game::layers::mark_layers_full(state);
     }
 
     // CR 702.145c + CR 702.145f: Daybound/Nightbound permanents entering under

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2491,7 +2491,19 @@ fn parse_zone_phrase(input: &str) -> OracleResult<'_, Zone> {
 /// etc.) without enumerating each (zone × zone) permutation.
 fn parse_source_in_zone_condition(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = parse_source_self_token(input)?;
-    let (rest, _) = tag(" is").parse(rest)?;
+    // CR 113.6b vs CR 113.6c: the copula polarity decides which zone-function
+    // rule applies. Affirmative ("~ is on the battlefield") names the zones the
+    // ability functions IN (CR 113.6b). Negated ("~ isn't on the battlefield" /
+    // "~ is not on the battlefield") names the zones it does NOT function in,
+    // i.e. it functions everywhere except those zones (CR 113.6c) — modeled by
+    // wrapping the affirmative reading in `Not`. Negated copulae are tried first
+    // so " is not " is not greedily split into " is " + "not …" (mirrors the
+    // polarity alternation in `parse_recipient_is_filter_condition`).
+    let (rest, negated) = alt((
+        value(true, alt((tag(" isn't"), tag(" is not")))),
+        value(false, tag(" is")),
+    ))
+    .parse(rest)?;
     let (rest, first) = parse_zone_phrase(rest)?;
     // CR 113.6b: a single ability that names multiple zones functions in each
     // of them — the "or"-separated zone list composes disjunctively across the
@@ -2499,15 +2511,26 @@ fn parse_source_in_zone_condition(input: &str) -> OracleResult<'_, StaticConditi
     // authority for the disjunction is the same CR 113.6b that authorizes the
     // zone clause itself.)
     let (rest, more) = many0(preceded(parse_zone_list_separator, parse_zone_phrase)).parse(rest)?;
-    if more.is_empty() {
-        return Ok((rest, StaticCondition::SourceInZone { zone: first }));
-    }
-    let mut conditions = Vec::with_capacity(more.len() + 1);
-    conditions.push(StaticCondition::SourceInZone { zone: first });
-    for zone in more {
-        conditions.push(StaticCondition::SourceInZone { zone });
-    }
-    Ok((rest, StaticCondition::Or { conditions }))
+    let condition = if more.is_empty() {
+        StaticCondition::SourceInZone { zone: first }
+    } else {
+        let mut conditions = Vec::with_capacity(more.len() + 1);
+        conditions.push(StaticCondition::SourceInZone { zone: first });
+        for zone in more {
+            conditions.push(StaticCondition::SourceInZone { zone });
+        }
+        StaticCondition::Or { conditions }
+    };
+    let condition = if negated {
+        // CR 113.6c: an ability that states which zones it doesn't function in
+        // functions everywhere except those zones.
+        StaticCondition::Not {
+            condition: Box::new(condition),
+        }
+    } else {
+        condition
+    };
+    Ok((rest, condition))
 }
 
 fn parse_zone_list_separator(input: &str) -> OracleResult<'_, ()> {
@@ -5026,6 +5049,55 @@ mod tests {
                         scope: CountScope::Controller,
                     },
                 },
+            },
+        );
+    }
+
+    /// CR 113.6c: "as long as ~ isn't on the battlefield" (Grist, the Hunger
+    /// Tide's command-zone-as-creature static) — the negated copula must wrap
+    /// the affirmative `SourceInZone { Battlefield }` reading in `Not`, marking
+    /// that the ability functions everywhere EXCEPT the battlefield.
+    #[test]
+    fn parse_source_isnt_on_battlefield_wraps_in_not() {
+        let (rest, c) = parse_condition("as long as ~ isn't on the battlefield").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            c,
+            StaticCondition::Not {
+                condition: Box::new(StaticCondition::SourceInZone {
+                    zone: crate::types::zones::Zone::Battlefield,
+                }),
+            },
+        );
+    }
+
+    /// CR 113.6b: the affirmative copula still produces the bare
+    /// `SourceInZone { Battlefield }` (no `Not` wrapper) — guards against the
+    /// polarity alternation regressing the existing affirmative path.
+    #[test]
+    fn parse_source_is_on_battlefield_stays_affirmative() {
+        let (rest, c) = parse_condition("as long as ~ is on the battlefield").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            c,
+            StaticCondition::SourceInZone {
+                zone: crate::types::zones::Zone::Battlefield,
+            },
+        );
+    }
+
+    /// CR 113.6c: the "is not" spelling variant must also wrap in `Not` and must
+    /// not be greedily split into " is " + "not on the battlefield".
+    #[test]
+    fn parse_source_is_not_on_battlefield_wraps_in_not() {
+        let (rest, c) = parse_condition("as long as ~ is not on the battlefield").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            c,
+            StaticCondition::Not {
+                condition: Box::new(StaticCondition::SourceInZone {
+                    zone: crate::types::zones::Zone::Battlefield,
+                }),
             },
         );
     }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3873,6 +3873,35 @@ pub struct TriggerIndex {
     pub unclassified: smallvec::SmallVec<[ObjectId; 4]>,
 }
 
+/// CR 611.2 + CR 613.1: Candidate pre-filter for `for_each_static_effect_source`.
+/// Holds the ids of objects that GENERATE ≥1 continuous effect for the TWO
+/// `layers_dirty`-covered source categories: battlefield permanents with a
+/// continuous `static_definitions` entry (including `GrantStaticAbility` hosts)
+/// and command-zone emblems. The opt-in-zone / off-zone arm (Incarnation cycle —
+/// Anger/Brawn/Filth/Wonder/Valor, `active_zones`-gated statics functioning from
+/// the graveyard) is INTENTIONALLY NOT indexed: its generator-set changes (e.g.
+/// self-milling an Anger into the graveyard) do not all mark `layers_dirty`
+/// (`zones.rs` marks dirty only on battlefield/hand transitions; mill/effect
+/// movers add no mark), so a `layers_dirty`-gated cache of off-zone generators
+/// would go stale. That arm keeps its live `state.objects` scan in
+/// `for_each_static_effect_source`.
+///
+/// Backed by `im::Vector` so `GameState::clone()` stays O(1) structural share
+/// (and `GameState: Send` is preserved — no `Rc`). Rebuilt at the TOP of
+/// `evaluate_layers` / `apply_layers_incremental` (after the Step-1 base reset,
+/// before the first gather — unlike `TriggerIndex`, this index is consulted
+/// MID-pass, so it must be fresh before the gather) and lazily on first consult
+/// after deserialize via the empty-index direct-scan fallback.
+#[derive(Debug, Clone, Default)]
+pub struct StaticSourceIndex {
+    /// Battlefield generators, in `state.battlefield` order (preserves the
+    /// current gather order; phased-out objects are included here and skipped
+    /// at consult via `is_phased_out()`).
+    pub battlefield_sources: im::Vector<ObjectId>,
+    /// Command-zone emblem generators, in `state.command_zone` order.
+    pub command_sources: im::Vector<ObjectId>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GameState {
     pub turn_number: u32,
@@ -4026,6 +4055,15 @@ pub struct GameState {
     /// `trigger_definitions` whenever needed.
     #[serde(skip)]
     pub trigger_index: TriggerIndex,
+    /// CR 611.2 + CR 613.1: Derived generator index for the layer gather.
+    /// `#[serde(skip)]` derived state (like `trigger_index`/`layers_dirty`);
+    /// reconstructed from `state.battlefield` + `state.command_zone` +
+    /// per-object `static_definitions` at the top of every layer pass, and
+    /// lazily on first consult after deserialize via the empty-index fallback.
+    /// INTENTIONALLY omitted from `impl PartialEq for GameState` — derived state
+    /// must not break AI-search dedup on semantically-identical positions.
+    #[serde(skip)]
+    pub static_source_index: StaticSourceIndex,
     pub next_timestamp: u64,
     #[serde(skip, default = "PublicStateDirty::all_dirty")]
     pub public_state_dirty: PublicStateDirty,
@@ -5073,6 +5111,7 @@ impl GameState {
             layers_dirty: LayersDirty::full(),
             static_gate_truth: std::collections::HashMap::new(),
             trigger_index: TriggerIndex::default(),
+            static_source_index: StaticSourceIndex::default(),
             next_timestamp: 1,
             public_state_dirty: PublicStateDirty::all_dirty(),
             state_revision: 0,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3883,8 +3883,11 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_decision_controller: Option<PlayerId>,
 
-    // Central object store
-    pub objects: im::HashMap<ObjectId, GameObject>,
+    // Central object store. Uses FxBuildHasher (fast, deterministic) instead of
+    // the default SipHash RandomState: ObjectId is a thin integer key and this
+    // map is looked up millions of times per large-board resolution — profiling
+    // showed SipHash hashing + HAMT lookup was ~35% of resolution CPU.
+    pub objects: im::HashMap<ObjectId, GameObject, rustc_hash::FxBuildHasher>,
     pub next_object_id: u64,
 
     // Shared zones
@@ -5041,7 +5044,7 @@ impl GameState {
             players,
             priority_player: PlayerId(0),
             turn_decision_controller: None,
-            objects: im::HashMap::new(),
+            objects: im::HashMap::default(),
             next_object_id: 1,
             battlefield: im::Vector::new(),
             stack: im::Vector::new(),

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1239,6 +1239,29 @@ impl LayersDirty {
     }
 }
 
+/// Cache key for the source-level enabling-condition truth of a single
+/// CONTINUOUS static ability, used by the incremental layer-flush
+/// truth-delta short-circuit (`game/layers.rs`).
+///
+/// CR 611.3a + CR 611.3b: a static-ability continuous effect isn't "locked
+/// in"; it applies at all times the source is on the battlefield, re-evaluated
+/// against whatever its text indicates. When an object enters, an incremental
+/// flush re-derives only the entered objects. If a pre-existing source's
+/// population-sensitive, SOURCE-LEVEL (non-recipient-context) enabling
+/// condition would change truth, pre-existing recipients must be re-derived —
+/// so the flush must escalate to a full pass. This key indexes the recorded
+/// BEFORE truth so the consult can compare against a freshly-recomputed AFTER.
+///
+/// `def_index` indexes the LIVE post-layer `static_definitions` vec
+/// (`iter_all().enumerate()`), NOT `base_static_definitions`. The refresh and
+/// the consult both observe the identical live vec for pre-existing sources, so
+/// the index aligns (see invariant 5 in the plan / the consult below).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StaticGateKey {
+    pub source: ObjectId,
+    pub def_index: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PublicStateDirty {
     pub all_objects_dirty: bool,
@@ -3978,6 +4001,20 @@ pub struct GameState {
     // serializing the (derived) entered-object set.
     #[serde(skip, default = "LayersDirty::full")]
     pub layers_dirty: LayersDirty,
+    /// CR 611.3a + CR 611.3b: truth of each CONTINUOUS static's SOURCE-LEVEL
+    /// (non-recipient-context) enabling condition as of the last full
+    /// `evaluate_layers`. Read by the incremental-flush truth-delta
+    /// short-circuit to skip escalation when an entry perturbs the gate but
+    /// does not flip it. Recipient-context conditions are NEVER stored here
+    /// (their truth is per-recipient; `source_condition_gate_passes` is only an
+    /// over-approximation for them) and always escalate. Refreshed wholesale
+    /// every full eval (`refresh_static_gate_truth`). `#[serde(skip)]` derived
+    /// state, like `layers_dirty`/`trigger_index`. NOTE: a plain
+    /// `std::collections::HashMap` (not `im`-backed), so it deep-clones on every
+    /// `GameState::clone()` — kept small by storing only source-level-gated
+    /// continuous statics (a small fraction of the board).
+    #[serde(skip)]
+    pub static_gate_truth: std::collections::HashMap<StaticGateKey, bool>,
     /// CR 603.2: Candidate pre-filter for `collect_pending_triggers`. Rebuilt
     /// lazily after deserialize via a sentinel check at the top of the consult
     /// site; rebuilt eagerly at the end of `evaluate_layers` (CR 611.2e) so the
@@ -5031,6 +5068,7 @@ impl GameState {
             pending_spell_resolution: None,
             deferred_entry_events: Vec::new(),
             layers_dirty: LayersDirty::full(),
+            static_gate_truth: std::collections::HashMap::new(),
             trigger_index: TriggerIndex::default(),
             next_timestamp: 1,
             public_state_dirty: PublicStateDirty::all_dirty(),
@@ -5320,6 +5358,13 @@ impl PartialEq for GameState {
             && self.pending_spell_resolution == other.pending_spell_resolution
             && self.deferred_entry_events == other.deferred_entry_events
             && self.layers_dirty == other.layers_dirty
+            // `static_gate_truth` is INTENTIONALLY excluded: unlike
+            // `layers_dirty`/`public_state_dirty` (which encode pending work),
+            // it is pure derived/self-healing state (reconstructed at the next
+            // full eval; implied entirely by objects + battlefield +
+            // static_definitions). Including it would break AI-search dedup on
+            // semantically-identical positions whose caches differ only in
+            // freshness.
             && self.next_timestamp == other.next_timestamp
             && self.public_state_dirty == other.public_state_dirty
             && self.state_revision == other.state_revision

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1189,6 +1189,56 @@ pub struct TargetSelectionProgress {
     pub current_legal_targets: Vec<TargetRef>,
 }
 
+/// Lattice tracking which battlefield objects need layer (continuous-effect)
+/// re-evaluation. Replaces the old `bool` flag so that a token / conjure / copy
+/// entry can request an INCREMENTAL re-derive of only the entering object(s)
+/// instead of a full battlefield reset+reapply.
+///
+/// CR 613.1: continuous effects are evaluated in layer order over the whole
+/// board. A full evaluation is always correct; the incremental path is a
+/// performance optimization that `flush_layers` only takes when it can prove
+/// (per-entered preconditions + a board-wide escalation scan) that re-deriving
+/// just the entered objects produces a board state identical to a full pass.
+/// `mark_full()` is the conservative escalation any non-entry mutation uses.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum LayersDirty {
+    /// Layers are up to date; nothing to flush.
+    #[default]
+    Clean,
+    /// Only these objects entered the battlefield since the last flush and no
+    /// other layer-affecting mutation occurred. Candidate for the incremental
+    /// fast path.
+    EnteredObjects(HashSet<ObjectId>),
+    /// A full battlefield re-evaluation is required.
+    Full,
+}
+
+impl LayersDirty {
+    /// Constructor used as the `#[serde(default)]` for the field: deserialized
+    /// snapshots conservatively rebuild fully on first flush.
+    pub fn full() -> Self {
+        Self::Full
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        !matches!(self, Self::Clean)
+    }
+
+    pub fn mark_full(&mut self) {
+        *self = Self::Full;
+    }
+
+    pub fn mark_entered(&mut self, id: ObjectId) {
+        match self {
+            Self::Full => {}
+            Self::Clean => *self = Self::EnteredObjects(HashSet::from([id])),
+            Self::EnteredObjects(s) => {
+                s.insert(id);
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PublicStateDirty {
     pub all_objects_dirty: bool,
@@ -3922,7 +3972,12 @@ pub struct GameState {
     pub deferred_entry_events: Vec<GameEvent>,
 
     // Layer system
-    pub layers_dirty: bool,
+    // CONSERVATIVE: deserialized snapshots (e.g. the WASM-export repro) rebuild
+    // fully on first flush. The previous `bool` field serialized as `true`
+    // initially; skipping + defaulting to `Full` preserves that intent without
+    // serializing the (derived) entered-object set.
+    #[serde(skip, default = "LayersDirty::full")]
+    pub layers_dirty: LayersDirty,
     /// CR 603.2: Candidate pre-filter for `collect_pending_triggers`. Rebuilt
     /// lazily after deserialize via a sentinel check at the top of the consult
     /// site; rebuilt eagerly at the end of `evaluate_layers` (CR 611.2e) so the
@@ -4975,7 +5030,7 @@ impl GameState {
             post_replacement_event_target: None,
             pending_spell_resolution: None,
             deferred_entry_events: Vec::new(),
-            layers_dirty: true,
+            layers_dirty: LayersDirty::full(),
             trigger_index: TriggerIndex::default(),
             next_timestamp: 1,
             public_state_dirty: PublicStateDirty::all_dirty(),
@@ -5202,7 +5257,7 @@ impl GameState {
                 condition,
                 source_name,
             });
-        self.layers_dirty = true;
+        self.layers_dirty.mark_full();
         id
     }
 

--- a/crates/engine/tests/integration/frostcliff_siege_anchor_word_modes.rs
+++ b/crates/engine/tests/integration/frostcliff_siege_anchor_word_modes.rs
@@ -273,7 +273,7 @@ fn temur_mode_grants_plus_one_zero_trample_haste_to_creatures_you_control() {
     // explicitly so we read post-choice characteristics regardless.
     {
         let s = runner.state_mut();
-        s.layers_dirty = true;
+        s.layers_dirty.mark_full();
         evaluate_layers(s);
     }
 
@@ -348,7 +348,7 @@ fn no_choice_persisted_means_neither_linked_ability_functions() {
     // permissive when the label is absent.
     {
         let s = runner.state_mut();
-        s.layers_dirty = true;
+        s.layers_dirty.mark_full();
         evaluate_layers(s);
     }
 
@@ -409,7 +409,7 @@ fn jeskai_mode_does_not_grant_temur_anthem() {
 
     {
         let s = runner.state_mut();
-        s.layers_dirty = true;
+        s.layers_dirty.mark_full();
         evaluate_layers(s);
     }
 

--- a/crates/engine/tests/integration/kaito_integration.rs
+++ b/crates/engine/tests/integration/kaito_integration.rs
@@ -181,7 +181,7 @@ fn setup_kaito_on_battlefield(phase: Phase) -> (GameRunner, ObjectId) {
             generic: 2,
         };
 
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
     }
 
     (runner, kaito_id)
@@ -315,7 +315,7 @@ fn kaito_emblem_creation() {
         obj.base_power = Some(2);
         obj.base_toughness = Some(2);
         obj.entered_battlefield_turn = Some(state.turn_number.saturating_sub(1));
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         id
     };
 
@@ -332,7 +332,7 @@ fn kaito_emblem_creation() {
         obj.base_power = Some(1);
         obj.base_toughness = Some(1);
         obj.entered_battlefield_turn = Some(state.turn_number.saturating_sub(1));
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         id
     };
 
@@ -442,7 +442,7 @@ fn kaito_not_animated_on_opponents_turn() {
 
     // Switch to opponent's turn
     runner.state_mut().active_player = P1;
-    runner.state_mut().layers_dirty = true;
+    runner.state_mut().layers_dirty.mark_full();
     let _ = runner.act(GameAction::PassPriority);
 
     let state = runner.state();
@@ -475,7 +475,7 @@ fn kaito_not_animated_without_loyalty_counters() {
         .unwrap()
         .counters
         .remove(&CounterType::Loyalty);
-    runner.state_mut().layers_dirty = true;
+    runner.state_mut().layers_dirty.mark_full();
     let _ = runner.act(GameAction::PassPriority);
 
     let state = runner.state();

--- a/crates/engine/tests/integration/urzas_saga_chapter_two.rs
+++ b/crates/engine/tests/integration/urzas_saga_chapter_two.rs
@@ -126,7 +126,7 @@ fn chapter_two_construct_survives_sba_via_self_count_boost() {
         obj.summoning_sick = false;
         std::sync::Arc::make_mut(&mut obj.abilities).push(chapter_two_granted_ability());
         std::sync::Arc::make_mut(&mut obj.base_abilities).push(chapter_two_granted_ability());
-        state.layers_dirty = true;
+        state.layers_dirty.mark_full();
         id
     };
 


### PR DESCRIPTION
- **perf(engine): batch cross-source token swarms to fix Scute Swarm O(N²) stack resolution**
- **perf(engine): incremental layer evaluation for mass permanent entry**
- **perf(engine): entry-aware layer escalation for incremental flush**
- **perf(engine): condition-truth-delta short-circuit for incremental layer escalation**
- **fix(engine): reconcile combat layers_dirty call sites to LayersDirty API**
- **feat(client): show resolution progress overlay for large stack drains**
- **perf(engine): use FxHasher for the objects map**
- **perf(engine): index static-effect sources to skip the full-battlefield scan**
