### PR TITLE
fix(parser): honor "you control" on becomes-target triggers (Valiant #1378)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -7095,19 +7095,19 @@ mod tests {
         }
     }
 
-    /// CR 115.1: "a spell or ability you control" source filter — the shape the
-    /// trigger parser emits for Valiant (Heartfire Hero, Emberheart Challenger).
-    fn you_control_stack_source_filter() -> TargetFilter {
+    /// CR 115.1: "a spell or ability you control / an opponent controls" source
+    /// filter — the shape the trigger parser emits for Valiant-style triggers.
+    fn stack_source_filter(controller: ControllerRef) -> TargetFilter {
         TargetFilter::Or {
             filters: vec![
                 TargetFilter::And {
                     filters: vec![
                         TargetFilter::StackSpell,
-                        TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::You)),
+                        TargetFilter::Typed(TypedFilter::default().controller(controller.clone())),
                     ],
                 },
                 TargetFilter::StackAbility {
-                    controller: Some(ControllerRef::You),
+                    controller: Some(controller),
                 },
             ],
         }
@@ -7225,6 +7225,58 @@ mod tests {
     }
 
     #[test]
+    fn becomes_target_opponent_controls_matches_opponent_spell() {
+        // CR 115.1: "an opponent controls" must accept a spell controlled by an
+        // opponent of the permanent's controller.
+        let (mut state, spell_id) = setup_with_spell_on_stack(false); // spell controlled by PlayerId(0)
+        let trigger_owner = create_object(
+            &mut state,
+            CardId(7),
+            PlayerId(1),
+            "Opponent-Scoped Observer".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(stack_source_filter(ControllerRef::Opponent));
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(trigger_owner),
+            source_id: spell_id,
+        };
+        assert!(match_becomes_target(
+            &event,
+            &trigger,
+            trigger_owner,
+            &state
+        ));
+    }
+
+    #[test]
+    fn becomes_target_opponent_controls_rejects_own_spell() {
+        // CR 115.1: "an opponent controls" must reject a spell controlled by the
+        // permanent's own controller.
+        let (mut state, spell_id) = setup_with_spell_on_stack(false); // spell controlled by PlayerId(0)
+        let trigger_owner = create_object(
+            &mut state,
+            CardId(7),
+            PlayerId(0),
+            "Opponent-Scoped Observer".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(stack_source_filter(ControllerRef::Opponent));
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(trigger_owner),
+            source_id: spell_id,
+        };
+        assert!(!match_becomes_target(
+            &event,
+            &trigger,
+            trigger_owner,
+            &state
+        ));
+    }
+
+    #[test]
     fn becomes_target_you_control_matches_own_spell() {
         // Valiant (#1378): "you control" must accept a spell you control.
         let (mut state, spell_id) = setup_with_spell_on_stack(false); // spell controlled by PlayerId(0)
@@ -7236,12 +7288,17 @@ mod tests {
             Zone::Battlefield,
         );
         let mut trigger = make_trigger(TriggerMode::BecomesTarget);
-        trigger.valid_source = Some(you_control_stack_source_filter());
+        trigger.valid_source = Some(stack_source_filter(ControllerRef::You));
         let event = GameEvent::BecomesTarget {
             target: TargetRef::Object(trigger_owner),
             source_id: spell_id,
         };
-        assert!(match_becomes_target(&event, &trigger, trigger_owner, &state));
+        assert!(match_becomes_target(
+            &event,
+            &trigger,
+            trigger_owner,
+            &state
+        ));
     }
 
     #[test]
@@ -7257,12 +7314,17 @@ mod tests {
             Zone::Battlefield,
         );
         let mut trigger = make_trigger(TriggerMode::BecomesTarget);
-        trigger.valid_source = Some(you_control_stack_source_filter());
+        trigger.valid_source = Some(stack_source_filter(ControllerRef::You));
         let event = GameEvent::BecomesTarget {
             target: TargetRef::Object(trigger_owner),
             source_id: spell_id,
         };
-        assert!(!match_becomes_target(&event, &trigger, trigger_owner, &state));
+        assert!(!match_becomes_target(
+            &event,
+            &trigger,
+            trigger_owner,
+            &state
+        ));
     }
 
     #[test]
@@ -7277,12 +7339,17 @@ mod tests {
             Zone::Battlefield,
         );
         let mut trigger = make_trigger(TriggerMode::BecomesTarget);
-        trigger.valid_source = Some(you_control_stack_source_filter());
+        trigger.valid_source = Some(stack_source_filter(ControllerRef::You));
         let event = GameEvent::BecomesTarget {
             target: TargetRef::Object(trigger_owner),
             source_id: ability_id,
         };
-        assert!(match_becomes_target(&event, &trigger, trigger_owner, &state));
+        assert!(match_becomes_target(
+            &event,
+            &trigger,
+            trigger_owner,
+            &state
+        ));
     }
 
     #[test]
@@ -7297,12 +7364,17 @@ mod tests {
             Zone::Battlefield,
         );
         let mut trigger = make_trigger(TriggerMode::BecomesTarget);
