### PR TITLE
fix(client): gate cEDH mode toggle to Commander + Duel Commander formats

### DIFF
--- a/client/src/components/menu/AiOpponentConfig.tsx
+++ b/client/src/components/menu/AiOpponentConfig.tsx
@@ -71,10 +71,24 @@ export function AiOpponentConfig({
   const bracketFilter = usePreferencesStore((s) => s.aiBracketFilter);
   const setBracketFilter = usePreferencesStore((s) => s.setAiBracketFilter);
 
+  // cEDH (competitive EDH, bracket 5) is a Commander-only concept, so the
+  // table-wide toggle only applies to the Commander variants.
+  const isCedhFormat = selectedFormat === "Commander" || selectedFormat === "DuelCommander";
+
   // Keep the persisted seat list in sync with the setup page's player count.
   useEffect(() => {
     ensureAiSeatCount(opponentCount);
   }, [opponentCount, ensureAiSeatCount]);
+
+  // cEDH mode is a persisted preference read directly at game start
+  // (GameProvider → effectiveAiDifficulty). When the format is known to be a
+  // non-Commander variant the toggle is hidden, so clear any stale enabled
+  // state to stop it silently forcing cEDH difficulty on non-Commander tables.
+  // Guard on a defined format so the brief `formatConfig === null` window while
+  // the setup page resolves its format doesn't clobber a legitimate flag.
+  useEffect(() => {
+    if (selectedFormat !== undefined && !isCedhFormat && cedhMode) setCedhMode(false);
+  }, [selectedFormat, isCedhFormat, cedhMode, setCedhMode]);
 
   const { candidates, loading, error } = useAiDeckCatalog({ selectedFormat, selectedMatchType });
 
@@ -136,29 +150,31 @@ export function AiOpponentConfig({
 
       {/* Table-wide cEDH toggle. cEDH is a table property (every deck bracket 5),
           not a per-seat difficulty — enabling it makes all AI play cEDH without
-          touching each opponent's remembered difficulty. */}
-      <div className="flex items-center justify-between gap-3 rounded-lg border border-rose-500/25 bg-rose-500/5 px-3 py-2">
-        <div className="flex min-w-0 flex-col">
-          <span className="text-xs font-semibold text-rose-200">{t("aiOpponent.cedhToggle.label")}</span>
-          <span className="text-[10px] text-slate-400">{t("aiOpponent.cedhToggle.hint")}</span>
-        </div>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={cedhMode}
-          aria-label={t("aiOpponent.cedhToggle.label")}
-          onClick={() => setCedhMode(!cedhMode)}
-          className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/60 ${
-            cedhMode ? "bg-rose-500" : "bg-white/15"
-          }`}
-        >
-          <span
-            className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${
-              cedhMode ? "translate-x-5" : "translate-x-0.5"
+          touching each opponent's remembered difficulty. Commander-only. */}
+      {isCedhFormat && (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-rose-500/25 bg-rose-500/5 px-3 py-2">
+          <div className="flex min-w-0 flex-col">
+            <span className="text-xs font-semibold text-rose-200">{t("aiOpponent.cedhToggle.label")}</span>
+            <span className="text-[10px] text-slate-400">{t("aiOpponent.cedhToggle.hint")}</span>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={cedhMode}
+            aria-label={t("aiOpponent.cedhToggle.label")}
+            onClick={() => setCedhMode(!cedhMode)}
+            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/60 ${
+              cedhMode ? "bg-rose-500" : "bg-white/15"
             }`}
-          />
-        </button>
-      </div>
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${
+                cedhMode ? "translate-x-5" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+        </div>
+      )}
 
       <div className="flex flex-col gap-1.5">
         {seatsToRender.map((seat, i) => (

--- a/client/src/components/menu/__tests__/AiOpponentConfig.test.tsx
+++ b/client/src/components/menu/__tests__/AiOpponentConfig.test.tsx
@@ -104,6 +104,39 @@ describe("AiOpponentConfig — cEDH toggle", () => {
   });
 });
 
+describe("AiOpponentConfig — cEDH toggle format gating", () => {
+  it("renders the toggle for Commander", () => {
+    render(<AiOpponentConfig selectedFormat="Commander" opponentCount={1} />);
+    expect(screen.getByRole("switch", { name: /cEDH mode/i })).toBeInTheDocument();
+  });
+
+  it("renders the toggle for Duel Commander", () => {
+    render(<AiOpponentConfig selectedFormat="DuelCommander" opponentCount={1} />);
+    expect(screen.getByRole("switch", { name: /cEDH mode/i })).toBeInTheDocument();
+  });
+
+  it("hides the toggle for non-Commander formats", () => {
+    render(<AiOpponentConfig selectedFormat="Standard" opponentCount={1} />);
+    expect(screen.queryByRole("switch", { name: /cEDH mode/i })).not.toBeInTheDocument();
+  });
+
+  it("clears a stale cEDH flag when switching away from a Commander format", async () => {
+    act(() => {
+      usePreferencesStore.getState().setCedhMode(true);
+    });
+
+    const { rerender } = render(<AiOpponentConfig selectedFormat="Commander" opponentCount={1} />);
+    expect(usePreferencesStore.getState().cedhMode).toBe(true);
+
+    // Simulate the setup page re-passing a new format prop on dropdown change.
+    rerender(<AiOpponentConfig selectedFormat="Standard" opponentCount={1} />);
+
+    await waitFor(() => {
+      expect(usePreferencesStore.getState().cedhMode).toBe(false);
+    });
+  });
+});
+
 describe("AiOpponentConfig — cEDH badge + disabled difficulty", () => {
   it("badges the seat and disables the difficulty dropdown when cEDH mode is on", async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
The table-wide cEDH toggle (AiOpponentConfig) was shown for every format.
cEDH (competitive EDH, bracket 5) is a Commander-only concept, so it now
only renders for Commander and DuelCommander.

cedhMode is a persisted preference read directly at game start
(GameProvider -> effectiveAiDifficulty), so hiding the toggle alone would
let a flag enabled on Commander silently force every AI seat to cEDH
difficulty after switching to a non-Commander format. Add a reset effect
that clears a stale cedhMode when the format is known to be non-Commander,
guarded on a defined format so the brief formatConfig === null window
during setup-page load doesn't clobber a legitimate flag.
