### PR TITLE
fix(engine): gate Bolas's Citadel library casts on life affordability

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1727,6 +1727,30 @@ pub fn top_of_library_land_playable_by_permission(
     Some((top_id, src_id))
 }
 
+/// CR 118.9 + CR 401.5: When `object_id` is the current top of `player`'s library
+/// and a `TopOfLibraryCastPermission` static grants an alt-cost rider (Bolas's
+/// Citadel: pay life equal to mana value), return that cost for castability
+/// pre-checks and the `check_additional_cost_or_pay` payment path.
+pub(crate) fn top_of_library_alt_ability_cost_for_object(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+) -> Option<crate::types::ability::AbilityCost> {
+    let obj = state.objects.get(&object_id)?;
+    if obj.zone != Zone::Library || obj.owner != player {
+        return None;
+    }
+    top_of_library_permission_source(state, player, Some(CardPlayMode::Cast)).and_then(
+        |(top_id, _src, alt)| {
+            if top_id == object_id {
+                alt
+            } else {
+                None
+            }
+        },
+    )
+}
+
 /// CR 604.2 + CR 305.1: Find lands in the player's graveyard that can be played
 /// via a GraveyardCastPermission static with `play_mode: Play`.
 pub fn graveyard_lands_playable_by_permission(
@@ -6205,6 +6229,20 @@ fn can_cast_prepared_now(
                 if !super::life_costs::can_pay_life_cast_or_activation_cost(state, player, amount) {
                     return false;
                 }
+            }
+        }
+    }
+
+    // CR 401.5 + CR 118.9 + CR 119.8: Top-of-library alt-cost casts (Bolas's
+    // Citadel) replace the mana cost with a PayLife cost equal to the spell's
+    // mana value. Gate legal actions on life affordability so the UI never offers
+    // a cast the payment pipeline would reject after the player taps mana.
+    if let Some(alt_cost) =
+        top_of_library_alt_ability_cost_for_object(state, player, prepared.object_id)
+    {
+        if let Some(amount) = find_pay_life_cost(&alt_cost, state, player, prepared.object_id) {
+            if !super::life_costs::can_pay_life_cast_or_activation_cost(state, player, amount) {
+                return false;
             }
         }
     }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2018,15 +2018,8 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
         } else if obj.zone == Zone::Library && obj.owner == player {
             // CR 401.5 + CR 118.9 + CR 601.2a: Top-of-library cast with an
             // alt-cost rider (Bolas's Citadel: "pay life equal to its mana
-            // value rather than paying its mana cost"). The static lives on
-            // the granting permanent on the battlefield, not on the spell;
-            // resolve through `top_of_library_permission_source` to fetch it.
-            super::casting::top_of_library_permission_source(
-                state,
-                player,
-                Some(crate::types::ability::CardPlayMode::Cast),
-            )
-            .and_then(|(top_id, _src, alt)| if top_id == object_id { alt } else { None })
+            // value rather than paying its mana cost").
+            super::casting::top_of_library_alt_ability_cost_for_object(state, player, object_id)
         } else {
             None
         }

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -220,8 +220,8 @@ impl GameScenario {
 
     /// Add generic named cards to the top of a player's library.
     ///
-    /// The last supplied name becomes the current top card, matching the engine's
-    /// library-top convention (`Vec::last()` / pop-from-end flows).
+    /// The first supplied name becomes the current top card, matching the
+    /// engine's library-top convention (`library[0]`).
     pub fn with_library_top(&mut self, player: PlayerId, names_top_first: &[&str]) -> &mut Self {
         for &name in names_top_first.iter().rev() {
             self.add_card_to_library_top(player, name);
@@ -239,8 +239,9 @@ impl GameScenario {
             name.to_string(),
             Zone::Library,
         );
-        // CR 402.2: `library[0]` is the top — `create_object` appends to the
-        // bottom, so re-seat this card at index 0 for deterministic top tests.
+        // Engine convention: `library[0]` is the top. `create_object` appends
+        // to the bottom, so re-seat this card at index 0 for deterministic top
+        // tests.
         let player_state = self
             .state
             .players

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -232,13 +232,24 @@ impl GameScenario {
     /// Add one generic named card to the top of a player's library.
     pub fn add_card_to_library_top(&mut self, player: PlayerId, name: &str) -> ObjectId {
         let card_id = CardId(self.state.next_object_id);
-        create_object(
+        let id = create_object(
             &mut self.state,
             card_id,
             player,
             name.to_string(),
             Zone::Library,
-        )
+        );
+        // CR 402.2: `library[0]` is the top — `create_object` appends to the
+        // bottom, so re-seat this card at index 0 for deterministic top tests.
+        let player_state = self
+            .state
+            .players
+            .iter_mut()
+            .find(|p| p.id == player)
+            .expect("player exists");
+        player_state.library.retain(|&oid| oid != id);
+        player_state.library.insert(0, id);
+        id
     }
 
     /// Add generic named cards to a player's graveyard without rules text.
@@ -613,6 +624,17 @@ impl GameScenario {
         };
         obj.card_types.core_types.push(core_type);
         obj.base_card_types = obj.card_types.clone();
+
+        if zone == Zone::Library {
+            let player_state = self
+                .state
+                .players
+                .iter_mut()
+                .find(|p| p.id == player)
+                .expect("player exists");
+            player_state.library.retain(|&oid| oid != id);
+            player_state.library.insert(0, id);
+        }
 
         CardBuilder {
             state: &mut self.state,

--- a/crates/engine/tests/integration/bolas_citadel_regression.rs
+++ b/crates/engine/tests/integration/bolas_citadel_regression.rs
@@ -1,0 +1,222 @@
+//! Regression: GitHub issue #946 — Bolas's Citadel casting blocked despite
+//! tapping the correct mana.
+//!
+//! Covers two surfaces:
+//! 1. Casting the Citadel artifact from hand at {3}{B}{B}{B}.
+//! 2. Casting a spell from the top of the library via Citadel's permission
+//!    (pay life equal to mana value, not mana).
+
+use engine::game::casting::{
+    can_cast_object_now, display_spell_cost, effective_spell_cost, spell_objects_available_to_cast,
+};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
+
+const BOLAS_ORACLE: &str = "You may look at the top card of your library any time.\n\
+You may play lands and cast spells from the top of your library. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.\n\
+{T}, Sacrifice ten nonland permanents: Each opponent loses 10 life.";
+
+fn citadel_mana_cost() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![
+            ManaCostShard::Black,
+            ManaCostShard::Black,
+            ManaCostShard::Black,
+        ],
+        generic: 3,
+    }
+}
+
+fn pool_units(colors: &[ManaType]) -> Vec<ManaUnit> {
+    let dummy = engine::types::identifiers::ObjectId(0);
+    colors
+        .iter()
+        .map(|&color| ManaUnit::new(color, dummy, false, vec![]))
+        .collect()
+}
+
+/// Issue #946: the Citadel itself must be castable from hand when the pool can
+/// pay {3}{B}{B}{B} (the common "I tapped the specific black mana" report).
+#[test]
+fn bolas_citadel_castable_from_hand_with_exact_mana() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let citadel_id = scenario
+        .add_creature_to_hand(P0, "Bolas's Citadel", 0, 0)
+        .as_artifact()
+        .with_mana_cost(citadel_mana_cost())
+        .from_oracle_text(BOLAS_ORACLE)
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        pool_units(&[
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Black,
+            ManaType::Black,
+            ManaType::Black,
+        ]),
+    );
+
+    let runner = scenario.build();
+    assert!(
+        can_cast_object_now(runner.state(), P0, citadel_id),
+        "Bolas's Citadel must be castable from hand when 3BBB is in the pool"
+    );
+    assert!(
+        engine::ai_support::legal_actions(runner.state())
+            .iter()
+            .any(
+                |a| matches!(a, GameAction::CastSpell { object_id, .. } if *object_id == citadel_id)
+            ),
+        "legal_actions must expose CastSpell for Citadel in hand"
+    );
+}
+
+/// Citadel on the battlefield must parse the top-of-library permission with a
+/// PayLife alt-cost rider so library casts replace mana with life.
+#[test]
+fn bolas_citadel_static_carries_library_alt_cost() {
+    let mut scenario = GameScenario::new();
+    let citadel_id = scenario
+        .add_creature(P0, "Bolas's Citadel", 0, 0)
+        .as_artifact()
+        .from_oracle_text(BOLAS_ORACLE)
+        .id();
+    let runner = scenario.build();
+    let obj = runner.state().objects.get(&citadel_id).unwrap();
+    let top_perm = obj
+        .static_definitions
+        .iter_unchecked()
+        .find(|d| matches!(d.mode, StaticMode::TopOfLibraryCastPermission { .. }))
+        .expect("TopOfLibraryCastPermission static");
+    match &top_perm.mode {
+        StaticMode::TopOfLibraryCastPermission { alt_cost, .. } => {
+            assert!(
+                alt_cost.is_some(),
+                "Bolas's Citadel must attach PayLife alt_cost to the library permission"
+            );
+        }
+        other => panic!("unexpected static mode: {other:?}"),
+    }
+}
+
+/// Issue #946 sibling: with Citadel in play, a bolt on top of library must be
+/// castable with life only — prepared mana cost is zeroed.
+#[test]
+fn bolas_citadel_library_top_zeros_mana_and_surfaces_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let _citadel = scenario
+        .add_creature(P0, "Bolas's Citadel", 0, 0)
+        .as_artifact()
+        .from_oracle_text(BOLAS_ORACLE)
+        .id();
+    let bolt_id = scenario
+        .add_spell_to_library_top(P0, "Lightning Bolt", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 0,
+        })
+        .from_oracle_text("Lightning Bolt deals 3 damage to any target.")
+        .id();
+    scenario.with_life(P0, 20);
+
+    let runner = scenario.build();
+    let effective = effective_spell_cost(runner.state(), P0, bolt_id).expect("effective cost");
+    assert_eq!(
+        effective,
+        ManaCost::zero(),
+        "library cast via Citadel must zero the mana cost"
+    );
+    let display = display_spell_cost(runner.state(), P0, bolt_id).expect("display cost");
+    assert_eq!(
+        display,
+        ManaCost::zero(),
+        "UI cost display must not show the printed mana cost for Citadel casts"
+    );
+
+    let available = spell_objects_available_to_cast(runner.state(), P0);
+    assert!(
+        available.contains(&bolt_id),
+        "Citadel must surface the library top as castable"
+    );
+    assert!(
+        can_cast_object_now(runner.state(), P0, bolt_id),
+        "library-top bolt must pass can_cast when life is available"
+    );
+}
+
+/// PayLife affordability must gate library-top casts — not just mana.
+#[test]
+fn bolas_citadel_library_top_not_castable_without_life() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let _citadel = scenario
+        .add_creature(P0, "Bolas's Citadel", 0, 0)
+        .as_artifact()
+        .from_oracle_text(BOLAS_ORACLE)
+        .id();
+    let bolt_id = scenario
+        .add_spell_to_library_top(P0, "Lightning Bolt", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 0,
+        })
+        .from_oracle_text("Lightning Bolt deals 3 damage to any target.")
+        .id();
+    scenario
+        .with_life(P0, 0)
+        .with_mana_pool(P0, pool_units(&[ManaType::Red]));
+
+    let runner = scenario.build();
+    assert!(
+        !can_cast_object_now(runner.state(), P0, bolt_id),
+        "library-top cast must be uncastable at 0 life even with mana in pool"
+    );
+}
+
+/// End-to-end: casting from the library top via Citadel must route through
+/// target selection, not a nonzero mana-payment step.
+#[test]
+fn bolas_citadel_library_top_cast_enters_targeting_not_mana_payment() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain).with_life(P0, 20);
+    let _citadel = scenario
+        .add_creature(P0, "Bolas's Citadel", 0, 0)
+        .as_artifact()
+        .from_oracle_text(BOLAS_ORACLE)
+        .id();
+    let bolt_id = scenario
+        .add_spell_to_library_top(P0, "Lightning Bolt", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 0,
+        })
+        .from_oracle_text("Lightning Bolt deals 3 damage to any target.")
+        .id();
+    let target = scenario.add_creature(P1, "Target", 2, 2).id();
+
+    let mut runner: GameRunner = scenario.build();
+    let card_id = runner.state().objects[&bolt_id].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: bolt_id,
+            card_id,
+            targets: vec![target],
+        })
+        .expect("CastSpell from library top should start");
+
+    match &runner.state().waiting_for {
+        WaitingFor::TargetSelection { .. } | WaitingFor::OptionalCostChoice { .. } => {}
+        WaitingFor::ManaPayment { .. } => {
+            panic!("Citadel library cast must not enter ManaPayment for a zeroed mana cost")
+        }
+        other => panic!("unexpected waiting state after starting library-top cast: {other:?}"),
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -13,6 +13,7 @@ mod balance_equalization;
 mod batched_trigger_subject_count;
 mod belbe_thornbow_life_loss;
 mod betor_lifelink_counters_repro;
+mod bolas_citadel_regression;
 mod boon_reflection_gain_life_drain;
 mod bracket_signals;
 mod braids_arisen_nightmare_decline;

--- a/crates/engine/tests/integration/terra_magical_adept_milled_enchantment.rs
+++ b/crates/engine/tests/integration/terra_magical_adept_milled_enchantment.rs
@@ -27,6 +27,16 @@ fn mark_enchantment(runner: &mut GameRunner, id: ObjectId) {
         .push(CoreType::Enchantment);
 }
 
+fn seed_terra_library(scenario: &mut GameScenario) -> ObjectId {
+    for i in 0..10 {
+        scenario.add_card_to_library_top(P0, &format!("Padding {i}"));
+    }
+    for i in (0..4).rev() {
+        scenario.add_card_to_library_top(P0, &format!("Instant {i}"));
+    }
+    scenario.add_card_to_library_top(P0, "Milled Aura")
+}
+
 /// Issue #1298: parsed ETB must chain `Mill` → `ChangeZone` with
 /// `TrackedSetFiltered`, not a bare type filter.
 #[test]
@@ -102,14 +112,7 @@ fn terra_etb_offers_only_milled_enchantments_not_battlefield() {
         .add_creature_to_hand(P0, "Terra, Magical Adept", 2, 2)
         .id();
 
-    // Library convention: first added = top (`library.iter().take(n)`).
-    let milled_enchantment = scenario.add_card_to_library_top(P0, "Milled Aura");
-    for i in 0..4 {
-        scenario.add_card_to_library_top(P0, &format!("Instant {i}"));
-    }
-    for i in 0..10 {
-        scenario.add_card_to_library_top(P0, &format!("Padding {i}"));
-    }
+    let milled_enchantment = seed_terra_library(&mut scenario);
 
     let mut runner = scenario.build();
     mark_enchantment(&mut runner, milled_enchantment);
@@ -190,13 +193,7 @@ fn terra_cast_etb_offers_only_milled_enchantments() {
         .with_trigger_definition(etb)
         .id();
 
-    let milled_enchantment = scenario.add_card_to_library_top(P0, "Milled Aura");
-    for i in 0..4 {
-        scenario.add_card_to_library_top(P0, &format!("Instant {i}"));
-    }
-    for i in 0..10 {
-        scenario.add_card_to_library_top(P0, &format!("Padding {i}"));
-    }
+    let milled_enchantment = seed_terra_library(&mut scenario);
 
     let mut runner = scenario.build();
     mark_enchantment(&mut runner, milled_enchantment);


### PR DESCRIPTION
## Summary

Fixes [#946](https://github.com/phase-rs/phase/issues/946). When casting from the top of the library with **Bolas's Citadel**, the engine must charge **life equal to the spell's mana value**, not mana. `can_cast_object_now` treated those casts as zero-mana affordable but skipped the **PayLife** check, so players could see a legal **Cast** action, tap mana, and still fail to finish the cast.

- Add `top_of_library_alt_ability_cost_for_object` as the single resolver for Citadel-style alt costs.
- Gate `can_cast_object_now` on life affordability for library-top alt-cost casts (same pattern as flashback non-mana costs).
- Route `casting_costs` through the shared helper.
- Correct `GameScenario` library helpers so cards land at `library[0]` (top).
- Add `bolas_citadel_regression` integration tests (hand cast, static parse, display cost, life gate, cast flow).

## Test plan

- [x] `cargo test -p engine bolas_citadel`
- [ ] `./scripts/tilt-wait.sh test-engine` (or full engine test suite before merge)