-        trigger.valid_source = Some(you_control_stack_source_filter());
+        trigger.valid_source = Some(stack_source_filter(ControllerRef::You));
         let event = GameEvent::BecomesTarget {
             target: TargetRef::Object(trigger_owner),
             source_id: ability_id,
         };
-        assert!(!match_becomes_target(&event, &trigger, trigger_owner, &state));
+        assert!(!match_becomes_target(
+            &event,
+            &trigger,
+            trigger_owner,
+            &state
+        ));
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -7095,6 +7095,24 @@ mod tests {
         }
     }
 
+    /// CR 115.1: "a spell or ability you control" source filter — the shape the
+    /// trigger parser emits for Valiant (Heartfire Hero, Emberheart Challenger).
+    fn you_control_stack_source_filter() -> TargetFilter {
+        TargetFilter::Or {
+            filters: vec![
+                TargetFilter::And {
+                    filters: vec![
+                        TargetFilter::StackSpell,
+                        TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::You)),
+                    ],
+                },
+                TargetFilter::StackAbility {
+                    controller: Some(ControllerRef::You),
+                },
+            ],
+        }
+    }
+
     fn setup_with_ability_on_stack() -> (GameState, ObjectId) {
         let mut state = setup();
         let ability_id = ObjectId(60);
@@ -7204,6 +7222,87 @@ mod tests {
             trigger_owner,
             &state
         ));
