### PR TITLE
ship/ai suggestions batch

### DIFF
--- a/crates/draft-wasm/src/suggest.rs
+++ b/crates/draft-wasm/src/suggest.rs
@@ -4,8 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use draft_core::types::{DeckAddableCardPolicy, DeckAddableCards, DraftCardInstance};
 use engine::database::CardDatabase;
+use engine::types::mana::ManaType;
 use phase_ai::config::AiDifficulty;
-use phase_ai::draft_eval;
+use phase_ai::{draft_eval, mana_colors};
 
 /// A suggested Limited deck: spell names + land distribution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -93,11 +94,88 @@ pub fn suggest_deck(
     // (e.g. 23 spells + 17 lands in `main_deck`, then +17 lands again = 57).
     let spell_names: Vec<String> = spells.iter().map(|c| c.name.clone()).collect();
     let land_total = min_deck_size.saturating_sub(spell_names.len()) as u8;
-    let lands = suggest_addable_cards(&spell_names, pool, land_total, addable_cards);
+
+    // Admit on-color drafted nonbasic fixing lands into the manabase — only under
+    // the standard basic-land fill (a custom addable-card policy supplies its own
+    // lands, so injecting nonbasics there would be wrong). Each admitted nonbasic
+    // replaces exactly one basic, so the deck total is unchanged.
+    let nonbasic_lands = if matches!(
+        addable_cards.policy,
+        DeckAddableCardPolicy::StandardBasics | DeckAddableCardPolicy::StandardBasicsPlusCustom
+    ) {
+        select_fixing_lands(pool, &best_colors, card_db, land_total)
+    } else {
+        HashMap::new()
+    };
+    let nonbasic_count: u8 = nonbasic_lands.values().copied().sum();
+    let basics_total = land_total.saturating_sub(nonbasic_count);
+    let mut lands = suggest_addable_cards(&spell_names, pool, basics_total, addable_cards);
+    for (name, count) in nonbasic_lands {
+        *lands.entry(name).or_insert(0) += count;
+    }
 
     SuggestedDeck {
         main_deck: spell_names,
         lands,
+    }
+}
+
+/// On-color drafted nonbasic fixing lands as a `name -> copy-count` map, capped at
+/// `cap` lands total. A fixing land is a drafted nonbasic that taps for 2+ colors
+/// (via basic land subtypes and/or `Effect::Mana` abilities — shared with draft
+/// pick value through [`mana_colors::land_produced_color_types`]) including at
+/// least one of the deck's colors. Each admitted copy is a real drafted entry, so
+/// copy counts never exceed what the drafter owns. Empty without a card database
+/// (produced colors can't be read from the printed type line alone).
+fn select_fixing_lands(
+    pool: &[DraftCardInstance],
+    best_colors: &[&str],
+    card_db: Option<&CardDatabase>,
+    cap: u8,
+) -> HashMap<String, u8> {
+    let Some(db) = card_db else {
+        return HashMap::new();
+    };
+    let mut result: HashMap<String, u8> = HashMap::new();
+    let mut admitted: u8 = 0;
+    for card in pool {
+        if admitted >= cap {
+            break;
+        }
+        if !is_land(card) {
+            continue;
+        }
+        let Some(face) = db.get_face_by_name(&card.name) else {
+            continue;
+        };
+        let colors =
+            mana_colors::land_produced_color_types(&face.card_type.subtypes, &face.abilities);
+        if colors.len() < 2 {
+            continue;
+        }
+        let on_color = colors
+            .iter()
+            .filter_map(|&t| mana_type_to_color_str(t))
+            .any(|s| best_colors.contains(&s));
+        if !on_color {
+            continue;
+        }
+        *result.entry(card.name.clone()).or_insert(0) += 1;
+        admitted += 1;
+    }
+    result
+}
+
+/// Map a produced `ManaType` to the "W/U/B/R/G" key the color logic uses;
+/// colorless has no color key.
+fn mana_type_to_color_str(t: ManaType) -> Option<&'static str> {
+    match t {
+        ManaType::White => Some("W"),
+        ManaType::Blue => Some("U"),
+        ManaType::Black => Some("B"),
+        ManaType::Red => Some("R"),
+        ManaType::Green => Some("G"),
+        ManaType::Colorless => None,
     }
 }
 
@@ -326,5 +404,124 @@ fn color_to_land(color: &str) -> &'static str {
         "R" => "Mountain",
         "G" => "Forest",
         _ => "Wastes",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn instance(name: &str, colors: &[&str], cmc: u8, type_line: &str) -> DraftCardInstance {
+        DraftCardInstance {
+            instance_id: format!("id-{name}"),
+            name: name.to_string(),
+            set_code: "TST".to_string(),
+            collector_number: "1".to_string(),
+            rarity: "common".to_string(),
+            colors: colors.iter().map(|s| s.to_string()).collect(),
+            cmc,
+            type_line: type_line.to_string(),
+        }
+    }
+
+    /// Card DB with four W/U creatures plus an on-color (Plains/Island) and an
+    /// off-color (Swamp/Mountain) typed dual. The duals carry no `Effect::Mana`;
+    /// their produced colors come from the basic land subtypes (true-dual shape).
+    fn fixture_db() -> CardDatabase {
+        let creature = |name: &str| {
+            format!(
+                r#""{name}": {{ "name": "{name}", "mana_cost": {{ "type": "NoCost" }},
+                "card_type": {{ "supertypes": [], "core_types": ["Creature"], "subtypes": [] }},
+                "power": "2", "toughness": "2", "loyalty": null, "defense": null,
+                "oracle_text": null, "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [], "keywords": [] }}"#
+            )
+        };
+        let dual = |name: &str, a: &str, b: &str| {
+            format!(
+                r#""{name}": {{ "name": "{name}", "mana_cost": {{ "type": "NoCost" }},
+                "card_type": {{ "supertypes": [], "core_types": ["Land"], "subtypes": ["{a}", "{b}"] }},
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [], "keywords": [] }}"#
+            )
+        };
+        let json = format!(
+            "{{ {}, {}, {}, {}, {}, {} }}",
+            creature("White Bear"),
+            creature("White Knight"),
+            creature("Blue Bird"),
+            creature("Blue Wizard"),
+            dual("On Color Dual", "Plains", "Island"),
+            dual("Off Color Dual", "Swamp", "Mountain"),
+        );
+        CardDatabase::from_json_str(&json).unwrap()
+    }
+
+    fn wu_pool() -> Vec<DraftCardInstance> {
+        vec![
+            instance("White Bear", &["W"], 2, "Creature — Bear"),
+            instance("White Knight", &["W"], 2, "Creature — Knight"),
+            instance("Blue Bird", &["U"], 1, "Creature — Bird"),
+            instance("Blue Wizard", &["U"], 3, "Creature — Wizard"),
+            instance("On Color Dual", &[], 0, "Land — Plains Island"),
+            instance("Off Color Dual", &[], 0, "Land — Swamp Mountain"),
+        ]
+    }
+
+    #[test]
+    fn admits_on_color_fixing_land_and_rejects_off_color() {
+        let db = fixture_db();
+        let deck = suggest_deck(
+            &wu_pool(),
+            AiDifficulty::Medium,
+            Some(&db),
+            8,
+            &DeckAddableCards::standard_basics(),
+        );
+        assert!(
+            deck.lands.contains_key("On Color Dual"),
+            "on-color (W/U) fixing land should be admitted to the manabase, got {:?}",
+            deck.lands
+        );
+        assert!(
+            !deck.lands.contains_key("Off Color Dual"),
+            "off-color (B/R) fixing land must not be admitted, got {:?}",
+            deck.lands
+        );
+    }
+
+    #[test]
+    fn admitting_nonbasics_keeps_deck_total_exact() {
+        let db = fixture_db();
+        let deck = suggest_deck(
+            &wu_pool(),
+            AiDifficulty::Medium,
+            Some(&db),
+            8,
+            &DeckAddableCards::standard_basics(),
+        );
+        let land_count: u32 = deck.lands.values().map(|&c| c as u32).sum();
+        // Each admitted nonbasic replaces one basic — the total never drifts.
+        assert_eq!(
+            deck.main_deck.len() as u32 + land_count,
+            8,
+            "spells + lands must equal min_deck_size; lands = {:?}",
+            deck.lands
+        );
+    }
+
+    #[test]
+    fn no_card_db_admits_no_nonbasics() {
+        // Without a card DB the produced colors are unknown, so no nonbasic is
+        // admitted (the manabase falls back to basics only).
+        let deck = suggest_deck(
+            &wu_pool(),
+            AiDifficulty::Medium,
+            None,
+            8,
+            &DeckAddableCards::standard_basics(),
+        );
+        assert!(!deck.lands.contains_key("On Color Dual"));
     }
 }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -16898,6 +16898,170 @@ mod tests {
         assert_eq!(state.players[0].life, 20);
     }
 
+    /// Auto-tap should spend a free colorless land row (card_tier 0) on the
+    /// generic part of a cost, preserving a pain-free colored dual whose
+    /// production a later shard might need. Cost {1}{G}: phase 1 taps the
+    /// Forest for {G} (fewest rows); phase 2's generic taps the brushland's
+    /// free {C} row (tier 0) rather than the dual (tier 1), leaving the dual
+    /// untapped.
+    #[test]
+    fn auto_tap_uses_colorless_row_for_generic_preserving_dual() {
+        let mut state = setup_game_at_main_phase();
+
+        // Spell costing {1}{G}.
+        let spell_id = create_single_color_spell_in_hand(
+            &mut state,
+            CardId(40),
+            "Test Generic Plus Green",
+            ManaCostShard::Green,
+        );
+        state.objects.get_mut(&spell_id).unwrap().mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 1,
+        };
+
+        // 1. Basic Forest — single {G} row.
+        let forest = add_basic_land(&mut state, CardId(41), "Forest", "Forest");
+
+        // 2. Pain-free dual producing {B} and {G} (penalty None) — inserted
+        //    BEFORE the brushland.
+        let dual = create_object(
+            &mut state,
+            CardId(42),
+            PlayerId(0),
+            "Pain-Free Dual".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&dual).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::AnyOneColor {
+                            count: QuantityExpr::Fixed { value: 1 },
+                            color_options: vec![ManaColor::Black, ManaColor::Green],
+                            contribution: ManaContribution::Base,
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+            );
+        }
+
+        // 3. Brushland-shape land (free {C} row + AnyOneColor{Green,White}),
+        //    penalty None — inserted AFTER the dual.
+        let brushland = add_brushland_like_land(&mut state, CardId(43), "Llanowar Wastes", false);
+
+        let mut events = Vec::new();
+        handle_cast_spell(&mut state, PlayerId(0), spell_id, CardId(40), &mut events).unwrap();
+
+        assert!(
+            !state.objects[&dual].tapped,
+            "auto-tap should preserve the pain-free dual by spending the free colorless row on generic"
+        );
+        assert!(
+            state.objects[&forest].tapped,
+            "Forest should pay the {{G}} shard"
+        );
+        assert!(
+            state.objects[&brushland].tapped,
+            "brushland's free colorless row should pay the generic"
+        );
+    }
+
+    /// Auto-tap should preserve a non-land creature mana dork (card_tier 3) as
+    /// a potential blocker (CR 509.1a) by spending an equivalent non-creature
+    /// rock (card_tier 2) instead. Cost {G}: the rock taps, the dork stays
+    /// untapped.
+    #[test]
+    fn auto_tap_prefers_rock_over_creature_dork() {
+        let mut state = setup_game_at_main_phase();
+
+        let spell_id = create_single_color_spell_in_hand(
+            &mut state,
+            CardId(44),
+            "Test Mono Green",
+            ManaCostShard::Green,
+        );
+
+        // 1. Mono-green creature dork (T: Add {G}) — inserted BEFORE the rock.
+        let dork = create_object(
+            &mut state,
+            CardId(45),
+            PlayerId(0),
+            "Green Dork".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&dork).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.summoning_sick = false;
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::Fixed {
+                            colors: vec![ManaColor::Green],
+                            contribution: ManaContribution::Base,
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+            );
+        }
+
+        // 2. Mono-green non-creature non-land rock (T: Add {G}).
+        let rock = create_object(
+            &mut state,
+            CardId(46),
+            PlayerId(0),
+            "Green Rock".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&rock).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::Fixed {
+                            colors: vec![ManaColor::Green],
+                            contribution: ManaContribution::Base,
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+            );
+        }
+
+        let mut events = Vec::new();
+        handle_cast_spell(&mut state, PlayerId(0), spell_id, CardId(44), &mut events).unwrap();
+
+        assert!(
+            state.objects[&rock].tapped,
+            "auto-tap should spend the rock for {{G}}"
+        );
+        assert!(
+            !state.objects[&dork].tapped,
+            "auto-tap should preserve the creature dork as a blocker"
+        );
+    }
+
     #[test]
     fn cancel_cast_during_target_selection_returns_to_priority() {
         use crate::game::engine::apply_as_current;

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1,8 +1,9 @@
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AdditionalCost, CardPlayMode,
     CastTimingPermission, CastingPermission, ChoiceType, ContinuousModification, Duration, Effect,
-    GameRestriction, ModalSelectionCondition, ProhibitedActivity, QuantityExpr, ResolvedAbility,
-    RestrictionPlayerScope, StaticDefinition, TargetFilter, TargetRef,
+    GameRestriction, ModalSelectionCondition, ObjectScope, PlayerScope, ProhibitedActivity,
+    QuantityExpr, QuantityRef, ResolvedAbility, RestrictionPlayerScope, StaticDefinition,
+    TargetFilter, TargetRef,
 };
 use crate::types::card::LayoutKind;
 use crate::types::events::GameEvent;
@@ -28,7 +29,8 @@ use super::ability_utils::{
     ability_target_legality_needs_chosen_x, assign_targets_in_chain, auto_select_targets,
     auto_select_targets_for_ability, begin_target_selection, begin_target_selection_for_ability,
     build_resolved_from_def, build_target_slots, compute_unavailable_modes,
-    flatten_targets_in_chain, has_legal_target_assignment_for_ability, modal_choice_for_player,
+    filter_references_target_player, flatten_targets_in_chain,
+    has_legal_target_assignment_for_ability, modal_choice_for_player,
     target_constraints_from_modal,
 };
 use super::casting_costs::{self, check_additional_cost_or_pay};
@@ -8247,6 +8249,96 @@ pub fn can_activate_ability_now(
     }
 }
 
+/// CR 608.2c: Evaluate an activated ability's intervening-if `condition` against
+/// the CURRENT game state, as it would be evaluated at resolution. Returns `None`
+/// when the ability has no condition (nothing is gated) or when the condition
+/// depends on resolution-time context that does not exist before activation
+/// (chosen targets, the cast/trigger event, mana spent, prior-effect amounts), so
+/// callers must treat only `Some(false)` as "the payoff is gated off right now".
+///
+/// This is a decision aid for AI value heuristics — e.g. to avoid paying a cost
+/// for a hideaway land's "play the exiled card if your creatures' total power is
+/// 10 or greater" when the threshold is unmet. The engine deliberately does NOT
+/// gate activation legality on this condition (CR 602.5 + the Shelldock Isle
+/// ruling: the ability is legal to activate regardless; only the effect is gated
+/// at resolution), so this must never be used as a legality gate.
+pub fn ability_condition_currently_met(
+    state: &GameState,
+    source_id: ObjectId,
+    ability_index: usize,
+) -> Option<bool> {
+    let obj = state.objects.get(&source_id)?;
+    let def = obj.abilities.get(ability_index)?;
+    let condition = def.condition.as_ref()?;
+    if !ability_condition_is_board_state_evaluable(condition) {
+        return None;
+    }
+    let resolved = build_resolved_from_def(def, source_id, obj.controller);
+    Some(crate::game::effects::evaluate_condition(
+        condition, state, &resolved,
+    ))
+}
+
+/// True when `condition` resolves purely from persistent board/controller state,
+/// so evaluating it before the ability is activated is meaningful (no chosen
+/// targets, no cast/trigger event, no spell context). Conservative by design: any
+/// shape not positively known to be board-state-only returns `false`, so callers
+/// decline to judge it rather than read uninitialized resolution context. Covers
+/// the hideaway / "Cost: do X if [board condition]" class (a `QuantityCheck` whose
+/// operands are board/controller-relative); extend the allowlist as new
+/// board-state condition shapes need pre-activation evaluation.
+fn ability_condition_is_board_state_evaluable(condition: &AbilityCondition) -> bool {
+    match condition {
+        AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
+            quantity_expr_is_board_state_relative(lhs) && quantity_expr_is_board_state_relative(rhs)
+        }
+        _ => false,
+    }
+}
+
+fn quantity_expr_is_board_state_relative(expr: &QuantityExpr) -> bool {
+    match expr {
+        QuantityExpr::Fixed { .. } => true,
+        QuantityExpr::Ref { qty } => quantity_ref_is_board_state_relative(qty),
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::Multiply { inner, .. } => quantity_expr_is_board_state_relative(inner),
+        QuantityExpr::Sum { exprs } => exprs.iter().all(quantity_expr_is_board_state_relative),
+        _ => false,
+    }
+}
+
+fn quantity_ref_is_board_state_relative(qty: &QuantityRef) -> bool {
+    // A player axis is concrete (resolvable now) unless it needs a chosen target
+    // or an outer scoped-player iteration context.
+    let player_is_concrete =
+        |p: &PlayerScope| !matches!(p, PlayerScope::Target | PlayerScope::ScopedPlayer);
+    match qty {
+        QuantityRef::HandSize { player }
+        | QuantityRef::LifeTotal { player }
+        | QuantityRef::GraveyardSize { player }
+        | QuantityRef::LifeLostThisTurn { player }
+        | QuantityRef::PartySize { player }
+        | QuantityRef::Speed { player } => player_is_concrete(player),
+        QuantityRef::LifeAboveStarting | QuantityRef::StartingLifeTotal => true,
+        QuantityRef::ObjectCount { filter }
+        | QuantityRef::ObjectCountDistinct { filter, .. }
+        | QuantityRef::CountersOnObjects { filter, .. }
+        | QuantityRef::Aggregate { filter, .. } => !filter_references_target_player(filter),
+        QuantityRef::CountersOn { scope, .. }
+        | QuantityRef::Power { scope }
+        | QuantityRef::Toughness { scope }
+        | QuantityRef::ObjectManaValue { scope }
+        | QuantityRef::ObjectColorCount { scope }
+        | QuantityRef::ObjectNameWordCount { scope } => matches!(scope, ObjectScope::Source),
+        // Conservative default: any ref not positively known to be
+        // board/controller-relative (Variable/X, target-relative scopes,
+        // cast/trigger-event context, etc.) makes the condition non-evaluable
+        // before activation, so the helper returns `None`.
+        _ => false,
+    }
+}
+
 /// CR 602.2: To activate an ability is to put it onto the stack and pay its costs.
 /// CR 602.2a: Only an object's controller can activate its activated ability unless
 /// the object specifically says otherwise.
