### PR TITLE
feat(ui): configurable card-hover preview latency (default instant)

### DIFF
--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -6,7 +6,12 @@ import { audioManager } from "../../audio/AudioManager.ts";
 import { cacheThemeManifest, clearThemeCache } from "../../audio/audioCache.ts";
 import { BUILT_IN_THEMES, findManifest, validateThemeManifest } from "../../audio/themeRegistry.ts";
 import { PLANESWALKER_THEME } from "../../audio/planeswalkerTheme.ts";
-import { usePreferencesStore } from "../../stores/preferencesStore.ts";
+import {
+  CARD_PREVIEW_HOVER_DELAY_MAX,
+  CARD_PREVIEW_HOVER_DELAY_MIN,
+  CARD_PREVIEW_HOVER_DELAY_STEP,
+  usePreferencesStore,
+} from "../../stores/preferencesStore.ts";
 import { useMultiplayerStore } from "../../stores/multiplayerStore.ts";
 import {
   ANIMATION_SPEED_DEFAULT,
@@ -169,6 +174,8 @@ export function PreferencesModal({
   const setBattlefieldPeekOnHover = usePreferencesStore((s) => s.setBattlefieldPeekOnHover);
   const cardPreviewMode = usePreferencesStore((s) => s.cardPreviewMode) ?? "follow";
   const setCardPreviewMode = usePreferencesStore((s) => s.setCardPreviewMode);
+  const cardPreviewHoverDelayMs = usePreferencesStore((s) => s.cardPreviewHoverDelayMs) ?? 0;
+  const setCardPreviewHoverDelayMs = usePreferencesStore((s) => s.setCardPreviewHoverDelayMs);
   const artChain = usePreferencesStore((s) => s.artChain);
   const addArtChainEntry = usePreferencesStore((s) => s.addArtChainEntry);
   const removeArtChainEntry = usePreferencesStore((s) => s.removeArtChainEntry);
@@ -399,6 +406,34 @@ export function PreferencesModal({
                       {t(`visual.cardPreviewHint.${cardPreviewMode}`)}
                     </p>
                   </SettingGroup>
+
+                  {/* Hover latency only applies to the hover-driven modes; the
+                      "shift" bind-key mode is keypress-triggered, so the control
+                      is mutually exclusive with it and hidden in that mode. */}
+                  {cardPreviewMode !== "shift" && (
+                    <SettingGroup label={t("visual.cardPreviewDelay")}>
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                        <input
+                          type="range"
+                          min={CARD_PREVIEW_HOVER_DELAY_MIN}
+                          max={CARD_PREVIEW_HOVER_DELAY_MAX}
+                          step={CARD_PREVIEW_HOVER_DELAY_STEP}
+                          value={cardPreviewHoverDelayMs}
+                          onChange={(e) => setCardPreviewHoverDelayMs(Number(e.target.value))}
+                          aria-label={t("visual.cardPreviewDelay")}
+                          className="flex-1 accent-cyan-500"
+                        />
+                        <span className="font-mono text-xs tabular-nums text-slate-400 sm:w-20 sm:text-right">
+                          {cardPreviewHoverDelayMs === 0
+                            ? t("visual.cardPreviewDelayInstant")
+                            : t("visual.cardPreviewDelayValue", { ms: cardPreviewHoverDelayMs })}
+                        </span>
+                      </div>
+                      <p className="mt-1.5 text-xs text-slate-400">
+                        {t("visual.cardPreviewDelayHint")}
+                      </p>
+                    </SettingGroup>
+                  )}
 
                   <SettingGroup label={t("visual.cardArtPreferences")}>
                     <ArtChainEditor

--- a/client/src/hooks/useCardHover.ts
+++ b/client/src/hooks/useCardHover.ts
@@ -22,7 +22,10 @@ export function useCardHover(objectId: number | null) {
   const { handlers: longPressHandlers, firedRef } = useLongPress(
     useCallback(() => {
       if (objectId != null) {
-        inspectObject(objectId);
+        // Long-press is an explicit-intent gesture (already a 400ms hold), so it
+        // bypasses the configurable hover latency and shows the sticky preview now
+        // — and setting it synchronously avoids orphaning previewSticky.
+        inspectObject(objectId, undefined, "immediate");
         setPreviewSticky(true);
       }
     }, [inspectObject, setPreviewSticky, objectId]),

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -49,6 +49,10 @@
     "showKeywords": "Schlüsselwörter auf Schlachtfeldkarten anzeigen",
     "opponentHoverPreview": "Gegner-Hover-Vorschau",
     "showOpponentBoard": "Spielfeld des Gegners beim Hovern über das HUD anzeigen",
+    "cardPreviewDelay": "Hover-Verzögerung",
+    "cardPreviewDelayInstant": "Sofort",
+    "cardPreviewDelayValue": "{{ms}} ms",
+    "cardPreviewDelayHint": "So lange nach dem Überfahren einer Karte warten, bevor die Vorschau erscheint.",
     "cardPreview": "Karten-Hover-Vorschau",
     "cardPreviewOptions": {
       "follow": "Dem Cursor folgen",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -49,6 +49,10 @@
     "showKeywords": "Show keywords on battlefield cards",
     "opponentHoverPreview": "Opponent Hover Preview",
     "showOpponentBoard": "Show opponent's board on HUD hover",
+    "cardPreviewDelay": "Hover Delay",
+    "cardPreviewDelayInstant": "Instant",
+    "cardPreviewDelayValue": "{{ms}} ms",
+    "cardPreviewDelayHint": "Wait this long after hovering a card before the preview appears.",
     "cardPreview": "Card Hover Preview",
     "cardPreviewOptions": {
       "follow": "Follow cursor",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -49,6 +49,10 @@
     "showKeywords": "Mostrar palabras clave en las cartas del campo de batalla",
     "opponentHoverPreview": "Vista previa al pasar el cursor sobre el oponente",
     "showOpponentBoard": "Mostrar el tablero del oponente al pasar el cursor sobre el HUD",
+    "cardPreviewDelay": "Retardo al pasar el cursor",
+    "cardPreviewDelayInstant": "Instantáneo",
+    "cardPreviewDelayValue": "{{ms}} ms",
+    "cardPreviewDelayHint": "Espera este tiempo tras pasar el cursor sobre una carta antes de mostrar la vista previa.",
     "cardPreview": "Vista previa de la carta al pasar el cursor",
     "cardPreviewOptions": {
       "follow": "Seguir el cursor",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -49,6 +49,10 @@
     "showKeywords": "Afficher les mots-clés sur les cartes du champ de bataille",
     "opponentHoverPreview": "Aperçu au survol de l'adversaire",
     "showOpponentBoard": "Afficher le plateau de l'adversaire au survol du HUD",
+    "cardPreviewDelay": "Délai de survol",
+    "cardPreviewDelayInstant": "Instantané",
+    "cardPreviewDelayValue": "{{ms}} ms",
+    "cardPreviewDelayHint": "Attendre ce délai après le survol d'une carte avant d'afficher l'aperçu.",
     "cardPreview": "Aperçu de la carte au survol",
     "cardPreviewOptions": {
       "follow": "Suivre le curseur",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -49,6 +49,10 @@
     "showKeywords": "Mostra le parole chiave sulle carte sul campo di battaglia",
     "opponentHoverPreview": "Anteprima al passaggio sull'avversario",
     "showOpponentBoard": "Mostra il campo dell'avversario passando sull'HUD",
+    "cardPreviewDelay": "Ritardo al passaggio",
+    "cardPreviewDelayInstant": "Istantaneo",
+    "cardPreviewDelayValue": "{{ms}} ms",
+    "cardPreviewDelayHint": "Attendi questo tempo dopo aver passato il cursore su una carta prima di mostrare l'anteprima.",
     "cardPreview": "Anteprima della carta al passaggio del mouse",
     "cardPreviewOptions": {
       "follow": "Segui il cursore",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -49,6 +49,10 @@
     "showKeywords": "Pokaż słowa kluczowe na kartach na polu bitwy",
     "opponentHoverPreview": "Podgląd po najechaniu na przeciwnika",
     "showOpponentBoard": "Pokaż pole bitwy przeciwnika po najechaniu na HUD",
+    "cardPreviewDelay": "Opóźnienie podglądu",
+    "cardPreviewDelayInstant": "Natychmiast",
+    "cardPreviewDelayValue": "{{ms}} ms",
+    "cardPreviewDelayHint": "Odczekaj tyle czasu po najechaniu na kartę, zanim pojawi się podgląd.",
     "cardPreview": "Podgląd karty po najechaniu",
     "cardPreviewOptions": {
       "follow": "Podążaj za kursorem",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -49,6 +49,10 @@
     "showKeywords": "Mostrar palavras-chave nas cartas do campo de batalha",
     "opponentHoverPreview": "Pré-visualização ao Passar o Mouse sobre o Oponente",
     "showOpponentBoard": "Mostrar o tabuleiro do oponente ao passar o mouse sobre o HUD",
+    "cardPreviewDelay": "Atraso ao passar o cursor",
+    "cardPreviewDelayInstant": "Instantâneo",
+    "cardPreviewDelayValue": "{{ms}} ms",
+    "cardPreviewDelayHint": "Aguarde este tempo após passar o cursor sobre uma carta antes de mostrar a pré-visualização.",
     "cardPreview": "Pré-visualização da Carta ao Passar o Mouse",
     "cardPreviewOptions": {
       "follow": "Seguir o cursor",

--- a/client/src/stores/__tests__/uiStoreHoverLatency.test.ts
+++ b/client/src/stores/__tests__/uiStoreHoverLatency.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+import { useUiStore } from "../uiStore";
+import { usePreferencesStore } from "../preferencesStore";
+
+/**
+ * Covers the configurable card-hover latency wired into `inspectObject`. The
+ * delay is the whole feature, so these exercise the branches a regression would
+ * silently break: delayed first show, cancel-on-hover-out, instant retarget
+ * while a preview is already open, the "shift" bind-key exclusion, and the
+ * "immediate" timing bypass used by long-press.
+ */
+describe("uiStore inspectObject hover latency", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // jsdom has no matchMedia; the latency only applies on hover-capable
+    // devices, so stub "(hover: hover)" → true for these tests.
+    window.matchMedia = ((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+    useUiStore.getState().dismissPreview();
+    useUiStore.setState({ inspectedObjectId: null });
+    usePreferencesStore.setState({ cardPreviewMode: "follow", cardPreviewHoverDelayMs: 0 });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("defers the first preview by cardPreviewHoverDelayMs", () => {
+    usePreferencesStore.setState({ cardPreviewHoverDelayMs: 300 });
+    useUiStore.getState().inspectObject(5);
+
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+    vi.advanceTimersByTime(299);
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+    vi.advanceTimersByTime(1);
+    expect(useUiStore.getState().inspectedObjectId).toBe(5);
+  });
+
+  it("shows instantly when the delay is 0 (default)", () => {
+    useUiStore.getState().inspectObject(7);
+    expect(useUiStore.getState().inspectedObjectId).toBe(7);
+  });
+
+  it("cancels a pending show when the cursor leaves before the delay elapses", () => {
+    usePreferencesStore.setState({ cardPreviewHoverDelayMs: 300 });
+    useUiStore.getState().inspectObject(5);
+    vi.advanceTimersByTime(100);
+    useUiStore.getState().inspectObject(null);
+    vi.advanceTimersByTime(500);
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+  });
+
+  it("switches instantly while a preview is already open", () => {
+    usePreferencesStore.setState({ cardPreviewHoverDelayMs: 300 });
+    useUiStore.getState().inspectObject(5);
+    vi.advanceTimersByTime(300);
+    expect(useUiStore.getState().inspectedObjectId).toBe(5);
+
+    // Retarget without leaving: a preview is open, so the swap is immediate.
+    useUiStore.getState().inspectObject(6);
+    expect(useUiStore.getState().inspectedObjectId).toBe(6);
+  });
+
+  it("ignores the latency in shift bind-key mode", () => {
+    usePreferencesStore.setState({ cardPreviewMode: "shift", cardPreviewHoverDelayMs: 300 });
+    useUiStore.getState().inspectObject(5);
+    expect(useUiStore.getState().inspectedObjectId).toBe(5);
+  });
+
+  it("bypasses the latency for immediate (long-press) inspects", () => {
+    usePreferencesStore.setState({ cardPreviewHoverDelayMs: 300 });
+    useUiStore.getState().inspectObject(5, undefined, "immediate");
+    expect(useUiStore.getState().inspectedObjectId).toBe(5);
+  });
+});

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -56,6 +56,15 @@ export type CardSizePreference = "small" | "medium" | "large";
  *  "shift"  = the preview only appears while the Shift key is held (Tabletop
  *             Simulator style), letting the player read the board uninterrupted. */
 export type CardPreviewMode = "follow" | "side" | "shift";
+/** Card-preview hover latency bounds (milliseconds). `0` = instant (the
+ *  default — the preview appears the moment the cursor lands on a card). The
+ *  upper bound keeps the slider meaningful; a delay longer than ~1s defeats the
+ *  purpose of an at-a-glance preview. Only applies to the hover-driven preview
+ *  modes ("follow"/"side"); the "shift" bind-key mode shows immediately on
+ *  keypress, so the latency is mutually exclusive with it. */
+export const CARD_PREVIEW_HOVER_DELAY_MIN = 0;
+export const CARD_PREVIEW_HOVER_DELAY_MAX = 1000;
+export const CARD_PREVIEW_HOVER_DELAY_STEP = 50;
 export type HudLayout = "inline" | "floating";
 export type LogDefaultState = "open" | "closed";
 export type BattlefieldCardDisplay = "art_crop" | "full_card";
@@ -135,6 +144,7 @@ function buildDefaultPreferences(): PreferencesState {
     showKeywordStrip: true,
     battlefieldPeekOnHover: true,
     cardPreviewMode: "follow",
+    cardPreviewHoverDelayMs: 0,
     stackDockSide: "right",
     opponentHudDensity: "comfortable",
     aiSeats: [defaultAiSeat()],
@@ -192,6 +202,10 @@ interface PreferencesState {
   /** Desktop hover card-preview behavior — follow cursor, dock to the side, or
    *  only show while Shift is held. See {@link CardPreviewMode}. */
   cardPreviewMode: CardPreviewMode;
+  /** Latency (ms) before the hover preview appears in the "follow"/"side"
+   *  modes. `0` = instant (default). Ignored in "shift" mode, which is
+   *  keypress-triggered. See {@link CARD_PREVIEW_HOVER_DELAY_MAX}. */
+  cardPreviewHoverDelayMs: number;
   /** Screen edge the stack panel docks to and collapses toward. */
   stackDockSide: StackDockSide;
   /** Density of the multi-opponent HUD rail (comfortable two-row vs compact thin row). */
@@ -249,6 +263,7 @@ interface PreferencesActions {
   setShowKeywordStrip: (show: boolean) => void;
   setBattlefieldPeekOnHover: (enabled: boolean) => void;
   setCardPreviewMode: (mode: CardPreviewMode) => void;
+  setCardPreviewHoverDelayMs: (ms: number) => void;
   setAiSeatDifficulty: (index: number, difficulty: AIDifficulty) => void;
   setAiSeatDeckId: (index: number, id: AiDeckSelection) => void;
   /** Grow or shrink `aiSeats` to `count` slots. New slots inherit defaults;
@@ -361,6 +376,14 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       setShowKeywordStrip: (show) => set({ showKeywordStrip: show }),
       setBattlefieldPeekOnHover: (enabled) => set({ battlefieldPeekOnHover: enabled }),
       setCardPreviewMode: (mode) => set({ cardPreviewMode: mode }),
+      setCardPreviewHoverDelayMs: (ms) =>
+        set({
+          cardPreviewHoverDelayMs: clamp(
+            ms,
+            CARD_PREVIEW_HOVER_DELAY_MIN,
+            CARD_PREVIEW_HOVER_DELAY_MAX,
+          ),
+        }),
       setAiSeatDifficulty: (index, difficulty) =>
         set((state) => {
           if (index < 0 || index >= state.aiSeats.length) return state;
@@ -444,7 +467,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
     }),
     {
       name: "phase-preferences",
-      version: 13,
+      version: 14,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -465,6 +488,8 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       //          fixed behavior).
       // v12 → v13: Add cardPreviewMode; legacy stores default to "follow" (the
       //          prior fixed cursor-following behavior) via the shallow merge.
+      // v13 → v14: Add cardPreviewHoverDelayMs; legacy stores default to 0
+      //          (instant — the prior behavior) via the shallow merge.
       migrate: (persisted: unknown, version: number) => {
         if (!persisted || typeof persisted !== "object") return persisted;
         let migrated = persisted as Record<string, unknown>;

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -11,6 +11,10 @@ import { usePreferencesStore } from "./preferencesStore";
 // Clears are deferred — if the cursor is still over a card/preview element
 // when the timer fires, the clear is suppressed.
 let pendingClearTimer: ReturnType<typeof setTimeout> | null = null;
+// Deferred-show timer for the configurable hover latency (cardPreviewHoverDelayMs).
+// Holds the pending "set inspectedObjectId" so a hover-out before the delay
+// elapses cancels it — the preview only appears once the cursor rests on a card.
+let pendingShowTimer: ReturnType<typeof setTimeout> | null = null;
 let lastPointer = { x: 0, y: 0 };
 if (typeof window !== "undefined") {
   window.addEventListener("pointermove", (e) => { lastPointer = { x: e.clientX, y: e.clientY }; }, { passive: true });
@@ -71,7 +75,9 @@ interface UiStoreState {
 interface UiStoreActions {
   selectObject: (id: ObjectId | null) => void;
   hoverObject: (id: ObjectId | null) => void;
-  inspectObject: (id: ObjectId | null, faceIndex?: number) => void;
+  /** `timing` defaults to "hover" (subject to the configurable preview latency);
+   *  "immediate" bypasses the delay for explicit-intent triggers (long-press). */
+  inspectObject: (id: ObjectId | null, faceIndex?: number, timing?: "hover" | "immediate") => void;
   dismissPreview: () => void;
   setAltHeld: (held: boolean) => void;
   setShiftHeld: (held: boolean) => void;
@@ -116,7 +122,7 @@ interface UiStoreActions {
 
 export type UiStore = UiStoreState & UiStoreActions;
 
-export const useUiStore = create<UiStore>()((set) => ({
+export const useUiStore = create<UiStore>()((set, get) => ({
   selectedObjectId: null,
   hoveredObjectId: null,
   inspectedObjectId: null,
@@ -154,16 +160,53 @@ export const useUiStore = create<UiStore>()((set) => ({
   setDebugHighlightedPlayerId: (id) => set({ debugHighlightedPlayerId: id }),
   setAltHeld: (held) => set({ altHeld: held }),
   setShiftHeld: (held) => set({ shiftHeld: held }),
-  inspectObject: (id, faceIndex) => {
+  inspectObject: (id, faceIndex, timing = "hover") => {
     if (id != null) {
-      // Setting a new inspection target: cancel any pending clear and apply immediately
+      // Setting a new inspection target: cancel any pending clear, and drop a
+      // pending delayed-show for a previous target before scheduling this one.
       if (pendingClearTimer != null) {
         clearTimeout(pendingClearTimer);
         pendingClearTimer = null;
       }
-      set({ inspectedObjectId: id, inspectedFaceIndex: faceIndex ?? 0 });
+      if (pendingShowTimer != null) {
+        clearTimeout(pendingShowTimer);
+        pendingShowTimer = null;
+      }
+      const applyInspect = () =>
+        set({ inspectedObjectId: id, inspectedFaceIndex: faceIndex ?? 0 });
+      // Configurable hover latency (cardPreviewHoverDelayMs). The delay gates only
+      // the FIRST appearance on a hover-capable device: while a preview is already
+      // open, sweeping to an adjacent card switches instantly, and the "shift"
+      // bind-key mode is keypress-triggered so it never waits (mutually exclusive
+      // with the latency). A 0ms delay (the default) keeps the prior instant feel.
+      const prefs = usePreferencesStore.getState();
+      const canHover =
+        typeof window !== "undefined" &&
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(hover: hover)").matches;
+      const delay =
+        canHover &&
+        timing !== "immediate" &&
+        prefs.cardPreviewMode !== "shift" &&
+        get().inspectedObjectId == null
+          ? prefs.cardPreviewHoverDelayMs
+          : 0;
+      if (delay > 0) {
+        pendingShowTimer = setTimeout(() => {
+          pendingShowTimer = null;
+          applyInspect();
+        }, delay);
+      } else {
+        applyInspect();
+      }
     } else {
-      // Clearing: defer so spurious mouseleave from re-render-induced layout shifts
+      // Clearing: drop any pending delayed-show so a hover-out before the latency
+      // elapses never pops the preview.
+      if (pendingShowTimer != null) {
+        clearTimeout(pendingShowTimer);
+        pendingShowTimer = null;
+      }
+      // Defer the clear so spurious mouseleave from re-render-induced layout shifts
       // is cancelled if a new inspectObject(id) arrives in the same frame.
       if (pendingClearTimer != null) return; // already scheduled
       pendingClearTimer = setTimeout(() => {
@@ -183,6 +226,10 @@ export const useUiStore = create<UiStore>()((set) => ({
     if (pendingClearTimer != null) {
       clearTimeout(pendingClearTimer);
       pendingClearTimer = null;
+    }
+    if (pendingShowTimer != null) {
+      clearTimeout(pendingShowTimer);
+      pendingShowTimer = null;
     }
     set({ inspectedObjectId: null, inspectedFaceIndex: 0, previewSticky: false, altHeld: false });
   },


### PR DESCRIPTION
Adds a per-user **card-hover preview latency**, mutually exclusive with the existing Shift bind-key preview mode. Default is **0 ms (instant)**, so existing behavior is unchanged.

### What changed
- **preferencesStore**: new `cardPreviewHoverDelayMs` (+ clamp setter, bounds consts); persist `v13 → v14` (additive, filled via shallow-merge default).
- **uiStore.inspectObject**: the latency gates only the *first* preview appearance on hover-capable devices (`matchMedia("(hover: hover)")`); retargeting while a preview is already open is instant, and the `"shift"` bind-key mode plus the new `"immediate"` timing (long-press) bypass the delay entirely.
- **useCardHover**: long-press uses `"immediate"` timing (no orphaned `previewSticky`).
- **PreferencesModal**: a "Hover Delay" slider, hidden when Shift mode is selected (the mutual exclusivity).
- **i18n**: new keys added to all 7 supported locales (parity-gated).
- **Tests**: `uiStoreHoverLatency.test.ts` covers delay / cancel-on-leave / instant-retarget / shift-exclusion / immediate-bypass.

### Scope note
Latency applies to the in-game hover preview. Deck-builder/draft browsing previews (`mouseHoverPreview`) remain instant — left intentionally, since rapid card browsing benefits from immediate previews.

### Verification
`tsc -b`, ESLint, and Vitest (i18n + stores, incl. 6 new latency tests) all green. Browser UAT not performed.
