### PR TITLE
Fix commander cast-from-zone count for anthem statics

### DIFF
--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -19,7 +19,15 @@ pub fn commander_tax(state: &GameState, commander_id: ObjectId) -> u32 {
 
 /// CR 408.3 + CR 903.8: Record that a commander was cast from the command zone, incrementing its cast count.
 pub fn record_commander_cast(state: &mut GameState, commander_id: ObjectId) {
+    let Some(obj) = state.objects.get(&commander_id) else {
+        return;
+    };
+    if !obj.is_commander {
+        return;
+    }
+    let owner = obj.owner;
     *state.commander_cast_count.entry(commander_id).or_insert(0) += 1;
+    state.commander_cast_owners.insert(commander_id, owner);
 }
 
 /// CR 903.8: Count previous times `player` has cast their commander(s) from
@@ -29,13 +37,26 @@ pub fn commander_casts_from_command_zone(state: &GameState, player: PlayerId) ->
         .commander_cast_count
         .iter()
         .filter(|(commander_id, _)| {
-            state
-                .objects
-                .get(commander_id)
-                .is_some_and(|obj| obj.is_commander && obj.owner == player)
+            cast_owner_for_command_zone_count(state, **commander_id) == Some(player)
         })
         .map(|(_, count)| *count)
         .sum()
+}
+
+/// Resolve which player owns a recorded command-zone cast for aggregation.
+fn cast_owner_for_command_zone_count(
+    state: &GameState,
+    commander_id: ObjectId,
+) -> Option<PlayerId> {
+    if let Some(&owner) = state.commander_cast_owners.get(&commander_id) {
+        return Some(owner);
+    }
+    // Legacy saves / tests that called `record_commander_cast` before owner stamping.
+    state
+        .objects
+        .get(&commander_id)
+        .filter(|obj| obj.is_commander)
+        .map(|obj| obj.owner)
 }
 
 /// CR 903.3d: "you control a commander" (generic) — true when any commander on
@@ -904,6 +925,97 @@ mod tests {
 
         // Commander tax should be 2 after first cast (for next cast)
         assert_eq!(commander_tax(&state, cmd_id), 2);
+        assert_eq!(
+            commander_casts_from_command_zone(&state, PlayerId(0)),
+            1,
+            "CR 903.8: cast-from-command-zone count must include committed casts"
+        );
+    }
+
+    /// CR 903.8: `commander_casts_from_command_zone` must count casts after the
+    /// commander has left the command zone (stack or battlefield), not only while
+    /// the recorded object id still looks like a command-zone commander.
+    #[test]
+    fn integration_commander_cast_count_survives_battlefield_resolution() {
+        use crate::game::casting::handle_cast_spell;
+        use crate::types::ability::{AbilityDefinition, AbilityKind, Effect};
+        use crate::types::game_state::WaitingFor;
+        use crate::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+        use crate::types::phase::Phase;
+
+        let mut state = setup_commander_game();
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        state.turn_number = 2;
+
+        let cmd_id = create_commander_in_command_zone(
+            &mut state,
+            PlayerId(0),
+            "Kaalia",
+            vec![ManaColor::Red, ManaColor::White, ManaColor::Black],
+        );
+        let card_id = state.objects[&cmd_id].card_id;
+        {
+            let obj = state.objects.get_mut(&cmd_id).unwrap();
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 2,
+            };
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Unimplemented {
+                    name: "Commander".to_string(),
+                    description: None,
+                },
+            ));
+        }
+
+        let player_data = state
+            .players
+            .iter_mut()
+            .find(|p| p.id == PlayerId(0))
+            .unwrap();
+        for _ in 0..3 {
+            player_data.mana_pool.add(ManaUnit {
+                color: ManaType::Red,
+                source_id: crate::types::identifiers::ObjectId(0),
+                snow: false,
+                source_could_produce_two_or_more_colors: false,
+                restrictions: Vec::new(),
+                grants: vec![],
+                expiry: None,
+            });
+        }
+
+        let mut events = Vec::new();
+        handle_cast_spell(&mut state, PlayerId(0), cmd_id, card_id, &mut events)
+            .expect("cast commander from command zone");
+
+        assert_eq!(commander_casts_from_command_zone(&state, PlayerId(0)), 1);
+        assert_eq!(state.objects[&cmd_id].zone, Zone::Stack);
+
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Battlefield, &mut events);
+        assert_eq!(state.objects[&cmd_id].zone, Zone::Battlefield);
+
+        assert_eq!(
+            commander_casts_from_command_zone(&state, PlayerId(0)),
+            1,
+            "cast count must persist after commander resolves to the battlefield"
+        );
+
+        // Regression guard: cast counts must not depend on `is_commander` still
+        // being stamped on the object (deck rehydration / copy paths can clear it).
+        state.objects.get_mut(&cmd_id).unwrap().is_commander = false;
+        assert_eq!(
+            commander_casts_from_command_zone(&state, PlayerId(0)),
+            1,
+            "cast count must not require is_commander on the recorded object id"
+        );
     }
 
     /// CR 107.4f + CR 601.2h: Casting a Phyrexian commander with insufficient colored

