### PR TITLE
Fix Carpet of Flowers phase trigger timing

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -10579,6 +10579,40 @@ pub mod tests {
         ));
     }
 
+    #[test]
+    fn parsed_each_of_your_main_phases_fires_only_on_controller_main_phases() {
+        fn run(active_player: PlayerId, phase: Phase) -> usize {
+            let mut state = setup();
+            state.active_player = active_player;
+            state.priority_player = active_player;
+            state.phase = phase;
+
+            let source = make_creature(&mut state, PlayerId(0), "Carpet of Flowers", 0, 1);
+            let mut trig_def = crate::parser::oracle_trigger::parse_trigger_line(
+                "At the beginning of each of your main phases, if you haven't added mana with this ability this turn, you may add X mana of any one color, where X is the number of Islands target opponent controls.",
+                "Carpet of Flowers",
+            );
+            trig_def.execute = Some(Box::new(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )));
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.trigger_definitions.push(trig_def.clone());
+            std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trig_def);
+
+            process_triggers(&mut state, &[GameEvent::PhaseChanged { phase }]);
+            state.stack.len()
+        }
+
+        assert_eq!(run(PlayerId(0), Phase::PreCombatMain), 1);
+        assert_eq!(run(PlayerId(0), Phase::PostCombatMain), 1);
+        assert_eq!(run(PlayerId(0), Phase::Upkeep), 0);
+        assert_eq!(run(PlayerId(1), Phase::PreCombatMain), 0);
+    }
+
     /// CR 601.2h + CR 603.4: Increment intervening-if gates the counter-placement
     /// trigger on the amount of mana spent to cast the triggering spell exceeding
     /// either the source creature's power or its toughness. This is the regression

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7644,12 +7644,27 @@ fn try_parse_phase_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinitio
     let phase_text = stripped.trim();
     let mut def = make_base();
     def.mode = TriggerMode::Phase;
-    def.phase = scan_for_phase(phase_text);
+    let phase = scan_for_phase(phase_text);
+    let is_generic_main_phase = phase.is_none() && scan_for_generic_main_phase(phase_text);
+    def.phase = phase;
 
     // CR 503.1a / CR 507.1: Parse possessive qualifier and trailing suffix for turn constraint.
     // Uses nom prefix dispatch: opponent possessives checked before bare "your" to avoid
     // "your opponent's" matching as "your".
-    def.constraint = parse_turn_constraint(phase_text);
+    let turn_constraint = parse_turn_constraint(phase_text);
+    def.constraint = if is_generic_main_phase {
+        match turn_constraint {
+            // CR 505.1 + CR 603.2b: "each of your main phases" is not one
+            // concrete phase; it triggers at the start of either main phase
+            // on the source controller's turn.
+            Some(TriggerConstraint::OnlyDuringYourTurn) => {
+                Some(TriggerConstraint::OnlyDuringYourMainPhase)
+            }
+            other => other,
+        }
+    } else {
+        turn_constraint
+    };
     if scan_contains(phase_text, "enchanted player's") {
         def.valid_target = Some(TargetFilter::AttachedTo);
     }
@@ -10034,9 +10049,18 @@ fn parse_phase_keyword(input: &str) -> nom::IResult<&str, Phase, OracleError<'_>
     .parse(input)
 }
 
+fn parse_generic_main_phase_keyword(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
+    value((), pair(tag("main phase"), opt(tag("s")))).parse(input)
+}
+
 /// Scan phase_text for a phase keyword at each word boundary using nom combinators.
 fn scan_for_phase(text: &str) -> Option<Phase> {
     super::oracle_nom::primitives::scan_at_word_boundaries(text, parse_phase_keyword)
+}
+
+fn scan_for_generic_main_phase(text: &str) -> bool {
+    super::oracle_nom::primitives::scan_at_word_boundaries(text, parse_generic_main_phase_keyword)
+        .is_some()
 }
 
 /// CR 503.1a / CR 507.1: Parse turn constraint from phase text using nom prefix dispatch.
