### PR TITLE
Fix category choice sacrifice filters

### DIFF
--- a/client/src/adapter/__tests__/contract-fixtures.test.ts
+++ b/client/src/adapter/__tests__/contract-fixtures.test.ts
@@ -132,10 +132,22 @@ describe("shared adapter contract fixtures", () => {
   it("loads the curated action, waiting state, and object fixtures", () => {
     const gameAction = readFixture<GameAction>("game_action.json");
     const waitingFor = readFixture<WaitingFor>("waiting_for.json");
+    const categoryChoice = readFixture<WaitingFor>("waiting_for_category_choice.json");
     const gameObject = readFixture<GameObject>("game_object.json");
 
     expect(gameAction.type).toBe("ChooseLegend");
     expect(waitingFor.type).toBe("EffectZoneChoice");
+    expect(categoryChoice.type).toBe("CategoryChoice");
+    if (categoryChoice.type === "CategoryChoice") {
+      expect(categoryChoice.data.chooser_scope).toBe("ControllerForAll");
+      expect(categoryChoice.data.source_controller).toBe(0);
+      expect(categoryChoice.data.choose_filter?.type).toBe("Typed");
+      expect(categoryChoice.data.sacrifice_filter?.type).toBe("Typed");
+      expect(JSON.stringify(categoryChoice.data.choose_filter)).toContain('"Non":"Land"');
+      expect(JSON.stringify(categoryChoice.data.sacrifice_filter)).toContain('"Non":"Land"');
+      expect(categoryChoice.data.eligible_per_category[0]).toEqual([10]);
+      expect(categoryChoice.data.all_kept).toEqual([]);
+    }
     expect(gameObject.name).toBe("Fixture Bear");
     expect(gameObject.id).toBe(1);
   });

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1159,10 +1159,15 @@ export type WaitingFor =
       player: PlayerId;
       target_player: PlayerId;
       categories: string[];
+      chooser_scope?: "EachPlayerSelf" | "ControllerForAll";
+      choose_filter?: TargetFilter;
+      sacrifice_filter?: TargetFilter;
+      source_controller?: PlayerId;
       eligible_per_category: ObjectId[][];
       source_id: ObjectId;
       remaining_players: PlayerId[];
       all_kept: ObjectId[];
+      scoped_players: PlayerId[];
     } }
   | { type: "CopyRetarget"; data: { player: PlayerId; copy_id: ObjectId; target_slots: CopyTargetSlot[]; current_slot?: number } }
   // CR 700.3 + CR 700.3a: Subject is partitioning their own eligible objects

--- a/client/src/components/modal/CategoryChoiceModal.tsx
+++ b/client/src/components/modal/CategoryChoiceModal.tsx
@@ -11,15 +11,10 @@ import { gameButtonClass } from "../ui/buttonStyles.ts";
 
 type CategoryChoice = Extract<WaitingFor, { type: "CategoryChoice" }>;
 
-// CR 101.4 + CR 701.21a: Choose one permanent of each given type category from
-// among the nonland permanents controlled by `target_player`; every permanent
-// not chosen is sacrificed. The engine pre-filters `eligible_per_category` by
-// controller and core type — this modal is purely the chooser. An object that
-// belongs to multiple categories (e.g. an artifact creature) appears in each
-// eligible list, but the engine rejects selecting the same object for two
-// categories (`engine_resolution_choices.rs` SelectCategoryPermanents duplicate
-// guard); this component mirrors that rule by disabling an already-chosen
-// object in sibling categories.
+// CR 101.4 + CR 701.21a: The engine pre-filters `eligible_per_category` by
+// controller, category, and effect-specific filters; this modal is purely the
+// chooser. An object that belongs to multiple categories may appear in each
+// eligible list and may be submitted for each matching category slot.
 //
 // CR 800.4g: if `target_player` has left the game mid-resolution, the engine
 // substitutes the choice — that leaver path is handled engine-side and is out
@@ -54,6 +49,9 @@ export function CategoryChoiceModal({ data }: { data: CategoryChoice["data"] }) 
 
   if (!objects) return null;
 
