### PR TITLE
Fix expiry-bound mana (Klauth) emptied at step/phase boundaries

### DIFF
--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -169,7 +169,27 @@ pub(super) fn drain_pending_phase_transition_progress(
         let scan_entries = scan_step_end_mana_handlers(state, player_id);
         state.pending_step_end_mana_handlers = scan_entries;
 
-        // Build per-unit decision payload from the player's surviving (non-expiry) pool.
+        // Build per-unit decision payload from the player's surviving pool.
+        //
+        // CR 500.5 + CR 703.4q (H2 invariant): expiry-bound units (e.g.
+        // Klauth's "you don't lose this mana as steps and phases end",
+        // Firebending's "Until end of combat, you don't lose this mana as
+        // steps and phases end" — CR 702.189a) have *already* had their fate
+        // decided by `clear_expiring_at_step_end` above — they were either
+        // dropped (their rule fired) or deliberately retained.
+        //
+        // CR 614.17 + CR 614.17c: "you don't lose this mana …" is a "can't"
+        // effect, not a replacement effect. It prevents the CR 106.4 /
+        // CR 703.4q lose-mana event for the protected units, and per
+        // CR 614.17c, once that event can't happen no other replacement
+        // effect — including a step-end mana handler (Upwelling, Horizon
+        // Stone, Kruphix) — can modify or replace it. So such units must NOT
+        // enter the empty-pool replacement pipeline at all; emitting a `Drop`
+        // decision here would empty the very mana the card promises to keep.
+        // Only `None`-expiry units flow into the pipeline as Drop-disposition
+        // decisions. The `enumerate` runs over the full pool so `pool_index`
+        // stays aligned with the retained expiry units that remain in
+        // `mana_pool.mana`.
         let units: Vec<crate::types::mana::UnitDecision> = state
             .players
             .iter()
@@ -179,6 +199,7 @@ pub(super) fn drain_pending_phase_transition_progress(
                     .mana
                     .iter()
                     .enumerate()
+                    .filter(|(_, u)| u.expiry.is_none())
                     .map(|(idx, u)| crate::types::mana::UnitDecision {
                         pool_index: idx,
                         color: u.color,
@@ -2055,6 +2076,53 @@ mod tests {
         );
         assert_eq!(state.players[0].mana_pool.count_color(ManaType::Red), 0);
         assert_eq!(state.players[1].mana_pool.total(), 0);
+    }
+
+    #[test]
+    fn advance_phase_keeps_end_of_turn_mana_until_cleanup() {
+        // CR 500.5 + CR 703.4q (H2 invariant, Klauth, Unrivaled Ancient):
+        // "Until end of turn, you don't lose this mana as steps and phases
+        // end." A unit carrying `ManaExpiry::EndOfTurn` must survive every
+        // non-cleanup phase/step transition and only drain when the turn
+        // actually ends. A plain `None`-expiry unit drains on the very first
+        // transition. RUNTIME test driving `advance_phase` through the live
+        // empty-pool pipeline — guards the payload builder that previously
+        // emitted a `Drop` decision for retained expiry-bound units.
+        use crate::types::mana::{ManaExpiry, ManaType, ManaUnit};
+
+        let mut state = setup();
+        state.phase = Phase::PreCombatMain;
+
+        let mut klauth_mana = ManaUnit::new(ManaType::Red, ObjectId(10), false, Vec::new());
+        klauth_mana.expiry = Some(ManaExpiry::EndOfTurn);
+        state.players[0].mana_pool.add(klauth_mana);
+        state.players[0].mana_pool.add(ManaUnit::new(
+            ManaType::Blue,
+            ObjectId(11),
+            false,
+            Vec::new(),
+        ));
+
+        // First transition (PreCombatMain → next step, not cleanup): the
+        // plain Blue mana drains; the EndOfTurn Red mana is retained.
+        advance_phase(&mut state, &mut Vec::new());
+        assert_ne!(state.phase, Phase::Cleanup);
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Red), 1);
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Blue), 0);
+
+        // Drive forward until cleanup; the EndOfTurn mana survives each
+        // intermediate step and only drains once the turn ends.
+        while state.phase != Phase::Cleanup {
+            assert_eq!(
+                state.players[0].mana_pool.count_color(ManaType::Red),
+                1,
+                "EndOfTurn mana must persist through {:?}",
+                state.phase
+            );
+            advance_phase(&mut state, &mut Vec::new());
+        }
+        assert_eq!(state.phase, Phase::Cleanup);
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Red), 0);
     }
 
     #[test]

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -2126,6 +2126,42 @@ mod tests {
     }
 
     #[test]
