### PR TITLE
Add Obliterate board wipe regression

### DIFF
--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -466,6 +466,103 @@ mod tests {
     }
 
     #[test]
+    fn destroy_all_or_filter_destroys_every_matching_permanent() {
+        fn permanent(
+            state: &mut GameState,
+            card_id: u64,
+            owner: PlayerId,
+            name: &str,
+            core_type: CoreType,
+        ) -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(card_id),
+                owner,
+                name.to_string(),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(core_type);
+            id
+        }
+
+        let mut state = GameState::new_two_player(42);
+        let p0_artifact = permanent(
+            &mut state,
+            1,
+            PlayerId(0),
+            "Player Artifact",
+            CoreType::Artifact,
+        );
+        let p0_creature = permanent(
+            &mut state,
+            2,
+            PlayerId(0),
+            "Player Creature",
+            CoreType::Creature,
+        );
+        let p0_land = permanent(&mut state, 3, PlayerId(0), "Player Land", CoreType::Land);
+        let p1_artifact = permanent(
+            &mut state,
+            4,
+            PlayerId(1),
+            "Opponent Artifact",
+            CoreType::Artifact,
+        );
+        let p1_creature = permanent(
+            &mut state,
+            5,
+            PlayerId(1),
+            "Opponent Creature",
+            CoreType::Creature,
+        );
+        let p1_land = permanent(&mut state, 6, PlayerId(1), "Opponent Land", CoreType::Land);
+        let enchantment = permanent(
+            &mut state,
+            7,
+            PlayerId(1),
+            "Opponent Enchantment",
+            CoreType::Enchantment,
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::DestroyAll {
+                target: TargetFilter::Or {
+                    filters: vec![
+                        TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
+                        TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+                        TargetFilter::Typed(TypedFilter::new(TypeFilter::Land)),
+                    ],
+                },
+                cant_regenerate: true,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_all(&mut state, &ability, &mut events).unwrap();
+
+        for destroyed in [
+            p0_artifact,
+            p0_creature,
+            p0_land,
+            p1_artifact,
+            p1_creature,
+            p1_land,
+        ] {
+            assert_eq!(state.objects[&destroyed].zone, Zone::Graveyard);
+        }
+        assert_eq!(state.objects[&enchantment].zone, Zone::Battlefield);
+    }
+
+    #[test]
     fn destroy_prevented_by_regen_shield() {
         use crate::types::ability::ReplacementDefinition;
         use crate::types::replacements::ReplacementEvent;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -75,6 +75,7 @@ mod master_of_ceremonies;
 mod militant_angel_attacked_opponents;
 mod mycoloth_upkeep_trigger;
 mod mystic_forge_regression;
+mod obliterate_regression;
 mod old_growth_troll_return_as_aura;
 mod oracle_parser;
 mod oversimplify_per_player_fractal;

--- a/crates/engine/tests/integration/obliterate_regression.rs
+++ b/crates/engine/tests/integration/obliterate_regression.rs
@@ -1,0 +1,168 @@
+//! Regression: GitHub issue #1521 — Obliterate must destroy every artifact,
+//! creature, and land, not equalize to one permanent per player.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use engine::database::card_db::CardDatabase;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::game::zones::create_object;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+fn load_db() -> Option<&'static CardDatabase> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../client/public/card-data.json");
+    if !path.exists() {
+        return None;
+    }
+    static DB: OnceLock<CardDatabase> = OnceLock::new();
+    Some(DB.get_or_init(|| CardDatabase::from_export(&path).expect("export should load")))
+}
+
+fn add_mana(runner: &mut engine::game::scenario::GameRunner, mana: &[ManaType]) {
+    let dummy = ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool;
+    for m in mana {
+        pool.add(ManaUnit::new(*m, dummy, false, vec![]));
+    }
+}
+
+fn add_permanent(
+    state: &mut engine::types::game_state::GameState,
+    owner: PlayerId,
+    card_id: u64,
+    name: &str,
+    core_type: CoreType,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(card_id),
+        owner,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(core_type);
+    obj.base_card_types = obj.card_types.clone();
+    id
+}
+
+fn assert_in_zone(
+    state: &engine::types::game_state::GameState,
+    object_id: ObjectId,
+    expected: Zone,
+) {
+    assert_eq!(
+        state.objects.get(&object_id).map(|obj| obj.zone),
+        Some(expected)
+    );
+}
+
+/// Loads Obliterate from the generated card-data export and resolves it through
+/// the same cast/stack path gameplay uses. The board is intentionally
+/// asymmetric: if this regresses to Balance-style equalization, several matching
+/// permanents will survive.
+#[test]
+fn obliterate_destroys_all_artifacts_creatures_and_lands_from_card_data() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let obliterate = scenario.add_real_card(P0, "Obliterate", Zone::Hand, db);
+    let mut runner = scenario.build();
+    let p0_artifact = add_permanent(
+        runner.state_mut(),
+        P0,
+        101,
+        "Player Artifact",
+        CoreType::Artifact,
+    );
+    let p0_creature = add_permanent(
+        runner.state_mut(),
+        P0,
+        102,
+        "Player Creature",
+        CoreType::Creature,
+    );
+    let p0_land = add_permanent(runner.state_mut(), P0, 103, "Player Land", CoreType::Land);
+    let p1_artifact = add_permanent(
+        runner.state_mut(),
+        P1,
+        201,
+        "Opponent Artifact",
+        CoreType::Artifact,
+    );
+    let p1_creature = add_permanent(
+        runner.state_mut(),
+        P1,
+        202,
+        "Opponent Creature",
+        CoreType::Creature,
+    );
+    let p1_land = add_permanent(runner.state_mut(), P1, 203, "Opponent Land", CoreType::Land);
+    let p1_enchantment = add_permanent(
+        runner.state_mut(),
+        P1,
+        204,
+        "Opponent Enchantment",
+        CoreType::Enchantment,
+    );
+
+    add_mana(
+        &mut runner,
+        &[
+            ManaType::Red,
+            ManaType::Red,
+            ManaType::Red,
+            ManaType::Red,
+            ManaType::Red,
+            ManaType::Red,
+            ManaType::Red,
+            ManaType::Red,
+        ],
+    );
+
+    let card_id = runner.state().objects[&obliterate].card_id;
+    let result = runner
+        .act(GameAction::CastSpell {
+            object_id: obliterate,
+            card_id,
+            targets: vec![],
+        })
+        .expect("Obliterate cast should be accepted");
+    assert!(
+        matches!(result.waiting_for, WaitingFor::Priority { .. }),
+        "Obliterate must not request target selection, got {:?}",
+        result.waiting_for
+    );
+
+    runner.advance_until_stack_empty();
+
+    for destroyed in [
+        p0_artifact,
+        p0_creature,
+        p0_land,
+        p1_artifact,
+        p1_creature,
+        p1_land,
+    ] {
+        assert_in_zone(runner.state(), destroyed, Zone::Graveyard);
+    }
+    assert_in_zone(runner.state(), p1_enchantment, Zone::Battlefield);
+}


### PR DESCRIPTION
## Summary
- add a resolver-level regression for DestroyAll over artifact/creature/land OR filters
- add a card-data-backed integration regression that casts Obliterate through the gameplay stack path

Closes #1521

## Verification
- cargo fmt --all
- CARGO_TARGET_DIR=/tmp/forge-rs-gh-issues-target cargo test -p engine destroy_all_or_filter_destroys_every_matching_permanent --lib
- CARGO_TARGET_DIR=/tmp/forge-rs-gh-issues-target cargo test -p engine --test integration obliterate_destroys_all_artifacts_creatures_and_lands_from_card_data -- --nocapture
- verified no diff in data/card-data.json / client/public/card-data.json for this runtime-regression change