@@ -9474,6 +9566,104 @@ mod tests {
             .cost(AbilityCost::Tap),
         );
         source
+    }
+
+    #[test]
+    fn ability_condition_currently_met_gates_on_board_relative_quantity() {
+        let mut state = GameState::new_two_player(42);
+        // Hideaway-shaped source: a {T}-cost ability gated by "creatures you
+        // control have total power 10 or greater" (Mosswort's condition shape).
+        let source = create_object(
+            &mut state,
+            CardId(80),
+            PlayerId(0),
+            "Hideaway".to_string(),
+            Zone::Battlefield,
+        );
+        let your_power_ge_10 = AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: crate::types::ability::AggregateFunction::Sum,
+                    property: crate::types::ability::ObjectProperty::Power,
+                    filter: TargetFilter::Typed(
+                        crate::types::ability::TypedFilter::default()
+                            .with_type(crate::types::ability::TypeFilter::Creature)
+                            .controller(crate::types::ability::ControllerRef::You),
+                    ),
+                },
+            },
+            comparator: crate::types::ability::Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 10 },
+        };
+        Arc::make_mut(&mut state.objects.get_mut(&source).unwrap().abilities).push(
+            AbilityDefinition::new(AbilityKind::Activated, Effect::Proliferate)
+                .cost(AbilityCost::Tap)
+                .condition(your_power_ge_10),
+        );
+
+        // No creatures → total power 0 < 10 → board-relative, gated off.
+        assert_eq!(
+            ability_condition_currently_met(&state, source, 0),
+            Some(false)
+        );
+
+        // A 12-power creature → condition now met.
+        let big = create_object(
+            &mut state,
+            CardId(81),
+            PlayerId(0),
+            "Giant".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let c = state.objects.get_mut(&big).unwrap();
+            c.card_types.core_types.push(CoreType::Creature);
+            c.base_power = Some(12);
+            c.power = Some(12);
+        }
+        assert_eq!(
+            ability_condition_currently_met(&state, source, 0),
+            Some(true)
+        );
+
+        // An ability with no condition → nothing gated → None.
+        let plain = create_object(
+            &mut state,
+            CardId(82),
+            PlayerId(0),
+            "Plain".to_string(),
+            Zone::Battlefield,
+        );
+        Arc::make_mut(&mut state.objects.get_mut(&plain).unwrap().abilities).push(
+            AbilityDefinition::new(AbilityKind::Activated, Effect::Proliferate)
+                .cost(AbilityCost::Tap),
+        );
+        assert_eq!(ability_condition_currently_met(&state, plain, 0), None);
+
+        // A target-relative condition can't be evaluated before targets exist →
+        // the allowlist declines it (None), so the policy never penalizes it.
+        let targeter = create_object(
+            &mut state,
+            CardId(83),
+            PlayerId(0),
+            "Targeter".to_string(),
+            Zone::Battlefield,
+        );
+        let target_life_ge_5 = AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::LifeTotal {
+                    player: PlayerScope::Target,
+                },
+            },
+            comparator: crate::types::ability::Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 5 },
+        };
+        Arc::make_mut(&mut state.objects.get_mut(&targeter).unwrap().abilities).push(
+            AbilityDefinition::new(AbilityKind::Activated, Effect::Proliferate)
+                .cost(AbilityCost::Tap)
+                .condition(target_life_ge_5),
+        );
+        assert_eq!(ability_condition_currently_met(&state, targeter, 0), None);
     }
 
     #[test]

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3736,13 +3736,15 @@ fn auto_tap_mana_sources_inner(
         .flatten()
         .collect();
 
-    // CR 605.3b: Auto-tap sort key. Tier layout (preserved from the
-    // pre-refactor sort; the enum factors the two scattered bool flags):
+    // CR 605.3b: Auto-tap sort key. Tier layout (the enum factors the two
+    // scattered bool flags):
     //   outer (tier_byte): 0 = non-sacrifice mana source; 1 = sacrifice-for-mana
     //     (source will not come back — always last).
-    //   middle (card_tier): 0 = pure land, 1 = non-land mana dork,
-    //     2 = land-creature (preserve for combat), 3 = deprioritized source
-    //     (spell's own source).
+    //   middle (card_tier): 0 = free-colorless land row (ideal generic filler);
+    //     1 = other land row; 2 = non-land non-creature rock (Signet);
+    //     3 = non-land creature dork (preserve as blocker); 4 = land-creature
+    //     manland (preserve as blocker); 5 = deprioritized source (spell's own
+    //     source).
     //   inner (priority_amount): penalty sub-tier + fixed-amount tiebreak
     //     (e.g. painland-1 < painland-2 < painland-None). Replaces the
     //     collapsed `harms_controller` bool — amounts now rank.
@@ -3754,14 +3756,29 @@ fn auto_tap_mana_sources_inner(
         let is_land = obj.is_some_and(|o| o.card_types.core_types.contains(&CoreType::Land));
         let is_creature =
             obj.is_some_and(|o| o.card_types.core_types.contains(&CoreType::Creature));
+        let row_is_free_colorless =
+            option.atomic_combination.is_none() && option.mana_type == ManaType::Colorless;
         let card_tier: u32 = if deprioritize_source == Some(option.object_id) {
-            3
+            5
         } else if is_land && is_creature {
-            2
-        } else if is_land {
+            // CR 509.1a: a chosen blocker must be untapped. An animated manland
+            // is a creature body — preserve it (and after a 1/1 dork: it is
+            // usually the bigger blocker, so it sorts after the dork).
+            4
+        } else if is_creature {
+            // CR 509.1a: preserve a non-land creature mana source (dork) as a
+            // blocker.
+            3
+        } else if is_land && row_is_free_colorless {
+            // Heuristic (no CR): a free colorless row is the ideal generic
+            // filler — it commits no colored production a later shard in this
+            // same payment needs.
             0
-        } else {
+        } else if is_land {
             1
+        } else {
+            // non-land non-creature mana source (rock / Signet)
+            2
         };
         (
             option.penalty.tier_byte() as u32,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2521,6 +2521,7 @@ fn fmt_modification(m: &crate::types::ability::ContinuousModification) -> String
         }
         ContinuousModification::AddAllCreatureTypes => "all creature types".into(),
         ContinuousModification::AddAllBasicLandTypes => "all basic land types".into(),
+        ContinuousModification::AddAllLandTypes => "all land types".into(),
         ContinuousModification::AddChosenSubtype { .. } => "add chosen subtype".into(),
         ContinuousModification::AddChosenColor => "add chosen color".into(),
         // CR 608.2d + CR 613.1f: Urborg / Walking Sponge — strip the

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2525,6 +2525,7 @@ fn depends_on(a: &ActiveContinuousEffect, b: &ActiveContinuousEffect, _state: &G
             | ContinuousModification::RemoveSupertype { .. }
             | ContinuousModification::AddAllCreatureTypes
             | ContinuousModification::AddAllBasicLandTypes
+            | ContinuousModification::AddAllLandTypes
             | ContinuousModification::AddChosenSubtype { .. }
             | ContinuousModification::SetBasicLandType { .. }
     );
@@ -2783,6 +2784,7 @@ fn modification_dynamic_quantity(m: &ContinuousModification) -> Option<&Quantity
         | ContinuousModification::RemoveAllSubtypes { .. }
         | ContinuousModification::AddAllCreatureTypes
         | ContinuousModification::AddAllBasicLandTypes
+        | ContinuousModification::AddAllLandTypes
         | ContinuousModification::AddChosenSubtype { .. }
         | ContinuousModification::AddChosenColor
         | ContinuousModification::RemoveChosenKeyword
@@ -3265,6 +3267,18 @@ fn apply_continuous_effect_filtered(
                     let subtype = land_type.as_subtype_str().to_string();
                     if !obj.card_types.subtypes.iter().any(|s| s == &subtype) {
                         obj.card_types.subtypes.push(subtype);
+                    }
+                }
+            }
+            // CR 205.3i: every land type is one of the 17 land subtypes.
+            // CR 305.7: a land that gains land types in addition to its own
+            // keeps its types and gains the new land types and their mana
+            // abilities. The basic types among the 17 grant their mana ability
+            // automatically via `apply_intrinsic_basic_land_mana_abilities`.
+            ContinuousModification::AddAllLandTypes => {
+                for subtype in crate::types::card_type::LAND_SUBTYPES {
+                    if !obj.card_types.subtypes.iter().any(|s| s == subtype) {
+                        obj.card_types.subtypes.push((*subtype).to_string());
                     }
                 }
             }
@@ -7049,6 +7063,131 @@ mod tests {
                 "Missing basic land type: {name}"
             );
         }
