### PR TITLE
fix(engine): cap Lathiel distribute targets to life gained (fixes #1660)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3105,6 +3105,19 @@ fn parse_leading_command_return_destination(input: &str) -> OracleResult<'_, Ret
     ))
 }
 
+/// CR 601.2d: Cap "any number of" target selection to the distribution pool.
+/// Without this, the controller can select more permanents than counters or
+/// damage and the assign step deadlocks (each target must receive at least one).
+fn multi_target_for_distribute_among(distribution_amount: &QuantityExpr) -> MultiTargetSpec {
+    let (inner, is_up_to) = distribution_amount.peel_up_to();
+    let min = if is_up_to {
+        QuantityExpr::Fixed { value: 0 }
+    } else {
+        QuantityExpr::Fixed { value: 1 }
+    };
+    MultiTargetSpec::bounded_expr(min, inner.clone())
+}
+
 /// CR 601.2d: Parse "deal N damage divided as you choose among [targets]" and
 /// "deal N damage distributed among [targets]" → Effect::DealDamage with distribute flag.
 ///
@@ -3174,8 +3187,7 @@ pub(super) fn try_parse_distribute_damage(lower: &str, text: &str) -> Option<Par
         let skip = target_lower.len() - rest.len();
         (
             &target_text[skip..],
-            // CR 601.2d: min: 1 because each target must receive at least 1.
-            Some(MultiTargetSpec::unlimited(1)),
+            Some(multi_target_for_distribute_among(&amount)),
         )
     } else {
         (target_text, None)
@@ -3251,8 +3263,7 @@ pub(super) fn try_parse_distribute_counters(lower: &str, text: &str) -> Option<P
         let skip = target_text_lower.len() - rest.len();
         (
             &target_text[skip..],
-            // CR 601.2d: min: 1 because each target must receive at least 1.
-            Some(MultiTargetSpec::unlimited(1)),
+            Some(multi_target_for_distribute_among(&count_expr)),
         )
     } else {
         strip_optional_target_prefix(target_text)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12333,6 +12333,12 @@ pub(crate) fn rewrite_gained_life_that_many_distribution_refs(def: &mut AbilityD
     }
 
     each_quantity_expr_mut(&mut def.effect, &mut rewrite_qty);
+    if let Some(spec) = def.multi_target.as_mut() {
+        rewrite_qty(&mut spec.min);
+        if let Some(max) = spec.max.as_mut() {
+            rewrite_qty(max);
+        }
+    }
     if let Some(sub) = def.sub_ability.as_mut() {
         rewrite_gained_life_that_many_distribution_refs(sub);
     }
@@ -22733,6 +22739,26 @@ mod tests {
             ),
             "Expected targeted PutCounter with multi_target, got {:?}",
             clause.effect
+        );
+    }
+
+    #[test]
+    fn distribute_counters_among_any_number_caps_targets_to_pool() {
+        let clause = parse_effect_clause(
+            "distribute up to two +1/+1 counters among any number of other target creatures",
+            &mut ParseContext::default(),
+        );
+
+        assert_eq!(
+            clause.multi_target,
+            Some(MultiTargetSpec::bounded_expr(
+                QuantityExpr::Fixed { value: 0 },
+                QuantityExpr::Fixed { value: 2 },
+            ))
+        );
+        assert_eq!(
+            clause.distribute,
+            Some(DistributionUnit::Counters("P1P1".to_string()))
         );
     }
 

--- a/crates/engine/tests/integration/lathiel_end_step_counters_repro.rs
+++ b/crates/engine/tests/integration/lathiel_end_step_counters_repro.rs
@@ -1,5 +1,5 @@
-//! Issue #1610: Lathiel, the Bounteous Dawn end-step distributed +1/+1 counters
-//! from life gained this turn.
+//! Issues #1610 / #1660: Lathiel, the Bounteous Dawn end-step distributed +1/+1
+//! counters from life gained this turn.
 //!
 //! Oracle: "Lifelink. At the beginning of each end step, if you gained life this
 //! turn, distribute up to that many +1/+1 counters among any number of other
@@ -100,5 +100,36 @@ fn lathiel_end_step_distributes_counters_from_lifelink_gain() {
         p1p1_counters(&runner, receiver),
         2,
         "Lathiel must distribute exactly 2 +1/+1 counters (= life gained via lifelink)"
+    );
+}
+
+#[test]
+fn lathiel_target_selection_capped_to_life_gained_not_creature_count() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let lathiel = scenario
+        .add_creature_from_oracle(P0, "Lathiel, the Bounteous Dawn", 2, 2, LATHIEL_ORACLE)
+        .id();
+    scenario.add_creature(P0, "Receiver A", 1, 1);
+    scenario.add_creature(P0, "Receiver B", 1, 1);
+    scenario.add_creature(P0, "Receiver C", 1, 1);
+    scenario.add_creature(P1, "Blocker", 3, 3);
+
+    let mut runner = scenario.build();
+    run_combat(&mut runner, vec![lathiel], vec![]);
+
+    assert_eq!(runner.state().players[0].life_gained_this_turn, 2);
+
+    advance_to_end_step_trigger(&mut runner);
+
+    let slot_count = match &runner.state().waiting_for {
+        WaitingFor::TriggerTargetSelection { target_slots, .. }
+        | WaitingFor::TargetSelection { target_slots, .. } => target_slots.len(),
+        other => panic!("expected target selection at end step, got {other:?}"),
+    };
+    assert_eq!(
+        slot_count, 2,
+        "must not offer more target slots than life gained (issue #1660 softlock)"
     );
 }


### PR DESCRIPTION
## Summary

Fixes a softlock on Lathiel, the Bounteous Dawn when the controller selects more creatures than life gained this turn during the end-step distribute trigger.

- Cap `multi_target` for `"distribute … among any number of"` to the distribution pool size (same quantity as the counters being divided).
- Extend the existing `"that many"` → `LifeGainedThisTurn` rewrite to `multi_target` bounds so oracle-parsed triggers resolve the cap correctly.

## Test plan

- [x] `cargo test -p engine distribute_counters_among_any_number_caps_targets_to_pool`
- [x] `cargo test -p engine --test integration lathiel`

Fixes #1660