--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -43,7 +43,7 @@ pub fn commander_casts_from_command_zone(state: &GameState, player: PlayerId) ->
         .sum()
 }
 
-/// Resolve which player owns a recorded command-zone cast for aggregation.
+/// CR 903.8: Resolve which player owns a recorded command-zone cast for aggregation.
 fn cast_owner_for_command_zone_count(
     state: &GameState,
     commander_id: ObjectId,

--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -19,15 +19,12 @@ pub fn commander_tax(state: &GameState, commander_id: ObjectId) -> u32 {
 
 /// CR 408.3 + CR 903.8: Record that a commander was cast from the command zone, incrementing its cast count.
 pub fn record_commander_cast(state: &mut GameState, commander_id: ObjectId) {
-    let Some(obj) = state.objects.get(&commander_id) else {
-        return;
-    };
-    if !obj.is_commander {
-        return;
-    }
-    let owner = obj.owner;
     *state.commander_cast_count.entry(commander_id).or_insert(0) += 1;
-    state.commander_cast_owners.insert(commander_id, owner);
+    if let Some(obj) = state.objects.get(&commander_id) {
+        if obj.is_commander {
+            state.commander_cast_owners.insert(commander_id, obj.owner);
+        }
+    }
 }
 
 /// CR 903.8: Count previous times `player` has cast their commander(s) from

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4234,6 +4234,12 @@ pub struct GameState {
     #[serde(default)]
     pub commander_cast_count: HashMap<ObjectId, u32>,
 
+    /// Owner stamped when a commander cast from the command zone is recorded.
+    /// CR 903.8: `commander_casts_from_command_zone` must count committed casts
+    /// even when the recorded `ObjectId` no longer has `is_commander` set.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub commander_cast_owners: HashMap<ObjectId, PlayerId>,
+
     /// CR 903.9a: Commanders whose owner declined the zone-return choice this
     /// SBA cycle. Cleared when the commander changes zones again (giving the
     /// owner a fresh choice opportunity).
@@ -5178,6 +5184,7 @@ impl GameState {
             next_tracked_set_id: 1,
             chain_tracked_set_id: None,
             commander_cast_count: HashMap::new(),
+            commander_cast_owners: HashMap::new(),
             extra_turns: Vec::new(),
             turns_to_skip: vec![0; player_count as usize],
             steps_to_skip: vec![HashMap::new(); player_count as usize],
@@ -5469,6 +5476,7 @@ impl PartialEq for GameState {
             && self.next_tracked_set_id == other.next_tracked_set_id
             && self.chain_tracked_set_id == other.chain_tracked_set_id
             && self.commander_cast_count == other.commander_cast_count
+            && self.commander_cast_owners == other.commander_cast_owners
             && self.commander_declined_zone_return == other.commander_declined_zone_return
             && self.extra_turns == other.extra_turns
             && self.turns_to_skip == other.turns_to_skip


### PR DESCRIPTION
## Summary

- Stamp each command-zone commander cast with its owner in `commander_cast_owners` when `record_commander_cast` runs.
- Aggregate `CommanderCastFromCommandZoneCount` from stored owners instead of requiring the recorded `ObjectId` to still have `is_commander` in `state.objects`.

This fixes Vanguard of the Restless (and any card using `CommanderCastFromCommandZoneCount`) resolving to +0/+0 after casting your commander, even though commander tax was already tracking casts correctly.

## Test plan

- [x] `cargo test -p engine commander_cast`
- [x] `cargo test -p engine derived::`
- [x] New regression: cast count survives battlefield resolution and does not depend on `is_commander` remaining on the recorded object id

Fixes #1666