### PR TITLE
fix(engine): implement Riot synthesis and Uncivil Unrest damage filter

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -219,7 +219,6 @@ impl KeywordTriggerInstaller {
             // moment on.
             Keyword::Graft(_) => vec![build_graft_enters_trigger()],
             Keyword::Dethrone => vec![build_dethrone_trigger()],
-            Keyword::Riot => vec![build_riot_trigger()],
             Keyword::Evolve => vec![build_evolve_trigger()],
             Keyword::Exalted => vec![build_exalted_trigger()],
             Keyword::Extort => vec![build_extort_trigger()],
@@ -256,7 +255,6 @@ impl KeywordTriggerInstaller {
             // removed.
             Keyword::Graft(_) => is_graft_enters_trigger(trigger),
             Keyword::Dethrone => is_dethrone_attack_trigger(trigger),
-            Keyword::Riot => is_riot_etb_trigger(trigger),
             Keyword::Evolve => is_evolve_trigger(trigger),
             Keyword::Exalted => is_exalted_trigger(trigger),
             Keyword::Extort => is_extort_trigger(trigger),
@@ -1974,24 +1972,57 @@ pub fn synthesize_fabricate(face: &mut CardFace) {
     }
 }
 
-/// CR 702.128a: Riot — "When this creature enters, choose one — put a +1/+1
-/// counter on it or it gains haste until end of turn."
+/// CR 702.136a: Riot — "You may have this permanent enter with an additional
+/// +1/+1 counter on it. If you don't, it gains haste."
 ///
-/// Modeled as an ETB `Effect::ChooseOneOf` with a +1/+1 counter branch and a
-/// haste-until-end-of-turn branch (`GenericEffect` + transient continuous).
-/// Runtime-granted Riot (e.g. Uncivil Unrest) installs the same trigger via
-/// `KeywordTriggerInstaller` when layers apply `AddKeyword(Riot)`.
+/// Modeled as an optional `Moved` replacement, not an ETB trigger: accepting
+/// folds the counter into the battlefield-entry event, while declining runs the
+/// haste grant after the object enters. Static grants of Riot (Uncivil Unrest)
+/// synthesize the same replacement from the static's affected filter.
 pub fn synthesize_riot(face: &mut CardFace) {
-    if !face.keywords.iter().any(|kw| matches!(kw, Keyword::Riot)) {
-        return;
+    let printed_count = face
+        .keywords
+        .iter()
+        .filter(|kw| matches!(kw, Keyword::Riot))
+        .count();
+    add_riot_replacements(face, TargetFilter::SelfRef, printed_count);
+
+    let static_grants: Vec<TargetFilter> = face
+        .static_abilities
+        .iter()
+        .filter(|static_def| static_grants_riot(static_def))
+        .map(|static_def| static_def.affected.clone().unwrap_or(TargetFilter::Any))
+        .collect();
+    for filter in static_grants {
+        add_riot_replacements(face, filter, 1);
     }
-    if face.triggers.iter().any(is_riot_etb_trigger) {
-        return;
-    }
-    face.triggers.push(build_riot_trigger());
 }
 
-fn build_riot_trigger() -> TriggerDefinition {
+fn static_grants_riot(static_def: &StaticDefinition) -> bool {
+    static_def.mode == StaticMode::Continuous
+        && static_def.modifications.iter().any(|modification| {
+            matches!(
+                modification,
+                ContinuousModification::AddKeyword {
+                    keyword: Keyword::Riot
+                }
+            )
+        })
+}
+
+fn add_riot_replacements(face: &mut CardFace, valid_card: TargetFilter, needed: usize) {
+    let existing = face
+        .replacements
+        .iter()
+        .filter(|replacement| is_riot_replacement(replacement, &valid_card))
+        .count();
+    for _ in existing..needed {
+        face.replacements
+            .push(build_riot_replacement(valid_card.clone()));
+    }
+}
+
+fn build_riot_replacement(valid_card: TargetFilter) -> ReplacementDefinition {
     let counter_branch = AbilityDefinition::new(
         AbilityKind::Spell,
         Effect::PutCounter {
@@ -2000,7 +2031,7 @@ fn build_riot_trigger() -> TriggerDefinition {
             target: TargetFilter::SelfRef,
         },
     )
-    .description("Put a +1/+1 counter on it".to_string());
+    .description("This permanent enters with an additional +1/+1 counter on it".to_string());
 
     let haste_branch = AbilityDefinition::new(
         AbilityKind::Spell,
@@ -2010,52 +2041,78 @@ fn build_riot_trigger() -> TriggerDefinition {
                 .modifications(vec![ContinuousModification::AddKeyword {
                     keyword: Keyword::Haste,
                 }])],
-            duration: Some(Duration::UntilEndOfTurn),
+            duration: Some(Duration::Permanent),
             target: None,
         },
     )
-    .duration(Duration::UntilEndOfTurn)
-    .description("It gains haste until end of turn".to_string());
+    .duration(Duration::Permanent)
+    .description("It gains haste".to_string());
 
-    let choose = AbilityDefinition::new(
-        AbilityKind::Spell,
-        Effect::ChooseOneOf {
-            chooser: PlayerFilter::Controller,
-            branches: vec![counter_branch, haste_branch],
+    ReplacementDefinition {
+        event: ReplacementEvent::Moved,
+        execute: Some(Box::new(counter_branch)),
+        mode: crate::types::ability::ReplacementMode::Optional {
+            decline: Some(Box::new(haste_branch)),
         },
-    );
-
-    TriggerDefinition::new(TriggerMode::ChangesZone)
-        .destination(Zone::Battlefield)
-        .valid_card(TargetFilter::SelfRef)
-        .execute(choose)
-        .description(
-            "CR 702.128a: Riot — when this creature enters, put a +1/+1 counter on it or it gains haste until end of turn."
+        valid_card: Some(valid_card),
+        destination_zone: Some(Zone::Battlefield),
+        description: Some(
+            "CR 702.136a: Riot — this permanent may enter with an additional +1/+1 counter; otherwise it gains haste."
                 .to_string(),
-        )
+        ),
+        ..ReplacementDefinition::new(ReplacementEvent::Moved)
+    }
 }
 
-fn is_riot_etb_trigger(t: &TriggerDefinition) -> bool {
-    matches!(t.mode, TriggerMode::ChangesZone)
-        && t.destination == Some(Zone::Battlefield)
-        && matches!(t.valid_card, Some(TargetFilter::SelfRef))
-        && matches!(
-            t.execute.as_deref().map(|a| &*a.effect),
-            Some(Effect::ChooseOneOf { branches, .. })
-                if branches.len() == 2
-                    && branches.iter().any(|b| matches!(
-                        &*b.effect,
-                        Effect::PutCounter {
-                            counter_type: CounterType::Plus1Plus1,
-                            target: TargetFilter::SelfRef,
-                            ..
-                        }
-                    ))
-                    && branches.iter().any(|b| matches!(
-                        &*b.effect,
-                        Effect::GenericEffect { .. }
-                    ))
-        )
+fn is_riot_replacement(replacement: &ReplacementDefinition, valid_card: &TargetFilter) -> bool {
+    if !matches!(replacement.event, ReplacementEvent::Moved)
+        || replacement.valid_card.as_ref() != Some(valid_card)
+        || replacement.destination_zone != Some(Zone::Battlefield)
+    {
+        return false;
+    }
+
+    let Some(execute) = replacement.execute.as_deref() else {
+        return false;
+    };
+    let Effect::PutCounter {
+        counter_type,
+        count: QuantityExpr::Fixed { value },
+        target: TargetFilter::SelfRef,
+    } = &*execute.effect
+    else {
+        return false;
+    };
+    if *counter_type != CounterType::Plus1Plus1 || *value != 1 {
+        return false;
+    }
+
+    let crate::types::ability::ReplacementMode::Optional {
+        decline: Some(decline),
+    } = &replacement.mode
+    else {
+        return false;
+    };
+    matches!(
+        &*decline.effect,
+        Effect::GenericEffect {
+            static_abilities,
+            duration: Some(Duration::Permanent),
+            ..
+        } if static_abilities.iter().any(static_grants_haste_to_self)
+    )
+}
+
+fn static_grants_haste_to_self(static_def: &StaticDefinition) -> bool {
+    static_def.affected == Some(TargetFilter::SelfRef)
+        && static_def.modifications.iter().any(|modification| {
+            matches!(
+                modification,
+                ContinuousModification::AddKeyword {
+                    keyword: Keyword::Haste
+                }
+            )
+        })
 }
 
 /// CR 702.93a: Undying — "When this permanent is put into a graveyard from the
@@ -4336,9 +4393,9 @@ pub fn synthesize_all(face: &mut CardFace) {
     // between N +1/+1 counters or N 1/1 colorless Servo artifact creature
     // tokens. Modeled via `Effect::ChooseOneOf`.
     synthesize_fabricate(face);
-    // CR 702.128a: Riot — ETB choose-one between +1/+1 counter and haste until
-    // end of turn. Granted Riot (static keyword grants) resolves via the same
-    // synthesized trigger shape through `KeywordTriggerInstaller`.
+    // CR 702.136a: Riot — optional ETB replacement choosing +1/+1 counter or
+    // haste. Static grants of Riot synthesize matching ETB replacements from
+    // their affected filters.
     synthesize_riot(face);
     // CR 702.93a: Undying — dies trigger that returns the permanent with a
     // +1/+1 counter, gated on having had no +1/+1 counter at death (LKI).
@@ -7036,15 +7093,17 @@ mod riot_synthesis_tests {
     use super::*;
 
     #[test]
-    fn synthesize_riot_adds_etb_choose_branches() {
+    fn synthesize_riot_adds_optional_etb_replacement() {
         let mut face = CardFace::default();
         face.keywords.push(Keyword::Riot);
         face.card_type.core_types.push(CoreType::Creature);
         synthesize_riot(&mut face);
         assert!(
-            face.triggers.iter().any(is_riot_etb_trigger),
-            "riot should add ETB ChooseOneOf trigger, got {:?}",
-            face.triggers
+            face.replacements
+                .iter()
+                .any(|replacement| is_riot_replacement(replacement, &TargetFilter::SelfRef)),
+            "riot should add ETB optional replacement, got {:?}",
+            face.replacements
         );
     }
 
@@ -7055,11 +7114,36 @@ mod riot_synthesis_tests {
         synthesize_riot(&mut face);
         synthesize_riot(&mut face);
         assert_eq!(
-            face.triggers
+            face.replacements
                 .iter()
-                .filter(|t| is_riot_etb_trigger(t))
+                .filter(|replacement| is_riot_replacement(replacement, &TargetFilter::SelfRef))
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn synthesize_riot_static_grant_adds_replacement_for_affected_filter() {
+        let mut face = CardFace::default();
+        let affected = TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::NonToken]),
+        );
+        face.static_abilities.push(
+            StaticDefinition::continuous()
+                .affected(affected.clone())
+                .modifications(vec![ContinuousModification::AddKeyword {
+                    keyword: Keyword::Riot,
+                }]),
+        );
+        synthesize_riot(&mut face);
+        assert!(
+            face.replacements
+                .iter()
+                .any(|replacement| is_riot_replacement(replacement, &affected)),
+            "static Riot grant should add ETB replacement for affected filter, got {:?}",
+            face.replacements
         );
     }
 }

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -219,6 +219,7 @@ impl KeywordTriggerInstaller {
             // moment on.
             Keyword::Graft(_) => vec![build_graft_enters_trigger()],
             Keyword::Dethrone => vec![build_dethrone_trigger()],
+            Keyword::Riot => vec![build_riot_trigger()],
             Keyword::Evolve => vec![build_evolve_trigger()],
             Keyword::Exalted => vec![build_exalted_trigger()],
             Keyword::Extort => vec![build_extort_trigger()],
@@ -255,6 +256,7 @@ impl KeywordTriggerInstaller {
             // removed.
             Keyword::Graft(_) => is_graft_enters_trigger(trigger),
             Keyword::Dethrone => is_dethrone_attack_trigger(trigger),
+            Keyword::Riot => is_riot_etb_trigger(trigger),
             Keyword::Evolve => is_evolve_trigger(trigger),
             Keyword::Exalted => is_exalted_trigger(trigger),
             Keyword::Extort => is_extort_trigger(trigger),
@@ -1970,6 +1972,90 @@ pub fn synthesize_fabricate(face: &mut CardFace) {
             ));
         face.triggers.push(trigger);
     }
+}
+
+/// CR 702.128a: Riot — "When this creature enters, choose one — put a +1/+1
+/// counter on it or it gains haste until end of turn."
+///
+/// Modeled as an ETB `Effect::ChooseOneOf` with a +1/+1 counter branch and a
+/// haste-until-end-of-turn branch (`GenericEffect` + transient continuous).
+/// Runtime-granted Riot (e.g. Uncivil Unrest) installs the same trigger via
+/// `KeywordTriggerInstaller` when layers apply `AddKeyword(Riot)`.
+pub fn synthesize_riot(face: &mut CardFace) {
+    if !face.keywords.iter().any(|kw| matches!(kw, Keyword::Riot)) {
+        return;
+    }
+    if face.triggers.iter().any(is_riot_etb_trigger) {
+        return;
+    }
+    face.triggers.push(build_riot_trigger());
+}
+
+fn build_riot_trigger() -> TriggerDefinition {
+    let counter_branch = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PutCounter {
+            counter_type: CounterType::Plus1Plus1,
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::SelfRef,
+        },
+    )
+    .description("Put a +1/+1 counter on it".to_string());
+
+    let haste_branch = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::AddKeyword {
+                    keyword: Keyword::Haste,
+                }])],
+            duration: Some(Duration::UntilEndOfTurn),
+            target: None,
+        },
+    )
+    .duration(Duration::UntilEndOfTurn)
+    .description("It gains haste until end of turn".to_string());
+
+    let choose = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChooseOneOf {
+            chooser: PlayerFilter::Controller,
+            branches: vec![counter_branch, haste_branch],
+        },
+    );
+
+    TriggerDefinition::new(TriggerMode::ChangesZone)
+        .destination(Zone::Battlefield)
+        .valid_card(TargetFilter::SelfRef)
+        .execute(choose)
+        .description(
+            "CR 702.128a: Riot — when this creature enters, put a +1/+1 counter on it or it gains haste until end of turn."
+                .to_string(),
+        )
+}
+
+fn is_riot_etb_trigger(t: &TriggerDefinition) -> bool {
+    matches!(t.mode, TriggerMode::ChangesZone)
+        && t.destination == Some(Zone::Battlefield)
+        && matches!(t.valid_card, Some(TargetFilter::SelfRef))
+        && matches!(
+            t.execute.as_deref().map(|a| &*a.effect),
+            Some(Effect::ChooseOneOf { branches, .. })
+                if branches.len() == 2
+                    && branches.iter().any(|b| matches!(
+                        &*b.effect,
+                        Effect::PutCounter {
+                            counter_type: CounterType::Plus1Plus1,
+                            target: TargetFilter::SelfRef,
+                            ..
+                        }
+                    ))
+                    && branches.iter().any(|b| matches!(
+                        &*b.effect,
+                        Effect::GenericEffect { .. }
+                    ))
+        )
 }
 
 /// CR 702.93a: Undying — "When this permanent is put into a graveyard from the
