### PR TITLE
fix(engine): gate Wernog's "each opponent who doesn't" decline and keep clause 3 (Rider's Chaplain)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3926,6 +3926,27 @@ fn resolve_chain_body(
                         effect_context_object.as_ref(),
                     );
                     resolve_ability_chain(state, &else_resolved, events, depth + 1)?;
+                } else if let Some(ref next) = sub.sub_ability {
+                    // CR 608.2c: A separate-sentence sibling after the gated sub is
+                    // the next independent instruction ("...in the order written")
+                    // and resolves regardless of the gate's failure (Wernog clause 3
+                    // "You investigate X times" after the per-opponent decline gate).
+                    // Mirrors the optional-decline handler's SequentialSibling check.
+                    // Predicate is `next.sub_link` (the sibling's link to the gated
+                    // sub), NOT `sub.sub_link` (the gated sub's link to its parent =
+                    // ContinuationStep).
+                    if next.sub_link == SubAbilityLink::SequentialSibling {
+                        let mut next_resolved = next.as_ref().clone();
+                        if next_resolved.targets.is_empty() && !ability.targets.is_empty() {
+                            next_resolved.targets = ability.targets.clone();
+                        }
+                        apply_parent_chain_context(
+                            &mut next_resolved,
+                            ability,
+                            effect_context_object.as_ref(),
+                        );
+                        resolve_ability_chain(state, &next_resolved, events, depth + 1)?;
+                    }
                 }
                 return Ok(());
             }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13322,6 +13322,41 @@ pub(crate) fn parse_effect_chain_ir(
                     ],
                 };
                 (body, Some(condition), DeclineDispatch::SubjectOnly)
+            } else if let Some((_scope, body)) = strip_each_scope_who_doesnt_subject(&text) {
+                // CR 118.12 + CR 608.2d + CR 109.5: subject-only OPTIONAL-decline
+                // tail (Wernog, Rider's Chaplain: "each opponent may investigate.
+                // Each opponent who doesn't loses 1 life."). Inverse of the
+                // `who can't` arm above; the parent is OPTIONAL ("may"), so the
+                // gate is Not{effect_performed()} (the CR 118.12 "doesn't" branch
+                // reading OptionalEffectPerformed), NOT Not{current_scope_succeeded()}.
+                //
+                // CR 608.2e: retarget the preceding Sentence boundary → Then so
+                // the body lowers as a within-action ContinuationStep — a
+                // SequentialSibling would resolve even when the opponent ACCEPTS
+                // (the current bug). Do NOT stamp `player_scope`: the body inherits
+                // the parent's Opponent iteration via sub_ability attachment;
+                // stamping it would start a nested fan-out and reset the
+                // per-iteration flag. Parallel to the `who can't` arm above.
+                //
+                // Uses the BARE `Not{effect_performed()}` (no
+                // `And{Not, ScopedPlayerMatches}` wrapper) to match the proven
+                // prepositional `doesn't` arm (`strip_for_each_opponent_who_doesnt`)
+                // exactly and hit the runtime decline fast-path. Dropping the
+                // ScopedPlayerMatches conjunct is rules-correct for the same-scope
+                // Wernog class: parent and decline both iterate `Opponent`, so the
+                // scope conjunct would be a trivial no-op (CR 109.5).
+                if let Some(prev) = clauses.last_mut() {
+                    if prev.boundary == Some(ClauseBoundary::Sentence) {
+                        prev.boundary = Some(ClauseBoundary::Then);
+                    }
+                }
+                (
+                    body,
+                    Some(AbilityCondition::Not {
+                        condition: Box::new(AbilityCondition::effect_performed()),
+                    }),
+                    DeclineDispatch::SubjectOnly,
+                )
             } else {
                 (text, condition, DeclineDispatch::None)
             };
@@ -15917,6 +15952,18 @@ fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, String) {
         // a defensive escape.
         tag("who can't"),
         tag("who cannot"),
+        // CR 118.12 + CR 608.2c: Reserve the relative-clause shape "who
+        // doesn't" / "who does not" for the Wernog-class subject-only
+        // OPTIONAL-decline tail dispatcher (`strip_each_scope_who_doesnt_subject`
+        // in `parse_effect_clause_inner`). This guard runs AFTER the
+        // `strip_controls_permanent_clause` consumer above, which
+        // already absorbs the "who doesn't control <type>" static-board shape
+        // (Thornbow Archer → ControlsCount) because that combinator requires a
+        // "control " verb after "doesn't". So a bare "who doesn't loses 1 life"
+        // (no "control") reaches here and must survive as `(None, full_text)`
+        // for the dispatcher — ordering invariant, not a defensive escape.
+        tag("who doesn't"),
+        tag("who does not"),
     ))
     .parse(rest_lower.as_str())
     .is_ok()