+    fn advance_phase_keeps_end_of_combat_mana_until_combat_ends() {
+        // CR 500.5 + CR 703.4q + CR 702.189a: Firebending mana says "Until
+        // end of combat, you don't lose this mana as steps and phases end."
+        // It must survive combat step transitions through the live empty-pool
+        // pipeline, then drain when the game leaves combat.
+        use crate::types::mana::{ManaExpiry, ManaType, ManaUnit};
+
+        let mut state = setup();
+        state.phase = Phase::BeginCombat;
+
+        let mut firebending_mana = ManaUnit::new(ManaType::Red, ObjectId(10), false, Vec::new());
+        firebending_mana.expiry = Some(ManaExpiry::EndOfCombat);
+        state.players[0].mana_pool.add(firebending_mana);
+        state.players[0].mana_pool.add(ManaUnit::new(
+            ManaType::Blue,
+            ObjectId(11),
+            false,
+            Vec::new(),
+        ));
+
+        while state.phase != Phase::PostCombatMain {
+            assert_eq!(
+                state.players[0].mana_pool.count_color(ManaType::Red),
+                1,
+                "EndOfCombat mana must persist through {:?}",
+                state.phase
+            );
+            advance_phase(&mut state, &mut Vec::new());
+            assert_eq!(state.players[0].mana_pool.count_color(ManaType::Blue), 0);
+        }
+
+        assert_eq!(state.phase, Phase::PostCombatMain);
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Red), 0);
+    }
+
+    #[test]
     fn transient_retention_drives_player_retained_mana_query() {
         // CR 611.2b + CR 703.4q: The Last Agni Kai shape — a spell installs a
         // turn-scoped retention rule via `add_transient_continuous_effect` with


### PR DESCRIPTION
## Summary
Fixes a bug where mana with a `ManaExpiry` (e.g. **Klauth, Unrivaled Ancient** — "Until end of turn, you don't lose this mana as steps and phases end") was incorrectly emptied at the next step/phase boundary instead of persisting.

The mana was tagged with `expiry: EndOfTurn` correctly all the way onto the produced `ManaUnit`; the bug was in the step-end pool-emptying pipeline.

## Root cause
`drain_pending_phase_transition_progress` (turns.rs) empties pools in two stages:
1. `clear_expiring_at_step_end` correctly **retains** `EndOfTurn` units (except at cleanup) and `EndOfCombat` units (while in combat).
2. It then builds an `EmptyManaPool` payload — but emitted a `Drop` `UnitDecision` for **every** unit still in the pool, including the expiry-bound units just retained. `apply_empty_mana_pool_decisions` drops anything marked `Drop` without re-checking expiry.

This violated the documented "H2 invariant" already asserted in the code's own comments: *"expiry-bound units never enter the replacement pipeline."*

## Fix
Filter expiry-bound units (`expiry.is_some()`) out of the empty-pool payload — their fate is already decided by `clear_expiring_at_step_end`. `enumerate()` runs before the filter so `pool_index` stays aligned with the retained units that remain in `mana_pool.mana`.

This is a **class fix, not a Klauth special-case**: it also corrects Firebending's `EndOfCombat` mana, which was wrongly emptied between combat steps for the same reason.

## Files changed
- `crates/engine/src/game/turns.rs`

## CR references
- `CR 500.5` — mana pools empty between steps/phases
- `CR 703.4q` — "don't lose unspent mana as steps and phases end" rule

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: medium

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine` — clean (no warnings)
- `cargo test -p engine --lib mana` — 734 pass / 0 fail (includes new regression test)
- `cargo test -p engine --lib game::turns` — 80 pass / 0 fail
- `cargo test -p engine --lib firebending` — 12 pass / 0 fail
- New runtime test `advance_phase_keeps_end_of_turn_mana_until_cleanup` proven to catch the bug: it **fails** when the filter is reverted (mana gone on first transition: `left: 0, right: 1`) and **passes** with the fix.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)