### PR TITLE
fix(engine): Lurking Predators creature reveal branch (#1604)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4320,12 +4320,7 @@ pub(crate) fn evaluate_condition(
             let type_matches = state
                 .last_revealed_ids
                 .first()
-                .and_then(|id| {
-                    state
-                        .objects
-                        .get(id)
-                        .map(|obj| obj.card_types.core_types.contains(card_type))
-                })
+                .map(|id| super::printed_cards::object_has_core_type(state, *id, *card_type))
                 .unwrap_or(false);
             let filter_matches = match additional_filter {
                 // CR 205.3m: "of the chosen type" — check the revealed card's subtype

--- a/crates/engine/src/game/effects/reveal_top.rs
+++ b/crates/engine/src/game/effects/reveal_top.rs
@@ -44,28 +44,6 @@ pub fn resolve(
     // Store revealed IDs for sub_ability condition/target injection
     state.last_revealed_ids = revealed_ids.clone();
 
-    // CR 205.3m + issue #1604: Library objects created without `CardFace` data
-    // (name-only helpers) still need accurate types for `RevealedHasCardType`.
-    for &id in &revealed_ids {
-        let name = state.objects.get(&id).map(|obj| obj.name.clone());
-        let Some(name) = name else {
-            continue;
-        };
-        if state
-            .objects
-            .get(&id)
-            .is_some_and(|obj| obj.card_types.core_types.is_empty())
-        {
-            if let Some(core_types) =
-                crate::game::printed_cards::printed_core_types_for_name(state, &name)
-            {
-                if let Some(obj) = state.objects.get_mut(&id) {
-                    obj.card_types.core_types = core_types;
-                }
-            }
-        }
-    }
-
     // Emit event with card names
     let card_names: Vec<String> = revealed_ids
         .iter()

--- a/crates/engine/src/game/effects/reveal_top.rs
+++ b/crates/engine/src/game/effects/reveal_top.rs
@@ -44,6 +44,28 @@ pub fn resolve(
     // Store revealed IDs for sub_ability condition/target injection
     state.last_revealed_ids = revealed_ids.clone();
 
+    // CR 205.3m + issue #1604: Library objects created without `CardFace` data
+    // (name-only helpers) still need accurate types for `RevealedHasCardType`.
+    for &id in &revealed_ids {
+        let name = state.objects.get(&id).map(|obj| obj.name.clone());
+        let Some(name) = name else {
+            continue;
+        };
+        if state
+            .objects
+            .get(&id)
+            .is_some_and(|obj| obj.card_types.core_types.is_empty())
+        {
+            if let Some(core_types) =
+                crate::game::printed_cards::printed_core_types_for_name(state, &name)
+            {
+                if let Some(obj) = state.objects.get_mut(&id) {
+                    obj.card_types.core_types = core_types;
+                }
+            }
+        }
+    }
+
     // Emit event with card names
     let card_names: Vec<String> = revealed_ids
         .iter()

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -4,8 +4,10 @@ use crate::types::ability::{
     Effect, PtValue, ReplacementDefinition, ReplacementMode, StaticDefinition, TriggerDefinition,
 };
 use crate::types::card::{CardFace, CardLayout, LayoutKind, PrintedCardRef};
+use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
 use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use crate::types::zones::Zone;
@@ -17,6 +19,44 @@ use super::morph::apply_face_down_creature_characteristics;
 use super::public_state::{
     bump_state_revision, finalize_public_state, mark_public_state_all_dirty,
 };
+
+/// CR 205.3m: Look up printed core types for a card name from deck-pool faces or
+/// the conjure registry when a runtime `GameObject` lacks characteristic data.
+pub fn printed_core_types_for_name(state: &GameState, name: &str) -> Option<Vec<CoreType>> {
+    let key = name.to_lowercase();
+    if let Some(face) = state.card_face_registry.get(&key) {
+        return Some(face.card_type.core_types.clone());
+    }
+    for pool in &state.deck_pools {
+        for entries in [
+            pool.registered_main.as_ref(),
+            pool.registered_sideboard.as_ref(),
+            pool.current_main.as_ref(),
+            pool.current_sideboard.as_ref(),
+            pool.registered_commander.as_ref(),
+            pool.current_commander.as_ref(),
+        ] {
+            for entry in entries {
+                if entry.card.name.eq_ignore_ascii_case(name) {
+                    return Some(entry.card.card_type.core_types.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// CR 205.3m + CR 608.2c: Whether an object matches a core card type, including
+/// printed-type fallback for name-only library objects (issue #1604 class).
+pub fn object_has_core_type(state: &GameState, object_id: ObjectId, card_type: CoreType) -> bool {
+    let Some(obj) = state.objects.get(&object_id) else {
+        return false;
+    };
+    if obj.card_types.core_types.contains(&card_type) {
+        return true;
+    }
+    printed_core_types_for_name(state, &obj.name).is_some_and(|types| types.contains(&card_type))
+}
 
 pub fn printed_ref_from_face(card_face: &CardFace) -> Option<PrintedCardRef> {
     card_face

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -21,11 +21,11 @@ use super::public_state::{
 };
 
 /// CR 205.3m: Look up printed core types for a card name from deck-pool faces or
-/// the conjure registry when a runtime `GameObject` lacks characteristic data.
-pub fn printed_core_types_for_name(state: &GameState, name: &str) -> Option<Vec<CoreType>> {
+/// the card-face registry when a runtime `GameObject` lacks characteristic data.
+pub fn printed_core_types_for_name<'a>(state: &'a GameState, name: &str) -> Option<&'a [CoreType]> {
     let key = name.to_lowercase();
     if let Some(face) = state.card_face_registry.get(&key) {
-        return Some(face.card_type.core_types.clone());
+        return Some(&face.card_type.core_types);
     }
     for pool in &state.deck_pools {
         for entries in [
@@ -38,7 +38,7 @@ pub fn printed_core_types_for_name(state: &GameState, name: &str) -> Option<Vec<
         ] {
             for entry in entries {
                 if entry.card.name.eq_ignore_ascii_case(name) {
-                    return Some(entry.card.card_type.core_types.clone());
+                    return Some(&entry.card.card_type.core_types);
                 }
             }
         }

--- a/crates/engine/tests/integration/lurking_predators_1604_repro.rs
+++ b/crates/engine/tests/integration/lurking_predators_1604_repro.rs
@@ -1,0 +1,281 @@
+//! Issue #1604: Lurking Predators — optional bottom branch and creature reveal path.
+//!
+//! https://github.com/phase-rs/phase/issues/1604
+//!
+//! Oracle: "Whenever an opponent casts a spell, reveal the top card of your library.
+//! If it's a creature card, put it onto the battlefield. Otherwise, you may put that
+//! card on the bottom of your library."
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, OnceLock};
+
+use engine::database::card_db::CardDatabase;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityCondition, Effect};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const LURKING_PREDATORS: &str = "Whenever an opponent casts a spell, reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, you may put that card on the bottom of your library.";
+
+fn load_test_db() -> &'static CardDatabase {
+    static DB: OnceLock<CardDatabase> = OnceLock::new();
+    DB.get_or_init(|| {
+        let path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../data/mtgjson/test_fixture.json");
+        CardDatabase::from_mtgjson(&path).expect("test fixture database should load")
+    })
+}
+
+fn zone_of(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> Zone {
+    runner.state().objects.get(&id).expect("object exists").zone
+}
+
+fn cast_creature_from_hand(runner: &mut engine::game::scenario::GameRunner, hand_card: ObjectId) {
+    let card_id = runner
+        .state()
+        .objects
+        .get(&hand_card)
+        .expect("hand card exists")
+        .card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: hand_card,
+            card_id,
+            targets: vec![],
+        })
+        .expect("cast should succeed");
+}
+
+fn put_library_top(runner: &mut engine::game::scenario::GameRunner, id: ObjectId) {
+    let owner = runner.state().objects.get(&id).expect("object").owner;
+    let zone = runner.state().objects.get(&id).expect("object").zone;
+    let mut events = Vec::new();
+    if zone != Zone::Library {
+        engine::game::zones::remove_from_zone(runner.state_mut(), id, zone, owner);
+        runner.state_mut().objects.get_mut(&id).unwrap().zone = Zone::Library;
+        runner
+            .state_mut()
+            .players
+            .get_mut(owner.0 as usize)
+            .unwrap()
+            .library
+            .push_back(id);
+    }
+    engine::game::zones::move_to_library_position(runner.state_mut(), id, true, &mut events);
+}
+
+#[test]
+fn lurking_predators_puts_creature_from_library_top_when_opponent_casts() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature(P0, "Lurking Predators", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(LURKING_PREDATORS);
+
+    let library_creature = scenario.add_creature(P0, "Library Bear", 2, 2).id();
+    let opponent_spell = scenario
+        .add_creature_to_hand(P1, "Opponent Bear", 2, 2)
+        .id();
+
+    let mut runner = scenario.build();
+    put_library_top(&mut runner, library_creature);
+
+    assert!(
+        runner
+            .state()
+            .objects
+            .get(&library_creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .contains(&CoreType::Creature),
+        "precondition: library top is a creature card"
+    );
+
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+
+    cast_creature_from_hand(&mut runner, opponent_spell);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        zone_of(&runner, library_creature),
+        Zone::Battlefield,
+        "creature on top of library must enter the battlefield (no optional bottom prompt)"
+    );
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "mandatory creature branch must not leave an optional prompt pending"
+    );
+}
+
+#[test]
+fn lurking_predators_optional_bottom_moves_noncreature_when_accepted() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature(P0, "Lurking Predators", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(LURKING_PREDATORS);
+
+    let library_land = scenario
+        .add_creature(P0, "Library Land", 0, 0)
+        .as_enchantment()
+        .id();
+    let opponent_spell = scenario
+        .add_creature_to_hand(P1, "Opponent Bear", 2, 2)
+        .id();
+
+    let mut runner = scenario.build();
+    put_library_top(&mut runner, library_land);
+
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+
+    cast_creature_from_hand(&mut runner, opponent_spell);
+
+    let mut guard = 0;
+    while matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+        guard += 1;
+        assert!(guard < 40, "stack did not reach optional prompt");
+        runner.pass_both_players();
+    }
+
+    match &runner.state().waiting_for {
+        WaitingFor::OptionalEffectChoice { player, .. } => assert_eq!(*player, P0),
+        other => panic!("expected OptionalEffectChoice for bottom branch, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept optional bottom");
+
+    runner.advance_until_stack_empty();
+
+    let lib = &runner.state().players[P0.0 as usize].library;
+    assert_eq!(
+        lib.last().copied(),
+        Some(library_land),
+        "accepted optional must put the revealed noncreature on the bottom"
+    );
+    assert_eq!(zone_of(&runner, library_land), Zone::Library);
+}
+
+/// Regression for mis-filed library objects (name only, no `CoreType::Creature`):
+/// the creature branch must not fall through to the optional bottom prompt.
+#[test]
+fn lurking_predators_creature_branch_requires_card_types_on_library_object() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature(P0, "Lurking Predators", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(LURKING_PREDATORS);
+
+    let library_creature = scenario.add_card_to_library_top(P0, "Grizzly Bear");
+    let opponent_spell = scenario
+        .add_creature_to_hand(P1, "Opponent Bear", 2, 2)
+        .id();
+
+    let mut runner = scenario.build();
+    assert!(
+        !runner
+            .state()
+            .objects
+            .get(&library_creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .contains(&CoreType::Creature),
+        "precondition: generic library placement has no creature type"
+    );
+
+    let db = load_test_db();
+    let grizzly = db
+        .get_face_by_name("Grizzly Bears")
+        .expect("fixture has Grizzly Bears");
+    runner.state_mut().card_face_registry = Arc::new(HashMap::from([(
+        "grizzly bear".to_string(),
+        grizzly.clone(),
+    )]));
+
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+
+    cast_creature_from_hand(&mut runner, opponent_spell);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        zone_of(&runner, library_creature),
+        Zone::Battlefield,
+        "creature-typed library cards must take the battlefield branch even when \
+         the object was created without runtime core_types (issue #1604)"
+    );
+}
+
+#[test]
+fn lurking_predators_parsed_trigger_chain_shape() {
+    let parsed = parse_oracle_text(
+        LURKING_PREDATORS,
+        "Lurking Predators",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    let trigger = parsed.triggers.first().expect("expected one trigger");
+    let execute = trigger.execute.as_ref().expect("trigger must have execute");
+    assert!(
+        !execute.optional,
+        "trigger head must not be optional; only the otherwise branch may be"
+    );
+    assert!(matches!(*execute.effect, Effect::RevealTop { .. }));
+    let conditional = execute
+        .sub_ability
+        .as_ref()
+        .expect("RevealTop must chain to conditional sub");
+    assert!(matches!(
+        conditional.condition,
+        Some(AbilityCondition::RevealedHasCardType {
+            card_type: CoreType::Creature,
+            ..
+        })
+    ));
+    assert!(matches!(
+        *conditional.effect,
+        Effect::ChangeZone {
+            destination: Zone::Battlefield,
+            ..
+        }
+    ));
+    let else_branch = conditional
+        .else_ability
+        .as_ref()
+        .expect("otherwise bottom branch");
+    assert!(
+        else_branch.optional,
+        "otherwise 'you may put on bottom' must be optional"
+    );
+    assert!(matches!(
+        *else_branch.effect,
+        Effect::PutAtLibraryPosition {
+            position: engine::types::ability::LibraryPosition::Bottom,
+            ..
+        }
+    ));
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -69,6 +69,7 @@ mod lathiel_end_step_counters_repro;
 mod leyline_taps_for_mana_repro;
 mod liliana_waker_cross_scope_decline;
 mod louisoix_sacrifice_counter;
+mod lurking_predators_1604_repro;
 mod madame_null_integration;
 mod magnetic_mountain_choose_and_pay;
 mod mana_drain_refund;


### PR DESCRIPTION
## Summary
- Fixes [#1604](https://github.com/phase-rs/phase/issues/1604): when an opponent casts a spell, Lurking Predators now correctly puts a revealed creature from the top of your library onto the battlefield.
- `RevealedHasCardType` falls back to printed `CardFace` data (deck pools / conjure registry) when library objects lack runtime `core_types`, and `RevealTop` seeds those types before the conditional resolves.
- Adds integration coverage for the cast trigger, the optional bottom branch, parser shape, and the name-only library regression.

## Root cause
Library objects created with only a card name had empty `core_types`, so `If it's a creature card` evaluated false and the optional bottom branch ran instead of the battlefield branch.

## Test plan
- [x] `cargo test -p engine --test integration lurking_predators --`
- [ ] Opponent casts a spell with Lurking Predators on the battlefield and a creature on top → creature enters without an optional prompt
- [ ] Noncreature on top → optional bottom prompt; accepting moves the card to the bottom