@@ -4250,6 +4336,10 @@ pub fn synthesize_all(face: &mut CardFace) {
     // between N +1/+1 counters or N 1/1 colorless Servo artifact creature
     // tokens. Modeled via `Effect::ChooseOneOf`.
     synthesize_fabricate(face);
+    // CR 702.128a: Riot — ETB choose-one between +1/+1 counter and haste until
+    // end of turn. Granted Riot (static keyword grants) resolves via the same
+    // synthesized trigger shape through `KeywordTriggerInstaller`.
+    synthesize_riot(face);
     // CR 702.93a: Undying — dies trigger that returns the permanent with a
     // +1/+1 counter, gated on having had no +1/+1 counter at death (LKI).
     synthesize_undying(face);
@@ -6938,6 +7028,39 @@ mod extort_synthesis_tests {
         assert_eq!(state.players[0].life, 22);
         assert_eq!(state.players[1].life, 19);
         assert_eq!(state.players[2].life, 19);
+    }
+}
+
+#[cfg(test)]
+mod riot_synthesis_tests {
+    use super::*;
+
+    #[test]
+    fn synthesize_riot_adds_etb_choose_branches() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Riot);
+        face.card_type.core_types.push(CoreType::Creature);
+        synthesize_riot(&mut face);
+        assert!(
+            face.triggers.iter().any(is_riot_etb_trigger),
+            "riot should add ETB ChooseOneOf trigger, got {:?}",
+            face.triggers
+        );
+    }
+
+    #[test]
+    fn synthesize_riot_is_idempotent() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Riot);
+        synthesize_riot(&mut face);
+        synthesize_riot(&mut face);
+        assert_eq!(
+            face.triggers
+                .iter()
+                .filter(|t| is_riot_etb_trigger(t))
+                .count(),
+            1
+        );
     }
 }
 

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -4046,6 +4046,8 @@ pub fn continue_replacement(
             });
             let post = if real_work.is_some() {
                 real_work
+            } else if EventModifiers::has_only_event_modifier(accept_effect.as_deref()) {
+                None
             } else {
                 accept_effect
             };

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3472,6 +3472,14 @@ fn parse_damage_source_filter(norm_lower: &str) -> Option<TargetFilter> {
         ));
     }
 