@@ -15971,6 +16018,36 @@ fn strip_each_scope_who_cant_subject(text: &str) -> Option<(PlayerFilter, String
         ))
         .parse(i)?;
         let (i, _) = alt((tag("can't"), tag("cannot"))).parse(i)?;
+        let (i, _) = preceded(opt(tag(",")), opt(multispace1)).parse(i)?;
+        Ok((i, scope))
+    })
+    .map(|(scope, rest)| (scope, rest.to_string()))
+}
+
+/// CR 118.12 + CR 608.2d + CR 109.5: Strip a leading "each <scope> who doesn't /
+/// does not, <body>" subject-only OPTIONAL-decline tail. Returns the player scope
+/// and the body text. The body's recipient (e.g. LoseLife.target) must be
+/// rewritten Controller → ScopedPlayer by the caller; the body's condition must
+/// be stamped Not { effect_performed() } (the CR 118.12 "doesn't" branch reading
+/// OptionalEffectPerformed); the preceding clause's boundary must be retargeted
+/// Sentence → Then. Caller responsibilities — this combinator only does subject +
+/// scope detection.
+///
+/// PARALLEL INVERSE to `strip_each_scope_who_cant_subject` (subject-only +
+/// mandatory-impossible): this fills the subject-only + optional-decline cell of
+/// the 2×2 decline matrix (Wernog, Rider's Chaplain: "each opponent may
+/// investigate. Each opponent who doesn't loses 1 life."). Matches ONLY
+/// doesn't/does not; the can't/cannot arm stays with `strip_each_scope_who_cant_subject`.
+fn strip_each_scope_who_doesnt_subject(text: &str) -> Option<(PlayerFilter, String)> {
+    let lower = text.to_lowercase();
+    nom_on_lower(text, &lower, |i| {
+        let (i, scope) = alt((
+            value(PlayerFilter::Opponent, tag("each other player who ")),
+            value(PlayerFilter::Opponent, tag("each opponent who ")),
+            value(PlayerFilter::All, tag("each player who ")),
+        ))
+        .parse(i)?;
+        let (i, _) = alt((tag("doesn't"), tag("does not"))).parse(i)?;
         let (i, _) = preceded(opt(tag(",")), opt(multispace1)).parse(i)?;
         Ok((i, scope))
     })
@@ -33703,6 +33780,98 @@ mod tests {
             ),
             other => panic!("expected Draw, got {other:?}"),
         }
