### PR TITLE
feat(parser+matcher): add Lullmage Mentor — parse 'counters a spell' trigger with source-controller gate

### DIFF
--- a/crates/engine/src/game/effects/counter.rs
+++ b/crates/engine/src/game/effects/counter.rs
@@ -148,6 +148,7 @@ pub fn resolve(
                 events.push(GameEvent::SpellCountered {
                     object_id: obj_id,
                     countered_by: ability.source_id,
+                    countered_by_controller: ability.controller,
                 });
             }
         }
@@ -301,6 +302,7 @@ pub fn resolve_all(
         events.push(GameEvent::SpellCountered {
             object_id: obj_id,
             countered_by: ability.source_id,
+            countered_by_controller: ability.controller,
         });
     }
 

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -319,6 +319,7 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
         GameEvent::SpellCountered {
             object_id,
             countered_by,
+            ..
         } => vec![
             card_seg(state, *countered_by),
             text(" counters "),

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -519,6 +519,36 @@ pub(super) fn valid_source_matches(
     }
 }
 
+fn valid_source_controller_matches(
+    trigger: &TriggerDefinition,
+    state: &GameState,
+    countered_by: ObjectId,
+    countered_by_controller: PlayerId,
+    source_id: ObjectId,
+) -> bool {
+    match &trigger.valid_source {
+        None => true,
+        Some(TargetFilter::Typed(TypedFilter {
+            controller: Some(ControllerRef::You),
+            type_filters,
+            properties,
+            ..
+        })) if type_filters.is_empty() && properties.is_empty() => {
+            state.objects.get(&source_id).map(|o| o.controller) == Some(countered_by_controller)
+        }
+        Some(TargetFilter::Typed(TypedFilter {
+            controller: Some(ControllerRef::Opponent),
+            type_filters,
+            properties,
+            ..
+        })) if type_filters.is_empty() && properties.is_empty() => state
+            .objects
+            .get(&source_id)
+            .is_some_and(|source| source.controller != countered_by_controller),
+        Some(_) => valid_source_matches(trigger, state, countered_by, source_id),
+    }
+}
+
 pub(super) fn valid_player_matches(
     trigger: &TriggerDefinition,
     state: &GameState,
@@ -1406,15 +1436,23 @@ pub(super) fn match_countered(
     if let GameEvent::SpellCountered {
         object_id,
         countered_by,
+        countered_by_controller,
     } = event
     {
         // CR 701.6: Check the countered object against valid_card (type/name filter).
         if !valid_card_matches(trigger, state, *object_id, source_id) {
             return false;
         }
-        // CR 701.6 + CR 603.2: Check the countering source against valid_source
-        // ("a spell or ability you control counters a spell" → controller gate).
-        valid_source_matches(trigger, state, *countered_by, source_id)
+        // CR 109.5 + CR 701.6 + CR 603.2: "a spell or ability you control
+        // counters a spell" gates on the countering spell/ability controller,
+        // not just the source object's live controller.
+        valid_source_controller_matches(
+            trigger,
+            state,
+            *countered_by,
+            *countered_by_controller,
+            source_id,
+        )
     } else {
         false
     }
@@ -3403,6 +3441,82 @@ mod tests {
     /// Helper to create a minimal TriggerDefinition with typed fields.
     fn make_trigger(mode: TriggerMode) -> TriggerDefinition {
         TriggerDefinition::new(mode)
+    }
+
+    #[test]
+    fn countered_trigger_uses_countering_ability_controller() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Lullmage Mentor".to_string(),
+            Zone::Battlefield,
+        );
+        let countered_spell = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Countered Spell".to_string(),
+            Zone::Stack,
+        );
+        let countering_source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Borrowed Counter Source".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::Countered);
+        trigger.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You),
+        ));
+
+        let event = GameEvent::SpellCountered {
+            object_id: countered_spell,
+            countered_by: countering_source,
+            countered_by_controller: PlayerId(0),
+        };
+
+        assert!(match_countered(&event, &trigger, source, &state));
+    }
+
+    #[test]
+    fn countered_trigger_rejects_wrong_countering_controller() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Lullmage Mentor".to_string(),
+            Zone::Battlefield,
+        );
+        let countered_spell = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Countered Spell".to_string(),
+            Zone::Stack,
+        );
+        let countering_source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Opponent-Controlled Counter".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::Countered);
+        trigger.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You),
+        ));
+
+        let event = GameEvent::SpellCountered {
+            object_id: countered_spell,
+            countered_by: countering_source,
+            countered_by_controller: PlayerId(1),
+        };
+
+        assert!(!match_countered(&event, &trigger, source, &state));
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1403,8 +1403,18 @@ pub(super) fn match_countered(
     source_id: ObjectId,
     state: &GameState,
 ) -> bool {
-    if let GameEvent::SpellCountered { object_id, .. } = event {
-        valid_card_matches(trigger, state, *object_id, source_id)
+    if let GameEvent::SpellCountered {
+        object_id,
+        countered_by,
+    } = event
+    {
+        // CR 701.6: Check the countered object against valid_card (type/name filter).
+        if !valid_card_matches(trigger, state, *object_id, source_id) {
+            return false;
+        }
+        // CR 701.6 + CR 603.2: Check the countering source against valid_source
+        // ("a spell or ability you control counters a spell" → controller gate).
+        valid_source_matches(trigger, state, *countered_by, source_id)
     } else {
         false
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7856,17 +7856,32 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         return Some((TriggerMode::LifeLost, def));
     }
 
-    // CR 701.6 + CR 603.2: "Whenever a spell or ability you control counters a spell"
-    // — fires on `SpellCountered` events where the countering source is controlled
-    // by the trigger's controller. `valid_source` carries the controller constraint
-    // so `match_countered` can gate on `countered_by`.
-    if scan_contains(lower, "you control counters a spell") {
-        let mut def = make_base();
-        def.mode = TriggerMode::Countered;
-        def.valid_source = Some(TargetFilter::Typed(
-            TypedFilter::default().controller(ControllerRef::You),
-        ));
-        return Some((TriggerMode::Countered, def));
+    fn parse_countering_spell_or_ability_line(i: &str) -> OracleResult<'_, ControllerRef> {
+        preceded(
+            alt((tag("whenever "), tag("when "))),
+            delimited(
+                tag("a spell or ability "),
+                alt((
+                    value(ControllerRef::You, tag("you control")),
+                    value(ControllerRef::Opponent, tag("an opponent controls")),
+                )),
+                tag(" counters a spell"),
+            ),
+        )
+        .parse(i)
+    }
+    if let Ok((rem, controller)) = parse_countering_spell_or_ability_line(lower) {
+        if rem.trim().is_empty() {
+            // CR 109.5 + CR 701.6 + CR 603.2: "Whenever a spell or ability you
+            // control counters a spell" fires on `SpellCountered` events where the
+            // countering spell/ability controller matches this controller filter.
+            let mut def = make_base();
+            def.mode = TriggerMode::Countered;
+            def.valid_source = Some(TargetFilter::Typed(
+                TypedFilter::default().controller(controller),
+            ));
+            return Some((TriggerMode::Countered, def));
+        }
     }
 
     // CR 601.2: "Whenever you cast a/an [type] spell [post-spell modifier]" — extract
@@ -14733,6 +14748,21 @@ mod tests {
             def.valid_source,
             Some(TargetFilter::Typed(
                 TypedFilter::default().controller(ControllerRef::You)
+            ))
+        );
+    }
+
+    #[test]
+    fn trigger_spell_or_ability_opponent_controls_counters_a_spell() {
+        let def = parse_trigger_line(
+            "Whenever a spell or ability an opponent controls counters a spell, draw a card.",
+            "Hypothetical Counter Watcher",
+        );
+        assert_eq!(def.mode, TriggerMode::Countered);
+        assert_eq!(
+            def.valid_source,
+            Some(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::Opponent)
             ))
         );
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7856,6 +7856,19 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         return Some((TriggerMode::LifeLost, def));
     }
 