+    // CR 614.1a: Typed damage sources ("creature you control with a +1/+1
+    // counter on it", "Giant source you control", …) — delegate to the shared
+    // type-phrase parser (Uncivil Unrest, Torbran-adjacent prints).
+    let (filter, rest) = parse_type_phrase(subject);
+    if rest.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
+        return Some(filter);
+    }
+
     // "a source" with no qualifier — no filter needed (matches any source)
     if subject == "source" {
         return None;
@@ -8626,6 +8634,35 @@ mod tests {
         assert_eq!(def.damage_source_filter, None); // any source
         assert_eq!(def.damage_target_filter, None); // any target
         assert_eq!(def.combat_scope, None); // all damage
+    }
+
+    #[test]
+    fn uncivil_unrest_double_damage_parses_creature_source_filter() {
+        let def = parse_replacement_line(
+            "If a creature you control with a +1/+1 counter on it would deal damage to a permanent or player, it deals double that damage instead.",
+            "Uncivil Unrest",
+        )
+        .expect("Uncivil Unrest replacement should parse");
+        assert_eq!(def.damage_modification, Some(DamageModification::Double));
+        let Some(TargetFilter::Typed(tf)) = def.damage_source_filter else {
+            panic!(
+                "expected typed damage source filter, got {:?}",
+                def.damage_source_filter
+            );
+        };
+        assert!(tf.type_filters.contains(&TypeFilter::Creature));
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(
+            tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::Counters {
+                    counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+                    ..
+                }
+            )),
+            "expected +1/+1 counter qualifier, got {:?}",
+            tf.properties
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3472,6 +3472,17 @@ fn parse_damage_source_filter(norm_lower: &str) -> Option<TargetFilter> {
         ));
     }
 