+    }
+
+    /// CR 118.12 + CR 608.2d + CR 109.5: Wernog, Rider's Chaplain — subject-only
+    /// OPTIONAL-decline tail. "each opponent may investigate. Each opponent who
+    /// doesn't loses 1 life. You investigate." must lower clause 2 as a
+    /// `Not{effect_performed()}`-gated `ContinuationStep` sub-ability of the
+    /// optional `Effect::Investigate` (player_scope: Opponent), NOT as the
+    /// previous unconditional `SequentialSibling`. The body's life-loss recipient
+    /// is rebound `Controller → ScopedPlayer` by
+    /// `rebind_subject_only_body_recipient`.
+    #[test]
+    fn wernog_subject_only_who_doesnt_lowers_optional_decline_gate() {
+        use crate::types::ability::SubAbilityLink;
+        let def = parse_effect_chain(
+            "each opponent may investigate. Each opponent who doesn't loses 1 life. \
+             You investigate.",
+            AbilityKind::Spell,
+        );
+        // Root: each opponent's OPTIONAL investigate — player_scope: Opponent.
+        assert!(matches!(*def.effect, Effect::Investigate));
+        assert_eq!(
+            def.player_scope,
+            Some(PlayerFilter::Opponent),
+            "the optional investigate iterates per opponent"
+        );
+        assert!(
+            def.optional,
+            "\"each opponent may investigate\" is optional"
+        );
+
+        // Clause 2 sub-ability: LoseLife, gated on Not{IfYouDo}, ContinuationStep.
+        let lose_life = def
+            .sub_ability
+            .as_ref()
+            .expect("the optional investigate chains to the decline body");
+        assert_eq!(
+            lose_life.condition,
+            Some(AbilityCondition::Not {
+                condition: Box::new(AbilityCondition::effect_performed())
+            }),
+            "the decline body runs only for an opponent who did NOT investigate"
+        );
+        assert_eq!(
+            lose_life.sub_link,
+            SubAbilityLink::ContinuationStep,
+            "must be a within-action ContinuationStep, NOT the old unconditional \
+             SequentialSibling"
+        );
+        assert_eq!(
+            lose_life.player_scope, None,
+            "the body inherits player_scope from the parent — it does not set its own"
+        );
+        match &*lose_life.effect {
+            Effect::LoseLife { amount, target } => {
+                assert_eq!(*amount, QuantityExpr::Fixed { value: 1 });
+                assert_eq!(
+                    target.as_ref(),
+                    Some(&TargetFilter::ScopedPlayer),
+                    "the declining opponent loses the life (rebound Controller → ScopedPlayer)"
+                );
+            }
+            other => panic!("expected LoseLife, got {other:?}"),
+        }
+    }
+
+    /// CR 109.4 + CR 109.5: Thornbow no-regression invariant. "each opponent who
+    /// doesn't control an Elf loses 1 life" is a STATIC-BOARD shape consumed by
+    /// `strip_controls_permanent_clause` (→ `ControlsCount`), NOT a decline gate.
+    /// The new `who doesn't` guard/dispatcher must NOT intercept it: the clause
+    /// must carry `condition: None` (no decline gate) and a `ControlsCount`-scoped
+    /// player_scope. Locks the ordering invariant — `strip_controls_permanent_clause`
+    /// runs BEFORE the `who doesn't` guard.
+    #[test]
+    fn each_opponent_who_doesnt_control_type_is_controls_count_not_decline_gate() {
+        let def = parse_effect_chain(
+            "each opponent who doesn't control an Elf loses 1 life",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(*def.effect, Effect::LoseLife { .. }),
+            "expected a LoseLife effect, got {:?}",
+            def.effect
+        );
+        assert_eq!(
+            def.condition, None,
+            "a controls-count board filter is NOT a decline gate — condition must be None"
+        );
+        assert!(
+            matches!(def.player_scope, Some(PlayerFilter::ControlsCount { .. })),
+            "expected a ControlsCount-scoped subject, got {:?}",
+            def.player_scope
+        );
     }
 
     /// CR 101.3 + CR 608.2c + CR 118.12: Refurbished Familiar / Aclazotz,

--- a/crates/engine/tests/integration/wernog_riders_chaplain_investigate_count.rs
+++ b/crates/engine/tests/integration/wernog_riders_chaplain_investigate_count.rs
@@ -14,12 +14,14 @@
 //! then you do X once per opponent who did" machinery, but for Investigate
 //! instead of SearchLibrary.
 //!
-//! OUT OF SCOPE: clause 2 ("each opponent who doesn't loses 1 life") currently
-//! parses unconditionally (no decline-gate linking it to clause 1's optional
-//! investigate), so every opponent loses 1 life regardless of whether they
-//! investigated. That is a separate pre-existing parser gap (the decline-gate),
-//! not part of this count fix, and these tests deliberately assert nothing
-//! about clause-2 life loss.
+//! Clause 2 ("each opponent who doesn't loses 1 life") is now decline-gated to
+//! clause 1's optional investigate (CR 118.12 + CR 608.2d + CR 109.5): only an
+//! opponent who DECLINES the optional investigate loses 1 life. The
+//! subject-only OPTIONAL-decline path (`strip_each_scope_who_doesnt_subject` in
+//! `parser/oracle_effect/mod.rs`) lowers it as a `Not{effect_performed()}`-gated
+//! `ContinuationStep` sub-ability rather than the previous unconditional
+//! `SequentialSibling`. See `wernog_clause2_only_declining_opponent_loses_life`
+//! below for the discriminating runtime proof.
 
 use engine::game::ability_utils::build_resolved_from_def;
 use engine::game::effects::resolve_ability_chain;
@@ -162,6 +164,87 @@ fn wernog_clause3_count_is_one_plus_two_investigating_opponents() {
     );
 }
 
