### PR TITLE
Fix shared-quality count quantities

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1879,6 +1879,7 @@ fn quantity_ref_references_target_creature(qty: &QuantityRef) -> bool {
         }
         QuantityRef::ObjectCount { filter }
         | QuantityRef::ObjectCountDistinct { filter, .. }
+        | QuantityRef::ObjectCountBySharedQuality { filter, .. }
         | QuantityRef::CountersOnObjects { filter, .. }
         | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::EnteredThisTurn { filter }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -873,6 +873,22 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             };
             format!("# of {} {}", quality_str, fmt_target(filter))
         }
+        QuantityRef::ObjectCountBySharedQuality {
+            filter,
+            quality,
+            aggregate,
+        } => {
+            let func = match aggregate {
+                AggregateFunction::Max => "greatest",
+                AggregateFunction::Min => "fewest",
+                AggregateFunction::Sum => "total",
+            };
+            format!(
+                "{func} shared {:?} count among {}",
+                quality,
+                fmt_target(filter)
+            )
+        }
         QuantityRef::PlayerCount { filter } => format!("# of {}", fmt_player_filter(filter)),
         QuantityRef::CountersOn {
             scope,
@@ -5155,6 +5171,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::Speed { .. } => ("Speed", Handled),
         QuantityRef::ObjectCount { .. } => ("ObjectCount", Handled),
         QuantityRef::ObjectCountDistinct { .. } => ("ObjectCountDistinct", Handled),
+        QuantityRef::ObjectCountBySharedQuality { .. } => ("ObjectCountBySharedQuality", Handled),
         QuantityRef::PlayerCount { .. } => ("PlayerCount", Handled),
         QuantityRef::CountersOn { .. } => ("CountersOn", Handled),
         QuantityRef::CountersOnObjects { .. } => ("CountersOnObjects", Handled),

--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -477,9 +477,12 @@ mod tests {
     use crate::game::game_object::AttachTarget;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        ControllerRef, QuantityExpr, StaticDefinition, TargetFilter, TargetRef, TypedFilter,
+        AggregateFunction, ControllerRef, GainLifePlayer, QuantityExpr, QuantityRef, SharedQuality,
+        StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
     };
+    use crate::types::card_type::CoreType;
     use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::keywords::Keyword;
     use crate::types::player::PlayerId;
     use crate::types::statics::StaticMode;
     use crate::types::zones::Zone;
@@ -524,6 +527,79 @@ mod tests {
         resolve_gain(&mut state, &ability, &mut events).unwrap();
 
         assert_eq!(state.players[0].life, 25);
+    }
+
+    #[test]
+    fn skemfar_shadowsage_gain_life_mode_uses_shared_creature_type_count() {
+        let mut state = GameState::new_two_player(42);
+        state.all_creature_types = vec![
+            "Elf".to_string(),
+            "Warrior".to_string(),
+            "Druid".to_string(),
+            "Human".to_string(),
+        ];
+        let source = create_object(
+            &mut state,
+            CardId(901),
+            PlayerId(0),
+            "Skemfar Shadowsage".to_string(),
+            Zone::Battlefield,
+        );
+        for (name, subtypes) in [
+            ("Elf Warrior", vec!["Elf", "Warrior"]),
+            ("Elf Druid", vec!["Elf", "Druid"]),
+            ("Human Warrior", vec!["Human", "Warrior"]),
+        ] {
+            let id = create_object(
+                &mut state,
+                CardId(902),
+                PlayerId(0),
+                name.to_string(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types = vec![CoreType::Creature];
+            obj.card_types.subtypes = subtypes
+                .into_iter()
+                .map(|subtype| subtype.to_string())
+                .collect();
+        }
+        let changeling = create_object(
+            &mut state,
+            CardId(903),
+            PlayerId(0),
+            "Masked Vandal".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&changeling).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.card_types.subtypes = vec!["Shapeshifter".to_string()];
+        obj.keywords.push(Keyword::Changeling);
+
+        let ability = ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCountBySharedQuality {
+                        filter: TargetFilter::Typed(TypedFilter {
+                            type_filters: vec![TypeFilter::Creature],
+                            controller: Some(ControllerRef::You),
+                            properties: Vec::new(),
+                        }),
+                        quality: SharedQuality::CreatureType,
+                        aggregate: AggregateFunction::Max,
+                    },
+                },
+                player: GainLifePlayer::Controller,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_gain(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.players[0].life, 23);
     }
 
     #[test]

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -143,6 +143,7 @@ pub(crate) fn quantity_expr_uses_recipient(expr: &QuantityExpr) -> bool {
             } => true,
             QuantityRef::ObjectCount { filter }
             | QuantityRef::ObjectCountDistinct { filter, .. }
+            | QuantityRef::ObjectCountBySharedQuality { filter, .. }
             | QuantityRef::DistinctCardTypes {
                 source: CardTypeSetSource::Objects { filter },
             }
@@ -238,6 +239,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         // Read battlefield object population directly.
         QuantityRef::ObjectCount { .. }
         | QuantityRef::ObjectCountDistinct { .. }
+        | QuantityRef::ObjectCountBySharedQuality { .. }
         | QuantityRef::CountersOnObjects { .. }
         | QuantityRef::Aggregate { .. }
         | QuantityRef::ControlledByEachPlayer { .. }
@@ -376,6 +378,7 @@ fn entered_object_perturbs_quantity_ref(
         // object matches the population filter (CR 109.5 controller via `ctx`).
         QuantityRef::ObjectCount { filter }
         | QuantityRef::ObjectCountDistinct { filter, .. }
+        | QuantityRef::ObjectCountBySharedQuality { filter, .. }
         | QuantityRef::CountersOnObjects { filter, .. }
         | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::ControlledByEachPlayer { filter, .. }
@@ -1149,6 +1152,46 @@ fn resolve_ref(
                 signatures.insert(signature);
             }
             usize_to_i32_saturating(signatures.len())
+        }
+        // CR 109.3: Group the matching object population by a shared
+        // characteristic and aggregate the resulting bucket sizes. Each object
+        // contributes once to each distinct value it has for `quality`;
+        // objects with no value for that quality contribute to no bucket.
+        QuantityRef::ObjectCountBySharedQuality {
+            filter,
+            quality,
+            aggregate,
+        } => {
+            let mut buckets: std::collections::HashMap<String, usize> =
+                std::collections::HashMap::new();
+            for id in object_count_matching_ids(state, filter, &filter_ctx, source_id) {
+                let Some(obj) = state.objects.get(&id) else {
+                    continue;
+                };
+                for value in crate::game::filter::object_shared_quality_values_public(
+                    obj,
+                    quality,
+                    &state.all_creature_types,
+                ) {
+                    *buckets.entry(value).or_default() += 1;
+                }
+            }
+
+            match aggregate {
+                AggregateFunction::Max => buckets
+                    .values()
+                    .copied()
+                    .max()
+                    .map_or(0, usize_to_i32_saturating),
+                AggregateFunction::Min => buckets
+                    .values()
+                    .copied()
+                    .min()
+                    .map_or(0, usize_to_i32_saturating),
+                AggregateFunction::Sum => {
+                    usize_to_i32_saturating(buckets.values().copied().sum::<usize>())
+                }
+            }
         }
         QuantityRef::PlayerCount { filter } => {
             resolve_player_count(state, filter, controller, source_id)
@@ -4187,6 +4230,119 @@ mod tests {
             },
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(0)), 2);
+    }
+
+    fn shared_quality_count_expr(
+        aggregate: AggregateFunction,
+        quality: SharedQuality,
+    ) -> QuantityExpr {
+        QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCountBySharedQuality {
+                filter: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+                quality,
+                aggregate,
+            },
+        }
+    }
+
+    fn add_creature_with_subtypes(
+        state: &mut GameState,
+        owner: PlayerId,
+        name: &str,
+        subtypes: &[&str],
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(300),
+            owner,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.card_types.subtypes = subtypes
+            .iter()
+            .map(|subtype| (*subtype).to_string())
+            .collect();
+        id
+    }
+
+    #[test]
+    fn resolve_object_count_by_shared_quality_max_and_sum_creature_types() {
+        let mut state = GameState::new_two_player(42);
+        state.all_creature_types = vec![
+            "Elf".to_string(),
+            "Warrior".to_string(),
+            "Druid".to_string(),
+            "Human".to_string(),
+        ];
+        add_creature_with_subtypes(&mut state, PlayerId(0), "Elf Warrior", &["Elf", "Warrior"]);
+        add_creature_with_subtypes(&mut state, PlayerId(0), "Elf Druid", &["Elf", "Druid"]);
+        add_creature_with_subtypes(
+            &mut state,
+            PlayerId(0),
+            "Human Warrior",
+            &["Human", "Warrior"],
+        );
+        let changeling =
+            add_creature_with_subtypes(&mut state, PlayerId(0), "Masked Vandal", &["Shapeshifter"]);
+        state
+            .objects
+            .get_mut(&changeling)
+            .unwrap()
+            .keywords
+            .push(Keyword::Changeling);
+        add_creature_with_subtypes(&mut state, PlayerId(1), "Opponent Elf", &["Elf"]);
+
+        let source = ObjectId(0);
+        assert_eq!(
+            resolve_quantity(
+                &state,
+                &shared_quality_count_expr(AggregateFunction::Max, SharedQuality::CreatureType),
+                PlayerId(0),
+                source,
+            ),
+            3
+        );
+        assert_eq!(
+            resolve_quantity(
+                &state,
+                &shared_quality_count_expr(AggregateFunction::Sum, SharedQuality::CreatureType),
+                PlayerId(0),
+                source,
+            ),
+            10
+        );
+    }
+
+    #[test]
+    fn resolve_object_count_by_shared_quality_min_and_empty_buckets() {
+        let mut state = GameState::new_two_player(42);
+        state.all_creature_types = vec!["Elf".to_string(), "Warrior".to_string()];
+        add_creature_with_subtypes(&mut state, PlayerId(0), "Elf Warrior", &["Elf", "Warrior"]);
+        add_creature_with_subtypes(&mut state, PlayerId(0), "Elf", &["Elf"]);
+
+        assert_eq!(
+            resolve_quantity(
+                &state,
+                &shared_quality_count_expr(AggregateFunction::Min, SharedQuality::CreatureType),
+                PlayerId(0),
+                ObjectId(0),
+            ),
+            1
+        );
+
+        let mut empty_state = GameState::new_two_player(43);
+        add_creature_with_subtypes(&mut empty_state, PlayerId(0), "Typeless", &[]);
+        assert_eq!(
+            resolve_quantity(
+                &empty_state,
+                &shared_quality_count_expr(AggregateFunction::Max, SharedQuality::CreatureType),
+                PlayerId(0),
+                ObjectId(0),
+            ),
+            0
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -7554,6 +7554,82 @@ mod tests {
         ));
     }
 
