### PR TITLE
Fix Gemini review comments

### DIFF
--- a/client/public/feeds/mtggoldfish-modern.json
+++ b/client/public/feeds/mtggoldfish-modern.json
@@ -1300,11 +1300,7 @@
           "name": "Shifting Woodland"
         },
         {
-          "count": 1,
-          "name": "Devourer of Destiny"
-        },
-        {
-          "count": 1,
+          "count": 2,
           "name": "Devourer of Destiny"
         },
         {

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1923,6 +1923,9 @@ fn batch_eligible_siblings(
             let obj = state.objects.get(&id)?;
             (id != exclude
                 && obj.controller == player
+                // CR 702.26b: Phased-out permanents are treated as though they
+                // do not exist and cannot contribute batch mana activations.
+                && !obj.is_phased_out()
                 && obj.abilities.iter().enumerate().any(|(index, ability)| {
                     ability == ability_def
                         && mana_ability_ready_without_simulation(
@@ -3657,6 +3660,31 @@ mod tests {
         assert!(
             siblings.contains(&sick),
             "a hasty {{T}} mana creature IS a batch sibling (CR 702.10)"
+        );
+    }
+
+    /// CR 702.26b: Phased-out permanents are treated as though they do not
+    /// exist, so a phased-out mana source cannot batch with a visible twin.
+    #[test]
+    fn batch_excludes_phased_out_mana_sibling() {
+        let mut state = GameState::new_two_player(42);
+        let ready = make_any_color_treasure(&mut state, 9700, PlayerId(0), ManaColor::ALL.to_vec());
+        let phased =
+            make_any_color_treasure(&mut state, 9701, PlayerId(0), ManaColor::ALL.to_vec());
+        let def = state.objects.get(&ready).unwrap().abilities[0].clone();
+
+        let mut events = Vec::new();
+        crate::game::phasing::phase_out_object(
+            &mut state,
+            phased,
+            crate::game::game_object::PhaseOutCause::Directly,
+            &mut events,
+        );
+
+        let siblings = batch_eligible_siblings(&state, PlayerId(0), ready, &def);
+        assert!(
+            !siblings.contains(&phased),
+            "phased-out mana sources must not batch (CR 702.26b)"
         );
     }
 

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -1256,6 +1256,21 @@ fn choosable_objects(waiting_for: &WaitingFor, viewer: PlayerId) -> HashSet<Obje
         | WaitingFor::ManifestDreadChoice { player, cards }
         | WaitingFor::WardDiscardChoice { player, cards, .. }
         | WaitingFor::ConniveDiscard { player, cards, .. }
+        | WaitingFor::PairChoice {
+            player,
+            choices: cards,
+            ..
+        }
+        | WaitingFor::DiscardForCost { player, cards, .. }
+        | WaitingFor::BeholdForCost {
+            player,
+            choices: cards,
+            ..
+        }
+        | WaitingFor::DiscardForManaAbility { player, cards, .. }
+        | WaitingFor::ExileForManaAbility { player, cards, .. }
+        | WaitingFor::ExileForCost { player, cards, .. }
+        | WaitingFor::CollectEvidenceChoice { player, cards, .. }
             if *player == viewer =>
         {
             cards.iter().copied().collect()
@@ -1281,6 +1296,38 @@ fn choosable_objects(waiting_for: &WaitingFor, viewer: PlayerId) -> HashSet<Obje
         | WaitingFor::ChooseLegend {
             player,
             candidates: permanents,
+            ..
+        }
+        | WaitingFor::SacrificeForCost {
+            player, permanents, ..
+        }
+        | WaitingFor::ReturnToHandForCost {
+            player, permanents, ..
+        }
+        | WaitingFor::RemoveCounterForCost {
+            player, permanents, ..
+        }
+        | WaitingFor::TapCreaturesForSpellCost {
+            player,
+            creatures: permanents,
+            ..
+        }
+        | WaitingFor::TapCreaturesForManaAbility {
+            player,
+            creatures: permanents,
+            ..
+        }
+        | WaitingFor::SacrificeForManaAbility {
+            player, permanents, ..
+        }
+        | WaitingFor::BlightChoice {
+            player,
+            creatures: permanents,
+            ..
+        }
+        | WaitingFor::HarmonizeTapChoice {
+            player,
+            eligible_creatures: permanents,
             ..
         } if *player == viewer => permanents.iter().copied().collect(),
         WaitingFor::CategoryChoice {
@@ -1616,12 +1663,14 @@ mod tests {
         AbilityCost, CategoryChooserScope, Effect, ModalChoice, ResolvedAbility, TargetFilter,
     };
     use engine::types::card_type::CoreType;
+    use engine::types::counter::CounterMatch;
     use engine::types::game_state::{
         CombatTaxPending, CopyTargetSlot, ManaAbilityResume, ManaChoiceContext, ManaChoicePrompt,
         MulliganBottomEntry, MulliganDecisionEntry, PendingCast, PendingManaAbility,
         TargetSelectionProgress, TargetSelectionSlot,
     };
     use engine::types::identifiers::CardId;
+    use engine::types::zones::ExileCostSourceZone;
     use pretty_assertions::assert_eq;
 
     fn lookup(_: &GameObject) -> Option<String> {
@@ -1898,6 +1947,66 @@ mod tests {
                 PlayerId(0),
             ),
             HashSet::from([ObjectId(26)])
+        );
+        assert_eq!(
+            choosable_objects(
+                &WaitingFor::PairChoice {
+                    player: PlayerId(0),
+                    source_id: ObjectId(1),
+                    choices: vec![ObjectId(27)],
+                },
+                PlayerId(0),
+            ),
+            HashSet::from([ObjectId(27)])
+        );
+        assert_eq!(
+            choosable_objects(
+                &WaitingFor::ExileForCost {
+                    player: PlayerId(0),
+                    zone: ExileCostSourceZone::Graveyard,
+                    count: 1,
+                    cards: vec![ObjectId(28)],
+                    pending_cast: dummy_pending_cast(),
+                },
+                PlayerId(0),
+            ),
+            HashSet::from([ObjectId(28)])
+        );
+        assert_eq!(
+            choosable_objects(
+                &WaitingFor::RemoveCounterForCost {
+                    player: PlayerId(0),
+                    count: 1,
+                    counter_type: CounterMatch::Any,
+                    permanents: vec![ObjectId(29)],
+                    pending_cast: dummy_pending_cast(),
+                },
+                PlayerId(0),
+            ),
+            HashSet::from([ObjectId(29)])
+        );
+        assert_eq!(
+            choosable_objects(
+                &WaitingFor::TapCreaturesForManaAbility {
+                    player: PlayerId(0),
+                    count: 1,
+                    creatures: vec![ObjectId(30)],
+                    pending_mana_ability: dummy_pending_mana_ability(),
+                },
+                PlayerId(0),
+            ),
+            HashSet::from([ObjectId(30)])
+        );
+        assert_eq!(
+            choosable_objects(
+                &WaitingFor::HarmonizeTapChoice {
+                    player: PlayerId(0),
+                    eligible_creatures: vec![ObjectId(31)],
+                    pending_cast: dummy_pending_cast(),
+                },
+                PlayerId(0),
+            ),
+            HashSet::from([ObjectId(31)])
         );
     }
 


### PR DESCRIPTION
Follow-up to Gemini review comments on merged PRs:

- PR #1649: exclude phased-out mana siblings and broaden Manabrew choosable-object coverage.
- PR #1638: merge duplicate Devourer of Destiny entry in the Modern metagame feed.

No GitHub issue is closed by this PR; it addresses review comments only.

Verification:
- cargo fmt --all
- git diff --check -- crates/engine/src/game/mana_abilities.rs crates/manabrew-compat/src/lib.rs
- CARGO_TARGET_DIR=/Users/matt/dev/forge.rs-gh-issues/target/codex-gemini-followups cargo test -p manabrew-compat --lib
- CARGO_TARGET_DIR=/Users/matt/dev/forge.rs-gh-issues/target/codex-gemini-followups cargo test -p engine game::mana_abilities::tests::batch_excludes_phased_out_mana_sibling --lib
- CARGO_TARGET_DIR=/Users/matt/dev/forge.rs-gh-issues/target/codex-gemini-followups cargo clippy -p manabrew-compat -p engine --lib -- -D warnings
- jq empty client/public/feeds/mtggoldfish-modern.json