+/// CR 118.12 + CR 608.2d + CR 109.5 + CR 701.16a: Clause-2 decline-gate proof.
+/// With 3 players (P0 controller, P1 + P2 opponents), exactly one opponent
+/// declines the optional investigate and one accepts. The decliner (P1) loses
+/// 1 life (CR 118.12 "doesn't" branch); the accepter (P2) loses nothing; the
+/// controller (P0) is never affected (CR 109.5 — clause 2 iterates Opponent,
+/// not the controller). Before the fix, clause 2 was an unconditional
+/// `SequentialSibling` that drained 1 life from every opponent regardless of
+/// declining; this test fails on that old shape because P2 (who accepted) would
+/// also be at 19.
+#[test]
+fn wernog_clause2_only_declining_opponent_loses_life() {
+    let (mut state, ability) = make_game_and_ability(3);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    // Clause 1 fans out over opponents in APNAP order from P0 → P1 first.
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::OptionalEffectChoice {
+                player: PlayerId(1),
+                ..
+            }
+        ),
+        "expected P1 to be prompted to investigate first, got {:?}",
+        state.waiting_for
+    );
+
+    // P1 DECLINES — should lose 1 life via the decline gate.
+    apply(
+        &mut state,
+        PlayerId(1),
+        GameAction::DecideOptionalEffect { accept: false },
+    )
+    .unwrap();
+
+    // P2 is prompted next.
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::OptionalEffectChoice {
+                player: PlayerId(2),
+                ..
+            }
+        ),
+        "expected P2 to be prompted next, got {:?}",
+        state.waiting_for
+    );
+
+    // P2 ACCEPTS — investigates, so the decline gate must NOT fire for P2.
+    apply(
+        &mut state,
+        PlayerId(2),
+        GameAction::DecideOptionalEffect { accept: true },
+    )
+    .unwrap();
+
+    // Resolution completed.
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "all clauses should have resolved, got {:?}",
+        state.waiting_for
+    );
+
+    // KEY discriminating assertions: only the decliner lost life.
+    assert_eq!(
+        state.players[1].life, 19,
+        "P1 declined the optional investigate → must lose 1 life (CR 118.12 doesn't branch)"
+    );
+    assert_eq!(
+        state.players[2].life, 20,
+        "P2 accepted (investigated) → must NOT lose life; the old unconditional \
+         SequentialSibling would wrongly leave P2 at 19"
+    );
+    assert_eq!(
+        state.players[0].life, 20,
+        "controller P0 is never a clause-2 subject (clause 2 iterates Opponent only, CR 109.5)"
+    );
+}
+
 /// CR 608.2c + CR 109.5: Boundary — when no opponent investigates, the clause-3
 /// count resolves to `1 + 0 = 1`, so P0 investigates exactly once. Total Clues
 /// = P0(1) = 1.
@@ -207,6 +290,128 @@ fn wernog_clause3_count_is_one_when_no_opponent_investigates() {
         1,
         "with zero investigating opponents, X = 1 + 0 = 1, so exactly one Clue \
          (P0's) should exist; got a different count"
+    );
+}
+
+/// CR 608.2c + CR 118.12 + CR 609.3: Mixed decline/accept — the clause-2
+/// decline gate AND the unconditional clause-3 self-investigate must BOTH
+/// resolve correctly when the FINAL clause-1 iteration accepts. With 3 players
+/// (P0 controller, P1 + P2 opponents), P1 DECLINES and P2 ACCEPTS. P2's accept
+/// is the final clause-1 iteration: that resolution descends into clause 2 (the
+/// `Not{effect_performed()}` decline gate, which is NOT met for P2 → its
+/// `SequentialSibling` clause 3 must still run via the condition-false sibling
+/// descent, CR 608.2c "follows its instructions in the order written"). Before
+/// the runtime fix, clause 3 was silently dropped on this condition-false path,
+/// so P0 never investigated and the Clue total was wrong. Asserts:
+/// - P1 (declined) loses 1 life (CR 118.12 "doesn't" branch);
+/// - P2 (accepted) loses nothing;
+/// - P0 (controller) is never a clause-2 subject;
+/// - the ledger records P2 and P0 (clause-3), but not P1;
+/// - Clues = P2(1) + P0(X = 1 + 1 = 2) = 3 (CR 609.3: only the 1 investigating
+///   opponent counts toward X).
+#[test]
+fn wernog_mixed_decline_and_accept_gate_and_clause3() {
+    let (mut state, ability) = make_game_and_ability(3);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    // Clause 1 fans out over opponents in APNAP order from P0 → P1 first.
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::OptionalEffectChoice {
+                player: PlayerId(1),
+                ..
+            }
+        ),
+        "expected P1 to be prompted to investigate first, got {:?}",
+        state.waiting_for
+    );
+
+    // P1 DECLINES — loses 1 life via the decline gate.
+    apply(
+        &mut state,
+        PlayerId(1),
+        GameAction::DecideOptionalEffect { accept: false },
+    )
+    .unwrap();
+
+    // P2 is prompted next.
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::OptionalEffectChoice {
+                player: PlayerId(2),
+                ..
+            }
+        ),
+        "expected P2 to be prompted next, got {:?}",
+        state.waiting_for
+    );
+
+    // P2 ACCEPTS — the FINAL clause-1 iteration. Its resolution descends into
+    // the condition-false clause-2 gate (P2 investigated → not met) and must
+    // still run the SequentialSibling clause 3.
+    apply(
+        &mut state,
+        PlayerId(2),
+        GameAction::DecideOptionalEffect { accept: true },
+    )
+    .unwrap();
+
+    // Resolution completed.
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "all clauses should have resolved, got {:?}",
+        state.waiting_for
+    );
+
+    // CR 118.12: only the decliner lost life.
+    assert_eq!(
+        state.players[1].life, 19,
+        "P1 declined the optional investigate → must lose 1 life (CR 118.12 doesn't branch)"
+    );
+    assert_eq!(
+        state.players[2].life, 20,
+        "P2 accepted (investigated) → must NOT lose life"
+    );
+    assert_eq!(
+        state.players[0].life, 20,
+        "controller P0 is never a clause-2 subject (clause 2 iterates Opponent only)"
+    );
+
+    // P2 (accepted) and P0 (clause-3) are recorded; P1 (declined) is not.
+    assert!(
+        state
+            .player_actions_this_way
+            .contains(&(PlayerId(2), PlayerActionKind::Investigate)),
+        "P2 accepted → must be recorded as having investigated this way, got {:?}",
+        state.player_actions_this_way
+    );
+    assert!(
+        state
+            .player_actions_this_way
+            .contains(&(PlayerId(0), PlayerActionKind::Investigate)),
+        "controller P0 must have investigated via the clause-3 SequentialSibling; \
+         its absence means clause 3 was dropped on the condition-false path, got {:?}",
+        state.player_actions_this_way
+    );
+    assert!(
+        !state
+            .player_actions_this_way
+            .contains(&(PlayerId(1), PlayerActionKind::Investigate)),
+        "P1 declined → must NOT be recorded, got {:?}",
+        state.player_actions_this_way
+    );
+
+    // CR 609.3: X = 1 + (1 investigating opponent) = 2 → Clues = P2(1) + P0(2) =
+    // 3. If clause 3 were dropped on the condition-false path, this would be 1.
+    assert_eq!(
+        count_clues(&state),
+        3,
+        "expected 3 Clues: P2's 1 + P0's clause-3 count (1 + 1 investigating \
+         opponent = 2); a count of 1 means clause 3 was dropped"
     );
 }
 


