### PR TITLE
refactor(engine): collapse ReduceCost/RaiseCost/MinimumCost into Modi…

### DIFF
--- a/crates/engine/src/database/forge/static_ab.rs
+++ b/crates/engine/src/database/forge/static_ab.rs
@@ -1,7 +1,7 @@
 use crate::types::ability::{ContinuousModification, StaticDefinition};
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
-use crate::types::statics::StaticMode;
+use crate::types::statics::{CostModifyMode, StaticMode};
 
 use super::filter::translate_filter;
 use super::types::{ForgeAbilityLine, ForgeTranslateError};
@@ -142,7 +142,8 @@ fn translate_raise_cost(line: &ForgeAbilityLine) -> Result<StaticDefinition, For
         .get("ValidCard")
         .and_then(|s| translate_filter(s).ok());
 
-    let mut def = StaticDefinition::new(StaticMode::RaiseCost {
+    let mut def = StaticDefinition::new(StaticMode::ModifyCost {
+        mode: CostModifyMode::Raise,
         amount,
         spell_filter,
         dynamic_count: None,
@@ -166,7 +167,8 @@ fn translate_reduce_cost(line: &ForgeAbilityLine) -> Result<StaticDefinition, Fo
         .get("ValidCard")
         .and_then(|s| translate_filter(s).ok());
 
-    let mut def = StaticDefinition::new(StaticMode::ReduceCost {
+    let mut def = StaticDefinition::new(StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
         amount,
         spell_filter,
         dynamic_count: None,
@@ -194,7 +196,11 @@ mod tests {
         };
         let def = translate_static(&line).unwrap();
         match def.mode {
-            StaticMode::RaiseCost { amount, .. } => {
+            StaticMode::ModifyCost {
+                mode: CostModifyMode::Raise,
+                amount,
+                ..
+            } => {
                 assert_eq!(amount.mana_value(), 1);
             }
             other => panic!("expected RaiseCost, got {other:?}"),

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -19,7 +19,7 @@ use crate::types::mana::{
 };
 use crate::types::player::PlayerId;
 use crate::types::statics::{
-    ActivationExemption, CastFrequency, CastingProhibitionCondition, ExileCastCost,
+    ActivationExemption, CastFrequency, CastingProhibitionCondition, CostModifyMode, ExileCastCost,
     ProhibitionScope, StaticMode,
 };
 use crate::types::zones::{ExileCostSourceZone, Zone};
@@ -2899,17 +2899,17 @@ fn apply_self_spell_cost_modifiers_inner(
         }
 
         let (amount, spell_filter, dynamic_count, is_raise) = match &def.mode {
-            StaticMode::ReduceCost {
+            StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount,
                 spell_filter,
                 dynamic_count,
-                ..
             } => (amount, spell_filter, dynamic_count, false),
-            StaticMode::RaiseCost {
+            StaticMode::ModifyCost {
+                mode: CostModifyMode::Raise,
                 amount,
                 spell_filter,
                 dynamic_count,
-                ..
             } => (amount, spell_filter, dynamic_count, true),
             _ => continue,
         };
@@ -3155,12 +3155,14 @@ fn apply_battlefield_cost_modifiers_inner(
 
         {
             let (amount, spell_filter, dynamic_count, is_raise) = match &def.mode {
-                StaticMode::ReduceCost {
+                StaticMode::ModifyCost {
+                    mode: CostModifyMode::Reduce,
                     amount,
                     spell_filter,
                     dynamic_count,
                 } => (amount, spell_filter, dynamic_count, false),
-                StaticMode::RaiseCost {
+                StaticMode::ModifyCost {
+                    mode: CostModifyMode::Raise,
                     amount,
                     spell_filter,
                     dynamic_count,
@@ -3291,9 +3293,11 @@ fn apply_cost_floor_inner(
     for (bf_obj, def) in super::functioning_abilities::battlefield_functioning_statics(state) {
         let bf_id = bf_obj.id;
 
-        let StaticMode::MinimumCost {
+        let StaticMode::ModifyCost {
+            mode: CostModifyMode::Minimum,
             ref amount,
             ref spell_filter,
+            ..
         } = def.mode
         else {
             continue;
@@ -14002,7 +14006,8 @@ mod tests {
             // Self-spell cost reduction as the parser emits it: 1 generic per qualifying
             // card in the graveyard, affected = SelfRef, active in Hand/Stack/Command.
             use crate::types::ability::{CountScope, QuantityRef, ZoneRef};
-            let mut def = StaticDefinition::new(StaticMode::ReduceCost {
+            let mut def = StaticDefinition::new(StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount: ManaCost::generic(1),
                 spell_filter: None,
                 dynamic_count: Some(QuantityRef::ZoneCardCount {
@@ -14080,7 +14085,8 @@ mod tests {
                 shards: vec![ManaCostShard::Green, ManaCostShard::Green],
                 generic: 10,
             };
-            let mut def = StaticDefinition::new(StaticMode::ReduceCost {
+            let mut def = StaticDefinition::new(StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount: ManaCost::generic(1),
                 spell_filter: None,
                 dynamic_count: Some(QuantityRef::Aggregate {
@@ -14142,7 +14148,8 @@ mod tests {
             obj.chosen_attributes
                 .push(ChosenAttribute::CreatureType("Elf".to_string()));
             obj.static_definitions.push(
-                StaticDefinition::new(StaticMode::ReduceCost {
+                StaticDefinition::new(StaticMode::ModifyCost {
+                    mode: CostModifyMode::Reduce,
                     amount: ManaCost::Cost {
                         generic: 0,
                         shards: vec![
@@ -14436,7 +14443,8 @@ mod tests {
             let obj = state.objects.get_mut(&spell_id).unwrap();
             obj.card_types.core_types.push(CoreType::Instant);
             obj.mana_cost = ManaCost::generic(3);
-            let mut def = StaticDefinition::new(StaticMode::ReduceCost {
+            let mut def = StaticDefinition::new(StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount: ManaCost::generic(2),
                 spell_filter: Some(TargetFilter::Typed(TypedFilter::card().properties(vec![
                     FilterProp::Targets {
@@ -19461,7 +19469,8 @@ mod tests {
             .unwrap()
             .static_definitions
             .push(
-                StaticDefinition::new(StaticMode::RaiseCost {
+                StaticDefinition::new(StaticMode::ModifyCost {
+                    mode: CostModifyMode::Raise,
                     amount: ManaCost::generic(3),
                     spell_filter: Some(spell_filter),
                     dynamic_count: None,
@@ -26125,7 +26134,8 @@ mod tests {
         /// OR alternative — mirroring a flat cost reduction.
         fn add_self_cost_reduction(state: &mut GameState, obj_id: ObjectId, generic: u32) {
             let obj = state.objects.get_mut(&obj_id).unwrap();
-            let mut def = StaticDefinition::new(StaticMode::ReduceCost {
+            let mut def = StaticDefinition::new(StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount: ManaCost::generic(generic),
                 spell_filter: None,
                 dynamic_count: None,
@@ -28668,9 +28678,11 @@ mod tests {
         obj.card_types.core_types.push(CoreType::Artifact);
         obj.entered_battlefield_turn = Some(0);
         obj.static_definitions.push(
-            StaticDefinition::new(StaticMode::MinimumCost {
+            StaticDefinition::new(StaticMode::ModifyCost {
+                mode: CostModifyMode::Minimum,
                 amount: ManaCost::generic(3),
                 spell_filter: None,
+                dynamic_count: None,
             })
             .condition(StaticCondition::Not {
                 condition: Box::new(StaticCondition::SourceIsTapped),
@@ -29035,9 +29047,11 @@ mod tests {
             obj.card_types.core_types.push(CoreType::Artifact);
             obj.entered_battlefield_turn = Some(0);
             obj.static_definitions
-                .push(StaticDefinition::new(StaticMode::MinimumCost {
+                .push(StaticDefinition::new(StaticMode::ModifyCost {
+                    mode: CostModifyMode::Minimum,
                     amount: ManaCost::generic(5),
                     spell_filter: None,
+                    dynamic_count: None,
                 }));
         }
         let spell = create_stack_spell(&mut state, PlayerId(0), ManaCost::generic(2));

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4284,7 +4284,7 @@ pub(super) fn max_x_value_excluding(
     object_id: Option<ObjectId>,
     excluded_sources: &HashSet<ObjectId>,
 ) -> u32 {
-    use crate::types::statics::StaticMode;
+    use crate::types::statics::{CostModifyMode, StaticMode};
 
     let ManaCost::Cost { shards, generic } = cost else {
         return 0;
@@ -4390,8 +4390,16 @@ pub(super) fn max_x_value_excluding(
     // non-functional floor is correctly skipped there, yielding `formula_max` for
     // that candidate. The vast majority of games have zero `MinimumCost` statics,
     // so the hot X-announce / legal-actions path pays only one short-circuiting scan.
-    let floor_active = super::functioning_abilities::battlefield_functioning_statics(state)
-        .any(|(_, def)| matches!(def.mode, StaticMode::MinimumCost { .. }));
+    let floor_active =
+        super::functioning_abilities::battlefield_functioning_statics(state).any(|(_, def)| {
+            matches!(
+                def.mode,
+                StaticMode::ModifyCost {
+                    mode: CostModifyMode::Minimum,
+                    ..
+                }
+            )
+        });
     if !floor_active {
         return formula_max;
     }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -24,7 +24,7 @@ use crate::types::keywords::Keyword;
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use crate::types::phase::Phase;
 use crate::types::replacements::ReplacementEvent;
-use crate::types::statics::StaticMode;
+use crate::types::statics::{CostModifyMode, StaticMode};
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 use nom::bytes::complete::tag;
@@ -41,9 +41,7 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
         StaticMode::ReduceAbilityCost { .. }
             | StaticMode::ModifyActivationLimit { .. }
             | StaticMode::AdditionalLandDrop { .. }
-            | StaticMode::ReduceCost { .. }
-            | StaticMode::RaiseCost { .. }
-            | StaticMode::MinimumCost { .. }
+            | StaticMode::ModifyCost { .. }
             | StaticMode::DefilerCostReduction { .. }
             | StaticMode::CantPayCost { .. }
             | StaticMode::CantBeCast { .. }
@@ -6510,19 +6508,21 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                 effective_lower.contains("play with the top card")
                     || effective_lower.contains("play with the top")
             }
-            StaticMode::ReduceCost { .. } => {
-                effective_lower.contains("cost") && effective_lower.contains("less")
-            }
-            StaticMode::RaiseCost { .. } => {
-                effective_lower.contains("cost") && effective_lower.contains("more")
-            }
-            // CR 601.2f: Trinisphere class — "each spell that would cost less than N
-            // mana to cast costs N mana to cast." Coverage marker: "would cost less than"
-            // is the discriminator from RaiseCost ("more"), ReduceCost ("less to cast").
-            StaticMode::MinimumCost { .. } => {
-                effective_lower.contains("would cost less than")
-                    && effective_lower.contains("mana to cast")
-            }
+            // CR 601.2f: ReduceCost / RaiseCost / MinimumCost coverage markers,
+            // discriminated by the `mode` axis. Trinisphere's "would cost less than"
+            // distinguishes Minimum from Reduce ("less to cast") and Raise ("more").
+            StaticMode::ModifyCost { mode, .. } => match mode {
+                CostModifyMode::Reduce => {
+                    effective_lower.contains("cost") && effective_lower.contains("less")
+                }
+                CostModifyMode::Raise => {
+                    effective_lower.contains("cost") && effective_lower.contains("more")
+                }
+                CostModifyMode::Minimum => {
+                    effective_lower.contains("would cost less than")
+                        && effective_lower.contains("mana to cast")
+                }
+            },
             StaticMode::CantBeCountered => effective_lower.contains("can't be countered"),
             StaticMode::CantBeCopied => effective_lower.contains("can't be copied"),
             // CR 119.7: "can't gain life" or its compound form "life total can't change"

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -79,7 +79,7 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     // triggered and are unaffected by this variant.
     // CR 702.8a: CastWithFlash — card may be cast at instant speed.
     registry.insert(StaticMode::CastWithFlash, handle_rule_mod);
-    // CR 601.2f: ReduceCost/RaiseCost are data-carrying variants — runtime checks are
+    // CR 601.2f: ModifyCost (Reduce/Raise modes) is a data-carrying variant — runtime checks are
     // in game/casting.rs::apply_battlefield_cost_modifiers(). Coverage support is via
     // is_data_carrying_static() in game/coverage.rs.
     // Note: ReduceAbilityCost runtime checks are in game/keywords.rs::apply_ability_cost_reduction().
@@ -259,7 +259,7 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     //   - ChangesZoneAll            → `TriggerMode::ChangesZoneAll`
     //   - PreventDamage             → `Effect::PreventDamage`
     //   - DamageReduction / cost-mod variants → typed `StaticMode` variants
-    //     (`ReduceCost`, `RaiseCost`, `DefilerCostReduction`, etc.)
+    //     (`ModifyCost`, `DefilerCostReduction`, etc.)
     //   - ETBReplacement / LeavesPlay → `ReplacementDefinition`
     //     (ChangeZone / Moved events)
     //

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4216,7 +4216,7 @@ mod tests {
     use crate::types::keywords::{FlashbackCost, KeywordKind, WardCost};
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
     use crate::types::replacements::ReplacementEvent;
-    use crate::types::statics::{ProhibitionScope, StaticMode};
+    use crate::types::statics::{CostModifyMode, ProhibitionScope, StaticMode};
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
 
@@ -11324,7 +11324,8 @@ mod tests {
             r.abilities[0].effect
         );
         assert_eq!(r.statics.len(), 1);
-        let StaticMode::ReduceCost {
+        let StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::Cost { generic: 1, .. },
             dynamic_count:
                 Some(QuantityRef::ObjectCount {
@@ -11379,7 +11380,13 @@ mod tests {
         );
         assert_eq!(r.statics.len(), 1);
         assert!(
-            matches!(r.statics[0].mode, StaticMode::ReduceCost { .. }),
+            matches!(
+                r.statics[0].mode,
+                StaticMode::ModifyCost {
+                    mode: CostModifyMode::Reduce,
+                    ..
+                }
+            ),
             "cost-reduction sentence should be a static, got {:?}",
             r.statics[0].mode
         );

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
@@ -27,7 +27,8 @@ expression: "&ir"
     {
       "PreLoweredStatic": {
         "mode": {
-          "RaiseCost": {
+          "ModifyCost": {
+            "mode": "Raise",
             "amount": {
               "type": "Cost",
               "shards": [],
@@ -42,8 +43,7 @@ expression: "&ir"
               ],
               "controller": null,
               "properties": []
-            },
-            "dynamic_count": null
+            }
           }
         },
         "affected": {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_lowered.snap
@@ -27,7 +27,8 @@ expression: "&lowered"
   "statics": [
     {
       "mode": {
-        "RaiseCost": {
+        "ModifyCost": {
+          "mode": "Raise",
           "amount": {
             "type": "Cost",
             "shards": [],
@@ -42,8 +43,7 @@ expression: "&lowered"
             ],
             "controller": null,
             "properties": []
-          },
-          "dynamic_count": null
+          }
         }
       },
       "affected": {

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1546,7 +1546,7 @@ pub(crate) fn merge_cost_modifier_target_filter(
 /// ruling, this is a "directly affect the total cost" effect applied after
 /// every additive/subtractive modifier, just before the cost is "locked in".
 ///
-/// Returns a `StaticMode::MinimumCost` with `spell_filter = None` (the printed
+/// Returns a `StaticMode::ModifyCost` (Minimum) with `spell_filter = None` (the printed
 /// pattern affects all spells; future filtered variants would attach a filter
 /// here) and any trailing "as long as" / "if" condition lifted into the
 /// `StaticDefinition.condition` field (handles Trinisphere's "as long as this
@@ -1593,9 +1593,11 @@ pub(crate) fn try_parse_cost_floor(text: &str, lower: &str) -> Option<StaticDefi
     }
     let amount = ManaCost::generic(n1);
 
-    let mut definition = StaticDefinition::new(StaticMode::MinimumCost {
+    let mut definition = StaticDefinition::new(StaticMode::ModifyCost {
+        mode: CostModifyMode::Minimum,
         amount,
         spell_filter: None,
+        dynamic_count: None,
     })
     .description(text.to_string());
 

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -56,8 +56,8 @@ mod prelude {
     pub(super) use crate::types::phase::Phase;
     pub(super) use crate::types::statics::{
         ActivationExemption, BlockExceptionKind, CastFrequency, CastingProhibitionCondition,
-        CostPaymentProhibition, ExileCastCost, HandSizeModification, ProhibitionScope, StaticMode,
-        TriggerCause,
+        CostModifyMode, CostPaymentProhibition, ExileCastCost, HandSizeModification,
+        ProhibitionScope, StaticMode, TriggerCause,
     };
     pub(super) use crate::types::zones::Zone;
 }

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -313,18 +313,15 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
         amount
     };
 
-    let mode = if is_raise {
-        StaticMode::RaiseCost {
-            amount,
-            spell_filter: spell_filter.clone(),
-            dynamic_count: dynamic_count.clone(),
-        }
-    } else {
-        StaticMode::ReduceCost {
-            amount,
-            spell_filter: spell_filter.clone(),
-            dynamic_count: dynamic_count.clone(),
-        }
+    let mode = StaticMode::ModifyCost {
+        mode: if is_raise {
+            CostModifyMode::Raise
+        } else {
+            CostModifyMode::Reduce
+        },
+        amount,
+        spell_filter: spell_filter.clone(),
+        dynamic_count: dynamic_count.clone(),
     };
 
     // Build the affected filter for the static definition.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -877,7 +877,8 @@ fn static_this_spell_cost_less_self_scoped_in_castable_zones() {
     .unwrap();
     assert!(matches!(
         def.mode,
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::Cost { generic: 1, .. },
             dynamic_count: Some(_),
             ..
@@ -897,7 +898,8 @@ fn ghalta_self_cost_reduction_is_active_from_command_zone() {
     )
     .unwrap();
 
-    let StaticMode::ReduceCost {
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
         dynamic_count:
             Some(QuantityRef::Aggregate {
                 function: AggregateFunction::Sum,
@@ -923,7 +925,8 @@ fn static_this_spell_cost_less_for_each_creature_that_attacked_this_turn() {
     )
     .unwrap();
 
-    let StaticMode::ReduceCost {
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
         amount: ManaCost::Cost { generic: 1, .. },
         dynamic_count:
             Some(QuantityRef::ObjectCount {
@@ -958,7 +961,8 @@ fn static_this_spell_cost_less_for_each_creature_you_attacked_with_this_turn() {
 
     assert!(matches!(
         def.mode,
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::Cost { generic: 1, .. },
             dynamic_count: Some(QuantityRef::AttackedThisTurn),
             ..
@@ -1015,7 +1019,8 @@ fn self_cost_reduction_if_night_uses_day_night_condition() {
 
     assert!(matches!(
         def.mode,
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::Cost { generic: 2, .. },
             ..
         }
@@ -1048,7 +1053,8 @@ fn self_cost_reduction_if_bargained_uses_additional_cost_paid_condition() {
         assert!(
             matches!(
                 def.mode,
-                StaticMode::ReduceCost {
+                StaticMode::ModifyCost {
+                    mode: CostModifyMode::Reduce,
                     amount: ManaCost::Cost { generic: 2, .. },
                     ..
                 }
@@ -1070,7 +1076,13 @@ fn self_cost_reduction_if_control_wizard_still_uses_presence_condition() {
     // Regression: the bargained early-return must not divert other conditions.
     let def =
         parse_static_line("This spell costs {2} less to cast if you control a Wizard.").unwrap();
-    assert!(matches!(def.mode, StaticMode::ReduceCost { .. }));
+    assert!(matches!(
+        def.mode,
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
+            ..
+        }
+    ));
     assert!(
         !matches!(def.condition, Some(StaticCondition::AdditionalCostPaid)),
         "control-a-Wizard must not parse as AdditionalCostPaid, got {:?}",
@@ -1086,13 +1098,16 @@ fn static_this_spell_cost_less_if_it_targets_creature_filter() {
 
     assert!(matches!(
         def.mode,
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::Cost { generic: 2, .. },
             ..
         }
     ));
-    let StaticMode::ReduceCost {
-        ref spell_filter, ..
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        ref spell_filter,
+        ..
     } = def.mode
     else {
         panic!("expected ReduceCost");
@@ -1133,7 +1148,8 @@ fn static_spells_cost_less() {
     let def = parse_static_line("Spells you cast cost {1} less to cast.").unwrap();
     assert!(matches!(
         def.mode,
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             spell_filter: None,
             dynamic_count: None,
             ..
@@ -1142,7 +1158,8 @@ fn static_spells_cost_less() {
     // Verify amount is generic 1 (avoid assert_eq! on complex types — SIGABRT risk)
     assert!(matches!(
         def.mode,
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::Cost { generic: 1, .. },
             ..
         }
@@ -1154,7 +1171,8 @@ fn static_opponent_spells_cost_more() {
     let def = parse_static_line("Spells your opponents cast cost {1} more to cast.").unwrap();
     assert!(matches!(
         def.mode,
-        StaticMode::RaiseCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Raise,
             spell_filter: None,
             dynamic_count: None,
             ..
@@ -1162,7 +1180,8 @@ fn static_opponent_spells_cost_more() {
     ));
     assert!(matches!(
         def.mode,
-        StaticMode::RaiseCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Raise,
             amount: ManaCost::Cost { generic: 1, .. },
             ..
         }
@@ -1178,7 +1197,8 @@ fn static_opponent_spells_targeting_commanders_cost_more() {
 
     assert!(matches!(
         def.mode,
-        StaticMode::RaiseCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Raise,
             amount: ManaCost::Cost { generic: 3, .. },
             ..
         }
@@ -1190,8 +1210,10 @@ fn static_opponent_spells_targeting_commanders_cost_more() {
             ..
         }))
     ));
-    let StaticMode::RaiseCost {
-        ref spell_filter, ..
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Raise,
+        ref spell_filter,
+        ..
     } = def.mode
     else {
         panic!("expected RaiseCost");
@@ -1225,13 +1247,16 @@ fn static_spells_targeting_creature_cost_less() {
 
     assert!(matches!(
         def.mode,
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::Cost { generic: 2, .. },
             ..
         }
     ));
-    let StaticMode::ReduceCost {
-        ref spell_filter, ..
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        ref spell_filter,
+        ..
     } = def.mode
     else {
         panic!("expected ReduceCost");
@@ -1265,13 +1290,16 @@ fn static_opponent_spells_from_zones_cost_more() {
     .unwrap();
     assert!(matches!(
         def.mode,
-        StaticMode::RaiseCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Raise,
             amount: ManaCost::Cost { generic: 2, .. },
             ..
         }
     ));
-    if let StaticMode::RaiseCost {
-        ref spell_filter, ..
+    if let StaticMode::ModifyCost {
+        mode: CostModifyMode::Raise,
+        ref spell_filter,
+        ..
     } = def.mode
     {
         let filter = spell_filter
@@ -1307,13 +1335,16 @@ fn static_spells_from_exile_cost_less() {
     let def = parse_static_line("Spells you cast from exile cost {1} less to cast.").unwrap();
     assert!(matches!(
         def.mode,
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::Cost { generic: 1, .. },
             ..
         }
     ));
-    if let StaticMode::ReduceCost {
-        ref spell_filter, ..
+    if let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        ref spell_filter,
+        ..
     } = def.mode
     {
         let filter = spell_filter
@@ -1340,13 +1371,16 @@ fn static_creature_spells_cost_less() {
     let def = parse_static_line("Creature spells you cast cost {1} less to cast.").unwrap();
     assert!(matches!(
         def.mode,
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::Cost { generic: 1, .. },
             ..
         }
     ));
-    if let StaticMode::ReduceCost {
-        ref spell_filter, ..
+    if let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        ref spell_filter,
+        ..
     } = def.mode
     {
         let filter = spell_filter.as_ref().expect("Expected spell_filter");
@@ -1373,7 +1407,8 @@ fn static_spells_of_chosen_type_cost_less_carries_chosen_card_type() {
     // infix previously prevented the discriminator from being extracted.
     let def =
         parse_static_line("Spells you cast of the chosen type cost {1} less to cast.").unwrap();
-    let StaticMode::ReduceCost {
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
         spell_filter: Some(TargetFilter::Typed(ref tf)),
         ..
     } = def.mode
@@ -1400,7 +1435,8 @@ fn static_creature_spells_of_chosen_type_cost_less_carries_chosen_creature_type(
     let def =
         parse_static_line("Creature spells you cast of the chosen type cost {1} less to cast.")
             .unwrap();
-    let StaticMode::ReduceCost {
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
         spell_filter: Some(TargetFilter::Typed(ref tf)),
         ..
     } = def.mode
@@ -1436,11 +1472,19 @@ fn static_instant_sorcery_spells_cost_less() {
     );
     let def = def.unwrap();
     assert!(
-        matches!(def.mode, StaticMode::ReduceCost { .. }),
+        matches!(
+            def.mode,
+            StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
+                ..
+            }
+        ),
         "Expected ReduceCost mode"
     );
-    if let StaticMode::ReduceCost {
-        ref spell_filter, ..
+    if let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        ref spell_filter,
+        ..
     } = def.mode
     {
         assert!(
@@ -1473,9 +1517,17 @@ fn static_instant_sorcery_spells_cost_less() {
 fn static_white_spells_cost_more() {
     // "White spells your opponents cast cost {1} more to cast."
     let def = parse_static_line("White spells your opponents cast cost {1} more to cast.").unwrap();
-    assert!(matches!(def.mode, StaticMode::RaiseCost { .. }));
-    if let StaticMode::RaiseCost {
-        ref spell_filter, ..
+    assert!(matches!(
+        def.mode,
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Raise,
+            ..
+        }
+    ));
+    if let StaticMode::ModifyCost {
+        mode: CostModifyMode::Raise,
+        ref spell_filter,
+        ..
     } = def.mode
     {
         let filter = spell_filter.as_ref().expect("Expected spell_filter");
@@ -1500,13 +1552,16 @@ fn static_noncreature_spells_cost_more_thalia() {
     let def = parse_static_line("Noncreature spells cost {1} more to cast.").unwrap();
     assert!(matches!(
         def.mode,
-        StaticMode::RaiseCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Raise,
             amount: ManaCost::Cost { generic: 1, .. },
             ..
         }
     ));
-    if let StaticMode::RaiseCost {
-        ref spell_filter, ..
+    if let StaticMode::ModifyCost {
+        mode: CostModifyMode::Raise,
+        ref spell_filter,
+        ..
     } = def.mode
     {
         let filter = spell_filter.as_ref().expect("Expected spell_filter");
@@ -1536,7 +1591,8 @@ fn static_noncreature_spells_cost_more_thalia() {
 #[test]
 fn static_spells_with_chosen_name_cost_more_disruptor_flute() {
     let def = parse_static_line("Spells with the chosen name cost {3} more to cast.").unwrap();
-    let StaticMode::RaiseCost {
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Raise,
         amount,
         spell_filter,
         dynamic_count,
@@ -1566,9 +1622,11 @@ fn static_trinisphere_cost_floor_with_untapped_condition() {
         )
         .expect("Trinisphere line must parse");
     match &def.mode {
-        StaticMode::MinimumCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Minimum,
             amount,
             spell_filter,
+            ..
         } => {
             assert_eq!(amount, &ManaCost::generic(3), "floor must be {{3}}");
             assert!(spell_filter.is_none(), "Trinisphere has no spell filter");
@@ -1597,9 +1655,11 @@ fn static_cost_floor_canonical_form_no_condition() {
     assert!(
         matches!(
             def.mode,
-            StaticMode::MinimumCost {
+            StaticMode::ModifyCost {
+                mode: CostModifyMode::Minimum,
                 amount: ManaCost::Cost { generic: 3, .. },
                 spell_filter: None,
+                ..
             }
         ),
         "expected MinimumCost(3); got {:?}",
@@ -1618,9 +1678,17 @@ fn static_first_qualified_spell_costs_less_has_filter_and_condition() {
         )
         .unwrap();
 
-    assert!(matches!(def.mode, StaticMode::ReduceCost { .. }));
-    let StaticMode::ReduceCost {
-        ref spell_filter, ..
+    assert!(matches!(
+        def.mode,
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
+            ..
+        }
+    ));
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        ref spell_filter,
+        ..
     } = def.mode
     else {
         unreachable!();
@@ -1662,7 +1730,8 @@ fn static_spells_cost_x_less_where_x_is_your_speed() {
         "Noncreature spells you cast cost {X} less to cast, where X is your speed.",
     )
     .unwrap();
-    let StaticMode::ReduceCost {
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
         amount,
         dynamic_count,
         ..
@@ -1686,7 +1755,13 @@ fn static_noncreature_spells_cost_less_as_long_as_lesson_threshold() {
         )
         .unwrap();
 
-    assert!(matches!(def.mode, StaticMode::ReduceCost { .. }));
+    assert!(matches!(
+        def.mode,
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
+            ..
+        }
+    ));
     assert!(matches!(
         def.condition,
         Some(StaticCondition::QuantityComparison {
@@ -1724,7 +1799,8 @@ fn static_eminence_cost_reduction_command_zone_or_battlefield() {
     assert!(
         matches!(
             def.mode,
-            StaticMode::ReduceCost {
+            StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount: ManaCost::Cost { generic: 1, .. },
                 ..
             }
@@ -1779,7 +1855,8 @@ fn static_eminence_cost_reduction_inverted_form() {
     assert!(
         matches!(
             def.mode,
-            StaticMode::ReduceCost {
+            StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount: ManaCost::Cost { generic: 1, .. },
                 ..
             }
@@ -8308,7 +8385,8 @@ fn spell_cost_reduction_uses_card_types_in_graveyard_quantity() {
     )
     .unwrap();
     match def.mode {
-        StaticMode::ReduceCost {
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             dynamic_count:
                 Some(QuantityRef::DistinctCardTypes {
                     source:

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -817,11 +817,7 @@ fn target_filter_has_targets_property(filter: &TargetFilter) -> bool {
 
 fn static_has_target_gated_cost_modification(def: &StaticDefinition) -> bool {
     match &def.mode {
-        StaticMode::ReduceCost {
-            spell_filter: Some(filter),
-            ..
-        }
-        | StaticMode::RaiseCost {
+        StaticMode::ModifyCost {
             spell_filter: Some(filter),
             ..
         } => target_filter_has_targets_property(filter),
@@ -1149,7 +1145,7 @@ fn detect_dynamic_qty(
         // CR 601.2f / CR 117.7: spell- and ability-cost reductions whose
         // {N} amount is multiplied by a dynamic count of objects, zone
         // contents, mana value, etc. The carrier is the `dynamic_count`
-        // field on `StaticMode::ReduceCost` and `StaticMode::RaiseCost`,
+        // field on `StaticMode::ModifyCost` (Reduce / Raise modes),
         // populated with `ObjectCount` / `ZoneCardCount` / `Devotion` /
         // `ManaValue` typed quantity refs.
         "\"dynamic_count\":{",

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4013,7 +4013,7 @@ pub enum StaticCondition {
     /// "as long as enchanted creature is face down" gated statics (Unable to Scream, etc.).
     EnchantedIsFaceDown,
     /// CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid
-    /// for the spell currently being cast. Gates self-spell `ReduceCost` statics like
+    /// for the spell currently being cast. Gates self-spell `ModifyCost` statics like
     /// Hamlet Glutton's "This spell costs {2} less to cast if it's bargained." Evaluated
     /// against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).
     AdditionalCostPaid,

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -416,6 +416,19 @@ pub enum BlockExceptionKind {
     MinBlockers { min: u32 },
 }
 
+/// CR 601.2f: Direction/semantic axis for mana-cost modification statics.
+/// All three modes are applied in the CR 601.2f cost-locking step.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CostModifyMode {
+    /// Subtractive — reduce generic mana (floor: 0).
+    Reduce,
+    /// Additive — increase generic mana. Thalia, Guardian of Thraben class.
+    Raise,
+    /// Floor — cost cannot fall below `amount` after all Reduce/Raise settle.
+    /// CR 601.2f last-step floor. Trinisphere class.
+    Minimum,
+}
+
 /// All static ability modes from Forge's static ability registry.
 /// Matched case-sensitively against Forge mode strings.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -501,19 +514,26 @@ pub enum StaticMode {
     /// CR 118.9 + CR 601.2f: A permanent grants its controller a wholesale
     /// alternative MANA cost for spells matching `StaticDefinition::affected`
     /// that the controller casts — they may pay `cost` rather than the spell's
-    /// mana cost. Parallel to `CastWithKeyword`. Distinct from `ReduceCost`
-    /// (subtractive, CR 601.2f) — this REPLACES the mana cost wholesale
+    /// mana cost. Parallel to `CastWithKeyword`. Distinct from
+    /// `ModifyCost { mode: Reduce, .. }` (subtractive, CR 601.2f) — this REPLACES
+    /// the mana cost wholesale
     /// (CR 118.9) and is mutually exclusive with other alternative costs
     /// (CR 118.9a). Rooftop Storm ({0}, Zombie creature spells), Fist of Suns
     /// ({WUBRG}, any spell), Jodah (MV 5+).
     CastWithAlternativeCost {
         cost: ManaCost,
     },
-    /// CR 601.2f: Reduces the cost of spells matching the filter.
-    /// Permanent-based cost reduction applied during casting (not self-cost reduction).
-    ReduceCost {
+    /// CR 601.2f: Modifies the mana cost of spells matching `spell_filter`
+    /// (or all spells when `None`) by `amount`, in the direction described by `mode`.
+    /// `Reduce` subtracts generic mana (floor: 0), `Raise` adds generic mana,
+    /// `Minimum` floors the total cost after all Reduce/Raise settle.
+    ModifyCost {
+        mode: CostModifyMode,
         amount: ManaCost,
         spell_filter: Option<TargetFilter>,
+        /// Dynamic multiplier (e.g. "for each [thing] you control").
+        /// Only meaningful for `Reduce` and `Raise` — always `None` for `Minimum`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         dynamic_count: Option<QuantityRef>,
     },
     /// CR 601.2f: Reduces the generic mana cost of activated abilities matching a keyword type.
@@ -547,40 +567,6 @@ pub enum StaticMode {
     /// Canonical class: The Wandering Emperor's same-turn loyalty permission.
     ActivateAsInstant {
         cost_category: CostCategory,
-    },
-    /// CR 601.2f: Increases the cost of spells matching the filter.
-    /// Permanent-based cost increase applied during casting (Thalia, etc.).
-    RaiseCost {
-        amount: ManaCost,
-        spell_filter: Option<TargetFilter>,
-        dynamic_count: Option<QuantityRef>,
-    },
-    /// CR 601.2f: Floors the total mana cost of matching spells. Per CR 601.2f,
-    /// this belongs to the "any effects that directly affect the total cost"
-    /// step that runs after all additive/subtractive cost modifiers and just
-    /// before the cost is "locked in." Trinisphere class: "each spell that
-    /// would cost less than three mana to cast costs three mana to cast."
-    ///
-    /// Per the Trinisphere ruling: "apply Trinisphere's effect if the mana
-    /// component of the spell's cost is less than three mana" — applied last,
-    /// after RaiseCost / ReduceCost / pending reductions / Affinity have all
-    /// settled. The floor never reduces a cost.
-    ///
-    /// `amount` is the floor expressed as a `ManaCost` (always pure-generic in
-    /// printed cards; shape-shared with `RaiseCost`/`ReduceCost` for uniform
-    /// serialization). The runtime compares `mana_cost.mana_value()` against
-    /// `amount.mana_value()` and tops up generic mana to reach the floor —
-    /// colored requirements are never modified, per the Trinisphere reminder
-    /// text "Additional mana ... may be paid with any color of mana or
-    /// colorless mana."
-    ///
-    /// `spell_filter` narrows which spells are floored. `None` = all spells
-    /// (Trinisphere). No `dynamic_count` field — printed cost-floor effects
-    /// are always a fixed amount, distinguishing this variant's shape from
-    /// its `RaiseCost`/`ReduceCost` siblings.
-    MinimumCost {
-        amount: ManaCost,
-        spell_filter: Option<TargetFilter>,
     },
     /// CR 118.3 + CR 601.2h + CR 602.2b: The scoped player can't pay a
     /// matching non-mana cost to cast spells or activate abilities.
@@ -998,7 +984,7 @@ pub enum StaticMode {
     Other(String),
 }
 
-/// Manual Hash impl because `ReduceCost`/`RaiseCost` contain `TargetFilter` and `QuantityRef`
+/// Manual Hash impl because `ModifyCost` contains `TargetFilter` and `QuantityRef`
 /// which don't implement `Hash`. For data-carrying variants, we hash only the discriminant +
 /// simple fields. This is safe because data-carrying variants are never used as HashMap keys
 /// (they're handled by `is_data_carrying_static` in coverage.rs instead).
@@ -1072,9 +1058,7 @@ impl Hash for StaticMode {
             StaticMode::PayLifeAsColoredMana { color } => color.hash(state),
             // Data-carrying variants with non-Hash fields: discriminant only.
             // These are never used as HashMap keys (handled by is_data_carrying_static).
-            StaticMode::ReduceCost { .. }
-            | StaticMode::RaiseCost { .. }
-            | StaticMode::MinimumCost { .. }
+            StaticMode::ModifyCost { .. }
             | StaticMode::CantPayCost { .. }
             | StaticMode::DefilerCostReduction { .. }
             | StaticMode::CantDraw { .. }
@@ -1122,7 +1106,11 @@ impl fmt::Display for StaticMode {
             StaticMode::CastWithAlternativeCost { cost } => {
                 write!(f, "CastWithAlternativeCost({cost:?})")
             }
-            StaticMode::ReduceCost { .. } => write!(f, "ReduceCost"),
+            StaticMode::ModifyCost { mode, .. } => match mode {
+                CostModifyMode::Reduce => write!(f, "ReduceCost"),
+                CostModifyMode::Raise => write!(f, "RaiseCost"),
+                CostModifyMode::Minimum => write!(f, "MinimumCost"),
+            },
             StaticMode::ReduceAbilityCost {
                 keyword,
                 amount,
@@ -1141,8 +1129,6 @@ impl fmt::Display for StaticMode {
             StaticMode::ActivateAsInstant { cost_category } => {
                 write!(f, "ActivateAsInstant({cost_category:?})")
             }
-            StaticMode::RaiseCost { .. } => write!(f, "RaiseCost"),
-            StaticMode::MinimumCost { .. } => write!(f, "MinimumCost"),
             StaticMode::CantPayCost { who, cost } => write!(f, "CantPayCost({who},{cost})"),
             StaticMode::CantGainLife => write!(f, "CantGainLife"),
             StaticMode::CantLoseLife => write!(f, "CantLoseLife"),
@@ -1345,7 +1331,8 @@ impl FromStr for StaticMode {
                 exemption: ActivationExemption::None,
             },
             "CastWithFlash" => StaticMode::CastWithFlash,
-            "ReduceCost" => StaticMode::ReduceCost {
+            "ReduceCost" => StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount: ManaCost::zero(),
                 spell_filter: None,
                 dynamic_count: None,
@@ -1401,7 +1388,8 @@ impl FromStr for StaticMode {
                     _ => StaticMode::Other(s.to_string()),
                 }
             }
-            "RaiseCost" => StaticMode::RaiseCost {
+            "RaiseCost" => StaticMode::ModifyCost {
+                mode: CostModifyMode::Raise,
                 amount: ManaCost::zero(),
                 spell_filter: None,
                 dynamic_count: None,
@@ -1409,9 +1397,11 @@ impl FromStr for StaticMode {
             // CR 601.2f: Cost-floor static (Trinisphere class). Legacy unit-string
             // defaults to a zero floor — meaningful instances are constructed via
             // the parser with the printed amount.
-            "MinimumCost" => StaticMode::MinimumCost {
+            "MinimumCost" => StaticMode::ModifyCost {
+                mode: CostModifyMode::Minimum,
                 amount: ManaCost::zero(),
                 spell_filter: None,
+                dynamic_count: None,
             },
             "CantPayCost" => StaticMode::CantPayCost {
                 who: ProhibitionScope::AllPlayers,

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1784,11 +1784,52 @@ where
             }
         }
         other => {
+            if let Some(mode) = deserialize_legacy_modify_cost_object(&other) {
+                return mode.map_err(serde::de::Error::custom);
+            }
             // Data-carrying variant path. Delegate to the derived Deserialize
             // which handles all struct/newtype variants correctly.
             serde_json::from_value::<StaticMode>(other).map_err(serde::de::Error::custom)
         }
     }
+}
+
+#[derive(Deserialize)]
+struct LegacyModifyCostPayload {
+    #[serde(default)]
+    amount: ManaCost,
+    #[serde(default)]
+    spell_filter: Option<TargetFilter>,
+    #[serde(default)]
+    dynamic_count: Option<QuantityRef>,
+}
+
+fn deserialize_legacy_modify_cost_object(
+    raw: &serde_json::Value,
+) -> Option<serde_json::Result<StaticMode>> {
+    let map = raw.as_object()?;
+    if map.len() != 1 {
+        return None;
+    }
+
+    let (name, payload) = map.iter().next()?;
+    let mode = match name.as_str() {
+        "ReduceCost" => CostModifyMode::Reduce,
+        "RaiseCost" => CostModifyMode::Raise,
+        "MinimumCost" => CostModifyMode::Minimum,
+        _ => return None,
+    };
+
+    Some(
+        serde_json::from_value::<LegacyModifyCostPayload>(payload.clone()).map(|payload| {
+            StaticMode::ModifyCost {
+                mode,
+                amount: payload.amount,
+                spell_filter: payload.spell_filter,
+                dynamic_count: payload.dynamic_count,
+            }
+        }),
+    )
 }
 
 #[cfg(test)]
@@ -2023,6 +2064,37 @@ mod tests {
         let json2 = r#"{"mode":"GrantsExtraVote"}"#;
         let w2: Wrapper = serde_json::from_str(json2).unwrap();
         assert_eq!(w2.mode, StaticMode::GrantsExtraVote);
+    }
+
+    #[test]
+    fn fwd_compat_legacy_cost_modify_objects_map_to_modify_cost() {
+        #[derive(serde::Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            #[serde(deserialize_with = "deserialize_static_mode_fwd")]
+            mode: StaticMode,
+        }
+
+        let cases = [
+            ("ReduceCost", CostModifyMode::Reduce),
+            ("RaiseCost", CostModifyMode::Raise),
+            ("MinimumCost", CostModifyMode::Minimum),
+        ];
+
+        for (legacy_name, expected_mode) in cases {
+            let json = format!(
+                r#"{{"mode":{{"{legacy_name}":{{"amount":{{"type":"Cost","shards":[],"generic":2}},"spell_filter":null,"dynamic_count":null}}}}}}"#
+            );
+            let wrapper: Wrapper = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                wrapper.mode,
+                StaticMode::ModifyCost {
+                    mode: expected_mode,
+                    amount: ManaCost::generic(2),
+                    spell_filter: None,
+                    dynamic_count: None,
+                }
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -191,7 +191,7 @@ fn optional_cost_skipped_clears_flag() {
 #[test]
 fn bargain_additional_cost_paid_reduces_self_spell_cost() {
     use engine::types::ability::{StaticCondition, StaticDefinition};
-    use engine::types::statics::StaticMode;
+    use engine::types::statics::{CostModifyMode, StaticMode};
 
     fn build_scenario() -> (engine::game::scenario::GameRunner, ObjectId, Vec<ObjectId>) {
         let mut scenario = GameScenario::new();
@@ -201,7 +201,8 @@ fn bargain_additional_cost_paid_reduces_self_spell_cost() {
             .map(|_| scenario.add_basic_land(P0, ManaColor::Green))
             .collect();
 
-        let reduce_static = StaticDefinition::new(StaticMode::ReduceCost {
+        let reduce_static = StaticDefinition::new(StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: ManaCost::generic(2),
             spell_filter: None,
             dynamic_count: None,

--- a/crates/engine/tests/integration/the_ur_dragon_eminence.rs
+++ b/crates/engine/tests/integration/the_ur_dragon_eminence.rs
@@ -36,7 +36,7 @@ use engine::types::actions::GameAction;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaColor, ManaCost};
 use engine::types::phase::Phase;
-use engine::types::statics::StaticMode;
+use engine::types::statics::{CostModifyMode, StaticMode};
 use engine::types::zones::Zone;
 
 /// Build The Ur-Dragon's Eminence static — typed `ReduceCost {1}` over
@@ -55,7 +55,8 @@ fn build_eminence_static() -> StaticDefinition {
             .subtype("Dragon".to_string())
             .properties(vec![FilterProp::Another]),
     );
-    StaticDefinition::new(StaticMode::ReduceCost {
+    StaticDefinition::new(StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
         amount: ManaCost::generic(1),
         spell_filter: Some(dragon_filter),
         dynamic_count: None,

--- a/crates/mtgish-import/CLAUDE.md
+++ b/crates/mtgish-import/CLAUDE.md
@@ -91,7 +91,7 @@ When converting `Action::Unless(cond, body)`, prefer the parameter form if the i
 - `ReplacementDefinition` fields: `damage_modification`, `damage_source_filter`, `damage_target_filter`, `combat_scope`, `quantity_modification`, `redirect_target`, `valid_card`, `valid_player`, `destination_zone`, `mana_modification`, `additional_token_spec`, `ensure_token_specs`, `shield_kind`, `is_consumed`.
 - `TriggerDefinition` fields: `damage_kind: DamageKindFilter` (CombatOnly/NoncombatOnly), `combat_scope: Option<CombatDamageScope>`, `valid_player`, `valid_card`, `destination_zone`. Combat-damage triggers populate these on the existing `DamageDone` mode — don't add new variants.
 - `AbilityDefinition::player_scope: Option<PlayerFilter>` — exists for non-You PlayerAction scoping. Pure converter threading.
-- `StaticMode::ReduceCost { amount, spell_filter, dynamic_count }` / `RaiseCost` — cost-modification statics.
+- `StaticMode::ModifyCost { mode, amount, spell_filter, dynamic_count }` — cost-modification statics (`mode: CostModifyMode::{Reduce, Raise, Minimum}`).
 - `SpellCastingOption` family — alternative-cost / additional-cost / as-though-flash framework.
 - `CastingRestriction::RequiresCondition { condition }` — gated casting. **`condition: None` evaluates as ALWAYS-PASS** via `is_none_or` in `restrictions.rs:494` — never drop the condition to None as a "permissive fallback."
 

--- a/crates/mtgish-import/src/convert/cast_effect.rs
+++ b/crates/mtgish-import/src/convert/cast_effect.rs
@@ -29,7 +29,7 @@ use engine::types::ability::{
     AdditionalCost, CastingRestriction, QuantityExpr, QuantityRef, SpellCastingOption,
     SpellCastingOptionKind, StaticCondition, StaticDefinition, TargetFilter,
 };
-use engine::types::statics::StaticMode;
+use engine::types::statics::{CostModifyMode, StaticMode};
 use engine::types::{ManaCost, Zone};
 
 use crate::convert::condition as condition_conv;
@@ -144,14 +144,14 @@ pub fn apply(eff: &CastEffect, stub: &mut EngineFaceStub) -> ConvResult<()> {
         }),
         // CR 117.7 + CR 601.2f: Self-spell cost reduction. Mirrors the native
         // parser's `try_parse_cost_modification` self-spell branch
-        // (oracle_static.rs:6720). Emits `StaticMode::ReduceCost` with
+        // (oracle_static.rs:6720). Emits `StaticMode::ModifyCost` (Reduce) with
         // `affected = SelfRef` and `active_zones = [Hand, Stack]` so the
         // casting-time scanner finds the static on the spell being cast.
         E::ReduceCastingCost(reduction) => {
             push_self_reduce_cost_static(stub, reduction, None, None)
         }
         // CR 117.7 + CR 601.2f: Self-spell cost reduction with a dynamic
-        // "for each X" multiplier. The engine `StaticMode::ReduceCost.dynamic_count`
+        // "for each X" multiplier. The engine `StaticMode::ModifyCost.dynamic_count`
         // is `Option<QuantityRef>` — `QuantityExpr::Ref { qty }` unwraps cleanly;
         // `Fixed`/`Offset`/`Multiply`/`DivideRounded` cannot be expressed as a bare
         // `QuantityRef` and strict-fail.
@@ -180,7 +180,7 @@ pub fn apply(eff: &CastEffect, stub: &mut EngineFaceStub) -> ConvResult<()> {
         }
         // CR 601.2f + CR 117.7: Self-cost reduction gated on a Condition.
         // Mirrors the native parser's trailing if-clause attachment in
-        // `oracle_static.rs:6850-6917`: build a `StaticMode::ReduceCost` and
+        // `oracle_static.rs:6850-6917`: build a `StaticMode::ModifyCost` (Reduce) and
         // hang the translated `StaticCondition` off
         // `StaticDefinition.condition` (engine field declared at
         // `types/ability.rs:6245`, builder at :6295). The bridge
@@ -344,7 +344,7 @@ fn require_pure_mana(cost: &Cost, idiom: &'static str) -> ConvResult<ManaCost> {
     }
 }
 
-/// CR 117.7 + CR 601.2f: Build a self-spell `StaticMode::ReduceCost`
+/// CR 117.7 + CR 601.2f: Build a self-spell `StaticMode::ModifyCost` (Reduce)
 /// matching the native parser's emit shape (oracle_static.rs:6720+):
 /// `affected = SelfRef`, `active_zones = [Hand, Stack]` so the
 /// casting-time scanner picks it up on the spell being cast. The amount
@@ -398,7 +398,8 @@ fn push_self_reduce_cost_static_with_amount_and_filter(
     dynamic_count: Option<QuantityRef>,
     condition: Option<StaticCondition>,
 ) -> ConvResult<()> {
-    let mut def = StaticDefinition::new(StaticMode::ReduceCost {
+    let mut def = StaticDefinition::new(StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
         amount,
         spell_filter,
         dynamic_count,
@@ -470,7 +471,8 @@ mod tests {
         assert_eq!(static_def.affected, Some(TargetFilter::SelfRef));
         assert_eq!(static_def.active_zones, vec![Zone::Hand, Zone::Stack]);
 
-        let StaticMode::ReduceCost {
+        let StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount,
             spell_filter: Some(TargetFilter::Typed(TypedFilter { properties, .. })),
             dynamic_count: None,

--- a/crates/mtgish-import/src/convert/player_effect.rs
+++ b/crates/mtgish-import/src/convert/player_effect.rs
@@ -17,7 +17,8 @@ use engine::types::ability::{
 use engine::types::keywords::Keyword;
 use engine::types::phase::Phase;
 use engine::types::statics::{
-    CastFrequency, CastingProhibitionScope as ProhibitionScope, HandSizeModification, StaticMode,
+    CastFrequency, CastingProhibitionScope as ProhibitionScope, CostModifyMode,
+    HandSizeModification, StaticMode,
 };
 use engine::types::zones::Zone;
 
@@ -106,28 +107,31 @@ fn player_effect_to_static(
         // skip variants need engine work (multi-step phases) and stay
         // unsupported below.
         // CR 601.2f: "Spells [player] casts of [type] cost {N} less to cast."
-        // Maps directly to the engine's existing `ReduceCost` static. Player
-        // scope rides on `affected` (set below); spell scope rides on
+        // Maps directly to the engine's existing `ModifyCost` (Reduce) static.
+        // Player scope rides on `affected` (set below); spell scope rides on
         // `spell_filter`.
-        PlayerEffect::DecreaseSpellCost(spells, reduction) => StaticMode::ReduceCost {
+        PlayerEffect::DecreaseSpellCost(spells, reduction) => StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             amount: mana_conv::convert_reduction(reduction)?,
             spell_filter: Some(spells_to_filter(spells)?),
             dynamic_count: None,
         },
         // CR 601.2f: "Spells [player] casts of [type] cost {N} more to cast."
         // `IncreaseSpellCost(Spells, Cost)` carries a generic `Cost`; only
-        // pure-mana increases fit `RaiseCost.amount: ManaCost`.
-        PlayerEffect::IncreaseSpellCost(spells, cost) => StaticMode::RaiseCost {
+        // pure-mana increases fit `ModifyCost.amount: ManaCost`.
+        PlayerEffect::IncreaseSpellCost(spells, cost) => StaticMode::ModifyCost {
+            mode: CostModifyMode::Raise,
             amount: require_pure_mana_cost(cost, "PlayerEffect::IncreaseSpellCost")?,
             spell_filter: Some(spells_to_filter(spells)?),
             dynamic_count: None,
         },
         // CR 601.2f: "Spells [player] casts of [type] cost {N} less to cast for
-        // each [thing]." Reuses `ReduceCost` with a non-None `dynamic_count`
-        // — the engine multiplies the per-unit `amount` by the resolved
-        // `QuantityRef` at cast time.
+        // each [thing]." Reuses `ModifyCost` (Reduce) with a non-None
+        // `dynamic_count` — the engine multiplies the per-unit `amount` by the
+        // resolved `QuantityRef` at cast time.
         PlayerEffect::DecreaseSpellCostForEach(spells, reduction, count) => {
-            StaticMode::ReduceCost {
+            StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount: mana_conv::convert_reduction(reduction)?,
                 spell_filter: Some(spells_to_filter(spells)?),
                 dynamic_count: Some(quantity_ref_only(count)?),
@@ -352,7 +356,7 @@ fn u32_from_fixed(g: &GameNumber) -> ConvResult<u32> {
 
 /// CR 107.3 + CR 601.2f: Resolve a `GameNumber` to a `QuantityRef`
 /// (not a `QuantityExpr`) for slots that only accept the ref
-/// shape — `StaticMode::ReduceCost.dynamic_count` is one such
+/// shape — `StaticMode::ModifyCost.dynamic_count` is one such
 /// slot. Wraps `quantity_conv::convert` and unwraps the inner
 /// `QuantityRef`; non-Ref shapes (Fixed/Offset/Multiply/...)
 /// strict-fail with `EnginePrerequisiteMissing` so the report

--- a/crates/phase-ai/src/features/mana_ramp.rs
+++ b/crates/phase-ai/src/features/mana_ramp.rs
@@ -19,7 +19,7 @@
 //! - Controller scoping: `TypedFilter.controller: Option<ControllerRef>` at
 //!   `ability.rs:815-818`.
 //!
-//! `StaticMode::ReduceCost` is deliberately out of scope — cost reducers are a
+//! `StaticMode::ModifyCost` is deliberately out of scope — cost reducers are a
 //! follow-up feature.
 
 use engine::game::DeckEntry;

--- a/crates/phase-ai/src/features/tribal.rs
+++ b/crates/phase-ai/src/features/tribal.rs
@@ -14,7 +14,7 @@
 //! - `TypeFilter::Subtype(String)` at `ability.rs:794`;
 //!   `TypedFilter::get_subtype()` at `ability.rs:1061`.
 //! - `Effect::Token { types: Vec<String>, .. }` at `ability.rs:2131`.
-//! - `StaticMode::ReduceCost { spell_filter: Option<TargetFilter>, .. }`
+//! - `StaticMode::ModifyCost { spell_filter: Option<TargetFilter>, .. }`
 //!   at `statics.rs:136`.
 //! - `TriggerDefinition.execute: Option<Box<AbilityDefinition>>`
 //!   at `ability.rs:4520`.
@@ -37,7 +37,7 @@ use engine::types::ability::{
 };
 use engine::types::card::CardFace;
 use engine::types::card_type::CoreType;
-use engine::types::statics::StaticMode;
+use engine::types::statics::{CostModifyMode, StaticMode};
 use engine::types::triggers::TriggerMode;
 use engine::types::zones::Zone;
 
@@ -301,11 +301,12 @@ fn trigger_is_etb_payoff_for(t: &engine::types::ability::TriggerDefinition, trib
     filter_references_tribe_you_control(filter, tribe)
 }
 
-/// True if this face has a `ReduceCost` static whose `spell_filter` references
+/// True if this face has a `ModifyCost` (Reduce) static whose `spell_filter` references
 /// the tribe's subtype.
 fn is_cost_reducer(face: &CardFace, tribe: &str) -> bool {
     face.static_abilities.iter().any(|s| {
-        if let StaticMode::ReduceCost {
+        if let StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
             spell_filter: Some(filter),
             ..
         } = &s.mode
@@ -402,7 +403,7 @@ mod tests {
     };
     use engine::types::card::CardFace;
     use engine::types::card_type::{CardType, CoreType};
-    use engine::types::statics::StaticMode;
+    use engine::types::statics::{CostModifyMode, StaticMode};
     use engine::types::triggers::TriggerMode;
     use engine::types::zones::Zone;
 
@@ -547,7 +548,8 @@ mod tests {
         let mut reducer = creature_face("Elf Cost Reducer", vec!["Elf"]);
         reducer
             .static_abilities
-            .push(StaticDefinition::new(StaticMode::ReduceCost {
+            .push(StaticDefinition::new(StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
                 amount: ManaCost::generic(1),
                 spell_filter: Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype(
                     "Elf".to_string(),

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -25,8 +25,8 @@
     "crates/engine/src/types/attribution.rs",
     "crates/engine/src/types/card_type.rs"
   ],
-  "enum_count": 245,
-  "variant_count": 2775,
+  "enum_count": 250,
+  "variant_count": 2785,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -430,13 +430,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9026,
+      "line": 9145,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 9044,
+          "line": 9163,
           "kind": "struct",
           "field_names": [
             "source",
@@ -454,7 +454,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 9060,
+          "line": 9179,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -465,7 +465,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 9065,
+          "line": 9184,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -479,7 +479,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 9070,
+          "line": 9189,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -489,7 +489,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 9078,
+          "line": 9197,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -499,7 +499,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9081,
+          "line": 9200,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -511,7 +511,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9085,
+          "line": 9204,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -524,7 +524,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9088,
+          "line": 9207,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -537,7 +537,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9091,
+          "line": 9210,
           "kind": "struct",
           "field_names": [
             "color",
@@ -551,7 +551,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 9097,
+          "line": 9216,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -564,7 +564,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9105,
+          "line": 9224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -575,7 +575,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9108,
+          "line": 9227,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -588,7 +588,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 9113,
+          "line": 9232,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -602,7 +602,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 9117,
+          "line": 9236,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -616,7 +616,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 9126,
+          "line": 9245,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -630,7 +630,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9131,
+          "line": 9250,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -640,7 +640,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9133,
+          "line": 9252,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -650,7 +650,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9136,
+          "line": 9255,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -660,7 +660,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 9140,
+          "line": 9259,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -672,7 +672,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 9145,
+          "line": 9264,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -686,7 +686,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9153,
+          "line": 9272,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -698,7 +698,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9158,
+          "line": 9277,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -714,7 +714,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 9170,
+          "line": 9289,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -727,7 +727,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 9174,
+          "line": 9293,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -740,7 +740,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 9178,
+          "line": 9297,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -750,7 +750,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9186,
+          "line": 9305,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -763,7 +763,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9191,
+          "line": 9310,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -776,7 +776,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9196,
+          "line": 9315,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -788,7 +788,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 9202,
+          "line": 9321,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -800,7 +800,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 9206,
+          "line": 9325,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -814,7 +814,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9209,
+          "line": 9328,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -824,7 +824,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 9218,
+          "line": 9337,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -837,7 +837,7 @@
         },
         {
           "name": "And",
-          "line": 9223,
+          "line": 9342,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -849,7 +849,7 @@
         },
         {
           "name": "Or",
-          "line": 9228,
+          "line": 9347,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -861,7 +861,7 @@
         },
         {
           "name": "Not",
-          "line": 9236,
+          "line": 9355,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -873,7 +873,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 9240,
+          "line": 9359,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -883,7 +883,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 9242,
+          "line": 9361,
           "kind": "struct",
           "field_names": [
             "state"
@@ -895,7 +895,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 9252,
+          "line": 9371,
           "kind": "struct",
           "field_names": [
             "n"
@@ -907,7 +907,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 9255,
+          "line": 9374,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -919,7 +919,7 @@
         },
         {
           "name": "ScopedPlayerMatches",
-          "line": 9275,
+          "line": 9394,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -945,13 +945,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4316,
+      "line": 4397,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 4317,
+          "line": 4398,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -961,7 +961,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 4326,
+          "line": 4407,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -974,7 +974,7 @@
         },
         {
           "name": "Tap",
-          "line": 4329,
+          "line": 4410,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -982,7 +982,7 @@
         },
         {
           "name": "Untap",
-          "line": 4330,
+          "line": 4411,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -990,7 +990,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 4331,
+          "line": 4412,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1000,7 +1000,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 4334,
+          "line": 4415,
           "kind": "struct",
           "field_names": [
             "target",
@@ -1011,7 +1011,7 @@
         },
         {
           "name": "PayLife",
-          "line": 4346,
+          "line": 4427,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1023,7 +1023,7 @@
         },
         {
           "name": "Discard",
-          "line": 4349,
+          "line": 4430,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1036,7 +1036,7 @@
         },
         {
           "name": "Exile",
-          "line": 4360,
+          "line": 4441,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1048,7 +1048,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 4369,
+          "line": 4450,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1061,7 +1061,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 4372,
+          "line": 4453,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1072,7 +1072,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 4383,
+          "line": 4464,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1087,7 +1087,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 4389,
+          "line": 4470,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1097,7 +1097,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4393,
+          "line": 4474,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1110,7 +1110,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4401,
+          "line": 4482,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1124,7 +1124,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4410,
+          "line": 4491,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1134,7 +1134,7 @@
         },
         {
           "name": "Mill",
-          "line": 4411,
+          "line": 4492,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1144,7 +1144,7 @@
         },
         {
           "name": "Exert",
-          "line": 4414,
+          "line": 4495,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1152,7 +1152,7 @@
         },
         {
           "name": "Blight",
-          "line": 4417,
+          "line": 4498,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1162,7 +1162,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4420,
+          "line": 4501,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1173,7 +1173,7 @@
         },
         {
           "name": "Behold",
-          "line": 4428,
+          "line": 4509,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1185,7 +1185,7 @@
         },
         {
           "name": "Composite",
-          "line": 4434,
+          "line": 4515,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1195,7 +1195,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4451,
+          "line": 4532,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1208,7 +1208,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4455,
+          "line": 4536,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1218,7 +1218,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4460,
+          "line": 4541,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1231,7 +1231,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4467,
+          "line": 4548,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1243,7 +1243,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4483,
+          "line": 4564,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1257,7 +1257,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4488,
+          "line": 4569,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1270,13 +1270,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8165,
+      "line": 8284,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 8167,
+          "line": 8286,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1284,7 +1284,7 @@
         },
         {
           "name": "Activated",
-          "line": 8168,
+          "line": 8287,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1292,7 +1292,7 @@
         },
         {
           "name": "Database",
-          "line": 8169,
+          "line": 8288,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1300,7 +1300,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 8172,
+          "line": 8291,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1308,7 +1308,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 8178,
+          "line": 8297,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1321,7 +1321,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8319,
+      "line": 8438,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1329,7 +1329,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 8321,
+          "line": 8440,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1339,7 +1339,7 @@
         },
         {
           "name": "Evolve",
-          "line": 8323,
+          "line": 8442,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1349,7 +1349,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 8325,
+          "line": 8444,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1359,7 +1359,7 @@
         },
         {
           "name": "Outlast",
-          "line": 8327,
+          "line": 8446,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1428,13 +1428,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8335,
+      "line": 8454,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8336,
+          "line": 8455,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1442,7 +1442,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 8337,
+          "line": 8456,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1450,7 +1450,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8338,
+          "line": 8457,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1458,7 +1458,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8339,
+          "line": 8458,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1466,7 +1466,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8340,
+          "line": 8459,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1474,7 +1474,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8341,
+          "line": 8460,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1482,7 +1482,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8342,
+          "line": 8461,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1490,7 +1490,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 8343,
+          "line": 8462,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1498,7 +1498,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 8344,
+          "line": 8463,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1506,7 +1506,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 8345,
+          "line": 8464,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1516,7 +1516,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8348,
+          "line": 8467,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1526,7 +1526,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 8352,
+          "line": 8471,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1536,7 +1536,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 8354,
+          "line": 8473,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1548,7 +1548,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 8359,
+          "line": 8478,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1562,7 +1562,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 8370,
+          "line": 8489,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1576,7 +1576,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 8383,
+          "line": 8502,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1589,13 +1589,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4692,
+      "line": 4773,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 4698,
+          "line": 4779,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1606,7 +1606,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4708,
+          "line": 4789,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1622,7 +1622,7 @@
         },
         {
           "name": "Choice",
-          "line": 4715,
+          "line": 4796,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1630,7 +1630,7 @@
         },
         {
           "name": "Required",
-          "line": 4717,
+          "line": 4798,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1641,7 +1641,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4726,
+      "line": 4807,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1649,7 +1649,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 4728,
+          "line": 4809,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1657,7 +1657,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4729,
+          "line": 4810,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1665,7 +1665,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 4730,
+          "line": 4811,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1676,7 +1676,7 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3198,
+      "line": 3279,
       "doc": "CR 107.3e: Aggregate function applied over a set of objects.",
       "cr_refs": [
         "CR 107.3e"
@@ -1684,7 +1684,7 @@
       "variants": [
         {
           "name": "Max",
-          "line": 3199,
+          "line": 3280,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1692,7 +1692,7 @@
         },
         {
           "name": "Min",
-          "line": 3200,
+          "line": 3281,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1700,7 +1700,7 @@
         },
         {
           "name": "Sum",
-          "line": 3201,
+          "line": 3282,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1745,7 +1745,7 @@
     },
     "AlternativeCastKeyword": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1515,
+      "line": 1602,
       "doc": "CR 118.9: Identifies which keyword ability granted an alternative casting cost so the `WaitingFor::AlternativeCastChoice` dispatcher can route to the keyword-specific post-payment handler. The four keywords share a single player decision shape (printed cost vs. alternative cost) but diverge in post-payment semantics — this enum keeps the prompt unified while preserving CR fidelity at resolution.  Adding a new alternative-cost keyword (e.g., Madness CR 702.35a, Spectacle CR 702.137a) is a compile error at every dispatch site until handled.",
       "cr_refs": [
         "CR 118.9",
@@ -1755,7 +1755,7 @@
       "variants": [
         {
           "name": "Warp",
-          "line": 1517,
+          "line": 1604,
           "kind": "unit",
           "field_names": [],
           "doc": "Custom Warp keyword — exile-at-end-step rider; no CR section.",
@@ -1763,7 +1763,7 @@
         },
         {
           "name": "Evoke",
-          "line": 1520,
+          "line": 1607,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: ETB + sacrifice trigger fires when the resolving permanent was cast for its evoke cost (CR 702.74b).",
@@ -1774,7 +1774,7 @@
         },
         {
           "name": "Overload",
-          "line": 1522,
+          "line": 1609,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a: Spell's text changes \"target\" to \"each\" (CR 702.96b-c).",
@@ -1785,7 +1785,7 @@
         },
         {
           "name": "Bestow",
-          "line": 1524,
+          "line": 1611,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a: Spell becomes an Aura with enchant creature (CR 702.103b).",
@@ -1796,7 +1796,7 @@
         },
         {
           "name": "Awaken",
-          "line": 1529,
+          "line": 1616,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: \"If this spell's awaken cost was paid, put N +1/+1 counters on target land you control. That land becomes a 0/0 Elemental creature with haste. It's still a land.\" Paying the awaken cost adds the land target (CR 702.113b); casting normally adds no target and no rider.",
@@ -1807,7 +1807,7 @@
         },
         {
           "name": "Cleave",
-          "line": 1532,
+          "line": 1619,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Paying the cleave cost removes every square-bracketed span from the spell's text (a text-changing effect).",
@@ -1821,7 +1821,7 @@
     },
     "AttachmentKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1797,
+      "line": 1863,
       "doc": "CR 301 / CR 303: Kinds of attachments to permanents. Used by `FilterProp::HasAttachment` and `QuantityRef::AttachmentsOnLeavingObject` to parameterize attachment-predicate checks.",
       "cr_refs": [
         "CR 301",
@@ -1830,7 +1830,7 @@
       "variants": [
         {
           "name": "Aura",
-          "line": 1799,
+          "line": 1865,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4: Aura — enchantment subtype that attaches via Enchant ability.",
@@ -1840,7 +1840,7 @@
         },
         {
           "name": "Equipment",
-          "line": 1801,
+          "line": 1867,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5: Equipment — artifact subtype that attaches via Equip ability.",
@@ -1853,7 +1853,7 @@
     },
     "AttackTargetFilter": {
       "file": "crates/engine/src/types/triggers.rs",
-      "line": 160,
+      "line": 162,
       "doc": "CR 508.3a: Filter for attack target type in \"attacks [a target]\" triggers.",
       "cr_refs": [
         "CR 508.3a"
@@ -1861,22 +1861,6 @@
       "variants": [
         {
           "name": "Player",
-          "line": 161,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Planeswalker",
-          "line": 162,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PlayerOrPlaneswalker",
           "line": 163,
           "kind": "unit",
           "field_names": [],
@@ -1884,8 +1868,24 @@
           "cr_refs": []
         },
         {
-          "name": "Battle",
+          "name": "Planeswalker",
           "line": 164,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PlayerOrPlaneswalker",
+          "line": 165,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Battle",
+          "line": 166,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1896,13 +1896,13 @@
     },
     "AutoMayChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 476,
+      "line": 482,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Accept",
-          "line": 477,
+          "line": 483,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1910,7 +1910,7 @@
         },
         {
           "name": "Decline",
-          "line": 478,
+          "line": 484,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1921,13 +1921,13 @@
     },
     "AutoPassMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3335,
+      "line": 3369,
       "doc": "What the engine stores for auto-pass (includes captured state).",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3338,
+          "line": 3372,
           "kind": "struct",
           "field_names": [
             "initial_stack_len"
@@ -1937,7 +1937,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3342,
+          "line": 3376,
           "kind": "unit",
           "field_names": [],
           "doc": "Auto-pass through priority/combat stops until the flagged player's next turn starts. Interrupted by opponent stack activity (MTGA-style) or when the current phase matches the player's entry in `GameState::phase_stops`.",
@@ -1948,13 +1948,13 @@
     },
     "AutoPassRequest": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3327,
+      "line": 3361,
       "doc": "What the frontend requests for auto-pass (no internal state).  Phase stops that should interrupt `UntilEndOfTurn` are a separate per-player preference on `GameState::phase_stops`, managed via `GameAction::SetPhaseStops`. Keeping them out of the request preserves a single source of truth and lets the preference change mid-session without requiring a new auto-pass request.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3328,
+          "line": 3362,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1962,7 +1962,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3329,
+          "line": 3363,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2024,13 +2024,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4308,
+      "line": 4389,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 4309,
+          "line": 4390,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2038,7 +2038,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 4310,
+          "line": 4391,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2148,7 +2148,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5028,
+      "line": 5109,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2156,7 +2156,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 5031,
+          "line": 5112,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2164,7 +2164,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 5033,
+          "line": 5114,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2327,13 +2327,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2688,
+      "line": 2759,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 2690,
+          "line": 2761,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -2347,7 +2347,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2692,
+          "line": 2763,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -2358,7 +2358,7 @@
         },
         {
           "name": "Objects",
-          "line": 2694,
+          "line": 2765,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -2450,7 +2450,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2699,
+      "line": 2770,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -2458,7 +2458,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 2701,
+          "line": 2772,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -2466,7 +2466,7 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 2703,
+          "line": 2774,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
@@ -2477,7 +2477,7 @@
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2709,
+      "line": 2780,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -2486,7 +2486,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 2711,
+          "line": 2782,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -2494,7 +2494,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 2713,
+          "line": 2784,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -2502,7 +2502,7 @@
         },
         {
           "name": "FromSource",
-          "line": 2715,
+          "line": 2786,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -2513,9 +2513,97 @@
       ],
       "sibling_clusters": []
     },
+    "CastOfferKind": {
+      "file": "crates/engine/src/types/game_state.rs",
+      "line": 1677,
+      "doc": "The specific kind of cast offer being presented to the player. Parameterizes `WaitingFor::CastOffer` — all variants share `player: PlayerId` at the outer level; the kind-specific payload lives here.",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "Adventure",
+          "line": 1679,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "card_id",
+            "payment_mode"
+          ],
+          "doc": "CR 715.3a: Player chooses creature face vs Adventure half.",
+          "cr_refs": [
+            "CR 715.3a"
+          ]
+        },
+        {
+          "name": "Miracle",
+          "line": 1686,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "cost"
+          ],
+          "doc": "CR 702.94a: Miracle triggered ability resolved — cast for miracle cost.",
+          "cr_refs": [
+            "CR 702.94a"
+          ]
+        },
+        {
+          "name": "Madness",
+          "line": 1691,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "cost"
+          ],
+          "doc": "CR 702.35a: Madness triggered ability resolved — cast from exile or go to graveyard.",
+          "cr_refs": [
+            "CR 702.35a"
+          ]
+        },
+        {
+          "name": "Paradigm",
+          "line": 1696,
+          "kind": "struct",
+          "field_names": [
+            "offers"
+          ],
+          "doc": "CR 702.xxx: Paradigm (Strixhaven) — turn-based offer to cast a copy.",
+          "cr_refs": [
+            "CR 702"
+          ]
+        },
+        {
+          "name": "Cascade",
+          "line": 1698,
+          "kind": "struct",
+          "field_names": [
+            "hit_card",
+            "exiled_misses",
+            "source_mv"
+          ],
+          "doc": "CR 702.85a: Cascade — cast the hit card without paying mana cost or decline.",
+          "cr_refs": [
+            "CR 702.85a"
+          ]
+        },
+        {
+          "name": "Discover",
+          "line": 1704,
+          "kind": "struct",
+          "field_names": [
+            "hit_card",
+            "exiled_misses"
+          ],
+          "doc": "CR 701.57a: Discover — cast the discovered card or put it to hand.",
+          "cr_refs": [
+            "CR 701.57a"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "CastPaymentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 907,
+      "line": 913,
       "doc": "CR 601.2g-h: Whether the engine may auto-pay an unambiguous spell mana cost or must pause after announcement so the player can activate mana abilities manually before committing payment.",
       "cr_refs": [
         "CR 601.2g"
@@ -2523,7 +2611,7 @@
       "variants": [
         {
           "name": "Auto",
-          "line": 909,
+          "line": 915,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2531,7 +2619,7 @@
         },
         {
           "name": "Manual",
-          "line": 910,
+          "line": 916,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2556,7 +2644,7 @@
             "source_mv",
             "exiled_misses"
           ],
-          "doc": "CR 702.85a: Cascade — \"You may cast that card without paying its mana cost if the resulting spell's mana value is less than this spell's mana value.\" The resulting mana value is only determined after X, Kicker, and similar choices, so this check must run at cast finalization, not at offer time.  `exiled_misses` is rejection-cleanup state: when the cast-time check fails, the original `WaitingFor::CascadeChoice` has already been cleared, so the misses ride inside the permission so the bottom-shuffle step can still reach them.",
+          "doc": "CR 702.85a: Cascade — \"You may cast that card without paying its mana cost if the resulting spell's mana value is less than this spell's mana value.\" The resulting mana value is only determined after X, Kicker, and similar choices, so this check must run at cast finalization, not at offer time.  `exiled_misses` is rejection-cleanup state: when the cast-time check fails, the original `WaitingFor::CastOffer` (Cascade) has already been cleared, so the misses ride inside the permission so the bottom-shuffle step can still reach them.",
           "cr_refs": [
             "CR 702.85a"
           ]
@@ -2580,7 +2668,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4282,
+      "line": 4363,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -2589,7 +2677,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 4285,
+          "line": 4366,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -2600,7 +2688,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4244,
+      "line": 4325,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -2611,7 +2699,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4246,
+          "line": 4327,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -2622,7 +2710,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4249,
+          "line": 4330,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -2632,7 +2720,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4251,
+          "line": 4332,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -2642,7 +2730,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4253,
+          "line": 4334,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -2652,7 +2740,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4256,
+          "line": 4337,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -2662,7 +2750,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4262,
+          "line": 4343,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -2672,7 +2760,7 @@
         },
         {
           "name": "Escape",
-          "line": 4267,
+          "line": 4348,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -2683,7 +2771,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4270,
+          "line": 4351,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -2693,7 +2781,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4275,
+          "line": 4356,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -2887,13 +2975,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8391,
+      "line": 8510,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8392,
+          "line": 8511,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2901,7 +2989,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8393,
+          "line": 8512,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2909,7 +2997,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 8394,
+          "line": 8513,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2917,7 +3005,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8395,
+          "line": 8514,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2925,7 +3013,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8396,
+          "line": 8515,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2933,7 +3021,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 8397,
+          "line": 8516,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2941,7 +3029,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 8398,
+          "line": 8517,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2949,7 +3037,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 8399,
+          "line": 8518,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2957,7 +3045,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 8400,
+          "line": 8519,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2965,7 +3053,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 8401,
+          "line": 8520,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2973,7 +3061,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 8402,
+          "line": 8521,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2981,7 +3069,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8403,
+          "line": 8522,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2989,7 +3077,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 8404,
+          "line": 8523,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2997,7 +3085,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8405,
+          "line": 8524,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3005,7 +3093,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 8406,
+          "line": 8525,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3013,7 +3101,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8407,
+          "line": 8526,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3026,13 +3114,13 @@
     },
     "CastingVariant": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3420,
+      "line": 3454,
       "doc": "How a spell was cast — determines zone routing and post-resolution behavior. Replaces individual boolean flags (cast_as_adventure, cast_as_warp) with a single enum that captures the casting context.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Normal",
-          "line": 3423,
+          "line": 3457,
           "kind": "unit",
           "field_names": [],
           "doc": "Normal spell cast — no special resolution behavior.",
@@ -3040,7 +3128,7 @@
         },
         {
           "name": "Adventure",
-          "line": 3426,
+          "line": 3460,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.4: Cast as the Adventure half. On resolution, exiled with AdventureCreature permission and creature face restored.",
@@ -3050,7 +3138,7 @@
         },
         {
           "name": "Omen",
-          "line": 3429,
+          "line": 3463,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 720.3d / CR 720.4: Cast as the Omen half. On resolution, shuffled into its owner's library with normal characteristics restored.",
@@ -3061,7 +3149,7 @@
         },
         {
           "name": "Warp",
-          "line": 3432,
+          "line": 3466,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.185a: Cast via Warp alternative cost from hand. On resolution, creates a delayed trigger to exile at end step with WarpExile permission.",
@@ -3071,7 +3159,7 @@
         },
         {
           "name": "Escape",
-          "line": 3435,
+          "line": 3469,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138: Cast from graveyard via Escape. On resolution, goes to appropriate zone normally (unlike Flashback which exiles).",
@@ -3081,7 +3169,7 @@
         },
         {
           "name": "Retrace",
-          "line": 3438,
+          "line": 3472,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.81a: Cast from graveyard via Retrace by discarding a land card as an additional cost. Resolution uses normal spell routing.",
@@ -3091,7 +3179,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 3441,
+          "line": 3475,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.180a: Cast from graveyard for harmonize cost. On resolution, exiled instead of going anywhere else (unlike Escape which returns to graveyard).",
@@ -3101,7 +3189,7 @@
         },
         {
           "name": "Flashback",
-          "line": 3444,
+          "line": 3478,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34a: Cast from graveyard for flashback cost. On resolution (or whenever leaving the stack for any reason), exiled instead of going anywhere else.",
@@ -3111,7 +3199,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 3447,
+          "line": 3481,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Cast an aftermath half of a split card from a graveyard. If it was cast from a graveyard, exile it any time it leaves the stack.",
@@ -3121,7 +3209,7 @@
         },
         {
           "name": "GraveyardPermission",
-          "line": 3451,
+          "line": 3485,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3137,7 +3225,7 @@
         },
         {
           "name": "HandPermission",
-          "line": 3477,
+          "line": 3511,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3152,7 +3240,7 @@
         },
         {
           "name": "ExilePermission",
-          "line": 3493,
+          "line": 3527,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3168,7 +3256,7 @@
         },
         {
           "name": "Sneak",
-          "line": 3510,
+          "line": 3544,
           "kind": "struct",
           "field_names": [
             "returned_creature",
@@ -3182,7 +3270,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 3519,
+          "line": 3553,
           "kind": "struct",
           "field_names": [
             "returned_creature"
@@ -3194,7 +3282,7 @@
         },
         {
           "name": "Miracle",
-          "line": 3526,
+          "line": 3560,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94a: Cast from hand via Miracle's alternative cost after revealing the card as the first card drawn this turn. The granting keyword carries the miracle mana cost, which `prepare_spell_cast_with_variant_override` substitutes for the printed mana cost. The keyword's `ManaCost` payload is read at preparation time rather than stored here because `prepare_spell_cast` already reads `obj.keywords` for analogous paths.",
@@ -3204,7 +3292,7 @@
         },
         {
           "name": "Madness",
-          "line": 3529,
+          "line": 3563,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.35a: Cast from exile via Madness after the discard replacement exiled the card and its madness triggered ability resolved.",
@@ -3214,7 +3302,7 @@
         },
         {
           "name": "Evoke",
-          "line": 3533,
+          "line": 3567,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Cast from hand via Evoke's alternative cost. On resolution, the permanent enters tagged with `CastVariantPaid::Evoke`, which fires the synthesized intervening-if ETB sacrifice trigger.",
@@ -3224,7 +3312,7 @@
         },
         {
           "name": "Suspend",
-          "line": 3540,
+          "line": 3574,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast from exile via Suspend's \"play it without paying its mana cost\" trigger after the last time counter was removed. On resolution of the resulting permanent, the stack handler tags `CastVariantPaid::Suspend` and — for creature spells — installs a transient continuous \"has haste\" effect that lasts as long as the resolution-time controller still controls the permanent.",
@@ -3234,7 +3322,7 @@
         },
         {
           "name": "Plot",
-          "line": 3547,
+          "line": 3581,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.170d: Cast from exile via the Plot \"cast without paying its mana cost\" permission during the owner's main phase on a turn after the card was plotted. Detected at cast preparation when the exile-zone source has a `CastingPermission::Plotted { turn_plotted }` and the current turn is strictly greater than `turn_plotted`. Zeroes the mana cost and routes through the normal cast pipeline; no special resolution-time behavior.",
@@ -3244,7 +3332,7 @@
         },
         {
           "name": "Foretell",
-          "line": 3554,
+          "line": 3588,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143a-c: Cast from exile via a foretold card's foretell cost on a turn after it was foretold. Detected at cast preparation when the exile-zone source has a `CastingPermission::Foretold { .. }`. The permission supplies the alternative mana cost; stack finalization tags the source with `CastVariantPaid::Foretell` so \"if this spell was foretold\" clauses can evaluate while the spell resolves.",
@@ -3254,7 +3342,7 @@
         },
         {
           "name": "Overload",
-          "line": 3564,
+          "line": 3598,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a-c: Cast from hand via Overload's alternative cost. The printed mana cost is replaced by `Keyword::Overload(cost)` at cast preparation (mirrors `Evoke`/`Warp`). Per CR 702.96b, every \"target\" in the spell's text is replaced by \"each\" — applied as a cast-time transformation of the spell's ability tree (`Destroy`→`DestroyAll`, `Pump`→`PumpAll`, `DealDamage`→`DamageAll`, `Tap`→`TapAll`, `Bounce`→`ChangeZoneAll`). Per CR 702.96c, the resulting spell has no targets, so target selection is naturally skipped because the transformed effects carry no `TargetRef` slots.",
@@ -3266,7 +3354,7 @@
         },
         {
           "name": "Bestow",
-          "line": 3579,
+          "line": 3613,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a-b: Cast from hand via Bestow's alternative cost. The printed mana cost is replaced by `Keyword::Bestow(cost)` at cast preparation; the spell becomes an Aura with `enchant creature` while on the stack and as the resulting permanent (until it becomes unattached, per CR 702.103f). The type-changing mutation is applied directly to the stack object (mirroring `swap_to_alternative_spell_face` for Adventure/Omen) — Layers cannot be used here because they only apply to battlefield/hand objects, not stack objects.  Per CR 702.103e: if the target is illegal at resolution, the type-changing effect ends and the spell resolves as a creature spell. Per CR 702.103f: when a bestowed Aura becomes unattached on the battlefield, the type-changing effect ends — it remains as an enchantment creature (overrides CR 704.5m for bestow Auras).",
@@ -3279,7 +3367,7 @@
         },
         {
           "name": "Awaken",
-          "line": 3590,
+          "line": 3624,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: Cast from hand via Awaken's alternative cost. The printed mana cost is replaced by `Keyword::Awaken { cost }` at cast preparation (mirrors `Overload`). A resolution rider is appended to the tail of the spell's ability tree (`effects::awaken::append_awaken_rider`): the printed effect resolves first, then \"put N +1/+1 counters on target land you control; that land becomes a 0/0 Elemental creature with haste; it's still a land.\" Per CR 702.113b, the land target only exists on the awaken variant — a normal cast appends no rider and requests no land target. CR 702.113a: the spell goes to the graveyard normally, so this variant is deliberately absent from `exiles_when_leaving_stack_for_any_reason`.",
@@ -3290,7 +3378,7 @@
         },
         {
           "name": "Cleave",
-          "line": 3601,
+          "line": 3635,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Cast from hand via Cleave's alternative cost (CR 118.9). The printed mana cost is replaced by `Keyword::Cleave(cost)` at cast preparation (mirrors `Evoke`/`Overload`). Per CR 702.148a, paying the cleave cost is a text-changing effect (CR 612) that removes every square-bracketed span from the spell's rules text. The bracket-removed ability set is parsed at build time into `CardFace::cleave_variant` and swapped onto the stack object before preparation (mirroring the Bestow object-mutation-before-prepare seam). Resolution routing matches a normal spell — there is no on-resolve special behavior, so the spell goes to its owner's graveyard like any instant/sorcery.",
@@ -3804,7 +3892,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10098,
+      "line": 10218,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -3812,7 +3900,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 10099,
+          "line": 10219,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3820,7 +3908,7 @@
         },
         {
           "name": "Lost",
-          "line": 10100,
+          "line": 10220,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3831,13 +3919,13 @@
     },
     "CollectEvidenceResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1029,
+      "line": 1043,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Casting",
-          "line": 1030,
+          "line": 1044,
           "kind": "struct",
           "field_names": [
             "pending_cast"
@@ -3847,7 +3935,7 @@
         },
         {
           "name": "Effect",
-          "line": 1033,
+          "line": 1047,
           "kind": "struct",
           "field_names": [
             "pending_ability"
@@ -3860,7 +3948,7 @@
     },
     "CombatDamageAssignmentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2979,
+      "line": 3015,
       "doc": "CR 510.1c: Optional combat-damage assignment mode for attackers with text like \"you may have this creature assign its combat damage as though it weren't blocked.\"",
       "cr_refs": [
         "CR 510.1c"
@@ -3868,7 +3956,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 2981,
+          "line": 3017,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3876,7 +3964,7 @@
         },
         {
           "name": "AsThoughUnblocked",
-          "line": 2982,
+          "line": 3018,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3887,7 +3975,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10598,
+      "line": 10722,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -3895,7 +3983,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 10599,
+          "line": 10723,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3903,7 +3991,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 10600,
+          "line": 10724,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3914,13 +4002,13 @@
     },
     "CombatRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1839,
+      "line": 1905,
       "doc": "Combat relationship required by `FilterProp::CombatRelation`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "BlockingOrBlockedBy",
-          "line": 1841,
+          "line": 1907,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g/509.1h: Candidate is blocking the subject or is blocked by it.",
@@ -3933,13 +4021,13 @@
     },
     "CombatRelationSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1846,
+      "line": 1912,
       "doc": "Context object for a combat relationship filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 1848,
+          "line": 1914,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object of the resolving spell or ability.",
@@ -3947,7 +4035,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 1850,
+          "line": 1916,
           "kind": "unit",
           "field_names": [],
           "doc": "The first selected object target of the resolving spell or ability.",
@@ -3958,7 +4046,7 @@
     },
     "CombatTaxContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1230,
+      "line": 1317,
       "doc": "CR 508.1d + CR 509.1c: Which combat step a `WaitingFor::CombatTaxPayment` belongs to.  Drives the resume branch after the tax decision — on accept, the engine submits the stored attacker / blocker declaration; on decline, the engine filters the taxed creatures out of that declaration and submits the remainder.",
       "cr_refs": [
         "CR 508.1d",
@@ -3967,7 +4055,7 @@
       "variants": [
         {
           "name": "Attacking",
-          "line": 1231,
+          "line": 1318,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3975,7 +4063,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1232,
+          "line": 1319,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3986,7 +4074,7 @@
     },
     "CombatTaxPending": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1240,
+      "line": 1327,
       "doc": "CR 508.1d + CR 509.1c: The declaration that is paused awaiting a combat-tax decision. Keyed by `CombatTaxContext` — the engine resumes the matching variant on `GameAction::PayCombatTax`.",
       "cr_refs": [
         "CR 508.1d",
@@ -3995,7 +4083,7 @@
       "variants": [
         {
           "name": "Attack",
-          "line": 1241,
+          "line": 1328,
           "kind": "struct",
           "field_names": [
             "attacks"
@@ -4005,7 +4093,7 @@
         },
         {
           "name": "Block",
-          "line": 1244,
+          "line": 1331,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -4018,7 +4106,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3685,
+      "line": 3766,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -4026,7 +4114,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 3688,
+          "line": 3769,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -4037,7 +4125,7 @@
         },
         {
           "name": "Any",
-          "line": 3692,
+          "line": 3773,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -4141,13 +4229,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3556,
+      "line": 3637,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 3557,
+          "line": 3638,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4155,7 +4243,7 @@
         },
         {
           "name": "LT",
-          "line": 3558,
+          "line": 3639,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4163,7 +4251,7 @@
         },
         {
           "name": "GE",
-          "line": 3559,
+          "line": 3640,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4171,7 +4259,7 @@
         },
         {
           "name": "LE",
-          "line": 3560,
+          "line": 3641,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4179,7 +4267,7 @@
         },
         {
           "name": "EQ",
-          "line": 3561,
+          "line": 3642,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4187,7 +4275,7 @@
         },
         {
           "name": "NE",
-          "line": 3562,
+          "line": 3643,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4198,13 +4286,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11014,
+      "line": 11138,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 11015,
+          "line": 11139,
           "kind": "struct",
           "field_names": [
             "values",
@@ -4215,7 +4303,7 @@
         },
         {
           "name": "SetName",
-          "line": 11030,
+          "line": 11154,
           "kind": "struct",
           "field_names": [
             "name"
@@ -4229,7 +4317,7 @@
         },
         {
           "name": "AddPower",
-          "line": 11033,
+          "line": 11157,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4239,7 +4327,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 11036,
+          "line": 11160,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4249,7 +4337,7 @@
         },
         {
           "name": "SetPower",
-          "line": 11039,
+          "line": 11163,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4259,7 +4347,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 11042,
+          "line": 11166,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4269,7 +4357,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 11045,
+          "line": 11169,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4279,7 +4367,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 11048,
+          "line": 11172,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4289,7 +4377,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 11051,
+          "line": 11175,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4299,7 +4387,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 11058,
+          "line": 11182,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -4311,7 +4399,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 11061,
+          "line": 11185,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4319,7 +4407,7 @@
         },
         {
           "name": "AddType",
-          "line": 11062,
+          "line": 11186,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4329,7 +4417,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 11065,
+          "line": 11189,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4339,7 +4427,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 11068,
+          "line": 11192,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4349,7 +4437,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 11071,
+          "line": 11195,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4359,7 +4447,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 11078,
+          "line": 11202,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4372,7 +4460,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 11084,
+          "line": 11208,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4385,7 +4473,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 11088,
+          "line": 11212,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4395,7 +4483,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 11092,
+          "line": 11216,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4405,7 +4493,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 11099,
+          "line": 11223,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4417,7 +4505,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 11104,
+          "line": 11228,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4429,7 +4517,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 11108,
+          "line": 11232,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4441,7 +4529,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 11112,
+          "line": 11236,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4453,7 +4541,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 11117,
+          "line": 11241,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4466,7 +4554,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 11123,
+          "line": 11247,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4474,7 +4562,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 11126,
+          "line": 11250,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4484,8 +4572,20 @@
           ]
         },
         {
+          "name": "AddAllLandTypes",
+          "line": 11254,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 205.3i + CR 305.7: grants every land type (all 17 land subtypes) and their mana abilities, additive. Distinct from AddAllBasicLandTypes (CR 305.6, 5 basic types). Omo, Queen of Vesuva. Layer 4.",
+          "cr_refs": [
+            "CR 205.3i",
+            "CR 305.6",
+            "CR 305.7"
+          ]
+        },
+        {
           "name": "AddChosenSubtype",
-          "line": 11129,
+          "line": 11257,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4495,7 +4595,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 11134,
+          "line": 11262,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4505,7 +4605,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 11141,
+          "line": 11269,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -4516,7 +4616,7 @@
         },
         {
           "name": "SetColor",
-          "line": 11142,
+          "line": 11270,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4526,7 +4626,7 @@
         },
         {
           "name": "AddColor",
-          "line": 11145,
+          "line": 11273,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4536,7 +4636,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 11150,
+          "line": 11278,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4546,7 +4646,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 11164,
+          "line": 11292,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4561,7 +4661,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 11168,
+          "line": 11296,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4571,7 +4671,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 11171,
+          "line": 11299,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -4581,7 +4681,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 11173,
+          "line": 11301,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -4591,7 +4691,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 11175,
+          "line": 11303,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -4601,7 +4701,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 11178,
+          "line": 11306,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -4611,7 +4711,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 11181,
+          "line": 11309,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -4623,7 +4723,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 11195,
+          "line": 11323,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -4635,7 +4735,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 11203,
+          "line": 11331,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4650,7 +4750,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 11212,
+          "line": 11340,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4665,7 +4765,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 11226,
+          "line": 11354,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -4683,13 +4783,13 @@
     },
     "ControllerRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1749,
+      "line": 1815,
       "doc": "Controller reference for filter matching.",
       "cr_refs": [],
       "variants": [
         {
           "name": "You",
-          "line": 1750,
+          "line": 1816,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4697,7 +4797,7 @@
         },
         {
           "name": "Opponent",
-          "line": 1751,
+          "line": 1817,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4705,7 +4805,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 1754,
+          "line": 1820,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: Filter controller is the current player being affected by an \"each player/opponent\" instruction during resolution.",
@@ -4716,7 +4816,7 @@
         },
         {
           "name": "TargetPlayer",
-          "line": 1761,
+          "line": 1827,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 115.1: Filter controller is the player chosen as a target of the enclosing ability (e.g., \"each creature target player controls\"). At resolution time, `filter_inner` reads the first `TargetRef::Player` from `ability.targets`. At target-selection time, `collect_target_slots` surfaces a companion `TargetFilter::Player` slot so the player is chosen as part of CR 601.2c / CR 603.3d target declaration.",
@@ -4729,7 +4829,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 1765,
+          "line": 1831,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 109.4: Filter controller is the controller of the parent object target inherited by this chained effect (\"that permanent's controller may sacrifice a land\").",
@@ -4740,7 +4840,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 1770,
+          "line": 1836,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Filter controller is the defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by intervening-if quantity checks such as \"defending player controls more lands than you.\"",
@@ -4751,7 +4851,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 1781,
+          "line": 1847,
           "kind": "struct",
           "field_names": [
             "index"
@@ -4764,7 +4864,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 1790,
+          "line": 1856,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 109.4: Filter controller is the player identified by the triggering event (the drawer, life-gainer, attacker, etc.). Resolved against `state.current_trigger_event` via `extract_player_from_event`. Mirrors `PlayerFilter::TriggeringPlayer` and `TargetFilter::TriggeringPlayer`. Used by control-relative trigger restrictions (\"an opponent who controls F draws a card\").",
@@ -4788,7 +4888,7 @@
     },
     "ConvokeMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 125,
+      "line": 126,
       "doc": "CR 702.51a / Waterbend: Determines tap-to-pay behavior during mana payment.",
       "cr_refs": [
         "CR 702.51a"
@@ -4796,7 +4896,7 @@
       "variants": [
         {
           "name": "Convoke",
-          "line": 127,
+          "line": 128,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51a: Creature's color determines mana produced.",
@@ -4806,7 +4906,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 129,
+          "line": 130,
           "kind": "unit",
           "field_names": [],
           "doc": "Waterbend: always produces {1} colorless, emits Waterbend event.",
@@ -4814,7 +4914,7 @@
         },
         {
           "name": "Improvise",
-          "line": 131,
+          "line": 132,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.126a: Improvise — tap an untapped artifact to pay one generic mana.",
@@ -4827,7 +4927,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11305,
+      "line": 11433,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -4837,7 +4937,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 11308,
+          "line": 11436,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -4845,7 +4945,7 @@
         },
         {
           "name": "Finalized",
-          "line": 11310,
+          "line": 11438,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -4856,13 +4956,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4972,
+      "line": 5053,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 4973,
+          "line": 5054,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4873,7 +4973,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6940,
+      "line": 7054,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -4882,7 +4982,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 6942,
+          "line": 7056,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -4890,7 +4990,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 6944,
+          "line": 7058,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -5014,7 +5114,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4502,
+      "line": 4583,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -5022,7 +5122,7 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4503,
+          "line": 4584,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5030,7 +5130,7 @@
         },
         {
           "name": "TapsSelf",
-          "line": 4504,
+          "line": 4585,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5038,7 +5138,7 @@
         },
         {
           "name": "UntapsSelf",
-          "line": 4505,
+          "line": 4586,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5046,7 +5146,7 @@
         },
         {
           "name": "SacrificesPermanent",
-          "line": 4506,
+          "line": 4587,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5054,7 +5154,7 @@
         },
         {
           "name": "PaysLife",
-          "line": 4507,
+          "line": 4588,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5062,7 +5162,7 @@
         },
         {
           "name": "PaysLoyalty",
-          "line": 4508,
+          "line": 4589,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5070,7 +5170,7 @@
         },
         {
           "name": "Discards",
-          "line": 4509,
+          "line": 4590,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5078,7 +5178,7 @@
         },
         {
           "name": "ExilesCards",
-          "line": 4510,
+          "line": 4591,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5086,7 +5186,7 @@
         },
         {
           "name": "TapsOtherCreatures",
-          "line": 4511,
+          "line": 4592,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5094,7 +5194,7 @@
         },
         {
           "name": "RemovesCounters",
-          "line": 4512,
+          "line": 4593,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5102,7 +5202,7 @@
         },
         {
           "name": "PaysEnergy",
-          "line": 4513,
+          "line": 4594,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5110,7 +5210,7 @@
         },
         {
           "name": "PaysSpeed",
-          "line": 4514,
+          "line": 4595,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5118,7 +5218,7 @@
         },
         {
           "name": "ReturnsToHand",
-          "line": 4515,
+          "line": 4596,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5126,7 +5226,7 @@
         },
         {
           "name": "Unattaches",
-          "line": 4516,
+          "line": 4597,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5134,7 +5234,7 @@
         },
         {
           "name": "Mills",
-          "line": 4517,
+          "line": 4598,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5142,7 +5242,7 @@
         },
         {
           "name": "PutsCounters",
-          "line": 4518,
+          "line": 4599,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5150,7 +5250,7 @@
         },
         {
           "name": "Reveals",
-          "line": 4519,
+          "line": 4600,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5158,7 +5258,7 @@
         },
         {
           "name": "Exerts",
-          "line": 4520,
+          "line": 4601,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5166,11 +5266,48 @@
         },
         {
           "name": "KeywordCost",
-          "line": 4521,
+          "line": 4602,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "CostModifyMode": {
+      "file": "crates/engine/src/types/statics.rs",
+      "line": 422,
+      "doc": "CR 601.2f: Direction/semantic axis for mana-cost modification statics. All three modes are applied in the CR 601.2f cost-locking step.",
+      "cr_refs": [
+        "CR 601.2f"
+      ],
+      "variants": [
+        {
+          "name": "Reduce",
+          "line": 424,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Subtractive — reduce generic mana (floor: 0).",
+          "cr_refs": []
+        },
+        {
+          "name": "Raise",
+          "line": 426,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Additive — increase generic mana. Thalia, Guardian of Thraben class.",
+          "cr_refs": []
+        },
+        {
+          "name": "Minimum",
+          "line": 429,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Floor — cost cannot fall below `amount` after all Reduce/Raise settle. CR 601.2f last-step floor. Trinisphere class.",
+          "cr_refs": [
+            "CR 601.2f"
+          ]
         }
       ],
       "sibling_clusters": []
@@ -5200,6 +5337,38 @@
           "kind": "struct",
           "field_names": [
             "filter"
+          ],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "CostResume": {
+      "file": "crates/engine/src/types/game_state.rs",
+      "line": 1661,
+      "doc": "CR 601.2b + CR 605.3b: Resumption context after a PayCost choice completes. Determines whether the engine re-enters the spell-casting pipeline or the mana-ability pipeline.",
+      "cr_refs": [
+        "CR 601.2b",
+        "CR 605.3b"
+      ],
+      "variants": [
+        {
+          "name": "Spell",
+          "line": 1662,
+          "kind": "struct",
+          "field_names": [
+            "spell"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ManaAbility",
+          "line": 1666,
+          "kind": "struct",
+          "field_names": [
+            "mana_ability"
           ],
           "doc": "",
           "cr_refs": []
@@ -5569,7 +5738,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3210,
+      "line": 3291,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -5577,7 +5746,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 3213,
+          "line": 3294,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -5590,7 +5759,7 @@
     },
     "DamageKindFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1737,
+      "line": 1803,
       "doc": "Filter for damage type on trigger definitions. CR 120.3: Combat damage is dealt during the combat damage step; all other damage is noncombat.",
       "cr_refs": [
         "CR 120.3"
@@ -5598,7 +5767,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 1740,
+          "line": 1806,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches both combat and noncombat damage.",
@@ -5606,7 +5775,7 @@
         },
         {
           "name": "CombatOnly",
-          "line": 1742,
+          "line": 1808,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2a: Only combat damage (dealt as a result of combat).",
@@ -5616,7 +5785,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 1744,
+          "line": 1810,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2b: Only noncombat damage (dealt as an effect of a spell or ability).",
@@ -5629,7 +5798,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10475,
+      "line": 10595,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -5637,7 +5806,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10477,
+          "line": 10597,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -5645,7 +5814,7 @@
         },
         {
           "name": "Triple",
-          "line": 10479,
+          "line": 10599,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -5653,7 +5822,7 @@
         },
         {
           "name": "Plus",
-          "line": 10481,
+          "line": 10601,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5663,7 +5832,7 @@
         },
         {
           "name": "Minus",
-          "line": 10488,
+          "line": 10608,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5676,7 +5845,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 10492,
+          "line": 10612,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -5686,7 +5855,7 @@
         },
         {
           "name": "SetTo",
-          "line": 10498,
+          "line": 10618,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5698,7 +5867,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 10504,
+          "line": 10624,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -5748,7 +5917,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4953,
+      "line": 5034,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -5756,7 +5925,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 4955,
+          "line": 5036,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -5764,7 +5933,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 4958,
+          "line": 5039,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -5778,7 +5947,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10586,
+      "line": 10710,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -5786,7 +5955,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 10588,
+          "line": 10712,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -5794,7 +5963,7 @@
         },
         {
           "name": "Player",
-          "line": 10590,
+          "line": 10714,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5804,7 +5973,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 10593,
+          "line": 10717,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5817,7 +5986,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10574,
+      "line": 10694,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -5825,7 +5994,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10575,
+          "line": 10695,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5833,7 +6002,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10576,
+          "line": 10696,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5841,15 +6010,26 @@
         },
         {
           "name": "Controller",
-          "line": 10579,
+          "line": 10699,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
           "cr_refs": []
         },
         {
+          "name": "SourceChosenPlayer",
+          "line": 10703,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 607.2d + CR 614.1a: Damage recipient is the player chosen for the replacement source by a linked persisted choice, or a permanent that player controls for `PlayerOrPermanentsControlledBy`.",
+          "cr_refs": [
+            "CR 607.2d",
+            "CR 614.1a"
+          ]
+        },
+        {
           "name": "Specific",
-          "line": 10580,
+          "line": 10704,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -5860,7 +6040,7 @@
     },
     "DayNight": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 118,
+      "line": 119,
       "doc": "Tracks whether the game is in day or night state (CR 730).",
       "cr_refs": [
         "CR 730"
@@ -5868,7 +6048,7 @@
       "variants": [
         {
           "name": "Day",
-          "line": 119,
+          "line": 120,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5876,7 +6056,7 @@
         },
         {
           "name": "Night",
-          "line": 120,
+          "line": 121,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6392,7 +6572,7 @@
     },
     "DistributionUnit": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2998,
+      "line": 3034,
       "doc": "CR 601.2d: What is being distributed (damage, counters, life).",
       "cr_refs": [
         "CR 601.2d"
@@ -6400,7 +6580,7 @@
       "variants": [
         {
           "name": "Damage",
-          "line": 2999,
+          "line": 3035,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6408,7 +6588,7 @@
         },
         {
           "name": "EvenSplitDamage",
-          "line": 3002,
+          "line": 3038,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2d: Even split — engine auto-computes `total / num_targets` (rounded down). No player choice needed; bypasses `WaitingFor::DistributeAmong`.",
@@ -6418,7 +6598,7 @@
         },
         {
           "name": "Counters",
-          "line": 3003,
+          "line": 3039,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6426,7 +6606,7 @@
         },
         {
           "name": "Life",
-          "line": 3004,
+          "line": 3040,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6631,13 +6811,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5054,
+      "line": 5135,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 5056,
+          "line": 5137,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -6649,7 +6829,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 5062,
+          "line": 5143,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -6664,7 +6844,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 5073,
+          "line": 5154,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6676,7 +6856,7 @@
         },
         {
           "name": "Draw",
-          "line": 5093,
+          "line": 5174,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6692,7 +6872,7 @@
         },
         {
           "name": "Pump",
-          "line": 5099,
+          "line": 5180,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6704,7 +6884,7 @@
         },
         {
           "name": "PairWith",
-          "line": 5110,
+          "line": 5191,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6717,7 +6897,7 @@
         },
         {
           "name": "Destroy",
-          "line": 5113,
+          "line": 5194,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6728,7 +6908,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 5121,
+          "line": 5202,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6740,7 +6920,7 @@
         },
         {
           "name": "Counter",
-          "line": 5125,
+          "line": 5206,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6751,7 +6931,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 5146,
+          "line": 5227,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6765,7 +6945,7 @@
         },
         {
           "name": "Token",
-          "line": 5150,
+          "line": 5231,
           "kind": "struct",
           "field_names": [
             "name",
@@ -6788,7 +6968,7 @@
         },
         {
           "name": "GainLife",
-          "line": 5188,
+          "line": 5269,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6799,7 +6979,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 5195,
+          "line": 5276,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6810,7 +6990,7 @@
         },
         {
           "name": "Tap",
-          "line": 5202,
+          "line": 5283,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6820,7 +7000,7 @@
         },
         {
           "name": "Untap",
-          "line": 5206,
+          "line": 5287,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6830,7 +7010,7 @@
         },
         {
           "name": "TapAll",
-          "line": 5211,
+          "line": 5292,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6842,7 +7022,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 5216,
+          "line": 5297,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6854,7 +7034,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 5220,
+          "line": 5301,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6866,7 +7046,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 5227,
+          "line": 5308,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6878,7 +7058,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5235,
+          "line": 5316,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6890,7 +7070,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 5256,
+          "line": 5337,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6901,7 +7081,7 @@
         },
         {
           "name": "Mill",
-          "line": 5262,
+          "line": 5343,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6913,7 +7093,7 @@
         },
         {
           "name": "Scry",
-          "line": 5279,
+          "line": 5360,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6928,7 +7108,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 5285,
+          "line": 5366,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6940,7 +7120,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 5299,
+          "line": 5380,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6957,7 +7137,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 5323,
+          "line": 5404,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6970,7 +7150,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 5327,
+          "line": 5408,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6981,7 +7161,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 5334,
+          "line": 5415,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7000,7 +7180,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 5385,
+          "line": 5466,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7013,7 +7193,7 @@
         },
         {
           "name": "Dig",
-          "line": 5398,
+          "line": 5479,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7033,7 +7213,7 @@
         },
         {
           "name": "GainControl",
-          "line": 5424,
+          "line": 5505,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7043,7 +7223,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 5428,
+          "line": 5509,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7054,7 +7234,7 @@
         },
         {
           "name": "Attach",
-          "line": 5434,
+          "line": 5515,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7065,7 +7245,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 5446,
+          "line": 5527,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7078,7 +7258,7 @@
         },
         {
           "name": "Surveil",
-          "line": 5458,
+          "line": 5539,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7093,7 +7273,7 @@
         },
         {
           "name": "Fight",
-          "line": 5464,
+          "line": 5545,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7104,7 +7284,7 @@
         },
         {
           "name": "Bounce",
-          "line": 5472,
+          "line": 5553,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7116,7 +7296,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 5491,
+          "line": 5572,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7131,7 +7311,7 @@
         },
         {
           "name": "Explore",
-          "line": 5499,
+          "line": 5580,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7139,7 +7319,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 5503,
+          "line": 5584,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7151,7 +7331,7 @@
         },
         {
           "name": "Investigate",
-          "line": 5508,
+          "line": 5589,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Investigate — create a Clue token.",
@@ -7161,7 +7341,7 @@
         },
         {
           "name": "Tribute",
-          "line": 5515,
+          "line": 5596,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7174,7 +7354,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 5521,
+          "line": 5602,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -7184,7 +7364,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 5523,
+          "line": 5604,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -7194,7 +7374,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 5524,
+          "line": 5605,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7202,7 +7382,7 @@
         },
         {
           "name": "Populate",
-          "line": 5526,
+          "line": 5607,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -7212,7 +7392,7 @@
         },
         {
           "name": "Clash",
-          "line": 5528,
+          "line": 5609,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -7222,7 +7402,7 @@
         },
         {
           "name": "Vote",
-          "line": 5543,
+          "line": 5624,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7238,7 +7418,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 5587,
+          "line": 5668,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -7258,7 +7438,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 5606,
+          "line": 5687,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7270,7 +7450,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 5610,
+          "line": 5691,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7281,7 +7461,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 5619,
+          "line": 5700,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7294,7 +7474,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 5630,
+          "line": 5711,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7314,7 +7494,7 @@
         },
         {
           "name": "Myriad",
-          "line": 5677,
+          "line": 5758,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -7324,7 +7504,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 5680,
+          "line": 5761,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7340,7 +7520,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 5690,
+          "line": 5771,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7351,7 +7531,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 5696,
+          "line": 5777,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7363,7 +7543,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 5704,
+          "line": 5785,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7377,7 +7557,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 5711,
+          "line": 5792,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7389,7 +7569,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 5719,
+          "line": 5800,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7402,7 +7582,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 5725,
+          "line": 5806,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7415,7 +7595,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 5733,
+          "line": 5814,
           "kind": "struct",
           "field_names": [
             "source",
@@ -7433,7 +7613,7 @@
         },
         {
           "name": "Animate",
-          "line": 5753,
+          "line": 5834,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7448,7 +7628,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 5787,
+          "line": 5868,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -7472,7 +7652,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 5803,
+          "line": 5884,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -7482,7 +7662,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 5807,
+          "line": 5888,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -7494,7 +7674,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 5815,
+          "line": 5896,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -7511,7 +7691,7 @@
         },
         {
           "name": "Mana",
-          "line": 5833,
+          "line": 5914,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -7525,7 +7705,7 @@
         },
         {
           "name": "Discard",
-          "line": 5856,
+          "line": 5937,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7539,7 +7719,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 5878,
+          "line": 5959,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7549,7 +7729,7 @@
         },
         {
           "name": "Transform",
-          "line": 5882,
+          "line": 5963,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7559,9 +7739,10 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 5888,
+          "line": 5969,
           "kind": "struct",
           "field_names": [
+            "source_zones",
             "filter",
             "count",
             "reveal",
@@ -7574,7 +7755,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 5930,
+          "line": 6026,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7592,7 +7773,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 5941,
+          "line": 6037,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7606,7 +7787,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 5965,
+          "line": 6061,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7619,7 +7800,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5976,
+          "line": 6072,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7632,7 +7813,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 5981,
+          "line": 6077,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7645,7 +7826,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 5990,
+          "line": 6086,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7657,7 +7838,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 6013,
+          "line": 6109,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7667,7 +7848,7 @@
         },
         {
           "name": "Choose",
-          "line": 6019,
+          "line": 6115,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -7678,7 +7859,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 6030,
+          "line": 6126,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -7691,7 +7872,7 @@
         },
         {
           "name": "Suspect",
-          "line": 6035,
+          "line": 6131,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7703,7 +7884,7 @@
         },
         {
           "name": "Connive",
-          "line": 6042,
+          "line": 6138,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7717,7 +7898,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 6050,
+          "line": 6146,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7729,7 +7910,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 6057,
+          "line": 6153,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7741,7 +7922,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 6062,
+          "line": 6158,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7753,7 +7934,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 6067,
+          "line": 6163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -7763,7 +7944,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 6074,
+          "line": 6170,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7775,7 +7956,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 6081,
+          "line": 6177,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7787,7 +7968,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 6086,
+          "line": 6182,
           "kind": "struct",
           "field_names": [
             "level"
@@ -7799,7 +7980,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 6091,
+          "line": 6187,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -7813,7 +7994,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 6121,
+          "line": 6217,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -7827,7 +8008,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 6127,
+          "line": 6223,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -7839,7 +8020,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 6132,
+          "line": 6228,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7852,7 +8033,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 6139,
+          "line": 6235,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -7865,7 +8046,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 6148,
+          "line": 6244,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7878,7 +8059,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 6156,
+          "line": 6252,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -7892,7 +8073,7 @@
         },
         {
           "name": "PayCost",
-          "line": 6166,
+          "line": 6262,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -7905,7 +8086,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 6177,
+          "line": 6273,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7923,7 +8104,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 6207,
+          "line": 6303,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7939,7 +8120,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 6246,
+          "line": 6342,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -7960,7 +8141,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 6276,
+          "line": 6372,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: A player who meets this effect's condition loses the game. The affected player is determined by resolution context (controller's opponent if untargeted, or explicit target if targeted).",
@@ -7970,7 +8151,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 6278,
+          "line": 6374,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: The controller wins the game — all opponents lose.",
@@ -7980,7 +8161,7 @@
         },
         {
           "name": "RollDie",
-          "line": 6283,
+          "line": 6379,
           "kind": "struct",
           "field_names": [
             "sides",
@@ -7995,7 +8176,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 6291,
+          "line": 6387,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -8008,7 +8189,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 6303,
+          "line": 6399,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8022,7 +8203,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 6312,
+          "line": 6408,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -8034,7 +8215,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 6317,
+          "line": 6413,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -8044,7 +8225,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 6320,
+          "line": 6416,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -8054,7 +8235,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 6322,
+          "line": 6418,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -8066,7 +8247,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 6327,
+          "line": 6423,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -8077,7 +8258,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 6330,
+          "line": 6426,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -8087,7 +8268,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 6333,
+          "line": 6429,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -8099,7 +8280,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 6350,
+          "line": 6446,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8118,7 +8299,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 6383,
+          "line": 6479,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8133,11 +8314,13 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 6396,
+          "line": 6492,
           "kind": "struct",
           "field_names": [
             "categories",
-            "chooser_scope"
+            "chooser_scope",
+            "choose_filter",
+            "sacrifice_filter"
           ],
           "doc": "CR 101.4 + CR 701.21a: Each player chooses one permanent per type category from among the permanents they control, then sacrifices the rest. Building block for Cataclysm, Tragic Arrogance, Cataclysmic Gearhulk.",
           "cr_refs": [
@@ -8147,7 +8330,7 @@
         },
         {
           "name": "Exploit",
-          "line": 6405,
+          "line": 6507,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8159,7 +8342,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 6410,
+          "line": 6512,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8171,7 +8354,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 6415,
+          "line": 6517,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -8186,7 +8369,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 6427,
+          "line": 6529,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8198,7 +8381,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 6439,
+          "line": 6541,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8214,7 +8397,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 6450,
+          "line": 6552,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8232,7 +8415,7 @@
         },
         {
           "name": "Discover",
-          "line": 6484,
+          "line": 6586,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -8244,7 +8427,7 @@
         },
         {
           "name": "Cascade",
-          "line": 6496,
+          "line": 6598,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -8254,19 +8437,19 @@
         },
         {
           "name": "MiracleCast",
-          "line": 6500,
+          "line": 6602,
           "kind": "struct",
           "field_names": [
             "cost"
           ],
-          "doc": "CR 702.94a: Miracle trigger resolution — offers the player the chance to cast the source card from hand for its miracle cost. Carries the cost so the resolution handler can populate `WaitingFor::MiracleCastOffer`.",
+          "doc": "CR 702.94a: Miracle trigger resolution — offers the player the chance to cast the source card from hand for its miracle cost. Carries the cost so the resolution handler can populate `WaitingFor::CastOffer` (Miracle).",
           "cr_refs": [
             "CR 702.94a"
           ]
         },
         {
           "name": "MadnessCast",
-          "line": 6505,
+          "line": 6607,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8278,7 +8461,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 6518,
+          "line": 6620,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8290,7 +8473,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 6527,
+          "line": 6629,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8302,7 +8485,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 6536,
+          "line": 6638,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8312,7 +8495,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 6541,
+          "line": 6643,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -8322,7 +8505,7 @@
         },
         {
           "name": "Goad",
-          "line": 6547,
+          "line": 6649,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8334,7 +8517,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 6554,
+          "line": 6656,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8346,7 +8529,7 @@
         },
         {
           "name": "Detain",
-          "line": 6561,
+          "line": 6663,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8358,7 +8541,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 6572,
+          "line": 6674,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -8372,7 +8555,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 6583,
+          "line": 6685,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8386,7 +8569,7 @@
         },
         {
           "name": "Manifest",
-          "line": 6598,
+          "line": 6700,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8399,7 +8582,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 6604,
+          "line": 6706,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -8409,7 +8592,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 6608,
+          "line": 6710,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8421,7 +8604,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 6622,
+          "line": 6724,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8434,7 +8617,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 6633,
+          "line": 6735,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8447,7 +8630,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 6643,
+          "line": 6745,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8461,7 +8644,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 6655,
+          "line": 6757,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8477,7 +8660,7 @@
         },
         {
           "name": "Double",
-          "line": 6666,
+          "line": 6768,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -8491,7 +8674,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 6674,
+          "line": 6776,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -8503,7 +8686,7 @@
         },
         {
           "name": "Incubate",
-          "line": 6680,
+          "line": 6782,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8515,7 +8698,7 @@
         },
         {
           "name": "Amass",
-          "line": 6688,
+          "line": 6790,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -8528,7 +8711,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 6696,
+          "line": 6798,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8540,7 +8723,7 @@
         },
         {
           "name": "Renown",
-          "line": 6702,
+          "line": 6804,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8552,7 +8735,7 @@
         },
         {
           "name": "Bolster",
-          "line": 6708,
+          "line": 6810,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8564,7 +8747,7 @@
         },
         {
           "name": "Adapt",
-          "line": 6714,
+          "line": 6816,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8576,7 +8759,7 @@
         },
         {
           "name": "Learn",
-          "line": 6720,
+          "line": 6822,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -8586,7 +8769,7 @@
         },
         {
           "name": "Forage",
-          "line": 6722,
+          "line": 6824,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -8596,7 +8779,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6724,
+          "line": 6826,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8608,7 +8791,7 @@
         },
         {
           "name": "Endure",
-          "line": 6731,
+          "line": 6833,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8621,7 +8804,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 6736,
+          "line": 6838,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8633,7 +8816,7 @@
         },
         {
           "name": "Seek",
-          "line": 6741,
+          "line": 6843,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -8647,7 +8830,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 6758,
+          "line": 6860,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8660,7 +8843,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 6773,
+          "line": 6875,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8676,7 +8859,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 6780,
+          "line": 6882,
           "kind": "struct",
           "field_names": [
             "to"
@@ -8688,7 +8871,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 6785,
+          "line": 6887,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8701,7 +8884,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 6794,
+          "line": 6896,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8713,7 +8896,7 @@
         },
         {
           "name": "Conjure",
-          "line": 6801,
+          "line": 6903,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -8725,7 +8908,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 6822,
+          "line": 6924,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8739,7 +8922,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6833,
+          "line": 6935,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8834,13 +9017,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11693,
+      "line": 11825,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 11695,
+          "line": 11827,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8848,7 +9031,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 11697,
+          "line": 11829,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8856,7 +9039,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 11699,
+          "line": 11831,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8864,7 +9047,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 11701,
+          "line": 11833,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8872,7 +9055,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 11703,
+          "line": 11835,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8880,7 +9063,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 11705,
+          "line": 11837,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8891,13 +9074,13 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7807,
+      "line": 7926,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7808,
+          "line": 7927,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8905,7 +9088,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 7809,
+          "line": 7928,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8913,7 +9096,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 7810,
+          "line": 7929,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8921,7 +9104,7 @@
         },
         {
           "name": "Draw",
-          "line": 7811,
+          "line": 7930,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8929,7 +9112,7 @@
         },
         {
           "name": "Pump",
-          "line": 7812,
+          "line": 7931,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8937,7 +9120,7 @@
         },
         {
           "name": "PairWith",
-          "line": 7813,
+          "line": 7932,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8945,7 +9128,7 @@
         },
         {
           "name": "Destroy",
-          "line": 7814,
+          "line": 7933,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8953,7 +9136,7 @@
         },
         {
           "name": "Counter",
-          "line": 7815,
+          "line": 7934,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8961,7 +9144,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 7816,
+          "line": 7935,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8969,7 +9152,7 @@
         },
         {
           "name": "Token",
-          "line": 7817,
+          "line": 7936,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8977,7 +9160,7 @@
         },
         {
           "name": "GainLife",
-          "line": 7818,
+          "line": 7937,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8985,7 +9168,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 7819,
+          "line": 7938,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8993,7 +9176,7 @@
         },
         {
           "name": "Tap",
-          "line": 7820,
+          "line": 7939,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9001,7 +9184,7 @@
         },
         {
           "name": "Untap",
-          "line": 7821,
+          "line": 7940,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9009,7 +9192,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 7822,
+          "line": 7941,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9017,7 +9200,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 7823,
+          "line": 7942,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9025,7 +9208,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 7824,
+          "line": 7943,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9033,7 +9216,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 7825,
+          "line": 7944,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9041,7 +9224,7 @@
         },
         {
           "name": "Mill",
-          "line": 7826,
+          "line": 7945,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9049,7 +9232,7 @@
         },
         {
           "name": "Scry",
-          "line": 7827,
+          "line": 7946,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9057,7 +9240,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 7828,
+          "line": 7947,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9065,7 +9248,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 7829,
+          "line": 7948,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9073,7 +9256,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 7830,
+          "line": 7949,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9081,7 +9264,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 7831,
+          "line": 7950,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9089,7 +9272,7 @@
         },
         {
           "name": "TapAll",
-          "line": 7832,
+          "line": 7951,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9097,7 +9280,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 7833,
+          "line": 7952,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9105,7 +9288,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 7834,
+          "line": 7953,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9113,7 +9296,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 7835,
+          "line": 7954,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9121,7 +9304,7 @@
         },
         {
           "name": "Dig",
-          "line": 7836,
+          "line": 7955,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9129,7 +9312,7 @@
         },
         {
           "name": "GainControl",
-          "line": 7837,
+          "line": 7956,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9137,7 +9320,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 7838,
+          "line": 7957,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9145,7 +9328,7 @@
         },
         {
           "name": "Attach",
-          "line": 7839,
+          "line": 7958,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9153,7 +9336,7 @@
         },
         {
           "name": "AttachAll",
-          "line": 7840,
+          "line": 7959,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9161,7 +9344,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 7841,
+          "line": 7960,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9169,7 +9352,7 @@
         },
         {
           "name": "Surveil",
-          "line": 7842,
+          "line": 7961,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9177,7 +9360,7 @@
         },
         {
           "name": "Fight",
-          "line": 7843,
+          "line": 7962,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9185,7 +9368,7 @@
         },
         {
           "name": "Bounce",
-          "line": 7844,
+          "line": 7963,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9193,7 +9376,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 7845,
+          "line": 7964,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9201,7 +9384,7 @@
         },
         {
           "name": "Explore",
-          "line": 7846,
+          "line": 7965,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9209,7 +9392,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 7847,
+          "line": 7966,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9217,7 +9400,7 @@
         },
         {
           "name": "Investigate",
-          "line": 7848,
+          "line": 7967,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9225,7 +9408,7 @@
         },
         {
           "name": "Tribute",
-          "line": 7849,
+          "line": 7968,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9233,7 +9416,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 7850,
+          "line": 7969,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9241,7 +9424,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 7851,
+          "line": 7970,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9249,7 +9432,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 7852,
+          "line": 7971,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9257,7 +9440,7 @@
         },
         {
           "name": "Populate",
-          "line": 7853,
+          "line": 7972,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9265,7 +9448,7 @@
         },
         {
           "name": "Clash",
-          "line": 7854,
+          "line": 7973,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9273,7 +9456,7 @@
         },
         {
           "name": "Vote",
-          "line": 7856,
+          "line": 7975,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -9283,7 +9466,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7858,
+          "line": 7977,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -9293,7 +9476,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7859,
+          "line": 7978,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9301,7 +9484,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 7860,
+          "line": 7979,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9309,7 +9492,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 7861,
+          "line": 7980,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9317,7 +9500,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 7862,
+          "line": 7981,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9325,7 +9508,7 @@
         },
         {
           "name": "Myriad",
-          "line": 7863,
+          "line": 7982,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9333,7 +9516,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 7864,
+          "line": 7983,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9341,7 +9524,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 7865,
+          "line": 7984,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9349,7 +9532,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 7866,
+          "line": 7985,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9357,7 +9540,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 7867,
+          "line": 7986,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9365,7 +9548,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 7868,
+          "line": 7987,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9373,7 +9556,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 7869,
+          "line": 7988,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9381,7 +9564,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 7870,
+          "line": 7989,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9389,7 +9572,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 7871,
+          "line": 7990,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9397,7 +9580,7 @@
         },
         {
           "name": "Animate",
-          "line": 7872,
+          "line": 7991,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9405,7 +9588,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 7873,
+          "line": 7992,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9413,7 +9596,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 7874,
+          "line": 7993,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9421,7 +9604,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 7875,
+          "line": 7994,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9429,7 +9612,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 7876,
+          "line": 7995,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9437,7 +9620,7 @@
         },
         {
           "name": "Mana",
-          "line": 7877,
+          "line": 7996,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9445,7 +9628,7 @@
         },
         {
           "name": "Discard",
-          "line": 7878,
+          "line": 7997,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9453,7 +9636,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 7879,
+          "line": 7998,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9461,7 +9644,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 7880,
+          "line": 7999,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9469,7 +9652,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 7881,
+          "line": 8000,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9477,7 +9660,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 7882,
+          "line": 8001,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9485,7 +9668,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 7883,
+          "line": 8002,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9493,7 +9676,7 @@
         },
         {
           "name": "Choose",
-          "line": 7884,
+          "line": 8003,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9501,7 +9684,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 7885,
+          "line": 8004,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9509,7 +9692,7 @@
         },
         {
           "name": "Suspect",
-          "line": 7886,
+          "line": 8005,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9517,7 +9700,7 @@
         },
         {
           "name": "Connive",
-          "line": 7887,
+          "line": 8006,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9525,7 +9708,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 7888,
+          "line": 8007,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9533,7 +9716,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 7889,
+          "line": 8008,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9541,7 +9724,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 7890,
+          "line": 8009,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9549,7 +9732,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 7891,
+          "line": 8010,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9557,7 +9740,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 7893,
+          "line": 8012,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -9567,7 +9750,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 7895,
+          "line": 8014,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -9577,7 +9760,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 7896,
+          "line": 8015,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9585,7 +9768,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 7897,
+          "line": 8016,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9593,7 +9776,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 7898,
+          "line": 8017,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9601,7 +9784,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 7899,
+          "line": 8018,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9609,7 +9792,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 7900,
+          "line": 8019,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9617,7 +9800,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 7901,
+          "line": 8020,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9625,7 +9808,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 7902,
+          "line": 8021,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9633,7 +9816,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 7903,
+          "line": 8022,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9641,7 +9824,7 @@
         },
         {
           "name": "PayCost",
-          "line": 7904,
+          "line": 8023,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9649,7 +9832,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 7905,
+          "line": 8024,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9657,7 +9840,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 7906,
+          "line": 8025,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9665,7 +9848,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 7907,
+          "line": 8026,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9673,7 +9856,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 7908,
+          "line": 8027,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9681,7 +9864,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 7909,
+          "line": 8028,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9689,7 +9872,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 7910,
+          "line": 8029,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9697,7 +9880,7 @@
         },
         {
           "name": "RollDie",
-          "line": 7911,
+          "line": 8030,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9705,7 +9888,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 7912,
+          "line": 8031,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9713,7 +9896,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 7913,
+          "line": 8032,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9721,7 +9904,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 7914,
+          "line": 8033,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9729,7 +9912,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 7915,
+          "line": 8034,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9737,7 +9920,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 7916,
+          "line": 8035,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9745,7 +9928,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 7917,
+          "line": 8036,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9753,7 +9936,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 7918,
+          "line": 8037,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9761,7 +9944,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 7919,
+          "line": 8038,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9769,7 +9952,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 7920,
+          "line": 8039,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9777,7 +9960,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 7921,
+          "line": 8040,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9785,7 +9968,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 7922,
+          "line": 8041,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9793,7 +9976,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 7923,
+          "line": 8042,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9801,7 +9984,7 @@
         },
         {
           "name": "Exploit",
-          "line": 7924,
+          "line": 8043,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9809,7 +9992,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 7925,
+          "line": 8044,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9817,7 +10000,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 7926,
+          "line": 8045,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9825,7 +10008,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 7927,
+          "line": 8046,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9833,7 +10016,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 7928,
+          "line": 8047,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9841,7 +10024,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 7929,
+          "line": 8048,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9849,7 +10032,7 @@
         },
         {
           "name": "Discover",
-          "line": 7930,
+          "line": 8049,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9857,7 +10040,7 @@
         },
         {
           "name": "Cascade",
-          "line": 7931,
+          "line": 8050,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9865,7 +10048,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 7932,
+          "line": 8051,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9873,7 +10056,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 7933,
+          "line": 8052,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9881,7 +10064,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 7934,
+          "line": 8053,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9889,7 +10072,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 7935,
+          "line": 8054,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9897,7 +10080,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 7936,
+          "line": 8055,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9905,7 +10088,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 7937,
+          "line": 8056,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9913,7 +10096,7 @@
         },
         {
           "name": "Goad",
-          "line": 7938,
+          "line": 8057,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9921,7 +10104,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 7939,
+          "line": 8058,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9929,7 +10112,7 @@
         },
         {
           "name": "Detain",
-          "line": 7940,
+          "line": 8059,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9937,7 +10120,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 7941,
+          "line": 8060,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9945,7 +10128,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 7942,
+          "line": 8061,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9953,7 +10136,7 @@
         },
         {
           "name": "Incubate",
-          "line": 7943,
+          "line": 8062,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9961,7 +10144,7 @@
         },
         {
           "name": "Amass",
-          "line": 7944,
+          "line": 8063,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9969,7 +10152,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 7945,
+          "line": 8064,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9977,7 +10160,7 @@
         },
         {
           "name": "Renown",
-          "line": 7946,
+          "line": 8065,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9985,7 +10168,7 @@
         },
         {
           "name": "Bolster",
-          "line": 7947,
+          "line": 8066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9993,7 +10176,7 @@
         },
         {
           "name": "Adapt",
-          "line": 7948,
+          "line": 8067,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10001,7 +10184,7 @@
         },
         {
           "name": "Manifest",
-          "line": 7949,
+          "line": 8068,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10009,7 +10192,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 7950,
+          "line": 8069,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10017,7 +10200,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 7951,
+          "line": 8070,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10025,7 +10208,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 7952,
+          "line": 8071,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10033,7 +10216,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 7953,
+          "line": 8072,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10041,7 +10224,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 7954,
+          "line": 8073,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10049,7 +10232,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 7955,
+          "line": 8074,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10057,7 +10240,7 @@
         },
         {
           "name": "Double",
-          "line": 7956,
+          "line": 8075,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10065,7 +10248,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 7957,
+          "line": 8076,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10073,7 +10256,7 @@
         },
         {
           "name": "Learn",
-          "line": 7958,
+          "line": 8077,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10081,7 +10264,7 @@
         },
         {
           "name": "Forage",
-          "line": 7959,
+          "line": 8078,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10089,7 +10272,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 7960,
+          "line": 8079,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10097,7 +10280,7 @@
         },
         {
           "name": "Endure",
-          "line": 7961,
+          "line": 8080,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10105,7 +10288,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 7962,
+          "line": 8081,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10113,7 +10296,7 @@
         },
         {
           "name": "Seek",
-          "line": 7963,
+          "line": 8082,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10121,7 +10304,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 7964,
+          "line": 8083,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10129,7 +10312,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 7965,
+          "line": 8084,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10137,7 +10320,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 7966,
+          "line": 8085,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10145,7 +10328,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 7967,
+          "line": 8086,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10153,7 +10336,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 7968,
+          "line": 8087,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10161,7 +10344,7 @@
         },
         {
           "name": "Conjure",
-          "line": 7969,
+          "line": 8088,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10169,7 +10352,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 7970,
+          "line": 8089,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10177,7 +10360,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 7971,
+          "line": 8090,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10185,7 +10368,7 @@
         },
         {
           "name": "Equip",
-          "line": 7973,
+          "line": 8092,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -10193,7 +10376,7 @@
         },
         {
           "name": "Crew",
-          "line": 7975,
+          "line": 8094,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -10203,7 +10386,7 @@
         },
         {
           "name": "Station",
-          "line": 7977,
+          "line": 8096,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -10213,7 +10396,7 @@
         },
         {
           "name": "Saddle",
-          "line": 7979,
+          "line": 8098,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -10223,7 +10406,7 @@
         },
         {
           "name": "Reveal",
-          "line": 7981,
+          "line": 8100,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -10231,7 +10414,7 @@
         },
         {
           "name": "Transform",
-          "line": 7982,
+          "line": 8101,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10239,7 +10422,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 7983,
+          "line": 8102,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10247,7 +10430,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 7984,
+          "line": 8103,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10347,13 +10530,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9010,
+      "line": 9129,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 9014,
+          "line": 9133,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -10364,7 +10547,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 9017,
+          "line": 9136,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -10536,7 +10719,7 @@
     },
     "ExileLinkKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 631,
+      "line": 637,
       "doc": "CR 607.2a + CR 406.6: Tracks the link between an exiling source and the exiled card. When the source leaves the battlefield, the exiled card returns (CR 610.3a).",
       "cr_refs": [
         "CR 406.6",
@@ -10546,7 +10729,7 @@
       "variants": [
         {
           "name": "UntilSourceLeaves",
-          "line": 633,
+          "line": 639,
           "kind": "struct",
           "field_names": [
             "return_zone"
@@ -10558,7 +10741,7 @@
         },
         {
           "name": "TrackedBySource",
-          "line": 635,
+          "line": 641,
           "kind": "unit",
           "field_names": [],
           "doc": "Track cards \"exiled with\" a source without creating an automatic return.",
@@ -10566,7 +10749,7 @@
         },
         {
           "name": "ParadigmSource",
-          "line": 644,
+          "line": 650,
           "kind": "struct",
           "field_names": [
             "player"
@@ -10584,13 +10767,13 @@
     },
     "FilterProp": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1856,
+      "line": 1922,
       "doc": "Individual filter properties that can be combined in a Typed filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Token",
-          "line": 1858,
+          "line": 1924,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are tokens.",
@@ -10600,7 +10783,7 @@
         },
         {
           "name": "NonToken",
-          "line": 1860,
+          "line": 1926,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are not tokens.",
@@ -10610,7 +10793,7 @@
         },
         {
           "name": "Attacking",
-          "line": 1861,
+          "line": 1927,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10618,7 +10801,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1863,
+          "line": 1929,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Matches creatures that are blocking.",
@@ -10628,7 +10811,7 @@
         },
         {
           "name": "BlockingSource",
-          "line": 1866,
+          "line": 1932,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g: Matches creatures currently blocking the filter source. Used for \"creature(s) blocking it\" source-relative quantities and filters.",
@@ -10638,7 +10821,7 @@
         },
         {
           "name": "CombatRelation",
-          "line": 1869,
+          "line": 1935,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -10651,7 +10834,7 @@
         },
         {
           "name": "Unblocked",
-          "line": 1874,
+          "line": 1940,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Matches attacking creatures with no blockers assigned.",
@@ -10661,7 +10844,7 @@
         },
         {
           "name": "Tapped",
-          "line": 1875,
+          "line": 1941,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10669,7 +10852,7 @@
         },
         {
           "name": "Untapped",
-          "line": 1877,
+          "line": 1943,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 / CR 110.5: Untapped status as targeting qualifier.",
@@ -10680,7 +10863,7 @@
         },
         {
           "name": "WithKeyword",
-          "line": 1878,
+          "line": 1944,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10690,7 +10873,7 @@
         },
         {
           "name": "HasKeywordKind",
-          "line": 1881,
+          "line": 1947,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10700,7 +10883,7 @@
         },
         {
           "name": "WithoutKeyword",
-          "line": 1886,
+          "line": 1952,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10712,7 +10895,7 @@
         },
         {
           "name": "WithoutKeywordKind",
-          "line": 1889,
+          "line": 1955,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10722,7 +10905,7 @@
         },
         {
           "name": "CanEnchant",
-          "line": 1897,
+          "line": 1963,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10735,7 +10918,7 @@
         },
         {
           "name": "Counters",
-          "line": 1907,
+          "line": 1973,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -10749,7 +10932,7 @@
         },
         {
           "name": "Cmc",
-          "line": 1917,
+          "line": 1983,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -10762,7 +10945,7 @@
         },
         {
           "name": "ManaCostIn",
-          "line": 1924,
+          "line": 1990,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -10775,7 +10958,7 @@
         },
         {
           "name": "InZone",
-          "line": 1927,
+          "line": 1993,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -10785,7 +10968,7 @@
         },
         {
           "name": "Owned",
-          "line": 1930,
+          "line": 1996,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -10795,7 +10978,7 @@
         },
         {
           "name": "Foretold",
-          "line": 1936,
+          "line": 2002,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c-d: Matches cards in exile that have the foretold designation. This is a status of the exiled card, not equivalent to having the Foretell keyword or a generic exile casting permission.",
@@ -10805,7 +10988,7 @@
         },
         {
           "name": "EnchantedBy",
-          "line": 1937,
+          "line": 2003,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10813,7 +10996,7 @@
         },
         {
           "name": "EquippedBy",
-          "line": 1938,
+          "line": 2004,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10821,7 +11004,7 @@
         },
         {
           "name": "AttachedToSource",
-          "line": 1944,
+          "line": 2010,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the matched object's `attached_to` field equals the filter source's object ID. Inverse of `EnchantedBy`/`EquippedBy`, which check whether the source has an attachment. Used for \"Aura and Equipment attached to ~\" quantity clauses (Kellan, the Fae-Blooded) and for any compound filter whose subject is \"attached to <self>\".",
@@ -10832,7 +11015,7 @@
         },
         {
           "name": "AttachedToRecipient",
-          "line": 1958,
+          "line": 2024,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4 + CR 613.4c: True when the matched object's `attached_to` field equals the *recipient* of the resolving effect (the per-object `id` in a layer's affected list). Distinct from `AttachedToSource` — for an Aura/Equipment static \"Enchanted/Equipped creature gets +N/+M for each X attached to it\", the pronoun \"it\" refers to the affected creature, not to the static's source object. The recipient is supplied through `FilterContext::recipient_id`; when recipient is unknown (no per-recipient context), this prop evaluates to false. Covers ~25 cards: Strong Back, Mantle of the Ancients, Auramancer's Guise, Champion of the Flame, Bruenor Battlehammer's \"Each creature you control gets +2/+0 for each Equipment attached to it\", and the broader \"<subject> gets +N/+M for each Aura/Equipment attached to it\" family.",
@@ -10844,7 +11027,7 @@
         },
         {
           "name": "HasAttachment",
-          "line": 1970,
+          "line": 2036,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -10858,7 +11041,7 @@
         },
         {
           "name": "HasAnyAttachmentOf",
-          "line": 1981,
+          "line": 2047,
           "kind": "struct",
           "field_names": [
             "kinds",
@@ -10872,7 +11055,7 @@
         },
         {
           "name": "Another",
-          "line": 1987,
+          "line": 2053,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches any object that is NOT the trigger source (for \"another creature\" triggers).",
@@ -10880,7 +11063,7 @@
         },
         {
           "name": "Unpaired",
-          "line": 1989,
+          "line": 2055,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Matches objects that are not paired with another creature.",
@@ -10890,7 +11073,7 @@
         },
         {
           "name": "OtherThanTriggerObject",
-          "line": 1998,
+          "line": 2064,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 109.3: Matches any object that is NOT the object that caused the currently-evaluating trigger to fire (the \"triggering object\"). Distinct from `Another`, which excludes the *ability source*. Used for intervening-if count predicates like Valakut, the Molten Pinnacle's \"if you control at least five other Mountains\" — here \"other\" means \"other than the newly- entered Mountain,\" not \"other than Valakut.\" Resolves against `FilterContext::triggering_object_id`, populated at trigger-condition evaluation from the current `GameEvent`.",
@@ -10901,7 +11084,7 @@
         },
         {
           "name": "HasColor",
-          "line": 2000,
+          "line": 2066,
           "kind": "struct",
           "field_names": [
             "color"
@@ -10911,7 +11094,7 @@
         },
         {
           "name": "PtComparison",
-          "line": 2027,
+          "line": 2093,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -10929,7 +11112,7 @@
         },
         {
           "name": "PowerGTSource",
-          "line": 2036,
+          "line": 2102,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: Matches objects whose power is strictly greater than the source object's power. Used for \"creatures with greater power\" blocking restrictions (relative comparison).",
@@ -10939,7 +11122,7 @@
         },
         {
           "name": "ColorCount",
-          "line": 2040,
+          "line": 2106,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -10952,7 +11135,7 @@
         },
         {
           "name": "HasSupertype",
-          "line": 2045,
+          "line": 2111,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10962,7 +11145,7 @@
         },
         {
           "name": "IsChosenCreatureType",
-          "line": 2050,
+          "line": 2116,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose subtypes include the source object's chosen creature type. Used for \"of the chosen type\" patterns (Cavern of Souls, Metallic Mimic).",
@@ -10970,7 +11153,7 @@
         },
         {
           "name": "MostPrevalentCreatureTypeIn",
-          "line": 2063,
+          "line": 2129,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -10984,7 +11167,7 @@
         },
         {
           "name": "IsChosenColor",
-          "line": 2072,
+          "line": 2138,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose colors include the source object's chosen color. Used for \"of the chosen color\" patterns (Hall of Triumph, Runed Stalactite). Reads `ChosenAttribute::Color` from the source permanent.",
@@ -10992,7 +11175,7 @@
         },
         {
           "name": "IsChosenCardType",
-          "line": 2076,
+          "line": 2142,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose core type includes the source object's chosen card type. Used for \"spells of the chosen type\" patterns (Archon of Valor's Reach). Reads `ChosenAttribute::CardType` from the source permanent.",
@@ -11000,7 +11183,7 @@
         },
         {
           "name": "IsChosenLandOrNonlandKind",
-          "line": 2081,
+          "line": 2147,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.2 + CR 608.2c: Matches objects by the transient \"land or nonland\" choice made earlier in the same resolving instruction sequence. Used by \"of the chosen kind\" library filters, where \"Land\" means cards with the land card type and \"Nonland\" means cards without it.",
@@ -11011,7 +11194,7 @@
         },
         {
           "name": "HasSingleTarget",
-          "line": 2084,
+          "line": 2150,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.7: Matches stack entries that have exactly one target. Used for \"with a single target\" qualifiers on retarget effects.",
@@ -11021,7 +11204,7 @@
         },
         {
           "name": "NotColor",
-          "line": 2087,
+          "line": 2153,
           "kind": "struct",
           "field_names": [
             "color"
@@ -11033,7 +11216,7 @@
         },
         {
           "name": "NotSupertype",
-          "line": 2092,
+          "line": 2158,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11045,7 +11228,7 @@
         },
         {
           "name": "Suspected",
-          "line": 2096,
+          "line": 2162,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.60b: Matches suspected creatures.",
@@ -11055,7 +11238,7 @@
         },
         {
           "name": "Renowned",
-          "line": 2098,
+          "line": 2164,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112b: Matches permanents with the renowned designation.",
@@ -11065,7 +11248,7 @@
         },
         {
           "name": "ToughnessGTPower",
-          "line": 2100,
+          "line": 2166,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: Matches creatures whose toughness is greater than their power.",
@@ -11075,7 +11258,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 2107,
+          "line": 2173,
           "kind": "struct",
           "field_names": [
             "props"
@@ -11085,7 +11268,7 @@
         },
         {
           "name": "Modified",
-          "line": 2119,
+          "line": 2185,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.9: A permanent is modified if it has one or more counters on it (CR 122), if it is equipped (CR 301.5), or if it is enchanted by an Aura that is controlled by that permanent's controller (CR 303.4).  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.9 names \"modified\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Modified` for \"modified creature(s)\" subjects, analogous to how `FilterProp::Suspected` models CR 701.60b's \"suspected\" status.",
@@ -11099,7 +11282,7 @@
         },
         {
           "name": "Historic",
-          "line": 2129,
+          "line": 2195,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: An object is historic if it has the legendary supertype, the artifact card type, or the Saga subtype.  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.6 names \"historic\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Historic` for \"historic permanent\" / \"historic spell\" / \"historic card\" subjects, mirroring `FilterProp::Modified` for CR 700.9's \"modified\" predicate.",
@@ -11110,7 +11293,7 @@
         },
         {
           "name": "DifferentNameFrom",
-          "line": 2133,
+          "line": 2199,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -11120,7 +11303,7 @@
         },
         {
           "name": "InAnyZone",
-          "line": 2138,
+          "line": 2204,
           "kind": "struct",
           "field_names": [
             "zones"
@@ -11132,7 +11315,7 @@
         },
         {
           "name": "SharesQuality",
-          "line": 2144,
+          "line": 2210,
           "kind": "struct",
           "field_names": [
             "quality",
@@ -11144,7 +11327,7 @@
         },
         {
           "name": "WasDealtDamageThisTurn",
-          "line": 2153,
+          "line": 2219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1: Object was dealt damage during this turn. Checks `damage_marked > 0` (damage persists until cleanup step).",
@@ -11154,7 +11337,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2156,
+          "line": 2222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: Object entered the battlefield during this turn. Checks `entered_battlefield_turn == Some(current_turn)`.",
@@ -11164,7 +11347,7 @@
         },
         {
           "name": "ZoneChangedThisTurn",
-          "line": 2161,
+          "line": 2227,
           "kind": "struct",
           "field_names": [
             "from",
@@ -11178,7 +11361,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 2169,
+          "line": 2235,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Creature was declared as an attacker this turn. Checks `creatures_attacked_this_turn` tracking set on GameState.",
@@ -11188,7 +11371,7 @@
         },
         {
           "name": "BlockedThisTurn",
-          "line": 2172,
+          "line": 2238,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Creature was declared as a blocker this turn. Checks `creatures_blocked_this_turn` tracking set on GameState.",
@@ -11198,7 +11381,7 @@
         },
         {
           "name": "AttackedOrBlockedThisTurn",
-          "line": 2175,
+          "line": 2241,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a + CR 509.1a: Creature attacked or blocked this turn. Compound check used by \"that attacked or blocked this turn\" Oracle text.",
@@ -11209,7 +11392,7 @@
         },
         {
           "name": "FaceDown",
-          "line": 2178,
+          "line": 2244,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.2: Matches face-down objects on the battlefield. Used for \"face-down creature\" trigger subjects.",
@@ -11219,7 +11402,7 @@
         },
         {
           "name": "TargetsOnly",
-          "line": 2183,
+          "line": 2249,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -11231,7 +11414,7 @@
         },
         {
           "name": "Targets",
-          "line": 2189,
+          "line": 2255,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -11244,7 +11427,7 @@
         },
         {
           "name": "HasXInManaCost",
-          "line": 2198,
+          "line": 2264,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 202.1: Matches spells/objects whose printed mana cost contains an `{X}` shard. Used for \"spell with {X} in its mana cost\" qualifier on spell-cast triggers (Lattice Library, Nev the Practical Dean, Owlin Spiralmancer, Brass Infiniscope, Elementalist's Palette). Evaluated against `SpellCastRecord.has_x_in_cost` in the spell-history filter path and against `cost_has_x(&obj.mana_cost)` for live objects.",
@@ -11255,7 +11438,7 @@
         },
         {
           "name": "HasManaAbility",
-          "line": 2202,
+          "line": 2268,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1: Matches objects that have at least one ability classified as a mana ability by the engine's authoritative mana-ability classifier. Used for library filters such as \"artifact card with a mana ability\".",
@@ -11265,7 +11448,7 @@
         },
         {
           "name": "HasNoAbilities",
-          "line": 2206,
+          "line": 2272,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.1 + CR 113.3: Matches objects that currently have no abilities: no keyword, activated, triggered, replacement, or static abilities. Used for library filters such as \"creature card with no abilities\".",
@@ -11276,7 +11459,7 @@
         },
         {
           "name": "Named",
-          "line": 2210,
+          "line": 2276,
           "kind": "struct",
           "field_names": [
             "name"
@@ -11289,7 +11472,7 @@
         },
         {
           "name": "SameName",
-          "line": 2215,
+          "line": 2281,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects with the same name as a previously-referenced card. Used for \"search your library for a card with that name\" patterns.",
@@ -11297,7 +11480,7 @@
         },
         {
           "name": "SameNameAsParentTarget",
-          "line": 2228,
+          "line": 2294,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: Matches objects whose name equals the name of the resolving ability's first object target. Used by chained sub-abilities where a prior step targeted/exiled a card and the next step references \"cards with that name\" — e.g., Deadly Cover-Up's \"search ... for any number of cards with that name and exile them\" (the \"that name\" is the name of the card exiled by the immediately preceding effect, which is inherited as the first target via `TargetFilter::ParentTarget`).  Differs from `SameName` (which reads the source object's name): this reads from `ability.targets[0]` when that target is `TargetRef::Object`, looking up the name from `state.objects` (or `lki_cache` if the target has already left its zone).",
@@ -11307,7 +11490,7 @@
         },
         {
           "name": "NameMatchesAnyPermanent",
-          "line": 2235,
+          "line": 2301,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -11320,7 +11503,7 @@
         },
         {
           "name": "AttackingController",
-          "line": 2241,
+          "line": 2307,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1b: Matches attacking creatures whose defending player equals the filter's source controller (\"creatures attacking you\"). Distinct from `Attacking`, which matches any attacker regardless of defender.",
@@ -11330,7 +11513,7 @@
         },
         {
           "name": "IsCommander",
-          "line": 2248,
+          "line": 2314,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 903.3d: Matches permanents on the battlefield that are a commander. Reads `GameObject::is_commander`, set during deck construction per CR 903.3 (the legendary card designated as that deck's commander). Used for \"commander(s) you control\", \"your commander\" subject phrases and for \"target commander\" in commander-format effects (Codsworth, Falthis, Anara, Champions of Archery, etc.).",
@@ -11341,7 +11524,7 @@
         },
         {
           "name": "Other",
-          "line": 2249,
+          "line": 2315,
           "kind": "struct",
           "field_names": [
             "value"
@@ -12099,7 +12282,7 @@
             "object_id",
             "card_id"
           ],
-          "doc": "CR 702.35a: Accept a pending `WaitingFor::MadnessCastOffer` and cast `object_id` from exile for its madness cost. Decline is via the shared `DecideOptionalEffect { accept: false }`.",
+          "doc": "CR 702.35a: Accept a pending `WaitingFor::CastOffer` (Madness) and cast `object_id` from exile for its madness cost. Decline is via the shared `DecideOptionalEffect { accept: false }`.",
           "cr_refs": [
             "CR 702.35a"
           ]
@@ -12555,7 +12738,7 @@
           "field_names": [
             "source"
           ],
-          "doc": "CR 702.xxx: Paradigm (Strixhaven) — accept the turn-based offer during `WaitingFor::ParadigmCastOffer`, casting a token copy of the exiled source spell without paying its mana cost. The exiled source stays in exile. Assign when WotC publishes SOS CR update.",
+          "doc": "CR 702.xxx: Paradigm (Strixhaven) — accept the turn-based offer during `WaitingFor::CastOffer` (Paradigm), casting a token copy of the exiled source spell without paying its mana cost. The exiled source stays in exile. Assign when WotC publishes SOS CR update.",
           "cr_refs": [
             "CR 702"
           ]
@@ -12565,7 +12748,7 @@
           "line": 607,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 702.xxx: Paradigm (Strixhaven) — decline the turn-based offer during `WaitingFor::ParadigmCastOffer`. The exiled source stays in exile and may be offered again next turn. Assign when WotC publishes SOS CR update.",
+          "doc": "CR 702.xxx: Paradigm (Strixhaven) — decline the turn-based offer during `WaitingFor::CastOffer` (Paradigm). The exiled source stays in exile and may be offered again next turn. Assign when WotC publishes SOS CR update.",
           "cr_refs": [
             "CR 702"
           ]
@@ -13024,14 +13207,15 @@
           "kind": "struct",
           "field_names": [
             "object_id",
-            "countered_by"
+            "countered_by",
+            "countered_by_controller"
           ],
           "doc": "",
           "cr_refs": []
         },
         {
           "name": "CounterAdded",
-          "line": 328,
+          "line": 332,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13043,7 +13227,7 @@
         },
         {
           "name": "Evolved",
-          "line": 335,
+          "line": 339,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13055,7 +13239,7 @@
         },
         {
           "name": "CounterRemoved",
-          "line": 338,
+          "line": 342,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13067,7 +13251,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 343,
+          "line": 347,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13078,7 +13262,7 @@
         },
         {
           "name": "ObjectConjured",
-          "line": 348,
+          "line": 352,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13089,7 +13273,7 @@
         },
         {
           "name": "CreatureDestroyed",
-          "line": 352,
+          "line": 356,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13099,7 +13283,7 @@
         },
         {
           "name": "PermanentSacrificed",
-          "line": 355,
+          "line": 359,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13110,7 +13294,7 @@
         },
         {
           "name": "EffectResolved",
-          "line": 359,
+          "line": 363,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -13121,7 +13305,7 @@
         },
         {
           "name": "Unattached",
-          "line": 365,
+          "line": 369,
           "kind": "struct",
           "field_names": [
             "attachment_id",
@@ -13134,7 +13318,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 369,
+          "line": 373,
           "kind": "struct",
           "field_names": [
             "attacker_ids",
@@ -13146,7 +13330,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 376,
+          "line": 380,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -13156,7 +13340,7 @@
         },
         {
           "name": "CombatTaxPaid",
-          "line": 381,
+          "line": 385,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13170,7 +13354,7 @@
         },
         {
           "name": "CombatTaxDeclined",
-          "line": 387,
+          "line": 391,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13184,7 +13368,7 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 391,
+          "line": 395,
           "kind": "struct",
           "field_names": [
             "target",
@@ -13195,7 +13379,7 @@
         },
         {
           "name": "VehicleCrewed",
-          "line": 397,
+          "line": 401,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -13208,7 +13392,7 @@
         },
         {
           "name": "Stationed",
-          "line": 407,
+          "line": 411,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -13222,7 +13406,7 @@
         },
         {
           "name": "Saddled",
-          "line": 417,
+          "line": 421,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -13235,7 +13419,7 @@
         },
         {
           "name": "ReplacementApplied",
-          "line": 421,
+          "line": 425,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13246,7 +13430,7 @@
         },
         {
           "name": "Transformed",
-          "line": 425,
+          "line": 429,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13256,7 +13440,7 @@
         },
         {
           "name": "DayNightChanged",
-          "line": 428,
+          "line": 432,
           "kind": "struct",
           "field_names": [
             "new_state"
@@ -13266,7 +13450,7 @@
         },
         {
           "name": "TurnedFaceUp",
-          "line": 431,
+          "line": 435,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13276,7 +13460,7 @@
         },
         {
           "name": "CardsRevealed",
-          "line": 434,
+          "line": 438,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13288,7 +13472,7 @@
         },
         {
           "name": "CombatDamageDealtToPlayer",
-          "line": 440,
+          "line": 444,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13300,7 +13484,7 @@
         },
         {
           "name": "PlayerEliminated",
-          "line": 466,
+          "line": 470,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13310,7 +13494,7 @@
         },
         {
           "name": "CrimeCommitted",
-          "line": 469,
+          "line": 473,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13320,7 +13504,7 @@
         },
         {
           "name": "Cycled",
-          "line": 472,
+          "line": 476,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13331,7 +13515,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 476,
+          "line": 480,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13342,7 +13526,7 @@
         },
         {
           "name": "Regenerated",
-          "line": 481,
+          "line": 485,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13354,7 +13538,7 @@
         },
         {
           "name": "CreatureSuspected",
-          "line": 485,
+          "line": 489,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13366,7 +13550,7 @@
         },
         {
           "name": "Detained",
-          "line": 492,
+          "line": 496,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13378,7 +13562,7 @@
         },
         {
           "name": "BecamePrepared",
-          "line": 498,
+          "line": 502,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13390,7 +13574,7 @@
         },
         {
           "name": "BecameUnprepared",
-          "line": 504,
+          "line": 508,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13402,7 +13586,7 @@
         },
         {
           "name": "CaseSolved",
-          "line": 508,
+          "line": 512,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -13414,7 +13598,7 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 512,
+          "line": 516,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13427,7 +13611,7 @@
         },
         {
           "name": "MonarchChanged",
-          "line": 517,
+          "line": 521,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13439,7 +13623,7 @@
         },
         {
           "name": "CityBlessingGained",
-          "line": 521,
+          "line": 525,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13451,7 +13635,7 @@
         },
         {
           "name": "DieRolled",
-          "line": 525,
+          "line": 529,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13465,7 +13649,7 @@
         },
         {
           "name": "CoinFlipped",
-          "line": 531,
+          "line": 535,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13478,7 +13662,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 536,
+          "line": 540,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13490,7 +13674,7 @@
         },
         {
           "name": "RoomEntered",
-          "line": 540,
+          "line": 544,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13505,7 +13689,7 @@
         },
         {
           "name": "RoomDoorUnlocked",
-          "line": 547,
+          "line": 551,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13520,7 +13704,7 @@
         },
         {
           "name": "BecomesPlotted",
-          "line": 554,
+          "line": 558,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13533,7 +13717,7 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 559,
+          "line": 563,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13546,7 +13730,7 @@
         },
         {
           "name": "InitiativeTaken",
-          "line": 564,
+          "line": 568,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13558,7 +13742,7 @@
         },
         {
           "name": "Firebend",
-          "line": 568,
+          "line": 572,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13569,7 +13753,7 @@
         },
         {
           "name": "Airbend",
-          "line": 573,
+          "line": 577,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13580,7 +13764,7 @@
         },
         {
           "name": "Earthbend",
-          "line": 578,
+          "line": 582,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13591,7 +13775,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 583,
+          "line": 587,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13602,7 +13786,7 @@
         },
         {
           "name": "CompanionRevealed",
-          "line": 588,
+          "line": 592,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13615,7 +13799,7 @@
         },
         {
           "name": "CompanionMovedToHand",
-          "line": 593,
+          "line": 597,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13628,7 +13812,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 600,
+          "line": 604,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13641,7 +13825,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 610,
+          "line": 614,
           "kind": "struct",
           "field_names": [
             "ability_tag",
@@ -13658,7 +13842,7 @@
         },
         {
           "name": "CreatureExploited",
-          "line": 618,
+          "line": 622,
           "kind": "struct",
           "field_names": [
             "exploiter",
@@ -13671,7 +13855,7 @@
         },
         {
           "name": "EnergyChanged",
-          "line": 623,
+          "line": 627,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13684,7 +13868,7 @@
         },
         {
           "name": "SpeedChanged",
-          "line": 628,
+          "line": 632,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13698,7 +13882,7 @@
         },
         {
           "name": "PlayerCounterChanged",
-          "line": 634,
+          "line": 638,
           "kind": "struct",
           "field_names": [
             "player",
@@ -13712,7 +13896,7 @@
         },
         {
           "name": "ManaExpended",
-          "line": 640,
+          "line": 644,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13726,7 +13910,7 @@
         },
         {
           "name": "Clash",
-          "line": 646,
+          "line": 650,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -13742,7 +13926,7 @@
         },
         {
           "name": "VoteCast",
-          "line": 657,
+          "line": 661,
           "kind": "struct",
           "field_names": [
             "voter",
@@ -13756,7 +13940,7 @@
         },
         {
           "name": "VoteResolved",
-          "line": 665,
+          "line": 669,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13769,7 +13953,7 @@
         },
         {
           "name": "PowerToughnessChanged",
-          "line": 671,
+          "line": 675,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13783,7 +13967,7 @@
         },
         {
           "name": "CascadeMissed",
-          "line": 682,
+          "line": 686,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -13797,7 +13981,7 @@
         },
         {
           "name": "DebugActionUsed",
-          "line": 690,
+          "line": 694,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -13808,7 +13992,7 @@
         },
         {
           "name": "DebugPermissionGranted",
-          "line": 696,
+          "line": 700,
           "kind": "struct",
           "field_names": [
             "host",
@@ -13819,7 +14003,7 @@
         },
         {
           "name": "DebugPermissionRevoked",
-          "line": 701,
+          "line": 705,
           "kind": "struct",
           "field_names": [
             "host",
@@ -14149,7 +14333,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8804,
+      "line": 8923,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -14158,7 +14342,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 8807,
+          "line": 8926,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -15853,7 +16037,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11261,
+      "line": 11389,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -15862,7 +16046,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 11263,
+          "line": 11391,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -15875,7 +16059,7 @@
         },
         {
           "name": "Crew",
-          "line": 11269,
+          "line": 11397,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -15888,7 +16072,7 @@
         },
         {
           "name": "Saddle",
-          "line": 11275,
+          "line": 11403,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -15901,7 +16085,7 @@
         },
         {
           "name": "Station",
-          "line": 11283,
+          "line": 11411,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -17012,7 +17196,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9382,
+      "line": 9501,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -17022,7 +17206,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 9384,
+          "line": 9503,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -17032,7 +17216,7 @@
         },
         {
           "name": "Second",
-          "line": 9387,
+          "line": 9506,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -17143,24 +17327,59 @@
           ]
         },
         {
+          "name": "CounterPT",
+          "line": 36,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 613.4c: Layer 7c — +1/+1, -1/-1, and asymmetric P/T counters modifying P/T. Counters are part of layer 7c (not a distinct sublayer), applied with the other 7c effects and therefore BEFORE the 7d switch. Kept as its own variant so the counter fold has a positional step in the layer loop; it must order before `SwitchPT` (applying counters after the switch would transpose asymmetric counters onto the wrong axis).",
+          "cr_refs": [
+            "CR 613.4c"
+          ]
+        },
+        {
           "name": "SwitchPT",
-          "line": 31,
+          "line": 38,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Layer 7d — Effects that switch P/T.",
           "cr_refs": [
             "CR 613.4d"
           ]
-        },
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "LayersDirty": {
+      "file": "crates/engine/src/types/game_state.rs",
+      "line": 1218,
+      "doc": "Lattice tracking which battlefield objects need layer (continuous-effect) re-evaluation. Replaces the old `bool` flag so that a token / conjure / copy entry can request an INCREMENTAL re-derive of only the entering object(s) instead of a full battlefield reset+reapply.  CR 613.1: continuous effects are evaluated in layer order over the whole board. A full evaluation is always correct; the incremental path is a performance optimization that `flush_layers` only takes when it can prove (per-entered preconditions + a board-wide escalation scan) that re-deriving just the entered objects produces a board state identical to a full pass. `mark_full()` is the conservative escalation any non-entry mutation uses.",
+      "cr_refs": [
+        "CR 613.1"
+      ],
+      "variants": [
         {
-          "name": "CounterPT",
-          "line": 33,
+          "name": "Clean",
+          "line": 1221,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 613.4c: Layer 7e — +1/+1 and -1/-1 counters modifying P/T (applied after other 7c effects).",
-          "cr_refs": [
-            "CR 613.4c"
-          ]
+          "doc": "Layers are up to date; nothing to flush.",
+          "cr_refs": []
+        },
+        {
+          "name": "EnteredObjects",
+          "line": 1225,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "Only these objects entered the battlefield since the last flush and no other layer-affecting mutation occurred. Candidate for the incremental fast path.",
+          "cr_refs": []
+        },
+        {
+          "name": "Full",
+          "line": 1227,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "A full battlefield re-evaluation is required.",
+          "cr_refs": []
         }
       ],
       "sibling_clusters": []
@@ -17281,13 +17500,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4939,
+      "line": 5020,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 4940,
+          "line": 5021,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17295,7 +17514,7 @@
         },
         {
           "name": "Bottom",
-          "line": 4941,
+          "line": 5022,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17303,7 +17522,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 4943,
+          "line": 5024,
           "kind": "struct",
           "field_names": [
             "n"
@@ -17538,13 +17757,13 @@
     },
     "ManaAbilityResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1039,
+      "line": 1053,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1040,
+          "line": 1054,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17552,7 +17771,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1041,
+          "line": 1055,
           "kind": "struct",
           "field_names": [
             "convoke_mode"
@@ -17562,7 +17781,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 1045,
+          "line": 1059,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -17579,7 +17798,7 @@
     },
     "ManaChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1111,
+      "line": 1125,
       "doc": "CR 608.2d + CR 605.3b: Player's answer to a `ManaChoicePrompt`, carried by `GameAction::ChooseManaColor`. Shape mirrors the prompt variant.",
       "cr_refs": [
         "CR 605.3b",
@@ -17588,7 +17807,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1112,
+          "line": 1126,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17596,7 +17815,7 @@
         },
         {
           "name": "Combination",
-          "line": 1113,
+          "line": 1127,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17607,7 +17826,7 @@
     },
     "ManaChoiceContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1121,
+      "line": 1135,
       "doc": "CR 106.3 + CR 608.2d + CR 605.3b: What resumes after a mana-color choice. Mana abilities and resolving spell/ability effects share the same prompt and response action, but resume through different rules paths.",
       "cr_refs": [
         "CR 106.3",
@@ -17617,7 +17836,7 @@
       "variants": [
         {
           "name": "ManaAbility",
-          "line": 1122,
+          "line": 1136,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17625,7 +17844,7 @@
         },
         {
           "name": "ResolvingEffect",
-          "line": 1123,
+          "line": 1137,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -17636,7 +17855,7 @@
     },
     "ManaChoicePrompt": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1094,
+      "line": 1108,
       "doc": "CR 608.2d + CR 605.3b: The shape of the prompt surfaced via `WaitingFor::ChooseManaColor`. Typed enum rather than a bool discriminator: the continuation logic is identical (validate choice → produce mana → resume), only the option set differs.",
       "cr_refs": [
         "CR 605.3b",
@@ -17645,7 +17864,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1097,
+          "line": 1111,
           "kind": "struct",
           "field_names": [
             "options"
@@ -17655,7 +17874,7 @@
         },
         {
           "name": "Combination",
-          "line": 1099,
+          "line": 1113,
           "kind": "struct",
           "field_names": [
             "options"
@@ -17665,7 +17884,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 1101,
+          "line": 1115,
           "kind": "struct",
           "field_names": [
             "count",
@@ -18180,7 +18399,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10545,
+      "line": 10665,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -18189,7 +18408,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 10548,
+          "line": 10668,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -18201,7 +18420,7 @@
         },
         {
           "name": "Multiply",
-          "line": 10551,
+          "line": 10671,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -18447,7 +18666,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10557,
+      "line": 10677,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -18456,7 +18675,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10560,
+          "line": 10680,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -18464,7 +18683,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 10562,
+          "line": 10682,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -18846,13 +19065,13 @@
     },
     "MayTriggerOrigin": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 483,
+      "line": 489,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Printed",
-          "line": 484,
+          "line": 490,
           "kind": "struct",
           "field_names": [
             "trigger_index"
@@ -18862,7 +19081,7 @@
         },
         {
           "name": "Keyword",
-          "line": 485,
+          "line": 491,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -18875,13 +19094,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8244,
+      "line": 8363,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 8246,
+          "line": 8365,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -18893,7 +19112,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8249,
+          "line": 8368,
           "kind": "struct",
           "field_names": [
             "source",
@@ -18912,13 +19131,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8224,
+      "line": 8343,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 8225,
+          "line": 8344,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18926,7 +19145,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 8228,
+          "line": 8347,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -18941,7 +19160,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 8235,
+          "line": 8354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -18951,7 +19170,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 8238,
+          "line": 8357,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -19004,7 +19223,7 @@
     },
     "NextSpellModifier": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 298,
+      "line": 304,
       "doc": "CR 601.2f: The kind of modification to apply to the next qualifying spell.",
       "cr_refs": [
         "CR 601.2f"
@@ -19012,7 +19231,7 @@
       "variants": [
         {
           "name": "CantBeCountered",
-          "line": 300,
+          "line": 306,
           "kind": "unit",
           "field_names": [],
           "doc": "\"The next spell you cast this turn can't be countered.\"",
@@ -19020,7 +19239,7 @@
         },
         {
           "name": "HasKeyword",
-          "line": 302,
+          "line": 308,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -19030,7 +19249,7 @@
         },
         {
           "name": "CastAsThoughFlash",
-          "line": 304,
+          "line": 310,
           "kind": "unit",
           "field_names": [],
           "doc": "\"The next spell you cast this turn can be cast as though it had flash.\"",
@@ -19041,7 +19260,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4226,
+      "line": 4307,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -19051,7 +19270,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4228,
+          "line": 4309,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -19061,7 +19280,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4230,
+          "line": 4311,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -19074,13 +19293,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3218,
+      "line": 3299,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 3219,
+          "line": 3300,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19088,7 +19307,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3220,
+          "line": 3301,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19096,7 +19315,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 3221,
+          "line": 3302,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19107,13 +19326,13 @@
     },
     "ObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2644,
+      "line": 2715,
       "doc": "Scope selector for object-axis quantities (Round Π-5). Picks WHICH object to read from when a `QuantityRef` (and future per-object conditions) is per-object. Mirrors `PlayerScope` for the player axis.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 2650,
+          "line": 2721,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.7 + CR 113.7a: The source object of the resolving ability — \"this creature\", \"~\", \"it\" (when \"it\" anaphors back to the source). CR 113.7 defines the source as the object that generated the ability; CR 113.7a keeps the ability (and thus its source reference) valid on the stack even after the source leaves its expected zone, via LKI.",
@@ -19124,7 +19343,7 @@
         },
         {
           "name": "Target",
-          "line": 2653,
+          "line": 2724,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The first object target of the resolving ability — \"that creature\", \"the creature\", \"it\" (when \"it\" anaphors back to a target).",
@@ -19134,7 +19353,7 @@
         },
         {
           "name": "Recipient",
-          "line": 2659,
+          "line": 2730,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4c + CR 115.10: The object currently receiving an effect. In layer evaluation this is the per-object recipient. Outside layers, it resolves to the first object target when present, then to the source. Used for recipient-relative \"its colors\" boosts such as Blessing of the Nephilim and Civic Saber.",
@@ -19145,7 +19364,7 @@
         },
         {
           "name": "EventSource",
-          "line": 2661,
+          "line": 2732,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: The object referenced by the current trigger event.",
@@ -19155,7 +19374,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2668,
+          "line": 2739,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: The specific untargeted object previously referred to by this ability's cost OR trigger condition. Resolved (first match wins) via `ResolvedAbility.cost_paid_object` → trigger-event source → `effect_context_object`. Subsumes the former `EventContextSource*` trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger referent are the two enumerated members of CR 608.2k's single clause).",
@@ -19168,7 +19387,7 @@
         },
         {
           "name": "Anaphoric",
-          "line": 2682,
+          "line": 2753,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: A deferred anaphoric pronoun (\"it\" / \"its\") whose object referent is bound at parse time. The parser remaps this to a concrete scope wherever it can — `Source` when the clause subject is the ability source, `Target` when the recipient is \"itself\". For triggered abilities no remap applies and `Anaphoric` survives to runtime, where it resolves identically to `CostPaidObject` (behavior-preserving — these cards parsed to `CostPaidObject` before this variant existed). General rules-correct runtime resolution of triggered-ability anaphora (e.g. \"its mana value\" after a reveal — see issue #511) is separate per-card parser work. Distinguishing this from an explicit cost-paid possessive (\"the sacrificed creature's power\", CR 608.2k -> `CostPaidObject`) is what prevents the subject-injection rewrite from clobbering correctly-scoped possessives.",
@@ -19181,7 +19400,7 @@
     },
     "OpeningHandBottomReason": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1396,
+      "line": 1483,
       "doc": "CR 103.5 / TL:R 906.6a: Why a player is bottoming cards from an opening hand before the normal mulligan-decision step.",
       "cr_refs": [
         "CR 103.5"
@@ -19189,7 +19408,7 @@
       "variants": [
         {
           "name": "TinyLeadersMultiCommander",
-          "line": 1397,
+          "line": 1484,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19219,7 +19438,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10030,
+      "line": 10150,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -19229,7 +19448,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10032,
+          "line": 10152,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -19237,7 +19456,7 @@
         },
         {
           "name": "Equals",
-          "line": 10034,
+          "line": 10154,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -19245,7 +19464,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 10037,
+          "line": 10157,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -19253,7 +19472,7 @@
         },
         {
           "name": "OneOf",
-          "line": 10039,
+          "line": 10159,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -19264,7 +19483,7 @@
     },
     "OutsideGameChoiceSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1346,
+      "line": 1433,
       "doc": "CR 400.11 + CR 406.3: A discriminated source for one outside-game selection. Sideboard entries (the wishboard pool) and face-up exile cards (the Karn / Coax wishboard return pool) are surfaced through one choice list so the caster picks across both pools in a single decision.  The size delta between the two variants (`Sideboard` carries a full `CardFace` so the UI can render the wishboard card without a sideboard lookup; `FaceUpExile` holds only an `ObjectId`) is intentional — `OutsideGameChoiceEntry` lists are short-lived (one entry per offered candidate while a single `WaitingFor::OutsideGameChoice` is active) and never collected by the million, so the asymmetry doesn't warrant boxing every CardFace through a heap indirection.",
       "cr_refs": [
         "CR 400.11",
@@ -19273,7 +19492,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 1348,
+          "line": 1435,
           "kind": "struct",
           "field_names": [
             "sideboard_index",
@@ -19286,7 +19505,7 @@
         },
         {
           "name": "FaceUpExile",
-          "line": 1353,
+          "line": 1440,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -19395,7 +19614,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3952,
+      "line": 4033,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -19404,7 +19623,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 3953,
+          "line": 4034,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -19414,7 +19633,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3957,
+          "line": 4038,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -19424,7 +19643,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 3958,
+          "line": 4039,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19432,7 +19651,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3960,
+          "line": 4041,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -19442,7 +19661,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 3961,
+          "line": 4042,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19452,7 +19671,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 3964,
+          "line": 4045,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -19463,7 +19682,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 3968,
+          "line": 4049,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -19473,7 +19692,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3972,
+          "line": 4053,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -19483,7 +19702,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 3974,
+          "line": 4055,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -19493,7 +19712,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 3975,
+          "line": 4056,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19501,7 +19720,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 3976,
+          "line": 4057,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -19511,7 +19730,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 3979,
+          "line": 4060,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -19521,7 +19740,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 3982,
+          "line": 4063,
           "kind": "struct",
           "field_names": [
             "color"
@@ -19531,7 +19750,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 3985,
+          "line": 4066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19539,7 +19758,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 3986,
+          "line": 4067,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19547,7 +19766,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 3987,
+          "line": 4068,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19555,7 +19774,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 3988,
+          "line": 4069,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19566,7 +19785,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 3992,
+          "line": 4073,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19577,7 +19796,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 3996,
+          "line": 4077,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19589,7 +19808,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 4001,
+          "line": 4082,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19599,7 +19818,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 4004,
+          "line": 4085,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19609,7 +19828,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 4007,
+          "line": 4088,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -19619,7 +19838,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 4012,
+          "line": 4093,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19631,7 +19850,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4021,
+          "line": 4102,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19646,7 +19865,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 4026,
+          "line": 4107,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19656,7 +19875,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 4029,
+          "line": 4110,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -19666,7 +19885,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 4032,
+          "line": 4113,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -19677,7 +19896,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 4036,
+          "line": 4117,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -19688,7 +19907,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 4040,
+          "line": 4121,
           "kind": "struct",
           "field_names": [
             "color",
@@ -19699,7 +19918,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 4044,
+          "line": 4125,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -19709,7 +19928,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 4047,
+          "line": 4128,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19717,7 +19936,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 4048,
+          "line": 4129,
           "kind": "struct",
           "field_names": [
             "name"
@@ -19727,7 +19946,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 4055,
+          "line": 4136,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -19740,7 +19959,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 4059,
+          "line": 4140,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19750,7 +19969,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 4062,
+          "line": 4143,
           "kind": "struct",
           "field_names": [
             "power",
@@ -19761,7 +19980,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 4066,
+          "line": 4147,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19769,7 +19988,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 4067,
+          "line": 4148,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19779,7 +19998,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 4070,
+          "line": 4151,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19789,7 +20008,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 4073,
+          "line": 4154,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19799,7 +20018,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 4076,
+          "line": 4157,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19807,7 +20026,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 4077,
+          "line": 4158,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19815,7 +20034,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 4078,
+          "line": 4159,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19825,7 +20044,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 4084,
+          "line": 4165,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -19833,7 +20052,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 4087,
+          "line": 4168,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19846,7 +20065,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 4091,
+          "line": 4172,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19854,7 +20073,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 4092,
+          "line": 4173,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19864,7 +20083,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 4095,
+          "line": 4176,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19872,7 +20091,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 4096,
+          "line": 4177,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19880,7 +20099,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 4097,
+          "line": 4178,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19888,7 +20107,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 4098,
+          "line": 4179,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19896,7 +20115,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 4100,
+          "line": 4181,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -19906,7 +20125,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 4101,
+          "line": 4182,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19914,7 +20133,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 4102,
+          "line": 4183,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19922,7 +20141,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 4103,
+          "line": 4184,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19930,7 +20149,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 4104,
+          "line": 4185,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19941,7 +20160,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 4108,
+          "line": 4189,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19951,7 +20170,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 4113,
+          "line": 4194,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -19964,7 +20183,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4118,
+          "line": 4199,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -19974,7 +20193,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 4126,
+          "line": 4207,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -19984,7 +20203,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 4139,
+          "line": 4220,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -19998,7 +20217,7 @@
         },
         {
           "name": "And",
-          "line": 4147,
+          "line": 4228,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -20011,7 +20230,7 @@
         },
         {
           "name": "Or",
-          "line": 4153,
+          "line": 4234,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -20024,7 +20243,7 @@
         },
         {
           "name": "Not",
-          "line": 4160,
+          "line": 4241,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -20109,9 +20328,94 @@
       ],
       "sibling_clusters": []
     },
+    "PayCostKind": {
+      "file": "crates/engine/src/types/game_state.rs",
+      "line": 1635,
+      "doc": "CR 118.3 + CR 601.2b + CR 605.3b: Identifies the specific action to take on the objects a player selects while paying a cost.",
+      "cr_refs": [
+        "CR 118.3",
+        "CR 601.2b",
+        "CR 605.3b"
+      ],
+      "variants": [
+        {
+          "name": "Discard",
+          "line": 1636,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Sacrifice",
+          "line": 1637,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ReturnToHand",
+          "line": 1638,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExileFromZone",
+          "line": 1640,
+          "kind": "struct",
+          "field_names": [
+            "zone"
+          ],
+          "doc": "Exile objects from the specified zone.",
+          "cr_refs": []
+        },
+        {
+          "name": "ExileFromManaZone",
+          "line": 1644,
+          "kind": "struct",
+          "field_names": [
+            "zone"
+          ],
+          "doc": "Exile objects from any zone (mana-ability exile costs).",
+          "cr_refs": []
+        },
+        {
+          "name": "RemoveCounter",
+          "line": 1647,
+          "kind": "struct",
+          "field_names": [
+            "counter_type"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TapCreatures",
+          "line": 1650,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Behold",
+          "line": 1651,
+          "kind": "struct",
+          "field_names": [
+            "action"
+          ],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
     "PayableResource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3012,
+      "line": 3048,
       "doc": "CR 107.14 + CR 118.8: Resource that can be paid in a \"pay any amount of X\" prompt. Typed so the same `WaitingFor::PayAmountChoice` variant generalizes to future classes (energy, life, mana) without re-introducing boolean flags.",
       "cr_refs": [
         "CR 107.14",
@@ -20120,7 +20424,7 @@
       "variants": [
         {
           "name": "Energy",
-          "line": 3014,
+          "line": 3050,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.",
@@ -20130,7 +20434,7 @@
         },
         {
           "name": "ManaGeneric",
-          "line": 3016,
+          "line": 3052,
           "kind": "struct",
           "field_names": [
             "per_x"
@@ -20184,7 +20488,7 @@
     },
     "PaymentCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4173,
+      "line": 4254,
       "doc": "CR 118.1: A cost paid as part of an effect's resolution. Distinct from AbilityCost (which gates activation before the colon).",
       "cr_refs": [
         "CR 118.1"
@@ -20192,7 +20496,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 4174,
+          "line": 4255,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20202,7 +20506,7 @@
         },
         {
           "name": "Life",
-          "line": 4182,
+          "line": 4263,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20215,7 +20519,7 @@
         },
         {
           "name": "Speed",
-          "line": 4186,
+          "line": 4267,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20228,7 +20532,7 @@
         },
         {
           "name": "Energy",
-          "line": 4191,
+          "line": 4272,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20240,7 +20544,7 @@
         },
         {
           "name": "AbilityCost",
-          "line": 4198,
+          "line": 4279,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20253,7 +20557,7 @@
         },
         {
           "name": "ScaledMana",
-          "line": 4208,
+          "line": 4289,
           "kind": "struct",
           "field_names": [
             "base",
@@ -20449,7 +20753,7 @@
     },
     "PileSide": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1483,
+      "line": 1570,
       "doc": "CR 700.3: Identifies one of the two piles produced by a `SeparateIntoPiles` partition. Typed rather than `bool` so the `GameAction::ChoosePile` payload and the engine handler share a self-documenting domain and the parser/AI cannot accidentally swap pile semantics. Pile A is the partitioner's chosen subset; pile B is `eligible \\ pile_a`.",
       "cr_refs": [
         "CR 700.3"
@@ -20457,7 +20761,7 @@
       "variants": [
         {
           "name": "A",
-          "line": 1484,
+          "line": 1571,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20465,7 +20769,7 @@
         },
         {
           "name": "B",
-          "line": 1485,
+          "line": 1572,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20591,13 +20895,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3283,
+      "line": 3364,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 3287,
+          "line": 3368,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -20607,7 +20911,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3289,
+          "line": 3370,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -20615,7 +20919,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3291,
+          "line": 3372,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -20625,7 +20929,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 3293,
+          "line": 3374,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -20633,7 +20937,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 3295,
+          "line": 3376,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -20641,7 +20945,7 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 3305,
+          "line": 3386,
           "kind": "struct",
           "field_names": [
             "source"
@@ -20656,7 +20960,7 @@
         },
         {
           "name": "OpponentAttackedThisTurn",
-          "line": 3314,
+          "line": 3395,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.6: A player has \"attacked [a player]\" if they declared one or more creatures attacking that player. Each opponent the controller attacked this turn, resolved against `state.attacked_defenders_this_turn[controller]`. Used by \"the number of opponents you attacked this turn\" (Militant Angel). (CR 508.1b: declare-attackers announcement; CR 506.2: active = attacking player.)",
@@ -20668,7 +20972,7 @@
         },
         {
           "name": "All",
-          "line": 3316,
+          "line": 3397,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -20676,7 +20980,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 3318,
+          "line": 3399,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -20686,7 +20990,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 3321,
+          "line": 3402,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -20694,7 +20998,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 3325,
+          "line": 3406,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20708,7 +21012,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 3331,
+          "line": 3412,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -20716,7 +21020,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3335,
+          "line": 3416,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -20727,7 +21031,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 3344,
+          "line": 3425,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -20738,7 +21042,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 3355,
+          "line": 3436,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -20751,7 +21055,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3367,
+          "line": 3448,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -20762,7 +21066,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 3388,
+          "line": 3469,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20778,7 +21082,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 3412,
+          "line": 3493,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20808,7 +21112,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3271,
+      "line": 3352,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -20818,7 +21122,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 3273,
+          "line": 3354,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -20826,7 +21130,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3275,
+          "line": 3356,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -20834,7 +21138,7 @@
         },
         {
           "name": "All",
-          "line": 3277,
+          "line": 3358,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -20845,7 +21149,7 @@
     },
     "PlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2592,
+      "line": 2663,
       "doc": "CR 102 + CR 119 + CR 402: Player axis for player-scoped quantity references.  Parameterizes the player whose hand size, life total, or other per-player scalar is being read. Replaces sibling enum variants like `LifeTotal` / `TargetLifeTotal` / `OpponentLifeTotal` and `HandSize` / `OpponentHandSize` with a single parameterized form.  Categorical-boundary check (per the \"Parameterize, don't proliferate\" principle): every variant is a player-relativity choice within a single CR section. Aggregate scopes (`Opponent`, `AllPlayers`) compose `AggregateFunction` to express max/min/sum across a population — they do not introduce a new abstraction layer.",
       "cr_refs": [
         "CR 102",
@@ -20855,7 +21159,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 2594,
+          "line": 2665,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 / CR 113.6: The controller of the source ability or effect.",
@@ -20866,7 +21170,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2598,
+          "line": 2669,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This keeps \"their\" quantities separate from \"you\" quantities.",
@@ -20877,7 +21181,7 @@
         },
         {
           "name": "Target",
-          "line": 2601,
+          "line": 2672,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 113.6 + CR 115.1: The first player target of the resolving ability (read from `ability.targets`).",
@@ -20889,7 +21193,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2605,
+          "line": 2676,
           "kind": "struct",
           "field_names": [
             "aggregate"
@@ -20902,7 +21206,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2610,
+          "line": 2681,
           "kind": "struct",
           "field_names": [
             "aggregate",
@@ -20915,7 +21219,7 @@
         },
         {
           "name": "RecipientController",
-          "line": 2624,
+          "line": 2695,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4m + CR 613.4c: The controller of the object currently receiving a layer effect. Used for Aura/Equipment statics such as \"enchanted creature gets +1/+1 for each card in its controller's hand\", where \"its\" refers to the enchanted creature, not the Aura.",
@@ -20926,7 +21230,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2630,
+          "line": 2701,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by attack-trigger intervening-if quantities such as \"no opponent has more life than that player.\"",
@@ -20937,7 +21241,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 2636,
+          "line": 2707,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"that opponent\" anaphoring the controller of a bounced/destroyed creature). The player-scalar-axis analogue of `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -20978,7 +21282,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10659,
+      "line": 10783,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -20987,7 +21291,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 10660,
+          "line": 10784,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20995,7 +21299,7 @@
         },
         {
           "name": "Resolved",
-          "line": 10661,
+          "line": 10785,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21060,7 +21364,7 @@
     },
     "ProductionOverride": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1077,
+      "line": 1091,
       "doc": "CR 605.3b + CR 106.1a: A pre-resolved choice that short-circuits the normal `ChooseManaColor` prompt. Auto-tap sets this when the cost-payment planner has already determined the exact mana to produce; manual activation leaves it `None` so the player is prompted.  Typed enum (never a bool): `SingleColor` covers the one-color-repeated variants (`AnyOneColor`, `ChoiceAmongExiledColors`), while `Combination` carries the full pre-chosen multi-mana sequence for fixed combinations (`ChoiceAmongCombinations`) and free per-slot choices (`AnyCombination`).",
       "cr_refs": [
         "CR 106.1a",
@@ -21069,7 +21373,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1081,
+          "line": 1095,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked a single color; every unit of mana the ability produces becomes this color (mirrors the pre-widening `Option<ManaType>` semantics).",
@@ -21077,7 +21381,7 @@
         },
         {
           "name": "Combination",
-          "line": 1084,
+          "line": 1098,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked one complete mana sequence; the ability produces exactly these mana types in order.",
@@ -21575,7 +21879,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3596,
+      "line": 3677,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -21583,7 +21887,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 3598,
+          "line": 3679,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -21593,7 +21897,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3600,
+          "line": 3681,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -21603,7 +21907,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 3602,
+          "line": 3683,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -21649,7 +21953,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3611,
+      "line": 3692,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -21658,7 +21962,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 3614,
+          "line": 3695,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -21668,7 +21972,7 @@
         },
         {
           "name": "Base",
-          "line": 3617,
+          "line": 3698,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -21681,13 +21985,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3424,
+      "line": 3505,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 3426,
+          "line": 3507,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -21697,7 +22001,7 @@
         },
         {
           "name": "Fixed",
-          "line": 3428,
+          "line": 3509,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21707,7 +22011,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 3432,
+          "line": 3513,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21721,7 +22025,7 @@
         },
         {
           "name": "Offset",
-          "line": 3439,
+          "line": 3520,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -21734,7 +22038,7 @@
         },
         {
           "name": "Multiply",
-          "line": 3444,
+          "line": 3525,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -21745,7 +22049,7 @@
         },
         {
           "name": "Sum",
-          "line": 3453,
+          "line": 3534,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -21755,7 +22059,7 @@
         },
         {
           "name": "UpTo",
-          "line": 3478,
+          "line": 3559,
           "kind": "struct",
           "field_names": [
             "max"
@@ -21768,7 +22072,7 @@
         },
         {
           "name": "Power",
-          "line": 3484,
+          "line": 3565,
           "kind": "struct",
           "field_names": [
             "base",
@@ -21781,7 +22085,7 @@
         },
         {
           "name": "Difference",
-          "line": 3499,
+          "line": 3580,
           "kind": "struct",
           "field_names": [
             "left",
@@ -21797,7 +22101,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10511,
+      "line": 10631,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -21805,7 +22109,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10513,
+          "line": 10633,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -21813,7 +22117,7 @@
         },
         {
           "name": "Plus",
-          "line": 10515,
+          "line": 10635,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21823,7 +22127,7 @@
         },
         {
           "name": "Minus",
-          "line": 10517,
+          "line": 10637,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21833,7 +22137,7 @@
         },
         {
           "name": "Prevent",
-          "line": 10537,
+          "line": 10657,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -21850,13 +22154,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2721,
+      "line": 2792,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 2725,
+          "line": 2796,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21868,7 +22172,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 2728,
+          "line": 2799,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21880,7 +22184,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 2734,
+          "line": 2805,
           "kind": "struct",
           "field_names": [
             "player"
@@ -21892,7 +22196,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 2737,
+          "line": 2808,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -21900,7 +22204,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 2739,
+          "line": 2810,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -21910,7 +22214,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 2742,
+          "line": 2813,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21920,7 +22224,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 2759,
+          "line": 2830,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -21933,8 +22237,23 @@
           ]
         },
         {
+          "name": "ObjectCountBySharedQuality",
+          "line": 2840,
+          "kind": "struct",
+          "field_names": [
+            "filter",
+            "quality",
+            "aggregate"
+          ],
+          "doc": "CR 109.3 + CR 205.3m: Count matching objects grouped by a shared object characteristic, including creature types, then aggregate the group sizes. Covers \"the greatest number of creatures you control that have a creature type in common\" without encoding the shared-quality clause as a target filter.",
+          "cr_refs": [
+            "CR 109.3",
+            "CR 205.3m"
+          ]
+        },
+        {
           "name": "PlayerCount",
-          "line": 2766,
+          "line": 2847,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21944,7 +22263,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 2787,
+          "line": 2868,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -21957,7 +22276,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 2796,
+          "line": 2877,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -21970,7 +22289,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 2815,
+          "line": 2896,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -21987,7 +22306,7 @@
         },
         {
           "name": "Variable",
-          "line": 2820,
+          "line": 2901,
           "kind": "struct",
           "field_names": [
             "name"
@@ -21997,7 +22316,7 @@
         },
         {
           "name": "Power",
-          "line": 2827,
+          "line": 2908,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22011,7 +22330,7 @@
         },
         {
           "name": "Toughness",
-          "line": 2832,
+          "line": 2913,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22025,7 +22344,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 2838,
+          "line": 2919,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22038,7 +22357,7 @@
         },
         {
           "name": "ObjectColorCount",
-          "line": 2844,
+          "line": 2925,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22051,7 +22370,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 2849,
+          "line": 2930,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22064,7 +22383,7 @@
         },
         {
           "name": "ManaSymbolsInManaCost",
-          "line": 2856,
+          "line": 2937,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22078,7 +22397,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 2868,
+          "line": 2949,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -22090,7 +22409,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 2870,
+          "line": 2951,
           "kind": "struct",
           "field_names": [
             "function",
@@ -22104,7 +22423,7 @@
         },
         {
           "name": "ControlledByEachPlayer",
-          "line": 2887,
+          "line": 2968,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22118,7 +22437,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 2894,
+          "line": 2975,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22128,7 +22447,7 @@
         },
         {
           "name": "Devotion",
-          "line": 2896,
+          "line": 2977,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -22140,7 +22459,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 2900,
+          "line": 2981,
           "kind": "struct",
           "field_names": [
             "source"
@@ -22152,7 +22471,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 2905,
+          "line": 2986,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -22163,7 +22482,7 @@
         },
         {
           "name": "ZoneCardCount",
-          "line": 2909,
+          "line": 2990,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22177,7 +22496,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 2916,
+          "line": 2997,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -22189,7 +22508,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 2920,
+          "line": 3001,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -22199,7 +22518,7 @@
         },
         {
           "name": "ExiledFromHandThisResolution",
-          "line": 2926,
+          "line": 3007,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -22210,7 +22529,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 2930,
+          "line": 3011,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -22220,7 +22539,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 2945,
+          "line": 3026,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22233,7 +22552,7 @@
         },
         {
           "name": "PartySize",
-          "line": 2954,
+          "line": 3035,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22246,7 +22565,7 @@
         },
         {
           "name": "Speed",
-          "line": 2961,
+          "line": 3042,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22258,7 +22577,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 2964,
+          "line": 3045,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -22268,7 +22587,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 2972,
+          "line": 3053,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -22282,7 +22601,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 2984,
+          "line": 3065,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -22294,7 +22613,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 2987,
+          "line": 3068,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22307,7 +22626,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2994,
+          "line": 3075,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22317,7 +22636,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 3000,
+          "line": 3081,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22330,7 +22649,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 3005,
+          "line": 3086,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -22340,7 +22659,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 3011,
+          "line": 3092,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22352,7 +22671,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 3016,
+          "line": 3097,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22364,7 +22683,7 @@
         },
         {
           "name": "LandsPlayedThisTurn",
-          "line": 3020,
+          "line": 3101,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22377,7 +22696,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 3023,
+          "line": 3104,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -22387,7 +22706,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 3027,
+          "line": 3108,
           "kind": "struct",
           "field_names": [
             "from",
@@ -22402,7 +22721,7 @@
         },
         {
           "name": "DamageDealtThisTurn",
-          "line": 3047,
+          "line": 3128,
           "kind": "struct",
           "field_names": [
             "source",
@@ -22419,7 +22738,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 3060,
+          "line": 3141,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -22427,7 +22746,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 3064,
+          "line": 3145,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Number of creatures the controller attacked with this turn. Used for \"if you attacked this turn\" and \"for each creature you attacked with this turn\" patterns.",
@@ -22437,7 +22756,7 @@
         },
         {
           "name": "DescendedThisTurn",
-          "line": 3066,
+          "line": 3147,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -22447,7 +22766,7 @@
         },
         {
           "name": "LoyaltyAbilitiesActivatedThisTurn",
-          "line": 3074,
+          "line": 3155,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22461,7 +22780,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 3077,
+          "line": 3158,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -22471,7 +22790,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 3091,
+          "line": 3172,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22485,7 +22804,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 3102,
+          "line": 3183,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -22500,7 +22819,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 3111,
+          "line": 3192,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22513,7 +22832,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 3116,
+          "line": 3197,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22527,7 +22846,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 3124,
+          "line": 3205,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22541,7 +22860,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 3129,
+          "line": 3210,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -22551,7 +22870,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 3136,
+          "line": 3217,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -22561,7 +22880,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 3139,
+          "line": 3220,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -22572,7 +22891,7 @@
         },
         {
           "name": "AdditionalCostPaymentCount",
-          "line": 3143,
+          "line": 3224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost payments made for the source spell. Used by Squad so its payment count remains distinct from Kicker's CR 702.33 payment model.",
@@ -22584,7 +22903,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 3147,
+          "line": 3228,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -22594,7 +22913,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 3152,
+          "line": 3233,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22608,7 +22927,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 3163,
+          "line": 3244,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -22619,7 +22938,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 3168,
+          "line": 3249,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -22629,7 +22948,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 3175,
+          "line": 3256,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22643,7 +22962,7 @@
         },
         {
           "name": "DistinctCounterKindsAmong",
-          "line": 3184,
+          "line": 3265,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22726,7 +23045,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8789,
+      "line": 8908,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -22735,7 +23054,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 8793,
+          "line": 8912,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -22748,13 +23067,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9818,
+      "line": 9938,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 9821,
+          "line": 9941,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -22766,7 +23085,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 9827,
+          "line": 9947,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22776,7 +23095,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 9834,
+          "line": 9954,
           "kind": "struct",
           "field_names": [
             "count",
@@ -22789,7 +23108,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 9839,
+          "line": 9959,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22801,7 +23120,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 9844,
+          "line": 9964,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -22814,7 +23133,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 9847,
+          "line": 9967,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -22826,7 +23145,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 9850,
+          "line": 9970,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -22836,7 +23155,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 9853,
+          "line": 9973,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -22847,7 +23166,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 9861,
+          "line": 9981,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22860,7 +23179,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 9875,
+          "line": 9995,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22873,7 +23192,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9884,
+          "line": 10004,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -22884,7 +23203,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 9887,
+          "line": 10007,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -22894,7 +23213,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9893,
+          "line": 10013,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -22906,7 +23225,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9898,
+          "line": 10018,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22918,7 +23237,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 9903,
+          "line": 10023,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -22929,7 +23248,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 9912,
+          "line": 10032,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -22941,7 +23260,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 9919,
+          "line": 10039,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -22955,7 +23274,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 9927,
+          "line": 10047,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -22965,7 +23284,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 9932,
+          "line": 10052,
           "kind": "struct",
           "field_names": [
             "source"
@@ -22979,7 +23298,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 9936,
+          "line": 10056,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -22992,7 +23311,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 9941,
+          "line": 10061,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -23003,7 +23322,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 9952,
+          "line": 10072,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -23016,7 +23335,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9963,
+          "line": 10083,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -23028,7 +23347,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 9971,
+          "line": 10091,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -23041,7 +23360,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9981,
+          "line": 10101,
           "kind": "struct",
           "field_names": [
             "level"
@@ -23053,7 +23372,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 9986,
+          "line": 10106,
           "kind": "struct",
           "field_names": [
             "text"
@@ -23457,13 +23776,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10625,
+      "line": 10749,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 10628,
+          "line": 10752,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -23471,7 +23790,7 @@
         },
         {
           "name": "Optional",
-          "line": 10630,
+          "line": 10754,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -23481,7 +23800,7 @@
         },
         {
           "name": "MayCost",
-          "line": 10637,
+          "line": 10761,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -23498,7 +23817,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10613,
+      "line": 10737,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 614.1a"
@@ -23506,7 +23825,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 10615,
+          "line": 10739,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source's controller.",
@@ -23514,7 +23833,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10617,
+          "line": 10741,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source's controller.",
@@ -23522,7 +23841,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 10619,
+          "line": 10743,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -23652,7 +23971,7 @@
     },
     "RetargetScope": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3029,
+      "line": 3065,
       "doc": "CR 115.7: Scope of retargeting — single target, all targets, or forced.",
       "cr_refs": [
         "CR 115.7"
@@ -23660,7 +23979,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 3030,
+          "line": 3066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23668,7 +23987,7 @@
         },
         {
           "name": "All",
-          "line": 3031,
+          "line": 3067,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23676,7 +23995,7 @@
         },
         {
           "name": "ForcedTo",
-          "line": 3032,
+          "line": 3068,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -23687,7 +24006,7 @@
     },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3191,
+      "line": 3272,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -23695,7 +24014,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 3192,
+          "line": 3273,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23703,7 +24022,7 @@
         },
         {
           "name": "Down",
-          "line": 3193,
+          "line": 3274,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23714,7 +24033,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4302,
+      "line": 4383,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -23722,7 +24041,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 4304,
+          "line": 4385,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -23791,7 +24110,7 @@
     },
     "ShardChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1273,
+      "line": 1360,
       "doc": "CR 107.4f + CR 601.2f: The caster's resolved choice for one Phyrexian shard.",
       "cr_refs": [
         "CR 107.4f",
@@ -23800,7 +24119,7 @@
       "variants": [
         {
           "name": "PayMana",
-          "line": 1275,
+          "line": 1362,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay one mana of the shard's color (or either component color for hybrid-Phyrexian).",
@@ -23808,7 +24127,7 @@
         },
         {
           "name": "PayLife",
-          "line": 1277,
+          "line": 1364,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay 2 life.",
@@ -23819,7 +24138,7 @@
     },
     "ShardOptions": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1261,
+      "line": 1348,
       "doc": "CR 107.4f + CR 601.2h: Which legal payments a single Phyrexian shard offers to the caster. Computed from the mana pool state (Phyrexian color availability) combined with the caster's life total and CantLoseLife status (CR 118.3 + CR 119.8).  The engine pauses at `WaitingFor::PhyrexianPayment` whenever any shard would deduct life — both `ManaOrLife` (player explicitly picks mana vs life) and `LifeOnly` (life is the only remaining payment route; player confirms or cancels via `CancelCast`). Only `ManaOnly` shards auto-resolve without surfacing the prompt, since they have no life consequence (issue #704: silent life deduction violated CR 601.2h's right to refuse the cast).",
       "cr_refs": [
         "CR 107.4f",
@@ -23830,7 +24149,7 @@
       "variants": [
         {
           "name": "ManaOrLife",
-          "line": 1263,
+          "line": 1350,
           "kind": "unit",
           "field_names": [],
           "doc": "Both mana and 2 life are legal payments; player must choose.",
@@ -23838,7 +24157,7 @@
         },
         {
           "name": "ManaOnly",
-          "line": 1265,
+          "line": 1352,
           "kind": "unit",
           "field_names": [],
           "doc": "Only mana is legal (insufficient life or CR 119.8 CantLoseLife lock).",
@@ -23848,7 +24167,7 @@
         },
         {
           "name": "LifeOnly",
-          "line": 1267,
+          "line": 1354,
           "kind": "unit",
           "field_names": [],
           "doc": "Only 2 life is legal (no mana of the shard's color available, given restrictions).",
@@ -23859,13 +24178,13 @@
     },
     "SharedQuality": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1807,
+      "line": 1873,
       "doc": "Qualities that can be shared across multi-target selections. Used by `FilterProp::SharesQuality` for group constraint validation at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Name",
-          "line": 1809,
+          "line": 1875,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: object names compared by shared name.",
@@ -23875,7 +24194,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 1811,
+          "line": 1877,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: mana value.",
@@ -23885,7 +24204,7 @@
         },
         {
           "name": "Power",
-          "line": 1813,
+          "line": 1879,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: power.",
@@ -23895,7 +24214,7 @@
         },
         {
           "name": "Toughness",
-          "line": 1815,
+          "line": 1881,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: toughness.",
@@ -23905,7 +24224,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 1817,
+          "line": 1883,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: sum of power and toughness.",
@@ -23915,7 +24234,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 1818,
+          "line": 1884,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23923,7 +24242,7 @@
         },
         {
           "name": "Color",
-          "line": 1819,
+          "line": 1885,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23931,7 +24250,7 @@
         },
         {
           "name": "CardType",
-          "line": 1820,
+          "line": 1886,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23939,7 +24258,7 @@
         },
         {
           "name": "LandType",
-          "line": 1822,
+          "line": 1888,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.6: land subtypes, including the five basic land types.",
@@ -23953,13 +24272,13 @@
     },
     "SharedQualityRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1827,
+      "line": 1893,
       "doc": "Relationship required by `FilterProp::SharesQuality`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Shares",
-          "line": 1829,
+          "line": 1895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23967,7 +24286,7 @@
         },
         {
           "name": "DoesNotShare",
-          "line": 1830,
+          "line": 1896,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24076,7 +24395,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3624,
+      "line": 3705,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -24085,7 +24404,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 3626,
+          "line": 3707,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -24097,7 +24416,7 @@
         },
         {
           "name": "Text",
-          "line": 3632,
+          "line": 3713,
           "kind": "struct",
           "field_names": [
             "description"
@@ -24110,7 +24429,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4980,
+      "line": 5061,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -24118,7 +24437,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 4982,
+          "line": 5063,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -24128,7 +24447,7 @@
         },
         {
           "name": "Decrease",
-          "line": 4984,
+          "line": 5065,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -24141,13 +24460,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4789,
+      "line": 4870,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 4790,
+          "line": 4871,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24155,7 +24474,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 4791,
+          "line": 4872,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24163,7 +24482,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 4792,
+          "line": 4873,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24171,7 +24490,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 4794,
+          "line": 4875,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -24184,13 +24503,13 @@
     },
     "StackEntryKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3637,
+      "line": 3671,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 3638,
+          "line": 3672,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -24203,7 +24522,7 @@
         },
         {
           "name": "ActivatedAbility",
-          "line": 3652,
+          "line": 3686,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -24214,7 +24533,7 @@
         },
         {
           "name": "TriggeredAbility",
-          "line": 3656,
+          "line": 3690,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -24230,7 +24549,7 @@
         },
         {
           "name": "KeywordAction",
-          "line": 3692,
+          "line": 3726,
           "kind": "struct",
           "field_names": [
             "action"
@@ -24246,13 +24565,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3698,
+      "line": 3779,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 3699,
+          "line": 3780,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -24263,7 +24582,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 3703,
+          "line": 3784,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24273,7 +24592,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 3709,
+          "line": 3790,
           "kind": "struct",
           "field_names": [
             "color"
@@ -24283,7 +24602,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 3718,
+          "line": 3799,
           "kind": "struct",
           "field_names": [
             "label"
@@ -24296,7 +24615,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3724,
+          "line": 3805,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -24308,7 +24627,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 3730,
+          "line": 3811,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -24318,7 +24637,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 3732,
+          "line": 3813,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -24331,7 +24650,7 @@
         },
         {
           "name": "And",
-          "line": 3736,
+          "line": 3817,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24341,7 +24660,7 @@
         },
         {
           "name": "Or",
-          "line": 3740,
+          "line": 3821,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24351,7 +24670,7 @@
         },
         {
           "name": "Not",
-          "line": 3746,
+          "line": 3827,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -24361,7 +24680,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 3750,
+          "line": 3831,
           "kind": "struct",
           "field_names": [
             "state"
@@ -24373,7 +24692,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 3759,
+          "line": 3840,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24389,7 +24708,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 3770,
+          "line": 3851,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24404,7 +24723,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 3778,
+          "line": 3859,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24416,7 +24735,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 3785,
+          "line": 3866,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24428,7 +24747,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 3789,
+          "line": 3870,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -24438,7 +24757,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3793,
+          "line": 3874,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -24449,7 +24768,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 3797,
+          "line": 3878,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -24460,7 +24779,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3801,
+          "line": 3882,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -24470,7 +24789,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 3803,
+          "line": 3884,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -24480,7 +24799,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 3806,
+          "line": 3887,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -24490,7 +24809,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 3808,
+          "line": 3889,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -24500,7 +24819,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 3811,
+          "line": 3892,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -24510,7 +24829,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 3817,
+          "line": 3898,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -24522,7 +24841,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 3825,
+          "line": 3906,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -24534,7 +24853,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3829,
+          "line": 3910,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24546,7 +24865,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 3854,
+          "line": 3935,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -24564,7 +24883,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 3863,
+          "line": 3944,
           "kind": "struct",
           "field_names": [
             "text"
@@ -24574,7 +24893,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 3866,
+          "line": 3947,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24582,7 +24901,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3869,
+          "line": 3950,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -24592,7 +24911,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 3871,
+          "line": 3952,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -24602,7 +24921,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 3873,
+          "line": 3954,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24614,7 +24933,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 3879,
+          "line": 3960,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -24628,7 +24947,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 3884,
+          "line": 3965,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -24638,7 +24957,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 3891,
+          "line": 3972,
           "kind": "struct",
           "field_names": [
             "player"
@@ -24651,7 +24970,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 3896,
+          "line": 3977,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -24661,7 +24980,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 3900,
+          "line": 3981,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -24671,7 +24990,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 3904,
+          "line": 3985,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -24682,7 +25001,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 3908,
+          "line": 3989,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24694,7 +25013,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 3920,
+          "line": 4001,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24706,7 +25025,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 3924,
+          "line": 4005,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -24716,7 +25035,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 3927,
+          "line": 4008,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -24728,7 +25047,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 3933,
+          "line": 4014,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -24739,10 +25058,10 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 3938,
+          "line": 4019,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ReduceCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
+          "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ModifyCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
           "cr_refs": [
             "CR 601.2f",
             "CR 702.166a"
@@ -24750,7 +25069,7 @@
         },
         {
           "name": "None",
-          "line": 3939,
+          "line": 4020,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24761,13 +25080,13 @@
     },
     "StaticMode": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 422,
+      "line": 435,
       "doc": "All static ability modes from Forge's static ability registry. Matched case-sensitively against Forge mode strings.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Continuous",
-          "line": 423,
+          "line": 436,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24775,7 +25094,7 @@
         },
         {
           "name": "CantAttack",
-          "line": 424,
+          "line": 437,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24783,7 +25102,7 @@
         },
         {
           "name": "CantBlock",
-          "line": 425,
+          "line": 438,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24791,7 +25110,7 @@
         },
         {
           "name": "CantAttackOrBlock",
-          "line": 426,
+          "line": 439,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24799,7 +25118,7 @@
         },
         {
           "name": "MaxAttackersEachCombat",
-          "line": 429,
+          "line": 442,
           "kind": "struct",
           "field_names": [
             "max"
@@ -24811,7 +25130,7 @@
         },
         {
           "name": "MaxBlockersEachCombat",
-          "line": 434,
+          "line": 447,
           "kind": "struct",
           "field_names": [
             "max"
@@ -24823,7 +25142,7 @@
         },
         {
           "name": "CantBeTargeted",
-          "line": 437,
+          "line": 450,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24831,7 +25150,7 @@
         },
         {
           "name": "CantBeCast",
-          "line": 440,
+          "line": 453,
           "kind": "struct",
           "field_names": [
             "who"
@@ -24843,7 +25162,7 @@
         },
         {
           "name": "CantBeActivated",
-          "line": 466,
+          "line": 479,
           "kind": "struct",
           "field_names": [
             "who",
@@ -24859,7 +25178,7 @@
         },
         {
           "name": "CantSearchLibrary",
-          "line": 479,
+          "line": 492,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -24872,7 +25191,7 @@
         },
         {
           "name": "CastWithFlash",
-          "line": 482,
+          "line": 495,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24880,7 +25199,7 @@
         },
         {
           "name": "GrantsExtraVote",
-          "line": 494,
+          "line": 507,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38d: While voting, the controller of this permanent may vote an additional time. Each active source grants +1 to the controller's `Player::extra_votes_per_session` snapshot taken at vote-session start (Tivit, Seller of Secrets — \"While voting, you may vote an additional time.\").  The vote-effect resolver scans the battlefield for permanents with this static at session start (CR 701.38d: extra votes happen at the same time the player would otherwise have voted). It does *not* feed into layer 7 — there is no continuous P/T or keyword grant; the static is a pure \"session-start +1 votes\" signal.",
@@ -24890,7 +25209,7 @@
         },
         {
           "name": "CastWithKeyword",
-          "line": 498,
+          "line": 511,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -24902,12 +25221,12 @@
         },
         {
           "name": "CastWithAlternativeCost",
-          "line": 509,
+          "line": 523,
           "kind": "struct",
           "field_names": [
             "cost"
           ],
-          "doc": "CR 118.9 + CR 601.2f: A permanent grants its controller a wholesale alternative MANA cost for spells matching `StaticDefinition::affected` that the controller casts — they may pay `cost` rather than the spell's mana cost. Parallel to `CastWithKeyword`. Distinct from `ReduceCost` (subtractive, CR 601.2f) — this REPLACES the mana cost wholesale (CR 118.9) and is mutually exclusive with other alternative costs (CR 118.9a). Rooftop Storm ({0}, Zombie creature spells), Fist of Suns ({WUBRG}, any spell), Jodah (MV 5+).",
+          "doc": "CR 118.9 + CR 601.2f: A permanent grants its controller a wholesale alternative MANA cost for spells matching `StaticDefinition::affected` that the controller casts — they may pay `cost` rather than the spell's mana cost. Parallel to `CastWithKeyword`. Distinct from `ModifyCost { mode: Reduce, .. }` (subtractive, CR 601.2f) — this REPLACES the mana cost wholesale (CR 118.9) and is mutually exclusive with other alternative costs (CR 118.9a). Rooftop Storm ({0}, Zombie creature spells), Fist of Suns ({WUBRG}, any spell), Jodah (MV 5+).",
           "cr_refs": [
             "CR 118.9",
             "CR 118.9a",
@@ -24915,22 +25234,23 @@
           ]
         },
         {
-          "name": "ReduceCost",
-          "line": 514,
+          "name": "ModifyCost",
+          "line": 530,
           "kind": "struct",
           "field_names": [
+            "mode",
             "amount",
             "spell_filter",
             "dynamic_count"
           ],
-          "doc": "CR 601.2f: Reduces the cost of spells matching the filter. Permanent-based cost reduction applied during casting (not self-cost reduction).",
+          "doc": "CR 601.2f: Modifies the mana cost of spells matching `spell_filter` (or all spells when `None`) by `amount`, in the direction described by `mode`. `Reduce` subtracts generic mana (floor: 0), `Raise` adds generic mana, `Minimum` floors the total cost after all Reduce/Raise settle.",
           "cr_refs": [
             "CR 601.2f"
           ]
         },
         {
           "name": "ReduceAbilityCost",
-          "line": 523,
+          "line": 543,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -24945,7 +25265,7 @@
         },
         {
           "name": "ModifyActivationLimit",
-          "line": 538,
+          "line": 558,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -24958,7 +25278,7 @@
         },
         {
           "name": "ActivateAsInstant",
-          "line": 548,
+          "line": 568,
           "kind": "struct",
           "field_names": [
             "cost_category"
@@ -24970,35 +25290,8 @@
           ]
         },
         {
-          "name": "RaiseCost",
-          "line": 553,
-          "kind": "struct",
-          "field_names": [
-            "amount",
-            "spell_filter",
-            "dynamic_count"
-          ],
-          "doc": "CR 601.2f: Increases the cost of spells matching the filter. Permanent-based cost increase applied during casting (Thalia, etc.).",
-          "cr_refs": [
-            "CR 601.2f"
-          ]
-        },
-        {
-          "name": "MinimumCost",
-          "line": 581,
-          "kind": "struct",
-          "field_names": [
-            "amount",
-            "spell_filter"
-          ],
-          "doc": "CR 601.2f: Floors the total mana cost of matching spells. Per CR 601.2f, this belongs to the \"any effects that directly affect the total cost\" step that runs after all additive/subtractive cost modifiers and just before the cost is \"locked in.\" Trinisphere class: \"each spell that would cost less than three mana to cast costs three mana to cast.\"  Per the Trinisphere ruling: \"apply Trinisphere's effect if the mana component of the spell's cost is less than three mana\" — applied last, after RaiseCost / ReduceCost / pending reductions / Affinity have all settled. The floor never reduces a cost.  `amount` is the floor expressed as a `ManaCost` (always pure-generic in printed cards; shape-shared with `RaiseCost`/`ReduceCost` for uniform serialization). The runtime compares `mana_cost.mana_value()` against `amount.mana_value()` and tops up generic mana to reach the floor — colored requirements are never modified, per the Trinisphere reminder text \"Additional mana ... may be paid with any color of mana or colorless mana.\"  `spell_filter` narrows which spells are floored. `None` = all spells (Trinisphere). No `dynamic_count` field — printed cost-floor effects are always a fixed amount, distinguishing this variant's shape from its `RaiseCost`/`ReduceCost` siblings.",
-          "cr_refs": [
-            "CR 601.2f"
-          ]
-        },
-        {
           "name": "CantPayCost",
-          "line": 592,
+          "line": 578,
           "kind": "struct",
           "field_names": [
             "who",
@@ -25013,7 +25306,7 @@
         },
         {
           "name": "CantGainLife",
-          "line": 596,
+          "line": 582,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25021,7 +25314,7 @@
         },
         {
           "name": "CantLoseLife",
-          "line": 597,
+          "line": 583,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25029,7 +25322,7 @@
         },
         {
           "name": "PlayerProtection",
-          "line": 606,
+          "line": 592,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.16: The scoped player(s) have protection from a quality — e.g. Serra's Emissary's \"You ... have protection from the chosen card type.\" Player scope rides on `StaticDefinition::affected` (identical to `CantGainLife`); `ProtectionTarget` is the canonical protection-quality axis. Data-carrying variant — not registry-registered (see `coverage::is_data_carrying_static`); consumed by direct pattern-match in `player_protection_from`. Only the `ChosenCardType` arm is runtime-implemented; other arms are inert.",
@@ -25039,7 +25332,7 @@
         },
         {
           "name": "MustAttack",
-          "line": 607,
+          "line": 593,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25047,7 +25340,7 @@
         },
         {
           "name": "MustBlock",
-          "line": 608,
+          "line": 594,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25055,7 +25348,7 @@
         },
         {
           "name": "CantDraw",
-          "line": 609,
+          "line": 595,
           "kind": "struct",
           "field_names": [
             "who"
@@ -25065,7 +25358,7 @@
         },
         {
           "name": "DoubleTriggers",
-          "line": 616,
+          "line": 602,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -25077,7 +25370,7 @@
         },
         {
           "name": "IgnoreHexproof",
-          "line": 619,
+          "line": 605,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25085,7 +25378,7 @@
         },
         {
           "name": "ExtraBlockers",
-          "line": 622,
+          "line": 608,
           "kind": "struct",
           "field_names": [
             "count"
@@ -25098,7 +25391,7 @@
         },
         {
           "name": "RevealTopOfLibrary",
-          "line": 627,
+          "line": 613,
           "kind": "struct",
           "field_names": [
             "all_players"
@@ -25110,7 +25403,7 @@
         },
         {
           "name": "GraveyardCastPermission",
-          "line": 632,
+          "line": 618,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -25125,7 +25418,7 @@
         },
         {
           "name": "TopOfLibraryCastPermission",
-          "line": 662,
+          "line": 648,
           "kind": "struct",
           "field_names": [
             "play_mode",
@@ -25140,7 +25433,7 @@
         },
         {
           "name": "CastFromHandFree",
-          "line": 679,
+          "line": 665,
           "kind": "struct",
           "field_names": [
             "frequency"
@@ -25153,7 +25446,7 @@
         },
         {
           "name": "ExileCastPermission",
-          "line": 706,
+          "line": 692,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -25169,7 +25462,7 @@
         },
         {
           "name": "CantBeCountered",
-          "line": 725,
+          "line": 711,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2: This spell/permanent can't be countered.",
@@ -25179,7 +25472,7 @@
         },
         {
           "name": "CantBeCopied",
-          "line": 728,
+          "line": 714,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2 + CR 707.10: This spell can't be copied by spells or abilities. Enforced in `copy_spell::resolve` when selecting the spell to copy.",
@@ -25190,7 +25483,7 @@
         },
         {
           "name": "CantEnterBattlefieldFrom",
-          "line": 730,
+          "line": 716,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 604.3: Cards in specified zones can't enter the battlefield.",
@@ -25200,7 +25493,7 @@
         },
         {
           "name": "CantCastFrom",
-          "line": 732,
+          "line": 718,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 604.3: Players can't cast spells from specified zones.",
@@ -25210,7 +25503,7 @@
         },
         {
           "name": "CantCastDuring",
-          "line": 736,
+          "line": 722,
           "kind": "struct",
           "field_names": [
             "who",
@@ -25223,7 +25516,7 @@
         },
         {
           "name": "CantActivateDuring",
-          "line": 763,
+          "line": 749,
           "kind": "struct",
           "field_names": [
             "who",
@@ -25241,7 +25534,7 @@
         },
         {
           "name": "PerTurnCastLimit",
-          "line": 773,
+          "line": 759,
           "kind": "struct",
           "field_names": [
             "who",
@@ -25256,7 +25549,7 @@
         },
         {
           "name": "PerTurnDrawLimit",
-          "line": 781,
+          "line": 767,
           "kind": "struct",
           "field_names": [
             "who",
@@ -25269,7 +25562,7 @@
         },
         {
           "name": "SuppressTriggers",
-          "line": 808,
+          "line": 794,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -25284,7 +25577,7 @@
         },
         {
           "name": "CantBeBlocked",
-          "line": 815,
+          "line": 801,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: This creature can't be blocked.",
@@ -25294,7 +25587,7 @@
         },
         {
           "name": "CantBeBlockedExceptBy",
-          "line": 817,
+          "line": 803,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -25306,7 +25599,7 @@
         },
         {
           "name": "CantBeBlockedBy",
-          "line": 822,
+          "line": 808,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25318,7 +25611,7 @@
         },
         {
           "name": "Protection",
-          "line": 826,
+          "line": 812,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16: Protection prevents targeting, blocking, damage, and attachment.",
@@ -25328,7 +25621,7 @@
         },
         {
           "name": "Indestructible",
-          "line": 828,
+          "line": 814,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.12: Indestructible — prevents destruction by lethal damage and destroy effects.",
@@ -25338,7 +25631,7 @@
         },
         {
           "name": "CantBeDestroyed",
-          "line": 830,
+          "line": 816,
           "kind": "unit",
           "field_names": [],
           "doc": "Permanent cannot be destroyed (distinct from Indestructible).",
@@ -25346,7 +25639,7 @@
         },
         {
           "name": "FlashBack",
-          "line": 832,
+          "line": 818,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34: Flashback — allows casting from graveyard, exiled after resolution.",
@@ -25356,7 +25649,7 @@
         },
         {
           "name": "Shroud",
-          "line": 834,
+          "line": 820,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.18: Shroud — permanent cannot be the target of spells or abilities.",
@@ -25366,7 +25659,7 @@
         },
         {
           "name": "Hexproof",
-          "line": 839,
+          "line": 825,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.11: Hexproof — affected player/permanent cannot be the target of spells or abilities an opponent controls. Applied at the player scope (\"You have hexproof.\") mirroring `Shroud`; permanent-scope hexproof grants flow through `ContinuousModification::AddKeyword` instead.",
@@ -25376,7 +25669,7 @@
         },
         {
           "name": "Vigilance",
-          "line": 841,
+          "line": 827,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.20: Vigilance — attacking doesn't cause this creature to tap.",
@@ -25386,7 +25679,7 @@
         },
         {
           "name": "Menace",
-          "line": 843,
+          "line": 829,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.111: Menace — can't be blocked except by two or more creatures.",
@@ -25396,7 +25689,7 @@
         },
         {
           "name": "Reach",
-          "line": 845,
+          "line": 831,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.17: Reach — can block creatures with flying.",
@@ -25406,7 +25699,7 @@
         },
         {
           "name": "Flying",
-          "line": 847,
+          "line": 833,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.9: Flying — can't be blocked except by creatures with flying or reach.",
@@ -25416,7 +25709,7 @@
         },
         {
           "name": "Trample",
-          "line": 849,
+          "line": 835,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.19: Trample — excess combat damage is assigned to the defending player.",
@@ -25426,7 +25719,7 @@
         },
         {
           "name": "Deathtouch",
-          "line": 851,
+          "line": 837,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.2: Deathtouch — any amount of damage dealt is lethal.",
@@ -25436,7 +25729,7 @@
         },
         {
           "name": "Lifelink",
-          "line": 853,
+          "line": 839,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.15: Lifelink — damage dealt also causes controller to gain that much life.",
@@ -25446,7 +25739,7 @@
         },
         {
           "name": "CantTap",
-          "line": 856,
+          "line": 842,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25454,7 +25747,7 @@
         },
         {
           "name": "CantUntap",
-          "line": 857,
+          "line": 843,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25462,7 +25755,7 @@
         },
         {
           "name": "MustBeBlocked",
-          "line": 859,
+          "line": 845,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: This creature must be blocked if able.",
@@ -25472,7 +25765,7 @@
         },
         {
           "name": "Goaded",
-          "line": 863,
+          "line": 849,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.15b: This creature is goaded for as long as the static applies. The source controller is the goading player for the \"attack another player if able\" requirement.",
@@ -25482,7 +25775,7 @@
         },
         {
           "name": "CantAttackAlone",
-          "line": 864,
+          "line": 850,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25490,7 +25783,7 @@
         },
         {
           "name": "CantBlockAlone",
-          "line": 865,
+          "line": 851,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25498,7 +25791,7 @@
         },
         {
           "name": "MayLookAtTopOfLibrary",
-          "line": 866,
+          "line": 852,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25506,7 +25799,7 @@
         },
         {
           "name": "MayChooseNotToUntap",
-          "line": 870,
+          "line": 856,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3: You may choose not to untap this permanent during your untap step.",
@@ -25516,7 +25809,7 @@
         },
         {
           "name": "AdditionalLandDrop",
-          "line": 873,
+          "line": 859,
           "kind": "struct",
           "field_names": [
             "count"
@@ -25528,7 +25821,7 @@
         },
         {
           "name": "EmblemStatic",
-          "line": 876,
+          "line": 862,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25536,7 +25829,7 @@
         },
         {
           "name": "BlockRestriction",
-          "line": 877,
+          "line": 863,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25544,7 +25837,7 @@
         },
         {
           "name": "NoMaximumHandSize",
-          "line": 879,
+          "line": 865,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 402.2: No maximum hand size.",
@@ -25554,7 +25847,7 @@
         },
         {
           "name": "MaximumHandSize",
-          "line": 882,
+          "line": 868,
           "kind": "struct",
           "field_names": [
             "modification"
@@ -25567,7 +25860,7 @@
         },
         {
           "name": "MayPlayAdditionalLand",
-          "line": 885,
+          "line": 871,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25575,7 +25868,7 @@
         },
         {
           "name": "CantHaveKeyword",
-          "line": 889,
+          "line": 875,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -25587,7 +25880,7 @@
         },
         {
           "name": "CantWinTheGame",
-          "line": 894,
+          "line": 880,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: This player can't win the game (Platinum Angel effect).",
@@ -25597,7 +25890,7 @@
         },
         {
           "name": "CantLoseTheGame",
-          "line": 896,
+          "line": 882,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3b: This player can't lose the game (Platinum Angel effect).",
@@ -25607,7 +25900,7 @@
         },
         {
           "name": "LegendRuleDoesntApply",
-          "line": 905,
+          "line": 891,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 704.5j: The \"legend rule\" doesn't apply to the affected permanents, so they are excluded from the same-name legendary grouping in the legend-rule SBA. Scope rides on `StaticDefinition::affected`: `None` = global (Mirror Gallery, \"the legend rule doesn't apply\"); a controller-scoped filter = \"doesn't apply to [permanents/tokens/Slivers/commanders] you control\" (Sakashima of a Thousand Faces, Mirror Box, Cadric, Sliver Gravemother, Try-My-Deck Elemental, ...). Enforced per-permanent in `sba.rs` via `check_static_ability` with the candidate as the target object.",
@@ -25617,7 +25910,7 @@
         },
         {
           "name": "SpeedCanIncreaseBeyondFour",
-          "line": 907,
+          "line": 893,
           "kind": "unit",
           "field_names": [],
           "doc": "Speed may increase beyond 4, and 4+ still counts as max speed for that player.",
@@ -25625,7 +25918,7 @@
         },
         {
           "name": "DefilerCostReduction",
-          "line": 911,
+          "line": 897,
           "kind": "struct",
           "field_names": [
             "color",
@@ -25639,7 +25932,7 @@
         },
         {
           "name": "SkipStep",
-          "line": 921,
+          "line": 907,
           "kind": "struct",
           "field_names": [
             "step"
@@ -25652,7 +25945,7 @@
         },
         {
           "name": "SpendManaAsAnyColor",
-          "line": 926,
+          "line": 912,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.4b: \"You may spend mana as though it were mana of any color.\" Allows the controller to pay colored mana costs with mana of any color.",
@@ -25662,7 +25955,7 @@
         },
         {
           "name": "PayLifeAsColoredMana",
-          "line": 938,
+          "line": 924,
           "kind": "struct",
           "field_names": [
             "color"
@@ -25674,7 +25967,7 @@
         },
         {
           "name": "StepEndUnspentMana",
-          "line": 952,
+          "line": 938,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25690,7 +25983,7 @@
         },
         {
           "name": "CanAttackWithDefender",
-          "line": 958,
+          "line": 944,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.3b: Allows creatures with defender to attack despite having the keyword. \"can attack as though it didn't have defender\" overrides the defender restriction.",
@@ -25700,7 +25993,7 @@
         },
         {
           "name": "IgnoreLandwalkForBlocking",
-          "line": 975,
+          "line": 961,
           "kind": "struct",
           "field_names": [
             "qualifier"
@@ -25715,7 +26008,7 @@
         },
         {
           "name": "CanActivateAbilitiesAsThoughHaste",
-          "line": 983,
+          "line": 969,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.5a: Bypasses the summoning-sickness gate on a creature's `{T}`/`{Q}` activated abilities — \"You may activate abilities of creatures you control as though those creatures had haste.\" This is NOT `AddKeyword(Haste)`: only the CR 602.5a activation restriction is lifted, combat attacker validation (CR 508.1a) is untouched. Canonical card: Tyvar, Jubilant Brawler.",
@@ -25726,7 +26019,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 987,
+          "line": 973,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage. Used for creatures like Ornithopter of Paradise and various Walls that can attack/block but deal 0 combat damage.",
@@ -25736,7 +26029,7 @@
         },
         {
           "name": "UntapsDuringEachOtherPlayersUntapStep",
-          "line": 996,
+          "line": 982,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3 + CR 113.6: Continuous static that grants a second untap pass during each OTHER player's untap step. The source's controller untaps the permanents matching `StaticDefinition.affected` — NOT the active player's permanents. Canonical card: Seedborn Muse (\"Untap all permanents you control during each other player's untap step.\"). Runtime: `turns::execute_untap` runs a second pass after the active player's normal untap, scanning the battlefield for this variant on permanents whose controller != active_player.",
@@ -25747,7 +26040,7 @@
         },
         {
           "name": "Other",
-          "line": 998,
+          "line": 984,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized static mode strings.",
@@ -25789,7 +26082,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4992,
+      "line": 5073,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -25798,7 +26091,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 4993,
+          "line": 5074,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25806,7 +26099,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 4994,
+          "line": 5075,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25817,7 +26110,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8754,
+      "line": 8873,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -25825,7 +26118,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 8762,
+          "line": 8881,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -25833,7 +26126,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 8767,
+          "line": 8886,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -26012,7 +26305,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8424,
+      "line": 8543,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -26022,7 +26315,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 8426,
+          "line": 8545,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26030,7 +26323,7 @@
         },
         {
           "name": "Resolution",
-          "line": 8427,
+          "line": 8546,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26041,13 +26334,13 @@
     },
     "TargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2387,
+      "line": 2453,
       "doc": "Typed target filter replacing all Forge filter strings and TargetSpec.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 2388,
+          "line": 2454,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26055,7 +26348,7 @@
         },
         {
           "name": "Any",
-          "line": 2389,
+          "line": 2455,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26063,7 +26356,7 @@
         },
         {
           "name": "Player",
-          "line": 2390,
+          "line": 2456,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26071,7 +26364,7 @@
         },
         {
           "name": "Controller",
-          "line": 2391,
+          "line": 2457,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26079,7 +26372,7 @@
         },
         {
           "name": "SelfRef",
-          "line": 2392,
+          "line": 2458,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26087,7 +26380,7 @@
         },
         {
           "name": "SourceOrPaired",
-          "line": 2395,
+          "line": 2461,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Resolves to the source object and the creature it is paired with. If the source is not paired, this matches no objects.",
@@ -26097,7 +26390,7 @@
         },
         {
           "name": "Typed",
-          "line": 2396,
+          "line": 2462,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26105,7 +26398,7 @@
         },
         {
           "name": "Not",
-          "line": 2397,
+          "line": 2463,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26115,7 +26408,7 @@
         },
         {
           "name": "Or",
-          "line": 2400,
+          "line": 2466,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -26125,7 +26418,7 @@
         },
         {
           "name": "And",
-          "line": 2403,
+          "line": 2469,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -26135,7 +26428,7 @@
         },
         {
           "name": "StackAbility",
-          "line": 2408,
+          "line": 2474,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26145,7 +26438,7 @@
         },
         {
           "name": "StackSpell",
-          "line": 2414,
+          "line": 2480,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches spells on the stack (not activated/triggered abilities). CR 115.1a: Used by \"becomes the target of a spell\" triggers to filter source type.",
@@ -26155,7 +26448,7 @@
         },
         {
           "name": "SpecificObject",
-          "line": 2418,
+          "line": 2484,
           "kind": "struct",
           "field_names": [
             "id"
@@ -26165,7 +26458,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 2426,
+          "line": 2492,
           "kind": "struct",
           "field_names": [
             "id"
@@ -26178,7 +26471,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2432,
+          "line": 2498,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This is not the ability controller; \"you\" and \"your\" still refer to `controller`.",
@@ -26189,7 +26482,7 @@
         },
         {
           "name": "AttachedTo",
-          "line": 2435,
+          "line": 2501,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches the permanent that the trigger source (Equipment/Aura) is attached to. Used for \"equipped creature\" / \"enchanted creature\" trigger subjects.",
@@ -26197,7 +26490,7 @@
         },
         {
           "name": "LastCreated",
-          "line": 2438,
+          "line": 2504,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the most recently created token(s) from Effect::Token. Used for \"create X and [verb] it\" patterns (e.g. \"create a token and suspect it\").",
@@ -26205,7 +26498,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2442,
+          "line": 2508,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the resolving spell or ability. Used by effects such as \"the exiled card\" after an exile-as-cost clause.",
@@ -26216,7 +26509,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 2445,
+          "line": 2511,
           "kind": "struct",
           "field_names": [
             "id"
@@ -26228,7 +26521,7 @@
         },
         {
           "name": "TrackedSetFiltered",
-          "line": 2460,
+          "line": 2526,
           "kind": "struct",
           "field_names": [
             "id",
@@ -26242,7 +26535,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2466,
+          "line": 2532,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 610.3: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
@@ -26252,7 +26545,7 @@
         },
         {
           "name": "TriggeringSpellController",
-          "line": 2468,
+          "line": 2534,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the controller of the spell/ability that triggered this.",
@@ -26262,7 +26555,7 @@
         },
         {
           "name": "TriggeringSpellOwner",
-          "line": 2470,
+          "line": 2536,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the owner of the spell/ability that triggered this.",
@@ -26272,7 +26565,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 2472,
+          "line": 2538,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the player involved in the triggering event.",
@@ -26282,7 +26575,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 2474,
+          "line": 2540,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the source object of the triggering event.",
@@ -26292,7 +26585,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 2479,
+          "line": 2545,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the same target(s) as the parent ability. Used for anaphoric \"it\"/\"that creature\"/\"that player\" in compound effects (e.g., \"tap target creature and put a stun counter on it\"). At resolution time, the sub_ability chain inherits parent targets automatically.",
@@ -26300,7 +26593,7 @@
         },
         {
           "name": "ParentTargetSlot",
-          "line": 2484,
+          "line": 2550,
           "kind": "struct",
           "field_names": [
             "index"
@@ -26312,7 +26605,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2490,
+          "line": 2556,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Resolves to the controller of the parent ability's target object. Used for \"its controller\" in compound effects (e.g., \"counter target spell. Its controller loses 2 life.\"). At resolution time, looks up the controller of the first parent target.",
@@ -26322,7 +26615,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 2501,
+          "line": 2567,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 608.2c: Resolves to the *owner* of the parent ability's target object. Used for \"its owner\" anaphoric references where the acting player is the owner of a previously-mentioned permanent — e.g., Enslave's \"enchanted creature deals 1 damage to its owner\" or Bomb Squad's \"that creature deals 4 damage to its owner\". Resolution mirrors `ParentTargetController` (parent target slot → trigger-event source → AttachedTo host on source for Aura phase triggers), but returns the resolved object's `owner` rather than `controller` per CR 108.3.  Distinct from `Owner` (which always reads the source object's owner) and `ParentTargetController` (which returns the controller per CR 109.4).",
@@ -26333,8 +26626,19 @@
           ]
         },
         {
+          "name": "SourceChosenPlayer",
+          "line": 2572,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 607.2d + CR 608.2c: Resolves to the player chosen for the source by a linked persisted choice (\"the chosen player\"). This is not a target slot and is distinct from `ControllerRef::ChosenPlayer`, which is resolution-scoped to the current ability chain.",
+          "cr_refs": [
+            "CR 607.2d",
+            "CR 608.2c"
+          ]
+        },
+        {
           "name": "OriginalController",
-          "line": 2522,
+          "line": 2593,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 + CR 608.2c: Resolves to the ability's *original* controller — the player who put the spell or ability on the stack — even when a surrounding `player_scope` iteration has rebound `ResolvedAbility::controller` to a different player for the current per-player iteration.  At resolution time, returns `ability.original_controller.unwrap_or(ability.controller)`. This mirrors the quantity-layer behavior in `resolve_quantity_with_targets`, where \"you\" / \"your\" quantities always read the original controller.  Used by parser-level distribution of compound subjects like \"you and that player each Y\" — the first half (\"you\") MUST resolve to the printed ability controller, not the iterated voter, even when the parent ability has `player_scope: PlayerFilter::VotedFor` (Master of Ceremonies pattern, CR 800.4g).  Distinct from `Controller` (which resolves to `ability.controller` and is rebound per-iteration by the player_scope driver in `resolve_ability_chain`). Distinct from `ParentTargetController` (parent's target's controller) and `PostReplacementSourceController` (replacement-context source's controller).",
@@ -26346,7 +26650,7 @@
         },
         {
           "name": "PostReplacementSourceController",
-          "line": 2541,
+          "line": 2612,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5 + CR 609.7: Resolves to the controller of the *prevented event's* damage source. Used by prevention follow-up sentences such as \"the source's controller draws cards equal to the damage prevented this way\" (Swans of Bryn Argoll) and \"deals damage to that source's controller\" (Deflecting Palm class). At resolution time, looks up `state.post_replacement_event_source` and returns its controller.  Distinct from `ParentTargetController` (which resolves via the parent ability's target slot) and `TriggeringSpellController` (which resolves via `state.current_trigger_event`, which is `None` during post-replacement resolution). Architectural twin of the quantity-side `last_effect_count` fallback at `replacement.rs:317` — both stash event context that lives outside the trigger window. The parser never emits this variant directly; the prevention follow-up call site rewrites `ParentTargetController` → `PostReplacementSourceController` via `each_target_filter_mut` after `parse_effect_chain` returns, so the surface phrase \"the source's controller\" can stay consolidated in `parse_target` for non-prevention callers.",
@@ -26357,7 +26661,7 @@
         },
         {
           "name": "PostReplacementDamageTarget",
-          "line": 2546,
+          "line": 2617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5: Resolves to the player or permanent that was the target of the prevented damage event. Used by prevention follow-up sentences such as \"that player exiles that many cards\" where the affected player is the damage recipient, not the replacement source or damage source.",
@@ -26367,7 +26671,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2550,
+          "line": 2621,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Resolves to the defending player for the source attacking creature, looked up per attacker through `combat::defending_player_for_attacker`.",
@@ -26378,7 +26682,7 @@
         },
         {
           "name": "HasChosenName",
-          "line": 2553,
+          "line": 2624,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose name equals the source's ChosenAttribute::CardName. Used for \"card with the chosen name\" patterns.",
@@ -26386,7 +26690,7 @@
         },
         {
           "name": "ChosenDamageSource",
-          "line": 2557,
+          "line": 2628,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.7a: Matches the object stored as the source's chosen damage source. Resolution-time prevention effects should resolve this to `SpecificObject` when the shield is created so global shields do not depend on a live source.",
@@ -26396,7 +26700,7 @@
         },
         {
           "name": "Named",
-          "line": 2560,
+          "line": 2631,
           "kind": "struct",
           "field_names": [
             "name"
@@ -26406,7 +26710,7 @@
         },
         {
           "name": "Owner",
-          "line": 2568,
+          "line": 2639,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.3: Resolves to the owner of the object referenced by `source_id`. Used for \"its owner's library/hand/graveyard\" phrasings where the acting player must be the card's owner, not its current controller (e.g., Nexus of Fate's shuffle-back replacement when the card is under opposing control via Mind Control).",
@@ -26416,7 +26720,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2575,
+          "line": 2646,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.12a: Every player in the game (controller + opponents), polled in APNAP order. The unless-payer population for \"[Effect] unless any player pays ...\" clauses (Cleansing, Rhystic cycle, Soul Strings). Resolution is a sequential poll — the first player to pay prevents the effect — so this variant is only valid as an `UnlessPayModifier.payer`; it is never used as a target or affected filter.",
@@ -26447,13 +26751,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11243,
+      "line": 11371,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 11244,
+          "line": 11372,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26461,7 +26765,7 @@
         },
         {
           "name": "Player",
-          "line": 11245,
+          "line": 11373,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26472,13 +26776,13 @@
     },
     "TargetSelectionConstraint": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1217,
+      "line": 1304,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 1218,
+          "line": 1305,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26486,7 +26790,7 @@
         },
         {
           "name": "DifferentObjectControllers",
-          "line": 1220,
+          "line": 1307,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1 + CR 601.2c: Object targets must be controlled by different players.",
@@ -26500,7 +26804,7 @@
     },
     "TargetSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2366,
+      "line": 2432,
       "doc": "CR 115.1 + CR 701.9b: How a target slot's referent is selected.  CR 115.1: Default — the spell/ability's controller chooses each target. CR 701.9b: Some effects override the controller-choice default by requiring the game to make the selection (analogous to \"random discard\" — the affected player does not choose). Magic Oracle text expresses this with the modifier \"random target [predicate]\" appearing immediately before the target word (Mana Clash, Goblin Lyre, Pixie Queen, Vexing Sphinx, Maddening Hex, etc.).  Categorical-boundary check (per CLAUDE.md \"Parameterize, don't proliferate\"): this enum is the *selection-mode* axis — one level above the predicate (`TargetFilter`) and orthogonal to slot count (`MultiTargetSpec`). It does not belong on `TargetFilter` (which captures *what* matches), nor on `MultiTargetSpec` (which captures *how many*). It captures *who selects*.",
       "cr_refs": [
         "CR 115.1",
@@ -26509,7 +26813,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 2369,
+          "line": 2435,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The spell or ability's controller chooses each target.",
@@ -26519,7 +26823,7 @@
         },
         {
           "name": "Random",
-          "line": 2372,
+          "line": 2438,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9b (analogous): The game selects each target uniformly at random from the legal-target set. The controller does not choose.",
@@ -26617,13 +26921,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9514,
+      "line": 9633,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 9517,
+          "line": 9636,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26633,7 +26937,7 @@
         },
         {
           "name": "LostLife",
-          "line": 9519,
+          "line": 9638,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -26641,7 +26945,7 @@
         },
         {
           "name": "Descended",
-          "line": 9521,
+          "line": 9640,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -26649,7 +26953,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 9523,
+          "line": 9642,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26659,7 +26963,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 9525,
+          "line": 9644,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -26669,7 +26973,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 9527,
+          "line": 9646,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -26679,7 +26983,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 9537,
+          "line": 9656,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26692,7 +26996,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9540,
+          "line": 9659,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -26703,7 +27007,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 9543,
+          "line": 9662,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -26713,7 +27017,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 9547,
+          "line": 9666,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26725,7 +27029,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 9550,
+          "line": 9669,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -26735,7 +27039,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9553,
+          "line": 9672,
           "kind": "struct",
           "field_names": [
             "level"
@@ -26747,17 +27051,20 @@
         },
         {
           "name": "WasCast",
-          "line": 9558,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "\"if you cast it\" — zoneless cast check (unlike CastFromZone which requires a specific zone). CR 701.57a: Used by Discover ETB triggers. Negation (\"if it wasn't cast\") is expressed via `Not { Box::new(WasCast) }`.",
+          "line": 9675,
+          "kind": "struct",
+          "field_names": [
+            "zone"
+          ],
+          "doc": "CR 601.2 + CR 603.4: reads the ENTERING object's `cast_from_zone`, never the source.",
           "cr_refs": [
-            "CR 701.57a"
+            "CR 601.2",
+            "CR 603.4"
           ]
         },
         {
           "name": "WasPlayed",
-          "line": 9562,
+          "line": 9682,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -26768,7 +27075,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 9567,
+          "line": 9687,
           "kind": "struct",
           "field_names": [
             "source",
@@ -26784,7 +27091,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 9583,
+          "line": 9703,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -26794,7 +27101,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9589,
+          "line": 9709,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26809,7 +27116,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 9593,
+          "line": 9713,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -26820,7 +27127,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 9597,
+          "line": 9717,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -26831,7 +27138,7 @@
         },
         {
           "name": "WasType",
-          "line": 9602,
+          "line": 9722,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -26844,7 +27151,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 9605,
+          "line": 9725,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26856,7 +27163,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 9609,
+          "line": 9729,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26869,7 +27176,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 9613,
+          "line": 9733,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26881,7 +27188,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 9617,
+          "line": 9737,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -26891,7 +27198,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9620,
+          "line": 9740,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -26903,7 +27210,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 9624,
+          "line": 9744,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26915,7 +27222,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 9627,
+          "line": 9747,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26927,7 +27234,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9633,
+          "line": 9753,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -26937,7 +27244,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9636,
+          "line": 9756,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -26947,7 +27254,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 9639,
+          "line": 9759,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -26957,7 +27264,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9646,
+          "line": 9766,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26969,7 +27276,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9651,
+          "line": 9771,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26981,7 +27288,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9655,
+          "line": 9775,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -26991,7 +27298,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 9660,
+          "line": 9780,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -27003,7 +27310,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9666,
+          "line": 9786,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -27013,7 +27320,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 9671,
+          "line": 9791,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -27023,7 +27330,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 9674,
+          "line": 9794,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -27033,7 +27340,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 9677,
+          "line": 9797,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -27043,7 +27350,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 9679,
+          "line": 9799,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -27055,7 +27362,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 9682,
+          "line": 9802,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -27065,7 +27372,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 9686,
+          "line": 9806,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -27075,7 +27382,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 9690,
+          "line": 9810,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27088,7 +27395,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 9693,
+          "line": 9813,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -27098,7 +27405,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9697,
+          "line": 9817,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -27111,7 +27418,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9700,
+          "line": 9820,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -27124,7 +27431,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9702,
+          "line": 9822,
           "kind": "struct",
           "field_names": [
             "color",
@@ -27137,7 +27444,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 9704,
+          "line": 9824,
           "kind": "struct",
           "field_names": [
             "text"
@@ -27149,7 +27456,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 9706,
+          "line": 9826,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -27161,7 +27468,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 9710,
+          "line": 9830,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -27175,7 +27482,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 9712,
+          "line": 9832,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -27185,7 +27492,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 9717,
+          "line": 9837,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -27200,7 +27507,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9728,
+          "line": 9848,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -27216,7 +27523,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 9743,
+          "line": 9863,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -27228,7 +27535,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9746,
+          "line": 9866,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27241,7 +27548,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 9756,
+          "line": 9876,
           "kind": "struct",
           "field_names": [
             "label"
@@ -27255,7 +27562,7 @@
         },
         {
           "name": "AttackersDeclaredMin",
-          "line": 9769,
+          "line": 9889,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27271,7 +27578,7 @@
         },
         {
           "name": "NoneOfAttackersTargetedYou",
-          "line": 9774,
+          "line": 9894,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 603.4: Intervening-if \"if none of those creatures attacked you\". Reads the triggering `AttackersDeclared` event's per-attacker `AttackTarget` tuples (CR 508.1b) and returns true iff no attacker in the batch targeted the trigger's controller directly (`AttackTarget::Player(trigger_controller)`).",
@@ -27283,7 +27590,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9784,
+          "line": 9904,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -27295,7 +27602,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 9795,
+          "line": 9915,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -27307,7 +27614,7 @@
         },
         {
           "name": "And",
-          "line": 9799,
+          "line": 9919,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27317,7 +27624,7 @@
         },
         {
           "name": "Or",
-          "line": 9801,
+          "line": 9921,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27327,7 +27634,7 @@
         },
         {
           "name": "Not",
-          "line": 9811,
+          "line": 9931,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -27343,13 +27650,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9992,
+      "line": 10112,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 9994,
+          "line": 10114,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -27357,7 +27664,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 9996,
+          "line": 10116,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -27365,7 +27672,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 9998,
+          "line": 10118,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -27373,7 +27680,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 10003,
+          "line": 10123,
           "kind": "struct",
           "field_names": [
             "n",
@@ -27384,7 +27691,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 10010,
+          "line": 10130,
           "kind": "struct",
           "field_names": [
             "n"
@@ -27394,7 +27701,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 10012,
+          "line": 10132,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -27402,7 +27709,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 10016,
+          "line": 10136,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -27412,7 +27719,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 10018,
+          "line": 10138,
           "kind": "struct",
           "field_names": [
             "level"
@@ -27424,7 +27731,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 10021,
+          "line": 10141,
           "kind": "struct",
           "field_names": [
             "max"
@@ -27923,13 +28230,23 @@
           "cr_refs": [
             "CR 701.14"
           ]
+        },
+        {
+          "name": "PhaseIn",
+          "line": 157,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.26c: A permanent phased in.",
+          "cr_refs": [
+            "CR 702.26c"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "TriggerMode": {
       "file": "crates/engine/src/types/triggers.rs",
-      "line": 176,
+      "line": 178,
       "doc": "All trigger modes from Forge's TriggerType enum (CR 603).  Triggered abilities have a trigger condition and an effect, written as \"[When/Whenever/At] [trigger condition], [effect]\" (CR 603.1). When a game event matches a trigger condition, the ability automatically triggers (CR 603.2) and is placed on the stack the next time a player would receive priority (CR 603.3).  Matched case-sensitively against Forge trigger mode strings.",
       "cr_refs": [
         "CR 603",
@@ -27940,7 +28257,7 @@
       "variants": [
         {
           "name": "ChangesZone",
-          "line": 179,
+          "line": 181,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6a: Enters-the-battlefield and other zone-change triggers.",
@@ -27950,7 +28267,7 @@
         },
         {
           "name": "ChangesZoneAll",
-          "line": 181,
+          "line": 183,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6: Zone change affecting all objects matching a filter.",
@@ -27960,7 +28277,7 @@
         },
         {
           "name": "ChangesController",
-          "line": 183,
+          "line": 185,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2e: \"Becomes\" trigger — fires when control changes, not while state persists.",
@@ -27970,7 +28287,7 @@
         },
         {
           "name": "LeavesBattlefield",
-          "line": 185,
+          "line": 187,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6c: Leaves-the-battlefield trigger — fires when a permanent moves from battlefield.",
@@ -27980,7 +28297,7 @@
         },
         {
           "name": "DamageDone",
-          "line": 189,
+          "line": 191,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2: Trigger when a source deals damage.",
@@ -27990,22 +28307,6 @@
         },
         {
           "name": "DamageDoneOnce",
-          "line": 190,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DamageAll",
-          "line": 191,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DamageDealtOnce",
           "line": 192,
           "kind": "unit",
           "field_names": [],
@@ -28013,7 +28314,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageDoneOnceByController",
+          "name": "DamageAll",
           "line": 193,
           "kind": "unit",
           "field_names": [],
@@ -28021,8 +28322,24 @@
           "cr_refs": []
         },
         {
-          "name": "DamageReceived",
+          "name": "DamageDealtOnce",
+          "line": 194,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DamageDoneOnceByController",
           "line": 195,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DamageReceived",
+          "line": 197,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2: Trigger when an object or player is dealt damage.",
@@ -28032,22 +28349,6 @@
         },
         {
           "name": "DamagePreventedOnce",
-          "line": 196,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ExcessDamage",
-          "line": 197,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ExcessDamageAll",
           "line": 198,
           "kind": "unit",
           "field_names": [],
@@ -28055,8 +28356,24 @@
           "cr_refs": []
         },
         {
+          "name": "ExcessDamage",
+          "line": 199,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExcessDamageAll",
+          "line": 200,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "SpellCast",
-          "line": 202,
+          "line": 204,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2i: Triggers when a spell becomes cast.",
@@ -28066,22 +28383,6 @@
         },
         {
           "name": "SpellCopy",
-          "line": 203,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SpellCastOrCopy",
-          "line": 204,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AbilityCast",
           "line": 205,
           "kind": "unit",
           "field_names": [],
@@ -28089,7 +28390,7 @@
           "cr_refs": []
         },
         {
-          "name": "AbilityResolves",
+          "name": "SpellCastOrCopy",
           "line": 206,
           "kind": "unit",
           "field_names": [],
@@ -28097,7 +28398,7 @@
           "cr_refs": []
         },
         {
-          "name": "AbilityTriggered",
+          "name": "AbilityCast",
           "line": 207,
           "kind": "unit",
           "field_names": [],
@@ -28105,7 +28406,7 @@
           "cr_refs": []
         },
         {
-          "name": "SpellAbilityCast",
+          "name": "AbilityResolves",
           "line": 208,
           "kind": "unit",
           "field_names": [],
@@ -28113,7 +28414,7 @@
           "cr_refs": []
         },
         {
-          "name": "SpellAbilityCopy",
+          "name": "AbilityTriggered",
           "line": 209,
           "kind": "unit",
           "field_names": [],
@@ -28121,8 +28422,24 @@
           "cr_refs": []
         },
         {
-          "name": "Countered",
+          "name": "SpellAbilityCast",
+          "line": 210,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SpellAbilityCopy",
           "line": 211,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Countered",
+          "line": 213,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2g: Triggers when a spell or ability is countered (event must actually occur).",
@@ -28132,7 +28449,7 @@
         },
         {
           "name": "Attacks",
-          "line": 215,
+          "line": 217,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3a: \"Whenever [a creature] attacks\" — triggers when declared as attacker.",
@@ -28142,7 +28459,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 217,
+          "line": 219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d: \"Whenever [a player] attacks\" — triggers when one or more creatures attack.",
@@ -28152,7 +28469,7 @@
         },
         {
           "name": "YouAttack",
-          "line": 219,
+          "line": 221,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d: \"Whenever you attack\" — triggers for the attacking player.",
@@ -28162,7 +28479,7 @@
         },
         {
           "name": "AttackersDeclaredOneTarget",
-          "line": 220,
+          "line": 222,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28170,7 +28487,7 @@
         },
         {
           "name": "AttackerBlocked",
-          "line": 222,
+          "line": 224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Triggers when an attacking creature becomes blocked.",
@@ -28180,7 +28497,7 @@
         },
         {
           "name": "AttackerBlockedOnce",
-          "line": 223,
+          "line": 225,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28188,7 +28505,7 @@
         },
         {
           "name": "AttackerBlockedByCreature",
-          "line": 225,
+          "line": 227,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Triggers when a specific creature blocks the attacker.",
@@ -28198,7 +28515,7 @@
         },
         {
           "name": "AttackerUnblocked",
-          "line": 226,
+          "line": 228,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28206,7 +28523,7 @@
         },
         {
           "name": "AttackerUnblockedOnce",
-          "line": 227,
+          "line": 229,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28214,7 +28531,7 @@
         },
         {
           "name": "Blocks",
-          "line": 231,
+          "line": 233,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: \"Whenever [a creature] blocks\" — triggers when declared as blocker.",
@@ -28224,7 +28541,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 233,
+          "line": 235,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.4: Triggers after all blockers are declared.",
@@ -28234,7 +28551,7 @@
         },
         {
           "name": "BecomesBlocked",
-          "line": 235,
+          "line": 237,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h + CR 603.2e: \"Becomes blocked\" trigger.",
@@ -28245,7 +28562,7 @@
         },
         {
           "name": "CounterAdded",
-          "line": 239,
+          "line": 241,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.6: Triggers when one or more counters are placed on a permanent or player.",
@@ -28255,22 +28572,6 @@
         },
         {
           "name": "CounterAddedOnce",
-          "line": 240,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterAddedAll",
-          "line": 241,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterPlayerAddedAll",
           "line": 242,
           "kind": "unit",
           "field_names": [],
@@ -28278,7 +28579,7 @@
           "cr_refs": []
         },
         {
-          "name": "CounterTypeAddedAll",
+          "name": "CounterAddedAll",
           "line": 243,
           "kind": "unit",
           "field_names": [],
@@ -28286,7 +28587,7 @@
           "cr_refs": []
         },
         {
-          "name": "CounterRemoved",
+          "name": "CounterPlayerAddedAll",
           "line": 244,
           "kind": "unit",
           "field_names": [],
@@ -28294,7 +28595,7 @@
           "cr_refs": []
         },
         {
-          "name": "CounterRemovedOnce",
+          "name": "CounterTypeAddedAll",
           "line": 245,
           "kind": "unit",
           "field_names": [],
@@ -28302,8 +28603,24 @@
           "cr_refs": []
         },
         {
+          "name": "CounterRemoved",
+          "line": 246,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CounterRemovedOnce",
+          "line": 247,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Sacrificed",
-          "line": 249,
+          "line": 251,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.21: Triggers when a permanent is sacrificed.",
@@ -28313,7 +28630,7 @@
         },
         {
           "name": "SacrificedOnce",
-          "line": 250,
+          "line": 252,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28321,7 +28638,7 @@
         },
         {
           "name": "Destroyed",
-          "line": 252,
+          "line": 254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8: Triggers when a permanent is destroyed.",
@@ -28331,7 +28648,7 @@
         },
         {
           "name": "Taps",
-          "line": 254,
+          "line": 256,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26: Triggers when a permanent becomes tapped.",
@@ -28341,7 +28658,7 @@
         },
         {
           "name": "TapsForMana",
-          "line": 256,
+          "line": 258,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.12a: Triggers when a permanent is tapped for mana.",
@@ -28351,7 +28668,7 @@
         },
         {
           "name": "TapAll",
-          "line": 257,
+          "line": 259,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28359,7 +28676,7 @@
         },
         {
           "name": "Untaps",
-          "line": 259,
+          "line": 261,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26: Triggers when a permanent becomes untapped.",
@@ -28369,7 +28686,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 260,
+          "line": 262,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28377,7 +28694,7 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 264,
+          "line": 266,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2e: \"Becomes the target\" trigger — fires when a spell/ability targets an object.",
@@ -28387,7 +28704,7 @@
         },
         {
           "name": "BecomesTargetOnce",
-          "line": 265,
+          "line": 267,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28395,7 +28712,7 @@
         },
         {
           "name": "Drawn",
-          "line": 269,
+          "line": 271,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1: Triggers when a player draws a card.",
@@ -28405,7 +28722,7 @@
         },
         {
           "name": "Discarded",
-          "line": 271,
+          "line": 273,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9: Triggers when a player discards a card.",
@@ -28415,7 +28732,7 @@
         },
         {
           "name": "DiscardedAll",
-          "line": 272,
+          "line": 274,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28423,7 +28740,7 @@
         },
         {
           "name": "Milled",
-          "line": 274,
+          "line": 276,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.17: Triggers when cards are milled (put from library into graveyard).",
@@ -28433,22 +28750,6 @@
         },
         {
           "name": "MilledOnce",
-          "line": 275,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MilledAll",
-          "line": 276,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Exiled",
           "line": 277,
           "kind": "unit",
           "field_names": [],
@@ -28456,7 +28757,7 @@
           "cr_refs": []
         },
         {
-          "name": "Revealed",
+          "name": "MilledAll",
           "line": 278,
           "kind": "unit",
           "field_names": [],
@@ -28464,8 +28765,24 @@
           "cr_refs": []
         },
         {
-          "name": "Shuffled",
+          "name": "Exiled",
+          "line": 279,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Revealed",
           "line": 280,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Shuffled",
+          "line": 282,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.24: Triggers when a library is shuffled.",
@@ -28475,7 +28792,7 @@
         },
         {
           "name": "LifeGained",
-          "line": 284,
+          "line": 286,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player gains life.",
@@ -28485,7 +28802,7 @@
         },
         {
           "name": "LifeLost",
-          "line": 286,
+          "line": 288,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player loses life.",
@@ -28495,7 +28812,7 @@
         },
         {
           "name": "LifeLostAll",
-          "line": 287,
+          "line": 289,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28503,7 +28820,7 @@
         },
         {
           "name": "PayLife",
-          "line": 288,
+          "line": 290,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28511,7 +28828,7 @@
         },
         {
           "name": "PayCumulativeUpkeep",
-          "line": 290,
+          "line": 292,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.24: Cumulative upkeep trigger.",
@@ -28521,7 +28838,7 @@
         },
         {
           "name": "PayEcho",
-          "line": 292,
+          "line": 294,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30: Echo trigger.",
@@ -28531,7 +28848,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 296,
+          "line": 298,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Triggers when a token is created.",
@@ -28541,7 +28858,7 @@
         },
         {
           "name": "TokenCreatedOnce",
-          "line": 297,
+          "line": 299,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28549,7 +28866,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 301,
+          "line": 303,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.37e: Triggers when a face-down permanent is turned face up (morph/manifest/cloak).",
@@ -28559,7 +28876,7 @@
         },
         {
           "name": "Transformed",
-          "line": 303,
+          "line": 305,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27: Triggers when a permanent transforms.",
@@ -28569,7 +28886,7 @@
         },
         {
           "name": "Phase",
-          "line": 307,
+          "line": 309,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2b: \"At the beginning of [phase/step]\" — triggers at phase start.",
@@ -28579,7 +28896,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 309,
+          "line": 311,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26: Triggers when a phased-out permanent phases in.",
@@ -28589,7 +28906,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 311,
+          "line": 313,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26: Triggers when a permanent phases out.",
@@ -28599,7 +28916,7 @@
         },
         {
           "name": "PhaseOutAll",
-          "line": 312,
+          "line": 314,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28607,7 +28924,7 @@
         },
         {
           "name": "TurnBegin",
-          "line": 314,
+          "line": 316,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2b: \"At the beginning of [a player's] turn\" trigger.",
@@ -28617,7 +28934,7 @@
         },
         {
           "name": "NewGame",
-          "line": 315,
+          "line": 317,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28625,7 +28942,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 319,
+          "line": 321,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725: Triggers when a player becomes the monarch.",
@@ -28635,7 +28952,7 @@
         },
         {
           "name": "TakesInitiative",
-          "line": 321,
+          "line": 323,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725: Triggers when a player takes the initiative.",
@@ -28645,7 +28962,7 @@
         },
         {
           "name": "LosesGame",
-          "line": 325,
+          "line": 327,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: Triggers when a player loses the game.",
@@ -28655,7 +28972,7 @@
         },
         {
           "name": "Championed",
-          "line": 329,
+          "line": 331,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.72: Champion trigger.",
@@ -28665,7 +28982,7 @@
         },
         {
           "name": "Exerted",
-          "line": 331,
+          "line": 333,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.43: Triggers when a creature is exerted.",
@@ -28675,7 +28992,7 @@
         },
         {
           "name": "Crewed",
-          "line": 333,
+          "line": 335,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122: Triggers when a Vehicle becomes crewed.",
@@ -28685,7 +29002,7 @@
         },
         {
           "name": "Crews",
-          "line": 335,
+          "line": 337,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122: Actor-side crew trigger — fires when this permanent crews a Vehicle.",
@@ -28695,7 +29012,7 @@
         },
         {
           "name": "Saddled",
-          "line": 337,
+          "line": 339,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: Triggers when a creature becomes saddled.",
@@ -28705,7 +29022,7 @@
         },
         {
           "name": "Saddles",
-          "line": 340,
+          "line": 342,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171c: Actor-side saddle trigger — fires when this permanent saddles a Mount. Reserved — no cards today print this without the compound form.",
@@ -28715,7 +29032,7 @@
         },
         {
           "name": "SaddlesOrCrews",
-          "line": 343,
+          "line": 345,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122 + CR 702.171c: Compound actor-side trigger — fires on either saddling a Mount OR crewing a Vehicle.",
@@ -28726,7 +29043,7 @@
         },
         {
           "name": "Cycled",
-          "line": 345,
+          "line": 347,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29: Triggers when a card is cycled.",
@@ -28736,7 +29053,7 @@
         },
         {
           "name": "CycledOrDiscarded",
-          "line": 348,
+          "line": 350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29d: Triggers when a card is cycled or discarded. Fires on either event but only once per cycling action.",
@@ -28746,7 +29063,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 350,
+          "line": 352,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Triggers when a player activates a ninjutsu-family ability.",
@@ -28756,7 +29073,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 354,
+          "line": 356,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.107a + CR 702.142b + CR 702.177a: Triggers when a player activates a keyword ability tagged by `AbilityTag`. Parameterized to avoid per-keyword sibling proliferation: `AbilityTag::Boast`, `AbilityTag::Exhaust`, `AbilityTag::Outlast` are the current values.",
@@ -28768,7 +29085,7 @@
         },
         {
           "name": "AbilityActivated",
-          "line": 367,
+          "line": 369,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.1 + CR 605.1a: Triggers when any activated ability is activated. Listens to `GameEvent::AbilityActivated`, which is emitted only for stack-using activated abilities — by CR 605.3b, mana abilities resolve without using the stack and do not produce this event. The \"that isn't a mana ability\" qualifier on cards like Burning-Tree Shaman and Flamescroll Celebrant is thus automatically satisfied by listening here, and is additionally preserved in the AST via `TriggerCondition::ActivatedAbilityIsNonMana` for future-proofing should the event family ever widen. Player scope (`a player` / `an opponent` / `you`) lives on `valid_target` (`TargetFilter`); source-object filters (e.g., \"an ability of an artifact source\") live on `valid_card` — both reuse existing infrastructure shared with `KeywordAbilityActivated`.",
@@ -28780,7 +29097,7 @@
         },
         {
           "name": "Evolve",
-          "line": 369,
+          "line": 371,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: Evolve keyword trigger — when a creature enters with greater power/toughness.",
@@ -28790,7 +29107,7 @@
         },
         {
           "name": "Evolved",
-          "line": 371,
+          "line": 373,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100b: Triggers when a creature evolves.",
@@ -28800,7 +29117,7 @@
         },
         {
           "name": "Explored",
-          "line": 373,
+          "line": 375,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.44: Triggers when a creature explores.",
@@ -28810,7 +29127,7 @@
         },
         {
           "name": "Exploited",
-          "line": 375,
+          "line": 377,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.110: Exploit trigger — when a creature exploits another creature.",
@@ -28820,7 +29137,7 @@
         },
         {
           "name": "Enlisted",
-          "line": 377,
+          "line": 379,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.154: Triggers when a creature becomes enlisted.",
@@ -28830,7 +29147,7 @@
         },
         {
           "name": "ManaAdded",
-          "line": 381,
+          "line": 383,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.4: Triggers when mana is added to a player's mana pool.",
@@ -28840,7 +29157,7 @@
         },
         {
           "name": "ManaExpend",
-          "line": 382,
+          "line": 384,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28848,7 +29165,7 @@
         },
         {
           "name": "LandPlayed",
-          "line": 386,
+          "line": 388,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 505.6b: Triggers when a land is played.",
@@ -28859,7 +29176,7 @@
         },
         {
           "name": "Attached",
-          "line": 390,
+          "line": 392,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3: Triggers when an Aura, Equipment, or Fortification becomes attached.",
@@ -28869,7 +29186,7 @@
         },
         {
           "name": "Unattach",
-          "line": 392,
+          "line": 394,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3: Triggers when an Equipment or Aura becomes unattached.",
@@ -28879,7 +29196,7 @@
         },
         {
           "name": "Adapt",
-          "line": 396,
+          "line": 398,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.46: Triggers when a creature adapts.",
@@ -28889,7 +29206,7 @@
         },
         {
           "name": "Foretell",
-          "line": 398,
+          "line": 400,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143: Triggers when a card is foretold.",
@@ -28899,7 +29216,7 @@
         },
         {
           "name": "Investigated",
-          "line": 400,
+          "line": 402,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Triggers when a player investigates.",
@@ -28909,7 +29226,7 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 403,
+          "line": 405,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28917,7 +29234,7 @@
         },
         {
           "name": "RoomEntered",
-          "line": 404,
+          "line": 406,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28925,22 +29242,6 @@
         },
         {
           "name": "PlanarDice",
-          "line": 407,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PlaneswalkedFrom",
-          "line": 408,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PlaneswalkedTo",
           "line": 409,
           "kind": "unit",
           "field_names": [],
@@ -28948,7 +29249,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChaosEnsues",
+          "name": "PlaneswalkedFrom",
           "line": 410,
           "kind": "unit",
           "field_names": [],
@@ -28956,23 +29257,23 @@
           "cr_refs": []
         },
         {
+          "name": "PlaneswalkedTo",
+          "line": 411,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChaosEnsues",
+          "line": 412,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "RolledDie",
-          "line": 413,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RolledDieOnce",
-          "line": 414,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlippedCoin",
           "line": 415,
           "kind": "unit",
           "field_names": [],
@@ -28980,7 +29281,7 @@
           "cr_refs": []
         },
         {
-          "name": "Clashed",
+          "name": "RolledDieOnce",
           "line": 416,
           "kind": "unit",
           "field_names": [],
@@ -28988,8 +29289,24 @@
           "cr_refs": []
         },
         {
+          "name": "FlippedCoin",
+          "line": 417,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Clashed",
+          "line": 418,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "DayTimeChanges",
-          "line": 420,
+          "line": 422,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730: Triggers when it becomes day or night.",
@@ -28999,7 +29316,7 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 423,
+          "line": 425,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29007,7 +29324,7 @@
         },
         {
           "name": "Copied",
-          "line": 426,
+          "line": 428,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29015,7 +29332,7 @@
         },
         {
           "name": "ConjureAll",
-          "line": 427,
+          "line": 429,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29023,7 +29340,7 @@
         },
         {
           "name": "Vote",
-          "line": 430,
+          "line": 432,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29031,7 +29348,7 @@
         },
         {
           "name": "BecomeRenowned",
-          "line": 434,
+          "line": 436,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112: Triggers when a creature becomes renowned.",
@@ -29041,7 +29358,7 @@
         },
         {
           "name": "BecomeMonstrous",
-          "line": 436,
+          "line": 438,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99: Triggers when a creature becomes monstrous.",
@@ -29051,7 +29368,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 440,
+          "line": 442,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.34: Triggers when a player proliferates.",
@@ -29061,7 +29378,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 441,
+          "line": 443,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29069,7 +29386,7 @@
         },
         {
           "name": "Surveil",
-          "line": 445,
+          "line": 447,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.25: Triggers when a player surveils.",
@@ -29079,7 +29396,7 @@
         },
         {
           "name": "Scry",
-          "line": 447,
+          "line": 449,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.22: Triggers when a player scries.",
@@ -29089,7 +29406,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 449,
+          "line": 451,
           "kind": "unit",
           "field_names": [],
           "doc": "General typed player-action trigger for joined action lists.",
@@ -29097,7 +29414,7 @@
         },
         {
           "name": "Fight",
-          "line": 453,
+          "line": 455,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.14: Triggers when creatures fight.",
@@ -29107,7 +29424,7 @@
         },
         {
           "name": "FightOnce",
-          "line": 454,
+          "line": 456,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29115,22 +29432,6 @@
         },
         {
           "name": "Abandoned",
-          "line": 457,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CaseSolved",
-          "line": 458,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ClaimPrize",
           "line": 459,
           "kind": "unit",
           "field_names": [],
@@ -29138,7 +29439,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "CaseSolved",
           "line": 460,
           "kind": "unit",
           "field_names": [],
@@ -29146,7 +29447,7 @@
           "cr_refs": []
         },
         {
-          "name": "CommitCrime",
+          "name": "ClaimPrize",
           "line": 461,
           "kind": "unit",
           "field_names": [],
@@ -29154,7 +29455,7 @@
           "cr_refs": []
         },
         {
-          "name": "CrankContraption",
+          "name": "CollectEvidence",
           "line": 462,
           "kind": "unit",
           "field_names": [],
@@ -29162,7 +29463,7 @@
           "cr_refs": []
         },
         {
-          "name": "Devoured",
+          "name": "CommitCrime",
           "line": 463,
           "kind": "unit",
           "field_names": [],
@@ -29170,7 +29471,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discover",
+          "name": "CrankContraption",
           "line": 464,
           "kind": "unit",
           "field_names": [],
@@ -29178,7 +29479,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "Devoured",
           "line": 465,
           "kind": "unit",
           "field_names": [],
@@ -29186,7 +29487,7 @@
           "cr_refs": []
         },
         {
-          "name": "FullyUnlock",
+          "name": "Discover",
           "line": 466,
           "kind": "unit",
           "field_names": [],
@@ -29194,7 +29495,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveGift",
+          "name": "Forage",
           "line": 467,
           "kind": "unit",
           "field_names": [],
@@ -29202,7 +29503,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "FullyUnlock",
           "line": 468,
           "kind": "unit",
           "field_names": [],
@@ -29210,7 +29511,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mentored",
+          "name": "GiveGift",
           "line": 469,
           "kind": "unit",
           "field_names": [],
@@ -29218,7 +29519,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mutates",
+          "name": "ManifestDread",
           "line": 470,
           "kind": "unit",
           "field_names": [],
@@ -29226,7 +29527,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchedLibrary",
+          "name": "Mentored",
           "line": 471,
           "kind": "unit",
           "field_names": [],
@@ -29234,7 +29535,7 @@
           "cr_refs": []
         },
         {
-          "name": "SeekAll",
+          "name": "Mutates",
           "line": 472,
           "kind": "unit",
           "field_names": [],
@@ -29242,7 +29543,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetInMotion",
+          "name": "SearchedLibrary",
           "line": 473,
           "kind": "unit",
           "field_names": [],
@@ -29250,7 +29551,7 @@
           "cr_refs": []
         },
         {
-          "name": "Specializes",
+          "name": "SeekAll",
           "line": 474,
           "kind": "unit",
           "field_names": [],
@@ -29258,7 +29559,7 @@
           "cr_refs": []
         },
         {
-          "name": "Stationed",
+          "name": "SetInMotion",
           "line": 475,
           "kind": "unit",
           "field_names": [],
@@ -29266,7 +29567,7 @@
           "cr_refs": []
         },
         {
-          "name": "Trains",
+          "name": "Specializes",
           "line": 476,
           "kind": "unit",
           "field_names": [],
@@ -29274,7 +29575,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnlockDoor",
+          "name": "Stationed",
           "line": 477,
           "kind": "unit",
           "field_names": [],
@@ -29282,7 +29583,7 @@
           "cr_refs": []
         },
         {
-          "name": "VisitAttraction",
+          "name": "Trains",
           "line": 478,
           "kind": "unit",
           "field_names": [],
@@ -29290,7 +29591,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomesCrewed",
+          "name": "UnlockDoor",
           "line": 479,
           "kind": "unit",
           "field_names": [],
@@ -29298,7 +29599,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomesPlotted",
+          "name": "VisitAttraction",
           "line": 480,
           "kind": "unit",
           "field_names": [],
@@ -29306,7 +29607,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomesSaddled",
+          "name": "BecomesCrewed",
           "line": 481,
           "kind": "unit",
           "field_names": [],
@@ -29314,7 +29615,7 @@
           "cr_refs": []
         },
         {
-          "name": "Immediate",
+          "name": "BecomesPlotted",
           "line": 482,
           "kind": "unit",
           "field_names": [],
@@ -29322,8 +29623,24 @@
           "cr_refs": []
         },
         {
-          "name": "Always",
+          "name": "BecomesSaddled",
+          "line": 483,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Immediate",
           "line": 484,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Always",
+          "line": 486,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.1: \"Always\" — a special trigger mode representing a continuous trigger condition.",
@@ -29333,7 +29650,7 @@
         },
         {
           "name": "EntersOrAttacks",
-          "line": 488,
+          "line": 490,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Whenever ~ enters or attacks\" — fires on both ETB (CR 603.6a) and attack (CR 508.3a) events.",
@@ -29344,7 +29661,7 @@
         },
         {
           "name": "AttacksOrBlocks",
-          "line": 490,
+          "line": 492,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Whenever ~ attacks or blocks\" — fires on both attack (CR 508.3a) and block (CR 509.1h) events.",
@@ -29355,7 +29672,7 @@
         },
         {
           "name": "StateCondition",
-          "line": 496,
+          "line": 498,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.8: State trigger — fires when a game-state condition becomes true, rather than in response to an event. Checked whenever a player would receive priority. The engine tracks whether the trigger is already on the stack to prevent re-triggering until the ability has resolved, been countered, or otherwise left the stack.",
@@ -29365,22 +29682,6 @@
         },
         {
           "name": "Airbend",
-          "line": 499,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Earthbend",
-          "line": 500,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Firebend",
           "line": 501,
           "kind": "unit",
           "field_names": [],
@@ -29388,7 +29689,7 @@
           "cr_refs": []
         },
         {
-          "name": "Waterbend",
+          "name": "Earthbend",
           "line": 502,
           "kind": "unit",
           "field_names": [],
@@ -29396,7 +29697,7 @@
           "cr_refs": []
         },
         {
-          "name": "ElementalBend",
+          "name": "Firebend",
           "line": 503,
           "kind": "unit",
           "field_names": [],
@@ -29404,8 +29705,24 @@
           "cr_refs": []
         },
         {
+          "name": "Waterbend",
+          "line": 504,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ElementalBend",
+          "line": 505,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Unknown",
-          "line": 506,
+          "line": 508,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized trigger mode strings.",
@@ -29473,13 +29790,13 @@
     },
     "TypeFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1710,
+      "line": 1776,
       "doc": "Type filter for card type matching in filters.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Creature",
-          "line": 1711,
+          "line": 1777,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29487,7 +29804,7 @@
         },
         {
           "name": "Land",
-          "line": 1712,
+          "line": 1778,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29495,7 +29812,7 @@
         },
         {
           "name": "Artifact",
-          "line": 1713,
+          "line": 1779,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29503,7 +29820,7 @@
         },
         {
           "name": "Enchantment",
-          "line": 1714,
+          "line": 1780,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29511,7 +29828,7 @@
         },
         {
           "name": "Instant",
-          "line": 1715,
+          "line": 1781,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29519,7 +29836,7 @@
         },
         {
           "name": "Sorcery",
-          "line": 1716,
+          "line": 1782,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29527,7 +29844,7 @@
         },
         {
           "name": "Planeswalker",
-          "line": 1717,
+          "line": 1783,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29535,7 +29852,7 @@
         },
         {
           "name": "Battle",
-          "line": 1719,
+          "line": 1785,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 310: Battle — a permanent type introduced in March of the Machine.",
@@ -29545,7 +29862,7 @@
         },
         {
           "name": "Permanent",
-          "line": 1720,
+          "line": 1786,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29553,7 +29870,7 @@
         },
         {
           "name": "Card",
-          "line": 1721,
+          "line": 1787,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29561,7 +29878,7 @@
         },
         {
           "name": "Any",
-          "line": 1722,
+          "line": 1788,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29569,7 +29886,7 @@
         },
         {
           "name": "Non",
-          "line": 1725,
+          "line": 1791,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.4b: Negation — matches objects whose type does NOT match the inner filter. \"noncreature\" → `Non(Box::new(Creature))`, \"non-Human\" → `Non(Box::new(Subtype(\"Human\")))`",
@@ -29579,7 +29896,7 @@
         },
         {
           "name": "Subtype",
-          "line": 1728,
+          "line": 1794,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.3: Matches objects with a specific subtype (creature type, land type, etc.). String because MTG has 250+ creature subtypes (CR 205.3m) with new ones each set.",
@@ -29590,7 +29907,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 1731,
+          "line": 1797,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2b: Disjunction — matches if ANY inner filter matches. \"creature or enchantment\" → `AnyOf(vec![Creature, Enchantment])`",
@@ -29669,7 +29986,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3651,
+      "line": 3732,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -29678,7 +29995,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 3653,
+          "line": 3734,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29686,7 +30003,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 3654,
+          "line": 3735,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29694,7 +30011,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 3655,
+          "line": 3736,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29704,7 +30021,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 3658,
+          "line": 3739,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29714,7 +30031,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 3670,
+          "line": 3751,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -29730,7 +30047,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3243,
+      "line": 3324,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -29743,7 +30060,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 3247,
+          "line": 3328,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29756,7 +30073,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 3251,
+          "line": 3332,
           "kind": "struct",
           "field_names": [
             "property",
@@ -29774,7 +30091,7 @@
     },
     "VoteActor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1458,
+      "line": 1545,
       "doc": "CR 101.4 + CR 608.2 (Battlebond friend-or-foe keyword action — no explicit CR section): The \"who acts\" semantic for a `WaitingFor::VoteChoice` step.  * `SubjectActs` — the player named by `player` casts the vote for   themselves. Classic Council's-dilemma (CR 701.38) is exclusively this   case: each voter acts on their own behalf and APNAP iteration changes   both subject and actor together. * `Delegated(actor)` — a fixed `actor` casts every vote on behalf of the   cycling subjects. The Battlebond friend-or-foe spell controller pins   themselves here so `player` cycles through every player in APNAP order   while authorization stays with the controller.  Stored on `WaitingFor::VoteChoice` instead of `Option<PlayerId>` so the \"is this delegated?\" discriminator is a named sum type with a meaningful pair of variant names, not a boolean-flavored optional. Callers route through [`VoteActor::resolve`] to get the authorized submitter without branching at every call site.",
       "cr_refs": [
         "CR 101.4",
@@ -29784,7 +30101,7 @@
       "variants": [
         {
           "name": "SubjectActs",
-          "line": 1459,
+          "line": 1546,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29792,7 +30109,7 @@
         },
         {
           "name": "Delegated",
-          "line": 1460,
+          "line": 1547,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -29803,7 +30120,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7149,
+      "line": 7267,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -29812,7 +30129,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 7152,
+          "line": 7270,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -29822,7 +30139,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 7156,
+          "line": 7274,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -29832,7 +30149,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 7164,
+          "line": 7282,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",
@@ -29846,13 +30163,13 @@
     },
     "WaitingFor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1546,
+      "line": 1712,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1547,
+          "line": 1713,
           "kind": "struct",
           "field_names": [
             "player"
@@ -29862,7 +30179,7 @@
         },
         {
           "name": "MulliganDecision",
-          "line": 1563,
+          "line": 1729,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -29877,7 +30194,7 @@
         },
         {
           "name": "MulliganBottomCards",
-          "line": 1576,
+          "line": 1742,
           "kind": "struct",
           "field_names": [
             "pending"
@@ -29889,7 +30206,7 @@
         },
         {
           "name": "OpeningHandBottomCards",
-          "line": 1582,
+          "line": 1748,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -29900,7 +30217,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1586,
+          "line": 1752,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29911,7 +30228,7 @@
         },
         {
           "name": "ChooseXValue",
-          "line": 1604,
+          "line": 1770,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29928,12 +30245,13 @@
         },
         {
           "name": "TargetSelection",
-          "line": 1613,
+          "line": 1779,
           "kind": "struct",
           "field_names": [
             "player",
             "pending_cast",
             "target_slots",
+            "mode_labels",
             "selection"
           ],
           "doc": "",
@@ -29941,7 +30259,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 1620,
+          "line": 1795,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29953,7 +30271,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 1626,
+          "line": 1801,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29966,7 +30284,7 @@
         },
         {
           "name": "UntapChoice",
-          "line": 1642,
+          "line": 1817,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29980,7 +30298,7 @@
         },
         {
           "name": "ExertChoice",
-          "line": 1654,
+          "line": 1829,
           "kind": "struct",
           "field_names": [
             "player",
@@ -29995,7 +30313,7 @@
         },
         {
           "name": "GameOver",
-          "line": 1660,
+          "line": 1835,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -30005,7 +30323,7 @@
         },
         {
           "name": "ReplacementChoice",
-          "line": 1663,
+          "line": 1838,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30017,7 +30335,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 1676,
+          "line": 1851,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30032,7 +30350,7 @@
         },
         {
           "name": "CopyTargetChoice",
-          "line": 1682,
+          "line": 1857,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30047,7 +30365,7 @@
         },
         {
           "name": "ExploreChoice",
-          "line": 1692,
+          "line": 1867,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30063,7 +30381,7 @@
         },
         {
           "name": "ReturnAsAuraTarget",
-          "line": 1714,
+          "line": 1889,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30086,7 +30404,7 @@
         },
         {
           "name": "EquipTarget",
-          "line": 1731,
+          "line": 1906,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30098,7 +30416,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 1737,
+          "line": 1912,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30113,7 +30431,7 @@
         },
         {
           "name": "StationTarget",
-          "line": 1748,
+          "line": 1923,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30127,7 +30445,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 1756,
+          "line": 1931,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30142,7 +30460,7 @@
         },
         {
           "name": "ScryChoice",
-          "line": 1764,
+          "line": 1939,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30153,7 +30471,7 @@
         },
         {
           "name": "DigChoice",
-          "line": 1769,
+          "line": 1944,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30173,7 +30491,7 @@
         },
         {
           "name": "SurveilChoice",
-          "line": 1793,
+          "line": 1968,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30184,7 +30502,7 @@
         },
         {
           "name": "RevealChoice",
-          "line": 1797,
+          "line": 1972,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30198,7 +30516,7 @@
         },
         {
           "name": "SearchChoice",
-          "line": 1816,
+          "line": 1991,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30214,7 +30532,7 @@
         },
         {
           "name": "SearchPartitionChoice",
-          "line": 1850,
+          "line": 2025,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30233,7 +30551,7 @@
         },
         {
           "name": "OutsideGameChoice",
-          "line": 1863,
+          "line": 2038,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30252,7 +30570,7 @@
         },
         {
           "name": "ChooseFromZoneChoice",
-          "line": 1877,
+          "line": 2052,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30269,7 +30587,7 @@
         },
         {
           "name": "ChooseOneOfBranch",
-          "line": 1889,
+          "line": 2064,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30288,7 +30606,7 @@
         },
         {
           "name": "ConniveDiscard",
-          "line": 1907,
+          "line": 2082,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30304,7 +30622,7 @@
         },
         {
           "name": "DiscardChoice",
-          "line": 1916,
+          "line": 2091,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30322,7 +30640,7 @@
         },
         {
           "name": "EffectZoneChoice",
-          "line": 1932,
+          "line": 2107,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30349,7 +30667,7 @@
         },
         {
           "name": "DrawnThisTurnTopdeckChoice",
-          "line": 1985,
+          "line": 2160,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30364,7 +30682,7 @@
         },
         {
           "name": "LearnChoice",
-          "line": 1995,
+          "line": 2170,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30377,7 +30695,7 @@
         },
         {
           "name": "ManifestDreadChoice",
-          "line": 2001,
+          "line": 2176,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30390,11 +30708,12 @@
         },
         {
           "name": "TriggerTargetSelection",
-          "line": 2005,
+          "line": 2180,
           "kind": "struct",
           "field_names": [
             "player",
             "target_slots",
+            "mode_labels",
             "target_constraints",
             "selection",
             "source_id",
@@ -30405,7 +30724,7 @@
         },
         {
           "name": "BetweenGamesSideboard",
-          "line": 2019,
+          "line": 2200,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30417,7 +30736,7 @@
         },
         {
           "name": "BetweenGamesChoosePlayDraw",
-          "line": 2024,
+          "line": 2205,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30429,7 +30748,7 @@
         },
         {
           "name": "NamedChoice",
-          "line": 2030,
+          "line": 2211,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30442,7 +30761,7 @@
         },
         {
           "name": "DamageSourceChoice",
-          "line": 2040,
+          "line": 2221,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30456,7 +30775,7 @@
         },
         {
           "name": "ModeChoice",
-          "line": 2046,
+          "line": 2227,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30468,7 +30787,7 @@
         },
         {
           "name": "DiscardToHandSize",
-          "line": 2052,
+          "line": 2233,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30480,7 +30799,7 @@
         },
         {
           "name": "OptionalCostChoice",
-          "line": 2060,
+          "line": 2241,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30493,7 +30812,7 @@
         },
         {
           "name": "DefilerPayment",
-          "line": 2072,
+          "line": 2253,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30507,23 +30826,26 @@
           ]
         },
         {
-          "name": "AdventureCastChoice",
-          "line": 2082,
+          "name": "CastOffer",
+          "line": 2263,
           "kind": "struct",
           "field_names": [
             "player",
-            "object_id",
-            "card_id",
-            "payment_mode"
+            "kind"
           ],
-          "doc": "CR 715.3a: Player chooses creature face vs Adventure half when casting an Adventure card from hand (or exile with permission).",
+          "doc": "CR 715.3a + CR 702.94a + CR 702.35a + CR 702.85a + CR 701.57a + CR 702.xxx: A player is offered a card to cast via a special rule.",
           "cr_refs": [
+            "CR 701.57a",
+            "CR 702",
+            "CR 702.35a",
+            "CR 702.85a",
+            "CR 702.94a",
             "CR 715.3a"
           ]
         },
         {
           "name": "ModalFaceChoice",
-          "line": 2099,
+          "line": 2277,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30539,7 +30861,7 @@
         },
         {
           "name": "AlternativeCastChoice",
-          "line": 2122,
+          "line": 2300,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30565,7 +30887,7 @@
         },
         {
           "name": "CastingVariantChoice",
-          "line": 2154,
+          "line": 2332,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30581,7 +30903,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 2166,
+          "line": 2344,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30598,7 +30920,7 @@
         },
         {
           "name": "MultiTargetSelection",
-          "line": 2177,
+          "line": 2355,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30614,7 +30936,7 @@
         },
         {
           "name": "AbilityModeChoice",
-          "line": 2188,
+          "line": 2366,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30631,7 +30953,7 @@
         },
         {
           "name": "OptionalEffectChoice",
-          "line": 2211,
+          "line": 2389,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30646,7 +30968,7 @@
         },
         {
           "name": "PairChoice",
-          "line": 2222,
+          "line": 2400,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30661,7 +30983,7 @@
         },
         {
           "name": "TributeChoice",
-          "line": 2233,
+          "line": 2411,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30676,7 +30998,7 @@
         },
         {
           "name": "MiracleReveal",
-          "line": 2245,
+          "line": 2423,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30690,37 +31012,8 @@
           ]
         },
         {
-          "name": "MiracleCastOffer",
-          "line": 2255,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "object_id",
-            "cost"
-          ],
-          "doc": "CR 702.94a: The miracle triggered ability has resolved — the player may now cast the revealed card for its miracle cost. This happens during trigger resolution per CR 608.2g (timing restrictions do not apply). `GameAction::CastSpellAsMiracle` accepts; `GameAction::DecideOptionalEffect { accept: false }` declines.",
-          "cr_refs": [
-            "CR 608.2g",
-            "CR 702.94a"
-          ]
-        },
-        {
-          "name": "MadnessCastOffer",
-          "line": 2264,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "object_id",
-            "cost"
-          ],
-          "doc": "CR 702.35a: The madness triggered ability has resolved — the player may cast the exiled discarded card for its madness cost or put it into their graveyard. `GameAction::CastSpellAsMadness` accepts; `DecideOptionalEffect { accept: false }` declines.",
-          "cr_refs": [
-            "CR 702.35a"
-          ]
-        },
-        {
           "name": "OpponentMayChoice",
-          "line": 2271,
+          "line": 2430,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30736,7 +31029,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 2284,
+          "line": 2443,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30754,7 +31047,7 @@
         },
         {
           "name": "UnlessPaymentChooseCost",
-          "line": 2318,
+          "line": 2477,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30772,7 +31065,7 @@
         },
         {
           "name": "WardDiscardChoice",
-          "line": 2348,
+          "line": 2507,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30786,7 +31079,7 @@
         },
         {
           "name": "WardSacrificeChoice",
-          "line": 2356,
+          "line": 2515,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30801,7 +31094,7 @@
         },
         {
           "name": "UnlessBounceChoice",
-          "line": 2367,
+          "line": 2526,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30816,7 +31109,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 2375,
+          "line": 2534,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30829,7 +31122,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 2380,
+          "line": 2539,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30842,7 +31135,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 2385,
+          "line": 2544,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30856,56 +31149,27 @@
           ]
         },
         {
-          "name": "DiscardForCost",
-          "line": 2393,
+          "name": "PayCost",
+          "line": 2556,
           "kind": "struct",
           "field_names": [
             "player",
-            "count",
-            "cards",
-            "pending_cast"
-          ],
-          "doc": "CR 601.2b: Player must choose a card to discard as part of an additional casting cost. After selection, the card is discarded and casting continues via `pay_and_push`.",
-          "cr_refs": [
-            "CR 601.2b"
-          ]
-        },
-        {
-          "name": "SacrificeForCost",
-          "line": 2403,
-          "kind": "struct",
-          "field_names": [
-            "player",
+            "kind",
+            "choices",
             "count",
             "min_count",
-            "permanents",
-            "pending_cast"
+            "resume"
           ],
-          "doc": "CR 118.3 / CR 601.2b: Player must choose permanent(s) to sacrifice as cost.",
+          "doc": "CR 118.3 + CR 601.2b + CR 605.3b: Player must select `count` objects from `choices` to pay a cost, then the engine resumes via `resume`. Replaces: DiscardForCost, SacrificeForCost, ReturnToHandForCost, ExileForCost, RemoveCounterForCost, TapCreaturesForSpellCost, BeholdForCost, TapCreaturesForManaAbility, DiscardForManaAbility, ExileForManaAbility, SacrificeForManaAbility.",
           "cr_refs": [
             "CR 118.3",
-            "CR 601.2b"
-          ]
-        },
-        {
-          "name": "ReturnToHandForCost",
-          "line": 2416,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "count",
-            "permanents",
-            "pending_cast"
-          ],
-          "doc": "CR 118.3 / CR 601.2b: Player must choose permanent(s) to return to hand as cost.",
-          "cr_refs": [
-            "CR 118.3",
-            "CR 601.2b"
+            "CR 601.2b",
+            "CR 605.3b"
           ]
         },
         {
           "name": "ActivationCostOneOfChoice",
-          "line": 2426,
+          "line": 2570,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30918,26 +31182,8 @@
           ]
         },
         {
-          "name": "RemoveCounterForCost",
-          "line": 2433,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "count",
-            "counter_type",
-            "permanents",
-            "pending_cast"
-          ],
-          "doc": "CR 118.3 / CR 122.1 / CR 601.2b: Player must choose a permanent to remove counters from as a cost.",
-          "cr_refs": [
-            "CR 118.3",
-            "CR 122.1",
-            "CR 601.2b"
-          ]
-        },
-        {
           "name": "BlightChoice",
-          "line": 2443,
+          "line": 2576,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30949,105 +31195,8 @@
           "cr_refs": []
         },
         {
-          "name": "TapCreaturesForSpellCost",
-          "line": 2454,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "count",
-            "creatures",
-            "pending_cast"
-          ],
-          "doc": "CR 702.34a / CR 601.2b: Player must choose untapped creatures to tap as a spell cost (e.g., \"Flashback—Tap three untapped white creatures you control\").",
-          "cr_refs": [
-            "CR 601.2b",
-            "CR 702.34a"
-          ]
-        },
-        {
-          "name": "BeholdForCost",
-          "line": 2462,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "count",
-            "choices",
-            "action",
-            "pending_cast"
-          ],
-          "doc": "Player must choose a matching permanent they control or matching card from hand to pay a behold casting cost.",
-          "cr_refs": []
-        },
-        {
-          "name": "TapCreaturesForManaAbility",
-          "line": 2470,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "count",
-            "creatures",
-            "pending_mana_ability"
-          ],
-          "doc": "CR 118.3 / CR 605.3b: Player must choose untapped creatures to pay a mana ability cost.",
-          "cr_refs": [
-            "CR 118.3",
-            "CR 605.3b"
-          ]
-        },
-        {
-          "name": "DiscardForManaAbility",
-          "line": 2477,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "count",
-            "cards",
-            "pending_mana_ability"
-          ],
-          "doc": "CR 118.3 / CR 605.3b: Player must choose cards to discard to pay a mana ability cost.",
-          "cr_refs": [
-            "CR 118.3",
-            "CR 605.3b"
-          ]
-        },
-        {
-          "name": "ExileForManaAbility",
-          "line": 2487,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "count",
-            "zone",
-            "cards",
-            "pending_mana_ability"
-          ],
-          "doc": "CR 117.1 + CR 118.3 + CR 605.3b: Player must choose object(s) from the specified zone to exile to pay a mana ability cost. Used by Food Chain's battlefield exile cost and Titans' Nest's graveyard exile cost.",
-          "cr_refs": [
-            "CR 117.1",
-            "CR 118.3",
-            "CR 605.3b"
-          ]
-        },
-        {
-          "name": "SacrificeForManaAbility",
-          "line": 2499,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "count",
-            "permanents",
-            "pending_mana_ability"
-          ],
-          "doc": "CR 117.1 + CR 118.3 + CR 605.3b: Player must choose battlefield permanent(s) to sacrifice to pay a mana ability cost. Used by Phyrexian Altar (\"Sacrifice a creature: Add one mana of any color.\") and the broader sacrifice-for-mana-by-property class.",
-          "cr_refs": [
-            "CR 117.1",
-            "CR 118.3",
-            "CR 605.3b"
-          ]
-        },
-        {
           "name": "PayManaAbilityMana",
-          "line": 2515,
+          "line": 2594,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31063,7 +31212,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 2525,
+          "line": 2604,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31078,27 +31227,8 @@
           ]
         },
         {
-          "name": "ExileForCost",
-          "line": 2538,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "zone",
-            "count",
-            "cards",
-            "pending_cast"
-          ],
-          "doc": "CR 118.9a + CR 601.2b + CR 601.2h: Player must choose cards to exile from `zone` as part of an alternative or additional casting cost. Used by both escape (CR 702.138a, `zone = Graveyard`) and pitch spells such as Force of Will, Force of Negation, Force of Vigor, Misdirection, Unmask, and Mindbreak Trap (CR 118.9a, `zone = Hand`). CR 118.9a authorizes alternative costs; CR 601.2b covers cost announcement; CR 601.2h covers payment. Eligibility is pre-filtered against the cost's `TargetFilter`; the spell being cast is excluded.",
-          "cr_refs": [
-            "CR 118.9a",
-            "CR 601.2b",
-            "CR 601.2h",
-            "CR 702.138a"
-          ]
-        },
-        {
           "name": "CollectEvidenceChoice",
-          "line": 2553,
+          "line": 2611,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31114,7 +31244,7 @@
         },
         {
           "name": "HarmonizeTapChoice",
-          "line": 2562,
+          "line": 2620,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31130,22 +31260,8 @@
           ]
         },
         {
-          "name": "DiscoverChoice",
-          "line": 2570,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "hit_card",
-            "exiled_misses"
-          ],
-          "doc": "CR 701.57a: Player chooses to cast the discovered card or put it to hand.",
-          "cr_refs": [
-            "CR 701.57a"
-          ]
-        },
-        {
           "name": "RevealUntilKeptChoice",
-          "line": 2582,
+          "line": 2632,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31166,7 +31282,7 @@
         },
         {
           "name": "RepeatDecision",
-          "line": 2603,
+          "line": 2653,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31179,23 +31295,8 @@
           ]
         },
         {
-          "name": "CascadeChoice",
-          "line": 2613,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "hit_card",
-            "exiled_misses",
-            "source_mv"
-          ],
-          "doc": "CR 702.85a: Player chooses to cast the cascaded card without paying its mana cost or decline. Unlike `DiscoverChoice`, the declined card goes to the bottom of the library in a random order together with the misses (cascade has no put-to-hand branch).",
-          "cr_refs": [
-            "CR 702.85a"
-          ]
-        },
-        {
           "name": "TopOrBottomChoice",
-          "line": 2629,
+          "line": 2660,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31207,21 +31308,8 @@
           ]
         },
         {
-          "name": "ParadigmCastOffer",
-          "line": 2638,
-          "kind": "struct",
-          "field_names": [
-            "player",
-            "offers"
-          ],
-          "doc": "CR 702.xxx: Paradigm (Strixhaven) — turn-based offer at the beginning of the player's first precombat main phase. `offers` is the list of exiled paradigm sources belonging to `player`; each may be cast as a token copy without paying its mana cost, or passed. Assign when WotC publishes SOS CR update.",
-          "cr_refs": [
-            "CR 702"
-          ]
-        },
-        {
           "name": "PopulateChoice",
-          "line": 2643,
+          "line": 2665,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31235,7 +31323,7 @@
         },
         {
           "name": "ClashCardPlacement",
-          "line": 2651,
+          "line": 2673,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31249,7 +31337,7 @@
         },
         {
           "name": "VoteChoice",
-          "line": 2662,
+          "line": 2684,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31271,7 +31359,7 @@
         },
         {
           "name": "SeparatePilesPartition",
-          "line": 2721,
+          "line": 2743,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31292,7 +31380,7 @@
         },
         {
           "name": "SeparatePilesChoice",
-          "line": 2751,
+          "line": 2773,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31309,7 +31397,7 @@
         },
         {
           "name": "CompanionReveal",
-          "line": 2766,
+          "line": 2788,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31322,7 +31410,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 2773,
+          "line": 2795,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31336,7 +31424,7 @@
         },
         {
           "name": "CommanderZoneChoice",
-          "line": 2782,
+          "line": 2804,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31350,7 +31438,7 @@
         },
         {
           "name": "BattleProtectorChoice",
-          "line": 2793,
+          "line": 2815,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31366,7 +31454,7 @@
         },
         {
           "name": "ProliferateChoice",
-          "line": 2800,
+          "line": 2822,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31379,7 +31467,7 @@
         },
         {
           "name": "ChooseObjectsSelection",
-          "line": 2810,
+          "line": 2832,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31393,12 +31481,16 @@
         },
         {
           "name": "CategoryChoice",
-          "line": 2823,
+          "line": 2845,
           "kind": "struct",
           "field_names": [
             "player",
             "target_player",
             "categories",
+            "chooser_scope",
+            "choose_filter",
+            "sacrifice_filter",
+            "source_controller",
             "eligible_per_category",
             "source_id",
             "remaining_players",
@@ -31413,7 +31505,7 @@
         },
         {
           "name": "CopyRetarget",
-          "line": 2846,
+          "line": 2882,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31428,7 +31520,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 2856,
+          "line": 2892,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31450,7 +31542,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 2880,
+          "line": 2916,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31465,7 +31557,7 @@
         },
         {
           "name": "MoveCountersDistribution",
-          "line": 2888,
+          "line": 2924,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31483,7 +31575,7 @@
         },
         {
           "name": "PayAmountChoice",
-          "line": 2902,
+          "line": 2938,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31501,7 +31593,7 @@
         },
         {
           "name": "RetargetChoice",
-          "line": 2915,
+          "line": 2951,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31517,7 +31609,7 @@
         },
         {
           "name": "CombatTaxPayment",
-          "line": 2937,
+          "line": 2973,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31537,7 +31629,7 @@
         },
         {
           "name": "PhyrexianPayment",
-          "line": 2955,
+          "line": 2991,
           "kind": "struct",
           "field_names": [
             "player",


### PR DESCRIPTION
## Summary

- `StaticMode` had three structurally identical siblings (`ReduceCost`, `RaiseCost`, `MinimumCost`) differing only on a direction/floor axis — a classic sibling-cluster smell (CLAUDE.md). All three live in the same CR 601.2f cost-locking step.
- Added `CostModifyMode { Reduce, Raise, Minimum }` enum and collapsed all three variants into `StaticMode::ModifyCost { mode, amount, spell_filter, dynamic_count }`.
- Every `match` arm that previously needed three arms now uses one; future cost-modification variants (e.g. multiplicative scaling) slot into `CostModifyMode` without adding new siblings.

## Before / After

| Before | After |
|---|---|
| `StaticMode::ReduceCost { amount, spell_filter, dynamic_count }` | `StaticMode::ModifyCost { mode: CostModifyMode::Reduce, amount, spell_filter, dynamic_count }` |
| `StaticMode::RaiseCost { amount, spell_filter, dynamic_count }` | `StaticMode::ModifyCost { mode: CostModifyMode::Raise, amount, spell_filter, dynamic_count }` |
| `StaticMode::MinimumCost { amount, spell_filter }` | `StaticMode::ModifyCost { mode: CostModifyMode::Minimum, amount, spell_filter, dynamic_count: None }` |

## Wire Compatibility

`Display`/`FromStr` preserve legacy string names — existing card-data JSON that loads via the string path continues to work:
- `"ReduceCost"` → `ModifyCost { mode: Reduce, .. }`
- `"RaiseCost"` → `ModifyCost { mode: Raise, .. }`
- `"MinimumCost"` → `ModifyCost { mode: Minimum, .. }`

Serde struct-variant serialization now emits `{ "mode": "Reduce", "amount": ..., "spell_filter": ... }` (two Thalia IR snapshots re-blessed).

## Files Changed (19)

| File | Change |
|---|---|
| `types/statics.rs` | Add `CostModifyMode`; replace 3 variants with `ModifyCost`; merge Hash/Display/FromStr arms |
| `game/casting.rs` | Three resolver sites + ~8 test constructors updated |
| `game/casting_costs.rs` | Floor-active probe matches `ModifyCost { mode: Minimum, .. }` |
| `game/coverage.rs` | `is_data_carrying_static` arm collapsed; coverage-marker match merged |
| `game/static_abilities.rs` | Prose comments updated |
| `parser/oracle_static.rs` | ~50 constructor/pattern sites migrated |
| `parser/oracle.rs` | 2 test patterns migrated |
| `parser/swallow_check.rs` | Two-arm match collapsed to one |
| `parser/oracle_ir/snapshots/*.snap` (2) | Re-blessed for new serde shape |
| `database/forge/static_ab.rs` | `translate_raise_cost`/`translate_reduce_cost` constructors + test |
| `types/ability.rs` | Doc comment updated |
| `tests/integration/the_ur_dragon_eminence.rs` | Constructor migrated |
| `tests/integration/rules/casting.rs` | Constructor migrated |
| `mtgish-import/convert/cast_effect.rs` | All `ReduceCost` constructors/patterns migrated |
| `mtgish-import/convert/player_effect.rs` | Constructors migrated |
| `mtgish-import/CLAUDE.md` | Catalog reference updated |
| `phase-ai/features/tribal.rs` | Match arm + constructor migrated |
| `phase-ai/features/mana_ramp.rs` | Doc comment updated |

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p engine -p mtgish-import -p phase-ai --all-targets -- -D warnings` — clean, exit 0
- [x] Executor ran engine test suites: `cost` (42), `casting` (28), `oracle_static` (564), `oracle` (343), `oracle_ir` snapshots (67 incl. both Thalia), `coverage` (67), `trinisphere` (9)
- [x] `mtgish-import` tests (112 + 11 + golden_structural 11)
- [x] `phase-ai` `tribal` (29) + `mana_ramp`
- [x] Integration test binary compiles clean
- [ ] `gen-card-data.sh` + `cargo semantic-audit` — requires `jq` in runtime env; CI should confirm