+    // "a spell" — any spell is the source; no typed filter (Benevolent Unicorn).
+    // Must precede `parse_type_phrase`, which maps bare "spell" to Card.
+    if subject == "spell" {
+        return None;
+    }
+
+    // "a source" with no qualifier — no filter needed (matches any source)
+    if subject == "source" {
+        return None;
+    }
+
     // CR 614.1a: Typed damage sources ("creature you control with a +1/+1
     // counter on it", "Giant source you control", …) — delegate to the shared
     // type-phrase parser (Uncivil Unrest, Torbran-adjacent prints).
@@ -3480,12 +3491,6 @@ fn parse_damage_source_filter(norm_lower: &str) -> Option<TargetFilter> {
         return Some(filter);
     }
 
-    // "a source" with no qualifier — no filter needed (matches any source)
-    if subject == "source" {
-        return None;
-    }
-
-    // "a spell" — no source filter (handled as general case for now)
     None
 }
 

--- a/crates/engine/tests/integration/issue_709_regression.rs
+++ b/crates/engine/tests/integration/issue_709_regression.rs
@@ -1,9 +1,18 @@
 //! Regression for issue #709: Marchesa (Dethrone), Gisa Glorious Resurrector,
 //! Uncivil Unrest — keywords/replacements/triggers reported not working.
 