+    fn assert_shared_creature_type_max(expr: &QuantityExpr) {
+        let QuantityExpr::Ref {
+            qty:
+                QuantityRef::ObjectCountBySharedQuality {
+                    filter:
+                        TargetFilter::Typed(TypedFilter {
+                            type_filters,
+                            controller,
+                            properties,
+                        }),
+                    quality,
+                    aggregate,
+                },
+        } = expr
+        else {
+            panic!("expected ObjectCountBySharedQuality quantity, got {expr:?}");
+        };
+        assert_eq!(type_filters.as_slice(), &[TypeFilter::Creature]);
+        assert_eq!(controller, &Some(ControllerRef::You));
+        assert!(properties.is_empty());
+        assert_eq!(quality, &SharedQuality::CreatureType);
+        assert_eq!(aggregate, &AggregateFunction::Max);
+    }
+
+    #[test]
+    fn skemfar_shadowsage_gain_mode_parses_shared_creature_type_count() {
+        let r = parse(
+            "You gain X life, where X is the greatest number of creatures you control that have a creature type in common.",
+            "Skemfar Shadowsage",
+            &[],
+            &["Creature"],
+            &["Elf", "Cleric"],
+        );
+        let Effect::GainLife { amount, .. } = &*r.abilities[0].effect else {
+            panic!("expected GainLife, got {:?}", r.abilities[0].effect);
+        };
+        assert_shared_creature_type_max(amount);
+    }
+
+    #[test]
+    fn basalt_ravager_damage_parses_shared_creature_type_count() {
+        let r = parse(
+            "Basalt Ravager deals X damage to any target, where X is the greatest number of creatures you control that have a creature type in common.",
+            "Basalt Ravager",
+            &[],
+            &["Creature"],
+            &["Giant", "Wizard"],
+        );
+        let Effect::DealDamage { amount, .. } = &*r.abilities[0].effect else {
+            panic!("expected DealDamage, got {:?}", r.abilities[0].effect);
+        };
+        assert_shared_creature_type_max(amount);
+    }
+
+    #[test]
+    fn white_lotus_tile_mana_parses_shared_creature_type_count() {
+        let r = parse(
+            "{T}: Add X mana of any one color, where X is the greatest number of creatures you control that have a creature type in common.",
+            "White Lotus Tile",
+            &[],
+            &["Artifact"],
+            &[],
+        );
+        let Effect::Mana {
+            produced: ManaProduction::AnyOneColor { count, .. },
+            ..
+        } = &*r.abilities[0].effect
+        else {
+            panic!(
+                "expected AnyOneColor mana ability, got {:?}",
+                r.abilities[0].effect
+            );
+        };
+        assert_shared_creature_type_max(count);
+    }
+
     #[test]
     fn conditional_modal_max_reuses_static_condition_parser() {
         let r = parse(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11788,55 +11788,58 @@ pub(crate) fn each_target_filter_mut(effect: &mut Effect, f: &mut impl FnMut(&mu
 /// hand, then sacrifices half the permanents they control") picks up the
 /// rewrite uniformly. Only reached when the top-level `def.player_scope` is
 /// set, so non-scoped abilities keep the target-scoped resolution path.
-fn rewrite_player_scope_refs(def: &mut AbilityDefinition) {
-    fn rewrite_filter_controller_to_scoped(filter: &mut TargetFilter) {
-        match filter {
-            TargetFilter::Typed(typed) if typed.controller == Some(ControllerRef::You) => {
-                typed.controller = Some(ControllerRef::ScopedPlayer);
+fn rewrite_filter_controller_to_scoped(filter: &mut TargetFilter) {
+    match filter {
+        TargetFilter::Typed(typed) if typed.controller == Some(ControllerRef::You) => {
+            typed.controller = Some(ControllerRef::ScopedPlayer);
+        }
+        TargetFilter::Not { filter } => rewrite_filter_controller_to_scoped(filter),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            for filter in filters {
+                rewrite_filter_controller_to_scoped(filter);
             }
-            TargetFilter::Not { filter } => rewrite_filter_controller_to_scoped(filter),
-            TargetFilter::Or { filters } | TargetFilter::And { filters } => {
-                for filter in filters {
-                    rewrite_filter_controller_to_scoped(filter);
-                }
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_condition_quantity_expr(expr: &mut QuantityExpr) {
+    match expr {
+        QuantityExpr::Ref { qty } => match qty {
+            QuantityRef::LifeTotal { player }
+            | QuantityRef::HandSize { player }
+            | QuantityRef::LifeLostThisTurn { player }
+            | QuantityRef::LifeGainedThisTurn { player }
+            | QuantityRef::PartySize { player }
+                if *player == PlayerScope::Controller =>
+            {
+                *player = PlayerScope::ScopedPlayer;
+            }
+            QuantityRef::ObjectCount { filter }
+            | QuantityRef::ObjectCountBySharedQuality { filter, .. } => {
+                rewrite_filter_controller_to_scoped(filter)
             }
             _ => {}
-        }
-    }
-
-    fn rewrite_condition_quantity_expr(expr: &mut QuantityExpr) {
-        match expr {
-            QuantityExpr::Ref { qty } => match qty {
-                QuantityRef::LifeTotal { player }
-                | QuantityRef::HandSize { player }
-                | QuantityRef::LifeLostThisTurn { player }
-                | QuantityRef::LifeGainedThisTurn { player }
-                | QuantityRef::PartySize { player }
-                    if *player == PlayerScope::Controller =>
-                {
-                    *player = PlayerScope::ScopedPlayer;
-                }
-                QuantityRef::ObjectCount { filter } => rewrite_filter_controller_to_scoped(filter),
-                _ => {}
-            },
-            QuantityExpr::DivideRounded { inner, .. }
-            | QuantityExpr::Multiply { inner, .. }
-            | QuantityExpr::Offset { inner, .. } => rewrite_condition_quantity_expr(inner),
-            QuantityExpr::Sum { exprs } => {
-                for inner in exprs {
-                    rewrite_condition_quantity_expr(inner);
-                }
+        },
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Multiply { inner, .. }
+        | QuantityExpr::Offset { inner, .. } => rewrite_condition_quantity_expr(inner),
+        QuantityExpr::Sum { exprs } => {
+            for inner in exprs {
+                rewrite_condition_quantity_expr(inner);
             }
-            QuantityExpr::UpTo { max } => rewrite_condition_quantity_expr(max),
-            QuantityExpr::Power { exponent, .. } => rewrite_condition_quantity_expr(exponent),
-            QuantityExpr::Difference { left, right } => {
-                rewrite_condition_quantity_expr(left);
-                rewrite_condition_quantity_expr(right);
-            }
-            QuantityExpr::Fixed { .. } => {}
         }
+        QuantityExpr::UpTo { max } => rewrite_condition_quantity_expr(max),
+        QuantityExpr::Power { exponent, .. } => rewrite_condition_quantity_expr(exponent),
+        QuantityExpr::Difference { left, right } => {
+            rewrite_condition_quantity_expr(left);
+            rewrite_condition_quantity_expr(right);
+        }
+        QuantityExpr::Fixed { .. } => {}
     }
+}
 
+fn rewrite_player_scope_refs(def: &mut AbilityDefinition) {
     fn rewrite_condition(condition: &mut AbilityCondition) {
         match condition {
             AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
@@ -19960,8 +19963,8 @@ mod tests {
         ControllerRef, CopyRetargetPermission, CountScope, DoublePTMode, Duration, FilterProp,
         GainLifePlayer, LibraryPosition, LinkedExileScope, ManaContribution, ManaProduction,
         ObjectProperty, ObjectScope, PaymentCost, PermissionGrantee, PtStat, PtValueScope,
-        QuantityExpr, QuantityRef, SearchSelectionConstraint, TargetChoiceTiming, TypeFilter,
-        TypedFilter, ZoneRef,
+        QuantityExpr, QuantityRef, SearchSelectionConstraint, SharedQuality, TargetChoiceTiming,
+        TypeFilter, TypedFilter, ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::keywords::Keyword;
@@ -19980,6 +19983,36 @@ mod tests {
             TargetFilter::Not { filter } => target_filter_contains_nonland(filter),
             _ => false,
         }
+    }
+
+    #[test]
+    fn rewrite_condition_quantity_expr_scopes_shared_quality_count_filter() {
+        let mut expr = QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCountBySharedQuality {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Creature],
+                    controller: Some(ControllerRef::You),
+                    properties: Vec::new(),
+                }),
+                quality: SharedQuality::CreatureType,
+                aggregate: AggregateFunction::Max,
+            },
+        };
+
+        rewrite_condition_quantity_expr(&mut expr);
+
+        assert!(matches!(
+            expr,
+            QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCountBySharedQuality {
+                    filter: TargetFilter::Typed(TypedFilter {
+                        controller: Some(ControllerRef::ScopedPlayer),
+                        ..
+                    }),
+                    ..
+                }
+            }
+        ));
     }
 
     /// Build a typed Cat trigger subject ("one or more other Cats you

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -15,7 +15,9 @@ use super::context::ParseContext;
 use super::error::OracleResult;
 use super::primitives::{parse_article, parse_counter_type_typed, parse_number};
 use super::target::parse_type_filter_word;
-use crate::parser::oracle_target::{parse_shared_quality_clause, parse_type_phrase};
+use crate::parser::oracle_target::{
+    parse_shared_quality, parse_shared_quality_clause, parse_type_phrase,
+};
 use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
     AggregateFunction, CardTypeSetSource, CastManaObjectScope, CastManaSpentMetric, ControllerRef,
@@ -394,6 +396,7 @@ pub fn parse_quantity_expr_number(input: &str) -> OracleResult<'_, QuantityExpr>
 /// "your life total", "cards in your hand", etc.
 pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     alt((
+        parse_object_count_by_shared_quality,
         parse_the_number_of,
         parse_distinct_card_types_exiled_with_source,
         parse_linked_exile_mana_value_ref,
@@ -434,6 +437,50 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         parse_counters_among_ref,
     )))
     .parse(input)
+}
+
+/// CR 109.3: Parse "the greatest/fewest/total number of <type-phrase> that
+/// have/share [a] <quality> in common" into a grouped object-count quantity.
+///
+/// The "in common" wrapper is not a target predicate: it asks for the size of
+/// quality buckets within the already-matched population. Keep it separate from
+/// `FilterProp::SharesQuality`, which validates a chosen group against a
+/// reference object/set.
+fn parse_object_count_by_shared_quality(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("the ").parse(input)?;
+    let (rest, aggregate) = alt((
+        value(AggregateFunction::Max, tag("greatest")),
+        value(AggregateFunction::Min, tag("fewest")),
+        value(AggregateFunction::Sum, tag("total")),
+    ))
+    .parse(rest)?;
+    let (rest, _) = tag(" number of ").parse(rest)?;
+    let (rest, type_text) = take_until(" that ").parse(rest)?;
+    let (rest, _) = tag(" that ").parse(rest)?;
+    let (rest, _) = alt((tag("have "), tag("has "), tag("share "), tag("shares "))).parse(rest)?;
+    let (rest, _) = opt(alt((tag("a "), tag("at least one ")))).parse(rest)?;
+    let (rest, quality) = parse_shared_quality(rest)?;
+    let (rest, _) = tag(" in common").parse(rest)?;
+
+    let (filter, type_remainder) = parse_type_phrase(type_text.trim());
+    if !type_remainder.trim().is_empty()
+        || matches!(filter, TargetFilter::Any)
+        || !quantity_filter_has_meaningful_content(&filter)
+    {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+
+    Ok((
+        rest,
+        QuantityRef::ObjectCountBySharedQuality {
+            filter,
+            quality,
+            aggregate,
+        },
+    ))
 }
 
 /// CR 607.2a: Parse linked-exile mana-value phrases into the shared aggregate
@@ -4005,6 +4052,109 @@ mod tests {
             }
             other => panic!("expected Treasure TokensCreatedThisTurn, got {other:?}"),
         }
+    }
+
+    fn assert_shared_quality_count_typed(
+        q: QuantityRef,
+    ) -> (
+        Vec<TypeFilter>,
+        Option<ControllerRef>,
+        Vec<FilterProp>,
+        SharedQuality,
+        AggregateFunction,
+    ) {
+        match q {
+            QuantityRef::ObjectCountBySharedQuality {
+                filter:
+                    TargetFilter::Typed(TypedFilter {
+                        type_filters,
+                        controller,
+                        properties,
+                    }),
+                quality,
+                aggregate,
+            } => (type_filters, controller, properties, quality, aggregate),
+            other => panic!("expected ObjectCountBySharedQuality over Typed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_greatest_creature_type_count_in_common() {
+        let (rest, q) = parse_quantity_ref(
+            "the greatest number of creatures you control that have a creature type in common",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        let (type_filters, controller, properties, quality, aggregate) =
+            assert_shared_quality_count_typed(q);
+        assert_eq!(type_filters, vec![TypeFilter::Creature]);
+        assert_eq!(controller, Some(ControllerRef::You));
+        assert!(!properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::SharesQuality { .. })));
+        assert_eq!(quality, SharedQuality::CreatureType);
+        assert_eq!(aggregate, AggregateFunction::Max);
+    }
+
+    #[test]
+    fn parse_fewest_noncreature_shared_quality_count_in_common() {
+        let (rest, q) = parse_quantity_ref(
+            "the fewest number of artifacts you control that share a color in common",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        let (type_filters, controller, _properties, quality, aggregate) =
+            assert_shared_quality_count_typed(q);
+        assert_eq!(type_filters, vec![TypeFilter::Artifact]);
+        assert_eq!(controller, Some(ControllerRef::You));
+        assert_eq!(quality, SharedQuality::Color);
+        assert_eq!(aggregate, AggregateFunction::Min);
+    }
+
+    #[test]
+    fn parse_singular_at_least_one_shared_quality_count_in_common() {
+        let (rest, q) = parse_quantity_ref(
+            "the greatest number of permanent you control that has at least one color in common",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        let (type_filters, controller, _properties, quality, aggregate) =
+            assert_shared_quality_count_typed(q);
+        assert_eq!(type_filters, vec![TypeFilter::Permanent]);
+        assert_eq!(controller, Some(ControllerRef::You));
+        assert_eq!(quality, SharedQuality::Color);
+        assert_eq!(aggregate, AggregateFunction::Max);
+    }
+
+    #[test]
+    fn parse_total_shared_quality_count_in_common() {
+        let (rest, q) = parse_quantity_ref(
+            "the total number of permanents you control that have a card type in common",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        let (type_filters, controller, _properties, quality, aggregate) =
+            assert_shared_quality_count_typed(q);
+        assert_eq!(type_filters, vec![TypeFilter::Permanent]);
+        assert_eq!(controller, Some(ControllerRef::You));
+        assert_eq!(quality, SharedQuality::CardType);
+        assert_eq!(aggregate, AggregateFunction::Sum);
+    }
+
+    #[test]
+    fn parse_shared_quality_count_rejects_partial_population() {
+        assert!(parse_quantity_ref(
+            "the greatest number of creatures you control banana that have a creature type in common",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn parse_shared_quality_count_rejects_empty_population() {
+        assert!(parse_quantity_ref(
+            "the greatest number of you control that have a creature type in common",
+        )
+        .is_err());
     }
 
     /// Helper: pull the `(type_filters, controller, properties, qualities)` tuple

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3637,7 +3637,9 @@ fn parse_keyword_match(text: &str) -> Option<KeywordMatch> {
     Some(KeywordMatch::Concrete(keyword))
 }
 
-fn parse_shared_quality(input: &str) -> nom::IResult<&str, SharedQuality, OracleError<'_>> {
+pub(crate) fn parse_shared_quality(
+    input: &str,
+) -> nom::IResult<&str, SharedQuality, OracleError<'_>> {
     alt((
         value(
             SharedQuality::TotalPowerToughness,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2109,6 +2109,20 @@ fn substitute_another_in_expr(expr: &QuantityExpr) -> QuantityExpr {
                 qualities: qualities.clone(),
             },
         },
+        QuantityExpr::Ref {
+            qty:
+                QuantityRef::ObjectCountBySharedQuality {
+                    filter,
+                    quality,
+                    aggregate,
+                },
+        } => QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCountBySharedQuality {
+                filter: substitute_another_in_filter(filter),
+                quality: quality.clone(),
+                aggregate: *aggregate,
+            },
+        },
         // CR 603.4 + CR 109.3: Aggregate populations are also "object
         // populations" in the same sense as ObjectCount — when an
         // intervening-if references an aggregate over "each other <type>",
@@ -10217,7 +10231,7 @@ mod tests {
         CastingPermission, Comparator, ContinuousModification, ControllerRef, CountScope,
         DamageModification, DelayedTriggerCondition, Duration, Effect, FilterProp,
         ManaSpendPermission, ObjectScope, PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope,
-        QuantityExpr, QuantityRef, TargetFilter, TypeFilter, TypedFilter,
+        QuantityExpr, QuantityRef, SharedQuality, TargetFilter, TypeFilter, TypedFilter,
     };
     use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::replacements::ReplacementEvent;
@@ -22621,6 +22635,34 @@ mod tests {
              clause-level condition, got {:?}",
             execute.condition,
         );
+    }
+
+    #[test]
+    fn substitute_another_rewrites_shared_quality_count_filter() {
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCountBySharedQuality {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Creature],
+                    controller: Some(ControllerRef::You),
+                    properties: vec![FilterProp::Another],
+                }),
+                quality: SharedQuality::CreatureType,
+                aggregate: AggregateFunction::Max,
+            },
+        };
+
+        let rewritten = substitute_another_in_expr(&expr);
+        let QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCountBySharedQuality { filter, .. },
+        } = rewritten
+        else {
+            panic!("expected ObjectCountBySharedQuality, got {rewritten:?}");
+        };
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(tf.properties.contains(&FilterProp::OtherThanTriggerObject));
+        assert!(!tf.properties.contains(&FilterProp::Another));
     }
 
     /// Issue #444 — Odric, Lunarch Marshal. The full trigger parses to a

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2827,6 +2827,15 @@ pub enum QuantityRef {
         #[serde(default = "default_distinct_names")]
         qualities: Vec<SharedQuality>,
     },
+    /// CR 109.3: Count matching objects grouped by a shared object
+    /// characteristic, then aggregate the group sizes. Covers "the greatest
+    /// number of creatures you control that have a creature type in common"
+    /// without encoding the shared-quality clause as a target filter.
+    ObjectCountBySharedQuality {
+        filter: TargetFilter,
+        quality: SharedQuality,
+        aggregate: AggregateFunction,
+    },
     /// Count of players matching a player-level filter.
     /// Used for "for each opponent who lost life this turn" and similar patterns.
     PlayerCount { filter: PlayerFilter },


### PR DESCRIPTION
Closes #1590.

Summary:
- Parse shared-quality count quantities as typed ObjectCountBySharedQuality refs.
- Resolve grouped object counts for greatest/fewest/total shared characteristics.
- Add parser/runtime regressions for Skemfar Shadowsage, Basalt Ravager, and White Lotus Tile.

Verification:
- cargo fmt --all
- ./scripts/check-parser-combinators.sh
- CARGO_TARGET_DIR=/tmp/forge-rs-gh-issues-target cargo clippy -p engine --lib -- -D warnings
- targeted engine tests for shared-quality quantity parsing/resolution and Skemfar/Basalt/White Lotus regressions
- regenerated card-data.json and verified affected entries change from Variable to ObjectCountBySharedQuality