+    }
+
+    #[test]
+    fn omo_everything_counter_grants_all_land_and_creature_types() {
+        // CR 205.3i + CR 305.7 + CR 122.1: Omo, Queen of Vesuva.
+        // "Each land with an everything counter on it is every land type in
+        //  addition to its other types."
+        // "Each nonland creature with an everything counter on it is every
+        //  creature type."
+        // A land and a nonland creature each carrying an `everything` counter
+        // gain all land types / all creature types respectively; the basic land
+        // types also grant their intrinsic mana ability (CR 305.7). A land and
+        // creature WITHOUT the counter gain nothing (FilterProp::Counters
+        // affected-set gating drives the layer).
+        let mut state = setup();
+        state.all_creature_types = vec!["Bear".to_string(), "Goblin".to_string()];
+        let p0 = PlayerId(0);
+
+        // Counter filter shared by both statics.
+        let counter_prop = FilterProp::Counters {
+            counters: CounterMatch::OfType(CounterType::Generic("everything".to_string())),
+            comparator: crate::types::ability::Comparator::GE,
+            count: QuantityExpr::Fixed { value: 1 },
+        };
+
+        // Land WITH an everything counter (gains all land types).
+        let land_with = make_land(&mut state, "Plain Land", p0);
+        state
+            .objects
+            .get_mut(&land_with)
+            .unwrap()
+            .counters
+            .insert(CounterType::Generic("everything".to_string()), 1);
+        // Land WITHOUT the counter (mutation control — gains nothing).
+        let land_without = make_land(&mut state, "Bare Land", p0);
+
+        // Nonland creature WITH an everything counter (gains all creature types).
+        let creature_with = make_creature(&mut state, "Test Beast", 2, 2, p0);
+        state
+            .objects
+            .get_mut(&creature_with)
+            .unwrap()
+            .counters
+            .insert(CounterType::Generic("everything".to_string()), 1);
+        // Nonland creature WITHOUT the counter (mutation control).
+        let creature_without = make_creature(&mut state, "Bare Beast", 2, 2, p0);
+
+        // Omo's two statics as a single source.
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            p0,
+            "Omo, Queen of Vesuva".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let ts = state.next_timestamp();
+            let obj = state.objects.get_mut(&source_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.timestamp = ts;
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::land().properties(vec![counter_prop.clone()]),
+                    ))
+                    .modifications(vec![ContinuousModification::AddAllLandTypes]),
+            );
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::creature()
+                            .with_type(TypeFilter::Non(Box::new(TypeFilter::Land)))
+                            .properties(vec![counter_prop.clone()]),
+                    ))
+                    .modifications(vec![ContinuousModification::AddAllCreatureTypes]),
+            );
+        }
+
+        evaluate_layers(&mut state);
+
+        // Land with the counter has all 17 land subtypes (spot-check a spread).
+        let land = state.objects.get(&land_with).unwrap();
+        for name in ["Forest", "Island", "Desert", "Gate", "Locus"] {
+            assert!(
+                land.card_types.subtypes.contains(&name.to_string()),
+                "Counter land missing land type: {name}"
+            );
+        }
+        // CR 305.7: a basic land type among the 17 grants its intrinsic mana ability.
+        assert!(
+            has_basic_land_mana_ability(land, ManaColor::Green),
+            "Counter land should gain Forest's intrinsic {{T}}: Add {{G}} (CR 305.7)"
+        );
+
+        // Creature with the counter gains the global creature types.
+        let creature = state.objects.get(&creature_with).unwrap();
+        for name in &state.all_creature_types {
+            assert!(
+                creature.card_types.subtypes.contains(name),
+                "Counter creature missing creature type: {name}"
+            );
+        }
+
+        // Mutation check: objects WITHOUT the counter gain nothing.
+        let bare_land = state.objects.get(&land_without).unwrap();
+        assert!(
+            !bare_land
+                .card_types
+                .subtypes
+                .contains(&"Forest".to_string()),
+            "Land without the counter must NOT gain land types"
+        );
+        assert!(
+            !has_basic_land_mana_ability(bare_land, ManaColor::Green),
+            "Land without the counter must NOT gain a mana ability"
+        );
+        let bare_creature = state.objects.get(&creature_without).unwrap();
+        assert!(
+            !bare_creature
+                .card_types
+                .subtypes
+                .contains(&"Bear".to_string()),
+            "Creature without the counter must NOT gain creature types"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -480,6 +480,7 @@ fn walk_continuous_mod(modification: &ContinuousModification, out: &mut Vec<Stri
         | ContinuousModification::AddDynamicKeyword { .. }
         | ContinuousModification::AddAllCreatureTypes
         | ContinuousModification::AddAllBasicLandTypes
+        | ContinuousModification::AddAllLandTypes
         | ContinuousModification::AddChosenSubtype { .. }
         | ContinuousModification::AddChosenColor
         | ContinuousModification::RemoveChosenKeyword

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -1325,8 +1325,10 @@ mod tests {
 
         // "up to one" encodes optional targeting as a MultiTargetSpec with
         // min == 0 (CR 601.2c). The parsed clauses carry it via `multi_target`.
-        let is_optional =
-            |spec: &Option<MultiTargetSpec>| spec.as_ref().is_some_and(|s| s.min == 0);
+        let is_optional = |spec: &Option<MultiTargetSpec>| {
+            spec.as_ref()
+                .is_some_and(|s| matches!(s.min, QuantityExpr::Fixed { value: 0 }))
+        };
 
         // Primary clause: land target, up to one, optional.
         let Effect::PutCounter {

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -1311,6 +1311,74 @@ mod tests {
         );
     }
 
+    /// CR 122.1 + CR 115.1d: Omo, Queen of Vesuva's trigger effect —
+    /// "put an everything counter on each of up to one target land and up to
+    /// one target creature." Must produce TWO PutCounter siblings: the primary
+    /// (land target, up to one) and a chained sub_ability (creature target, up
+    /// to one), each optional. Neither may be `Unimplemented`.
+    #[test]
+    fn omo_dual_target_put_counter_emits_two_siblings() {
+        let def = super::super::parse_effect_chain(
+            "Put an everything counter on each of up to one target land and up to one target creature.",
+            crate::types::ability::AbilityKind::Spell,
+        );
+
+        // "up to one" encodes optional targeting as a MultiTargetSpec with
+        // min == 0 (CR 601.2c). The parsed clauses carry it via `multi_target`.
+        let is_optional =
+            |spec: &Option<MultiTargetSpec>| spec.as_ref().is_some_and(|s| s.min == 0);
+
+        // Primary clause: land target, up to one, optional.
+        let Effect::PutCounter {
+            ref counter_type,
+            target: ref land_target,
+            ..
+        } = *def.effect
+        else {
+            panic!("expected primary PutCounter, got {:?}", def.effect);
+        };
+        assert_eq!(
+            *counter_type,
+            CounterType::Generic("everything".to_string())
+        );
+        assert!(matches!(land_target, TargetFilter::Typed(_)));
+        assert!(
+            is_optional(&def.multi_target),
+            "primary land target must be optional (up to one)"
+        );
+
+        // Second sibling: creature target, up to one, optional.
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("expected a second PutCounter sub_ability");
+        let Effect::PutCounter {
+            counter_type: ref sub_counter,
+            target: ref creature_target,
+            ..
+        } = *sub.effect
+        else {
+            panic!(
+                "expected second PutCounter sub_ability, got {:?}",
+                sub.effect
+            );
+        };
+        assert_eq!(
+            *sub_counter,
+            CounterType::Generic("everything".to_string()),
+            "second sibling reuses the same counter type"
+        );
+        assert!(matches!(creature_target, TargetFilter::Typed(_)));
+        assert!(
+            is_optional(&sub.multi_target),
+            "second creature target must be optional (up to one)"
+        );
+
+        // Neither clause may be Unimplemented.
+        assert!(!matches!(*def.effect, Effect::Unimplemented { .. }));
+        assert!(!matches!(*sub.effect, Effect::Unimplemented { .. }));
+    }
+
     /// Sibling coverage: same dynamic-count phrase shape with a different
     /// quantity reference ("equal to the number of cards in your hand").
     /// Confirms the building block generalizes beyond just SelfPower.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7432,11 +7432,68 @@ fn try_split_targeted_compound(text: &str, ctx: &mut ParseContext) -> Option<Par
         }
     }
 
-    // CR 608.2c: Verb carry-forward for "up to N [other] target X" clauses in compound actions.
-    // When the sub-text starts with "up to" and parsed as Unimplemented, prepend
-    // the verb from the primary effect and re-parse. Handles "destroy target artifact
-    // or enchantment and up to one other target artifact or enchantment" (Relic Crush)
-    // where "up to one other target ..." lacks a verb.
+    // CR 122.1 + CR 115.6: Counter-clause carry-forward for a second targeted
+    // PutCounter conjunct. "put an everything counter on each of up to one
+    // target land and up to one target creature" (Omo, Queen of Vesuva) splits
+    // on " and " into the verbless sub-text "up to one target creature". The
+    // generic verb-only carry-forward below would reparse "put up to one target
+    // creature" — which has no counter phrase and stays Unimplemented. Instead,
+    // when the primary effect is a PutCounter, reuse its counter_type/count and
+    // build the second PutCounter sibling directly against the trailing target,
+    // carrying its own "up to N" multi_target. Mirrors `try_parse_tap_goad_compound`'s
+    // direct sub-effect construction.
+    if matches!(sub_clause.effect, Effect::Unimplemented { .. })
+        && tag::<_, _, OracleError<'_>>("up to ")
+            .parse(sub_lower.as_str())
+            .is_ok()
+    {
+        if let Effect::PutCounter {
+            counter_type,
+            count,
+            ..
+        } = &primary_effect
+        {
+            // CR 115.1d: strip the "up to N" / "each of up to N" cardinality from
+            // the sub-text and emit the corresponding MultiTargetSpec, mirroring
+            // `resolve_counter_placement_target`'s own up-to handling.
+            let (target_text, up_to_spec): (&str, Option<MultiTargetSpec>) =
+                if let Some(((), after_up_to)) =
+                    super::oracle_nom::bridge::nom_on_lower(sub_text, sub_lower.as_str(), |i| {
+                        value((), alt((tag("each of up to "), tag("up to ")))).parse(i)
+                    })
+                {
+                    match parse_multi_target_count_expr(
+                        &sub_lower[sub_lower.len() - after_up_to.len()..],
+                    ) {
+                        Ok((after_qty, max)) => (
+                            &sub_text[sub_text.len() - after_qty.len()..],
+                            Some(MultiTargetSpec::up_to(max)),
+                        ),
+                        Err(_) => (sub_text, None),
+                    }
+                } else {
+                    (sub_text, None)
+                };
+            let (sub_target, sub_rem) =
+                parse_target_with_ctx(target_text.trim_start(), &mut continuation_ctx);
+            if sub_rem.trim().is_empty() && !matches!(sub_target, TargetFilter::Any) {
+                sub_clause = ParsedEffectClause {
+                    effect: Effect::PutCounter {
+                        counter_type: counter_type.clone(),
+                        count: count.clone(),
+                        target: sub_target,
+                    },
+                    duration: None,
+                    sub_ability: None,
+                    distribute: None,
+                    multi_target: up_to_spec,
+                    condition: None,
+                    optional: false,
+                    unless_pay: None,
+                };
+            }
+        }
+    }
     if matches!(sub_clause.effect, Effect::Unimplemented { .. })
         && tag::<_, _, OracleError<'_>>("up to ")
             .parse(sub_lower.as_str())
@@ -7571,12 +7628,27 @@ fn try_split_targeted_compound(text: &str, ctx: &mut ParseContext) -> Option<Par
     // remains optional (e.g. "up to one other target artifact or enchantment").
     sub_ability.multi_target = sub_clause.multi_target;
 
+    // CR 115.1d: Recover the PRIMARY clause's "up to N" cardinality, which
+    // `try_parse_verb_and_target` discards when it lowers a PutCounter to a
+    // `ZoneCounterProxy`. Without this the primary target of e.g. Omo, Queen of
+    // Vesuva ("...on each of up to one target land and up to one target
+    // creature") would be wrongly mandatory. Re-derive it from the consumed
+    // primary-clause prefix via the same building block that produced it.
+    let primary_multi_target = if matches!(&primary_effect, Effect::PutCounter { .. }) {
+        let primary_clause = &text[..text.len() - remainder.len()];
+        let primary_lower = primary_clause.to_ascii_lowercase();
+        counter::try_parse_put_counter(&primary_lower, primary_clause, &mut ctx.clone())
+            .and_then(|(_, _, multi)| multi)
+    } else {
+        None
+    };
+
     Some(ParsedEffectClause {
         effect: primary_effect,
         duration: None,
         sub_ability: Some(Box::new(sub_ability)),
         distribute: None,
-        multi_target: None,
+        multi_target: primary_multi_target,
         condition: None,
         optional: false,
         unless_pay: None,

--- a/crates/engine/src/parser/oracle_static.rs
+++ b/crates/engine/src/parser/oracle_static.rs
@@ -4021,6 +4021,13 @@ pub(crate) fn parse_additive_type_clause_modifications(
     ) {
         return None;
     }
+    // CR 205.3i + CR 305.7: "is every land type in addition to its other types"
+    // grants all 17 land subtypes additively (Omo, Queen of Vesuva). The token
+    // is already combinator-extracted above; gate it against the fixed CR
+    // phrase here (mirrors the adjacent placeholder `matches!`).
+    if normalized_type_words == "every land type" {
+        return Some(vec![ContinuousModification::AddAllLandTypes]);
+    }
     let granted_lower = opt(preceded(
         alt((tag::<_, _, VE>(" and have "), tag::<_, _, VE>(" and has "))),
         rest::<_, VE>,
@@ -12003,10 +12010,7 @@ fn parse_land_type_change_subject(subject: &str) -> Option<TargetFilter> {
 /// dispatcher catches the residual subject shapes that those code paths
 /// don't strip, plus every self-reference grant.
 ///
-/// Returns None when the line's subject doesn't map to a recognized filter
-/// (e.g., "each nonland creature with an everything counter on it" — Omo,
-/// Queen of Vesuva — needs the same counter-filter parsing the land variant
-/// also lacks).
+/// Returns None when the line's subject doesn't map to a recognized filter.
 fn parse_all_creature_types_grant(tp: &TextPair<'_>, text: &str) -> Option<StaticDefinition> {
     let (subject_tp, rest_tp) = tp
         .split_around(" is every creature type")
@@ -12047,10 +12051,9 @@ fn parse_all_creature_types_grant(tp: &TextPair<'_>, text: &str) -> Option<Stati
 /// CR 205.3 + CR 613.1d: Map the subject of an "{is|are} every creature
 /// type" static into a TargetFilter restricting which battlefield objects
 /// receive the grant. Sibling of `parse_land_type_change_subject` for the
-/// CR 702.73a creature-type class. Complex filter subjects ("each nonland
-/// creature with an everything counter on it" — Omo) are intentionally not
-/// recognized here; their counter-filter parsing is a separate gap shared
-/// with the land variant.
+/// CR 702.73a creature-type class. Counter-conditioned subjects ("each nonland
+/// creature with an everything counter on it" — Omo, Queen of Vesuva) are
+/// handled by `parse_counter_conditioned_nonland_creature_subject`.
 fn parse_creature_type_change_subject(subject: &str) -> Option<TargetFilter> {
     // Combinator dispatch — each subject phrase maps to its TypedFilter
     // shape. `all_consuming` requires the whole subject to be matched, so a
@@ -12058,6 +12061,11 @@ fn parse_creature_type_change_subject(subject: &str) -> Option<TargetFilter> {
     // false-positive. "creatures" must come last among the bare-creature
     // arms so the longer "creatures you control" prefix wins first.
     all_consuming(alt((
+        // CR 205.3 + CR 122.1: "each nonland creature with an everything counter
+        // on it" (Omo, Queen of Vesuva). The nonland constraint reuses the
+        // existing `TypeFilter::Non` building block; the counter clause is
+        // delegated to `parse_counter_suffix`. No new engine surface.
+        parse_counter_conditioned_nonland_creature_subject,
         map(
             tag::<_, _, OracleError<'_>>("creatures you control"),
             |_| TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
@@ -12076,6 +12084,39 @@ fn parse_creature_type_change_subject(subject: &str) -> Option<TargetFilter> {
     .parse(subject)
     .ok()
     .map(|(_, filter)| filter)
+}
+
+/// CR 205.3 + CR 122.1: Parse "[each] nonland creature with an everything
+/// counter on it" into a creature `TypedFilter` carrying
+/// `TypeFilter::Non(Land)` plus the counter `FilterProp` produced by the shared
+/// `parse_counter_suffix` combinator. Used by Omo, Queen of Vesuva's
+/// "Each nonland creature with an everything counter on it is every creature
+/// type" — routes to `AddAllCreatureTypes` via `parse_all_creature_types_grant`.
+fn parse_counter_conditioned_nonland_creature_subject(
+    input: &str,
+) -> OracleResult<'_, TargetFilter> {
+    let (input, _) = opt(alt((
+        tag::<_, _, OracleError<'_>>("each "),
+        tag::<_, _, OracleError<'_>>("all "),
+    )))
+    .parse(input)?;
+    let (input, _) = tag("nonland ").parse(input)?;
+    let (input, _) = alt((tag("creatures"), tag("creature"))).parse(input)?;
+    let (input, _) = space1.parse(input)?;
+    // Delegate the counter clause (e.g. "with an everything counter on it") to
+    // the shared building block rather than re-implementing counter recognition.
+    let Some((counter_prop, consumed)) = parse_counter_suffix(input) else {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    };
+    let filter = TargetFilter::Typed(
+        TypedFilter::creature()
+            .with_type(TypeFilter::Non(Box::new(TypeFilter::Land)))
+            .properties(vec![counter_prop]),
+    );
+    Ok((&input[consumed..], filter))
 }
 
 /// CR 604.1: Strip turn-condition suffixes from predicate text.
@@ -19269,6 +19310,69 @@ mod tests {
 
         let mods_plural = parse_continuous_modifications("are every creature type");
         assert!(mods_plural.contains(&ContinuousModification::AddAllCreatureTypes));
+    }
+
+    #[test]
+    fn omo_land_every_land_type_is_add_all_land_types() {
+        // CR 205.3i + CR 305.7: Omo, Queen of Vesuva — "Each land with an
+        // everything counter on it is every land type in addition to its other
+        // types." Must produce the additive `AddAllLandTypes` marker, NOT a
+        // no-op `AddType { Land }`.
+        let def = parse_static_line(
+            "Each land with an everything counter on it is every land type in addition to its other types.",
+        )
+        .unwrap();
+        assert_eq!(def.mode, StaticMode::Continuous);
+        assert_eq!(
+            def.modifications,
+            vec![ContinuousModification::AddAllLandTypes]
+        );
+        // Regression guard: the old broken parse produced AddType { Land }.
+        assert!(!def
+            .modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::AddType { .. })));
+        // The affected subject carries the everything-counter FilterProp.
+        match &def.affected {
+            Some(TargetFilter::Typed(tf)) => {
+                assert!(tf.type_filters.contains(&TypeFilter::Land));
+                assert!(tf
+                    .properties
+                    .iter()
+                    .any(|p| matches!(p, FilterProp::Counters { .. })));
+            }
+            other => panic!("Expected Typed land with counter prop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn omo_nonland_creature_counter_subject_is_all_creature_types() {
+        // CR 205.3 + CR 122.1: Omo, Queen of Vesuva — "Each nonland creature
+        // with an everything counter on it is every creature type." The subject
+        // is a nonland creature gated on the everything counter; the grant is
+        // the existing `AddAllCreatureTypes` modification.
+        let def = parse_static_line(
+            "Each nonland creature with an everything counter on it is every creature type.",
+        )
+        .unwrap();
+        assert_eq!(def.mode, StaticMode::Continuous);
+        assert_eq!(
+            def.modifications,
+            vec![ContinuousModification::AddAllCreatureTypes]
+        );
+        match &def.affected {
+            Some(TargetFilter::Typed(tf)) => {
+                assert!(tf.type_filters.contains(&TypeFilter::Creature));
+                assert!(tf
+                    .type_filters
+                    .contains(&TypeFilter::Non(Box::new(TypeFilter::Land))));
+                assert!(tf
+                    .properties
+                    .iter()
+                    .any(|p| matches!(p, FilterProp::Counters { .. })));
+            }
+            other => panic!("Expected Typed nonland creature with counter prop, got {other:?}"),
+        }
     }
 
     // --- CantCastDuring: turn/phase-scoped casting prohibitions ---

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11238,6 +11238,10 @@ pub enum ContinuousModification {
     /// CR 305.6 + CR 305.7: Adds all five basic land types in addition to
     /// existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.
     AddAllBasicLandTypes,
+    /// CR 205.3i + CR 305.7: grants every land type (all 17 land subtypes) and
+    /// their mana abilities, additive. Distinct from AddAllBasicLandTypes
+    /// (CR 305.6, 5 basic types). Omo, Queen of Vesuva. Layer 4.
+    AddAllLandTypes,
     /// Adds the source object's chosen subtype (creature type or basic land type).
     /// Resolved at layer evaluation time from the source's `chosen_attributes`.
     AddChosenSubtype {

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -104,6 +104,7 @@ impl ContinuousModification {
             | ContinuousModification::RemoveSupertype { .. }
             | ContinuousModification::AddAllCreatureTypes
             | ContinuousModification::AddAllBasicLandTypes
+            | ContinuousModification::AddAllLandTypes
             | ContinuousModification::AddChosenSubtype { .. }
             | ContinuousModification::SetBasicLandType { .. } => Layer::Type, // CR 613.1d + CR 205.4b
             // CR 122.1 + CR 614.1c: One-shot counter placement at copy

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -80,6 +80,7 @@ mod mycoloth_upkeep_trigger;
 mod mystic_forge_regression;
 mod obliterate_regression;
 mod old_growth_troll_return_as_aura;
+mod omo_queen_of_vesuva;
 mod oracle_parser;
 mod oversimplify_per_player_fractal;
 mod peter_parker_modal_back_face_cast;

--- a/crates/engine/tests/integration/omo_queen_of_vesuva.rs
+++ b/crates/engine/tests/integration/omo_queen_of_vesuva.rs
@@ -1,0 +1,158 @@
+//! Full-pipeline integration test for Omo, Queen of Vesuva (M3C).
+//!
+//! Oracle text:
+//!   Whenever Omo enters or attacks, put an everything counter on each of up to
+//!   one target land and up to one target creature.
+//!   Each land with an everything counter on it is every land type in addition
+//!   to its other types.
+//!   Each nonland creature with an everything counter on it is every creature
+//!   type.
+//!
+//! This drives the REAL trigger -> counter -> layer pipeline:
+//!   cast Omo (0-cost) -> resolves onto the battlefield -> ETB trigger fires
+//!   through `process_triggers` -> `WaitingFor::TriggerTargetSelection` over a
+//!   land slot and a creature slot -> `SelectTargets` places an `everything`
+//!   counter on each -> layer evaluation grants the land every land type and
+//!   the creature every creature type.
+//!
+//! NOT a shape test: no synthetic `pending_trigger`, no hand-rolled counters,
+//! no hand-built `WaitingFor`. The two `PutCounter` siblings, the counter
+//! placement, and the continuous-type grants all run through `apply`.
+//!
+//! CR 122.1 (counters) + CR 205.3i / CR 305.7 (every land type + mana abilities)
+//! + CR 205.3 (every creature type) + CR 601.2c / CR 603.3d (target selection).
+
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaCost;
+use engine::types::player::PlayerId;
+
+const OMO_ORACLE: &str = "Whenever Omo enters or attacks, put an everything counter on \
+     each of up to one target land and up to one target creature.\n\
+     Each land with an everything counter on it is every land type in addition to its \
+     other types.\n\
+     Each nonland creature with an everything counter on it is every creature type.";
+
+const P0: PlayerId = PlayerId(0);
+
+fn everything_counter() -> CounterType {
+    CounterType::Generic("everything".to_string())
+}
+
+/// CR 122.1 + CR 205.3i + CR 305.7 + CR 205.3: Omo's ETB places an everything
+/// counter on a target land and a target creature; the resulting continuous
+/// statics make the land every land type (with mana abilities) and the creature
+/// every creature type.
+#[test]
+fn omo_etb_grants_all_land_and_creature_types_through_pipeline() {
+    let mut scenario = engine::game::scenario::GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+
+    // A vanilla land and a vanilla creature to receive the counters.
+    let forest = scenario.add_basic_land(P0, engine::types::mana::ManaColor::Green);
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    // Omo enters P0's hand as a 0-cost legendary creature so casting needs no
+    // mana prompt; its abilities parse from the real Oracle text.
+    let omo = scenario
+        .add_creature_to_hand_from_oracle(P0, "Omo, Queen of Vesuva", 3, 3, OMO_ORACLE)
+        .as_legendary()
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    // The scenario harness loads no deck, so the engine's global creature-type
+    // set (normally derived from the card pool in `deck_loading`) is empty.
+    // Seed it so `AddAllCreatureTypes` has a set to expand at layer evaluation,
+    // mirroring a real game's populated `all_creature_types`.
+    runner.state_mut().all_creature_types = vec![
+        "Bear".to_string(),
+        "Goblin".to_string(),
+        "Sliver".to_string(),
+    ];
+    let omo_card = runner.state().objects[&omo].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: omo,
+            card_id: omo_card,
+            targets: vec![],
+        })
+        .expect("casting a 0-cost legendary creature should succeed");
+    // Resolve Omo onto the battlefield so its ETB trigger fires.
+    runner.advance_until_stack_empty();
+
+    // The ETB trigger must pause on target selection (land slot + creature slot).
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "Omo's ETB must pause on TriggerTargetSelection, got {:?}",
+        runner.state().waiting_for
+    );
+
+    // Select the land for the land slot and the creature for the creature slot.
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![
+                engine::types::ability::TargetRef::Object(forest),
+                engine::types::ability::TargetRef::Object(bear),
+            ],
+        })
+        .expect("selecting a land and a creature target must succeed");
+    runner.advance_until_stack_empty();
+
+    // Both objects received an everything counter from the real resolution.
+    let forest_obj = runner.state().objects.get(&forest).expect("forest present");
+    assert!(
+        forest_obj
+            .counters
+            .get(&everything_counter())
+            .copied()
+            .unwrap_or(0)
+            >= 1,
+        "land should have an everything counter; counters = {:?}",
+        forest_obj.counters
+    );
+    let bear_obj = runner.state().objects.get(&bear).expect("bear present");
+    assert!(
+        bear_obj
+            .counters
+            .get(&everything_counter())
+            .copied()
+            .unwrap_or(0)
+            >= 1,
+        "creature should have an everything counter; counters = {:?}",
+        bear_obj.counters
+    );
+
+    // CR 205.3i + CR 305.7: the land is now every land type (spot-check a
+    // spread of basic + nonbasic types) and gains a basic-land mana ability.
+    let forest_obj = runner.state().objects.get(&forest).expect("forest present");
+    for name in [
+        "Forest", "Island", "Swamp", "Mountain", "Plains", "Desert", "Gate", "Locus",
+    ] {
+        assert!(
+            forest_obj.card_types.subtypes.contains(&name.to_string()),
+            "land missing land type {name}; subtypes = {:?}",
+            forest_obj.card_types.subtypes
+        );
+    }
+
+    // CR 205.3: the nonland creature is now every creature type — assert it
+    // carries the game's global creature-type set.
+    let bear_obj = runner.state().objects.get(&bear).expect("bear present");
+    let all_creature_types = runner.state().all_creature_types.clone();
+    assert!(
+        !all_creature_types.is_empty(),
+        "game state must expose the global creature-type set"
+    );
+    for ct in &all_creature_types {
+        assert!(
+            bear_obj.card_types.subtypes.contains(ct),
+            "creature missing creature type {ct}"
+        );
+    }
+}

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -33,7 +33,14 @@ pub fn choose_attackers_with_targets(
     state: &GameState,
     player: PlayerId,
 ) -> Vec<(ObjectId, AttackTarget)> {
-    choose_attackers_with_targets_with_profile(state, player, &AiProfile::default(), false, None)
+    choose_attackers_with_targets_with_profile(
+        state,
+        player,
+        &AiProfile::default(),
+        false,
+        None,
+        None,
+    )
 }
 
 pub fn choose_attackers_with_targets_with_profile(
@@ -42,6 +49,7 @@ pub fn choose_attackers_with_targets_with_profile(
     profile: &AiProfile,
     combat_lookahead: bool,
     valid_attacker_ids: Option<&[ObjectId]>,
+    valid_attack_targets: Option<&[AttackTarget]>,
 ) -> Vec<(ObjectId, AttackTarget)> {
     let opponents = players::opponents(state, player);
     if opponents.is_empty() {
@@ -116,6 +124,7 @@ pub fn choose_attackers_with_targets_with_profile(
 
         let is_unblockable = has_cant_be_blocked(state, obj);
         let has_lifelink = obj.has_keyword(&Keyword::Lifelink);
+        let is_commander = obj.is_commander;
 
         if is_unblockable || opponent_blockers.is_empty() {
             attacking_ids.push(id);
@@ -143,7 +152,8 @@ pub fn choose_attackers_with_targets_with_profile(
                     favorable_trade,
                     has_lifelink,
                     my_power,
-                    profile,
+                    attacker_survives,
+                    is_commander,
                 ) {
                     attacking_ids.push(id);
                 }
@@ -162,21 +172,44 @@ pub fn choose_attackers_with_targets_with_profile(
             CombatObjective::PreserveAdvantage | CombatObjective::Race
         )
     {
-        let mut valued: Vec<(ObjectId, f64)> = candidates
+        // CR 903.8: exclude the commander from the desperation alpha-strike for
+        // the same reason the per-creature gate does — don't trade it away.
+        // Alpha-strike only fires under PreserveAdvantage|Race when the per-loop
+        // gate rejected every candidate, so any commander here was a
+        // `!free_damage` rejection: `is_commander` is equivalent to the loop's
+        // `is_commander && !free_damage && objective != PushLethal`. Filter
+        // BEFORE the cost/benefit math so unblocked_power/worst_loss_value match
+        // the actual swing set. (A goaded commander is re-added by the
+        // must-attack union below, which runs after this block.)
+        let alpha_candidates: Vec<ObjectId> = candidates
             .iter()
-            .map(|&id| (id, evaluate_creature(state, id)))
+            .copied()
+            .filter(|&id| {
+                !state
+                    .objects
+                    .get(&id)
+                    .map(|o| o.is_commander)
+                    .unwrap_or(false)
+            })
             .collect();
-        valued.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
 
-        let blocked_count = opponent_blockers.len();
-        let unblocked_power: i32 = valued[blocked_count..]
-            .iter()
-            .filter_map(|&(id, _)| state.objects.get(&id)?.power)
-            .sum();
-        let worst_loss_value: f64 = valued[..blocked_count].iter().map(|&(_, v)| v).sum();
+        if alpha_candidates.len() > opponent_blockers.len() {
+            let mut valued: Vec<(ObjectId, f64)> = alpha_candidates
+                .iter()
+                .map(|&id| (id, evaluate_creature(state, id)))
+                .collect();
+            valued.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
 
-        if unblocked_power as f64 > worst_loss_value {
-            attacking_ids = candidates.clone();
+            let blocked_count = opponent_blockers.len();
+            let unblocked_power: i32 = valued[blocked_count..]
+                .iter()
+                .filter_map(|&(id, _)| state.objects.get(&id)?.power)
+                .sum();
+            let worst_loss_value: f64 = valued[..blocked_count].iter().map(|&(_, v)| v).sum();
+
+            if unblocked_power as f64 > worst_loss_value {
+                attacking_ids = alpha_candidates;
+            }
         }
     }
 
@@ -259,14 +292,115 @@ pub fn choose_attackers_with_targets_with_profile(
         }
     }
 
-    // Single opponent: all attackers go to the same target
+    // Single opponent: attackers go to the player, except a "kill it or ignore
+    // it" planeswalker redirect (see redirect_attackers_to_planeswalker).
     if opponents.len() == 1 {
-        let target = AttackTarget::Player(opponents[0]);
-        return attacking_ids.into_iter().map(|id| (id, target)).collect();
+        let opp = opponents[0];
+        let opponent_life = state.players[opp.0 as usize].life;
+        return redirect_attackers_to_planeswalker(
+            state,
+            &attacking_ids,
+            valid_attack_targets,
+            objective,
+            opp,
+            opponent_life,
+        );
     }
 
-    // Multi-opponent: assign attack targets
+    // Multi-opponent: assign attack targets (planeswalker redirect deferred).
     assign_attack_targets(state, player, &opponents, attacking_ids)
+}
+
+/// Single-opponent planeswalker redirect (CR 508.1: legality of attacking a
+/// planeswalker is decided by the engine, which surfaces every legal target in
+/// `valid_attack_targets` — this only *chooses* among them).
+///
+/// Policy: when not pushing lethal and the full swing isn't near-lethal at the
+/// face, redirect the *fewest large* attackers needed to KILL the
+/// highest-loyalty opponent planeswalker (largest-power-first), provided at
+/// least one attacker still hits the player. Otherwise every attacker goes to
+/// the player. "Kill it or ignore it" — never dribble partial loyalty damage,
+/// never empty the face, never dilute a lethal race. Loyalty is a rough
+/// entrenchment proxy, not a true threat score (deferred refinement).
+fn redirect_attackers_to_planeswalker(
+    state: &GameState,
+    attacking_ids: &[ObjectId],
+    valid_attack_targets: Option<&[AttackTarget]>,
+    objective: CombatObjective,
+    opponent: PlayerId,
+    opponent_life: i32,
+) -> Vec<(ObjectId, AttackTarget)> {
+    let player_target = AttackTarget::Player(opponent);
+    let all_at_player = || -> Vec<(ObjectId, AttackTarget)> {
+        attacking_ids
+            .iter()
+            .map(|&id| (id, player_target))
+            .collect()
+    };
+
+    // Don't dilute a lethal / near-lethal swing at the face.
+    if objective == CombatObjective::PushLethal {
+        return all_at_player();
+    }
+    let total_power: i32 = attacking_ids
+        .iter()
+        .filter_map(|&id| state.objects.get(&id)?.power)
+        .sum();
+    if total_power >= opponent_life {
+        return all_at_player();
+    }
+
+    // Highest-loyalty attackable opponent planeswalker from the engine's list.
+    let Some(targets) = valid_attack_targets else {
+        return all_at_player();
+    };
+    let best_pw = targets
+        .iter()
+        .filter_map(|t| match t {
+            AttackTarget::Planeswalker(id) => {
+                let loyalty = state.objects.get(id)?.loyalty.unwrap_or(0);
+                (loyalty > 0).then_some((*id, loyalty as i32))
+            }
+            _ => None,
+        })
+        .max_by_key(|&(_, loyalty)| loyalty);
+    let Some((pw_id, loyalty)) = best_pw else {
+        return all_at_player();
+    };
+
+    // Largest-power-first: the fewest big attackers that sum to >= loyalty.
+    let mut by_power: Vec<(ObjectId, i32)> = attacking_ids
+        .iter()
+        .filter_map(|&id| Some((id, state.objects.get(&id)?.power.unwrap_or(0))))
+        .collect();
+    by_power.sort_by_key(|b| std::cmp::Reverse(b.1));
+
+    let mut redirected: Vec<ObjectId> = Vec::new();
+    let mut acc: i32 = 0;
+    for (id, power) in &by_power {
+        if acc >= loyalty {
+            break;
+        }
+        redirected.push(*id);
+        acc += power;
+    }
+
+    // Kill-it-or-ignore-it: bail if we can't kill it or doing so empties the face.
+    if acc < loyalty || redirected.len() == attacking_ids.len() {
+        return all_at_player();
+    }
+
+    let pw_target = AttackTarget::Planeswalker(pw_id);
+    attacking_ids
+        .iter()
+        .map(|&id| {
+            if redirected.contains(&id) {
+                (id, pw_target)
+            } else {
+                (id, player_target)
+            }
+        })
+        .collect()
 }
 
 fn preferred_attack_opponent(
@@ -1011,11 +1145,27 @@ fn should_attack_given_objective(
     favorable_trade: bool,
     has_lifelink: bool,
     attacker_power: i32,
-    _profile: &AiProfile,
+    attacker_survives: bool,
+    is_commander: bool,
 ) -> bool {
-    // Lifelink creates a life swing: opponent loses N, you gain N = 2N effective swing.
-    // This makes marginal attacks worthwhile, especially while racing.
-    let lifelink_bonus = has_lifelink && attacker_power > 0;
+    // CR 903.8: a commander recast from the command zone costs an extra {2} per
+    // prior cast (commander tax), and trading it away surrenders the player's
+    // most valuable permanent. Don't trade the commander in combat — only swing
+    // it into a block when it survives (free_damage) or when pushing lethal.
+    // Unblockable / no-blocker commander swings are handled by the earlier
+    // branch (before this function is reached), so this only suppresses trades.
+    if is_commander && !free_damage && objective != CombatObjective::PushLethal {
+        return false;
+    }
+    // CR 702.15b: lifelink gains life whenever the creature *deals* combat
+    // damage — including a value-unfavorable simultaneous trade, and a
+    // first-strike pinger that then dies. So life IS still gained on a bad
+    // trade; this is a VALUE decision, not a rules claim: don't let the lifelink
+    // swing justify throwing the creature away for nothing (it dies, the blocker
+    // lives, no kill). Pursue the swing only when the attack is otherwise
+    // non-losing — free damage, a favorable trade, or the attacker survives.
+    let lifelink_bonus =
+        has_lifelink && attacker_power > 0 && (free_damage || favorable_trade || attacker_survives);
     match objective {
         CombatObjective::PushLethal => true,
         CombatObjective::Stabilize => free_damage || lifelink_bonus,
@@ -1568,6 +1718,32 @@ mod tests {
         obj.keywords = keywords;
         obj.entered_battlefield_turn = Some(1);
         id
+    }
+
+    /// Battlefield planeswalker for `owner` with the given starting loyalty.
+    /// Used to drive the planeswalker-attack redirect through the real engine
+    /// path: `get_valid_attack_targets` classifies it as an attackable PW.
+    fn add_planeswalker(state: &mut GameState, owner: PlayerId, loyalty: u32) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(state.next_object_id),
+            owner,
+            "Planeswalker".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Planeswalker);
+        obj.loyalty = Some(loyalty);
+        obj.entered_battlefield_turn = Some(1);
+        id
+    }
+
+    /// Engine-derived legal attack targets — the same list the live
+    /// `WaitingFor::DeclareAttackers` carries. Deriving from the engine (rather
+    /// than hand-building) proves the engine offers the PW and the AI consumes
+    /// it, not just that the AI routes to a target we injected.
+    fn valid_targets(state: &GameState) -> Vec<AttackTarget> {
+        engine::game::combat::get_valid_attack_targets(state)
     }
 
     /// Issue #484 (P0) — E2E: a goaded creature the value heuristic would skip
@@ -2747,6 +2923,253 @@ mod tests {
         assert!(
             !blockers.is_empty(),
             "5/5 wall must block 3/3 bear; got empty assignment"
+        );
+    }
+
+    // ───────────────────────── #8 lifelink block correctness ─────────────────
+
+    /// #8: a lifelinker must NOT attack into a pure loss (it dies, the blocker
+    /// lives, no kill) just for the life swing. Discriminating: reverting the
+    /// `(free_damage || favorable_trade || attacker_survives)` gate in
+    /// `should_attack_given_objective` flips this — the old code attacked.
+    #[test]
+    fn lifelink_does_not_attack_into_pure_loss() {
+        let mut state = setup();
+        let lifelinker = add_creature(
+            &mut state,
+            PlayerId(0),
+            "Vamp",
+            2,
+            2,
+            vec![Keyword::Lifelink],
+        );
+        // 3/4 wall: kills the 2/2, survives (2 < 4). Pure loss.
+        add_creature(&mut state, PlayerId(1), "Wall", 3, 4, vec![]);
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        assert!(
+            !attacks.iter().any(|(id, _)| *id == lifelinker),
+            "lifelinker must not be thrown into a pure-loss block for life gain"
+        );
+    }
+
+    /// #8 guard (don't over-correct): a lifelinker that SURVIVES the block (2/5
+    /// into a 3/3 — survives, deals 2, gains 2) should still attack. Confirms
+    /// the gate only suppresses pure losses, not all lifelink swings.
+    #[test]
+    fn lifelink_still_attacks_when_surviving() {
+        let mut state = setup();
+        let lifelinker = add_creature(
+            &mut state,
+            PlayerId(0),
+            "Vamp",
+            2,
+            5,
+            vec![Keyword::Lifelink],
+        );
+        add_creature(&mut state, PlayerId(1), "Bear", 3, 3, vec![]);
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        assert!(
+            attacks.iter().any(|(id, _)| *id == lifelinker),
+            "a surviving lifelinker should still attack"
+        );
+    }
+
+    // ───────────────────────── #6 commander trade avoidance ──────────────────
+
+    /// #6: the AI must not trade its commander into an even block (both die),
+    /// forcing commander tax — while a vanilla creature in the same spot SHOULD
+    /// trade. Discriminating: removing the commander gate makes the commander
+    /// attack (the 3/3-vs-3/3 is a `favorable_trade`).
+    #[test]
+    fn commander_does_not_trade_into_equal_block() {
+        let mut state = setup();
+        let commander = add_creature(&mut state, PlayerId(0), "General", 3, 3, vec![]);
+        state.objects.get_mut(&commander).unwrap().is_commander = true;
+        let bear = add_creature(&mut state, PlayerId(0), "Bear", 3, 3, vec![]);
+        add_creature(&mut state, PlayerId(1), "Blocker", 3, 3, vec![]);
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        assert!(
+            !attacks.iter().any(|(id, _)| *id == commander),
+            "commander must not trade into an equal block"
+        );
+        assert!(
+            attacks.iter().any(|(id, _)| *id == bear),
+            "a vanilla creature in the same spot should still trade"
+        );
+    }
+
+    /// B1 regression: the commander must also be excluded from the desperation
+    /// ALPHA-STRIKE fallback (which re-adds the whole candidate set). A swarm of
+    /// bears still alpha-strikes; the commander stays home. Discriminating:
+    /// reverting to `attacking_ids = candidates.clone()` re-adds the commander.
+    #[test]
+    fn commander_excluded_from_alpha_strike() {
+        let mut state = setup();
+        let commander = add_creature(&mut state, PlayerId(0), "General", 2, 2, vec![]);
+        state.objects.get_mut(&commander).unwrap().is_commander = true;
+        // Five 3/3 bears: enough excess unblocked power to justify the
+        // alpha-strike even after the single 0/4 wall "blocks" one body.
+        let mut bears = Vec::new();
+        for _ in 0..5 {
+            bears.push(add_creature(&mut state, PlayerId(0), "Bear", 3, 3, vec![]));
+        }
+        add_creature(&mut state, PlayerId(1), "Wall", 0, 4, vec![]);
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        assert!(
+            !attacks.iter().any(|(id, _)| *id == commander),
+            "commander must be excluded from the alpha-strike swing"
+        );
+        assert!(
+            bears.iter().any(|b| attacks.iter().any(|(id, _)| id == b)),
+            "the bear swarm should still alpha-strike (the swing fires without the commander)"
+        );
+    }
+
+    // ───────────────────────── #5 attacking planeswalkers ────────────────────
+
+    /// #5: with no lethal/near-lethal at the face, redirect the FEWEST large
+    /// attackers needed to kill the opp planeswalker (largest-power-first),
+    /// leaving the rest on the player. PW + targets derived from the engine.
+    #[test]
+    fn redirects_fewest_bodies_to_planeswalker() {
+        let mut state = setup();
+        let big = add_creature(&mut state, PlayerId(0), "Ogre", 5, 5, vec![]);
+        let small_a = add_creature(&mut state, PlayerId(0), "Cub", 2, 2, vec![]);
+        let small_b = add_creature(&mut state, PlayerId(0), "Cub", 2, 2, vec![]);
+        let pw = add_planeswalker(&mut state, PlayerId(1), 3);
+        let targets = valid_targets(&state);
+
+        let attacks = choose_attackers_with_targets_with_profile(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            false,
+            None,
+            Some(&targets),
+        );
+
+        // The lone 5/5 (>= loyalty 3) goes at the planeswalker; the 2/2s at the player.
+        assert_eq!(
+            attacks.iter().find(|(id, _)| *id == big).map(|(_, t)| *t),
+            Some(AttackTarget::Planeswalker(pw)),
+            "the fewest-bodies killing subset (the 5/5) should hit the planeswalker"
+        );
+        for cub in [small_a, small_b] {
+            assert_eq!(
+                attacks.iter().find(|(id, _)| *id == cub).map(|(_, t)| *t),
+                Some(AttackTarget::Player(PlayerId(1))),
+                "spare attackers stay on the player"
+            );
+        }
+    }
+
+    /// #5 guard: if the swing can't KILL the planeswalker, don't dribble — send
+    /// everyone at the player.
+    #[test]
+    fn does_not_redirect_when_cannot_kill_pw() {
+        let mut state = setup();
+        add_creature(&mut state, PlayerId(0), "Cub", 2, 2, vec![]);
+        add_creature(&mut state, PlayerId(0), "Cub", 2, 2, vec![]);
+        add_planeswalker(&mut state, PlayerId(1), 6); // 4 total power < 6 loyalty
+        let targets = valid_targets(&state);
+
+        let attacks = choose_attackers_with_targets_with_profile(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            false,
+            None,
+            Some(&targets),
+        );
+        assert!(
+            attacks
+                .iter()
+                .all(|(_, t)| matches!(t, AttackTarget::Player(_))),
+            "can't-kill planeswalker → no dribble, all at player"
+        );
+    }
+
+    /// #5 guard: never empty the face — a lone attacker that could kill the PW
+    /// still goes at the player.
+    #[test]
+    fn does_not_redirect_when_would_empty_face() {
+        let mut state = setup();
+        add_creature(&mut state, PlayerId(0), "Ogre", 5, 5, vec![]);
+        add_planeswalker(&mut state, PlayerId(1), 3);
+        let targets = valid_targets(&state);
+
+        let attacks = choose_attackers_with_targets_with_profile(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            false,
+            None,
+            Some(&targets),
+        );
+        assert!(
+            attacks
+                .iter()
+                .all(|(_, t)| matches!(t, AttackTarget::Player(_))),
+            "redirecting the only attacker would empty the face → stay on player"
+        );
+    }
+
+    /// #5 guard: don't dilute a near-lethal swing (raw power >= opp life) into a
+    /// planeswalker, even when not formally PushLethal (a blocker is present).
+    #[test]
+    fn does_not_redirect_when_near_lethal() {
+        let mut state = setup();
+        state.players[1].life = 6;
+        add_creature(&mut state, PlayerId(0), "Brute", 4, 4, vec![]);
+        add_creature(&mut state, PlayerId(0), "Brute", 4, 4, vec![]);
+        add_creature(&mut state, PlayerId(1), "Chump", 0, 1, vec![]); // blocker → not PushLethal
+        add_planeswalker(&mut state, PlayerId(1), 3);
+        let targets = valid_targets(&state);
+
+        let attacks = choose_attackers_with_targets_with_profile(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            false,
+            None,
+            Some(&targets),
+        );
+        assert!(
+            attacks
+                .iter()
+                .any(|(_, t)| matches!(t, AttackTarget::Player(PlayerId(1)))),
+            "near-lethal swing should pressure the player, not the planeswalker"
+        );
+        assert!(
+            !attacks
+                .iter()
+                .any(|(_, t)| matches!(t, AttackTarget::Planeswalker(_))),
+            "no attacker should be diverted to the planeswalker when near-lethal"
+        );
+    }
+
+    /// #5 regression: no planeswalker present → targeting is unchanged (player).
+    #[test]
+    fn no_pw_target_single_opponent_unchanged() {
+        let mut state = setup();
+        let bear = add_creature(&mut state, PlayerId(0), "Bear", 3, 3, vec![]);
+        let targets = valid_targets(&state);
+
+        let attacks = choose_attackers_with_targets_with_profile(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            false,
+            None,
+            Some(&targets),
+        );
+        assert_eq!(
+            attacks.iter().find(|(id, _)| *id == bear).map(|(_, t)| *t),
+            Some(AttackTarget::Player(PlayerId(1))),
         );
     }
 }

--- a/crates/phase-ai/src/draft_eval.rs
+++ b/crates/phase-ai/src/draft_eval.rs
@@ -60,6 +60,10 @@ pub struct DraftWeights {
     pub static_ability_each: f64,
     /// Cap on the total static-ability bonus.
     pub static_ability_cap: f64,
+    /// Flat bonus for a nonbasic fixing land (taps for 2+ colors). A dual/tri
+    /// land is playable in any deck running those colors, so it carries real
+    /// pick value — but below spells/removal, since fixing is a support piece.
+    pub fixing_land: f64,
 }
 
 impl Default for DraftWeights {
@@ -79,6 +83,9 @@ impl Default for DraftWeights {
             search: 0.5,
             static_ability_each: 0.75,
             static_ability_cap: 2.0,
+            // ~card-draw value: above a filler creature, below a 2/2 (~3.5),
+            // removal (4), and a bomb — bots take fixing mid-pack, not over playables.
+            fixing_land: 2.0,
         }
     }
 }
@@ -104,11 +111,19 @@ pub fn evaluate_draft_card(face: &CardFace, w: &DraftWeights) -> f64 {
     let is_creature = core.contains(&CoreType::Creature);
     let is_planeswalker = core.contains(&CoreType::Planeswalker);
 
-    // A land with no nonland type carries no spell value. Checked *after* the
-    // creature/planeswalker tests so Land Creatures (Dryad Arbor) and creature/PW
-    // manlands are scored on their bodies, not zeroed as bare lands.
+    // A pure land carries no spell value, but a fixing land (taps for 2+ colors)
+    // is a real pick — duals/tri-lands slot into any deck running those colors.
+    // Mono-color nonbasics, colorless utility lands, and basics stay at 0 (not
+    // worth a pick over a spell). Checked *after* the creature/planeswalker tests
+    // so Land Creatures (Dryad Arbor) and creature/PW manlands score on their
+    // bodies. Deck-color matching ("in their colors") is a deck-context concern
+    // handled at the call sites, not here — this is the context-free quality.
     if !is_creature && !is_planeswalker && core.contains(&CoreType::Land) {
-        return 0.0;
+        return if produced_color_count(face) >= 2 {
+            w.fixing_land
+        } else {
+            0.0
+        };
     }
 
     // ── Effect-chain value ──────────────────────────────────────────────
@@ -168,6 +183,14 @@ pub fn evaluate_draft_card_default(face: &CardFace) -> f64 {
     evaluate_draft_card(face, &DraftWeights::default())
 }
 
+/// Count of distinct colors this face can produce — unioning intrinsic mana from
+/// its basic land subtypes and its activated `Effect::Mana` abilities. `>= 2`
+/// marks a fixing land. Delegates to the shared [`crate::mana_colors`] core so
+/// draft pick value and the deck-builder manabase agree on what "fixing" means.
+pub fn produced_color_count(face: &CardFace) -> usize {
+    crate::mana_colors::land_produced_color_types(&face.card_type.subtypes, &face.abilities).len()
+}
+
 /// Extract a fixed power/toughness value, ignoring `*` / variable / derived stats.
 fn fixed_pt(pt: &Option<PtValue>) -> Option<i32> {
     match pt {
@@ -180,11 +203,12 @@ fn fixed_pt(pt: &Option<PtValue>) -> Option<i32> {
 mod tests {
     use super::*;
     use engine::types::ability::{
-        AbilityDefinition, AbilityKind, Effect, TargetFilter, TriggerDefinition,
+        AbilityDefinition, AbilityKind, Effect, ManaContribution, ManaProduction, QuantityExpr,
+        TargetFilter, TriggerDefinition,
     };
     use engine::types::card_type::CardType;
     use engine::types::keywords::Keyword;
-    use engine::types::mana::ManaCost;
+    use engine::types::mana::{ManaColor, ManaCost};
     use engine::types::triggers::TriggerMode;
     use engine::types::zones::Zone;
 
@@ -291,5 +315,80 @@ mod tests {
         let mut dryad_arbor = vanilla_creature(1, 1, 0);
         dryad_arbor.card_type.core_types = vec![CoreType::Land, CoreType::Creature];
         assert!(evaluate_draft_card_default(&dryad_arbor) > 0.0);
+    }
+
+    fn land_with_subtypes(subtypes: &[&str]) -> CardFace {
+        let mut f = face(vec![CoreType::Land]);
+        f.card_type.subtypes = subtypes.iter().map(|s| s.to_string()).collect();
+        f
+    }
+
+    fn tap_for(colors: Vec<ManaColor>) -> AbilityDefinition {
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::Fixed {
+                    colors,
+                    contribution: ManaContribution::Base,
+                },
+                restrictions: Vec::new(),
+                grants: Vec::new(),
+                expiry: None,
+                target: None,
+            },
+        )
+    }
+
+    #[test]
+    fn fixing_land_via_basic_subtypes_scores_positive() {
+        // A true dual (Land — Plains Island) makes W+U via its types, no Effect::Mana.
+        let dual = land_with_subtypes(&["Plains", "Island"]);
+        assert_eq!(produced_color_count(&dual), 2);
+        assert_eq!(
+            evaluate_draft_card_default(&dual),
+            DraftWeights::default().fixing_land
+        );
+    }
+
+    #[test]
+    fn fixing_land_via_mana_abilities_scores_positive() {
+        // A painland-style land with two colored tap abilities.
+        let mut painland = face(vec![CoreType::Land]);
+        painland.abilities = vec![
+            tap_for(vec![ManaColor::White]),
+            tap_for(vec![ManaColor::Blue]),
+        ];
+        assert_eq!(produced_color_count(&painland), 2);
+        assert_eq!(
+            evaluate_draft_card_default(&painland),
+            DraftWeights::default().fixing_land
+        );
+    }
+
+    #[test]
+    fn mono_color_nonbasic_land_scores_zero() {
+        let mono = land_with_subtypes(&["Forest"]);
+        assert_eq!(produced_color_count(&mono), 1);
+        assert_eq!(evaluate_draft_card_default(&mono), 0.0);
+    }
+
+    #[test]
+    fn colorless_only_land_scores_zero() {
+        // Produces only {C} → no colored sources → not a fixing pick.
+        let mut utility = face(vec![CoreType::Land]);
+        utility.abilities = vec![AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::Colorless {
+                    count: QuantityExpr::Fixed { value: 1 },
+                },
+                restrictions: Vec::new(),
+                grants: Vec::new(),
+                expiry: None,
+                target: None,
+            },
+        )];
+        assert_eq!(produced_color_count(&utility), 0);
+        assert_eq!(evaluate_draft_card_default(&utility), 0.0);
     }
 }

--- a/crates/phase-ai/src/lib.rs
+++ b/crates/phase-ai/src/lib.rs
@@ -14,6 +14,7 @@ pub mod draft_eval;
 pub mod duel_suite;
 pub mod eval;
 pub mod features;
+pub mod mana_colors;
 pub mod plan;
 pub mod planner;
 pub mod policies;

--- a/crates/phase-ai/src/mana_colors.rs
+++ b/crates/phase-ai/src/mana_colors.rs
@@ -1,0 +1,93 @@
+//! Shared mana-color extraction: which colors a land can produce.
+//!
+//! One building block used by both draft fixing-land evaluation
+//! (`draft_eval::produced_color_count`) and the mulligan land-count keepables
+//! (`policies::mulligan::keepables_by_land_count`). Operates on *parts*
+//! (`subtypes` + `abilities`) so a `GameObject` view and a `CardFace` view share
+//! a single implementation, mirroring the `*_parts` pattern in `features`.
+
+use engine::game::mana_payment::land_subtype_to_mana_type;
+use engine::game::mana_sources::mana_color_to_type;
+use engine::types::ability::{AbilityDefinition, AbilityKind, Effect, ManaProduction};
+use engine::types::mana::ManaType;
+
+/// Distinct colored-mana types a land can produce, unioning (a) intrinsic mana
+/// from its basic land subtypes (a typed dual like "Land — Plains Island" makes
+/// W and U with no printed `Effect::Mana`) and (b) the colors of every activated
+/// `Effect::Mana` ability (painlands, filter lands, etc.). Colorless never counts
+/// as a color, so the length is the count of *colored* sources — `>= 2` marks a
+/// fixing land.
+pub fn land_produced_color_types(
+    subtypes: &[String],
+    abilities: &[AbilityDefinition],
+) -> Vec<ManaType> {
+    let mut colors = Vec::new();
+    for subtype in subtypes {
+        if let Some(mana_type) = land_subtype_to_mana_type(subtype) {
+            push_color(&mut colors, mana_type);
+        }
+    }
+    for ability in abilities {
+        if ability.kind != AbilityKind::Activated {
+            continue;
+        }
+        let Effect::Mana { produced, .. } = &*ability.effect else {
+            continue;
+        };
+        collect_mana_production_colors(&mut colors, produced);
+    }
+    colors
+}
+
+/// Union the colors of a single `ManaProduction` into `colors` (deduplicated,
+/// colorless excluded). Exhaustive over every `ManaProduction` variant: the
+/// statically-known producers (Fixed/Mixed/AnyOneColor/AnyCombination, and the
+/// filter-land `ChoiceAmongCombinations`) contribute their colors; the dynamic
+/// producers (chosen/opponent/commander-identity/etc.) and pure Colorless
+/// contribute nothing, since their colors aren't known from the card alone.
+pub(crate) fn collect_mana_production_colors(
+    colors: &mut Vec<ManaType>,
+    produced: &ManaProduction,
+) {
+    match produced {
+        ManaProduction::Fixed {
+            colors: produced, ..
+        }
+        | ManaProduction::Mixed {
+            colors: produced, ..
+        }
+        | ManaProduction::AnyOneColor {
+            color_options: produced,
+            ..
+        }
+        | ManaProduction::AnyCombination {
+            color_options: produced,
+            ..
+        } => {
+            for color in produced {
+                push_color(colors, mana_color_to_type(color));
+            }
+        }
+        ManaProduction::ChoiceAmongCombinations { options } => {
+            for option in options {
+                for color in option {
+                    push_color(colors, mana_color_to_type(color));
+                }
+            }
+        }
+        ManaProduction::Colorless { .. }
+        | ManaProduction::ChosenColor { .. }
+        | ManaProduction::OpponentLandColors { .. }
+        | ManaProduction::AnyTypeProduceableBy { .. }
+        | ManaProduction::ChoiceAmongExiledColors { .. }
+        | ManaProduction::AnyInCommandersColorIdentity { .. }
+        | ManaProduction::DistinctColorsAmongPermanents { .. }
+        | ManaProduction::TriggerEventManaType => {}
+    }
+}
+
+fn push_color(colors: &mut Vec<ManaType>, mana_type: ManaType) {
+    if mana_type != ManaType::Colorless && !colors.contains(&mana_type) {
+        colors.push(mana_type);
+    }
+}

--- a/crates/phase-ai/src/policies/condition_gated_activation.rs
+++ b/crates/phase-ai/src/policies/condition_gated_activation.rs
@@ -1,0 +1,299 @@
+//! Condition-gated activation tactical policy.
+//!
+//! Report (Discord #ai-suggestions, "Mosswort Bridge"): the AI activates a
+//! hideaway land's payoff ability (`{G}, {T}: You may play the exiled card
+//! without paying its mana cost if creatures you control have total power 10 or
+//! greater`) every turn even when it has far less than 10 power, burning mana
+//! and the tap for an effect that does nothing.
+//!
+//! The engine is rules-correct: per CR 602.5 (and the Shelldock Isle ruling) the
+//! hideaway payoff ability is *legal* to activate under the threshold — only the
+//! `CastFromZone` effect is gated, and it correctly does nothing at resolution
+//! (CR 608.2c) when the condition is false. So this is purely an AI-value miss:
+//! paying a cost for an activation whose entire payoff is currently gated off.
+//!
+//! This penalizes activating any ability whose top-level intervening-if
+//! `condition` evaluates false right now, so `PassPriority` (or a better line)
+//! wins. It generalizes across the whole class of "Cost: do X if [board
+//! condition]" activated abilities — every hideaway land (Shelldock Isle,
+//! Windbrisk Heights, Spinerock Knoll, Howltooth Hollow, Mosswort Bridge) and
+//! beyond — not a single card.
+//!
+//! Condition evaluation is delegated to the engine
+//! (`ability_condition_currently_met`), which only judges board/controller-
+//! relative conditions and returns `None` for anything that needs resolution-time
+//! context (chosen targets, the cast/trigger event). A soft penalty (not a hard
+//! `Reject`) is used because an ability's *cost* can change the very thing its
+//! condition checks (e.g. a sacrifice cost that makes "if you control no
+//! creatures" true at resolution); the condition here is read pre-cost, so the
+//! AI may still take such a line if strongly favored.
+
+use engine::game::casting::ability_condition_currently_met;
+use engine::types::actions::GameAction;
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::features::DeckFeatures;
+
+/// Penalty for activating an ability whose entire payoff is gated behind a
+/// currently-false condition. Modest — enough to lose to `PassPriority` when
+/// nothing else pushes the activation (mirrors `EquipmentPriority`'s
+/// no-better-home penalty), never an absolute veto.
+const CONDITION_UNMET_PENALTY: f64 = 2.5;
+
+pub struct ConditionGatedActivationPolicy;
+
+impl TacticalPolicy for ConditionGatedActivationPolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::ConditionGatedActivation
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::ActivateAbility]
+    }
+
+    fn activation(
+        &self,
+        _features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        // Applies to every deck; the verdict's condition guard self-gates.
+        // activation-constant: conditional-payoff activation check, universal.
+        Some(1.0)
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let score = |delta: f64, kind: &'static str| PolicyVerdict::Score {
+            delta,
+            reason: PolicyReason::new(kind),
+        };
+
+        let GameAction::ActivateAbility {
+            source_id,
+            ability_index,
+        } = &ctx.candidate.action
+        else {
+            return score(0.0, "condition_gated_na");
+        };
+
+        // Only matters when activating costs something — paying a cost for a
+        // gated-off payoff is the waste being avoided. Free activations are
+        // harmless even when the condition is unmet.
+        let has_cost = ctx
+            .state
+            .objects
+            .get(source_id)
+            .and_then(|obj| obj.abilities.get(*ability_index))
+            .is_some_and(|def| def.cost.is_some());
+        if !has_cost {
+            return score(0.0, "condition_gated_ok");
+        }
+
+        // CR 608.2c: delegate the intervening-if evaluation to the engine. Only
+        // `Some(false)` — the payoff is provably gated off right now — is penalized.
+        match ability_condition_currently_met(ctx.state, *source_id, *ability_index) {
+            Some(false) => score(-CONDITION_UNMET_PENALTY, "condition_gated_payoff_unmet"),
+            _ => score(0.0, "condition_gated_ok"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::game::zones::create_object;
+    use engine::types::ability::{
+        AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction,
+        Comparator, ControllerRef, Effect, ObjectProperty, QuantityExpr, QuantityRef, TargetFilter,
+        TypeFilter, TypedFilter,
+    };
+    use engine::types::card_type::CoreType;
+    use engine::types::game_state::{GameState, WaitingFor};
+    use engine::types::identifiers::{CardId, ObjectId};
+    use engine::types::mana::{ManaCost, ManaCostShard};
+    use engine::types::zones::Zone;
+    use std::sync::Arc;
+
+    use crate::config::AiConfig;
+    use crate::context::AiContext;
+
+    const AI: PlayerId = PlayerId(0);
+
+    /// "Sum of power of creatures you control" — Mosswort's condition operand.
+    fn your_creatures_power_ge(threshold: i32) -> AbilityCondition {
+        AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: AggregateFunction::Sum,
+                    property: ObjectProperty::Power,
+                    filter: TargetFilter::Typed(
+                        TypedFilter::default()
+                            .with_type(TypeFilter::Creature)
+                            .controller(ControllerRef::You),
+                    ),
+                },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: threshold },
+        }
+    }
+
+    /// A permanent with one activated ability: `{G}, {T}: <effect>` gated by an
+    /// optional `condition`. Models Mosswort's hideaway payoff shape.
+    fn source_with_gated_ability(
+        state: &mut GameState,
+        condition: Option<AbilityCondition>,
+        with_cost: bool,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(1),
+            AI,
+            "Hideaway".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Land);
+        // The effect kind is irrelevant — the policy keys off cost + condition.
+        let mut def = AbilityDefinition::new(AbilityKind::Activated, Effect::Proliferate);
+        if with_cost {
+            def.cost = Some(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::Green],
+                    generic: 0,
+                },
+            });
+        }
+        def.condition = condition;
+        Arc::make_mut(&mut obj.abilities).push(def);
+        id
+    }
+
+    /// A vanilla creature with the given power (to drive the Sum-power condition).
+    fn creature(state: &mut GameState, power: i32) -> ObjectId {
+        let id = create_object(state, CardId(2), AI, "Bear".to_string(), Zone::Battlefield);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_power = Some(power);
+        obj.power = Some(power);
+        obj.base_toughness = Some(power);
+        obj.toughness = Some(power);
+        id
+    }
+
+    fn activate_verdict(state: &GameState, source_id: ObjectId) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id,
+                ability_index: 0,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Ability,
+            },
+        };
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let config = AiConfig::default();
+        let context = AiContext::empty(&config.weights);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        ConditionGatedActivationPolicy.verdict(&ctx)
+    }
+
+    fn assert_score(verdict: PolicyVerdict, kind: &str, delta: f64) {
+        match verdict {
+            PolicyVerdict::Score { delta: d, reason } => {
+                assert_eq!(reason.kind, kind, "reason kind");
+                assert_eq!(d, delta, "delta");
+            }
+            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+        }
+    }
+
+    #[test]
+    fn gated_activation_penalized_when_condition_unmet() {
+        let mut state = GameState::new_two_player(42);
+        // Two 3-power creatures → total power 6 < 10 (a real, non-vacuous <10).
+        creature(&mut state, 3);
+        creature(&mut state, 3);
+        let source = source_with_gated_ability(&mut state, Some(your_creatures_power_ge(10)), true);
+        assert_score(
+            activate_verdict(&state, source),
+            "condition_gated_payoff_unmet",
+            -CONDITION_UNMET_PENALTY,
+        );
+    }
+
+    #[test]
+    fn gated_activation_ok_when_condition_met() {
+        let mut state = GameState::new_two_player(42);
+        // Two 6-power creatures → total power 12 >= 10.
+        creature(&mut state, 6);
+        creature(&mut state, 6);
+        let source = source_with_gated_ability(&mut state, Some(your_creatures_power_ge(10)), true);
+        assert_score(activate_verdict(&state, source), "condition_gated_ok", 0.0);
+    }
+
+    #[test]
+    fn unconditional_activation_na() {
+        let mut state = GameState::new_two_player(42);
+        let source = source_with_gated_ability(&mut state, None, true);
+        assert_score(activate_verdict(&state, source), "condition_gated_ok", 0.0);
+    }
+
+    /// A free (no-cost) gated ability is not penalized — there's no wasted cost.
+    #[test]
+    fn free_gated_activation_not_penalized() {
+        let mut state = GameState::new_two_player(42);
+        creature(&mut state, 3);
+        let source =
+            source_with_gated_ability(&mut state, Some(your_creatures_power_ge(10)), false);
+        assert_score(activate_verdict(&state, source), "condition_gated_ok", 0.0);
+    }
+
+    #[test]
+    fn non_activate_decision_na() {
+        let state = GameState::new_two_player(42);
+        let candidate = CandidateAction {
+            action: GameAction::PassPriority,
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Pass,
+            },
+        };
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let config = AiConfig::default();
+        let context = AiContext::empty(&config.weights);
+        let ctx = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        assert_score(
+            ConditionGatedActivationPolicy.verdict(&ctx),
+            "condition_gated_na",
+            0.0,
+        );
+    }
+}

--- a/crates/phase-ai/src/policies/equipment_priority.rs
+++ b/crates/phase-ai/src/policies/equipment_priority.rs
@@ -1,0 +1,284 @@
+//! Equipment equip-priority tactical policy.
+//!
+//! Report (Discord #ai-suggestions): the AI "spends all remaining mana every
+//! turn moving an Equipment from one creature to another for no reason." It
+//! re-activates an equip ability when the equipment is already on a perfectly
+//! good creature, burning mana for no board improvement.
+//!
+//! The AI reaches equip via `GameAction::ActivateAbility` on the equipment's
+//! equip ability (effect `Effect::Attach`), where mana is committed and
+//! `PassPriority` is a sibling candidate — NOT via the human-UI
+//! `GameAction::Equip`/`WaitingFor::EquipTarget` path. So this policy fires on
+//! the activation and penalizes it when the equipment is already on the best
+//! available body, making the AI keep its mana.
+//!
+//! It never *rewards* equipping (the reported problem is over-equipping); fresh
+//! equips and genuine upgrades are neutral, leaving eval/other policies to
+//! decide. The only thing penalized is a re-equip with no bigger body to move
+//! to.
+//!
+//! CR 301.5: Equipment can be attached only to creatures (its host is always a
+//! creature), so the "bigger body" comparison is over creatures you control.
+
+use engine::types::ability::Effect;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::features::DeckFeatures;
+
+/// Penalty for activating an equip ability when the equipment is already on the
+/// best body (no own creature out-base-powers the current host). Modest — large
+/// enough to make `PassPriority` win when nothing else pushes the re-equip.
+const NO_BETTER_HOME_PENALTY: f64 = 2.0;
+
+pub struct EquipmentPriorityPolicy;
+
+impl TacticalPolicy for EquipmentPriorityPolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::EquipmentPriority
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::ActivateAbility]
+    }
+
+    fn activation(
+        &self,
+        _features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        // Applies to every deck; the verdict's equipment+Attach guard self-gates.
+        // activation-constant: equipment equip-or-not decision, universal.
+        Some(1.0)
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let score = |delta: f64, kind: &'static str| PolicyVerdict::Score {
+            delta,
+            reason: PolicyReason::new(kind),
+        };
+        let na = || score(0.0, "equipment_priority_na");
+
+        let (source_id, ability_index) = match &ctx.candidate.action {
+            GameAction::ActivateAbility {
+                source_id,
+                ability_index,
+            } => (*source_id, *ability_index),
+            _ => return na(),
+        };
+
+        let Some(equip) = ctx.state.objects.get(&source_id) else {
+            return na();
+        };
+        if !equip.card_types.subtypes.iter().any(|s| s == "Equipment") {
+            return na();
+        }
+        let Some(ability) = equip.abilities.get(ability_index) else {
+            return na();
+        };
+        // The equip ability lowers to Effect::Attach (verified via card-data).
+        if !matches!(&*ability.effect, Effect::Attach { .. }) {
+            return na();
+        }
+
+        // Unattached → a fresh equip is fine; stay neutral.
+        let Some(host_id) = equip.attached_to.as_ref().and_then(|a| a.as_object()) else {
+            return score(0.0, "equipment_equip_fresh");
+        };
+
+        // Compare BASE power: the host's live `power` already includes this
+        // equipment's own +P buff (folded in via `attached_to` in the layer
+        // system), which would make the host spuriously out-power every bare
+        // upgrade target. base_power is the printed baseline — the correct
+        // "which body is bigger" proxy, consistent on both sides.
+        let host_base = ctx
+            .state
+            .objects
+            .get(&host_id)
+            .and_then(|o| o.base_power)
+            .unwrap_or(0);
+        let best_other_base = ctx
+            .state
+            .battlefield
+            .iter()
+            .filter(|&&id| id != host_id)
+            .filter_map(|&id| {
+                let o = ctx.state.objects.get(&id)?;
+                if o.controller != ctx.ai_player
+                    || !o.card_types.core_types.contains(&CoreType::Creature)
+                {
+                    return None;
+                }
+                o.base_power
+            })
+            .max()
+            .unwrap_or(i32::MIN);
+
+        if best_other_base > host_base {
+            // A genuinely bigger body to move to — allow the upgrade.
+            score(0.0, "equipment_upgrade_available")
+        } else {
+            // Already on the best body — don't burn mana shuffling.
+            score(-NO_BETTER_HOME_PENALTY, "equipment_no_better_home")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::game::game_object::AttachTarget;
+    use engine::game::zones::create_object;
+    use engine::types::ability::{AbilityDefinition, AbilityKind, QuantityExpr, TargetFilter};
+    use engine::types::game_state::{GameState, WaitingFor};
+    use engine::types::identifiers::{CardId, ObjectId};
+    use engine::types::zones::Zone;
+    use std::sync::Arc;
+
+    use crate::config::AiConfig;
+    use crate::context::AiContext;
+
+    const AI: PlayerId = PlayerId(0);
+
+    /// An Equipment object with one activated equip ability (`Effect::Attach`).
+    fn equipment(state: &mut GameState) -> ObjectId {
+        let id = create_object(state, CardId(1), AI, "Sword".to_string(), Zone::Battlefield);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.card_types.subtypes.push("Equipment".to_string());
+        Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Attach {
+                attachment: TargetFilter::SelfRef,
+                target: TargetFilter::Any,
+            },
+        ));
+        id
+    }
+
+    fn creature(state: &mut GameState, base_power: i32) -> ObjectId {
+        let id = create_object(state, CardId(2), AI, "Bear".to_string(), Zone::Battlefield);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_power = Some(base_power);
+        obj.power = Some(base_power);
+        obj.base_toughness = Some(base_power);
+        obj.toughness = Some(base_power);
+        id
+    }
+
+    /// Attach `equip` to `host` and apply the equip's `+buff/+0` to the host's
+    /// LIVE power (mirroring the layer system) so tests exercise the
+    /// base-vs-live distinction.
+    fn attach(state: &mut GameState, equip: ObjectId, host: ObjectId, live_buff: i32) {
+        state.objects.get_mut(&equip).unwrap().attached_to = Some(AttachTarget::Object(host));
+        let h = state.objects.get_mut(&host).unwrap();
+        h.power = Some(h.power.unwrap_or(0) + live_buff);
+    }
+
+    fn equip_verdict(state: &GameState, equip: ObjectId) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id: equip,
+                ability_index: 0,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Ability,
+            },
+        };
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let config = AiConfig::default();
+        let context = AiContext::empty(&config.weights);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        EquipmentPriorityPolicy.verdict(&ctx)
+    }
+
+    fn assert_score(verdict: PolicyVerdict, kind: &str, delta: f64) {
+        match verdict {
+            PolicyVerdict::Score { delta: d, reason } => {
+                assert_eq!(reason.kind, kind, "reason kind");
+                assert_eq!(d, delta, "delta");
+            }
+            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+        }
+    }
+
+    #[test]
+    fn unattached_equip_not_penalized() {
+        let mut state = GameState::new_two_player(42);
+        let equip = equipment(&mut state);
+        creature(&mut state, 3);
+        assert_score(equip_verdict(&state, equip), "equipment_equip_fresh", 0.0);
+    }
+
+    #[test]
+    fn reequip_no_better_home_penalized() {
+        let mut state = GameState::new_two_player(42);
+        let equip = equipment(&mut state);
+        let host = creature(&mut state, 3);
+        creature(&mut state, 2); // smaller alternative
+        attach(&mut state, equip, host, 2);
+        assert_score(
+            equip_verdict(&state, equip),
+            "equipment_no_better_home",
+            -NO_BETTER_HOME_PENALTY,
+        );
+    }
+
+    /// B1 trap: a +2/+0 equip on a base-2 host (LIVE power 4) with a base-3
+    /// creature present. Using base_power, the 3 out-powers the host's base 2 →
+    /// upgrade allowed. Comparing LIVE power (4 > 3) would wrongly penalize.
+    #[test]
+    fn equip_upgrade_allowed() {
+        let mut state = GameState::new_two_player(42);
+        let equip = equipment(&mut state);
+        let host = creature(&mut state, 2);
+        creature(&mut state, 3); // bigger base body
+        attach(&mut state, equip, host, 2); // host live power becomes 4
+        assert_score(
+            equip_verdict(&state, equip),
+            "equipment_upgrade_available",
+            0.0,
+        );
+    }
+
+    #[test]
+    fn non_equip_activation_na() {
+        let mut state = GameState::new_two_player(42);
+        let id = create_object(
+            &mut state,
+            CardId(3),
+            AI,
+            "Rock".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        ));
+        assert_score(equip_verdict(&state, id), "equipment_priority_na", 0.0);
+    }
+}

