### PR TITLE
Fix exact X target casting for Immoral Bargain

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1,9 +1,10 @@
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, CardTypeSetSource, CastManaSpentMetric,
     CombatRelationSubject, ControllerRef, CounterMoveSelection, Effect, FilterProp,
-    GameRestriction, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint, ObjectScope,
-    PlayerFilter, QuantityExpr, QuantityRef, ResolvedAbility, RestrictionPlayerScope, SpellContext,
-    TargetChoiceTiming, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+    GameRestriction, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
+    MultiTargetSpec, ObjectScope, PlayerFilter, QuantityExpr, QuantityRef, ResolvedAbility,
+    RestrictionPlayerScope, SpellContext, TargetChoiceTiming, TargetFilter, TargetRef, TypeFilter,
+    TypedFilter,
 };
 #[cfg(test)]
 use crate::types::counter::CounterType;
@@ -1176,27 +1177,21 @@ fn collect_target_slots(
                 // ability-wide "up to one" (`optional_targeting`) — may legally
                 // choose zero targets, so an empty legal-target set is acceptable.
                 // Only abilities that require at least one target error out here.
-                if legal_targets.is_empty() && !ability.targeting_is_optional() {
-                    return Err(EngineError::ActionNotAllowed(
-                        "No legal targets available".to_string(),
-                    ));
-                }
                 if let Some(spec) = ability.multi_target.as_ref() {
-                    if multi_target_max_needs_quantity_choice(state, ability, spec) {
-                        return Err(EngineError::ActionNotAllowed(
-                            "Target count requires a resolved quantity before target selection"
-                                .to_string(),
-                        ));
-                    }
-                    let slot_count =
-                        multi_target_slot_count(state, ability, spec, legal_targets.len());
-                    for slot_index in 0..slot_count {
+                    let bounds =
+                        resolve_multi_target_bounds(state, ability, spec, legal_targets.len())?;
+                    for slot_index in 0..bounds.max {
                         slots.push(TargetSelectionSlot {
                             legal_targets: legal_targets.clone(),
-                            optional: slot_index >= spec.min,
+                            optional: slot_index >= bounds.min,
                         });
                     }
                 } else {
+                    if legal_targets.is_empty() && !ability.optional_targeting {
+                        return Err(EngineError::ActionNotAllowed(
+                            "No legal targets available".to_string(),
+                        ));
+                    }
                     slots.push(TargetSelectionSlot {
                         legal_targets,
                         optional: ability.optional_targeting,
@@ -1244,21 +1239,71 @@ fn pair_with_legal_choices(
 fn resolve_multi_target_max(
     state: &GameState,
     ability: &ResolvedAbility,
-    spec: &crate::types::ability::MultiTargetSpec,
+    spec: &MultiTargetSpec,
 ) -> Option<usize> {
     spec.max
         .as_ref()
         .map(|expr| resolve_quantity_with_targets(state, expr, ability).max(0) as usize)
 }
 
-fn multi_target_max_needs_quantity_choice(
+fn resolve_multi_target_min(
     state: &GameState,
     ability: &ResolvedAbility,
-    spec: &crate::types::ability::MultiTargetSpec,
+    spec: &MultiTargetSpec,
+) -> usize {
+    resolve_quantity_with_targets(state, &spec.min, ability).max(0) as usize
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MultiTargetBounds {
+    pub min: usize,
+    pub max: usize,
+}
+
+/// CR 115.1d + CR 601.2c: Resolve a multi-target count after any required
+/// quantity choices have been announced, then cap optional slots at the live
+/// legal-target set while preserving the required minimum.
+pub(crate) fn resolve_multi_target_bounds(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    spec: &MultiTargetSpec,
+    legal_target_count: usize,
+) -> Result<MultiTargetBounds, EngineError> {
+    if multi_target_needs_quantity_choice(state, ability, spec) {
+        return Err(EngineError::ActionNotAllowed(
+            "Target count requires a resolved quantity before target selection".to_string(),
+        ));
+    }
+
+    let min = resolve_multi_target_min(state, ability, spec);
+    let raw_max = resolve_multi_target_max(state, ability, spec).unwrap_or(legal_target_count);
+    if raw_max < min {
+        return Err(EngineError::ActionNotAllowed(
+            "Multi-target maximum is below its minimum".to_string(),
+        ));
+    }
+    if legal_target_count < min {
+        return Err(EngineError::ActionNotAllowed(
+            "Not enough legal targets available".to_string(),
+        ));
+    }
+
+    Ok(MultiTargetBounds {
+        min,
+        max: raw_max.min(legal_target_count),
+    })
+}
+
+fn multi_target_needs_quantity_choice(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    spec: &MultiTargetSpec,
 ) -> bool {
-    spec.max
-        .as_ref()
-        .is_some_and(|expr| quantity_expr_has_unresolved_variable(state, ability, expr))
+    quantity_expr_has_unresolved_variable(state, ability, &spec.min)
+        || spec
+            .max
+            .as_ref()
+            .is_some_and(|expr| quantity_expr_has_unresolved_variable(state, ability, expr))
 }
 
 fn quantity_expr_has_unresolved_variable(
@@ -1302,9 +1347,11 @@ fn ability_target_legality_needs_chosen_x_inner(ability: &ResolvedAbility) -> bo
     triggers::extract_target_filter_from_effect(&ability.effect)
         .is_some_and(|filter| target_filter_needs_chosen_x(ability, filter))
         || ability.multi_target.as_ref().is_some_and(|spec| {
-            spec.max
-                .as_ref()
-                .is_some_and(|expr| quantity_expr_has_unresolved_x(ability, expr))
+            quantity_expr_has_unresolved_x(ability, &spec.min)
+                || spec
+                    .max
+                    .as_ref()
+                    .is_some_and(|expr| quantity_expr_has_unresolved_x(ability, expr))
         })
         || ability
             .sub_ability
@@ -1361,18 +1408,6 @@ fn quantity_expr_contains_x(expr: &QuantityExpr) -> bool {
         }
         QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => false,
     }
-}
-
-fn multi_target_slot_count(
-    state: &GameState,
-    ability: &ResolvedAbility,
-    spec: &crate::types::ability::MultiTargetSpec,
-    legal_target_count: usize,
-) -> usize {
-    resolve_multi_target_max(state, ability, spec)
-        .map(|max_targets| max_targets.max(spec.min))
-        .unwrap_or(legal_target_count)
-        .min(legal_target_count)
 }
 
 /// CR 109.4 + CR 115.1: Returns true if `effect` needs a companion
@@ -1882,13 +1917,15 @@ fn collect_target_slot_specs(
                 if let Some(spec) = ability.multi_target.as_ref() {
                     let legal_targets =
                         legal_targets_for_ability_filter(state, ability, filter, &[]);
-                    let slot_count =
-                        multi_target_slot_count(state, ability, spec, legal_targets.len());
-                    for slot_index in 0..slot_count {
-                        specs.push(TargetSlotSpec {
-                            filter: filter.clone(),
-                            optional: slot_index >= spec.min,
-                        });
+                    if let Ok(bounds) =
+                        resolve_multi_target_bounds(state, ability, spec, legal_targets.len())
+                    {
+                        for slot_index in 0..bounds.max {
+                            specs.push(TargetSlotSpec {
+                                filter: filter.clone(),
+                                optional: slot_index >= bounds.min,
+                            });
+                        }
                     }
                 } else {
                     specs.push(TargetSlotSpec {
@@ -3058,27 +3095,21 @@ fn assign_targets_recursive(
         && triggers::extract_target_filter_from_effect(&ability.effect).is_some()
     {
         if let Some(spec) = ability.multi_target.as_ref() {
-            if multi_target_max_needs_quantity_choice(state, ability, spec) {
-                return Err(EngineError::InvalidAction(
-                    "Target count requires a resolved quantity before target selection".to_string(),
-                ));
-            }
             let remaining_minimum = ability
                 .sub_ability
                 .as_deref()
-                .map(minimum_targets_in_chain)
+                .map(|sub| minimum_targets_in_chain(state, sub))
                 .unwrap_or(0);
             let remaining_after_current = targets.len().saturating_sub(*next_target);
             // Issue #321: cap at this node's own resolved `multi_target` max so a
             // node does not claim a downstream `up to N` effect's optional
             // targets. Mirrors the cap in `assign_selected_slots_recursive`.
-            let node_max = resolve_multi_target_max(state, ability, spec)
-                .map(|max_targets| max_targets.max(spec.min))
-                .unwrap_or(remaining_after_current);
+            let bounds = resolve_multi_target_bounds(state, ability, spec, remaining_after_current)
+                .map_err(|err| EngineError::InvalidAction(format!("{err:?}")))?;
             let current_count = remaining_after_current
                 .saturating_sub(remaining_minimum)
-                .min(node_max);
-            if current_count < spec.min {
+                .min(bounds.max);
+            if current_count < bounds.min {
                 return Err(EngineError::InvalidAction(
                     "Incorrect number of multi-target selections".to_string(),
                 ));
@@ -3285,7 +3316,7 @@ fn assign_selected_slots_recursive(
             let remaining_minimum = ability
                 .sub_ability
                 .as_deref()
-                .map(minimum_targets_in_chain)
+                .map(|sub| minimum_targets_in_chain(state, sub))
                 .unwrap_or(0);
             let remaining_after_current = selected_slots.len().saturating_sub(*next_slot);
             // Issue #321: A multi-target node must consume only as many slots as
@@ -3297,19 +3328,18 @@ fn assign_selected_slots_recursive(
             // Betor's "+1/+1 counters" PutCounter) to the graveyard-return
             // target as well. Cap at this node's max so each effect resolves
             // against exactly its own chosen targets (CR 601.2c).
-            let node_max = resolve_multi_target_max(state, ability, spec)
-                .map(|max_targets| max_targets.max(spec.min))
-                .unwrap_or(remaining_after_current);
+            let bounds = resolve_multi_target_bounds(state, ability, spec, remaining_after_current)
+                .map_err(|err| EngineError::InvalidAction(format!("{err:?}")))?;
             let current_slots = remaining_after_current
                 .saturating_sub(remaining_minimum)
-                .min(node_max);
+                .min(bounds.max);
             let end_slot = *next_slot + current_slots;
             let Some(window) = selected_slots.get(*next_slot..end_slot) else {
                 return Err(EngineError::InvalidAction(
                     "Missing required target".to_string(),
                 ));
             };
-            if window.len() < spec.min || window[..spec.min].iter().any(Option::is_none) {
+            if window.len() < bounds.min || window[..bounds.min].iter().any(Option::is_none) {
                 return Err(EngineError::InvalidAction(
                     "Missing required target".to_string(),
                 ));
@@ -3511,7 +3541,7 @@ fn chain_has_target_sink_after_deferred_effect(sub_ability: Option<&ResolvedAbil
     chain_has_target_sink(sub_ability)
 }
 
-fn minimum_targets_in_chain(ability: &ResolvedAbility) -> usize {
+fn minimum_targets_in_chain(state: &GameState, ability: &ResolvedAbility) -> usize {
     let attach_targets = if let Effect::Attach { attachment, target } = &ability.effect {
         if ability.optional_targeting {
             0
@@ -3584,7 +3614,7 @@ fn minimum_targets_in_chain(ability: &ResolvedAbility) -> usize {
             .as_ref()
             .filter(|spec| spec.max.is_some())
         {
-            spec.min
+            resolve_multi_target_min(state, ability, spec)
         } else if ability.optional_targeting {
             0
         } else {
@@ -3601,19 +3631,22 @@ fn minimum_targets_in_chain(ability: &ResolvedAbility) -> usize {
         + current;
 
     let rest = if defers_sub_ability_target_selection(&ability.effect) {
-        minimum_targets_after_deferred_effect(ability.sub_ability.as_deref())
+        minimum_targets_after_deferred_effect(state, ability.sub_ability.as_deref())
     } else {
         ability
             .sub_ability
             .as_deref()
-            .map(minimum_targets_in_chain)
+            .map(|sub| minimum_targets_in_chain(state, sub))
             .unwrap_or(0)
     };
 
     current + rest
 }
 
-fn minimum_targets_after_deferred_effect(sub_ability: Option<&ResolvedAbility>) -> usize {
+fn minimum_targets_after_deferred_effect(
+    state: &GameState,
+    sub_ability: Option<&ResolvedAbility>,
+) -> usize {
     let Some(sub_ability) = sub_ability else {
         return 0;
     };
@@ -3621,9 +3654,9 @@ fn minimum_targets_after_deferred_effect(sub_ability: Option<&ResolvedAbility>) 
         return 0;
     }
     if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
-        return minimum_targets_after_deferred_effect(sub_ability.sub_ability.as_deref());
+        return minimum_targets_after_deferred_effect(state, sub_ability.sub_ability.as_deref());
     }
-    minimum_targets_in_chain(sub_ability)
+    minimum_targets_in_chain(state, sub_ability)
 }
 
 /// CR 700.2a: The controller of a modal spell or activated ability chooses the mode(s)
@@ -6675,6 +6708,52 @@ mod tests {
 
         let slots = build_target_slots(&state, &ability).expect("chosen X should resolve max");
         assert_eq!(slots.len(), 1);
+    }
+
+    #[test]
+    fn build_target_slots_resolves_exact_dynamic_multi_target_min() {
+        let mut state = crate::types::game_state::GameState::new_two_player(42);
+        for index in 0..3 {
+            let creature = crate::game::zones::create_object(
+                &mut state,
+                crate::types::identifiers::CardId(index + 1),
+                PlayerId(0),
+                format!("Creature {index}"),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&creature)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+        }
+
+        let mut ability = ResolvedAbility::new(
+            Effect::Tap {
+                target: TargetFilter::Typed(TypedFilter::creature()),
+            },
+            vec![],
+            ObjectId(10),
+            PlayerId(0),
+        );
+        let x = QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        };
+        ability.multi_target = Some(crate::types::ability::MultiTargetSpec::exact(x));
+
+        assert!(build_target_slots(&state, &ability).is_err());
+        ability.chosen_x = Some(2);
+
+        let slots = build_target_slots(&state, &ability).expect("chosen X should resolve bounds");
+        assert_eq!(slots.len(), 2);
+        assert!(slots.iter().all(|slot| !slot.optional));
+
+        ability.chosen_x = Some(4);
+        assert!(build_target_slots(&state, &ability).is_err());
     }
 
     #[test]

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -25,10 +25,10 @@ use crate::types::zones::{ExileCostSourceZone, Zone};
 use std::collections::HashSet;
 
 use super::ability_utils::{
-    assign_targets_in_chain, auto_select_targets, auto_select_targets_for_ability,
-    begin_target_selection, begin_target_selection_for_ability, build_resolved_from_def,
-    build_target_slots, compute_unavailable_modes, flatten_targets_in_chain,
-    has_legal_target_assignment_for_ability, modal_choice_for_player,
+    ability_target_legality_needs_chosen_x, assign_targets_in_chain, auto_select_targets,
+    auto_select_targets_for_ability, begin_target_selection, begin_target_selection_for_ability,
+    build_resolved_from_def, build_target_slots, compute_unavailable_modes,
+    flatten_targets_in_chain, has_legal_target_assignment_for_ability, modal_choice_for_player,
     target_constraints_from_modal,
 };
 use super::casting_costs::{self, check_additional_cost_or_pay};
@@ -90,6 +90,20 @@ pub(crate) fn sacrifice_cost_bounds(count: u32, eligible_len: usize) -> (usize, 
         let exact = count as usize;
         (exact, exact)
     }
+}
+
+pub(crate) fn sacrifice_cost_bounds_with_chosen_x(
+    count: u32,
+    eligible_len: usize,
+    chosen_x: Option<u32>,
+) -> (usize, usize) {
+    if count == u32::MAX {
+        if let Some(value) = chosen_x {
+            let exact = value as usize;
+            return (exact, exact);
+        }
+    }
+    sacrifice_cost_bounds(count, eligible_len)
 }
 
 /// Emit `BecomesTarget` and `CrimeCommitted` events for each target.
@@ -5664,6 +5678,58 @@ fn continue_with_prepared(
         }
     }
 
+    // CR 601.2b/c/f: When target cardinality depends on an announced X, defer
+    // target selection until that X is chosen from the spell's required
+    // additional cost or mana cost.
+    if ability_target_legality_needs_chosen_x(&resolved) {
+        if let Some(required_cost) =
+            casting_costs::required_additional_cost_can_declare_x(state, player, prepared.object_id)
+        {
+            return casting_costs::begin_required_cost_before_targets(
+                state,
+                player,
+                prepared.object_id,
+                prepared.card_id,
+                resolved,
+                prepared.mana_cost,
+                required_cost,
+                prepared.casting_variant,
+                prepared.cast_timing_permission,
+                prepared
+                    .ability_def
+                    .as_ref()
+                    .and_then(|a| a.distribute.clone()),
+                prepared.origin_zone,
+                prepared.payment_mode,
+                events,
+            );
+        }
+        if casting_costs::cost_has_x(&prepared.mana_cost) {
+            let mut pending_x = PendingCast::new(
+                prepared.object_id,
+                prepared.card_id,
+                resolved,
+                prepared.mana_cost.clone(),
+            );
+            pending_x.casting_variant = prepared.casting_variant;
+            pending_x.cast_timing_permission = prepared.cast_timing_permission;
+            pending_x.distribute = prepared
+                .ability_def
+                .as_ref()
+                .and_then(|ability| ability.distribute.clone());
+            pending_x.target_constraints = prepared
+                .ability_def
+                .as_ref()
+                .map(|ability| ability.target_constraints.clone())
+                .unwrap_or_default();
+            pending_x.origin_zone = prepared.origin_zone;
+            pending_x.payment_mode = prepared.payment_mode;
+            pending_x.deferred_target_selection = true;
+            state.pending_cast = Some(Box::new(pending_x));
+            return casting_costs::enter_payment_step(state, player, None, events);
+        }
+    }
+
     let target_slots = build_target_slots(state, &resolved)?;
     if !target_slots.is_empty() {
         let target_constraints = prepared
@@ -5942,7 +6008,14 @@ pub fn spell_has_legal_targets(
                 )
             }
         }
-        Err(_) => false,
+        Err(_) => {
+            ability_target_legality_needs_chosen_x(&resolved)
+                && (casting_costs::required_additional_cost_can_declare_x(
+                    &simulated, player, obj.id,
+                )
+                .is_some()
+                    || casting_costs::cost_has_x(&obj.mana_cost))
+        }
     }
 }
 
@@ -8161,7 +8234,14 @@ pub fn can_activate_ability_now(
                     &ability_def.target_constraints,
                 )
         }
-        Err(_) => false,
+        Err(_) => {
+            ability_target_legality_needs_chosen_x(&resolved)
+                && ability_def.cost.as_ref().is_some_and(|cost| {
+                    casting_costs::extract_x_mana_cost(cost).is_some()
+                        || find_non_self_sacrifice_cost(cost)
+                            .is_some_and(|(count, _)| count == u32::MAX)
+                })
+        }
     }
 }
 
@@ -9301,9 +9381,10 @@ mod tests {
         ChosenAttribute, ChosenSubtypeKind, Comparator, ContinuousModification, ControllerRef,
         CostCategory, FilterProp, GainLifePlayer, GameRestriction, KickerVariant, ManaContribution,
         ManaProduction, ManaSpendPermission, ManaSpendRestriction, ModalSelectionCondition,
-        ModalSelectionConstraint, ObjectProperty, ProhibitedActivity, PtValue, QuantityExpr,
-        QuantityRef, RestrictionExpiry, RestrictionPlayerScope, SearchSelectionConstraint,
-        StaticCondition, StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
+        ModalSelectionConstraint, MultiTargetSpec, ObjectProperty, ProhibitedActivity, PtValue,
+        QuantityExpr, QuantityRef, RestrictionExpiry, RestrictionPlayerScope,
+        SearchSelectionConstraint, StaticCondition, StaticDefinition, TargetFilter, TypeFilter,
+        TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::{CoreType, Supertype};
@@ -11328,6 +11409,222 @@ mod tests {
             "X=4 should mark 4 damage on the target (actual={})",
             target.damage_marked
         );
+    }
+
+    #[test]
+    fn x_cost_exact_multi_target_spell_chooses_x_before_targets() {
+        let mut state = setup_game_at_main_phase();
+        let target_a = create_object(
+            &mut state,
+            CardId(920),
+            PlayerId(1),
+            "Target A".to_string(),
+            Zone::Battlefield,
+        );
+        let target_b = create_object(
+            &mut state,
+            CardId(921),
+            PlayerId(1),
+            "Target B".to_string(),
+            Zone::Battlefield,
+        );
+        for target in [target_a, target_b] {
+            state
+                .objects
+                .get_mut(&target)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+
+        let obj_id = create_object(
+            &mut state,
+            CardId(922),
+            PlayerId(0),
+            "Synthetic Builder's Bane".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&obj_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            let mut ability = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Destroy {
+                    target: TargetFilter::Typed(TypedFilter::creature()),
+                    cant_regenerate: false,
+                },
+            );
+            ability.multi_target = Some(MultiTargetSpec::exact(QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "X".to_string(),
+                },
+            }));
+            Arc::make_mut(&mut obj.abilities).push(ability);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::X],
+                generic: 0,
+            };
+        }
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 3);
+
+        let result = apply_as_current(
+            &mut state,
+            GameAction::CastSpell {
+                object_id: obj_id,
+                card_id: CardId(922),
+                targets: vec![],
+            },
+        )
+        .unwrap();
+        let max = match result.waiting_for {
+            WaitingFor::ChooseXValue { max, .. } => max,
+            other => panic!("expected ChooseXValue before target selection, got {other:?}"),
+        };
+        assert_eq!(max, 3);
+
+        assert!(
+            apply_as_current(&mut state, GameAction::ChooseX { value: 3 }).is_err(),
+            "X=3 should be rejected before mutating the pending cast when only two targets exist"
+        );
+        assert!(matches!(state.waiting_for, WaitingFor::ChooseXValue { .. }));
+        assert!(
+            state
+                .pending_cast
+                .as_ref()
+                .is_some_and(|pending| pending.ability.chosen_x.is_none()),
+            "failed prevalidation must not stamp chosen_x"
+        );
+
+        apply_as_current(&mut state, GameAction::ChooseX { value: 2 }).unwrap();
+        let WaitingFor::TargetSelection {
+            target_slots,
+            selection,
+            ..
+        } = &state.waiting_for
+        else {
+            panic!(
+                "expected exact-X target selection after ChooseX, got {:?}",
+                state.waiting_for
+            );
+        };
+        assert_eq!(target_slots.len(), 2);
+        assert!(target_slots.iter().all(|slot| !slot.optional));
+        assert_eq!(selection.current_slot, 0);
+        assert!(selection.selected_slots.is_empty());
+    }
+
+    #[test]
+    fn required_x_sacrifice_spell_selects_targets_before_sacrificing() {
+        let mut state = setup_game_at_main_phase();
+        let sacrifice_a = create_object(
+            &mut state,
+            CardId(930),
+            PlayerId(0),
+            "Sacrifice A".to_string(),
+            Zone::Battlefield,
+        );
+        let sacrifice_b = create_object(
+            &mut state,
+            CardId(931),
+            PlayerId(0),
+            "Sacrifice B".to_string(),
+            Zone::Battlefield,
+        );
+        let target_a = create_object(
+            &mut state,
+            CardId(932),
+            PlayerId(1),
+            "Target A".to_string(),
+            Zone::Battlefield,
+        );
+        let target_b = create_object(
+            &mut state,
+            CardId(933),
+            PlayerId(1),
+            "Target B".to_string(),
+            Zone::Battlefield,
+        );
+        for object_id in [sacrifice_a, sacrifice_b, target_a, target_b] {
+            state
+                .objects
+                .get_mut(&object_id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+
+        let obj_id = create_object(
+            &mut state,
+            CardId(934),
+            PlayerId(0),
+            "Synthetic Immoral Bargain".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&obj_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            let mut ability = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Destroy {
+                    target: TargetFilter::Typed(TypedFilter::creature()),
+                    cant_regenerate: false,
+                },
+            );
+            ability.multi_target = Some(MultiTargetSpec::exact(QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "X".to_string(),
+                },
+            }));
+            Arc::make_mut(&mut obj.abilities).push(ability);
+            obj.additional_cost = Some(AdditionalCost::Required(AbilityCost::Sacrifice {
+                target: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Creature],
+                    controller: Some(ControllerRef::You),
+                    ..Default::default()
+                }),
+                count: u32::MAX,
+            }));
+        }
+
+        apply_as_current(
+            &mut state,
+            GameAction::CastSpell {
+                object_id: obj_id,
+                card_id: CardId(934),
+                targets: vec![],
+            },
+        )
+        .unwrap();
+        match state.waiting_for {
+            WaitingFor::ChooseXValue { max, .. } => assert_eq!(max, 2),
+            ref other => panic!("expected ChooseXValue, got {other:?}"),
+        }
+
+        apply_as_current(&mut state, GameAction::ChooseX { value: 2 }).unwrap();
+        assert!(
+            matches!(state.waiting_for, WaitingFor::TargetSelection { .. }),
+            "targets must be selected before the required sacrifice cost is paid, got {:?}",
+            state.waiting_for
+        );
+
+        apply_as_current(
+            &mut state,
+            GameAction::SelectTargets {
+                targets: vec![TargetRef::Object(target_a), TargetRef::Object(target_b)],
+            },
+        )
+        .unwrap();
+        match state.waiting_for {
+            WaitingFor::SacrificeForCost {
+                count, min_count, ..
+            } => {
+                assert_eq!(count, 2);
+                assert_eq!(min_count, 2);
+            }
+            ref other => panic!("expected exact sacrifice prompt after targets, got {other:?}"),
+        }
     }
 
     /// Debt to the Deathless regression (GitHub #315): `{X}{W}{W}{B}{B}`

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1584,6 +1584,53 @@ pub(super) fn begin_optional_cost_before_targets(
     finish_pending_cost_or_cast(state, player, pending, events)
 }
 
+pub(super) fn required_additional_cost_can_declare_x(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+) -> Option<AbilityCost> {
+    let Some(AdditionalCost::Required(cost)) = state
+        .objects
+        .get(&object_id)
+        .and_then(|obj| obj.additional_cost.clone())
+    else {
+        return None;
+    };
+    additional_cost_x_max(state, player, object_id, &cost)
+        .is_some()
+        .then_some(cost)
+}
+
+/// CR 601.2b/c/f: Some required additional costs announce X before targets
+/// are chosen. Keep the required cost pending while the shared payment step
+/// asks for X, then returns to deferred target selection.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn begin_required_cost_before_targets(
+    state: &mut GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+    card_id: CardId,
+    ability: ResolvedAbility,
+    cost: ManaCost,
+    required_cost: AbilityCost,
+    casting_variant: CastingVariant,
+    cast_timing_permission: Option<CastTimingPermission>,
+    distribute: Option<DistributionUnit>,
+    origin_zone: Zone,
+    payment_mode: CastPaymentMode,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let mut pending = PendingCast::new(object_id, card_id, ability, cost);
+    pending.casting_variant = casting_variant;
+    pending.cast_timing_permission = cast_timing_permission;
+    pending.distribute = distribute;
+    pending.origin_zone = origin_zone;
+    pending.payment_mode = payment_mode;
+    pending.deferred_target_selection = true;
+    pending.additional_cost_flow = Some(AdditionalCost::Required(required_cost));
+    finish_pending_cost_or_cast(state, player, pending, events)
+}
+
 /// CR 601.2d: Extended version of `check_additional_cost_or_pay` that threads the
 /// `distribute` flag through PendingCast creation so X-spell distribution
 /// survives to the `(ManaPayment, PassPriority)` handler.
@@ -2234,7 +2281,7 @@ fn pay_additional_cost(
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
     if pending.ability.chosen_x.is_none() {
-        if let Some(max) = additional_cost_x_max(state, player, &cost) {
+        if let Some(max) = additional_cost_x_max(state, player, pending.object_id, &cost) {
             let min = pending.ability.min_x_value;
             if min > max {
                 super::casting::handle_cancel_cast(state, &pending, events);
@@ -2386,8 +2433,11 @@ fn pay_additional_cost(
                     pending.object_id,
                     target,
                 );
-                let (min_count, max_count) =
-                    super::casting::sacrifice_cost_bounds(count, eligible.len());
+                let (min_count, max_count) = super::casting::sacrifice_cost_bounds_with_chosen_x(
+                    count,
+                    eligible.len(),
+                    pending.ability.chosen_x,
+                );
                 if eligible.len() < min_count {
                     return Err(EngineError::ActionNotAllowed(
                         "Not enough eligible permanents to sacrifice".into(),
@@ -2595,16 +2645,29 @@ fn prepend_deferred_required_cost(cost: AbilityCost, pending: &mut PendingCast) 
     }
 }
 
-fn additional_cost_x_max(state: &GameState, player: PlayerId, cost: &AbilityCost) -> Option<u32> {
+fn additional_cost_x_max(
+    state: &GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    cost: &AbilityCost,
+) -> Option<u32> {
     match cost {
         AbilityCost::PayLife { amount } if quantity_expr_contains_x(amount) => {
             Some(max_pay_life_x(state, player))
         }
+        AbilityCost::Sacrifice { target, count } if *count == u32::MAX => Some(
+            super::casting::find_eligible_sacrifice_targets(state, player, source_id, target)
+                .len()
+                .try_into()
+                .unwrap_or(u32::MAX),
+        ),
         AbilityCost::Composite { costs } => costs
             .iter()
-            .filter_map(|cost| additional_cost_x_max(state, player, cost))
+            .filter_map(|cost| additional_cost_x_max(state, player, source_id, cost))
             .min(),
-        AbilityCost::PerCounter { base, .. } => additional_cost_x_max(state, player, base),
+        AbilityCost::PerCounter { base, .. } => {
+            additional_cost_x_max(state, player, source_id, base)
+        }
         _ => None,
     }
 }
@@ -4289,6 +4352,18 @@ pub fn enter_payment_step(
         }
     }
 
+    if state
+        .pending_cast
+        .as_ref()
+        .is_some_and(|pending| pending.deferred_target_selection)
+    {
+        let pending = *state
+            .pending_cast
+            .take()
+            .expect("checked pending cast presence");
+        return begin_deferred_target_selection(state, player, pending, events);
+    }
+
     if state.pending_cast.as_ref().is_some_and(|pending| {
         matches!(
             pending.additional_cost_flow,
@@ -4300,18 +4375,6 @@ pub fn enter_payment_step(
             .take()
             .expect("checked pending cast presence");
         return finish_pending_cost_or_cast(state, player, pending, events);
-    }
-
-    if state
-        .pending_cast
-        .as_ref()
-        .is_some_and(|pending| pending.deferred_target_selection)
-    {
-        let pending = *state
-            .pending_cast
-            .take()
-            .expect("checked pending cast presence");
-        return begin_deferred_target_selection(state, player, pending, events);
     }
 
     // CR 601.2h: Auto-finalize when no player-level decision remains. Convoke requires

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2389,8 +2389,8 @@ fn ability_details(def: &AbilityDefinition) -> Vec<(String, String)> {
         d.push((
             "targets".into(),
             match &mt.max {
-                Some(max) => format!("{}-{}", mt.min, fmt_quantity(max)),
-                None => format!("{}+", mt.min),
+                Some(max) => format!("{}-{}", fmt_quantity(&mt.min), fmt_quantity(max)),
+                None => format!("{}+", fmt_quantity(&mt.min)),
             },
         ));
     }

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -69,16 +69,15 @@ fn resolution_choice_cardinality(
         return (1, 0, up_to);
     };
 
-    let max = spec
-        .max
-        .as_ref()
-        .map(|expr| crate::game::quantity::resolve_quantity_with_targets(state, expr, ability))
-        .map(|value| value.max(0) as usize)
-        .unwrap_or(eligible_count)
-        .max(spec.min)
-        .min(eligible_count);
-    let min = spec.min.min(max);
-    (max, min, min != max)
+    match crate::game::ability_utils::resolve_multi_target_bounds(
+        state,
+        ability,
+        spec,
+        eligible_count,
+    ) {
+        Ok(bounds) => (bounds.max, bounds.min, bounds.min != bounds.max),
+        Err(_) => (0, 0, up_to),
+    }
 }
 
 /// Result of a single zone-move attempt through the replacement pipeline.

--- a/crates/engine/src/game/effects/tap_untap.rs
+++ b/crates/engine/src/game/effects/tap_untap.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use crate::game::quantity::resolve_quantity_with_targets;
 use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{
     Effect, EffectError, EffectKind, ResolvedAbility, TargetChoiceTiming, TargetFilter, TargetRef,
@@ -215,14 +214,16 @@ fn prompt_resolution_tap_untap_choice(
         .copied()
         .filter(|id| crate::game::filter::matches_target_filter(state, *id, target, &ctx))
         .collect();
-    let max_count = spec
-        .max
-        .as_ref()
-        .map(|qty| resolve_quantity_with_targets(state, qty, ability).max(0) as usize)
-        .unwrap_or(eligible.len())
-        .min(eligible.len());
+    let Ok(bounds) = crate::game::ability_utils::resolve_multi_target_bounds(
+        state,
+        ability,
+        spec,
+        eligible.len(),
+    ) else {
+        return false;
+    };
 
-    if max_count == 0 && spec.min == 0 {
+    if bounds.max == 0 && bounds.min == 0 {
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::from(&ability.effect),
             source_id: ability.source_id,
@@ -233,9 +234,9 @@ fn prompt_resolution_tap_untap_choice(
     state.waiting_for = WaitingFor::EffectZoneChoice {
         player: ability.controller,
         cards: eligible,
-        count: max_count,
-        min_count: spec.min.min(max_count),
-        up_to: spec.min == 0,
+        count: bounds.max,
+        min_count: bounds.min,
+        up_to: bounds.min != bounds.max,
         source_id: ability.source_id,
         effect_kind,
         zone: Zone::Battlefield,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -17,7 +17,7 @@ use crate::types::zones::Zone;
 
 use super::ability_utils::{
     begin_target_selection_for_ability, build_target_slots, compute_unavailable_modes,
-    modal_choice_for_player,
+    has_legal_target_assignment_for_ability, modal_choice_for_player,
 };
 use super::casting;
 use super::casting_costs;
@@ -2465,6 +2465,29 @@ fn apply_action(
             }
             let player = *player;
             let convoke_mode = *convoke_mode;
+            if let Some(pending) = state.pending_cast.as_ref() {
+                if pending.deferred_target_selection {
+                    // CR 601.2c + CR 601.2f: A chosen X that determines target
+                    // count must have a legal target assignment before it is
+                    // locked into the pending cast.
+                    let mut trial = pending.as_ref().clone();
+                    trial.ability.set_chosen_x_recursive(value);
+                    trial.cost.concretize_x(value);
+                    let target_slots = build_target_slots(state, &trial.ability)?;
+                    if !target_slots.is_empty()
+                        && !has_legal_target_assignment_for_ability(
+                            state,
+                            &trial.ability,
+                            &target_slots,
+                            &trial.target_constraints,
+                        )
+                    {
+                        return Err(EngineError::InvalidAction(format!(
+                            "X={value} has no legal target assignment"
+                        )));
+                    }
+                }
+            }
             let pending = state.pending_cast.as_mut().ok_or_else(|| {
                 EngineError::InvalidAction("No pending cast awaiting X".to_string())
             })?;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4058,10 +4058,10 @@ mod tests {
     use crate::types::ability::{
         AbilityCondition, AggregateFunction, Comparator, ContinuousModification, ControllerRef,
         Duration, FilterProp, ManaProduction, ManaSpendRestriction, ModalSelectionConstraint,
-        ObjectScope, ParsedCondition, PlayerFilter, PlayerScope, PreventionAmount, PtStat, PtValue,
-        PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition, RoundingMode, SharedQuality,
-        SharedQualityRelation, ShieldKind, StaticCondition, TargetFilter, TriggerCondition,
-        TypeFilter, TypedFilter,
+        MultiTargetSpec, ObjectScope, ParsedCondition, PlayerFilter, PlayerScope, PreventionAmount,
+        PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
+        RoundingMode, SharedQuality, SharedQualityRelation, ShieldKind, StaticCondition,
+        TargetFilter, TriggerCondition, TypeFilter, TypedFilter,
     };
     use crate::types::keywords::{FlashbackCost, KeywordKind, WardCost};
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
@@ -4567,6 +4567,32 @@ mod tests {
             }
             other => panic!("expected all-creature -X/-X pump, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn immoral_bargain_full_oracle_parses_exact_x_targets_and_required_x_sacrifice() {
+        let r = parse(
+            "As an additional cost to cast this spell, sacrifice X creatures.\nDestroy X target nonland permanents.",
+            "Immoral Bargain",
+            &[],
+            &["Sorcery"],
+            &[],
+        );
+
+        assert_eq!(
+            r.additional_cost,
+            Some(AdditionalCost::Required(AbilityCost::Sacrifice {
+                target: TargetFilter::Typed(TypedFilter::creature()),
+                count: u32::MAX,
+            }))
+        );
+        assert_eq!(r.abilities.len(), 1);
+        let x = QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        };
+        assert_eq!(r.abilities[0].multi_target, Some(MultiTargetSpec::exact(x)));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3390,7 +3390,7 @@ pub(super) fn parse_put_ast(text: &str, lower: &str) -> Option<PutImperativeAst>
             enter_transformed,
             enters_attacking,
             up_to,
-            choice_count,
+            choice_count: choice_count.map(Box::new),
             enter_with_counters,
         });
     }
@@ -6132,7 +6132,7 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
                 enter_with_counters,
             });
             let mut clause = parsed_clause(effect);
-            clause.multi_target = Some(choice_count);
+            clause.multi_target = Some(*choice_count);
             clause
         }
         ImperativeFamilyAst::ZoneCounter(ZoneCounterImperativeAst::PutCounterList {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -40,6 +40,7 @@ use super::oracle_util::{
     parse_number, split_around, starts_with_possessive, strip_after, TextPair,
 };
 use crate::database::mtgjson::parse_mtgjson_mana_cost;
+use crate::game::triggers;
 use crate::parser::oracle_effect::subject::parse_subject_application;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
@@ -3743,9 +3744,9 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
 
     // CR 115.1d: "Two target creatures" / "Three target artifacts" — numeric target prefix.
     // Strip the count, recursively parse the remainder, and attach MultiTargetSpec.
-    if let Some((count, rest)) = strip_numeric_target_prefix(tp.lower) {
+    if let Some((count, rest)) = strip_exact_target_prefix(tp.lower) {
         let mut clause = parse_effect_clause(rest, ctx);
-        clause.multi_target = Some(MultiTargetSpec::fixed(count, count));
+        clause.multi_target = Some(MultiTargetSpec::exact(count));
         return clause;
     }
 
@@ -6707,17 +6708,14 @@ fn lower_imperative_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectCl
     if matches!(clause.effect, Effect::PutCounter { .. }) && clause.multi_target.is_none() {
         clause.multi_target = extract_put_counter_multi_target(text);
     }
-    // Post-parse fixup for "exile N target" multi_target (same pattern as PutCounter above).
-    // "exile two target permanents" → strip "exile " → "two target permanents" → (2, ...)
-    if matches!(
-        clause.effect,
-        Effect::ChangeZone {
-            destination: Zone::Exile,
-            ..
-        }
-    ) && clause.multi_target.is_none()
+    // CR 601.2c: Post-parse fixup for exact-count multi-target text. The
+    // imperative parser lowers "destroy X target ..." to the target filter but
+    // the target count lives outside that filter, so recover it from the full
+    // source sentence here.
+    if clause.multi_target.is_none()
+        && triggers::extract_target_filter_from_effect(&clause.effect).is_some()
     {
-        clause.multi_target = extract_exile_multi_target(text);
+        clause.multi_target = extract_exact_target_multi_target(text);
     }
     if matches!(clause.effect, Effect::DealDamage { .. }) && clause.multi_target.is_none() {
         clause.multi_target = extract_deal_damage_multi_target(text);
@@ -15060,7 +15058,7 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         }
         // CR 115.1d: Apply multi-target spec — prefer explicit choose-count text,
         // then strip result, then clause-level propagation.
-        if let Some(spec) = extract_choose_numeric_target_multi_target(&clause_ir.source_text) {
+        if let Some(spec) = extract_exact_target_multi_target(&clause_ir.source_text) {
             def = def.multi_target(spec);
         } else if let Some(ref spec) = clause_ir.multi_target {
             def = def.multi_target(spec.clone());
@@ -16001,10 +15999,12 @@ fn parse_for_each_opponent_target_fanout_clause(
 
     Some((
         clause,
-        MultiTargetSpec::bounded(
+        MultiTargetSpec::bounded_expr(
             stripped_multi_target
-                .map(|spec| spec.min)
-                .unwrap_or_else(|| per_opponent_target_fanout_min(text)),
+                .map(|spec| spec.min.clone())
+                .unwrap_or_else(|| QuantityExpr::Fixed {
+                    value: per_opponent_target_fanout_min(text) as i32,
+                }),
             QuantityExpr::Ref {
                 qty: QuantityRef::PlayerCount {
                     filter: PlayerFilter::Opponent,
@@ -16055,7 +16055,7 @@ fn per_opponent_target_fanout_min(text: &str) -> usize {
         return 1;
     };
     let (_, spec) = strip_optional_target_prefix(rest);
-    if spec.is_some_and(|spec| spec.min == 0) {
+    if spec.is_some_and(|spec| spec.min_is_fixed_zero()) {
         0
     } else {
         1
@@ -17029,24 +17029,17 @@ fn extract_put_counter_multi_target(text: &str) -> Option<MultiTargetSpec> {
     Some(MultiTargetSpec::up_to(max))
 }
 
-/// Post-parse fixup for "exile N target" multi_target.
-/// Strips "exile " verb via nom tag, then delegates to `strip_numeric_target_prefix`.
-fn extract_exile_multi_target(text: &str) -> Option<MultiTargetSpec> {
+fn extract_exact_target_multi_target(text: &str) -> Option<MultiTargetSpec> {
     let lower = text.to_lowercase();
-    let (after_verb, _) = tag::<_, _, OracleError<'_>>("exile ")
-        .parse(lower.as_str())
-        .ok()?;
-    let (count, _) = strip_numeric_target_prefix(after_verb)?;
-    Some(MultiTargetSpec::fixed(count, count))
-}
-
-fn extract_choose_numeric_target_multi_target(text: &str) -> Option<MultiTargetSpec> {
-    let lower = text.to_lowercase();
-    let (after_choose, _) = tag::<_, _, OracleError<'_>>("choose ")
-        .parse(lower.as_str())
-        .ok()?;
-    let (count, _) = strip_numeric_target_prefix(after_choose)?;
-    Some(MultiTargetSpec::fixed(count, count))
+    for verb in MULTI_TARGET_VERBS {
+        let mut parser = terminated(tag::<_, _, OracleError<'_>>(*verb), tag(" "));
+        let Ok((after_verb, _)) = parser.parse(lower.as_str()) else {
+            continue;
+        };
+        let (count, _) = strip_exact_target_prefix(after_verb)?;
+        return Some(MultiTargetSpec::exact(count));
+    }
+    None
 }
 
 fn parse_controlled_by_different_players_target_constraint(text: &str) -> bool {
@@ -17160,20 +17153,12 @@ const MULTI_TARGET_VERBS: &[&str] = &[
     "exile", "tap", "untap", "goad", "return", "destroy", "choose",
 ];
 
-/// CR 115.1d: Strip numeric word prefix before "target" from effect text.
-/// "two target creatures" → (2, "target creatures")
-/// "three target artifacts" → (3, "target artifacts")
-/// Returns None if text doesn't start with a number word followed by "target".
-fn strip_numeric_target_prefix(lower: &str) -> Option<(usize, &str)> {
-    let (rest, count) = alt((
-        value(2usize, tag::<_, _, OracleError<'_>>("two ")),
-        value(3, tag("three ")),
-        value(4, tag("four ")),
-        value(5, tag("five ")),
-        value(6, tag("six ")),
-    ))
-    .parse(lower)
-    .ok()?;
+/// CR 115.1d + CR 601.2c: Strip exact target-count prefix before a targeted
+/// phrase. "two target creatures" and "X target creatures" both set the exact
+/// number of targets, unlike "up to X target creatures".
+fn strip_exact_target_prefix(lower: &str) -> Option<(QuantityExpr, &str)> {
+    let (rest, count) = parse_exact_target_count_expr(lower).ok()?;
+    let rest = rest.trim_start();
     if alt((tag::<_, _, OracleError<'_>>("target "), tag("target,")))
         .parse(rest)
         .is_ok()
@@ -17182,6 +17167,28 @@ fn strip_numeric_target_prefix(lower: &str) -> Option<(usize, &str)> {
     } else {
         None
     }
+}
+
+fn parse_exact_target_count_expr(
+    input: &str,
+) -> super::oracle_nom::error::OracleResult<'_, QuantityExpr> {
+    alt((
+        value(
+            QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "X".to_string(),
+                },
+            },
+            tag("x"),
+        ),
+        value(QuantityExpr::Fixed { value: 1 }, tag("one ")),
+        value(QuantityExpr::Fixed { value: 2 }, tag("two ")),
+        value(QuantityExpr::Fixed { value: 3 }, tag("three ")),
+        value(QuantityExpr::Fixed { value: 4 }, tag("four ")),
+        value(QuantityExpr::Fixed { value: 5 }, tag("five ")),
+        value(QuantityExpr::Fixed { value: 6 }, tag("six ")),
+    ))
+    .parse(input)
 }
 
 /// CR 115.1d: Strip optional target-count prefixes before a targeted phrase.
@@ -17215,6 +17222,14 @@ pub(super) fn parse_multi_target_count_expr(
     input: &str,
 ) -> super::oracle_nom::error::OracleResult<'_, QuantityExpr> {
     alt((
+        value(
+            QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "X".to_string(),
+                },
+            },
+            tag("x"),
+        ),
         nom_quantity::parse_quantity_expr_number,
         nom_quantity::parse_quantity,
     ))
@@ -18873,9 +18888,7 @@ fn apply_where_x_ability_expression(def: &mut AbilityDefinition, where_x_express
         ));
     }
     if let Some(spec) = def.multi_target.as_mut() {
-        if let Some(max) = spec.max.take() {
-            spec.max = Some(apply_where_x_quantity_expression(max, where_x_expression));
-        }
+        spec.map_quantities(|expr| apply_where_x_quantity_expression(expr, where_x_expression));
     }
     apply_where_x_effect_expression(def.effect.as_mut(), where_x_expression);
     if let Some(sub) = def.sub_ability.as_mut() {
@@ -26773,7 +26786,7 @@ mod tests {
             panic!("Expected PutCounter");
         }
         let spec = multi.expect("should have multi_target");
-        assert_eq!(spec.min, 0);
+        assert!(spec.min_is_fixed_zero());
         assert_eq!(spec, MultiTargetSpec::fixed(0, 1));
     }
 
@@ -28227,7 +28240,7 @@ mod tests {
         let (text, spec) = strip_any_number_quantifier("exile any number of creatures");
         assert_eq!(text, "exile creatures");
         let spec = spec.unwrap();
-        assert_eq!(spec.min, 0);
+        assert!(spec.min_is_fixed_zero());
         assert_eq!(spec.max, None);
     }
 
@@ -30994,6 +31007,22 @@ mod tests {
     }
 
     #[test]
+    fn destroy_x_target_nonland_permanents_exact_multi_target() {
+        let def = parse_effect_chain("Destroy X target nonland permanents.", AbilityKind::Spell);
+        assert!(
+            matches!(&*def.effect, Effect::Destroy { .. }),
+            "Expected Destroy, got {:?}",
+            def.effect
+        );
+        let x = QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        };
+        assert_eq!(def.multi_target, Some(MultiTargetSpec::exact(x)));
+    }
+
+    #[test]
     fn parse_gift_wasnt_promised_condition() {
         // "Destroy target creature. If the gift wasn't promised, you lose 2 life."
         let def = parse_effect_chain(
@@ -31429,21 +31458,34 @@ mod tests {
     }
 
     #[test]
-    fn strip_numeric_target_prefix_two() {
-        let result = strip_numeric_target_prefix("two target creatures");
-        assert_eq!(result, Some((2, "target creatures")));
+    fn strip_exact_target_prefix_two() {
+        let result = strip_exact_target_prefix("two target creatures");
+        assert_eq!(
+            result,
+            Some((QuantityExpr::Fixed { value: 2 }, "target creatures"))
+        );
     }
 
     #[test]
-    fn strip_numeric_target_prefix_three() {
-        let result = strip_numeric_target_prefix("three target artifacts");
-        assert_eq!(result, Some((3, "target artifacts")));
+    fn strip_exact_target_prefix_x() {
+        let result = strip_exact_target_prefix("x target artifacts");
+        assert_eq!(
+            result,
+            Some((
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string()
+                    }
+                },
+                "target artifacts"
+            ))
+        );
     }
 
     #[test]
-    fn strip_numeric_target_prefix_no_match() {
-        assert!(strip_numeric_target_prefix("target creature").is_none());
-        assert!(strip_numeric_target_prefix("a target creature").is_none());
+    fn strip_exact_target_prefix_no_match() {
+        assert!(strip_exact_target_prefix("target creature").is_none());
+        assert!(strip_exact_target_prefix("a target creature").is_none());
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -659,6 +659,14 @@ pub(super) fn parse_subject_application(
             return Some(application);
         }
     }
+    if let Some((count, target_text)) = super::strip_exact_target_prefix(lower.as_str()) {
+        let consumed = lower.len() - target_text.len();
+        let target_text = &subject[consumed..];
+        let (filter, _) = parse_target_with_ctx(target_text, ctx);
+        let mut application = subject_filter_application(filter, false)?;
+        application.multi_target = Some(MultiTargetSpec::exact(count));
+        return Some(application);
+    }
     // CR 115.1d: "any number of target creatures" — variable-count targeting.
     // Strip "any number of " prefix, delegate to parse_target for the filter,
     // and attach MultiTargetSpec { min: 0, max: None } (unlimited).

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -925,7 +925,7 @@ pub(crate) enum PutImperativeAst {
         /// CR 107.1c + CR 608.2c: Cardinality for non-targeted zone-change
         /// choices made during resolution, e.g. "put any number of creature
         /// cards from your hand onto the battlefield."
-        choice_count: Option<MultiTargetSpec>,
+        choice_count: Option<Box<MultiTargetSpec>>,
         /// CR 122.1 + CR 614.1c: Counters granted as the moved object enters
         /// (e.g., "with two additional +1/+1 counters on it"). Each entry is
         /// `(counter_type, count)`.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -1675,29 +1675,95 @@ pub enum DelayedTriggerCondition {
 /// CR 115.1d: "Any number" means zero or more.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MultiTargetSpec {
-    pub min: usize,
+    #[serde(
+        serialize_with = "serialize_multi_target_min",
+        deserialize_with = "deserialize_multi_target_min"
+    )]
+    pub min: QuantityExpr,
     /// `None` means "any number" (unlimited). CR 115.1d.
     pub max: Option<QuantityExpr>,
 }
 
 impl MultiTargetSpec {
     pub fn fixed(min: usize, max: usize) -> Self {
-        Self::bounded(min, QuantityExpr::Fixed { value: max as i32 })
+        Self::bounded_expr(
+            QuantityExpr::Fixed { value: min as i32 },
+            QuantityExpr::Fixed { value: max as i32 },
+        )
     }
 
     pub fn up_to(max: QuantityExpr) -> Self {
-        Self::bounded(0, max)
+        Self::bounded_expr(QuantityExpr::Fixed { value: 0 }, max)
+    }
+
+    pub fn exact(count: QuantityExpr) -> Self {
+        Self::bounded_expr(count.clone(), count)
     }
 
     pub fn unlimited(min: usize) -> Self {
-        Self { min, max: None }
+        Self {
+            min: QuantityExpr::Fixed { value: min as i32 },
+            max: None,
+        }
     }
 
     pub fn bounded(min: usize, max: QuantityExpr) -> Self {
+        Self::bounded_expr(QuantityExpr::Fixed { value: min as i32 }, max)
+    }
+
+    pub fn bounded_expr(min: QuantityExpr, max: QuantityExpr) -> Self {
         Self {
             min,
             max: Some(max),
         }
+    }
+
+    pub fn min_is_fixed_zero(&self) -> bool {
+        matches!(self.min, QuantityExpr::Fixed { value: 0 })
+    }
+
+    pub fn fixed_min_usize(&self) -> Option<usize> {
+        match self.min {
+            QuantityExpr::Fixed { value } if value >= 0 => Some(value as usize),
+            _ => None,
+        }
+    }
+
+    pub fn map_quantities<F>(&mut self, mut map: F)
+    where
+        F: FnMut(QuantityExpr) -> QuantityExpr,
+    {
+        self.min = map(self.min.clone());
+        if let Some(max) = self.max.take() {
+            self.max = Some(map(max));
+        }
+    }
+}
+
+fn serialize_multi_target_min<S>(min: &QuantityExpr, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match min {
+        QuantityExpr::Fixed { value } => serializer.serialize_i32(*value),
+        other => other.serialize(serializer),
+    }
+}
+
+fn deserialize_multi_target_min<'de, D>(deserializer: D) -> Result<QuantityExpr, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum MultiTargetMin {
+        Fixed(i32),
+        Expr(QuantityExpr),
+    }
+
+    match MultiTargetMin::deserialize(deserializer)? {
+        MultiTargetMin::Fixed(value) => Ok(QuantityExpr::Fixed { value }),
+        MultiTargetMin::Expr(expr) => Ok(expr),
     }
 }
 
@@ -11681,7 +11747,11 @@ impl ResolvedAbility {
     /// the same "zero targets is legal" fact, so target-slot collection must
     /// honor either.
     pub fn targeting_is_optional(&self) -> bool {
-        self.optional_targeting || self.multi_target.as_ref().is_some_and(|spec| spec.min == 0)
+        self.optional_targeting
+            || self
+                .multi_target
+                .as_ref()
+                .is_some_and(MultiTargetSpec::min_is_fixed_zero)
     }
 }
 
@@ -12312,6 +12382,32 @@ mod tests {
         let json = serde_json::to_string(&ability).unwrap();
         let deserialized: ResolvedAbility = serde_json::from_str(&json).unwrap();
         assert_eq!(ability, deserialized);
+    }
+
+    #[test]
+    fn multi_target_spec_serializes_fixed_min_compatibly_and_dynamic_min_roundtrips() {
+        let fixed = MultiTargetSpec::fixed(0, 2);
+        let fixed_json = serde_json::to_value(&fixed).unwrap();
+        assert_eq!(fixed_json["min"], serde_json::json!(0));
+        assert_eq!(
+            serde_json::from_value::<MultiTargetSpec>(fixed_json).unwrap(),
+            fixed
+        );
+
+        let dynamic = MultiTargetSpec::exact(QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        });
+        let dynamic_json = serde_json::to_value(&dynamic).unwrap();
+        assert!(
+            dynamic_json["min"].is_object(),
+            "dynamic min must serialize as a QuantityExpr object"
+        );
+        assert_eq!(
+            serde_json::from_value::<MultiTargetSpec>(dynamic_json).unwrap(),
+            dynamic
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1594

## Summary
- parse exact target counts such as `X target nonland permanents` into dynamic multi-target bounds
- choose X before target selection when target cardinality depends on X
- keep required X sacrifice costs pending until after targets are locked in

## Verification
- git diff --check HEAD~1..HEAD
- ./scripts/check-parser-combinators.sh
- CARGO_TARGET_DIR=/tmp/forge-rs-ship-x-target-casting-target cargo test -p engine immoral_bargain_full_oracle_parses_exact_x_targets_and_required_x_sacrifice --lib
- CARGO_TARGET_DIR=/tmp/forge-rs-ship-x-target-casting-target cargo test -p engine required_x_sacrifice_spell_selects_targets_before_sacrificing --lib
- CARGO_TARGET_DIR=/tmp/forge-rs-ship-x-target-casting-target cargo test -p engine x_cost_exact_multi_target_spell_chooses_x_before_targets --lib

Card-data check: regenerated card-data and confirmed Immoral Bargain changes from `multi_target: null` to exact dynamic X min/max.