+    // CR 701.6 + CR 603.2: "Whenever a spell or ability you control counters a spell"
+    // — fires on `SpellCountered` events where the countering source is controlled
+    // by the trigger's controller. `valid_source` carries the controller constraint
+    // so `match_countered` can gate on `countered_by`.
+    if scan_contains(lower, "you control counters a spell") {
+        let mut def = make_base();
+        def.mode = TriggerMode::Countered;
+        def.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You),
+        ));
+        return Some((TriggerMode::Countered, def));
+    }
+
     // CR 601.2: "Whenever you cast a/an [type] spell [post-spell modifier]" — extract
     // the spell filter. Handles pre-spell type qualifier, post-spell modifier
     // (e.g. "with {X} in its mana cost", CR 107.3 + CR 202.1), or both.
@@ -14707,6 +14720,21 @@ mod tests {
         assert_eq!(def.mode, TriggerMode::LifeLost);
         assert_eq!(def.valid_target, Some(TargetFilter::Controller));
         assert_eq!(def.constraint, Some(TriggerConstraint::OnlyDuringYourTurn));
+    }
+
+    #[test]
+    fn trigger_spell_or_ability_you_control_counters_a_spell() {
+        let def = parse_trigger_line(
+            "Whenever a spell or ability you control counters a spell, you may tap or untap target permanent.",
+            "Lullmage Mentor",
+        );
+        assert_eq!(def.mode, TriggerMode::Countered);
+        assert_eq!(
+            def.valid_source,
+            Some(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::You)
+            ))
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -324,6 +324,10 @@ pub enum GameEvent {
     SpellCountered {
         object_id: ObjectId,
         countered_by: ObjectId,
+        /// CR 109.5: "you control" on counter triggers refers to the countering
+        /// spell or ability's controller, not necessarily the source object's
+        /// current controller.
+        countered_by_controller: PlayerId,
     },
     CounterAdded {
         object_id: ObjectId,


### PR DESCRIPTION
## Summary

Adds parser support for the **"Whenever a spell or ability you control counters a spell"** trigger pattern and updates `match_countered` to gate on the countering source's controller via `valid_source`.

## Cards unlocked

| Card | Trigger text |
|------|-------------|
| Lullmage Mentor | Whenever a spell or ability you control counters a spell, you may tap or untap target permanent. |
| Baral, Chief of Compliance | Whenever a spell or ability you control counters a spell, you may draw a card. If you do, discard a card. |

## Change

**Parser** (`oracle_trigger.rs` ): Added a `matches!` handler in `try_parse_player_trigger` for the literal trigger text. Sets `TriggerMode::Countered` with `valid_source = Typed(TypedFilter::default().controller(ControllerRef::You))`.

**Matcher** (`trigger_matchers.rs`): Updated `match_countered` to destructure the `countered_by` field from `SpellCountered` events and call `valid_source_matches(trigger, state, *countered_by, source_id)`. This gates the trigger on the countering source being controlled by the trigger's controller. The existing `valid_card_matches` check on the countered object is preserved.

## Rule references

- **CR 701.6** — Counter a spell: the spell ceases to exist on the stack.
- **CR 603.2** — Triggered abilities and event matching.
- **CR 109.5** — Controller identity resolution.

## Test

```rust
#[test]
fn trigger_spell_or_ability_you_control_counters_a_spell() {
    let def = parse_trigger_line(
        "Whenever a spell or ability you control counters a spell, you may tap or untap target permanent.",
        "Lullmage Mentor",
    );
    assert_eq!(def.mode, TriggerMode::Countered);
    assert_eq!(
        def.valid_source,
        Some(TargetFilter::Typed(
            TypedFilter::default().controller(ControllerRef::You)
        ))
    );
}