--- a/crates/phase-ai/src/policies/land_sequencing.rs
+++ b/crates/phase-ai/src/policies/land_sequencing.rs
@@ -1,0 +1,292 @@
+//! Land-play sequencing tactical policy.
+//!
+//! Report (#ai-suggestions "AI Cast & Bounce lands"): the AI plays a Karoo
+//! bounce-land (Simic Growth Chamber) first when it should play a different
+//! land first, losing tempo (the bounce-land returns one of your lands to hand
+//! on ETB). `PlayLand` is declared in `BoardDevelopmentPolicy.decision_kinds()`
+//! but its `score()` only handles `CastSpell`/`PassPriority`, so land choice is
+//! otherwise unscored. This policy fills that gap for the bounce-land case.
+//!
+//! Scope (#4a): when the land being played is a self-bouncing Ravnica/MOM
+//! bounce-land AND a non-bouncing land is also in hand, deprioritize the
+//! bounce-land so the non-bounce land is played first. Deferred (#4b, a
+//! separate `SelectTarget` decision): when the bounce-land's ETB returns "a
+//! land you control," the AI should return the least-useful land, never the
+//! just-played bounce-land — that needs its own target-selection policy.
+//!
+//! Detection is structural (no card names): an ETB trigger that bounces a land
+//! you control. This matches the whole Ravnica/MOM `Effect::Bounce` cycle. The
+//! Mercadian "Karoo"/Coral Atoll cycle sacrifices itself (`Effect::Sacrifice`)
+//! and has no sequencing downside — it is deliberately NOT matched.
+
+use engine::game::game_object::GameObject;
+use engine::types::ability::{ControllerRef, Effect, TargetFilter, TypeFilter};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::ability_chain::collect_chain_effects;
+use crate::features::DeckFeatures;
+
+/// Penalty for playing a self-bouncing land while a non-bouncing land is also
+/// in hand. The non-bounce land's `PlayLand` scores `0.0` here, so it wins the
+/// argmax and is played first; the bounce-land is only deferred within the turn.
+const BOUNCE_DEPRIORITIZE: f64 = 1.5;
+
+pub struct LandSequencingPolicy;
+
+impl TacticalPolicy for LandSequencingPolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::LandSequencing
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::PlayLand]
+    }
+
+    fn activation(
+        &self,
+        _features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        // Applies to every deck; the verdict's bounce-land guard self-gates.
+        // activation-constant: land-play sequencing, universal.
+        Some(1.0)
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let score = |delta: f64, kind: &'static str| PolicyVerdict::Score {
+            delta,
+            reason: PolicyReason::new(kind),
+        };
+
+        let GameAction::PlayLand { object_id, .. } = &ctx.candidate.action else {
+            return score(0.0, "land_sequencing_na");
+        };
+        let object_id = *object_id;
+
+        let Some(played) = ctx.state.objects.get(&object_id) else {
+            return score(0.0, "land_sequencing_na");
+        };
+        if !is_self_bounce_land(played) {
+            return score(0.0, "land_sequencing_na");
+        }
+
+        // Is there another, non-bouncing land in hand to play first?
+        let hand = &ctx.state.players[ctx.ai_player.0 as usize].hand;
+        let has_non_bounce_alternative = hand.iter().any(|&id| {
+            id != object_id
+                && ctx.state.objects.get(&id).is_some_and(|o| {
+                    o.card_types.core_types.contains(&CoreType::Land) && !is_self_bounce_land(o)
+                })
+        });
+
+        if has_non_bounce_alternative {
+            score(-BOUNCE_DEPRIORITIZE, "land_sequencing_play_other_first")
+        } else {
+            // Bounce-land is the only land to play — let it through.
+            score(0.0, "land_sequencing_no_alternative")
+        }
+    }
+}
+
+/// True when `obj` has an ETB trigger that returns a land YOU control to hand
+/// (the Ravnica/MOM bounce-land / "Karoo" cycle). Structural, not name-matched.
+fn is_self_bounce_land(obj: &GameObject) -> bool {
+    obj.trigger_definitions.iter_unchecked().any(|t| {
+        t.mode == TriggerMode::ChangesZone
+            && t.destination == Some(Zone::Battlefield)
+            && matches!(t.valid_card, Some(TargetFilter::SelfRef))
+            && t.execute
+                .as_deref()
+                .is_some_and(|exec| collect_chain_effects(exec).iter().any(bounces_own_land))
+    })
+}
+
+fn bounces_own_land(effect: &&Effect) -> bool {
+    matches!(effect, Effect::Bounce { target, .. } if target_is_own_land(target))
+}
+
+fn target_is_own_land(filter: &TargetFilter) -> bool {
+    matches!(
+        filter,
+        TargetFilter::Typed(t)
+            if t.controller == Some(ControllerRef::You)
+                && t.type_filters.iter().any(type_filter_is_land)
+    )
+}
+
+fn type_filter_is_land(tf: &TypeFilter) -> bool {
+    match tf {
+        TypeFilter::Land => true,
+        TypeFilter::AnyOf(inner) => inner.iter().any(type_filter_is_land),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::game::zones::create_object;
+    use engine::types::ability::{
+        AbilityDefinition, AbilityKind, BounceSelection, TargetFilter, TriggerDefinition,
+        TypedFilter,
+    };
+    use engine::types::game_state::{GameState, WaitingFor};
+    use engine::types::identifiers::{CardId, ObjectId};
+    use engine::types::zones::Zone;
+
+    use crate::config::AiConfig;
+    use crate::context::AiContext;
+
+    const AI: PlayerId = PlayerId(0);
+
+    fn own_land_bounce_effect() -> Effect {
+        Effect::Bounce {
+            target: TargetFilter::Typed(
+                TypedFilter::default()
+                    .with_type(TypeFilter::Land)
+                    .controller(ControllerRef::You),
+            ),
+            destination: None,
+            selection: BounceSelection::default(),
+        }
+    }
+
+    /// A bounce-land in hand with the SGC-shape ETB self-bounce trigger.
+    fn bounce_land(state: &mut GameState) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(1),
+            AI,
+            "Growth Chamber".to_string(),
+            Zone::Hand,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Land);
+        obj.trigger_definitions.push(
+            TriggerDefinition::new(TriggerMode::ChangesZone)
+                .valid_card(TargetFilter::SelfRef)
+                .destination(Zone::Battlefield)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    own_land_bounce_effect(),
+                )),
+        );
+        id
+    }
+
+    fn plain_land(state: &mut GameState, name: &str) -> ObjectId {
+        let id = create_object(state, CardId(2), AI, name.to_string(), Zone::Hand);
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+        id
+    }
+
+    fn play_verdict(state: &GameState, object_id: ObjectId) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::PlayLand {
+                object_id,
+                card_id: CardId(0),
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Land,
+            },
+        };
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let config = AiConfig::default();
+        let context = AiContext::empty(&config.weights);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        LandSequencingPolicy.verdict(&ctx)
+    }
+
+    fn assert_score(verdict: PolicyVerdict, kind: &str, delta: f64) {
+        match verdict {
+            PolicyVerdict::Score { delta: d, reason } => {
+                assert_eq!(reason.kind, kind, "reason kind");
+                assert_eq!(d, delta, "delta");
+            }
+            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+        }
+    }
+
+    #[test]
+    fn bounce_land_deprioritized_when_alternative() {
+        let mut state = GameState::new_two_player(42);
+        let karoo = bounce_land(&mut state);
+        let basic = plain_land(&mut state, "Forest");
+        state.players[0].hand = [karoo, basic].into_iter().collect();
+        assert_score(
+            play_verdict(&state, karoo),
+            "land_sequencing_play_other_first",
+            -BOUNCE_DEPRIORITIZE,
+        );
+    }
+
+    #[test]
+    fn bounce_land_alone_not_penalized() {
+        let mut state = GameState::new_two_player(42);
+        let karoo = bounce_land(&mut state);
+        state.players[0].hand = [karoo].into_iter().collect();
+        assert_score(
+            play_verdict(&state, karoo),
+            "land_sequencing_no_alternative",
+            0.0,
+        );
+    }
+
+    #[test]
+    fn non_bounce_land_na() {
+        let mut state = GameState::new_two_player(42);
+        let karoo = bounce_land(&mut state);
+        let basic = plain_land(&mut state, "Forest");
+        state.players[0].hand = [karoo, basic].into_iter().collect();
+        assert_score(play_verdict(&state, basic), "land_sequencing_na", 0.0);
+    }
+
+    /// A land with a non-bounce ETB (e.g. a scry/tap land) must NOT be detected
+    /// as a bounce-land — guards the structural matcher against false positives.
+    #[test]
+    fn non_karoo_etb_land_na() {
+        let mut state = GameState::new_two_player(42);
+        let id = create_object(&mut state, CardId(3), AI, "Temple".to_string(), Zone::Hand);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Land);
+        obj.trigger_definitions.push(
+            TriggerDefinition::new(TriggerMode::ChangesZone)
+                .valid_card(TargetFilter::SelfRef)
+                .destination(Zone::Battlefield)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::Proliferate,
+                )),
+        );
+        let basic = plain_land(&mut state, "Forest");
+        state.players[0].hand = [id, basic].into_iter().collect();
+        assert_score(play_verdict(&state, id), "land_sequencing_na", 0.0);
+    }
+}

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -24,6 +24,7 @@ mod lethality_awareness;
 mod life_total_resource;
 mod mana_efficiency;
 pub mod mulligan;
