### PR TITLE
fix(engine): offer DFC/MDFC face choice when casting a commander from the command zone (#1548)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4994,7 +4994,8 @@ pub fn handle_cast_spell_with_payment_mode(
     // re-enters this function; the swap clears the back face's Modal
     // `layout_kind`, so the re-entry casts the chosen face without re-prompting.
     if let Some(obj) = state.objects.get(&object_id) {
-        if cast_face_choice_offered_from_zone(state, obj) && modal_spell_face_choice_available(obj) {
+        if cast_face_choice_offered_from_zone(state, obj) && modal_spell_face_choice_available(obj)
+        {
             return Ok(WaitingFor::ModalFaceChoice {
                 player,
                 object_id,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -3645,6 +3645,23 @@ fn modal_spell_face_choice_available(obj: &crate::game::game_object::GameObject)
     !front_is_land && !back_is_land
 }
 
+/// CR 712.11b + CR 903.8: A cast-time face choice (a spell//spell Modal DFC, or
+/// an Adventure/Omen alternative spell face) is offered both when casting from
+/// hand and when a player casts their commander from the command zone. A
+/// DFC/MDFC commander must let its owner choose which face to put on the stack —
+/// e.g. casting The Prismatic Bridge (the back face of Esika, God of the Tree)
+/// directly from the command zone (#1548). The downstream cast pipeline
+/// (`ChooseModalFace` re-entry, affordability via `can_cast_object_now`, and the
+/// commander-tax surcharge) is already zone-agnostic; only this prompt gate was
+/// restricted to the hand.
+fn cast_face_choice_offered_from_zone(
+    state: &GameState,
+    obj: &crate::game::game_object::GameObject,
+) -> bool {
+    obj.zone == Zone::Hand
+        || (state.format_config.command_zone && obj.zone == Zone::Command && obj.is_commander)
+}
+
 fn casting_variant_for_alternative_spell(layout: LayoutKind) -> CastingVariant {
     match layout {
         LayoutKind::Adventure => CastingVariant::Adventure,
@@ -4949,10 +4966,12 @@ pub fn handle_cast_spell_with_payment_mode(
         }
     }
 
-    // CR 715.3 / CR 720.3: Adventure-family cards from hand require choosing
-    // the normal creature face or alternative spell face.
+    // CR 715.3 / CR 720.3: Adventure-family cards from hand (or a commander cast
+    // from the command zone) require choosing the normal creature face or
+    // alternative spell face.
     if let Some(obj) = state.objects.get(&object_id) {
-        if obj.zone == Zone::Hand && alternative_spell_layout(obj).is_some() {
+        if cast_face_choice_offered_from_zone(state, obj) && alternative_spell_layout(obj).is_some()
+        {
             return Ok(WaitingFor::CastOffer {
                 player,
                 kind: CastOfferKind::Adventure {
@@ -4964,13 +4983,14 @@ pub fn handle_cast_spell_with_payment_mode(
         }
     }
 
-    // CR 712.11b: Spell//spell Modal DFCs from hand require choosing which face
-    // to cast (Esika, God of the Tree // The Prismatic Bridge, etc.). The
-    // `ChooseModalFace` handler swaps to the chosen face (if back) and re-enters
-    // this function; the swap clears the back face's Modal `layout_kind`, so the
-    // re-entry casts the chosen face without re-prompting.
+    // CR 712.11b + CR 903.8: Spell//spell Modal DFCs from hand — or from the
+    // command zone when the card is the player's commander — require choosing
+    // which face to cast (Esika, God of the Tree // The Prismatic Bridge, etc.).
+    // The `ChooseModalFace` handler swaps to the chosen face (if back) and
+    // re-enters this function; the swap clears the back face's Modal
+    // `layout_kind`, so the re-entry casts the chosen face without re-prompting.
     if let Some(obj) = state.objects.get(&object_id) {
-        if obj.zone == Zone::Hand && modal_spell_face_choice_available(obj) {
+        if cast_face_choice_offered_from_zone(state, obj) && modal_spell_face_choice_available(obj) {
             return Ok(WaitingFor::ModalFaceChoice {
                 player,
                 object_id,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -20629,6 +20629,65 @@ mod mdfc_land_tests {
         );
     }
 
+    // CR 712.11b + CR 903.8: A spell//spell Modal DFC commander (Esika, God of
+    // the Tree // The Prismatic Bridge) cast from the command zone must offer the
+    // face choice so the player can put either face on the stack (#1548). The
+    // choice was previously gated to the hand, so only the front face was
+    // castable from the command zone.
+    #[test]
+    fn mdfc_commander_cast_from_command_zone_offers_face_choice() {
+        let mut state = setup_game_at_main_phase();
+        state.format_config.command_zone = true;
+        let obj_id = create_object(
+            &mut state,
+            CardId(100),
+            PlayerId(0),
+            "Esika, God of the Tree".to_string(),
+            Zone::Command,
+        );
+        {
+            let obj = state.objects.get_mut(&obj_id).unwrap();
+            obj.is_commander = true;
+            obj.card_types = make_creature_type();
+            obj.back_face = Some(make_back_face(
+                "The Prismatic Bridge",
+                CardType {
+                    supertypes: vec![],
+                    core_types: vec![CoreType::Enchantment],
+                    subtypes: vec![],
+                },
+                Some(LayoutKind::Modal),
+            ));
+        }
+
+        let result = apply_as_current(
+            &mut state,
+            GameAction::CastSpell {
+                object_id: obj_id,
+                card_id: CardId(100),
+                targets: vec![],
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(result.waiting_for, WaitingFor::ModalFaceChoice { .. }),
+            "spell//spell MDFC commander cast from the command zone must offer \
+             ModalFaceChoice, got {:?}",
+            result.waiting_for
+        );
+
+        // Both faces must be offered (front: Esika; back: The Prismatic Bridge).
+        let candidates = crate::ai_support::legal_actions(&state);
+        let modal_actions = candidates
+            .iter()
+            .filter(|c| matches!(c, GameAction::ChooseModalFace { .. }))
+            .count();
+        assert_eq!(
+            modal_actions, 2,
+            "both MDFC commander faces must be offered from the command zone"
+        );
+    }
+
     // CR 712.8a: MDFC Creature/Land in graveyard — front face only, NOT a land
     #[test]
     fn mdfc_creature_land_in_graveyard_not_offered_as_land() {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -20660,6 +20660,17 @@ mod mdfc_land_tests {
             ));
         }
 
+        let cast_actions = crate::ai_support::legal_actions(&state)
+            .iter()
+            .filter(|action| {
+                matches!(action, GameAction::CastSpell { object_id, .. } if *object_id == obj_id)
+            })
+            .count();
+        assert_eq!(
+            cast_actions, 1,
+            "the MDFC commander must be offered as castable from the command zone"
+        );
+
         let result = apply_as_current(
             &mut state,
             GameAction::CastSpell {


### PR DESCRIPTION
## Problem

A spell//spell **Modal DFC commander** — Esika, God of the Tree // The Prismatic Bridge (and the other Kaldheim gods), Valki // Tibalt, etc. — could only be cast as its **front** face from the command zone. The back face was never offered, so its casting cost was unreachable (#1548: "Does not have the backside casting cost for prismatic bridge").

## Root cause

The two cast-time face-choice prompts were gated on `obj.zone == Zone::Hand`:
- the Adventure/Omen alternative-spell-face prompt (CR 715.3 / 720.3), and
- the spell//spell MDFC `ModalFaceChoice` prompt (CR 712.11b).

So a commander cast from the command zone passed the zone-validity check but **skipped the face choice** and cast its front face directly.

Everything *downstream* was already zone-agnostic:
- the `ChooseModalFace` re-entry handler operates on the object in any zone,
- the affordability check (`can_cast_object_now`) already simulates the back-face swap regardless of zone,
- the commander-tax surcharge (CR 903.8) keys off `Zone::Command`.

Only the two prompt gates were (incorrectly) hand-only.

## Fix

Replace the `== Zone::Hand` checks with a small predicate:

```rust
fn cast_face_choice_offered_from_zone(state, obj) -> bool {
    obj.zone == Zone::Hand
        || (state.format_config.command_zone && obj.zone == Zone::Command && obj.is_commander)
}
```

**Builds for the class**, not the card: every DFC/MDFC commander (and Adventure commander) now gets its face choice from the command zone. CR 712.11b + CR 903.8 (both verified against the rules text).

## Verification

- New test `mdfc_commander_cast_from_command_zone_offers_face_choice`: a spell//spell MDFC commander cast from the command zone returns `ModalFaceChoice`, and `legal_actions` surfaces **both** faces.
- `cargo clippy --all-targets -D warnings` clean; all 19 modal/mdfc tests pass; full `cargo test -p engine` lib suite green (9521).
- Note: two pre-existing integration tests (`elusive_otter_…`, `…yuriko…`) fail **locally** due to card-data export skew — verified failing on clean `main` without this change; they are green in CI (which regenerates card-data).

Closes #1548
