### PR TITLE
i18n(es): fix de+el contraction in exile-source labels and sideboard->banquillo (Gemini review)

### DIFF
--- a/client/src/i18n/locales/es/deck-builder.json
+++ b/client/src/i18n/locales/es/deck-builder.json
@@ -57,7 +57,7 @@
     "saveAndContinue": "Guardar y continuar"
   },
   "card": {
-    "moveToSideboard": "Mover un/a {{name}} al sideboard",
+    "moveToSideboard": "Mover un/a {{name}} al banquillo",
     "moveToMain": "Mover un/a {{name}} al mazo principal",
     "removeOne": "Quitar un/a {{name}}",
     "makeCommander": "Establecer a {{name}} como comandante",

--- a/client/src/i18n/locales/es/draft.json
+++ b/client/src/i18n/locales/es/draft.json
@@ -187,7 +187,7 @@
     },
     "bo3": {
       "label": "Al mejor de tres",
-      "description": "Juega una partida Bo3 con sideboard entre juegos."
+      "description": "Juega una partida Bo3 con banquillo entre juegos."
     },
     "run": {
       "label": "Recorrido completo",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -908,16 +908,16 @@
     },
     "exileForManaAbility": {
       "title": "Exiliar",
-      "subtitle_one": "Elige {{count}} carta de {{source}} para exiliar",
-      "subtitle_other": "Elige {{count}} cartas de {{source}} para exiliar",
+      "subtitle_one": "Elige {{count}} carta {{source}} para exiliar",
+      "subtitle_other": "Elige {{count}} cartas {{source}} para exiliar",
       "sources": {
-        "Library": "tu biblioteca",
-        "Hand": "tu mano",
-        "Battlefield": "el campo de batalla",
-        "Graveyard": "tu cementerio",
-        "Stack": "la pila",
-        "Exile": "el exilio",
-        "Command": "la Zona de Mando"
+        "Library": "de tu biblioteca",
+        "Hand": "de tu mano",
+        "Battlefield": "del campo de batalla",
+        "Graveyard": "de tu cementerio",
+        "Stack": "de la pila",
+        "Exile": "del exilio",
+        "Command": "de la Zona de Mando"
       }
     },
     "multiTarget": {


### PR DESCRIPTION
Addresses gemini-code-assist review on PR #1606:

- cardChoice.exileForManaAbility: the subtitle hardcoded 'de {{source}}'
  while the zone source strings began with 'el ' (Battlefield, Exile),
  rendering the ungrammatical 'de el campo de batalla' / 'de el exilio'.
  Moved the preposition into each source string with the mandatory
  de+el->del contraction; subtitle now interpolates {{source}} bare.
  (exileForCost is unaffected: its only sources are 'tu mano'/'tu
  cementerio', which render correctly as 'de tu ...'.)
- deck-builder moveToSideboard + draft Bo3 description: 'sideboard' ->
  'banquillo' for consistency with the rest of the es catalog.