+mod planeswalker_loyalty;
 mod plus_one_counters;
 mod ramp_timing;
 mod reactive_self_protection;

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -13,6 +13,7 @@ mod copy_value;
 mod downside_awareness;
 pub(crate) mod effect_classify;
 mod effect_timing;
+mod equipment_priority;
 mod etb_value;
 mod evasion_removal_priority;
 mod free_outlet_activation;

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -8,6 +8,7 @@ mod board_wipe_telegraph;
 mod card_advantage;
 mod combat_tax;
 pub(crate) mod combo_line;
+mod condition_gated_activation;
 pub(crate) mod context;
 mod copy_value;
 mod downside_awareness;

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -20,6 +20,7 @@ mod free_outlet_activation;
 pub(crate) mod hand_disruption;
 mod hold_mana_up;
 mod interaction_reservation;
+mod land_sequencing;
 mod landfall_timing;
 mod lethality_awareness;
 mod life_total_resource;

--- a/crates/phase-ai/src/policies/mulligan/keepables_by_land_count.rs
+++ b/crates/phase-ai/src/policies/mulligan/keepables_by_land_count.rs
@@ -13,7 +13,6 @@
 //! - Full-size hand with no early-castable spell → `ForceMulligan`.
 //! - Full-size hand that passes all checks → `Score { +3.0 }`.
 