+    }
+
+    #[test]
+    fn becomes_target_you_control_matches_own_spell() {
+        // Valiant (#1378): "you control" must accept a spell you control.
+        let (mut state, spell_id) = setup_with_spell_on_stack(false); // spell controlled by PlayerId(0)
+        let trigger_owner = create_object(
+            &mut state,
+            CardId(7),
+            PlayerId(0),
+            "Heartfire Hero".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(you_control_stack_source_filter());
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(trigger_owner),
+            source_id: spell_id,
+        };
+        assert!(match_becomes_target(&event, &trigger, trigger_owner, &state));
+    }
+
+    #[test]
+    fn becomes_target_you_control_rejects_opponent_spell() {
+        // Valiant (#1378): "you control" must reject an opponent's spell — the
+        // exact reported bug (trigger fired when the opponent targeted it).
+        let (mut state, spell_id) = setup_with_spell_on_stack(false); // spell controlled by PlayerId(0)
+        let trigger_owner = create_object(
+            &mut state,
+            CardId(7),
+            PlayerId(1),
+            "Heartfire Hero".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(you_control_stack_source_filter());
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(trigger_owner),
+            source_id: spell_id,
+        };
+        assert!(!match_becomes_target(&event, &trigger, trigger_owner, &state));
+    }
+
+    #[test]
+    fn becomes_target_you_control_matches_own_ability() {
+        // CR 115.1: "a spell or ability you control" also covers abilities.
+        let (mut state, ability_id) = setup_with_ability_on_stack(); // ability controlled by PlayerId(1)
+        let trigger_owner = create_object(
+            &mut state,
+            CardId(7),
+            PlayerId(1),
+            "Heartfire Hero".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(you_control_stack_source_filter());
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(trigger_owner),
+            source_id: ability_id,
+        };
+        assert!(match_becomes_target(&event, &trigger, trigger_owner, &state));
+    }
+
+    #[test]
+    fn becomes_target_you_control_rejects_opponent_ability() {
+        // CR 115.1: an opponent's ability must not fire the "you control" trigger.
+        let (mut state, ability_id) = setup_with_ability_on_stack(); // ability controlled by PlayerId(1)
+        let trigger_owner = create_object(
+            &mut state,
+            CardId(7),
+            PlayerId(0),
+            "Heartfire Hero".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(you_control_stack_source_filter());
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(trigger_owner),
+            source_id: ability_id,
+        };
+        assert!(!match_becomes_target(&event, &trigger, trigger_owner, &state));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -16904,6 +16904,21 @@ mod tests {
     }
 
     #[test]
+    fn trigger_becomes_target_opponent_controls_sets_controller_source() {
+        // CR 115.1: the same spell-or-ability controller grammar supports
+        // opponent-scoped source restrictions.
+        let def = parse_trigger_line(
+            "Whenever this creature becomes the target of a spell or ability an opponent controls, draw a card.",
+            "Opponent-Scoped Observer",
+        );
+        assert_eq!(def.mode, TriggerMode::BecomesTarget);
+        assert_eq!(
+            def.valid_source,
+            Some(becomes_target_source_filter(ControllerRef::Opponent))
+        );
+    }
+
+    #[test]
     fn trigger_becomes_target_of_aura_spell_only() {
         let def = parse_trigger_line(
             "Whenever this creature becomes the target of an Aura spell, you draw a card.",

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -101,6 +101,45 @@ fn with_owner_scope(filter: TargetFilter, controller: ControllerRef) -> TargetFi
     }
 }
 
+/// CR 115.1: A "becomes the target of a spell or ability you control / an
+/// opponent controls" trigger (e.g. Valiant — Heartfire Hero, Emberheart
+/// Challenger) restricts the targeting source's controller. Parse that optional
+/// controller off the front of the post-event remainder; `None` leaves the
+/// source unrestricted (bare "a spell or ability").
+fn parse_target_source_controller(rest: &str) -> Option<ControllerRef> {
+    alt((
+        value(
+            ControllerRef::You,
+            tag::<_, _, OracleError<'_>>("you control"),
+        ),
+        value(ControllerRef::Opponent, tag("an opponent controls")),
+    ))
+    .parse(rest.trim_start())
+    .ok()
+    .map(|(_, controller)| controller)
+}
+
+/// CR 115.1: The targeting source of such a trigger is a stack spell OR a stack
+/// ability controlled by `controller`. Mirrors the spell/ability split the
+/// stack-entry matcher (`stack_entry_matches_filter`) enforces at runtime: the
+/// spell branch pairs `StackSpell` with a controller-scoped `Typed`, the ability
+/// branch uses `StackAbility`'s own controller dimension.
+fn becomes_target_source_filter(controller: ControllerRef) -> TargetFilter {
+    TargetFilter::Or {
+        filters: vec![
+            TargetFilter::And {
+                filters: vec![
+                    TargetFilter::StackSpell,
+                    TargetFilter::Typed(TypedFilter::default().controller(controller.clone())),
+                ],
+            },
+            TargetFilter::StackAbility {
+                controller: Some(controller),
+            },
+        ],
+    }
+}
+
 fn parse_self_return_origin_zone(lower: &str) -> Option<Zone> {
     nom_primitives::scan_preceded(lower, |input| {
         let (rest, _) = (
@@ -5784,6 +5823,13 @@ fn try_parse_event(
             SimpleEvent::BecomesTargetSpellOrAbility => {
                 def.mode = TriggerMode::BecomesTarget;
                 set_trigger_subject(&mut def, subject);
+                // CR 115.1: "a spell or ability you control" / "an opponent
+                // controls" restricts the targeting source's controller. Without
+                // it the trigger fires for any source — including the opponent's
+                // (Valiant bug #1378).
+                if let Some(controller) = parse_target_source_controller(remaining) {
+                    def.valid_source = Some(becomes_target_source_filter(controller));
+                }
             }
             // CR 115.1a + CR 115.1b: "target" spell text defines targeted spells,
             // and Aura spells are always targeted via enchant.
@@ -16840,6 +16886,21 @@ mod tests {
         assert_eq!(def.mode, TriggerMode::BecomesTarget);
         assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
         assert_eq!(def.valid_source, Some(TargetFilter::StackSpell));
+    }
+
+    #[test]
+    fn trigger_becomes_target_you_control_sets_controller_source() {
+        // Valiant (#1378): "a spell or ability you control" must restrict the
+        // targeting source's controller, not fire for any source.
+        let def = parse_trigger_line(
+            "Whenever this creature becomes the target of a spell or ability you control for the first time each turn, put a +1/+1 counter on it.",
+            "Heartfire Hero",
+        );
+        assert_eq!(def.mode, TriggerMode::BecomesTarget);
+        assert_eq!(
+            def.valid_source,
+            Some(becomes_target_source_filter(ControllerRef::You))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Valiant cards (Heartfire Hero, Emberheart Challenger, …) read:

> Valiant — Whenever this creature becomes the target of a spell or ability **you control** for the first time each turn, …

The trigger parser matched the event phrase via `tag("becomes the target of a spell or ability")` but dropped the trailing **controller qualifier** and left `valid_source = None`. With no source restriction, the trigger fired for **any** targeting source — including an **opponent's** spell or ability. That's the reported bug (#1378): Valiant triggered when the opponent targeted the creature.

## Fix

Parse the optional `you control` / `an opponent controls` qualifier off the post-event remainder and set `valid_source` to a **stack spell OR stack ability scoped to that controller**, mirroring the spell/ability split that the runtime stack-entry matcher (`stack_entry_matches_filter`) already enforces:

```
Or[ And[StackSpell, Typed{controller}], StackAbility{controller} ]
```

- Bare `a spell or ability` (no qualifier) still leaves the source unrestricted — existing behavior preserved.
- **Builds for the class**, not the card: every "becomes the target of a spell or ability you control / an opponent controls" trigger is covered.
- **No new enum variant** — the runtime was already controller-aware. Parser-only change. CR 115.1.

## Verification

- `oracle-gen` confirms Heartfire Hero & Emberheart Challenger now emit the controller-scoped `valid_source` with `OncePerTurn` preserved.
- New tests:
  - parser test asserting the controller-scoped `valid_source`
  - 4 runtime matcher tests: your own spell/ability **fires** the trigger; an opponent's spell/ability **does not**
- `cargo test -p engine` green (9519 existing + 5 new), `cargo clippy --all-targets -D warnings` clean, parser-combinator gate clean.

Closes #1378
