### PR TITLE
fix(client): resolve AI mandatory-choice deadlock under stack pressure (stack ≥ 10)

### DIFF
--- a/client/src/components/board/GameBoard.tsx
+++ b/client/src/components/board/GameBoard.tsx
@@ -86,7 +86,22 @@ export function GameBoard({ oppHud, playerHud }: GameBoardProps) {
       }
     }
 
-    if (gameState?.lands_tapped_for_mana?.[localPlayerId]) {
+    // The undo (UntapLandForMana) is legal only in the three WaitingFor states
+    // whose `apply` match arms accept it: Priority (engine.rs:1345), ManaPayment
+    // (engine.rs:2705 — un-tap a land mid-cost-payment to change the mana mix),
+    // and UnlessPayment (engine.rs:2359 — same, during a "pay unless" choice).
+    // Note UnlessPaymentChooseCost is NOT accepted, so it stays excluded. When a
+    // mana ability instead pauses mid-resolution for a mandatory choice (e.g.
+    // ChooseManaColor for an AnyOneColor land), the source is already in
+    // `lands_tapped_for_mana` but the engine is in none of those states —
+    // surfacing the undo affordance there produces a rejected dispatch when the
+    // tapped land is clicked. Gate the affordance on these states so it matches
+    // engine legality exactly.
+    const undoLegal =
+      waitingFor?.type === "Priority"
+      || waitingFor?.type === "ManaPayment"
+      || waitingFor?.type === "UnlessPayment";
+    if (undoLegal && gameState?.lands_tapped_for_mana?.[localPlayerId]) {
       for (const objectId of gameState.lands_tapped_for_mana[localPlayerId]) {
         undoableTapObjectIds.add(objectId);
       }

--- a/client/src/game/controllers/aiController.ts
+++ b/client/src/game/controllers/aiController.ts
@@ -139,8 +139,20 @@ export function createAIController(config: AIControllerConfig): AIController {
       if (waitingPlayerId === PLAYER_ID) return;
     }
 
+    // Stack-pressure deferral applies ONLY to discretionary Priority decisions.
+    // Under pressure the batch-resolve path (gameLoopController → dispatchResolveAll
+    // → engine `resolve_all`) drains the stack by passing priority, so the AI
+    // controller steps aside to avoid racing it. But `resolve_all` is a
+    // priority-only loop: it breaks the instant `waiting_for` leaves Priority
+    // (engine-wasm/src/lib.rs) and hands any mandatory mid-resolution choice
+    // (EffectZoneChoice, ChooseManaColor, scry/surveil, discard, resolution
+    // targeting, …) back to the frontend. Those choices belong to THIS controller
+    // and are exactly what lets the stack drain. Deferring them on stack size
+    // deadlocks the game: stack ≥ 10 → AI won't choose → stack never shrinks →
+    // batch path never restarts (it only fires on Priority). So skip only when
+    // the AI's pending decision is Priority itself.
     const stackLen = state.stack?.length ?? 0;
-    if (stackLen >= STACK_PRESSURE_ELEVATED) return;
+    if (waitingFor.type === "Priority" && stackLen >= STACK_PRESSURE_ELEVATED) return;
 
     // Reset failure counters when the WaitingFor state changes (type or player).
     // `consecutiveFailures` gates normal→fallback escalation; `totalFailures`


### PR DESCRIPTION
When the stack reaches STACK_PRESSURE_ELEVATED (10), the AI controller
deferred ALL waiting states to the batch-resolve path (gameLoopController
→ dispatchResolveAll → engine resolve_all). But resolve_all is a
priority-only loop: it breaks the instant waiting_for leaves Priority and
hands any mandatory mid-resolution choice (EffectZoneChoice, ChooseManaColor,
scry/surveil, discard, resolution targeting, …) back to the frontend. Those
choices belong to the AI controller and are exactly what drains the stack.
gameLoopController only re-fires the batch path on Priority, so a mandatory
AI choice surfacing mid-drain deadlocked the game: stack ≥ 10 → AI won't
choose → stack never shrinks → batch path never restarts. Reproduces readily
on wide boards (e.g. High Perfect Morcant 'each opponent blights 1' piling
15 triggers, paused on the AI's EffectZoneChoice).

Gate the stack-pressure deferral to Priority only — the AI now always answers
mandatory non-Priority choices regardless of stack size, while still stepping
aside for discretionary Priority so the batch path handles storms.

Also gate GameBoard's undoable-tap affordance (UntapLandForMana) on Priority:
the undo is only legal at Priority, but the affordance was surfaced
unconditionally from lands_tapped_for_mana, producing a rejected dispatch when
a tapped any-color land was clicked while paused for ChooseManaColor.