+  const readyToConfirm = data.eligible_per_category.every(
+    (eligible, index) => eligible.length === 0 || choices[index] !== null,
+  );
   const choosingForOpponent = data.player !== data.target_player;
   const subtitle = choosingForOpponent
     ? t("categoryChoice.subtitleOpponent", {
@@ -65,7 +63,7 @@ export function CategoryChoiceModal({ data }: { data: CategoryChoice["data"] }) 
     <ChoiceOverlay
       title={t("categoryChoice.title")}
       subtitle={subtitle}
-      footer={<ConfirmButton onClick={handleConfirm} />}
+      footer={<ConfirmButton onClick={handleConfirm} disabled={!readyToConfirm} />}
     >
       <div className="mb-4 space-y-4">
         {data.categories.map((category, categoryIndex) => {
@@ -89,23 +87,16 @@ export function CategoryChoiceModal({ data }: { data: CategoryChoice["data"] }) 
               ) : (
                 eligible.map((id) => {
                   const isSelected = choices[categoryIndex] === id;
-                  // CR 101.4 + CR 701.21a: an object chosen in another
-                  // category cannot be chosen here too.
-                  const chosenElsewhere = choices.some(
-                    (chosen, i) => i !== categoryIndex && chosen === id,
-                  );
                   return (
                     <button
                       key={id}
                       type="button"
                       aria-pressed={isSelected}
-                      disabled={chosenElsewhere}
                       onClick={() => handleSelect(categoryIndex, id)}
                       className={
                         gameButtonClass({
                           tone: isSelected ? "blue" : "neutral",
                           size: "md",
-                          disabled: chosenElsewhere,
                         }) + " w-full text-left"
                       }
                       {...hoverProps(id)}

--- a/client/src/components/modal/__tests__/CategoryChoiceModal.test.tsx
+++ b/client/src/components/modal/__tests__/CategoryChoiceModal.test.tsx
@@ -72,6 +72,7 @@ function categoryData(
     source_id: 1,
     remaining_players: [],
     all_kept: [],
+    scoped_players: [0],
     ...overrides,
   };
 }
@@ -118,9 +119,10 @@ describe("CategoryChoiceModal", () => {
     expect(noneButton).toBeDisabled();
   });
 
-  it("disables an artifact creature in the Creature category once chosen as Artifact", () => {
+  it("allows one artifact creature to be chosen in multiple category slots", () => {
     render(<CategoryChoiceModal data={categoryData()} />);
 
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
     const hellkiteButtons = screen.getAllByRole("button", { name: "Steel Hellkite" });
     // Both enabled before selection.
     expect(hellkiteButtons[0]).not.toBeDisabled();
@@ -131,11 +133,19 @@ describe("CategoryChoiceModal", () => {
 
     const afterButtons = screen.getAllByRole("button", { name: "Steel Hellkite" });
     expect(afterButtons[0]).toHaveAttribute("aria-pressed", "true");
-    // The Creature-section copy is now disabled (engine duplicate-object rule).
-    expect(afterButtons[1]).toBeDisabled();
+    expect(afterButtons[1]).not.toBeDisabled();
+
+    fireEvent.click(afterButtons[1]);
+    expect(screen.getByRole("button", { name: "Confirm" })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "SelectCategoryPermanents",
+      data: { choices: [57, 57] },
+    });
   });
 
-  it("dispatches SelectCategoryPermanents with the chosen choices including null", () => {
+  it("dispatches SelectCategoryPermanents with all nonempty categories chosen", () => {
     render(<CategoryChoiceModal data={categoryData()} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Sol Ring" }));

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1179,8 +1179,8 @@
   },
   "categoryChoice": {
     "title": "Bleibende Karten zum Behalten wählen",
-    "subtitleOpponent": "Wähle eine bleibende Karte jedes Typs unter den bleibenden Nichtländer-Karten, die {{name}} kontrolliert; der Rest wird geopfert.",
-    "subtitleSelf": "Wähle eine bleibende Karte jedes Typs unter den bleibenden Nichtländer-Karten, die du kontrollierst; der Rest wird geopfert.",
+    "subtitleOpponent": "Wähle eine bleibende Karte für jede Kategorie für {{name}}.",
+    "subtitleSelf": "Wähle eine bleibende Karte für jede Kategorie.",
     "noneToKeep": "Kein {{category}} — keine zum Behalten",
     "objectFallback": "Objekt {{id}}"
   },

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1179,8 +1179,8 @@
   },
   "categoryChoice": {
     "title": "Choose Permanents to Keep",
-    "subtitleOpponent": "Choose one permanent of each type from among the nonland permanents {{name}} controls; the rest are sacrificed.",
-    "subtitleSelf": "Choose one permanent of each type from among the nonland permanents you control; the rest are sacrificed.",
+    "subtitleOpponent": "Choose a permanent for each category for {{name}}.",
+    "subtitleSelf": "Choose a permanent for each category.",
     "noneToKeep": "No {{category}} — none to keep",
     "objectFallback": "Object {{id}}"
   },

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1179,8 +1179,8 @@
   },
   "categoryChoice": {
     "title": "Elegir permanentes a conservar",
-    "subtitleOpponent": "Elige un permanente de cada tipo de entre los permanentes que no sean tierra que controla {{name}}; el resto se sacrifica.",
-    "subtitleSelf": "Elige un permanente de cada tipo de entre los permanentes que no sean tierra que controles; el resto se sacrifica.",
+    "subtitleOpponent": "Elige un permanente para cada categoría para {{name}}.",
+    "subtitleSelf": "Elige un permanente para cada categoría.",
     "noneToKeep": "Sin {{category}} — ninguno a conservar",
     "objectFallback": "Objeto {{id}}"
   },

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1179,8 +1179,8 @@
   },
   "categoryChoice": {
     "title": "Choisir les permanents à garder",
-    "subtitleOpponent": "Choisissez un permanent de chaque type parmi les permanents non-terrain que {{name}} contrôle ; le reste est sacrifié.",
-    "subtitleSelf": "Choisissez un permanent de chaque type parmi les permanents non-terrain que vous contrôlez ; le reste est sacrifié.",
+    "subtitleOpponent": "Choisissez un permanent pour chaque catégorie pour {{name}}.",
+    "subtitleSelf": "Choisissez un permanent pour chaque catégorie.",
     "noneToKeep": "Aucun {{category}} — rien à garder",
     "objectFallback": "Objet {{id}}"
   },

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1179,8 +1179,8 @@
   },
   "categoryChoice": {
     "title": "Scegli i permanenti da tenere",
-    "subtitleOpponent": "Scegli un permanente di ciascun tipo tra i permanenti non Terra che {{name}} controlla; il resto viene sacrificato.",
-    "subtitleSelf": "Scegli un permanente di ciascun tipo tra i permanenti non Terra che controlli; il resto viene sacrificato.",
+    "subtitleOpponent": "Scegli un permanente per ogni categoria per {{name}}.",
+    "subtitleSelf": "Scegli un permanente per ogni categoria.",
     "noneToKeep": "Nessuna {{category}} — niente da tenere",
     "objectFallback": "Oggetto {{id}}"
   },

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1179,8 +1179,8 @@
   },
   "categoryChoice": {
     "title": "Wybierz trwałe do zatrzymania",
-    "subtitleOpponent": "Wybierz po jednym trwałym każdego typu spośród trwałych niebędących ziemiami, które kontroluje {{name}}; reszta zostaje poświęcona.",
-    "subtitleSelf": "Wybierz po jednym trwałym każdego typu spośród trwałych niebędących ziemiami, które kontrolujesz; reszta zostaje poświęcona.",
+    "subtitleOpponent": "Wybierz trwały dla każdej kategorii dla {{name}}.",
+    "subtitleSelf": "Wybierz trwały dla każdej kategorii.",
     "noneToKeep": "Brak {{category}} — nic do zatrzymania",
     "objectFallback": "Obiekt {{id}}"
   },

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1179,8 +1179,8 @@
   },
   "categoryChoice": {
     "title": "Escolher Permanentes para Manter",
-    "subtitleOpponent": "Escolha um permanente de cada tipo dentre os permanentes que não são terrenos que {{name}} controla; o restante é sacrificado.",
-    "subtitleSelf": "Escolha um permanente de cada tipo dentre os permanentes que não são terrenos que você controla; o restante é sacrificado.",
+    "subtitleOpponent": "Escolha um permanente para cada categoria para {{name}}.",
+    "subtitleSelf": "Escolha um permanente para cada categoria.",
     "noneToKeep": "Nenhum {{category}} — nenhum para manter",
     "objectFallback": "Objeto {{id}}"
   },

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -1038,25 +1038,8 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
                 };
                 for existing in &all_combos {
                     for opt in &options {
-                        // Skip if this object was already chosen in a prior category.
-                        if let Some(_id) = opt {
-                            if existing.iter().any(|prev| prev == opt) {
-                                // Allow None duplicates, but not object duplicates.
-                                // However, also need None as fallback if all are taken.
-                                continue;
-                            }
-                        }
                         let mut combo = existing.clone();
                         combo.push(*opt);
-                        new_combos.push(combo);
-                    }
-                    // If all options for this category conflict, allow None.
-                    if category_eligible
-                        .iter()
-                        .all(|id| existing.contains(&Some(*id)))
-                    {
-                        let mut combo = existing.clone();
-                        combo.push(None);
                         new_combos.push(combo);
                     }
                 }

--- a/crates/engine/src/game/effects/choose_and_sacrifice_rest.rs
+++ b/crates/engine/src/game/effects/choose_and_sacrifice_rest.rs
@@ -1,6 +1,8 @@
+use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::players;
 use crate::types::ability::{
     CategoryChooserScope, Effect, EffectError, EffectKind, PlayerFilter, ResolvedAbility,
+    TargetFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
@@ -17,11 +19,18 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (categories, chooser_scope) = match &ability.effect {
+    let (categories, chooser_scope, choose_filter, sacrifice_filter) = match &ability.effect {
         Effect::ChooseAndSacrificeRest {
             categories,
             chooser_scope,
-        } => (categories.clone(), *chooser_scope),
+            choose_filter,
+            sacrifice_filter,
+        } => (
+            categories.clone(),
+            *chooser_scope,
+            choose_filter.clone(),
+            sacrifice_filter.clone(),
+        ),
         _ => {
             return Err(EffectError::MissingParam(
                 "ChooseAndSacrificeRest".to_string(),
@@ -64,7 +73,14 @@ pub fn resolve(
         CategoryChooserScope::ControllerForAll => ability.controller,
     };
 
-    let eligible = compute_eligible_per_category(state, current_player, &categories);
+    let filter_ctx = FilterContext::from_ability(ability);
+    let eligible = compute_eligible_per_category(
+        state,
+        current_player,
+        &categories,
+        &choose_filter,
+        &filter_ctx,
+    );
 
     // If all categories are empty for all players, skip directly to sacrifice.
     if eligible.iter().all(|e| e.is_empty()) && remaining_players.is_empty() {
@@ -72,7 +88,15 @@ pub fn resolve(
         // together — stamp the sub-slice so a co-departing leaves-the-battlefield
         // observer among them observes the rest.
         let before = events.len();
-        sacrifice_unchosen(state, &[], &player_order, ability.source_id, events);
+        sacrifice_unchosen(
+            state,
+            &[],
+            &player_order,
+            &sacrifice_filter,
+            ability.source_id,
+            ability.controller,
+            events,
+        );
         crate::game::zones::stamp_simultaneous_from_slice(state, &mut events[before..]);
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::ChooseAndSacrificeRest,
@@ -91,6 +115,8 @@ pub fn resolve(
             ability.source_id,
             &remaining_players,
             Vec::new(),
+            &choose_filter,
+            &sacrifice_filter,
             &player_order,
             events,
         );
@@ -103,7 +129,15 @@ pub fn resolve(
             // CR 603.10a: co-departing observer among the sacrificed group
             // observes the rest — stamp the sweep's sub-slice.
             let before = events.len();
-            sacrifice_unchosen(state, &kept, &player_order, ability.source_id, events);
+            sacrifice_unchosen(
+                state,
+                &kept,
+                &player_order,
+                &sacrifice_filter,
+                ability.source_id,
+                ability.controller,
+                events,
+            );
             crate::game::zones::stamp_simultaneous_from_slice(state, &mut events[before..]);
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::ChooseAndSacrificeRest,
@@ -119,6 +153,8 @@ pub fn resolve(
             ability.source_id,
             &remaining_players,
             kept,
+            &choose_filter,
+            &sacrifice_filter,
             &player_order,
             events,
         );
@@ -128,6 +164,10 @@ pub fn resolve(
         player: chooser,
         target_player: current_player,
         categories,
+        chooser_scope,
+        choose_filter,
+        sacrifice_filter,
+        source_controller: ability.controller,
         eligible_per_category: eligible,
         source_id: ability.source_id,
         remaining_players,
@@ -148,6 +188,8 @@ pub(crate) fn compute_eligible_per_category(
     state: &GameState,
     player: PlayerId,
     categories: &[CoreType],
+    choose_filter: &TargetFilter,
+    filter_ctx: &FilterContext<'_>,
 ) -> Vec<Vec<ObjectId>> {
     categories
         .iter()
@@ -161,6 +203,7 @@ pub(crate) fn compute_eligible_per_category(
                         obj.controller == player
                             && !obj.is_emblem
                             && obj.card_types.core_types.contains(core_type)
+                            && matches_target_filter(state, *id, choose_filter, filter_ctx)
                     })
                 })
                 .collect()
@@ -168,27 +211,14 @@ pub(crate) fn compute_eligible_per_category(
         .collect()
 }
 
-/// Try to auto-resolve when every category has at most one eligible permanent
-/// and no permanent appears in multiple categories.
+/// Try to auto-resolve when every category has at most one eligible permanent.
 fn try_auto_resolve(eligible: &[Vec<ObjectId>]) -> Option<Vec<Option<ObjectId>>> {
     let mut choices: Vec<Option<ObjectId>> = Vec::with_capacity(eligible.len());
-    let mut used = Vec::new();
 
     for category_eligible in eligible {
-        // Filter out already-used objects.
-        let available: Vec<ObjectId> = category_eligible
-            .iter()
-            .copied()
-            .filter(|id| !used.contains(id))
-            .collect();
-
-        match available.len() {
-            0 => choices.push(None),
-            1 => {
-                let id = available[0];
-                used.push(id);
-                choices.push(Some(id));
-            }
+        match category_eligible.as_slice() {
+            [] => choices.push(None),
+            [id] => choices.push(Some(*id)),
             _ => return None, // Multiple choices — needs player input.
         }
     }
@@ -206,14 +236,25 @@ pub(crate) fn advance_to_next_player(
     source_id: ObjectId,
     remaining: &[PlayerId],
     mut all_kept: Vec<ObjectId>,
+    choose_filter: &TargetFilter,
+    sacrifice_filter: &TargetFilter,
     scoped_players: &[PlayerId],
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
+    dedupe_object_ids(&mut all_kept);
     if remaining.is_empty() {
         // CR 603.10a: terminal APNAP sweep — the sacrificed group left the
         // battlefield together, so stamp this sub-slice for co-departing observers.
         let before = events.len();
-        sacrifice_unchosen(state, &all_kept, scoped_players, source_id, events);
+        sacrifice_unchosen(
+            state,
+            &all_kept,
+            scoped_players,
+            sacrifice_filter,
+            source_id,
+            controller,
+            events,
+        );
         crate::game::zones::stamp_simultaneous_from_slice(state, &mut events[before..]);
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::ChooseAndSacrificeRest,
@@ -230,7 +271,9 @@ pub(crate) fn advance_to_next_player(
         CategoryChooserScope::ControllerForAll => controller,
     };
 
-    let eligible = compute_eligible_per_category(state, next_player, categories);
+    let filter_ctx = FilterContext::from_source_with_controller(source_id, controller);
+    let eligible =
+        compute_eligible_per_category(state, next_player, categories, choose_filter, &filter_ctx);
 
     // If all categories empty for this player, skip ahead.
     if eligible.iter().all(|e| e.is_empty()) {
@@ -242,6 +285,8 @@ pub(crate) fn advance_to_next_player(
             source_id,
             &next_remaining,
             all_kept,
+            choose_filter,
+            sacrifice_filter,
             scoped_players,
             events,
         );
@@ -251,6 +296,7 @@ pub(crate) fn advance_to_next_player(
     if let Some(auto_choices) = try_auto_resolve(&eligible) {
         let kept: Vec<ObjectId> = auto_choices.iter().filter_map(|&opt| opt).collect();
         all_kept.extend(kept);
+        dedupe_object_ids(&mut all_kept);
         return advance_to_next_player(
             state,
             categories,
@@ -259,6 +305,8 @@ pub(crate) fn advance_to_next_player(
             source_id,
             &next_remaining,
             all_kept,
+            choose_filter,
+            sacrifice_filter,
             scoped_players,
             events,
         );
@@ -268,6 +316,10 @@ pub(crate) fn advance_to_next_player(
         player: chooser,
         target_player: next_player,
         categories: categories.to_vec(),
+        chooser_scope,
+        choose_filter: choose_filter.clone(),
+        sacrifice_filter: sacrifice_filter.clone(),
+        source_controller: controller,
         eligible_per_category: eligible,
         source_id,
         remaining_players: next_remaining,
@@ -284,10 +336,20 @@ pub(crate) fn sacrifice_unchosen_from_handler(
     state: &mut GameState,
     kept: &[ObjectId],
     scoped_players: &[PlayerId],
+    sacrifice_filter: &TargetFilter,
     source_id: ObjectId,
+    source_controller: PlayerId,
     events: &mut Vec<GameEvent>,
 ) {
-    sacrifice_unchosen(state, kept, scoped_players, source_id, events);
+    sacrifice_unchosen(
+        state,
+        kept,
+        scoped_players,
+        sacrifice_filter,
+        source_id,
+        source_controller,
+        events,
+    );
 }
 
 /// CR 701.21a: Sacrifice all permanents on the battlefield that were not chosen.
@@ -295,7 +357,9 @@ fn sacrifice_unchosen(
     state: &mut GameState,
     kept: &[ObjectId],
     scoped_players: &[PlayerId],
+    sacrifice_filter: &TargetFilter,
     source_id: ObjectId,
+    source_controller: PlayerId,
     events: &mut Vec<GameEvent>,
 ) {
     // CR 701.21a: Sacrifice each permanent NOT chosen, restricted to the
@@ -316,6 +380,7 @@ fn sacrifice_unchosen(
     };
     // Collect all battlefield permanents not in the kept set, controlled by a
     // player within scope.
+    let filter_ctx = FilterContext::from_source_with_controller(source_id, source_controller);
     let to_sacrifice: Vec<ObjectId> = state
         .battlefield
         .iter()
@@ -326,6 +391,7 @@ fn sacrifice_unchosen(
                     .objects
                     .get(id)
                     .is_some_and(|obj| !obj.is_emblem && effective_scope.contains(&obj.controller))
+                && matches_target_filter(state, *id, sacrifice_filter, &filter_ctx)
         })
         .collect();
 
@@ -349,8 +415,18 @@ fn sacrifice_unchosen(
             }
         }
     }
+}
 
-    let _ = source_id; // used by caller for EffectResolved event
+fn dedupe_object_ids(ids: &mut Vec<ObjectId>) {
+    let mut seen = Vec::new();
+    ids.retain(|id| {
+        if seen.contains(id) {
+            false
+        } else {
+            seen.push(*id);
+            true
+        }
+    });
 }
 
 #[cfg(test)]
@@ -362,6 +438,22 @@ mod tests {
     use crate::types::player::PlayerId;
     use crate::types::zones::Zone;
 
+    fn permanent_filter() -> TargetFilter {
+        TargetFilter::Typed(crate::types::ability::TypedFilter::permanent())
+    }
+
+    fn nonland_permanent_filter() -> TargetFilter {
+        TargetFilter::Typed(crate::types::ability::TypedFilter::permanent().with_type(
+            crate::types::ability::TypeFilter::Non(Box::new(
+                crate::types::ability::TypeFilter::Land,
+            )),
+        ))
+    }
+
+    fn test_filter_ctx() -> FilterContext<'static> {
+        FilterContext::from_source_with_controller(ObjectId(100), PlayerId(0))
+    }
+
     fn make_ability(
         categories: Vec<CoreType>,
         chooser_scope: CategoryChooserScope,
@@ -370,6 +462,8 @@ mod tests {
             Effect::ChooseAndSacrificeRest {
                 categories,
                 chooser_scope,
+                choose_filter: permanent_filter(),
+                sacrifice_filter: permanent_filter(),
             },
             vec![],
             ObjectId(100),
@@ -387,6 +481,8 @@ mod tests {
             Effect::ChooseAndSacrificeRest {
                 categories,
                 chooser_scope,
+                choose_filter: permanent_filter(),
+                sacrifice_filter: permanent_filter(),
             },
             vec![],
             ObjectId(100),
@@ -503,6 +599,101 @@ mod tests {
     }
 
     #[test]
+    fn category_choice_rejects_none_for_nonempty_category() {
+        use crate::game::engine::apply;
+        use crate::types::actions::GameAction;
+
+        let mut state = setup_two_player();
+        let artifact = add_battlefield_permanent(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Sol Ring",
+            vec![CoreType::Artifact],
+        );
+        let creature = add_battlefield_permanent(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Bear",
+            vec![CoreType::Creature],
+        );
+        let _creature2 = add_battlefield_permanent(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Lion",
+            vec![CoreType::Creature],
+        );
+
+        let ability = make_ability(
+            vec![CoreType::Artifact, CoreType::Creature],
+            CategoryChooserScope::EachPlayerSelf,
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let err = apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::SelectCategoryPermanents {
+                choices: vec![None, Some(creature)],
+            },
+        )
+        .expect_err("cannot decline a category with legal choices");
+        assert!(
+            format!("{err:?}").contains("Must choose a permanent"),
+            "unexpected error: {err:?}"
+        );
+        assert!(state.battlefield.contains(&artifact));
+        assert!(state.battlefield.contains(&creature));
+    }
+
+    #[test]
+    fn gearhulk_filter_keeps_duplicate_slot_permanent_and_spares_lands() {
+        let mut state = setup_two_player();
+        let artifact_creature = add_battlefield_permanent(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Steel Hellkite",
+            vec![CoreType::Artifact, CoreType::Creature],
+        );
+        let enchantment = add_battlefield_permanent(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Omen",
+            vec![CoreType::Enchantment],
+        );
+        let land = add_battlefield_permanent(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Island",
+            vec![CoreType::Land],
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::ChooseAndSacrificeRest {
+                categories: vec![CoreType::Artifact, CoreType::Creature],
+                chooser_scope: CategoryChooserScope::EachPlayerSelf,
+                choose_filter: nonland_permanent_filter(),
+                sacrifice_filter: nonland_permanent_filter(),
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(state.battlefield.contains(&artifact_creature));
+        assert!(!state.battlefield.contains(&enchantment));
+        assert!(state.battlefield.contains(&land));
+    }
+
+    #[test]
     fn controller_for_all_sets_correct_chooser() {
         let mut state = setup_two_player();
         // Player 1 has two creatures — needs a choice.
@@ -581,6 +772,8 @@ mod tests {
             &state,
             PlayerId(0),
             &[CoreType::Creature, CoreType::Artifact],
+            &permanent_filter(),
+            &test_filter_ctx(),
         );
 
         assert_eq!(eligible[0].len(), 1); // P0's creature
@@ -633,6 +826,8 @@ mod tests {
             Effect::ChooseAndSacrificeRest {
                 categories: vec![CoreType::Artifact, CoreType::Creature],
                 chooser_scope: CategoryChooserScope::EachPlayerSelf,
+                choose_filter: permanent_filter(),
+                sacrifice_filter: permanent_filter(),
             },
             vec![],
             ObjectId(100),
@@ -829,6 +1024,8 @@ mod tests {
             &state,
             PlayerId(0),
             &[CoreType::Artifact, CoreType::Creature],
+            &permanent_filter(),
+            &test_filter_ctx(),
         );
 
         // The artifact creature should appear in both categories.

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use crate::types::ability::{
-    CategoryChooserScope, ChoiceType, ChoiceValue, ChosenAttribute, Effect, EffectKind,
-    PaymentCost, QuantityExpr, QuantityRef, ResolvedAbility, TargetRef,
+    ChoiceType, ChoiceValue, ChosenAttribute, Effect, EffectKind, PaymentCost, QuantityExpr,
+    QuantityRef, ResolvedAbility, TargetRef,
 };
 use crate::types::actions::{GameAction, LearnOption, OutsideGameSelection};
 use crate::types::events::GameEvent;
@@ -2343,8 +2343,12 @@ pub(super) fn handle_resolution_choice(
         (
             WaitingFor::CategoryChoice {
                 player,
-                target_player,
+                target_player: _,
                 categories,
+                chooser_scope,
+                choose_filter,
+                sacrifice_filter,
+                source_controller,
                 eligible_per_category,
                 source_id,
                 remaining_players,
@@ -2362,36 +2366,33 @@ pub(super) fn handle_resolution_choice(
                 )));
             }
 
-            // Validate each choice is eligible for its category and no duplicates.
+            // Validate each choice is eligible for its category. A permanent can
+            // legally satisfy multiple category slots (artifact creature, etc.);
+            // dedupe only when building the final protected set.
             let mut chosen_this_round = Vec::new();
             for (i, choice) in choices.iter().enumerate() {
-                if let Some(obj_id) = choice {
-                    if !eligible_per_category[i].contains(obj_id) {
+                let Some(obj_id) = choice else {
+                    if !eligible_per_category[i].is_empty() {
                         return Err(EngineError::InvalidAction(format!(
-                            "Object {:?} is not eligible for category {:?}",
-                            obj_id, categories[i]
+                            "Must choose a permanent for category {:?}",
+                            categories[i]
                         )));
                     }
-                    if chosen_this_round.contains(obj_id) {
-                        return Err(EngineError::InvalidAction(format!(
-                            "Object {:?} chosen for multiple categories",
-                            obj_id
-                        )));
-                    }
+                    continue;
+                };
+                if !eligible_per_category[i].contains(obj_id) {
+                    return Err(EngineError::InvalidAction(format!(
+                        "Object {:?} is not eligible for category {:?}",
+                        obj_id, categories[i]
+                    )));
+                }
+                if !chosen_this_round.contains(obj_id) {
                     chosen_this_round.push(*obj_id);
                 }
             }
 
             // Accumulate kept permanents.
             all_kept.extend(chosen_this_round);
-
-            // Determine chooser_scope from context: if player == target_player, it's EachPlayerSelf.
-            // If player != target_player for a non-first player, it's ControllerForAll.
-            let chooser_scope = if player == target_player {
-                CategoryChooserScope::EachPlayerSelf
-            } else {
-                CategoryChooserScope::ControllerForAll
-            };
 
             // Issue #423 (Correction 1): `sacrifice_unchosen` moves permanents
             // to the graveyard via `sacrifice_permanent`. Mark where those
@@ -2413,17 +2414,21 @@ pub(super) fn handle_resolution_choice(
                     state,
                     &all_kept,
                     &scoped_players,
+                    &sacrifice_filter,
                     source_id,
+                    source_controller,
                     events,
                 );
             } else if let Err(e) = effects::choose_and_sacrifice_rest::advance_to_next_player(
                 state,
                 &categories,
                 chooser_scope,
-                player, // controller for ControllerForAll
+                source_controller,
                 source_id,
                 &remaining_players,
                 all_kept,
+                &choose_filter,
+                &sacrifice_filter,
                 &scoped_players,
                 events,
             ) {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -14951,6 +14951,12 @@ pub mod tests {
             Effect::ChooseAndSacrificeRest {
                 categories: vec![CoreType::Creature],
                 chooser_scope: crate::types::ability::CategoryChooserScope::EachPlayerSelf,
+                choose_filter: crate::types::ability::TargetFilter::Typed(
+                    crate::types::ability::TypedFilter::permanent(),
+                ),
+                sacrifice_filter: crate::types::ability::TargetFilter::Typed(
+                    crate::types::ability::TypedFilter::permanent(),
+                ),
             },
         );
         let trigger = TriggerDefinition::new(TriggerMode::Phase).execute(ability);
@@ -15508,6 +15514,14 @@ pub mod tests {
             player: PlayerId(0),
             target_player: PlayerId(0),
             categories: vec![CoreType::Creature],
+            chooser_scope: crate::types::ability::CategoryChooserScope::EachPlayerSelf,
+            choose_filter: crate::types::ability::TargetFilter::Typed(
+                crate::types::ability::TypedFilter::permanent(),
+            ),
+            sacrifice_filter: crate::types::ability::TargetFilter::Typed(
+                crate::types::ability::TypedFilter::permanent(),
+            ),
+            source_controller: PlayerId(0),
             eligible_per_category: vec![vec![observer, keeper, other]],
             source_id: source,
             remaining_players: vec![],

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1,7 +1,8 @@
-use crate::parser::oracle_nom::error::OracleError;
+use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::combinator::{all_consuming, eof, map, not, opt, rest, value};
+use nom::error::ParseError;
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
@@ -21,14 +22,13 @@ use crate::parser::oracle_nom::primitives as nom_primitives;
 use crate::parser::oracle_static::{
     parse_continuous_modifications, parse_quoted_ability_modifications,
 };
-#[cfg(test)]
-use crate::types::ability::TypeFilter;
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, CategoryChooserScope, ChoiceType,
     Chooser, ContinuousModification, ControllerRef, CopyRetargetPermission, Duration, Effect,
     FilterProp, GainLifePlayer, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool,
     PaymentCost, PlayerScope, PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr,
-    QuantityRef, SearchSelectionConstraint, StaticDefinition, TargetFilter, TypedFilter, ZoneOwner,
+    QuantityRef, SearchSelectionConstraint, StaticDefinition, TargetFilter, TypeFilter,
+    TypedFilter, ZoneOwner,
 };
 use crate::types::card_type::CoreType;
 use crate::types::phase::Phase;
@@ -2504,12 +2504,17 @@ pub(super) fn parse_category_and_sacrifice_rest_pub(
     rest_lower: &str,
 ) -> Option<ChooseImperativeAst> {
     parse_category_and_sacrifice_rest(rest_lower).map(|ast| match ast {
-        ChooseImperativeAst::CategoryAndSacrificeRest { categories, .. } => {
-            ChooseImperativeAst::CategoryAndSacrificeRest {
-                categories,
-                chooser_scope: CategoryChooserScope::ControllerForAll,
-            }
-        }
+        ChooseImperativeAst::CategoryAndSacrificeRest {
+            categories,
+            choose_filter,
+            sacrifice_filter,
+            ..
+        } => ChooseImperativeAst::CategoryAndSacrificeRest {
+            categories,
+            chooser_scope: CategoryChooserScope::ControllerForAll,
+            choose_filter,
+            sacrifice_filter,
+        },
         other => other,
     })
 }
@@ -2533,7 +2538,7 @@ const PERMANENT_TYPE_CATEGORIES: [CoreType; 6] = [
 ///
 /// Parser structure (nom combinators):
 /// - `tag("from among")` detects pattern 1
-/// - `take_until("from among")` + category parsing for pattern 2
+/// - `parse_category_list_prefix` consumes pattern 2's category list and returns the remainder
 /// - Category list: `parse_category_item` composed with comma + "and" separator
 fn parse_category_and_sacrifice_rest(rest_lower: &str) -> Option<ChooseImperativeAst> {
     type E<'a> = OracleError<'a>;
@@ -2558,6 +2563,8 @@ fn parse_category_and_sacrifice_rest(rest_lower: &str) -> Option<ChooseImperativ
                 return Some(ChooseImperativeAst::CategoryAndSacrificeRest {
                     categories: PERMANENT_TYPE_CATEGORIES.to_vec(),
                     chooser_scope: CategoryChooserScope::EachPlayerSelf,
+                    choose_filter: permanent_filter(),
+                    sacrifice_filter: permanent_filter(),
                 });
             }
         }
@@ -2567,58 +2574,65 @@ fn parse_category_and_sacrifice_rest(rest_lower: &str) -> Option<ChooseImperativ
     if let Ok((after_from_among, _)) = tag::<_, _, E>("from among ").parse(rest_lower) {
         // Skip past "the permanents they control" / "the permanents that player controls"
         // to find the category list.
-        let categories_text = skip_permanent_clause(after_from_among)?;
+        let (categories_text, choose_filter) = parse_choose_domain(after_from_among).ok()?;
         let categories = parse_category_list(categories_text)?;
         return Some(ChooseImperativeAst::CategoryAndSacrificeRest {
             categories,
             chooser_scope: CategoryChooserScope::EachPlayerSelf,
+            sacrifice_filter: choose_filter.clone(),
+            choose_filter,
         });
     }
 
     // Pattern 2: "an artifact, a creature, ... from among [the nonland] permanents they control"
-    if let Ok((_, before_from)) = take_until::<_, _, E>("from among").parse(rest_lower) {
-        let categories = parse_category_list(before_from.trim())?;
+    if let Ok((after_categories, categories)) = parse_category_list_prefix(rest_lower) {
+        let (_, choose_filter) = preceded(tag::<_, _, E>(" from among "), parse_choose_domain)
+            .parse(after_categories)
+            .ok()?;
         return Some(ChooseImperativeAst::CategoryAndSacrificeRest {
             categories,
             chooser_scope: CategoryChooserScope::EachPlayerSelf,
+            sacrifice_filter: choose_filter.clone(),
+            choose_filter,
         });
     }
 
     None
 }
 
-/// Skip past "the permanents they control" / "the [nonland] permanents that player controls"
-/// clauses to find the category list that follows.
-fn skip_permanent_clause(input: &str) -> Option<&str> {
+fn permanent_filter() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::permanent())
+}
+
+fn nonland_permanent_filter() -> TargetFilter {
+    TargetFilter::Typed(
+        TypedFilter::permanent().with_type(TypeFilter::Non(Box::new(TypeFilter::Land))),
+    )
+}
+
+/// Parse "the permanents they control" / "the [nonland] permanents that player controls"
+/// domains and return the category-list remainder plus the domain filter.
+fn parse_choose_domain(input: &str) -> OracleResult<'_, TargetFilter> {
     type E<'a> = OracleError<'a>;
 
-    // "the permanents they control " / "the permanents that player controls "
-    // / "the nonland permanents they control "
-    let (rest, _) = tag::<_, _, E>("the ").parse(input).ok()?;
-
-    // Optional "nonland " modifier
-    let rest = tag::<_, _, E>("nonland ")
-        .parse(rest)
-        .map(|(r, _)| r)
-        .unwrap_or(rest);
-
-    let (rest, _) = tag::<_, _, E>("permanents ").parse(rest).ok()?;
-
-    // "they control" / "that player controls"
-    let rest = if let Ok((r, _)) = tag::<_, _, E>("they control").parse(rest) {
-        r
-    } else if let Ok((r, _)) = tag::<_, _, E>("that player controls").parse(rest) {
-        r
-    } else {
-        return None;
-    };
-
-    // Strip optional trailing space/comma
-    let rest = rest.trim_start_matches(' ');
-    if rest.is_empty() {
-        return None;
-    }
-    Some(rest)
+    let (rest, _) = tag::<_, _, E>("the ").parse(input)?;
+    let (rest, nonland) = opt(tag::<_, _, E>("nonland ")).parse(rest)?;
+    let (rest, _) = tag::<_, _, E>("permanents ").parse(rest)?;
+    let (rest, _) = alt((
+        tag::<_, _, E>("they control"),
+        tag("you control"),
+        tag("that player controls"),
+    ))
+    .parse(rest)?;
+    let (rest, _) = opt(alt((tag::<_, _, E>(", "), tag(" ")))).parse(rest)?;
+    Ok((
+        rest,
+        if nonland.is_some() {
+            nonland_permanent_filter()
+        } else {
+            permanent_filter()
+        },
+    ))
 }
 
 /// Parse a comma-separated category list: "an artifact, a creature, an enchantment, and a land"
@@ -2626,41 +2640,53 @@ fn skip_permanent_clause(input: &str) -> Option<&str> {
 fn parse_category_list(input: &str) -> Option<Vec<CoreType>> {
     type E<'a> = OracleError<'a>;
 
-    let mut categories = Vec::new();
-    let mut remaining = input.trim();
+    let (remaining, categories) = parse_category_list_prefix(input).ok()?;
+    let remaining = remaining.trim_start();
+    if remaining.is_empty()
+        || tag::<_, _, E>(", then ").parse(remaining).is_ok()
+        || tag::<_, _, E>(". then ").parse(remaining).is_ok()
+        || tag::<_, _, E>(".").parse(remaining).is_ok()
+    {
+        return Some(categories);
+    }
 
-    loop {
-        // Strip optional leading ", " or ", and " or "and "
-        if let Ok((r, _)) = tag::<_, _, E>(", and ").parse(remaining) {
-            remaining = r;
-        } else if let Ok((r, _)) = tag::<_, _, E>(", ").parse(remaining) {
-            remaining = r;
-        } else if let Ok((r, _)) = tag::<_, _, E>("and ").parse(remaining) {
-            remaining = r;
-        }
+    None
+}
 
-        // Parse article + type: "an artifact" / "a creature" / "a land" / "a planeswalker" / "an enchantment"
-        let (after_article, _) = alt((tag::<_, _, E>("an "), tag("a ")))
-            .parse(remaining)
-            .ok()?;
+fn parse_category_list_prefix(input: &str) -> OracleResult<'_, Vec<CoreType>> {
+    type E<'a> = OracleError<'a>;
 
-        let (rest, core_type) = parse_core_type_name(after_article)?;
-        categories.push(core_type);
-        remaining = rest.trim();
+    let (mut remaining, first) = parse_category_item(input)?;
+    let mut categories = vec![first];
 
-        if remaining.is_empty()
-            || tag::<_, _, E>(", then ").parse(remaining).is_ok()
-            || tag::<_, _, E>(". then ").parse(remaining).is_ok()
-            || tag::<_, _, E>("from among").parse(remaining).is_ok()
-        {
+    while let Ok((after_separator, _)) = alt((
+        tag::<_, _, E>(", and "),
+        tag(", "),
+        tag(" and "),
+        tag("and "),
+    ))
+    .parse(remaining)
+    {
+        let Ok((after_item, core_type)) = parse_category_item(after_separator) else {
             break;
-        }
+        };
+        categories.push(core_type);
+        remaining = after_item;
     }
 
-    if categories.is_empty() {
-        return None;
-    }
-    Some(categories)
+    Ok((remaining, categories))
+}
+
+fn parse_category_item(input: &str) -> OracleResult<'_, CoreType> {
+    type E<'a> = OracleError<'a>;
+
+    let (input, _) = alt((tag::<_, _, E>("an "), tag("a "))).parse(input)?;
+    parse_core_type_name(input).ok_or_else(|| {
+        nom::Err::Error(OracleError::from_error_kind(
+            input,
+            nom::error::ErrorKind::Alt,
+        ))
+    })
 }
 
 /// Parse a core type name from lowercase text using nom combinators.
@@ -2739,9 +2765,13 @@ pub(super) fn lower_choose_ast(ast: ChooseImperativeAst) -> Effect {
         ChooseImperativeAst::CategoryAndSacrificeRest {
             categories,
             chooser_scope,
+            choose_filter,
+            sacrifice_filter,
         } => Effect::ChooseAndSacrificeRest {
             categories,
             chooser_scope,
+            choose_filter,
+            sacrifice_filter,
         },
         // CR 115.1c + CR 601.2c: Two independent target slots. The bare-Effect
         // lowering surfaces only the first slot — the chained `TargetOnly`
@@ -9238,6 +9268,7 @@ mod tests {
             Some(ChooseImperativeAst::CategoryAndSacrificeRest {
                 categories,
                 chooser_scope,
+                ..
             }) => {
                 assert_eq!(
                     categories,
@@ -9270,6 +9301,7 @@ mod tests {
             Some(ChooseImperativeAst::CategoryAndSacrificeRest {
                 categories,
                 chooser_scope,
+                ..
             }) => {
                 assert_eq!(
                     categories,
@@ -9301,6 +9333,8 @@ mod tests {
             Some(ChooseImperativeAst::CategoryAndSacrificeRest {
                 categories,
                 chooser_scope,
+                choose_filter,
+                sacrifice_filter,
             }) => {
                 assert_eq!(
                     categories,
@@ -9315,6 +9349,17 @@ mod tests {
                     chooser_scope,
                     crate::types::ability::CategoryChooserScope::EachPlayerSelf
                 );
+                assert!(
+                    matches!(
+                        &choose_filter,
+                        TargetFilter::Typed(TypedFilter {
+                            type_filters,
+                            ..
+                        }) if type_filters.contains(&TypeFilter::Non(Box::new(TypeFilter::Land)))
+                    ),
+                    "Gearhulk choose_filter should be nonland permanent, got {choose_filter:?}"
+                );
+                assert_eq!(choose_filter, sacrifice_filter);
             }
             other => panic!("Expected CategoryAndSacrificeRest, got {other:?}"),
         }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -19968,6 +19968,20 @@ mod tests {
     use crate::types::mana::{ManaColor, ManaExpiry};
     use crate::types::player::PlayerCounterKind;
 
+    fn target_filter_contains_nonland(filter: &TargetFilter) -> bool {
+        match filter {
+            TargetFilter::Typed(typed) => typed
+                .type_filters
+                .iter()
+                .any(|type_filter| matches!(type_filter, TypeFilter::Non(inner) if **inner == TypeFilter::Land)),
+            TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+                filters.iter().any(target_filter_contains_nonland)
+            }
+            TargetFilter::Not { filter } => target_filter_contains_nonland(filter),
+            _ => false,
+        }
+    }
+
     /// Build a typed Cat trigger subject ("one or more other Cats you
     /// control") for anaphor-resolution tests.
     fn cat_subject_ctx() -> ParseContext {
@@ -25381,6 +25395,57 @@ mod tests {
             def.sub_ability.is_some(),
             "should have sub_ability after ', then sacrifices'"
         );
+    }
+
+    #[test]
+    fn cataclysmic_gearhulk_absorbs_sacrifice_rest_into_filter() {
+        let def = parse_effect_chain(
+            "Each player chooses an artifact, a creature, an enchantment, and a planeswalker from among the nonland permanents they control, then sacrifices the rest.",
+            AbilityKind::Spell,
+        );
+
+        let Effect::ChooseAndSacrificeRest {
+            categories,
+            choose_filter,
+            sacrifice_filter,
+            ..
+        } = &*def.effect
+        else {
+            panic!("expected ChooseAndSacrificeRest, got {:?}", def.effect);
+        };
+        assert_eq!(categories.len(), 4);
+        assert!(
+            def.sub_ability.is_none(),
+            "unexpected sub_ability: {:?}",
+            def.sub_ability
+        );
+        assert_eq!(choose_filter, sacrifice_filter);
+        assert!(target_filter_contains_nonland(choose_filter));
+    }
+
+    #[test]
+    fn tragic_arrogance_absorbs_explicit_nonland_sacrifice_filter() {
+        let def = parse_effect_chain(
+            "For each player, you choose from among the permanents that player controls an artifact, a creature, an enchantment, and a planeswalker. Then each player sacrifices all other nonland permanents they control.",
+            AbilityKind::Spell,
+        );
+
+        let Effect::ChooseAndSacrificeRest {
+            choose_filter,
+            sacrifice_filter,
+            chooser_scope,
+            ..
+        } = &*def.effect
+        else {
+            panic!("expected ChooseAndSacrificeRest, got {:?}", def.effect);
+        };
+        assert!(def.sub_ability.is_none());
+        assert!(matches!(
+            chooser_scope,
+            crate::types::ability::CategoryChooserScope::ControllerForAll
+        ));
+        assert!(!target_filter_contains_nonland(choose_filter));
+        assert!(target_filter_contains_nonland(sacrifice_filter));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3,7 +3,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, tag_no_case, take_until};
 use nom::character::complete::multispace1;
 use nom::combinator::{all_consuming, eof, opt, value};
-use nom::sequence::preceded;
+use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
 use super::super::oracle_nom::bridge::nom_on_lower;
@@ -18,7 +18,7 @@ use crate::parser::oracle_quantity::{parse_cda_quantity, parse_quantity_ref};
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, CastingPermission, Chooser, CopyRetargetPermission,
     CounterSourceRider, Effect, LibraryPosition, PermissionGrantee, QuantityExpr, QuantityRef,
-    StaticDefinition, TargetFilter,
+    StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::counter::CounterType;
 use crate::types::keywords::Keyword;
@@ -591,6 +591,15 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                             && (opt(tag::<_, _, OracleError<'_>>("put ")), tag("the rest"))
                                 .parse(remainder_trimmed)
                                 .is_ok();
+                    let sacrifice_rest_remainder = preceded(
+                        opt(tag::<_, _, OracleError<'_>>("then ")),
+                        alt((
+                            tag::<_, _, OracleError<'_>>("sacrifices the rest"),
+                            tag("sacrifice the rest"),
+                        )),
+                    )
+                    .parse(remainder_trimmed)
+                    .is_ok();
                     // CR 109.5 + CR 608.2c + CR 800.4g: "you and that player each <body>"
                     // (and analogous "you and <player-noun> each <body>" compound
                     // subjects) is a SINGLE compound subject distributing the body
@@ -679,7 +688,8 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                         && alt((tag::<_, _, OracleError<'_>>("add "), tag("subtract ")))
                             .parse(remainder_trimmed)
                             .is_ok();
-                    let suppress = nom_primitives::scan_contains(&before_lower, "from among")
+                    let suppress = (nom_primitives::scan_contains(&before_lower, "from among")
+                        && !sacrifice_rest_remainder)
                         || is_inside_temporal_prefix(&before_lower)
                         || targeted_compound_continuation
                         || prevent_then_put_continuation
@@ -2212,6 +2222,21 @@ pub(super) fn apply_clause_continuation(
                 face_down,
             };
         }
+        ContinuationAst::ChooseAndSacrificeRestFilter { sacrifice_filter } => {
+            let Some(filter) = sacrifice_filter else {
+                return;
+            };
+            let Some(previous) = defs.last_mut() else {
+                return;
+            };
+            if let Effect::ChooseAndSacrificeRest {
+                sacrifice_filter: existing,
+                ..
+            } = &mut *previous.effect
+            {
+                *existing = filter;
+            }
+        }
     }
 }
 
@@ -2309,6 +2334,7 @@ pub(super) fn continuation_absorbs_current(
         // parse_followup_continuation_ast; the "exile it [face down]" clause is
         // folded into that Dig (rewritten to ExileTop) and emits no sibling def.
         ContinuationAst::ExileLookedAtCard { .. } => true,
+        ContinuationAst::ChooseAndSacrificeRestFilter { .. } => true,
     }
 }
 
@@ -2867,6 +2893,7 @@ pub(super) fn parse_followup_continuation_ast(
     let lower = text.to_lowercase();
 
     match previous_effect {
+        Effect::ChooseAndSacrificeRest { .. } => parse_choose_and_sacrifice_rest_followup(&lower),
         Effect::SearchLibrary { .. } if is_search_result_reveal_clause(&lower) => {
             Some(ContinuationAst::SearchRevealResult)
         }
@@ -3431,6 +3458,66 @@ pub(super) fn parse_followup_continuation_ast(
             .or_else(|| try_parse_put_counters_on_token_followup(&lower)),
         _ => None,
     }
+}
+
+fn parse_choose_and_sacrifice_rest_followup(lower: &str) -> Option<ContinuationAst> {
+    type E<'a> = OracleError<'a>;
+    let lower = lower.trim();
+
+    all_consuming(terminated(
+        preceded(
+            opt(tag::<_, _, E>("then ")),
+            alt((
+                parse_bare_choose_and_sacrifice_rest_filter,
+                parse_explicit_choose_and_sacrifice_rest_filter,
+            )),
+        ),
+        opt(tag(".")),
+    ))
+    .parse(lower)
+    .ok()
+    .map(|(_, sacrifice_filter)| ContinuationAst::ChooseAndSacrificeRestFilter { sacrifice_filter })
+}
+
+fn parse_bare_choose_and_sacrifice_rest_filter(
+    input: &str,
+) -> Result<(&str, Option<TargetFilter>), nom::Err<OracleError<'_>>> {
+    let (input, _) =
+        alt((tag::<_, _, OracleError<'_>>("sacrifices"), tag("sacrifice"))).parse(input)?;
+    let (input, _) = tag(" the rest").parse(input)?;
+    Ok((input, None))
+}
+
+fn parse_explicit_choose_and_sacrifice_rest_filter(
+    input: &str,
+) -> Result<(&str, Option<TargetFilter>), nom::Err<OracleError<'_>>> {
+    let (input, _) = opt(tag::<_, _, OracleError<'_>>("each player ")).parse(input)?;
+    let (input, _) = alt((
+        tag::<_, _, OracleError<'_>>("sacrifices "),
+        tag("sacrifice "),
+    ))
+    .parse(input)?;
+    let (input, _) = tag("all other ").parse(input)?;
+    let (input, filter) = parse_nonland_permanent_domain(input)?;
+    Ok((input, Some(filter)))
+}
+
+fn parse_nonland_permanent_domain(
+    input: &str,
+) -> Result<(&str, TargetFilter), nom::Err<OracleError<'_>>> {
+    let (input, _) = tag::<_, _, OracleError<'_>>("nonland permanents ").parse(input)?;
+    let (input, _) = alt((
+        tag::<_, _, OracleError<'_>>("they control"),
+        tag("you control"),
+        tag("that player controls"),
+    ))
+    .parse(input)?;
+    Ok((
+        input,
+        TargetFilter::Typed(
+            TypedFilter::permanent().with_type(TypeFilter::Non(Box::new(TypeFilter::Land))),
+        ),
+    ))
 }
 
 /// CR 122.6a: Parse "the token/it enters with X [counter type] counter(s) on it[, where X is ...]".
@@ -4163,6 +4250,38 @@ mod tests {
         assert_eq!(chunks.len(), 2);
         assert_eq!(chunks[0], "you gain 1 life");
         assert!(chunks[1].starts_with("~ deals 1 damage"));
+    }
+
+    #[test]
+    fn from_among_sacrifice_rest_splits_for_absorption() {
+        let chunks = clause_texts(
+            "each player chooses an artifact, a creature, an enchantment, and a planeswalker from among the nonland permanents they control, then sacrifices the rest.",
+        );
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(
+            chunks[1], "sacrifices the rest",
+            "sacrifice-rest continuation must be a separate chunk"
+        );
+    }
+
+    #[test]
+    fn choose_and_sacrifice_rest_followup_accepts_then_and_period() {
+        let effect = Effect::ChooseAndSacrificeRest {
+            categories: vec![crate::types::card_type::CoreType::Artifact],
+            chooser_scope: crate::types::ability::CategoryChooserScope::EachPlayerSelf,
+            choose_filter: TargetFilter::Typed(TypedFilter::permanent()),
+            sacrifice_filter: TargetFilter::Typed(TypedFilter::permanent()),
+        };
+        assert_eq!(
+            parse_followup_continuation_ast(
+                "then sacrifices the rest.",
+                &effect,
+                &mut ParseContext::default(),
+            ),
+            Some(ContinuationAst::ChooseAndSacrificeRestFilter {
+                sacrifice_filter: None,
+            })
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -333,6 +333,12 @@ pub(crate) enum ContinuationAst {
         count: QuantityExpr,
         face_down: bool,
     },
+    /// CR 608.2c + CR 701.21a: absorbs the explicit/bare sacrifice-rest clause
+    /// following a choose-and-sacrifice-rest effect, optionally narrowing the
+    /// final sacrifice sweep ("all other nonland permanents they control").
+    ChooseAndSacrificeRestFilter {
+        sacrifice_filter: Option<TargetFilter>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -884,6 +890,8 @@ pub(crate) enum ChooseImperativeAst {
     CategoryAndSacrificeRest {
         categories: Vec<crate::types::card_type::CoreType>,
         chooser_scope: crate::types::ability::CategoryChooserScope,
+        choose_filter: crate::types::ability::TargetFilter,
+        sacrifice_filter: crate::types::ability::TargetFilter,
     },
     /// CR 115.1c + CR 601.2c: "choose target X and target Y" — two independent
     /// target slots declared in a single targeting clause (Goblin Welder shape).

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -1238,6 +1238,14 @@ fn detect_dynamic_qty(
     if cleaned_for_each_is_only_decline_iteration(cleaned) && json_has_any(ast_json, &["\"Not\""]) {
         return;
     }
+    // CR 101.4 + CR 701.21a: Tragic Arrogance-style "For each player, you choose
+    // ..." is a turn-order choice procedure, not a numeric quantity. Its carrier
+    // is the dedicated ChooseAndSacrificeRest effect rather than a QuantityExpr.
+    if cleaned.contains("for each player, you choose ") // allow-noncombinator: swallow detector marker scan on classified text
+        && json_has_any(ast_json, &["ChooseAndSacrificeRest"])
+    {
+        return;
+    }
     // CR 701.38: Council's-dilemma vote-tally payoffs ("create a number of X
     // equal to [twice] the number of <choice> votes" — Emissary Green) realize
     // their dynamic count through the Vote resolver's per-vote fan-out: each
@@ -2639,6 +2647,17 @@ mod tests {
         let parsed = parse(
             "Put a +1/+1 counter on target creature you control, then double the number of +1/+1 counters on that creature.",
             &["Instant"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "DynamicQty"));
+    }
+
+    #[test]
+    fn dynamic_qty_accepts_choose_and_sacrifice_rest_for_each_player() {
+        let parsed = parse_named(
+            "For each player, you choose from among the permanents that player controls an artifact, a creature, an enchantment, and a planeswalker. Then each player sacrifices all other nonland permanents they control.",
+            "Tragic Arrogance",
+            &["Sorcery"],
         );
 
         assert!(!has_swallowed_detector(&parsed, "DynamicQty"));

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6465,6 +6465,12 @@ pub enum Effect {
         /// CR 101.4: Whether each player chooses independently or one player decides for all.
         #[serde(default)]
         chooser_scope: CategoryChooserScope,
+        /// Permanents eligible to be chosen for the category slots.
+        #[serde(default = "default_target_filter_permanent")]
+        choose_filter: TargetFilter,
+        /// Permanents in scope for the final sacrifice sweep.
+        #[serde(default = "default_target_filter_permanent")]
+        sacrifice_filter: TargetFilter,
     },
     /// CR 702.110b: Exploit — sacrifice a creature you control (optional).
     /// The controller may sacrifice any creature they control, including the exploiter itself.
@@ -7012,6 +7018,10 @@ pub enum CopyRetargetPermission {
 
 pub(crate) fn default_target_filter_any() -> TargetFilter {
     TargetFilter::Any
+}
+
+pub(crate) fn default_target_filter_permanent() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::permanent())
 }
 
 /// CR 115.1: a copy keeps the original spell's declared targets unless an

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6,11 +6,12 @@ use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 
 use super::ability::{
-    AbilityCost, AbilityDefinition, AdditionalCost, BeholdCostAction, ChoiceType, ChoiceValue,
-    ChooseFromZoneConstraint, ContinuousModification, CostPaidObjectSnapshot,
-    DelayedTriggerCondition, Duration, EffectKind, GameRestriction, KeywordAction, KickerVariant,
-    ModalChoice, ResolvedAbility, SearchDestinationSplit, SearchSelectionConstraint,
-    StaticCondition, TargetFilter, TargetRef, TriggerCondition,
+    default_target_filter_permanent, AbilityCost, AbilityDefinition, AdditionalCost,
+    BeholdCostAction, CategoryChooserScope, ChoiceType, ChoiceValue, ChooseFromZoneConstraint,
+    ContinuousModification, CostPaidObjectSnapshot, DelayedTriggerCondition, Duration, EffectKind,
+    GameRestriction, KeywordAction, KickerVariant, ModalChoice, ResolvedAbility,
+    SearchDestinationSplit, SearchSelectionConstraint, StaticCondition, TargetFilter, TargetRef,
+    TriggerCondition,
 };
 use super::attribution::ObjectAttribution;
 use super::card::CardFace;
@@ -2914,6 +2915,20 @@ pub enum WaitingFor {
         target_player: PlayerId,
         /// Type categories to fill (e.g., [Artifact, Creature, Enchantment, Land]).
         categories: Vec<CoreType>,
+        /// CR 101.4: Whether each player chooses independently or one player decides for all.
+        #[serde(default)]
+        chooser_scope: CategoryChooserScope,
+        /// Permanents eligible to be chosen for the category slots.
+        #[serde(default = "default_target_filter_permanent")]
+        choose_filter: TargetFilter,
+        /// Permanents in scope for the final sacrifice sweep.
+        #[serde(default = "default_target_filter_permanent")]
+        sacrifice_filter: TargetFilter,
+        /// Controller of the source ability. Needed after a save/reload or any
+        /// paused choice because `player` is the chooser, not necessarily the
+        /// source controller.
+        #[serde(default)]
+        source_controller: PlayerId,
         /// For each category, the eligible permanent IDs (battlefield objects matching that type).
         eligible_per_category: Vec<Vec<ObjectId>>,
         source_id: ObjectId,

--- a/crates/engine/tests/integration/adapter_contract_fixtures.rs
+++ b/crates/engine/tests/integration/adapter_contract_fixtures.rs
@@ -1,4 +1,5 @@
 use engine::game::game_object::GameObject;
+use engine::types::ability::{TargetFilter, TypeFilter};
 use engine::types::actions::GameAction;
 use engine::types::game_state::WaitingFor;
 
@@ -46,6 +47,55 @@ fn waiting_for_priority_fixture_matches_curated_client_contract() {
     match parsed {
         WaitingFor::Priority { player } => assert_eq!(player.0, 0),
         other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+#[test]
+fn waiting_for_category_choice_fixture_matches_curated_client_contract() {
+    let parsed: WaitingFor = serde_json::from_str(include_str!(
+        "../../../../fixtures/adapter-contract/waiting_for_category_choice.json"
+    ))
+    .unwrap();
+    match parsed {
+        WaitingFor::CategoryChoice {
+            player,
+            target_player,
+            categories,
+            choose_filter,
+            sacrifice_filter,
+            source_controller,
+            eligible_per_category,
+            remaining_players,
+            all_kept,
+            scoped_players,
+            ..
+        } => {
+            assert_eq!(player.0, 0);
+            assert_eq!(target_player.0, 0);
+            assert_eq!(categories.len(), 2);
+            assert!(filter_contains_nonland(&choose_filter));
+            assert!(filter_contains_nonland(&sacrifice_filter));
+            assert_eq!(source_controller.0, 0);
+            assert_eq!(eligible_per_category[0][0].0, 10);
+            assert_eq!(remaining_players[0].0, 1);
+            assert!(all_kept.is_empty());
+            assert_eq!(scoped_players.len(), 2);
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+fn filter_contains_nonland(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed
+            .type_filters
+            .iter()
+            .any(|type_filter| matches!(type_filter, TypeFilter::Non(inner) if **inner == TypeFilter::Land)),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_contains_nonland)
+        }
+        TargetFilter::Not { filter } => filter_contains_nonland(filter),
+        _ => false,
     }
 }
 

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1,7 +1,6 @@
 use rand::Rng;
 
 use engine::ai_support::build_decision_context;
-use engine::types::ability::{CategoryChooserScope, TargetFilter, TypedFilter};
 use engine::types::actions::{AlternativeCastDecision, GameAction, MulliganChoice};
 use engine::types::card_type::CoreType;
 use engine::types::game_state::{GameState, WaitingFor};
@@ -1794,7 +1793,7 @@ mod tests {
     use super::*;
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
     use engine::game::zones::create_object;
-    use engine::types::ability::TargetRef;
+    use engine::types::ability::{CategoryChooserScope, TargetFilter, TargetRef, TypedFilter};
     use engine::types::card_type::CoreType;
     use engine::types::identifiers::{CardId, ObjectId};
     use engine::types::mana::{ManaType, ManaUnit};

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1,6 +1,7 @@
 use rand::Rng;
 
 use engine::ai_support::build_decision_context;
+use engine::types::ability::{CategoryChooserScope, TargetFilter, TypedFilter};
 use engine::types::actions::{AlternativeCastDecision, GameAction, MulliganChoice};
 use engine::types::card_type::CoreType;
 use engine::types::game_state::{GameState, WaitingFor};
@@ -834,29 +835,18 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
             Some(GameAction::SelectCards { cards: Vec::new() })
         }
 
-        // CR 101.4 + CR 701.21a: Category choice — pick one distinct permanent
+        // CR 101.4 + CR 701.21a: Category choice — pick one permanent
         // per type category, the rest are sacrificed. A permanent that belongs
         // to multiple categories (e.g. an artifact creature) is eligible in
-        // each, but the engine rejects choosing the same object for more than
-        // one category (`engine_resolution_choices.rs` SelectCategoryPermanents
-        // duplicate guard). Greedily pick the first not-yet-used eligible
-        // object per category, mirroring the `used`-vec algorithm in
-        // `choose_and_sacrifice_rest::try_auto_resolve` so the two stay
-        // consistent. `None` for empty/exhausted categories is a legal choice.
+        // each and may be chosen in each eligible slot. `None` is legal only
+        // for an empty category.
         WaitingFor::CategoryChoice {
             eligible_per_category,
             ..
         } => {
-            let mut used: Vec<engine::types::identifiers::ObjectId> = Vec::new();
             let choices = eligible_per_category
                 .iter()
-                .map(|eligible| {
-                    let pick = eligible.iter().copied().find(|id| !used.contains(id));
-                    if let Some(id) = pick {
-                        used.push(id);
-                    }
-                    pick
-                })
+                .map(|eligible| eligible.first().copied())
                 .collect();
             Some(GameAction::SelectCategoryPermanents { choices })
         }
@@ -2640,15 +2630,12 @@ mod tests {
         );
     }
 
-    /// Regression for #447: when a permanent belongs to multiple type
-    /// categories (an artifact creature), the `CategoryChoice` fallback must
-    /// pick *distinct* objects per category. Picking the same object twice is
-    /// rejected by the engine (`engine_resolution_choices.rs`
-    /// SelectCategoryPermanents duplicate guard), which would softlock the AI
-    /// seat. The greedy `used`-vec algorithm mirrors
-    /// `choose_and_sacrifice_rest::try_auto_resolve`.
+    /// Regression for #1591: when a permanent belongs to multiple type
+    /// categories (an artifact creature), the `CategoryChoice` fallback may
+    /// choose that same object for every eligible category slot. The engine
+    /// dedupes only the protected set before sacrificing the rest.
     #[test]
-    fn category_choice_fallback_picks_distinct_objects_and_applies() {
+    fn category_choice_fallback_allows_duplicate_object_slots_and_applies() {
         let mut state = make_state();
         // Source of the ChooseAndSacrificeRest ability.
         let source_card = CardId(state.next_object_id);
@@ -2674,13 +2661,16 @@ mod tests {
             obj.card_types.core_types = vec![CoreType::Artifact, CoreType::Creature];
         }
 
-        // `[[X],[X]]` — X shared across both categories. The fallback must
-        // resolve this to distinct objects (X for the first, None for the
-        // second once X is used).
+        // `[[X],[X]]` — X shared across both categories. The fallback may use
+        // X for both slots because each slot asks a separate category question.
         state.waiting_for = WaitingFor::CategoryChoice {
             player: PlayerId(0),
             target_player: PlayerId(0),
             categories: vec![CoreType::Artifact, CoreType::Creature],
+            chooser_scope: CategoryChooserScope::EachPlayerSelf,
+            choose_filter: TargetFilter::Typed(TypedFilter::permanent()),
+            sacrifice_filter: TargetFilter::Typed(TypedFilter::permanent()),
+            source_controller: PlayerId(0),
             eligible_per_category: vec![vec![artifact_creature], vec![artifact_creature]],
             source_id: source,
             remaining_players: Vec::new(),
@@ -2694,19 +2684,13 @@ mod tests {
             other => panic!("expected SelectCategoryPermanents, got {other:?}"),
         };
 
-        // No object may be repeated across categories.
-        let picked: Vec<ObjectId> = choices.iter().filter_map(|c| *c).collect();
-        for (i, id) in picked.iter().enumerate() {
-            assert!(
-                !picked[i + 1..].contains(id),
-                "fallback must not repeat an object across categories: {choices:?}"
-            );
-        }
+        assert_eq!(
+            choices,
+            vec![Some(artifact_creature), Some(artifact_creature)]
+        );
 
-        // Driving the chosen action through the real engine must succeed —
-        // the duplicate guard would reject a repeated object.
         engine::game::engine::apply(&mut state, PlayerId(0), action)
-            .expect("engine must accept the distinct-object category choice");
+            .expect("engine must accept duplicate-object category choices");
     }
 
     // --- Multikicker mana-budget guard (issue #454) ---

--- a/fixtures/adapter-contract/waiting_for_category_choice.json
+++ b/fixtures/adapter-contract/waiting_for_category_choice.json
@@ -1,0 +1,27 @@
+{
+  "type": "CategoryChoice",
+    "data": {
+      "player": 0,
+    "target_player": 0,
+    "categories": ["Artifact", "Creature"],
+    "chooser_scope": "ControllerForAll",
+    "choose_filter": {
+      "type": "Typed",
+      "type_filters": ["Permanent", { "Non": "Land" }],
+      "controller": null,
+      "properties": []
+    },
+    "sacrifice_filter": {
+      "type": "Typed",
+      "type_filters": ["Permanent", { "Non": "Land" }],
+      "controller": null,
+      "properties": []
+    },
+    "source_controller": 0,
+    "eligible_per_category": [[10], [10, 11]],
+    "source_id": 99,
+    "remaining_players": [1],
+    "all_kept": [],
+    "scoped_players": [0, 1]
+  }
+}


### PR DESCRIPTION
## Summary
- parse Cataclysmic Gearhulk and Tragic Arrogance sacrifice-rest clauses into ChooseAndSacrificeRest filters instead of generated sacrifice sub-abilities
- apply separate choose/sacrifice filters at runtime and preserve source controller through CategoryChoice waits
- allow duplicate category slots for one permanent while requiring choices for nonempty categories
- update CategoryChoice adapter/frontend/AI coverage

Closes #1591

## Verification
- cargo fmt --all
- ./scripts/check-parser-combinators.sh
- CARGO_TARGET_DIR=/tmp/forge-gh-issues-target cargo test -p engine cataclysmic --lib
- CARGO_TARGET_DIR=/tmp/forge-gh-issues-target cargo test -p engine tragic_arrogance_absorbs_explicit_nonland_sacrifice_filter --lib
- CARGO_TARGET_DIR=/tmp/forge-gh-issues-target cargo test -p engine gearhulk_filter_keeps_duplicate_slot_permanent_and_spares_lands --lib
- CARGO_TARGET_DIR=/tmp/forge-gh-issues-target cargo test -p engine category_choice_rejects_none_for_nonempty_category --lib
- CARGO_TARGET_DIR=/tmp/forge-gh-issues-target cargo test -p engine dynamic_qty_accepts_choose_and_sacrifice_rest_for_each_player --lib
- CARGO_TARGET_DIR=/tmp/forge-gh-issues-target cargo test -p engine --test integration waiting_for_category_choice_fixture_matches_curated_client_contract
- CARGO_TARGET_DIR=/tmp/forge-gh-issues-target cargo test -p phase-ai category_choice_fallback_allows_duplicate_object_slots_and_applies --lib
- npm test -- --run src/components/modal/__tests__/CategoryChoiceModal.test.tsx src/adapter/__tests__/contract-fixtures.test.ts
- ./scripts/gen-card-data.sh; diffed affected card-data entries for Cataclysmic Gearhulk / Tragic Arrogance / Cataclysm / Liliana, Dreadhorde General
- review-impl: No findings