### PR DESCRIPTION
Wernog, Rider's Chaplain's ETB/LTB trigger has three clauses: "each opponent
may investigate. Each opponent who doesn't loses 1 life. You investigate X
times, where X is one plus the number of opponents who investigated this way."
Clause 2 previously parsed as an UNCONDITIONAL LoseLife (every opponent lost 1
life regardless of declining); gating it then exposed a runtime regression where
clause 3 was dropped whenever an opponent accepted.

Parser (oracle_effect/mod.rs): fill the empty "subject-only x optional-decline"
cell of the decline 2x2 matrix. A guard in strip_each_player_subject reserves
"who doesn't" / "who does not" (running AFTER strip_controls_permanent_clause, so
the "who doesn't CONTROL X" static-board shape -- Thornbow Archer -> ControlsCount
-- is unaffected); a new strip_each_scope_who_doesnt_subject detector (a parallel
inverse of strip_each_scope_who_cant_subject); and a dispatch arm that stamps
clause 2 with condition Not{EffectOutcome{OptionalEffectPerformed}} + boundary
Sentence->Then so it lowers as a per-opponent decline gate. Covers the class
"each {opponent|other player|player} who {doesn't|does not} <consequence>".

Runtime (game/effects/mod.rs): in resolve_chain_body's condition-false branch,
descend into a gated sub's trailing SequentialSibling sub when there is no
else-branch. A separate-sentence sibling (clause 3) is the next independent
instruction (CR 608.2c, "in the order written") and must resolve regardless of
the per-opponent gate's failure. The predicate is next.sub_link (clause 3's link
to clause 2 = SequentialSibling), NOT sub.sub_link (clause 2's link to clause 1 =
ContinuationStep); it mirrors the existing optional-decline handler. No type
change (sub_link already on ResolvedAbility), no new enum variant.

Tests: the existing wernog_clause3_count_is_one_plus_two_investigating_opponents
now passes; new wernog_mixed_decline_and_accept_gate_and_clause3 drives P1 decline
/ P2 accept in one resolution (P1 loses 1 life, P2 does not, controller still
investigates 1 + 1 = 2 times). Both parser and runtime fixes verified
load-bearing by neutralization; full engine suite green.

CR 608.2c (instructions in written order); CR 118.12 (optional decline branch);
CR 608.2e (multi-step APNAP processing); CR 609.3 (repeat); CR 701.16a (investigate).