@@ -10053,13 +10077,15 @@ fn parse_turn_constraint(phase_text: &str) -> Option<TriggerConstraint> {
         tag("your opponent's "),
         tag("your opponents\u{2019} "),
         tag("your opponents' "),
+        tag("each of your opponents\u{2019} "),
+        tag("each of your opponents' "),
     ))
     .parse(phase_text)
     .is_ok()
     {
         return Some(TriggerConstraint::OnlyDuringOpponentsTurn);
     }
-    if tag::<_, _, OracleError<'_>>("your ")
+    if alt((tag::<_, _, OracleError<'_>>("each of your "), tag("your ")))
         .parse(phase_text)
         .is_ok()
     {
@@ -19167,6 +19193,7 @@ mod tests {
         );
         assert_eq!(def.mode, TriggerMode::Phase);
         assert_eq!(def.phase, Some(Phase::PostCombatMain));
+        assert_eq!(def.constraint, Some(TriggerConstraint::OnlyDuringYourTurn));
         assert!(def.optional, "trigger should be optional ('you may')");
 
         let bound_qty = QuantityExpr::Ref {
@@ -19213,6 +19240,21 @@ mod tests {
         assert_eq!(def.mode, TriggerMode::Phase);
         assert_eq!(def.phase, Some(Phase::PreCombatMain));
         assert_eq!(def.constraint, Some(TriggerConstraint::OnlyDuringYourTurn));
+    }
+
+    #[test]
+    fn trigger_each_of_your_main_phases_uses_main_phase_constraint() {
+        let def = parse_trigger_line(
+            "At the beginning of each of your main phases, if you haven't added mana with this ability this turn, you may add X mana of any one color, where X is the number of Islands target opponent controls.",
+            "Carpet of Flowers",
+        );
+        assert_eq!(def.mode, TriggerMode::Phase);
+        assert_eq!(def.phase, None);
+        assert_eq!(
+            def.constraint,
+            Some(TriggerConstraint::OnlyDuringYourMainPhase)
+        );
+        assert!(def.optional, "trigger should be optional ('you may')");
     }
 
     /// Coalition Relic, third ability — Future Sight artifact, issue #130.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -10049,6 +10049,8 @@ fn parse_phase_keyword(input: &str) -> nom::IResult<&str, Phase, OracleError<'_>
     .parse(input)
 }
 
+/// CR 505.1: "main phase" collectively names the precombat and postcombat
+/// main phases without selecting one concrete `Phase` value.
 fn parse_generic_main_phase_keyword(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
     value((), pair(tag("main phase"), opt(tag("s")))).parse(input)
 }


### PR DESCRIPTION
## Summary
Fixes **Carpet of Flowers** phase-trigger timing.

Closes #1588.

## Files changed
- crates/engine/src/parser/oracle_trigger.rs

## CR references
- CR 505.1
- CR 603.2b

## Track
Developer

## LLM
Tier: Standard
Model: codex-5
Thinking: medium

## Verification
- `cargo fmt --all -- --check` — clean on PR branch
- `./scripts/check-parser-combinators.sh` — clean on PR branch
- `git diff --check` — clean on PR branch
- `cargo test -p engine trigger_each_of_your_main_phases_uses_main_phase_constraint` — clean on PR branch
- `cargo test -p engine trigger_tymna_the_weaver_pays_and_draws_bound_x` — clean on PR branch
- Pipeline pre-submit checks before isolated branch creation:
  - `cargo clippy --all-targets -- -D warnings` — clean
  - `cargo test -p engine` — 8874 passed, 0 failed, 1 ignored; integration 471 passed, 0 failed
  - `./scripts/gen-card-data.sh` — clean; Carpet of Flowers exports `OnlyDuringYourMainPhase`

## Gate A
`./scripts/check-parser-combinators.sh`

```text

```

Command exited 0.

## Anchored on
- crates/engine/src/parser/oracle_trigger.rs:10031 — existing `parse_phase_keyword` nom `alt()` maps concrete main-phase phrases to typed `Phase` values.
- crates/engine/src/parser/oracle_trigger.rs:10056 — existing `scan_for_phase` uses the shared word-boundary scanner for phase phrase detection.
- crates/engine/src/parser/oracle_trigger.rs:10071 — existing `parse_turn_constraint` uses nom prefix dispatch for phase-trigger controller scoping.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