-use engine::types::ability::{AbilityKind, Effect, ManaProduction};
 use engine::types::card_type::CoreType;
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
@@ -256,79 +255,9 @@ fn spell_colors_available(
 }
 
 fn land_could_produce_two_or_more_colors(obj: &engine::game::game_object::GameObject) -> bool {
-    let mut colors = Vec::new();
-    for subtype in &obj.card_types.subtypes {
-        if let Some(mana_type) = engine::game::mana_payment::land_subtype_to_mana_type(subtype) {
-            push_color(&mut colors, mana_type);
-        }
-    }
-    for ability in obj.abilities.iter() {
-        if ability.kind != AbilityKind::Activated {
-            continue;
-        }
-        let Effect::Mana { produced, .. } = &*ability.effect else {
-            continue;
-        };
-        collect_mana_production_colors(&mut colors, produced);
-    }
-    colors.len() >= 2
-}
-
-fn collect_mana_production_colors(colors: &mut Vec<ManaType>, produced: &ManaProduction) {
-    match produced {
-        ManaProduction::Fixed {
-            colors: produced, ..
-        }
-        | ManaProduction::AnyOneColor {
-            color_options: produced,
-            ..
-        }
-        | ManaProduction::AnyCombination {
-            color_options: produced,
-            ..
-        } => {
-            for color in produced {
-                push_color(
-                    colors,
-                    engine::game::mana_sources::mana_color_to_type(color),
-                );
-            }
-        }
-        ManaProduction::ChoiceAmongCombinations { options } => {
-            for option in options {
-                for color in option {
-                    push_color(
-                        colors,
-                        engine::game::mana_sources::mana_color_to_type(color),
-                    );
-                }
-            }
-        }
-        ManaProduction::Mixed {
-            colors: produced, ..
-        } => {
-            for color in produced {
-                push_color(
-                    colors,
-                    engine::game::mana_sources::mana_color_to_type(color),
-                );
-            }
-        }
-        ManaProduction::Colorless { .. }
-        | ManaProduction::ChosenColor { .. }
-        | ManaProduction::OpponentLandColors { .. }
-        | ManaProduction::AnyTypeProduceableBy { .. }
-        | ManaProduction::ChoiceAmongExiledColors { .. }
-        | ManaProduction::AnyInCommandersColorIdentity { .. }
-        | ManaProduction::DistinctColorsAmongPermanents { .. }
-        | ManaProduction::TriggerEventManaType => {}
-    }
-}
-
-fn push_color(colors: &mut Vec<ManaType>, mana_type: ManaType) {
-    if mana_type != ManaType::Colorless && !colors.contains(&mana_type) {
-        colors.push(mana_type);
-    }
+    // Shared with draft fixing-land evaluation via the parts-based core.
+    crate::mana_colors::land_produced_color_types(&obj.card_types.subtypes, &obj.abilities).len()
+        >= 2
 }
 
 #[cfg(test)]

