### PR TITLE
Guard phased-out mana checks to battlefield

### DIFF
--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1078,6 +1078,12 @@ impl GameObject {
         self.phase_status.is_phased_out()
     }
 
+    /// CR 702.26b: Only phased-out permanents on the battlefield are treated
+    /// as though they do not exist.
+    pub fn is_phased_out_permanent(&self) -> bool {
+        self.zone == Zone::Battlefield && self.is_phased_out()
+    }
+
     pub fn has_keyword_kind(&self, kind: KeywordKind) -> bool {
         super::keywords::has_keyword_kind(self, kind)
     }

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -395,7 +395,7 @@ pub fn activate_mana_ability(
         .ok_or_else(|| EngineError::InvalidAction("Mana ability source not found".to_string()))?;
     // CR 702.26b: Phased-out permanents are treated as though they do not
     // exist, so they cannot activate abilities.
-    if source.zone == Zone::Battlefield && source.is_phased_out() {
+    if source.is_phased_out_permanent() {
         return Err(EngineError::ActionNotAllowed(
             "Phased-out permanents cannot activate abilities (CR 702.26b)".to_string(),
         ));
@@ -910,7 +910,7 @@ fn mana_ability_ready_without_simulation(
     };
     // CR 702.26b: Phased-out permanents are treated as though they do not
     // exist, so they cannot activate abilities.
-    if obj.zone == Zone::Battlefield && obj.is_phased_out() {
+    if obj.is_phased_out_permanent() {
         return false;
     }
     // CR 701.35a: Detained permanents' activated abilities can't be activated.

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -395,7 +395,7 @@ pub fn activate_mana_ability(
         .ok_or_else(|| EngineError::InvalidAction("Mana ability source not found".to_string()))?;
     // CR 702.26b: Phased-out permanents are treated as though they do not
     // exist, so they cannot activate abilities.
-    if source.is_phased_out() {
+    if source.zone == Zone::Battlefield && source.is_phased_out() {
         return Err(EngineError::ActionNotAllowed(
             "Phased-out permanents cannot activate abilities (CR 702.26b)".to_string(),
         ));
@@ -910,7 +910,7 @@ fn mana_ability_ready_without_simulation(
     };
     // CR 702.26b: Phased-out permanents are treated as though they do not
     // exist, so they cannot activate abilities.
-    if obj.is_phased_out() {
+    if obj.zone == Zone::Battlefield && obj.is_phased_out() {
         return false;
     }
     // CR 701.35a: Detained permanents' activated abilities can't be activated.


### PR DESCRIPTION
Follow-up for Gemini review comments on merged PR #1658.

Fixes the phased-out mana activation gate so CR 702.26b only blocks objects while they are permanents on the battlefield. This preserves legitimate non-battlefield mana-ability checks for objects whose phased-out flag might be stale after a zone transition.

Gemini comments addressed:
- https://github.com/phase-rs/phase/pull/1658#discussion_r3330289178
- https://github.com/phase-rs/phase/pull/1658#discussion_r3330289182

Verification:
- `cargo fmt --all --check`
- `git diff --check`
- targeted test previously passed on the same commit before #1658 merged: `game::mana_abilities::tests::batch_excludes_phased_out_mana_sibling`

Review:
- review-impl: no blocking findings