### PR TITLE
Fix Gemini review followups

### DIFF
--- a/.claude/skills/project-reference/SKILL.md
+++ b/.claude/skills/project-reference/SKILL.md
@@ -120,7 +120,7 @@ cargo serve                         # Run phase-server (release)
 cargo coverage                      # Card support coverage report (reads data/card-data.json)
 cargo parser-gaps                   # Parser gap analysis report
 cargo rules-audit                   # MTG Comprehensive Rules audit (requires --features audit)
-cargo semantic-audit                 # Semantic audit of parsed card data (outputs data/semantic-audit.json + .md)
+cargo semantic-audit                # Semantic audit of parsed card data (outputs data/semantic-audit.json + .md)
 cargo scrape-feeds                  # Scrape metagame feeds from MTGGoldfish
 cargo tune-ai                       # Run AI weight tuning (requires --features tune)
 ```

--- a/client/src/components/menu/AiOpponentConfig.tsx
+++ b/client/src/components/menu/AiOpponentConfig.tsx
@@ -6,6 +6,7 @@ import { AI_DIFFICULTIES, type AIDifficulty } from "../../constants/ai";
 import type { AiDeckCandidate } from "../../services/aiDeckCatalog";
 import { filterByBracket, useAiDeckCatalog } from "../../services/aiDeckCatalog";
 import { CEDH_BRACKET } from "../../services/cedhLock";
+import { isCommanderFamilyFormat } from "../../types/bracket";
 import {
   AI_DECK_RANDOM,
   usePreferencesStore,
@@ -16,7 +17,7 @@ import type { DeckArchetype } from "../../services/engineRuntime";
 import { BracketFilter } from "./BracketFilter";
 
 interface Props {
-  selectedFormat?: GameFormat;
+  selectedFormat?: GameFormat | null;
   selectedMatchType?: MatchType;
   /** Number of AI opponents to configure (i.e. playerCount - 1). Defaults to 1
    *  so the component still renders sensibly when mounted outside the setup
@@ -70,10 +71,8 @@ export function AiOpponentConfig({
   const setCoverageFloor = usePreferencesStore((s) => s.setAiCoverageFloor);
   const bracketFilter = usePreferencesStore((s) => s.aiBracketFilter);
   const setBracketFilter = usePreferencesStore((s) => s.setAiBracketFilter);
-
-  // cEDH (competitive EDH, bracket 5) is a Commander-only concept, so the
-  // table-wide toggle only applies to the Commander variants.
-  const isCedhFormat = selectedFormat === "Commander" || selectedFormat === "DuelCommander";
+  const isCedhFormat = isCommanderFamilyFormat(selectedFormat);
+  const effectiveCedhMode = cedhMode && isCedhFormat;
 
   // Keep the persisted seat list in sync with the setup page's player count.
   useEffect(() => {
@@ -84,10 +83,12 @@ export function AiOpponentConfig({
   // (GameProvider → effectiveAiDifficulty). When the format is known to be a
   // non-Commander variant the toggle is hidden, so clear any stale enabled
   // state to stop it silently forcing cEDH difficulty on non-Commander tables.
-  // Guard on a defined format so the brief `formatConfig === null` window while
-  // the setup page resolves its format doesn't clobber a legitimate flag.
+  // Guard on a truthy format so the brief format-loading window doesn't clobber
+  // a legitimate flag.
   useEffect(() => {
-    if (selectedFormat !== undefined && !isCedhFormat && cedhMode) setCedhMode(false);
+    if (selectedFormat && !isCedhFormat && cedhMode) {
+      setCedhMode(false);
+    }
   }, [selectedFormat, isCedhFormat, cedhMode, setCedhMode]);
 
   const { candidates, loading, error } = useAiDeckCatalog({ selectedFormat, selectedMatchType });
@@ -102,19 +103,19 @@ export function AiOpponentConfig({
   // vary per seat.
   const filteredDecks = useMemo(() => {
     // In cEDH mode, restrict the random pool to bracket-5 decks.
-    const cedhFiltered = cedhMode ? filterByBracket(candidates, CEDH_BRACKET) : candidates;
+    const cedhFiltered = effectiveCedhMode ? filterByBracket(candidates, CEDH_BRACKET) : candidates;
     return cedhFiltered.filter((d) => {
       if (d.coveragePct != null && d.coveragePct < coverageFloor) return false;
       if (archetypeFilter !== "Any" && d.archetype && d.archetype !== archetypeFilter) {
         return false;
       }
-      if (!cedhMode && bracketFilter.length > 0 && selectedFormat === "Commander") {
+      if (!effectiveCedhMode && bracketFilter.length > 0 && isCedhFormat) {
         if (d.bracket === null) return false;             // untagged excluded
         if (!bracketFilter.includes(d.bracket)) return false;
       }
       return true;
     });
-  }, [candidates, coverageFloor, archetypeFilter, bracketFilter, selectedFormat, cedhMode]);
+  }, [candidates, coverageFloor, archetypeFilter, bracketFilter, isCedhFormat, effectiveCedhMode]);
 
   // Render exactly `opponentCount` panels regardless of how many slots the
   // store currently holds — the effect above will catch the store up on the
@@ -182,7 +183,7 @@ export function AiOpponentConfig({
             key={i}
             index={i}
             seat={seat}
-            cedhMode={cedhMode}
+            cedhMode={effectiveCedhMode}
             candidates={candidates}
             filteredDecks={filteredDecks}
             expanded={!isMulti || expandedIndex === i}
@@ -247,7 +248,7 @@ export function AiOpponentConfig({
           </span>
         </label>
 
-        {selectedFormat === "Commander" && (
+        {isCedhFormat && (
           <div className="flex flex-col gap-1">
             <span className="text-xs text-slate-400">{t("aiOpponent.bracket")}</span>
             <BracketFilter selected={bracketFilter} onChange={setBracketFilter} />

--- a/client/src/components/menu/__tests__/AiOpponentConfig.test.tsx
+++ b/client/src/components/menu/__tests__/AiOpponentConfig.test.tsx
@@ -169,6 +169,32 @@ describe("AiOpponentConfig — cEDH badge + disabled difficulty", () => {
     render(<AiOpponentConfig selectedFormat="Commander" opponentCount={1} />);
     expect(screen.queryByLabelText("cEDH")).not.toBeInTheDocument();
   });
+
+  it("clears cEDH mode when switching away from Commander-family formats", async () => {
+    act(() => {
+      usePreferencesStore.getState().setCedhMode(true);
+    });
+
+    const { rerender } = render(<AiOpponentConfig selectedFormat="Commander" opponentCount={1} />);
+    rerender(<AiOpponentConfig selectedFormat="Standard" opponentCount={1} />);
+
+    await waitFor(() => {
+      expect(usePreferencesStore.getState().cedhMode).toBe(false);
+    });
+  });
+
+  it("preserves cEDH mode when the selected format is not loaded", () => {
+    act(() => {
+      usePreferencesStore.getState().setCedhMode(true);
+    });
+
+    const { rerender } = render(<AiOpponentConfig selectedFormat="Commander" opponentCount={1} />);
+    rerender(<AiOpponentConfig selectedFormat={undefined} opponentCount={1} />);
+    expect(usePreferencesStore.getState().cedhMode).toBe(true);
+
+    rerender(<AiOpponentConfig selectedFormat={null} opponentCount={1} />);
+    expect(usePreferencesStore.getState().cedhMode).toBe(true);
+  });
 });
 
 describe("AiOpponentConfig — bracket filter", () => {

--- a/client/src/components/modal/CategoryChoiceModal.tsx
+++ b/client/src/components/modal/CategoryChoiceModal.tsx
@@ -50,7 +50,7 @@ export function CategoryChoiceModal({ data }: { data: CategoryChoice["data"] }) 
   if (!objects) return null;
 
   const readyToConfirm = data.eligible_per_category.every(
-    (eligible, index) => eligible.length === 0 || choices[index] !== null,
+    (eligible, index) => eligible.length === 0 || choices[index] != null,
   );
   const choosingForOpponent = data.player !== data.target_player;
   const subtitle = choosingForOpponent

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1369,6 +1369,8 @@ fn resolve_multi_target_max(
         .map(|expr| resolve_quantity_with_targets(state, expr, ability).max(0) as usize)
 }
 
+/// CR 601.2c: A spell with a variable number of targets announces how many
+/// targets it will choose before choosing them.
 fn resolve_multi_target_min(
     state: &GameState,
     ability: &ResolvedAbility,
@@ -1383,9 +1385,10 @@ pub(crate) struct MultiTargetBounds {
     pub max: usize,
 }
 
-/// CR 115.1d + CR 601.2c: Resolve a multi-target count after any required
-/// quantity choices have been announced, then cap optional slots at the live
-/// legal-target set while preserving the required minimum.
+/// CR 115.1d: A triggered ability's targets are chosen as it is put on the stack.
+/// CR 601.2c: Resolve a multi-target count after any required quantity choices
+/// have been announced, then cap optional slots at the live legal-target set
+/// while preserving the required minimum.
 pub(crate) fn resolve_multi_target_bounds(
     state: &GameState,
     ability: &ResolvedAbility,

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1586,6 +1586,7 @@ pub(super) fn begin_optional_cost_before_targets(
     finish_pending_cost_or_cast(state, player, pending, events)
 }
 
+/// CR 601.2b: X in a variable additional cost is announced before later target choices.
 pub(super) fn required_additional_cost_can_declare_x(
     state: &GameState,
     player: PlayerId,
@@ -1603,9 +1604,9 @@ pub(super) fn required_additional_cost_can_declare_x(
         .then_some(cost)
 }
 
-/// CR 601.2b/c/f: Some required additional costs announce X before targets
-/// are chosen. Keep the required cost pending while the shared payment step
-/// asks for X, then returns to deferred target selection.
+/// CR 601.2b: Some required additional costs announce X before targets are chosen.
+/// CR 601.2c: Target choices are deferred until that required cost X is known.
+/// CR 601.2f: The shared payment step then determines and pays the final total cost.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn begin_required_cost_before_targets(
     state: &mut GameState,
@@ -2659,12 +2660,15 @@ fn additional_cost_x_max(
         AbilityCost::PayLife { amount } if quantity_expr_contains_x(amount) => {
             Some(max_pay_life_x(state, player))
         }
-        AbilityCost::Sacrifice { target, count } if *count == u32::MAX => Some(
-            super::casting::find_eligible_sacrifice_targets(state, player, source_id, target)
-                .len()
-                .try_into()
-                .unwrap_or(u32::MAX),
-        ),
+        AbilityCost::Sacrifice { target, count } if *count == u32::MAX => {
+            // CR 601.2b: X in an additional sacrifice cost is announced before later target choices.
+            Some(
+                super::casting::find_eligible_sacrifice_targets(state, player, source_id, target)
+                    .len()
+                    .try_into()
+                    .unwrap_or(u32::MAX),
+            )
+        }
         AbilityCost::Composite { costs } => costs
             .iter()
             .filter_map(|cost| additional_cost_x_max(state, player, source_id, cost))

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -2467,9 +2467,10 @@ fn apply_action(
             let convoke_mode = *convoke_mode;
             if let Some(pending) = state.pending_cast.as_ref() {
                 if pending.deferred_target_selection {
-                    // CR 601.2c + CR 601.2f: A chosen X that determines target
-                    // count must have a legal target assignment before it is
-                    // locked into the pending cast.
+                    // CR 601.2c: A chosen X that determines target count must
+                    // have a legal target assignment before it is locked into
+                    // the pending cast.
+                    // CR 601.2f: The same X value then determines the total cost.
                     let mut trial = pending.as_ref().clone();
                     trial.ability.set_chosen_x_recursive(value);
                     trial.cost.concretize_x(value);

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1153,17 +1153,17 @@ fn resolve_ref(
             }
             usize_to_i32_saturating(signatures.len())
         }
-        // CR 109.3: Group the matching object population by a shared
-        // characteristic and aggregate the resulting bucket sizes. Each object
-        // contributes once to each distinct value it has for `quality`;
-        // objects with no value for that quality contribute to no bucket.
+        // CR 109.3 + CR 205.3m: Group the matching object population by a
+        // shared characteristic, such as creature type, and aggregate the
+        // resulting bucket sizes. Each object contributes once to each distinct
+        // value it has for `quality`; objects with no value for that quality
+        // contribute to no bucket.
         QuantityRef::ObjectCountBySharedQuality {
             filter,
             quality,
             aggregate,
         } => {
-            let mut buckets: std::collections::HashMap<String, usize> =
-                std::collections::HashMap::new();
+            let mut buckets: HashMap<String, HashSet<ObjectId>> = HashMap::new();
             for id in object_count_matching_ids(state, filter, &filter_ctx, source_id) {
                 let Some(obj) = state.objects.get(&id) else {
                     continue;
@@ -1173,23 +1173,29 @@ fn resolve_ref(
                     quality,
                     &state.all_creature_types,
                 ) {
-                    *buckets.entry(value).or_default() += 1;
+                    buckets.entry(value).or_default().insert(id);
                 }
             }
 
             match aggregate {
                 AggregateFunction::Max => buckets
                     .values()
-                    .copied()
+                    .map(HashSet::len)
                     .max()
                     .map_or(0, usize_to_i32_saturating),
                 AggregateFunction::Min => buckets
                     .values()
-                    .copied()
+                    .map(HashSet::len)
                     .min()
                     .map_or(0, usize_to_i32_saturating),
                 AggregateFunction::Sum => {
-                    usize_to_i32_saturating(buckets.values().copied().sum::<usize>())
+                    let unique_objects: HashSet<ObjectId> = buckets
+                        .values()
+                        .filter(|bucket| bucket.len() >= 2)
+                        .flatten()
+                        .copied()
+                        .collect();
+                    usize_to_i32_saturating(unique_objects.len())
                 }
             }
         }
@@ -4311,7 +4317,30 @@ mod tests {
                 PlayerId(0),
                 source,
             ),
-            10
+            4
+        );
+    }
+
+    #[test]
+    fn resolve_object_count_by_shared_quality_sum_deduplicates_multityped_objects() {
+        let mut state = GameState::new_two_player(42);
+        state.all_creature_types = vec![
+            "Elf".to_string(),
+            "Warrior".to_string(),
+            "Goblin".to_string(),
+        ];
+        add_creature_with_subtypes(&mut state, PlayerId(0), "Elf Warrior", &["Elf", "Warrior"]);
+        add_creature_with_subtypes(&mut state, PlayerId(0), "Elf", &["Elf"]);
+        add_creature_with_subtypes(&mut state, PlayerId(0), "Goblin", &["Goblin"]);
+
+        assert_eq!(
+            resolve_quantity(
+                &state,
+                &shared_quality_count_expr(AggregateFunction::Sum, SharedQuality::CreatureType),
+                PlayerId(0),
+                ObjectId(0),
+            ),
+            2
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2586,9 +2586,12 @@ fn parse_category_and_sacrifice_rest(rest_lower: &str) -> Option<ChooseImperativ
 
     // Pattern 2: "an artifact, a creature, ... from among [the nonland] permanents they control"
     if let Ok((after_categories, categories)) = parse_category_list_prefix(rest_lower) {
-        let (_, choose_filter) = preceded(tag::<_, _, E>(" from among "), parse_choose_domain)
-            .parse(after_categories)
-            .ok()?;
+        let (_, choose_filter) = preceded(
+            preceded(opt(tag::<_, _, E>(",")), tag(" from among ")),
+            parse_choose_domain,
+        )
+        .parse(after_categories)
+        .ok()?;
         return Some(ChooseImperativeAst::CategoryAndSacrificeRest {
             categories,
             chooser_scope: CategoryChooserScope::EachPlayerSelf,
@@ -9358,6 +9361,33 @@ mod tests {
                         }) if type_filters.contains(&TypeFilter::Non(Box::new(TypeFilter::Land)))
                     ),
                     "Gearhulk choose_filter should be nonland permanent, got {choose_filter:?}"
+                );
+                assert_eq!(choose_filter, sacrifice_filter);
+            }
+            other => panic!("Expected CategoryAndSacrificeRest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_choose_from_among_gearhulk_pattern_with_comma() {
+        let text = "choose an artifact, a creature, an enchantment, and a planeswalker, from among the nonland permanents they control";
+        let lower = text.to_lowercase();
+        let result = parse_choose_ast(text, &lower, &mut ParseContext::default());
+        match result {
+            Some(ChooseImperativeAst::CategoryAndSacrificeRest {
+                categories,
+                choose_filter,
+                sacrifice_filter,
+                ..
+            }) => {
+                assert_eq!(
+                    categories,
+                    vec![
+                        CoreType::Artifact,
+                        CoreType::Creature,
+                        CoreType::Enchantment,
+                        CoreType::Planeswalker
+                    ]
                 );
                 assert_eq!(choose_filter, sacrifice_filter);
             }

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -439,8 +439,9 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     .parse(input)
 }
 
-/// CR 109.3: Parse "the greatest/fewest/total number of <type-phrase> that
-/// have/share [a] <quality> in common" into a grouped object-count quantity.
+/// CR 109.3 + CR 205.3m: Parse "the greatest/fewest/total number of
+/// <type-phrase> that have/share [a] <quality> in common" into a grouped
+/// object-count quantity.
 ///
 /// The "in common" wrapper is not a target predicate: it asks for the size of
 /// quality buckets within the already-matched population. Keep it separate from

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1261,7 +1261,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
     let lower = text.to_lowercase();
     let mut pos = 0;
     let mut properties = Vec::new();
-    let mut property_disjunction_range: Option<(usize, usize)> = None;
+    let mut property_disjunction_ranges: Vec<(usize, usize)> = Vec::new();
     let lower_trimmed = lower.trim_start();
     let offset = lower.len() - lower_trimmed.len();
     pos += offset;
@@ -1311,7 +1311,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
         if let Ok((after_or, _)) = tag::<_, _, OracleError<'_>>("or ").parse(&lower[pos..]) {
             if let Some((next_prop, next_consumed)) = parse_combat_status_prefix(after_or) {
                 properties.push(next_prop);
-                property_disjunction_range = Some((disjunction_start, 2));
+                property_disjunction_ranges.push((disjunction_start, 2));
                 pos += "or ".len() + next_consumed;
             }
         }
@@ -1490,8 +1490,8 @@ pub fn parse_type_phrase_with_ctx<'a>(
         }
     }
 
-    // "outlaw creature[s]" uses the outlaw subtype disjunction as an adjective
-    // before the concrete Creature type.
+    // CR 700.12: "outlaw creature[s]" uses the outlaw subtype disjunction as
+    // an adjective before the concrete Creature type.
     if let Ok((rest, type_filter)) = nom_target::parse_type_filter_word(&lower[pos..]) {
         if matches!(type_filter, TypeFilter::AnyOf(_)) {
             let rest_trimmed = rest.trim_start();
@@ -1746,7 +1746,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
         pos += consumed;
     } else if let Some((suffix, consumed)) = parse_keyword_suffix(&lower[pos..]) {
         if suffix.disjunctive && suffix.properties.len() > 1 {
-            property_disjunction_range = Some((properties.len(), suffix.properties.len()));
+            property_disjunction_ranges.push((properties.len(), suffix.properties.len()));
         }
         properties.extend(suffix.properties);
         pos += consumed;
@@ -1983,33 +1983,51 @@ pub fn parse_type_phrase_with_ctx<'a>(
         neg_type_filters,
     ]
     .concat();
-    let filter = if let Some((start, len)) = property_disjunction_range {
-        let disjunctive_props = properties[start..start + len].to_vec();
-        let common_props = properties[..start]
-            .iter()
-            .chain(properties[start + len..].iter())
-            .cloned()
-            .collect::<Vec<_>>();
-        TargetFilter::Or {
-            filters: disjunctive_props
-                .into_iter()
-                .map(|disjunctive_prop| {
-                    let mut branch_props = common_props.clone();
-                    branch_props.push(disjunctive_prop);
-                    TargetFilter::Typed(TypedFilter {
-                        type_filters: type_filters.clone(),
-                        controller: controller.clone(),
-                        properties: branch_props,
-                    })
-                })
-                .collect(),
-        }
-    } else {
+    let filter = if property_disjunction_ranges.is_empty() {
         TargetFilter::Typed(TypedFilter {
             type_filters,
             controller,
             properties,
         })
+    } else {
+        let mut disjunctive_indices = vec![false; properties.len()];
+        for (start, len) in &property_disjunction_ranges {
+            for is_disjunctive in disjunctive_indices.iter_mut().skip(*start).take(*len) {
+                *is_disjunctive = true;
+            }
+        }
+        let common_props = properties
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| !disjunctive_indices[*idx])
+            .map(|(_, prop)| prop.clone())
+            .collect::<Vec<_>>();
+        let mut branch_props = vec![common_props];
+        for (start, len) in property_disjunction_ranges {
+            let disjunctive_props = properties[start..start + len].to_vec();
+            branch_props = branch_props
+                .into_iter()
+                .flat_map(|common| {
+                    disjunctive_props.iter().cloned().map(move |prop| {
+                        let mut branch = common.clone();
+                        branch.push(prop);
+                        branch
+                    })
+                })
+                .collect();
+        }
+        TargetFilter::Or {
+            filters: branch_props
+                .into_iter()
+                .map(|properties| {
+                    TargetFilter::Typed(TypedFilter {
+                        type_filters: type_filters.clone(),
+                        controller: controller.clone(),
+                        properties,
+                    })
+                })
+                .collect(),
+        }
     };
     let filter = if exclude_chosen_type {
         TargetFilter::And {
@@ -8213,6 +8231,37 @@ mod tests {
         assert!(second.type_filters.contains(&TypeFilter::Creature));
         assert!(first.properties.contains(&FilterProp::Attacking));
         assert!(second.properties.contains(&FilterProp::Blocking));
+    }
+
+    #[test]
+    fn parse_type_phrase_cross_products_multiple_property_disjunctions() {
+        let (filter, remainder) =
+            parse_type_phrase("attacking or blocking creature with flying or vigilance");
+        assert!(remainder.trim().is_empty(), "remainder: '{remainder}'");
+        let TargetFilter::Or { filters } = &filter else {
+            panic!("expected Or filter, got {filter:?}");
+        };
+        assert_eq!(filters.len(), 4);
+        let expected = [
+            (FilterProp::Attacking, Keyword::Flying),
+            (FilterProp::Attacking, Keyword::Vigilance),
+            (FilterProp::Blocking, Keyword::Flying),
+            (FilterProp::Blocking, Keyword::Vigilance),
+        ];
+        for (filter, (combat_prop, keyword)) in filters.iter().zip(expected) {
+            let typed = typed_leg(filter).expect("branch should be typed");
+            assert!(typed.type_filters.contains(&TypeFilter::Creature));
+            assert!(
+                typed.properties.contains(&combat_prop),
+                "missing {combat_prop:?} in {typed:?}"
+            );
+            assert!(
+                typed.properties.contains(&FilterProp::WithKeyword {
+                    value: keyword.clone()
+                }),
+                "missing {keyword:?} in {typed:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2827,10 +2827,11 @@ pub enum QuantityRef {
         #[serde(default = "default_distinct_names")]
         qualities: Vec<SharedQuality>,
     },
-    /// CR 109.3: Count matching objects grouped by a shared object
-    /// characteristic, then aggregate the group sizes. Covers "the greatest
-    /// number of creatures you control that have a creature type in common"
-    /// without encoding the shared-quality clause as a target filter.
+    /// CR 109.3 + CR 205.3m: Count matching objects grouped by a shared object
+    /// characteristic, including creature types, then aggregate the group
+    /// sizes. Covers "the greatest number of creatures you control that have a
+    /// creature type in common" without encoding the shared-quality clause as a
+    /// target filter.
     ObjectCountBySharedQuality {
         filter: TargetFilter,
         quality: SharedQuality,


### PR DESCRIPTION
Follow-up fixes for Gemini review comments on merged PRs from this session.

Covers:
- #1643: fix shared-quality `Sum` quantities so multi-typed objects are counted once, not once per shared type.
- #1612: use the existing Commander-family format helper for cEDH UI/filtering and preserve cEDH mode while format is null/undefined.
- #1616: preserve multiple property disjunctions by cross-producting target filter branches.
- #1640: accept optional comma before `from among` in category-choice parsing and handle `undefined` modal choices.
- #1615/#1631/#1608: CR annotation and formatting follow-ups.

Notes:
- I did not apply the suggested CR 700.9 annotation for #1643 because the local CR text says 700.9 is modified permanents. The shared-quality code uses verified CR 109.3 + CR 205.3m instead.
- Card-data evidence was checked for the #1643 parser/data change: the focused diff still shows Skemfar/Basalt/White Lotus moving from `Variable` to `ObjectCountBySharedQuality`.

Verification:
- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `CARGO_TARGET_DIR=/tmp/forge-rs-ship-gemini-target cargo test -p engine parse_type_phrase_cross_products_multiple_property_disjunctions --lib`
- `CARGO_TARGET_DIR=/tmp/forge-rs-ship-gemini-target cargo test -p engine parse_choose_from_among_gearhulk_pattern_with_comma --lib`
- `CARGO_TARGET_DIR=/tmp/forge-rs-ship-gemini-target cargo test -p engine resolve_object_count_by_shared_quality --lib`
- `CARGO_TARGET_DIR=/tmp/forge-rs-ship-gemini-target cargo clippy -p engine --lib -- -D warnings`
- `pnpm --dir client exec vitest run src/components/menu/__tests__/AiOpponentConfig.test.tsx`
- `./scripts/tilt-wait.sh check-frontend` in source worktree: ok

Review:
- review-impl: no blocking findings.