--- a/crates/phase-ai/src/policies/planeswalker_loyalty.rs
+++ b/crates/phase-ai/src/policies/planeswalker_loyalty.rs
@@ -1,0 +1,430 @@
+//! Planeswalker loyalty-ability tactical policy.
+//!
+//! Two observed blunders (Discord #ai-suggestions):
+//!   - The AI plays a planeswalker and does NOT use a loyalty ability that turn.
+//!   - The AI fires a value-negative minus that sacrifices the planeswalker for
+//!     a single-target combat trick (Quintorius: "-4: target creature gains
+//!     double strike") instead of the baseline plus that generates its value.
+//!
+//! Design — blunder-only penalty. The ONLY thing penalized is the specific
+//! blunder: sacrificing/crippling the planeswalker (left at <= 1 loyalty) for a
+//! single-target combat trick. Every other loyalty activation — plus abilities,
+//! removal, emblems/ultimates, tokens, draw, mass effects, steal, reanimation —
+//! earns a modest "use your planeswalker" bonus. This deliberately avoids
+//! classifying effect *value* (a "low-value vs high-value" split misclassifies
+//! the 76 `CreateEmblem` ultimates as low-value and would suppress them); by
+//! penalizing only the combat-trick-sacrifice shape, ultimates and removal are
+//! structurally never penalized.
+//!
+//! Effect-value ranking is NOT this policy's job — `EffectTimingPolicy` and
+//! `effect_classify` already reward removal/damage. This policy only encourages
+//! using the planeswalker and blocks the one clear self-sacrifice blunder.
+//!
+//! CR 606.1: Some activated abilities are loyalty abilities (an activated
+//! ability with a loyalty symbol in its cost), subject to special rules. The
+//! engine gates legality (sorcery speed, once per planeswalker per turn); this
+//! policy only chooses among the legal candidates the engine offers.
+
+use engine::types::ability::{
+    AbilityCost, ContinuousModification, Effect, StaticDefinition, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+
+use super::context::PolicyContext;
+use super::effect_classify::{effect_polarity, EffectPolarity};
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::features::DeckFeatures;
+
+/// Bonus for activating a loyalty ability — "use your planeswalker." Applied to
+/// plus abilities and every non-blunder minus. Beats passing.
+const USE_BONUS: f64 = 1.5;
+
+/// Penalty for sacrificing/crippling the planeswalker on a single-target combat
+/// trick. Net well below `USE_BONUS`, so a plus on the same planeswalker wins.
+const SACRIFICE_PENALTY: f64 = 5.0;
+
+/// A minus is a sacrifice blunder when it leaves the planeswalker at or below
+/// this loyalty (dead, or one ping from it).
+const SACRIFICE_FLOOR: i32 = 1;
+
+pub struct PlaneswalkerLoyaltyPolicy;
+
+impl TacticalPolicy for PlaneswalkerLoyaltyPolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::PlaneswalkerLoyalty
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::ActivateAbility]
+    }
+
+    fn activation(
+        &self,
+        _features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        // Applies to every deck; the verdict's planeswalker+loyalty guard
+        // self-gates (non-loyalty / non-PW activations return _na).
+        // activation-constant: planeswalker loyalty-ability choice, universal.
+        Some(1.0)
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let na = || PolicyVerdict::Score {
+            delta: 0.0,
+            reason: PolicyReason::new("planeswalker_loyalty_na"),
+        };
+
+        let (source_id, ability_index) = match &ctx.candidate.action {
+            GameAction::ActivateAbility {
+                source_id,
+                ability_index,
+            } => (*source_id, *ability_index),
+            _ => return na(),
+        };
+
+        let Some(obj) = ctx.state.objects.get(&source_id) else {
+            return na();
+        };
+        if !obj.card_types.core_types.contains(&CoreType::Planeswalker) {
+            return na();
+        }
+        let Some(ability) = obj.abilities.get(ability_index) else {
+            return na();
+        };
+        // CR 606.1: only loyalty-cost abilities are scored here.
+        let amount = match &ability.cost {
+            Some(AbilityCost::Loyalty { amount }) => *amount,
+            _ => return na(),
+        };
+
+        let score = |delta: f64, kind: &'static str| PolicyVerdict::Score {
+            delta,
+            reason: PolicyReason::new(kind),
+        };
+
+        // Plus / zero: always good — build loyalty and get value.
+        if amount >= 0 {
+            return score(USE_BONUS, "planeswalker_plus_ability");
+        }
+
+        // Minus: penalize ONLY the self-sacrifice-for-a-combat-trick blunder.
+        let loyalty = obj.loyalty.unwrap_or(0) as i32;
+        if is_combat_trick(&ability.effect) && loyalty + amount <= SACRIFICE_FLOOR {
+            return score(
+                -SACRIFICE_PENALTY,
+                "planeswalker_minus_sacrifices_for_trick",
+            );
+        }
+        // All other minuses (removal, emblem/ultimate, tokens, draw, mass,
+        // steal, reanimate, or an affordable trick): use your planeswalker.
+        score(USE_BONUS, "planeswalker_minus_ability")
+    }
+}
+
+/// A single-target *beneficial* P/T-or-keyword buff — the marginal "combat
+/// trick" class. Both arms exclude negative-pump removal (e.g. "target
+/// opponent's creature gets -3/-3", which is `Effect::Pump` with negative P/T)
+/// so removal minuses are never treated as tricks.
+fn is_combat_trick(effect: &Effect) -> bool {
+    match effect {
+        // Beneficial ⇒ non-negative P/T (effect_polarity's sign rule), so
+        // negative/shrink pumps are excluded.
+        Effect::Pump { .. } => matches!(effect_polarity(effect), EffectPolarity::Beneficial),
+        // A grant scoped to the single targeted creature (ParentTarget), whose
+        // every modification is a beneficial buff. A team anthem has
+        // `affected: Typed{controller: You}` and falls through.
+        Effect::GenericEffect {
+            static_abilities, ..
+        } => {
+            !static_abilities.is_empty()
+                && static_abilities.iter().all(static_is_single_target_buff)
+        }
+        _ => false,
+    }
+}
+
+fn static_is_single_target_buff(sd: &StaticDefinition) -> bool {
+    matches!(sd.affected, Some(TargetFilter::ParentTarget))
+        && !sd.modifications.is_empty()
+        && sd.modifications.iter().all(is_beneficial_buff_mod)
+}
+
+fn is_beneficial_buff_mod(m: &ContinuousModification) -> bool {
+    match m {
+        ContinuousModification::AddKeyword { .. } => true,
+        ContinuousModification::AddPower { value }
+        | ContinuousModification::AddToughness { value } => *value >= 0,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::game::zones::create_object;
+    use engine::types::ability::{
+        AbilityDefinition, AbilityKind, ControllerRef, PtValue, QuantityExpr, TypedFilter,
+    };
+    use engine::types::game_state::{GameState, WaitingFor};
+    use engine::types::identifiers::{CardId, ObjectId};
+    use engine::types::keywords::Keyword;
+    use engine::types::statics::StaticMode;
+    use engine::types::zones::Zone;
+    use std::sync::Arc;
+
+    use crate::config::AiConfig;
+    use crate::context::AiContext;
+
+    const AI: PlayerId = PlayerId(0);
+
+    /// Single-target double-strike grant (Quintorius shape): GenericEffect with
+    /// `affected: ParentTarget`, AddKeyword mod.
+    fn single_target_double_strike() -> Effect {
+        grant_effect(Some(TargetFilter::ParentTarget), Keyword::DoubleStrike)
+    }
+
+    fn grant_effect(affected: Option<TargetFilter>, keyword: Keyword) -> Effect {
+        Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition {
+                mode: StaticMode::Continuous,
+                affected,
+                modifications: vec![ContinuousModification::AddKeyword { keyword }],
+                condition: None,
+                per_player_condition: None,
+                affected_zone: None,
+                effect_zone: None,
+                active_zones: Vec::new(),
+                characteristic_defining: false,
+                description: None,
+            }],
+            target: None,
+            duration: None,
+        }
+    }
+
+    /// Battlefield planeswalker controlled by the AI with `loyalty` and a single
+    /// activated loyalty ability (`Loyalty{amount}`, effect `effect`) at index 0.
+    fn pw_with_loyalty_ability(
+        state: &mut GameState,
+        loyalty: u32,
+        amount: i32,
+        effect: Effect,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(1),
+            AI,
+            "Walker".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Planeswalker);
+        obj.loyalty = Some(loyalty);
+        let mut ability = AbilityDefinition::new(AbilityKind::Activated, effect);
+        ability.cost = Some(AbilityCost::Loyalty { amount });
+        Arc::make_mut(&mut obj.abilities).push(ability);
+        id
+    }
+
+    fn loyalty_verdict(state: &GameState, source_id: ObjectId) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id,
+                ability_index: 0,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Ability,
+            },
+        };
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let config = AiConfig::default();
+        let context = AiContext::empty(&config.weights);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        PlaneswalkerLoyaltyPolicy.verdict(&ctx)
+    }
+
+    fn assert_score(verdict: PolicyVerdict, expect_kind: &str, expect_delta: f64) {
+        match verdict {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, expect_kind, "reason kind");
+                assert_eq!(delta, expect_delta, "delta");
+            }
+            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+        }
+    }
+
+    #[test]
+    fn plus_ability_rewarded() {
+        let mut state = GameState::new_two_player(42);
+        let id = pw_with_loyalty_ability(
+            &mut state,
+            3,
+            1,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        assert_score(
+            loyalty_verdict(&state, id),
+            "planeswalker_plus_ability",
+            USE_BONUS,
+        );
+    }
+
+    #[test]
+    fn removal_minus_rewarded() {
+        let mut state = GameState::new_two_player(42);
+        let id = pw_with_loyalty_ability(
+            &mut state,
+            5,
+            -3,
+            Effect::Destroy {
+                target: TargetFilter::Any,
+                cant_regenerate: false,
+            },
+        );
+        assert_score(
+            loyalty_verdict(&state, id),
+            "planeswalker_minus_ability",
+            USE_BONUS,
+        );
+    }
+
+    /// BLOCKER-1 regression: a deep self-sacrificing ultimate (CreateEmblem,
+    /// which the effect_profile flag set misses) must NOT be penalized.
+    #[test]
+    fn emblem_ultimate_not_penalized() {
+        let mut state = GameState::new_two_player(42);
+        let id = pw_with_loyalty_ability(
+            &mut state,
+            7,
+            -7,
+            Effect::CreateEmblem {
+                statics: Vec::new(),
+                triggers: Vec::new(),
+            },
+        );
+        assert_score(
+            loyalty_verdict(&state, id),
+            "planeswalker_minus_ability",
+            USE_BONUS,
+        );
+    }
+
+    /// #4e discriminator: a single-target combat trick that sacrifices the
+    /// planeswalker (loyalty 4, -4 → 0) is penalized.
+    #[test]
+    fn combat_trick_sacrificing_pw_penalized() {
+        let mut state = GameState::new_two_player(42);
+        let id = pw_with_loyalty_ability(&mut state, 4, -4, single_target_double_strike());
+        assert_score(
+            loyalty_verdict(&state, id),
+            "planeswalker_minus_sacrifices_for_trick",
+            -SACRIFICE_PENALTY,
+        );
+    }
+
+    /// An affordable combat trick (loyalty 6, -2 → 4, above SACRIFICE_FLOOR) is
+    /// NOT a blunder — just use-credit.
+    #[test]
+    fn combat_trick_pw_survives_not_penalized() {
+        let mut state = GameState::new_two_player(42);
+        let id = pw_with_loyalty_ability(&mut state, 6, -2, single_target_double_strike());
+        assert_score(
+            loyalty_verdict(&state, id),
+            "planeswalker_minus_ability",
+            USE_BONUS,
+        );
+    }
+
+    /// A board-wide buff (`affected: Typed{controller: You}`) is not a
+    /// single-target trick even when it sacrifices the planeswalker.
+    #[test]
+    fn team_anthem_minus_not_a_trick() {
+        let mut state = GameState::new_two_player(42);
+        let anthem = grant_effect(
+            Some(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::You),
+            )),
+            Keyword::Trample,
+        );
+        let id = pw_with_loyalty_ability(&mut state, 3, -3, anthem);
+        assert_score(
+            loyalty_verdict(&state, id),
+            "planeswalker_minus_ability",
+            USE_BONUS,
+        );
+    }
+
+    /// BLOCKER-2 regression: a negative-pump removal minus ("-3/-3 to an
+    /// opponent's creature") must NOT be flagged as a combat trick.
+    #[test]
+    fn removal_minus_negative_pump_not_penalized() {
+        let mut state = GameState::new_two_player(42);
+        let neg_pump = Effect::Pump {
+            power: PtValue::Fixed(-3),
+            toughness: PtValue::Fixed(-3),
+            target: TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+        };
+        let id = pw_with_loyalty_ability(&mut state, 3, -3, neg_pump);
+        assert_score(
+            loyalty_verdict(&state, id),
+            "planeswalker_minus_ability",
+            USE_BONUS,
+        );
+    }
+
+    #[test]
+    fn non_planeswalker_activation_na() {
+        let mut state = GameState::new_two_player(42);
+        let id = create_object(
+            &mut state,
+            CardId(2),
+            AI,
+            "Rock".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        let mut ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        ability.cost = Some(AbilityCost::Tap);
+        Arc::make_mut(&mut obj.abilities).push(ability);
+        assert_score(loyalty_verdict(&state, id), "planeswalker_loyalty_na", 0.0);
+    }
+
+    #[test]
+    fn non_loyalty_planeswalker_ability_na() {
+        let mut state = GameState::new_two_player(42);
+        // A planeswalker with a mana-cost (non-loyalty) activated ability.
+        let id = pw_with_loyalty_ability(&mut state, 4, 1, Effect::Proliferate);
+        // Overwrite the cost with a non-loyalty cost.
+        let obj = state.objects.get_mut(&id).unwrap();
+        Arc::make_mut(&mut obj.abilities)[0].cost = Some(AbilityCost::Tap);
+        assert_score(loyalty_verdict(&state, id), "planeswalker_loyalty_na", 0.0);
+    }
+}

