### PR TITLE
fix(client): allow deselect + swap in mulligan bottoming selection

### DIFF
--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1922,7 +1922,7 @@ function MulliganBottomCardsPrompt({
   const player = useGameStore((s) => s.gameState?.players[playerId]);
   const objects = useGameStore((s) => s.gameState?.objects);
   const selectedCardIds = useUiStore((s) => s.selectedCardIds);
-  const addSelectedCard = useUiStore((s) => s.addSelectedCard);
+  const cycleSelectedCard = useUiStore((s) => s.cycleSelectedCard);
   const hoverProps = useInspectHoverProps();
 
   if (!player || !objects) return null;
@@ -1990,11 +1990,7 @@ function MulliganBottomCardsPrompt({
               return (
                 <motion.button
                   key={obj.id}
-                  onClick={() => {
-                    if (!isSelected && selectedCardIds.length < count) {
-                      addSelectedCard(obj.id);
-                    }
-                  }}
+                  onClick={() => cycleSelectedCard(obj.id, count)}
                   className={`flex-shrink-0 rounded-[18px] p-1 transition hover:z-50 ${
                     isSelected
                       ? "z-40 ring-2 ring-cyan-300 shadow-[0_0_0_1px_rgba(103,232,249,0.55)] opacity-75"

--- a/client/src/stores/__tests__/uiStore.test.ts
+++ b/client/src/stores/__tests__/uiStore.test.ts
@@ -40,6 +40,40 @@ describe("uiStore", () => {
     expect(useUiStore.getState().selectedCardIds).toEqual([5, 10]);
   });
 
+  it("cycleSelectedCard deselects an already-selected card", () => {
+    act(() => {
+      useUiStore.getState().cycleSelectedCard(5, 2);
+      useUiStore.getState().cycleSelectedCard(10, 2);
+      useUiStore.getState().cycleSelectedCard(5, 2);
+    });
+    expect(useUiStore.getState().selectedCardIds).toEqual([10]);
+  });
+
+  it("cycleSelectedCard adds while under the cap", () => {
+    act(() => {
+      useUiStore.getState().cycleSelectedCard(5, 2);
+      useUiStore.getState().cycleSelectedCard(10, 2);
+    });
+    expect(useUiStore.getState().selectedCardIds).toEqual([5, 10]);
+  });
+
+  it("cycleSelectedCard swaps the single selection at max === 1", () => {
+    act(() => {
+      useUiStore.getState().cycleSelectedCard(5, 1);
+      useUiStore.getState().cycleSelectedCard(10, 1);
+    });
+    expect(useUiStore.getState().selectedCardIds).toEqual([10]);
+  });
+
+  it("cycleSelectedCard evicts the oldest selection at the cap", () => {
+    act(() => {
+      useUiStore.getState().cycleSelectedCard(5, 2);
+      useUiStore.getState().cycleSelectedCard(10, 2);
+      useUiStore.getState().cycleSelectedCard(15, 2);
+    });
+    expect(useUiStore.getState().selectedCardIds).toEqual([10, 15]);
+  });
+
   it("clearSelectedCards resets selectedCardIds", () => {
     act(() => {
       useUiStore.getState().addSelectedCard(1);

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -72,6 +72,7 @@ interface UiStoreActions {
   setAltHeld: (held: boolean) => void;
   addSelectedCard: (cardId: ObjectId) => void;
   toggleSelectedCard: (cardId: ObjectId) => void;
+  cycleSelectedCard: (cardId: ObjectId, max: number) => void;
   setGroupSelectedCards: (groupIds: ObjectId[], selectedIds: ObjectId[]) => void;
   clearSelectedCards: () => void;
   toggleFullControl: () => void;
@@ -190,6 +191,23 @@ export const useUiStore = create<UiStore>()((set) => ({
         ? state.selectedCardIds.filter((id) => id !== cardId)
         : [...state.selectedCardIds, cardId],
     })),
+
+  // Capped multi-select for "choose exactly N" prompts (e.g. London mulligan
+  // bottoming). Clicking a selected card deselects it; clicking an unselected
+  // card adds it while under `max`; clicking an unselected card at `max` evicts
+  // the oldest selection so the click swaps the choice instead of being ignored
+  // (a straight swap when max === 1).
+  cycleSelectedCard: (cardId, max) =>
+    set((state) => {
+      const selected = state.selectedCardIds;
+      if (selected.includes(cardId)) {
+        return { selectedCardIds: selected.filter((id) => id !== cardId) };
+      }
+      if (selected.length < max) {
+        return { selectedCardIds: [...selected, cardId] };
+      }
+      return { selectedCardIds: [...selected.slice(1), cardId] };
+    }),
 
   setGroupSelectedCards: (groupIds, selectedIds) =>
     set((state) => {


### PR DESCRIPTION
MulliganBottomCardsPrompt used the one-way addSelectedCard with a guard
that only added cards, so once `count` cards were selected (immediately,
for the common bottom-1 case) every further click was a no-op — no
deselect, no switching. Players who picked the wrong card were stuck.

Add a cycleSelectedCard(cardId, max) selection primitive to uiStore: it
deselects a selected card, adds while under the cap, and evicts the oldest
selection at the cap (a straight swap when max === 1). The mulligan prompt
now dispatches it. Covers the capped-selection behavior PermanentCard's
convoke/tap-for-mana path half-implements with toggleSelectedCard.