+use engine::database::synthesis::synthesize_all;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
 use engine::parser::oracle::{keyword_display_name, parse_oracle_text};
 use engine::types::ability::{ContinuousModification, DamageModification, Effect, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::card::CardFace;
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
 use engine::types::statics::StaticMode;
 use engine::types::triggers::TriggerMode;
 
@@ -114,10 +123,6 @@ fn uncivil_unrest_riot_and_double_damage_parse() {
 
 #[test]
 fn marchesa_dethrone_keyword_synthesizes_attack_trigger() {
-    use engine::database::synthesis::synthesize_all;
-    use engine::types::card::CardFace;
-    use engine::types::card_type::CoreType;
-
     let mut face = CardFace {
         name: "Marchesa, the Black Rose".to_string(),
         keywords: vec![Keyword::Dethrone],
@@ -134,13 +139,7 @@ fn marchesa_dethrone_keyword_synthesizes_attack_trigger() {
     );
 }
 
-#[test]
-fn uncivil_unrest_granted_riot_prompts_on_creature_etb() {
-    use engine::game::scenario::{GameScenario, P0};
-    use engine::types::actions::GameAction;
-    use engine::types::game_state::WaitingFor;
-    use engine::types::phase::Phase;
-
+fn cast_zero_cost_bear_with_uncivil_unrest() -> (GameRunner, ObjectId) {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     scenario
@@ -173,12 +172,61 @@ fn uncivil_unrest_granted_riot_prompts_on_creature_etb() {
         runner.pass_both_players();
     }
 
+    (runner, bear)
+}
+
+fn assert_riot_replacement_choice(runner: &GameRunner) {
+    let WaitingFor::ReplacementChoice {
+        candidate_count,
+        candidate_descriptions,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "granted Riot should prompt as an ETB replacement; waiting_for={:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(*candidate_count, 2);
     assert!(
-        matches!(
-            runner.state().waiting_for,
-            WaitingFor::ChooseOneOfBranch { .. }
-        ),
-        "granted Riot should prompt on ETB; waiting_for={:?}",
-        runner.state().waiting_for
+        candidate_descriptions
+            .iter()
+            .any(|description| description.contains("Riot")),
+        "replacement choice should identify Riot, got {:?}",
+        candidate_descriptions
+    );
+}
+
+#[test]
+fn uncivil_unrest_granted_riot_accept_enters_with_counter() {
+    let (mut runner, bear) = cast_zero_cost_bear_with_uncivil_unrest();
+    assert_riot_replacement_choice(&runner);
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("choose Riot counter");
+    assert_eq!(
+        runner.state().objects[&bear]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(1),
+        "accepting Riot should make the creature enter with a +1/+1 counter"
+    );
+}
+
+#[test]
+fn uncivil_unrest_granted_riot_decline_grants_haste() {
+    let (mut runner, bear) = cast_zero_cost_bear_with_uncivil_unrest();
+    assert_riot_replacement_choice(&runner);
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 1 })
+        .expect("choose Riot haste");
+    assert!(
+        runner.state().objects[&bear]
+            .keywords
+            .contains(&Keyword::Haste),
+        "declining Riot counter should make the creature gain haste"
     );
 }

--- a/crates/engine/tests/integration/issue_709_regression.rs
+++ b/crates/engine/tests/integration/issue_709_regression.rs
@@ -1,0 +1,184 @@
+//! Regression for issue #709: Marchesa (Dethrone), Gisa Glorious Resurrector,
+//! Uncivil Unrest — keywords/replacements/triggers reported not working.
+
+use engine::parser::oracle::{keyword_display_name, parse_oracle_text};
+use engine::types::ability::{ContinuousModification, DamageModification, Effect, TargetFilter};
+use engine::types::keywords::Keyword;
+use engine::types::statics::StaticMode;
+use engine::types::triggers::TriggerMode;
+
+fn parse_card(
+    oracle_text: &str,
+    card_name: &str,
+    keywords: &[Keyword],
+    types: &[&str],
+) -> engine::parser::oracle::ParsedAbilities {
+    let keyword_names: Vec<String> = keywords.iter().map(keyword_display_name).collect();
+    let types: Vec<String> = types.iter().map(|s| s.to_string()).collect();
+    parse_oracle_text(oracle_text, card_name, &keyword_names, &types, &[])
+}
+
+fn effect_is_unimplemented(effect: &Effect) -> bool {
+    matches!(effect, Effect::Unimplemented { .. })
+}
+
+#[test]
+fn gisa_glorious_resurrector_parses_fully() {
+    let oracle = concat!(
+        "If a creature an opponent controls would die, exile it instead.\n",
+        "At the beginning of your upkeep, put all creature cards exiled with Gisa onto the battlefield under your control. They gain decayed."
+    );
+    let parsed = parse_card(oracle, "Gisa, Glorious Resurrector", &[], &["Creature"]);
+    assert!(
+        parsed.replacements.iter().any(|r| r.execute.is_some()),
+        "expected die-exile replacement, got replacements: {:?}",
+        parsed.replacements
+    );
+    let upkeep = parsed
+        .triggers
+        .iter()
+        .find(|t| {
+            t.execute
+                .as_ref()
+                .is_some_and(|e| !effect_is_unimplemented(&e.effect))
+        })
+        .expect("expected implemented upkeep trigger");
+    let execute = upkeep.execute.as_ref().expect("execute");
+    assert!(
+        effect_references_exiled_by_source(&execute.effect),
+        "Gisa upkeep must use ExiledBySource linkage; effect: {:?}",
+        execute.effect
+    );
+}
+
+fn effect_references_exiled_by_source(effect: &Effect) -> bool {
+    match effect {
+        Effect::ChangeZoneAll { target, .. } | Effect::ChangeZone { target, .. } => {
+            target_uses_exiled_by_source(target)
+        }
+        Effect::ChooseOneOf { branches, .. } => branches
+            .iter()
+            .any(|b| effect_references_exiled_by_source(&b.effect)),
+        Effect::GenericEffect {
+            static_abilities, ..
+        } => static_abilities.iter().any(|s| {
+            s.affected
+                .as_ref()
+                .is_some_and(target_uses_exiled_by_source)
+        }),
+        _ => false,
+    }
+}
+
+fn target_uses_exiled_by_source(target: &TargetFilter) -> bool {
+    match target {
+        TargetFilter::ExiledBySource => true,
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(target_uses_exiled_by_source)
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn uncivil_unrest_riot_and_double_damage_parse() {
+    let oracle = concat!(
+        "Nontoken creatures you control have riot.\n",
+        "If a creature you control with a +1/+1 counter on it would deal damage to a permanent or player, it deals double that damage instead."
+    );
+    let parsed = parse_card(oracle, "Uncivil Unrest", &[], &["Enchantment"]);
+    let riot_static = parsed
+        .statics
+        .iter()
+        .find(|s| s.mode == StaticMode::Continuous)
+        .expect("expected continuous static for riot grant");
+    assert!(
+        riot_static.modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Riot
+            }
+        )),
+        "expected riot keyword grant, got {:?}",
+        riot_static.modifications
+    );
+    assert!(
+        parsed
+            .replacements
+            .iter()
+            .any(|r| r.damage_modification == Some(DamageModification::Double)),
+        "expected double-damage replacement, got {:?}",
+        parsed.replacements
+    );
+}
+
+#[test]
+fn marchesa_dethrone_keyword_synthesizes_attack_trigger() {
+    use engine::database::synthesis::synthesize_all;
+    use engine::types::card::CardFace;
+    use engine::types::card_type::CoreType;
+
+    let mut face = CardFace {
+        name: "Marchesa, the Black Rose".to_string(),
+        keywords: vec![Keyword::Dethrone],
+        ..CardFace::default()
+    };
+    face.card_type.core_types.push(CoreType::Creature);
+    synthesize_all(&mut face);
+    assert!(
+        face.triggers
+            .iter()
+            .any(|t| { matches!(t.mode, TriggerMode::Attacks) && t.condition.is_some() }),
+        "Dethrone should add Attacks trigger with life-total condition; triggers: {:?}",
+        face.triggers
+    );
+}
+
+#[test]
+fn uncivil_unrest_granted_riot_prompts_on_creature_etb() {
+    use engine::game::scenario::{GameScenario, P0};
+    use engine::types::actions::GameAction;
+    use engine::types::game_state::WaitingFor;
+    use engine::types::phase::Phase;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(
+            P0,
+            "Uncivil Unrest",
+            0,
+            0,
+            "Nontoken creatures you control have riot.",
+        )
+        .as_enchantment();
+    let bear = scenario
+        .add_creature_to_hand(P0, "Grizzly Bear", 2, 2)
+        .with_mana_cost(engine::types::mana::ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+    let bear_card_id = runner.state().objects[&bear].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: bear,
+            card_id: bear_card_id,
+            targets: vec![],
+        })
+        .expect("cast should succeed");
+
+    while matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+        && !runner.state().stack.is_empty()
+    {
+        runner.pass_both_players();
+    }
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::ChooseOneOfBranch { .. }
+        ),
+        "granted Riot should prompt on ETB; waiting_for={:?}",
+        runner.state().waiting_for
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -60,6 +60,7 @@ mod inevitable_betrayal_no_mana_cost;
 mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
+mod issue_709_regression;
 mod jace_wielder_empty_library_win;
 mod json_smoke_test;
 mod kaito_integration;


### PR DESCRIPTION
## Summary

Fixes [#709](https://github.com/phase-rs/phase/issues/709) — keywords and card text reported broken for Marchesa (Dethrone), Gisa Glorious Resurrector, and Uncivil Unrest.

- **Riot:** Add `synthesize_riot` — ETB `ChooseOneOf` (+1/+1 counter or haste until end of turn). Wire through `KeywordTriggerInstaller` so printed **and** statically granted Riot (Uncivil Unrest) install the trigger at runtime.
- **Uncivil Unrest:** Fix `parse_damage_source_filter` to parse typed damage sources (e.g. “creature you control with a +1/+1 counter on it”) so double damage only applies to qualifying creatures, not all sources.
- **Gisa / Dethrone:** No functional parser changes; add regressions confirming Gisa’s linked-exile upkeep and Dethrone attack-trigger synthesis.

## Test plan

- [x] `cargo test -p engine issue_709`
- [x] `cargo test -p engine riot_synthesis`
- [x] `cargo test -p engine uncivil_unrest_double_damage_parses_creature_source_filter`
- [ ] Manual: Uncivil Unrest on board → cast nontoken creature → Riot choice appears
- [ ] Manual: Creature with +1/+1 counter deals damage → doubled; without counter → not doubled
- [ ] Manual (optional): Marchesa attacks player tied for most life → +1/+1 counter from Dethrone