### PR TITLE
fix(wasm): seed debug_permitted for sandbox P2P-host multiplayer games

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -518,6 +518,17 @@ pub fn initialize_game(
 
     let mut state = GameState::new(format_config, count, seed);
     state.debug_mode = true;
+    // Sandbox capability: in a P2P-host (WASM-authoritative) game, the
+    // `submit_action` gate checks `debug_permitted`, mirroring server-core's
+    // WebSocket gate. server-core seeds every seat when `allow_debug_actions`
+    // is set (session.rs); the WASM host must do the same or sandbox Debug
+    // actions are rejected for everyone — the host included. Every seat is
+    // permitted by default; the host's grant/revoke flow still narrows it.
+    if state.format_config.allow_debug_actions {
+        for i in 0..count {
+            state.debug_permitted.insert(PlayerId(i));
+        }
+    }
     state.match_config = if !match_config_js.is_null() && !match_config_js.is_undefined() {
         serde_wasm_bindgen::from_value::<MatchConfig>(match_config_js)
             .unwrap_or_else(|_| MatchConfig::default())


### PR DESCRIPTION
The WASM submit_action gate accepts a Debug action in multiplayer only
when the acting seat is in state.debug_permitted, mirroring server-core's
WebSocket gate. But initialize_game set debug_mode=true and never
populated debug_permitted, leaving the set permanently empty — so every
Debug action (the host's included) was rejected with "debug actions
disabled (Sandbox mode off or no permission)".

server-core seeds every seat into debug_permitted when allow_debug_actions
is set (session.rs:662); the WASM host path was never given the matching
change when "all seats permitted by default" landed (402227e71). This
mirrors that seeding into initialize_game. Single-player is unaffected —
it never enters the multiplayer gate.