--- a/crates/phase-ai/src/policies/reactive_self_protection.rs
+++ b/crates/phase-ai/src/policies/reactive_self_protection.rs
@@ -1,9 +1,12 @@
 //! Reactive self-protection tactical policy.
 //!
-//! Penalises the AI for casting "save yourself" spells when there is no
-//! immediate threat to react to. Empirically observed: AI casting Teferi's
-//! Protection on turn 3 against an empty board — wasting a 3-mana reactive
-//! spell that has no work to do.
+//! Penalises the AI for casting OR activating "save yourself" effects when
+//! there is no immediate threat to react to. Empirically observed: AI casting
+//! Teferi's Protection on turn 3 against an empty board; AI repeatedly paying
+//! "discard a card: ~ gains protection from everything" until its hand is
+//! empty; AI activating Sylvan Safekeeper ("sacrifice a land: target creature
+//! you control gains shroud") on turn 1 for no reason. All are the same class:
+//! paying a cost for a defensive grant with no work to do.
 //!
 //! The classifier keys on **typed effect signatures**, not card names or
 //! Oracle text. A spell is treated as self-protection when it grants
@@ -51,7 +54,7 @@ impl TacticalPolicy for ReactiveSelfProtectionPolicy {
     }
 
     fn decision_kinds(&self) -> &'static [DecisionKind] {
-        &[DecisionKind::CastSpell]
+        &[DecisionKind::CastSpell, DecisionKind::ActivateAbility]
     }
 
     fn activation(
@@ -67,7 +70,10 @@ impl TacticalPolicy for ReactiveSelfProtectionPolicy {
     }
 
     fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
-        if !matches!(ctx.candidate.action, GameAction::CastSpell { .. }) {
+        if !matches!(
+            ctx.candidate.action,
+            GameAction::CastSpell { .. } | GameAction::ActivateAbility { .. }
+        ) {
             return PolicyVerdict::Score {
                 delta: 0.0,
                 reason: PolicyReason::new("reactive_self_protection_na"),
@@ -193,18 +199,34 @@ fn is_self_protection_effect(effect: &Effect) -> bool {
         // CR 615.1: Damage prevention shielding the caster.
         Effect::PreventDamage { .. } => true,
         // CR 604.3: Continuous static abilities granting defensive keywords or
-        // modes to the caster's own permanents.
+        // modes to the caster's own permanents. The grant's scope may live on
+        // the static's `affected` filter (self-referential: "~ gains shroud")
+        // OR on the enclosing `GenericEffect.target` when `affected` is
+        // `ParentTarget` (targeted: "target creature you control gains shroud").
         Effect::GenericEffect {
-            static_abilities, ..
+            static_abilities,
+            target,
+            ..
         } => static_abilities
             .iter()
-            .any(static_definition_is_self_protection),
+            .any(|sd| static_definition_is_self_protection(sd, target.as_ref())),
         _ => false,
     }
 }
 
-fn static_definition_is_self_protection(sd: &StaticDefinition) -> bool {
-    let affects_self = sd.affected.as_ref().is_some_and(target_filter_self_scoped);
+fn static_definition_is_self_protection(
+    sd: &StaticDefinition,
+    parent_target: Option<&TargetFilter>,
+) -> bool {
+    let affects_self = match sd.affected.as_ref() {
+        // A static scoped to ParentTarget grants to whatever the parent ability
+        // targets (e.g. Sylvan Safekeeper: "target creature you control gains
+        // shroud"), so self-scoping is decided by the parent ability's target
+        // filter, not by `affected`.
+        Some(TargetFilter::ParentTarget) => parent_target.is_some_and(target_filter_self_scoped),
+        Some(f) => target_filter_self_scoped(f),
+        None => false,
+    };
     if !affects_self {
         return false;
     }
@@ -256,7 +278,92 @@ fn target_filter_self_scoped(filter: &TargetFilter) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use engine::types::ability::{ControllerRef, StaticDefinition, TypedFilter};
+    use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::game::zones::create_object;
+    use engine::types::ability::{
+        AbilityDefinition, AbilityKind, ControllerRef, QuantityExpr, StaticDefinition, TypedFilter,
+    };
+    use engine::types::game_state::WaitingFor;
+    use engine::types::identifiers::{CardId, ObjectId};
+    use engine::types::zones::Zone;
+    use std::sync::Arc;
+
+    use crate::config::AiConfig;
+    use crate::context::AiContext;
+
+    const AI: PlayerId = PlayerId(0);
+
+    /// Build a `GenericEffect` keyword grant with explicit `affected` (static
+    /// scope) and `target` (parent-ability scope) filters — the two axes that
+    /// decide self-scoping.
+    fn grant_effect(
+        affected: Option<TargetFilter>,
+        target: Option<TargetFilter>,
+        keyword: Keyword,
+    ) -> Effect {
+        Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition {
+                mode: StaticMode::Continuous,
+                affected,
+                modifications: vec![ContinuousModification::AddKeyword { keyword }],
+                condition: None,
+                per_player_condition: None,
+                affected_zone: None,
+                effect_zone: None,
+                active_zones: Vec::new(),
+                characteristic_defining: false,
+                description: None,
+            }],
+            target,
+            duration: None,
+        }
+    }
+
+    /// Battlefield object controlled by the AI with a single activated ability
+    /// whose effect is `effect` (ability index 0).
+    fn ai_object_with_activated(state: &mut GameState, effect: Effect) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(1),
+            AI,
+            "Self-Protector".to_string(),
+            Zone::Battlefield,
+        );
+        Arc::make_mut(&mut state.objects.get_mut(&id).unwrap().abilities)
+            .push(AbilityDefinition::new(AbilityKind::Activated, effect));
+        id
+    }
+
+    /// Run `ReactiveSelfProtectionPolicy::verdict` for activating `source_id`'s
+    /// ability 0 — drives the real policy path for an `ActivateAbility` candidate.
+    fn activate_verdict(state: &GameState, source_id: ObjectId) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id,
+                ability_index: 0,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Ability,
+            },
+        };
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let config = AiConfig::default();
+        let context = AiContext::empty(&config.weights);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        ReactiveSelfProtectionPolicy.verdict(&ctx)
+    }
 
     fn indestructible_grant_to_self() -> Effect {
         Effect::GenericEffect {
@@ -417,5 +524,150 @@ mod tests {
             duration: None,
         };
         assert!(is_self_protection_effect(&effect));
+    }
+
+    // ───────── #3: activation cost-benefit (extend to ActivateAbility) ────────
+
+    /// Classifier: a targeted grant scoped to ParentTarget with a self-scoped
+    /// parent target (Sylvan Safekeeper shape) IS self-protection.
+    /// Discriminating for the part-3 classifier extension.
+    #[test]
+    fn classifier_recognises_parent_target_grant_to_you() {
+        assert!(is_self_protection_effect(&grant_effect(
+            Some(TargetFilter::ParentTarget),
+            Some(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::You)
+            )),
+            Keyword::Shroud,
+        )));
+    }
+
+    /// Classifier: the same shape but granting to an OPPONENT's creature is NOT
+    /// self-protection (parent target is opponent-scoped).
+    #[test]
+    fn classifier_rejects_parent_target_grant_to_opponent() {
+        assert!(!is_self_protection_effect(&grant_effect(
+            Some(TargetFilter::ParentTarget),
+            Some(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::Opponent)
+            )),
+            Keyword::Shroud,
+        )));
+    }
+
+    /// Runtime: activating a SelfRef defensive grant ("~ gains indestructible")
+    /// with no threat present is penalized. Discriminating for the
+    /// decision_kinds/guard widening (revert → `_na`).
+    #[test]
+    fn activation_self_ref_protection_no_threat_penalized() {
+        let mut state = GameState::new_two_player(42);
+        let id = ai_object_with_activated(
+            &mut state,
+            grant_effect(Some(TargetFilter::SelfRef), None, Keyword::Indestructible),
+        );
+        match activate_verdict(&state, id) {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_no_threat");
+                assert_eq!(delta, NO_THREAT_PENALTY);
+            }
+            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+        }
+    }
+
+    /// Runtime: activating a ParentTarget grant to a creature you control
+    /// ("sac a land: target creature you control gains shroud", Sylvan
+    /// Safekeeper) with no threat is penalized. Discriminating for part 3
+    /// (revert the ParentTarget classifier branch → `_na`).
+    #[test]
+    fn activation_parent_target_protection_no_threat_penalized() {
+        let mut state = GameState::new_two_player(42);
+        let id = ai_object_with_activated(
+            &mut state,
+            grant_effect(
+                Some(TargetFilter::ParentTarget),
+                Some(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+                Keyword::Shroud,
+            ),
+        );
+        match activate_verdict(&state, id) {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_no_threat");
+                assert_eq!(delta, NO_THREAT_PENALTY);
+            }
+            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+        }
+    }
+
+    /// Runtime guard: a non-protection activated ability (draw) is unaffected.
+    #[test]
+    fn activation_non_protection_unaffected() {
+        let mut state = GameState::new_two_player(42);
+        let id = ai_object_with_activated(
+            &mut state,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        match activate_verdict(&state, id) {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_na");
+                assert_eq!(delta, 0.0);
+            }
+            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+        }
+    }
+
+    /// Runtime guard: with an opponent removal spell on the stack targeting the
+    /// AI's permanent, the protection activation IS allowed (threat present).
+    #[test]
+    fn activation_self_protection_with_threat_allowed() {
+        use engine::types::ability::{ResolvedAbility, TargetRef};
+        use engine::types::game_state::{StackEntry, StackEntryKind};
+
+        let mut state = GameState::new_two_player(42);
+        let id = ai_object_with_activated(
+            &mut state,
+            grant_effect(Some(TargetFilter::SelfRef), None, Keyword::Indestructible),
+        );
+        // Opponent Destroy spell on the stack targeting the AI's permanent.
+        let opp = PlayerId(1);
+        let spell_id = create_object(
+            &mut state,
+            CardId(99),
+            opp,
+            "Doom Blade".to_string(),
+            Zone::Stack,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::Destroy {
+                target: TargetFilter::Any,
+                cant_regenerate: false,
+            },
+            vec![TargetRef::Object(id)],
+            spell_id,
+            opp,
+        );
+        state.stack.push_back(StackEntry {
+            id: spell_id,
+            source_id: spell_id,
+            controller: opp,
+            kind: StackEntryKind::Spell {
+                card_id: CardId(99),
+                ability: Some(ability),
+                casting_variant: Default::default(),
+                actual_mana_spent: 0,
+            },
+        });
+
+        match activate_verdict(&state, id) {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_threat_present");
+                assert_eq!(delta, 0.0);
+            }
+            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+        }
     }
 }

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -90,6 +90,7 @@ pub enum PolicyId {
     ComboLineProgress,
     CedhKeepablesMulligan,
     PlaneswalkerLoyalty,
+    EquipmentPriority,
 }
 
 /// Coarse routing kind for a candidate decision. Each policy declares which
@@ -214,6 +215,7 @@ impl Default for PolicyRegistry {
             Box::new(ReactiveSelfProtectionPolicy),
             Box::new(super::combo_line::ComboLinePolicy::new()),
             Box::new(super::planeswalker_loyalty::PlaneswalkerLoyaltyPolicy),
+            Box::new(super::equipment_priority::EquipmentPriorityPolicy),
         ];
         let mut by_kind: HashMap<DecisionKind, Vec<usize>> = HashMap::new();
         for (idx, policy) in policies.iter().enumerate() {

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -89,6 +89,7 @@ pub enum PolicyId {
     ReactiveSelfProtection,
     ComboLineProgress,
     CedhKeepablesMulligan,
+    PlaneswalkerLoyalty,
 }
 
 /// Coarse routing kind for a candidate decision. Each policy declares which
@@ -212,6 +213,7 @@ impl Default for PolicyRegistry {
             Box::new(super::combat_tax::CombatTaxPaymentPolicy),
             Box::new(ReactiveSelfProtectionPolicy),
             Box::new(super::combo_line::ComboLinePolicy::new()),
+            Box::new(super::planeswalker_loyalty::PlaneswalkerLoyaltyPolicy),
         ];
         let mut by_kind: HashMap<DecisionKind, Vec<usize>> = HashMap::new();
         for (idx, policy) in policies.iter().enumerate() {

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -92,6 +92,7 @@ pub enum PolicyId {
     PlaneswalkerLoyalty,
     EquipmentPriority,
     LandSequencing,
+    ConditionGatedActivation,
 }
 
 /// Coarse routing kind for a candidate decision. Each policy declares which
@@ -218,6 +219,7 @@ impl Default for PolicyRegistry {
             Box::new(super::planeswalker_loyalty::PlaneswalkerLoyaltyPolicy),
             Box::new(super::equipment_priority::EquipmentPriorityPolicy),
             Box::new(super::land_sequencing::LandSequencingPolicy),
+            Box::new(super::condition_gated_activation::ConditionGatedActivationPolicy),
         ];
         let mut by_kind: HashMap<DecisionKind, Vec<usize>> = HashMap::new();
         for (idx, policy) in policies.iter().enumerate() {

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -91,6 +91,7 @@ pub enum PolicyId {
     CedhKeepablesMulligan,
     PlaneswalkerLoyalty,
     EquipmentPriority,
+    LandSequencing,
 }
 
 /// Coarse routing kind for a candidate decision. Each policy declares which
@@ -216,6 +217,7 @@ impl Default for PolicyRegistry {
             Box::new(super::combo_line::ComboLinePolicy::new()),
             Box::new(super::planeswalker_loyalty::PlaneswalkerLoyaltyPolicy),
             Box::new(super::equipment_priority::EquipmentPriorityPolicy),
+            Box::new(super::land_sequencing::LandSequencingPolicy),
         ];
         let mut by_kind: HashMap<DecisionKind, Vec<usize>> = HashMap::new();
         for (idx, policy) in policies.iter().enumerate() {

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1559,7 +1559,9 @@ pub(crate) fn deterministic_choice(
 
     // Combat decisions: delegate to specialized combat AI
     if let WaitingFor::DeclareAttackers {
-        valid_attacker_ids, ..
+        valid_attacker_ids,
+        valid_attack_targets,
+        ..
     } = &state.waiting_for
     {
         let attacks = choose_attackers_with_targets_with_profile(
@@ -1568,6 +1570,7 @@ pub(crate) fn deterministic_choice(
             &config.profile,
             config.combat_lookahead,
             Some(valid_attacker_ids),
+            Some(valid_attack_targets),
         );
         return Some(GameAction::DeclareAttackers { attacks });
     }
@@ -1615,7 +1618,9 @@ fn deterministic_combat_choice(
     profile: &crate::config::AiProfile,
 ) -> Option<GameAction> {
     if let WaitingFor::DeclareAttackers {
-        valid_attacker_ids, ..
+        valid_attacker_ids,
+        valid_attack_targets,
+        ..
     } = &state.waiting_for
     {
         let attacks = choose_attackers_with_targets_with_profile(
@@ -1624,6 +1629,7 @@ fn deterministic_combat_choice(
             profile,
             false,
             Some(valid_attacker_ids),
+            Some(valid_attack_targets),
         );
         return Some(GameAction::DeclareAttackers { attacks });
     }


### PR DESCRIPTION
- **fix(ai): combat correctness — attack planeswalkers, avoid commander trades, gate lifelink**
- **fix(ai): penalize self-protection ACTIVATIONS with no threat (not just spells)**
- **feat(ai): PlaneswalkerLoyaltyPolicy — use the planeswalker, don't sac it for a trick**
- **feat(ai): EquipmentPriorityPolicy — stop the every-turn equip shuffle**
- **feat(ai): LandSequencingPolicy — play a normal land before a Karoo bounce-land**
- **fix(engine): smarter auto-tap source order — colorless-for-generic, spare creatures**
- **feat(ai): don't pay for activations whose payoff is gated off (ConditionGatedActivation)**
- **fix(engine): make Omo's everything counter grant all land/creature types**
- **feat(ai): draft bots value and play nonbasic fixing lands**
