### PR TITLE
Centralize phased-out mana activation checks

### DIFF
--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -393,6 +393,13 @@ pub fn activate_mana_ability(
         .objects
         .get(&source_id)
         .ok_or_else(|| EngineError::InvalidAction("Mana ability source not found".to_string()))?;
+    // CR 702.26b: Phased-out permanents are treated as though they do not
+    // exist, so they cannot activate abilities.
+    if source.is_phased_out() {
+        return Err(EngineError::ActionNotAllowed(
+            "Phased-out permanents cannot activate abilities (CR 702.26b)".to_string(),
+        ));
+    }
     if source.controller != player {
         return Err(EngineError::NotYourPriority);
     }
@@ -901,6 +908,11 @@ fn mana_ability_ready_without_simulation(
     let Some(obj) = state.objects.get(&source_id) else {
         return false;
     };
+    // CR 702.26b: Phased-out permanents are treated as though they do not
+    // exist, so they cannot activate abilities.
+    if obj.is_phased_out() {
+        return false;
+    }
     // CR 701.35a: Detained permanents' activated abilities can't be activated.
     if !obj.detained_by.is_empty() {
         return false;
@@ -1923,9 +1935,6 @@ fn batch_eligible_siblings(
             let obj = state.objects.get(&id)?;
             (id != exclude
                 && obj.controller == player
-                // CR 702.26b: Phased-out permanents are treated as though they
-                // do not exist and cannot contribute batch mana activations.
-                && !obj.is_phased_out()
                 && obj.abilities.iter().enumerate().any(|(index, ability)| {
                     ability == ability_def
                         && mana_ability_ready_without_simulation(
@@ -3685,6 +3694,24 @@ mod tests {
         assert!(
             !siblings.contains(&phased),
             "phased-out mana sources must not batch (CR 702.26b)"
+        );
+        assert!(
+            !can_activate_mana_ability_now(&state, PlayerId(0), phased, 0, &def),
+            "phased-out mana sources must fail the readiness gate (CR 702.26b)"
+        );
+        let rejected = activate_mana_ability(
+            &mut state,
+            phased,
+            PlayerId(0),
+            0,
+            &def,
+            &mut events,
+            ManaAbilityResume::Priority,
+            None,
+        );
+        assert!(
+            matches!(rejected, Err(EngineError::ActionNotAllowed(_))),
+            "phased-out mana sources must fail executor activation (CR 702.26b)"
         );
     }
 


### PR DESCRIPTION
Addresses Gemini review feedback from merged PR #1651: https://github.com/phase-rs/phase/pull/1651#discussion_r3330183408

This moves the phased-out permanent gate into the shared mana readiness predicate and direct mana activation executor, so batching, can-activate filtering, and direct activation all enforce CR 702.26b.

Verification:
- cargo fmt --all --check
- cargo test -p engine game::mana_abilities::tests::batch_excludes_phased_out_mana_sibling --lib
- cargo clippy -p engine --lib -- -D warnings
- git diff --check