### PR TITLE
refactor(engine): collapse 12 Effect::*All scope siblings into Effect…

### DIFF
--- a/crates/engine/src/database/forge/effect.rs
+++ b/crates/engine/src/database/forge/effect.rs
@@ -1,6 +1,5 @@
 use crate::types::ability::{
-    ControllerRef, Effect, GainLifePlayer, ManaProduction, PtValue, QuantityExpr, TargetFilter,
-    TypedFilter,
+    ControllerRef, Effect, ManaProduction, PtValue, QuantityExpr, TargetFilter, TypedFilter,
 };
 use crate::types::mana::ManaColor;
 use crate::types::Zone;
@@ -143,14 +142,6 @@ fn resolve_defined(params: &ForgeParams) -> TargetFilter {
     }
 }
 
-/// Check if `Defined$` targets an opponent rather than the controller.
-fn defined_is_opponent(params: &ForgeParams) -> bool {
-    matches!(
-        params.get("Defined"),
-        Some("Opponent") | Some("OpponentOfTriggered")
-    )
-}
-
 // CR 120.2b: Deal damage as an effect of a spell or ability.
 fn translate_deal_damage(
     params: &ForgeParams,
@@ -180,16 +171,12 @@ fn translate_gain_life(
     resolver: &mut SvarResolver,
 ) -> Result<Effect, ForgeTranslateError> {
     let amount = resolve_quantity(params, "LifeAmount", resolver);
-    // Forge Defined$ determines who gains life. GainLifePlayer only has
-    // Controller and TargetedController — opponent gains aren't expressible
-    // in the current type, so we stay with Controller for non-opponent cases.
-    let player = if defined_is_opponent(params) {
-        // TODO: GainLifePlayer doesn't have an Opponent variant; this stays
-        // as Controller until the engine type is extended.
-        GainLifePlayer::Controller
-    } else {
-        GainLifePlayer::Controller
-    };
+    // Forge Defined$ determines who gains life. `player` is now a TargetFilter,
+    // so the opponent case can be expressed as
+    // `TargetFilter::Typed { controller: ControllerRef::Opponent }`.
+    // CR 119.3: Delegate to resolve_defined so Defined$Opponent, Targeted, etc.
+    // all map to the correct TargetFilter variant.
+    let player = resolve_defined(params);
     Ok(Effect::GainLife { amount, player })
 }
 

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8,11 +8,11 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AdditionalCost,
     AdditionalCostPaymentSource, AggregateFunction, CardPlayMode, CastVariantPaid, ChoiceType,
     Comparator, ContinuousModification, ControllerRef, CopyRetargetPermission,
-    CounterTriggerFilter, DamageKindFilter, Duration, Effect, FilterProp, GainLifePlayer,
-    KickerVariant, ManaContribution, ManaProduction, ModalSelectionCondition,
-    ModalSelectionConstraint, NinjutsuVariant, ObjectScope, PlayerFilter, PlayerScope, PtStat,
-    PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition,
-    RuntimeHandler, SearchSelectionConstraint, StaticDefinition, TargetChoiceTiming, TargetFilter,
+    CounterTriggerFilter, DamageKindFilter, Duration, Effect, FilterProp, KickerVariant,
+    ManaContribution, ManaProduction, ModalSelectionCondition, ModalSelectionConstraint,
+    NinjutsuVariant, ObjectScope, PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope,
+    QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition, RuntimeHandler,
+    SearchSelectionConstraint, StaticDefinition, TargetChoiceTiming, TargetFilter,
     TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
 };
 use crate::types::card::{CardFace, CardLayout, CleaveVariant};
@@ -2555,7 +2555,7 @@ fn build_extort_trigger() -> TriggerDefinition {
             amount: QuantityExpr::Ref {
                 qty: QuantityRef::PreviousEffectAmount,
             },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
     );
     let execute = AbilityDefinition::new(AbilityKind::Spell, drain_effect)
@@ -6597,7 +6597,7 @@ mod extort_synthesis_tests {
                 qty: QuantityRef::PreviousEffectAmount
             }
         ));
-        assert!(matches!(player, GainLifePlayer::Controller));
+        assert!(matches!(player, TargetFilter::Controller));
     }
 
     #[test]
@@ -6658,7 +6658,7 @@ mod extort_synthesis_tests {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::PreviousEffectAmount,
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9515,8 +9515,8 @@ mod tests {
         AbilityCost, AbilityTag, ActivationRestriction, AdditionalCost, AggregateFunction,
         BasicLandType, CastPermissionConstraint, CastVariantPaid, CastingPermission,
         ChosenAttribute, ChosenSubtypeKind, Comparator, ContinuousModification, ControllerRef,
-        CostCategory, FilterProp, GainLifePlayer, GameRestriction, KickerVariant, ManaContribution,
-        ManaProduction, ManaSpendPermission, ManaSpendRestriction, ModalSelectionCondition,
+        CostCategory, FilterProp, GameRestriction, KickerVariant, ManaContribution, ManaProduction,
+        ManaSpendPermission, ManaSpendRestriction, ModalSelectionCondition,
         ModalSelectionConstraint, MultiTargetSpec, ObjectProperty, ProhibitedActivity, PtValue,
         QuantityExpr, QuantityRef, RestrictionExpiry, RestrictionPlayerScope,
         SearchSelectionConstraint, StaticCondition, StaticDefinition, TargetFilter, TypeFilter,
@@ -11921,7 +11921,7 @@ mod tests {
                         amount: QuantityExpr::Ref {
                             qty: QuantityRef::PreviousEffectAmount,
                         },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )),
             );
@@ -14244,7 +14244,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 3 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )
                 .cost(AbilityCost::Composite {
@@ -14394,7 +14394,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )
                 .cost(AbilityCost::Mana {
@@ -18513,7 +18513,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 3 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
             ));
             obj.mana_cost = ManaCost::Cost {
@@ -20393,7 +20393,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 3 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
             )],
             trigger_definitions: Default::default(),

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -5111,7 +5111,7 @@ mod tests {
     #[test]
     fn cost_paid_multi_sacrifice_blood_artist_co_departed() {
         use crate::game::engine::apply_as_current;
-        use crate::types::ability::{GainLifePlayer, TargetFilter, TriggerDefinition};
+        use crate::types::ability::{TargetFilter, TriggerDefinition};
         use crate::types::phase::Phase;
         use crate::types::triggers::TriggerMode;
         use crate::types::GameAction;
@@ -5159,7 +5159,7 @@ mod tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ));
             obj.trigger_definitions.push(trig.clone());
@@ -5271,7 +5271,7 @@ mod tests {
                 is unreadable. Shares Unit B's cross-action consumption gap. See plan Unit B."]
     fn cost_paid_multi_sacrifice_kicker_paused_under_observes() {
         use crate::game::engine::apply_as_current;
-        use crate::types::ability::{GainLifePlayer, TargetFilter, TriggerDefinition};
+        use crate::types::ability::{TargetFilter, TriggerDefinition};
         use crate::types::phase::Phase;
         use crate::types::triggers::TriggerMode;
         use crate::types::GameAction;
@@ -5319,7 +5319,7 @@ mod tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ));
             obj.trigger_definitions.push(trig.clone());

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -11,8 +11,8 @@ use crate::types::ability::{
     AdditionalCost, AggregateFunction, CardTypeSetSource, ChoiceType, Comparator,
     ContinuousModification, ControllerRef, CountScope, CounterSourceRider, DelayedTriggerCondition,
     DieRollModifier, DoublePTMode, Duration, Effect, EffectOutcomeSignal, FilterProp,
-    GainLifePlayer, GameRestriction, ManaProduction, ObjectProperty, ObjectScope, PlayerFilter,
-    PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
+    GameRestriction, ManaProduction, ObjectProperty, ObjectScope, PlayerFilter, PlayerScope,
+    PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
     ReplacementDefinition, ReplacementMode, SharedQuality, SharedQualityRelation, SpeedDelta,
     SpellCastingOption, SpellCastingOptionKind, StaticCondition, StaticDefinition, TargetFilter,
     TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
@@ -1769,16 +1769,8 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         }
         Effect::GainLife { amount, player } => {
             d.push(("amount".into(), fmt_quantity(amount)));
-            if !matches!(player, GainLifePlayer::Controller) {
-                d.push((
-                    "player".into(),
-                    match player {
-                        GainLifePlayer::TargetedController => "target's controller",
-                        GainLifePlayer::TargetPlayer => "target player",
-                        GainLifePlayer::Controller => unreachable!(),
-                    }
-                    .into(),
-                ));
+            if !player.is_context_ref() {
+                d.push(("player".into(), fmt_target(player)));
             }
         }
         Effect::LoseLife { amount, .. } => {

--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -227,7 +227,7 @@ pub fn room_effects(
             lose.sub_ability = Some(Box::new(simple(
                 Effect::GainLife {
                     amount: fixed(1),
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 source_id,
                 controller,
@@ -268,7 +268,7 @@ pub fn room_effects(
             simple(
                 Effect::GainLife {
                     amount: fixed(1),
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 source_id,
                 controller,

--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -748,9 +748,7 @@ mod tests {
     // ---------------------------------------------------------------------
 
     use crate::game::effects::resolve_ability_chain;
-    use crate::types::ability::{
-        GainLifePlayer, QuantityExpr, QuantityRef, TypeFilter, TypedFilter,
-    };
+    use crate::types::ability::{QuantityExpr, QuantityRef, TypeFilter, TypedFilter};
 
     /// Builds the Fumigate-shape chain: `DestroyAll(creatures)` followed by
     /// `GainLife(amount = TrackedSetSize, player = Controller)`.
@@ -760,7 +758,7 @@ mod tests {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::TrackedSetSize,
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -922,7 +920,7 @@ mod tests {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::TrackedSetSize,
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(200),

--- a/crates/engine/src/game/effects/dig.rs
+++ b/crates/engine/src/game/effects/dig.rs
@@ -155,7 +155,7 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityCondition, AbilityKind, FilterProp, GainLifePlayer, QuantityExpr, TypedFilter,
+        AbilityCondition, AbilityKind, FilterProp, QuantityExpr, TypedFilter,
     };
     use crate::types::card_type::Supertype;
     use crate::types::identifiers::{CardId, ObjectId};
@@ -691,7 +691,7 @@ mod tests {
         let mut gain_life = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -761,7 +761,7 @@ mod tests {
         let mut gain_life = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -826,7 +826,7 @@ mod tests {
         let mut gain_life = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/effects/flip_coin.rs
+++ b/crates/engine/src/game/effects/flip_coin.rs
@@ -218,7 +218,7 @@ mod tests {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 5 },
-                player: crate::types::ability::GainLifePlayer::Controller,
+                player: crate::types::ability::TargetFilter::Controller,
             },
         ));
         let lose_effect = Box::new(AbilityDefinition::new(
@@ -361,7 +361,7 @@ mod tests {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: crate::types::ability::GainLifePlayer::Controller,
+                player: crate::types::ability::TargetFilter::Controller,
             },
         ));
 

--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{
-    Effect, EffectError, EffectKind, GainLifePlayer, ResolvedAbility, TargetFilter, TargetRef,
+    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
@@ -21,31 +21,16 @@ pub fn resolve_gain(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (amount, player_kind) = match &ability.effect {
+    let (amount, player_filter) = match &ability.effect {
         Effect::GainLife { amount, player } => (amount, player),
         _ => return Err(EffectError::MissingParam("GainLife amount".to_string())),
     };
 
-    // Resolve the target object (if any) for TargetedController.
-    let target_obj = ability.targets.iter().find_map(|t| {
-        if let TargetRef::Object(id) = t {
-            state.objects.get(id)
-        } else {
-            None
-        }
-    });
-
-    let player_id: PlayerId = match player_kind {
-        GainLifePlayer::TargetedController => target_obj
-            .map(|o| o.controller)
-            .unwrap_or(ability.controller),
-        GainLifePlayer::Controller => ability.controller,
-        // CR 115.2 + CR 601.2c: "Target player gains N life" — the
-        // chosen player is bound on `ability.targets` via the spell-
-        // announcement target slot. `target_player()` extracts the
-        // first `TargetRef::Player` and falls back to controller.
-        GainLifePlayer::TargetPlayer => ability.target_player(),
-    };
+    // CR 119.3: Who gains the life. `resolve_life_loss_target` is the single
+    // authority for player resolution from a TargetFilter — context-refs
+    // (Controller, ParentTargetController) resolve via state slots; explicit
+    // Player targets come from `ability.targets`.
+    let player_id: PlayerId = resolve_life_loss_target(state, ability, Some(player_filter));
 
     // CR 119.7: "If an effect says that a player can't gain life ... a replacement
     // effect that would replace a life gain event affecting that player won't do
@@ -477,7 +462,7 @@ mod tests {
     use crate::game::game_object::AttachTarget;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AggregateFunction, ControllerRef, GainLifePlayer, QuantityExpr, QuantityRef, SharedQuality,
+        AggregateFunction, ControllerRef, QuantityExpr, QuantityRef, SharedQuality,
         StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
@@ -516,7 +501,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 5 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -589,7 +574,7 @@ mod tests {
                         aggregate: AggregateFunction::Max,
                     },
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source,
@@ -699,7 +684,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -749,7 +734,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 5 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -995,7 +980,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 5 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(200),
@@ -1089,9 +1074,7 @@ mod tests {
     /// fallback path).
     #[test]
     fn lich_gain_life_substituted_by_draw_cards_instead() {
-        use crate::types::ability::{
-            AbilityDefinition, AbilityKind, GainLifePlayer, ReplacementDefinition,
-        };
+        use crate::types::ability::{AbilityDefinition, AbilityKind, ReplacementDefinition};
         use crate::types::replacements::ReplacementEvent;
 
         let mut state = GameState::new_two_player(42);
@@ -1137,7 +1120,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -1172,9 +1155,7 @@ mod tests {
     /// "substitution" (different event type).
     #[test]
     fn gain_life_scaling_shape_modifies_amount_does_not_substitute() {
-        use crate::types::ability::{
-            AbilityDefinition, AbilityKind, GainLifePlayer, ReplacementDefinition,
-        };
+        use crate::types::ability::{AbilityDefinition, AbilityKind, ReplacementDefinition};
         use crate::types::replacements::ReplacementEvent;
 
         let mut state = GameState::new_two_player(42);
@@ -1195,7 +1176,7 @@ mod tests {
                             qty: crate::types::ability::QuantityRef::EventContextAmount,
                         }),
                     },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         state
@@ -1208,7 +1189,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -1234,5 +1215,25 @@ mod tests {
              continuation; found {:?}",
             state.post_replacement_continuation
         );
+    }
+
+    #[test]
+    fn gain_life_target_player_uses_declared_target() {
+        // CR 115.1 + CR 119.3: "target player gains N life" — the gaining
+        // player is the declared target in ability.targets, not the controller.
+        let mut state = GameState::new_two_player(42);
+        let ability = ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 4 },
+                player: TargetFilter::Player,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve_gain(&mut state, &ability, &mut events).unwrap();
+        assert_eq!(state.players[1].life, 24, "target player (p1) gains 4 life");
+        assert_eq!(state.players[0].life, 20, "controller (p0) is unaffected");
     }
 }

--- a/crates/engine/src/game/effects/mill.rs
+++ b/crates/engine/src/game/effects/mill.rs
@@ -571,7 +571,7 @@ mod tests {
     /// `GainLife`. It is a runtime test, not a shape test.
     fn renegade_reaper_chain() -> ResolvedAbility {
         use crate::types::ability::{
-            AbilityCondition, GainLifePlayer, TargetFilter as TF, TypeFilter, TypedFilter,
+            AbilityCondition, TargetFilter as TF, TypeFilter, TypedFilter,
         };
         ResolvedAbility::new(
             Effect::Mill {
@@ -587,7 +587,7 @@ mod tests {
             let mut gain = ResolvedAbility::new(
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 4 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
                 vec![],
                 ObjectId(100),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5031,10 +5031,10 @@ mod tests {
     use crate::types::ability::{
         AbilityCondition, AbilityDefinition, AbilityKind, AggregateFunction, BounceSelection,
         CastingPermission, ChosenAttribute, Comparator, ContinuousModification, ControllerRef,
-        DelayedTriggerCondition, Duration, FilterProp, GainLifePlayer, ManaSpendPermission,
-        ObjectProperty, PermissionGrantee, PlayerFilter, PlayerScope, PtValue, QuantityExpr,
-        QuantityRef, SpellContext, StaticDefinition, TargetFilter, TargetRef, TypeFilter,
-        TypedFilter, UntilCondition,
+        DelayedTriggerCondition, Duration, FilterProp, ManaSpendPermission, ObjectProperty,
+        PermissionGrantee, PlayerFilter, PlayerScope, PtValue, QuantityExpr, QuantityRef,
+        SpellContext, StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+        UntilCondition,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -5234,7 +5234,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: amount },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -6047,7 +6047,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source,
@@ -6332,7 +6332,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::CostPaidObject,
                     },
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -6855,7 +6855,7 @@ mod tests {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::PreviousEffectAmount,
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -8004,7 +8004,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: crate::types::ability::GainLifePlayer::default(),
+                player: crate::types::ability::TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -8072,7 +8072,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: crate::types::ability::GainLifePlayer::default(),
+                player: crate::types::ability::TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -11757,7 +11757,7 @@ mod tests {
         let mut sub = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 100 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -11773,7 +11773,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -1077,7 +1077,7 @@ mod tests {
         let gain_life = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: crate::types::ability::GainLifePlayer::Controller,
+                player: crate::types::ability::TargetFilter::Controller,
             },
             vec![],
             ObjectId(500),

--- a/crates/engine/src/game/effects/reveal_hand.rs
+++ b/crates/engine/src/game/effects/reveal_hand.rs
@@ -281,7 +281,7 @@ mod tests {
     #[test]
     fn optional_reveal_hand_choice_decline_skips_continuation() {
         use crate::game::engine_resolution_choices::handle_resolution_choice;
-        use crate::types::ability::{AbilityKind, GainLifePlayer, QuantityExpr};
+        use crate::types::ability::{AbilityKind, QuantityExpr};
         use crate::types::actions::GameAction;
         use crate::types::game_state::PendingContinuation;
 
@@ -304,7 +304,7 @@ mod tests {
         let mut continuation = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -9,10 +9,9 @@ use crate::game::zones;
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, Comparator,
     ContinuousModification, ControllerRef, DelayedTriggerCondition, Duration, Effect, EffectError,
-    EffectKind, FilterProp, GainLifePlayer, ManaContribution, ManaProduction, PlayerFilter,
-    PtValue, QuantityExpr, QuantityRef, ResolvedAbility, SearchSelectionConstraint,
-    StaticDefinition, TargetFilter, TargetRef, TriggerCondition, TriggerDefinition, TypeFilter,
-    TypedFilter,
+    EffectKind, FilterProp, ManaContribution, ManaProduction, PlayerFilter, PtValue, QuantityExpr,
+    QuantityRef, ResolvedAbility, SearchSelectionConstraint, StaticDefinition, TargetFilter,
+    TargetRef, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::{CardType, CoreType, Supertype};
 use crate::types::counter::CounterType;
@@ -1564,7 +1563,7 @@ fn food_ability() -> AbilityDefinition {
         AbilityKind::Activated,
         Effect::GainLife {
             amount: QuantityExpr::Fixed { value: 3 },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
     )
     .cost(AbilityCost::Composite {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5687,9 +5687,8 @@ mod tests {
     use crate::parser::oracle::parse_oracle_text;
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ControllerRef, Effect,
-        GainLifePlayer, ManaContribution, ManaProduction, ManaSpendRestriction, QuantityExpr,
-        ResolvedAbility, StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter,
-        TypedFilter,
+        ManaContribution, ManaProduction, ManaSpendRestriction, QuantityExpr, ResolvedAbility,
+        StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CardType;
     use crate::types::card_type::CoreType;
@@ -10946,7 +10945,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 10 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )
                 .cost(AbilityCost::Composite {
@@ -11053,7 +11052,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )
                 .cost(AbilityCost::Composite {
@@ -11892,7 +11891,7 @@ mod tests {
             Box::new(ResolvedAbility::new(
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 vec![],
                 source,
@@ -12022,7 +12021,7 @@ mod trigger_target_tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, ControllerRef, Effect, GainLifePlayer, ModalChoice,
+        AbilityDefinition, AbilityKind, ControllerRef, Effect, ModalChoice,
         ModalSelectionConstraint, QuantityExpr, ResolvedAbility, StaticCondition, TargetFilter,
         TargetRef, TypedFilter,
     };
@@ -12417,7 +12416,7 @@ mod trigger_target_tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 2 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ),
                 AbilityDefinition::new(
@@ -12457,7 +12456,7 @@ mod trigger_target_tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 2 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ),
                 AbilityDefinition::new(
@@ -12544,7 +12543,7 @@ mod trigger_target_tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ),
                 AbilityDefinition::new(
@@ -12969,14 +12968,14 @@ mod trigger_target_tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 4 },
-                        player: crate::types::ability::GainLifePlayer::Controller,
+                        player: crate::types::ability::TargetFilter::Controller,
                     },
                 ),
                 AbilityDefinition::new(
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 2 },
-                        player: crate::types::ability::GainLifePlayer::Controller,
+                        player: crate::types::ability::TargetFilter::Controller,
                     },
                 ),
             ],
@@ -13984,9 +13983,9 @@ mod phase_trigger_regression_tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ControllerRef, Effect,
-        FilterProp, GainLifePlayer, ObjectScope, PlayerFilter, QuantityExpr, QuantityRef,
-        ResolvedAbility, TargetFilter, TargetRef, TriggerConstraint, TriggerDefinition, TypeFilter,
-        TypedFilter, UnlessPayModifier,
+        FilterProp, ObjectScope, PlayerFilter, QuantityExpr, QuantityRef, ResolvedAbility,
+        TargetFilter, TargetRef, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
+        UnlessPayModifier,
     };
     use crate::types::card_type::CoreType;
     use crate::types::format::FormatConfig;
@@ -14141,7 +14140,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Activated,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .trigger_zones(vec![Zone::Battlefield]),
@@ -14192,7 +14191,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Activated,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .trigger_zones(vec![Zone::Battlefield]),
@@ -14249,7 +14248,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Activated,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .trigger_zones(vec![Zone::Battlefield]),
@@ -14309,7 +14308,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Activated,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .trigger_zones(vec![Zone::Battlefield]),
@@ -14847,7 +14846,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Database,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     )),
             );
@@ -15036,7 +15035,7 @@ mod phase_trigger_regression_tests {
                                 }),
                                 offset: 1,
                             },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ),
                 ),
@@ -15420,7 +15419,7 @@ mod phase_trigger_regression_tests {
         let mut primary = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15429,7 +15428,7 @@ mod phase_trigger_regression_tests {
         let mut alternative = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15478,7 +15477,7 @@ mod phase_trigger_regression_tests {
         let mut primary = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15487,7 +15486,7 @@ mod phase_trigger_regression_tests {
         let mut alternative = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15533,7 +15532,7 @@ mod phase_trigger_regression_tests {
         let primary = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15582,7 +15581,7 @@ mod phase_trigger_regression_tests {
         let mut primary = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15591,7 +15590,7 @@ mod phase_trigger_regression_tests {
         let mut alternative = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15642,7 +15641,7 @@ mod phase_trigger_regression_tests {
             pending_effect: Box::new(ResolvedAbility::new(
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 vec![],
                 source_id,
@@ -15845,7 +15844,7 @@ mod phase_trigger_regression_tests {
             Box::new(ResolvedAbility::new(
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 2 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 vec![],
                 source_id,
@@ -15996,7 +15995,7 @@ mod phase_trigger_regression_tests {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
         let branch_lose = AbilityDefinition::new(

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -1043,9 +1043,7 @@ fn action_result(events: &mut Vec<GameEvent>, waiting_for: WaitingFor) -> Action
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{
-        AbilityCondition, GainLifePlayer, QuantityExpr, ResolvedAbility, SubAbilityLink,
-    };
+    use crate::types::ability::{AbilityCondition, QuantityExpr, ResolvedAbility, SubAbilityLink};
     use crate::types::game_state::{AutoMayChoice, MayTriggerAutoChoiceKey, MayTriggerOrigin};
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
@@ -1053,7 +1051,7 @@ mod tests {
     fn gain_life(value: i32) -> Effect {
         Effect::GainLife {
             amount: QuantityExpr::Fixed { value },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         }
     }
 

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -2117,7 +2117,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 3 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
             ),
             AbilityDefinition::new(

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3674,9 +3674,9 @@ mod tests {
     use crate::types::ability::{
         AbilityDefinition, AbilityKind, BasicLandType, ChosenSubtypeKind, CommanderOwnership,
         Comparator, ContinuousModification, ControllerRef, CountScope, Duration, Effect,
-        FilterProp, GainLifePlayer, ObjectScope, PlayerScope, PtStat, PtValueScope, QuantityExpr,
-        QuantityRef, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TypeFilter,
-        TypedFilter, ZoneRef,
+        FilterProp, ObjectScope, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef,
+        StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TypeFilter, TypedFilter,
+        ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::game_state::{StaticSourceIndex, TransientContinuousEffect};
@@ -5501,7 +5501,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ))
                 .with_trigger(TriggerMode::Attacks)
@@ -5547,7 +5547,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ))
                 .with_trigger(TriggerMode::Attacks);
@@ -5631,7 +5631,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ))
                 .with_trigger(TriggerMode::Attacks)
@@ -7296,7 +7296,7 @@ mod tests {
                 AbilityKind::Activated,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
             obj.abilities = Arc::new((*obj.base_abilities).clone());
@@ -8377,7 +8377,7 @@ mod tests {
             AbilityKind::Activated,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         )
         .cost(AbilityCost::Composite {

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -7139,7 +7139,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: target_expr.clone(),
-                player: crate::types::ability::GainLifePlayer::Controller,
+                player: crate::types::ability::TargetFilter::Controller,
             },
             vec![TargetRef::Object(target)],
             source,

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -4123,8 +4123,8 @@ mod tests {
     use crate::game::effects::token::apply_create_token_after_replacement;
     use crate::game::game_object::{AttachTarget, GameObject};
     use crate::types::ability::{
-        AbilityCost, AbilityDefinition, AbilityKind, ChosenAttribute, Effect, GainLifePlayer,
-        QuantityExpr, ReplacementDefinition, ReplacementPlayerScope, TargetFilter, TargetRef,
+        AbilityCost, AbilityDefinition, AbilityKind, ChosenAttribute, Effect, QuantityExpr,
+        ReplacementDefinition, ReplacementPlayerScope, TargetFilter, TargetRef,
     };
     use crate::types::game_state::DamageRecord;
     use crate::types::identifiers::{CardId, ObjectId};
@@ -4735,7 +4735,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ))
             .description("X".to_string());
@@ -4830,7 +4830,7 @@ mod tests {
                             qty: crate::types::ability::QuantityRef::EventContextAmount,
                         }),
                     },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         let mut state = test_state_with_object(ObjectId(10), Zone::Battlefield, vec![repl]);
@@ -4876,7 +4876,7 @@ mod tests {
                         }),
                         offset: 1,
                     },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         let mut state = test_state_with_object(ObjectId(10), Zone::Battlefield, vec![repl]);

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -735,15 +735,31 @@ pub(super) fn resolve_tap_mana_triggers_inline(
     }
 }
 
+/// CR 101.4 + CR 603.3b: APNAP rank of `controller` for trigger ordering — its
+/// index in the living turn order from the active player (0 = active player,
+/// then each non-active player in turn order). This is the primary key the
+/// simultaneous-trigger sorts must use: a binary "active vs non-active" key
+/// collapses every non-active player into one bucket and cannot order two or
+/// more of them by turn order. Controllers not in the living order (e.g. an
+/// eliminated player) sort after all living players. In a two-player game the
+/// rank is 0/1, identical to the old binary key, so nothing regresses there.
+fn apnap_rank(order: &[PlayerId], controller: PlayerId) -> usize {
+    order
+        .iter()
+        .position(|p| *p == controller)
+        .unwrap_or(order.len())
+}
+
 /// CR 603.2 + CR 603.3b: Collect every triggered ability matching `events`,
-/// apply trigger doubling, and return the contexts sorted into APNAP dispatch
-/// order (NAP first / bottom of stack, AP last / top). This is the pure
-/// *collection* half of trigger processing — it never touches
-/// `state.pending_trigger` or `state.waiting_for` and never pushes to the
-/// stack. `process_triggers` composes this with `dispatch_pending_trigger_context`
-/// for the standard path; `collect_triggers_into_deferred` composes it with the
-/// `deferred_triggers` queue for resolution-choice handlers that must collect
-/// without dispatching (issue #423).
+/// apply trigger doubling, and return the contexts sorted into APNAP stack
+/// placement order (active player first / bottom of stack, then each non-active
+/// player in turn order). This is the pure *collection* half of trigger
+/// processing — it never touches `state.pending_trigger` or `state.waiting_for`
+/// and never pushes to the stack. `process_triggers` composes this with
+/// `dispatch_pending_trigger_context` for the standard path;
+/// `collect_triggers_into_deferred` composes it with the `deferred_triggers`
+/// queue for resolution-choice handlers that must collect without dispatching
+/// (issue #423).
 fn collect_pending_triggers(
     state: &mut GameState,
     events: &[GameEvent],
@@ -1820,21 +1836,18 @@ fn collect_pending_triggers(
     // then clone matching pending triggers.
     apply_trigger_doubling(state, &mut pending);
 
-    // CR 603.3b: Active player's triggers are ordered before non-active player's triggers.
-    // Within same controller, order by timestamp.
+    // CR 603.3b + CR 101.4: Stack-placement order is full APNAP turn order
+    // (active player first / lowest on stack, then each non-active player in
+    // turn order) — not a binary active/non-active split, which mis-orders 2+
+    // non-active players in multiplayer. Within the same controller, seed the
+    // ordering prompt by timestamp.
+    let apnap = crate::game::players::apnap_order(state);
     pending.sort_by_key(|t| {
-        let is_nap = if t.pending.controller == state.active_player {
-            0
-        } else {
-            1
-        };
-        (is_nap, t.pending.timestamp)
+        (
+            apnap_rank(&apnap, t.pending.controller),
+            t.pending.timestamp,
+        )
     });
-
-    // Reverse so NAP triggers are placed first (bottom of stack), AP triggers last (top).
-    // CR 603.3b: LIFO means AP triggers resolve last (APNAP ordering).
-    pending.reverse();
-
     pending
 }
 
@@ -2054,7 +2067,7 @@ pub fn process_triggers(state: &mut GameState, events: &[GameEvent]) {
         }
         // No controller has 2+ triggers — dispatch immediately (zero behaviour
         // change for the single-trigger common case). `collect_pending_triggers`
-        // already returned the vec in NAP-first stack-placement order.
+        // already returned the vec in APNAP stack-placement order.
         TriggerOrderingDisposition::NoChoiceNeeded(pending) => {
             dispatch_collected_triggers(state, pending);
             clear_post_collection_transients(state);
@@ -2123,18 +2136,19 @@ enum TriggerOrderingDisposition {
     NoChoiceNeeded(Vec<PendingTriggerContext>),
 }
 
-/// CR 603.3b: Partition `pending` by controller (preserving the NAP-first
+/// CR 603.3b: Partition `pending` by controller (preserving the APNAP
 /// placement order produced by `collect_pending_triggers`), populate
 /// `state.pending_trigger_order` with one `TriggerOrderGroup` per controller,
-/// and return either the first ordering prompt (most-AP unordered group) or
+/// and return either the first ordering prompt (earliest APNAP unordered group) or
 /// `NoChoiceNeeded` when no group requires a choice.
 ///
 /// Choice order vs placement order — the two are intentionally distinct:
 ///   * Placement order (which group sits lower on the stack) is APNAP per
-///     CR 405.3 + 603.3b — NAP-first — and is locked by the input vec.
+///     CR 405.3 + 603.3b — active player first / lowest, then each non-active
+///     player in turn order — and is locked by the input vec.
 ///   * Choice order (which controller is prompted first) is APNAP per
-///     CR 101.4 — active player chooses first — so we prompt the
-///     most-AP unordered group, walking backwards through `groups`.
+///     CR 101.4 — active player chooses first — so we prompt the first
+///     unordered group in the same APNAP order.
 fn begin_trigger_ordering(
     state: &mut GameState,
     pending: Vec<PendingTriggerContext>,
@@ -2240,8 +2254,7 @@ pub fn drain_order_triggers_with_identity(
 }
 
 /// CR 603.3b: Build the next `WaitingFor::OrderTriggers` prompt by finding
-/// the most-AP unordered group (walk groups in reverse — `groups` is NAP-first
-/// placement order, so reverse iteration is AP-first choice order).
+/// the earliest unordered group in APNAP order.
 /// Returns `None` if every group is `ordered` (caller should dispatch).
 fn build_next_order_triggers_prompt(
     state: &GameState,
@@ -2249,7 +2262,7 @@ fn build_next_order_triggers_prompt(
     use crate::types::game_state::{PendingTriggerSummary, WaitingFor};
 
     let order = state.pending_trigger_order.as_ref()?;
-    let group = order.groups.iter().rev().find(|g| !g.ordered)?;
+    let group = order.groups.iter().find(|g| !g.ordered)?;
     let triggers: Vec<PendingTriggerSummary> = group
         .triggers
         .iter()
@@ -2286,8 +2299,8 @@ fn is_valid_permutation(order: &[usize], len: usize) -> bool {
 }
 
 /// CR 603.3b: Apply a player's chosen order to their group, then either emit
-/// the next `OrderTriggers` prompt (next-most-AP unordered group) or — when
-/// every group is ordered — concatenate them in placement order (NAP-first)
+/// the next `OrderTriggers` prompt (next APNAP unordered group) or — when
+/// every group is ordered — concatenate them in APNAP placement order
 /// and dispatch through the standard pipeline. The ordering-vs-input-pause
 /// invariant (issue #531 v2): every group's ordering is fully resolved
 /// *before* any trigger is dispatched, so a trigger that pauses on input
@@ -2305,11 +2318,12 @@ pub(crate) fn handle_order_triggers(
         )
     })?;
 
-    // Locate the most-AP unordered group — same selector as `build_next_order_triggers_prompt`.
+    // Locate the earliest APNAP unordered group — same selector as
+    // `build_next_order_triggers_prompt`.
     let target_idx = pending_order
         .groups
         .iter()
-        .rposition(|g| !g.ordered)
+        .position(|g| !g.ordered)
         .ok_or_else(|| {
             super::engine::EngineError::InvalidAction(
                 "OrderTriggers submitted but every group is already ordered".to_string(),
@@ -2341,7 +2355,7 @@ pub(crate) fn handle_order_triggers(
         return Ok(wf);
     }
 
-    // All groups ordered — concatenate in placement order (NAP-first) and
+    // All groups ordered — concatenate in APNAP placement order and
     // dispatch through the same loop `process_triggers` uses. Reset
     // `state.waiting_for` to Priority before dispatch so the post-dispatch
     // check below correctly detects whether dispatch set a NEW pause state
@@ -3064,16 +3078,11 @@ pub fn check_state_triggers(state: &mut GameState) {
         return;
     }
 
-    // CR 603.3b: APNAP ordering for state triggers.
-    pending.sort_by_key(|t| {
-        let is_nap = if t.controller == state.active_player {
-            0
-        } else {
-            1
-        };
-        (is_nap, t.timestamp)
-    });
-    pending.reverse();
+    // CR 603.3b + CR 101.4: Full APNAP stack-placement order for state triggers
+    // (active player lowest, then each non-active player in turn order),
+    // tiebroken by timestamp.
+    let apnap = crate::game::players::apnap_order(state);
+    pending.sort_by_key(|t| (apnap_rank(&apnap, t.controller), t.timestamp));
 
     let mut events_out = Vec::new();
     for trigger in pending {
@@ -3122,17 +3131,13 @@ pub fn check_delayed_triggers(state: &mut GameState, events: &[GameEvent]) -> Ve
 
     let mut new_events = Vec::new();
 
-    // CR 603.3b: APNAP ordering — active player's triggers go on stack last (resolve first).
-    // Sort so NAP triggers come first (pushed to stack bottom), AP triggers last (stack top).
-    to_fire.sort_by_key(|(trigger, _)| {
-        let is_nap = if trigger.controller == state.active_player {
-            0
-        } else {
-            1
-        };
-        (is_nap, state.turn_number)
-    });
-    to_fire.reverse();
+    // CR 603.3b + CR 101.4: Full APNAP stack-placement order — active player's
+    // triggers go lowest, then each non-active player's triggers in turn order.
+    // The old `state.turn_number` tiebreaker was constant across this batch, so
+    // dropping it changes nothing; `sort_by_key` is stable, preserving the
+    // prior same-controller ordering before stack placement.
+    let apnap = crate::game::players::apnap_order(state);
+    to_fire.sort_by_key(|(trigger, _)| apnap_rank(&apnap, trigger.controller));
 
     for (trigger, trigger_event) in to_fire {
         let pending = PendingTrigger {
@@ -4293,11 +4298,10 @@ pub mod tests {
         AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AdditionalCost,
         AggregateFunction, ChosenAttribute, ChosenSubtypeKind, CommanderOwnership, Comparator,
         ContinuousModification, ControllerRef, DelayedTriggerCondition, Duration, Effect,
-        FilterProp, GainLifePlayer, KickerVariant, MultiTargetSpec, PaymentCost, PlayerFilter,
-        PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, ResolvedAbility,
-        SearchSelectionConstraint, SharedQuality, SharedQualityRelation, StaticCondition,
-        StaticDefinition, TargetFilter, TargetRef, TriggerCondition, TriggerConstraint,
-        TriggerDefinition, TypeFilter, TypedFilter,
+        FilterProp, KickerVariant, MultiTargetSpec, PaymentCost, PlayerFilter, PlayerScope, PtStat,
+        PtValueScope, QuantityExpr, QuantityRef, ResolvedAbility, SearchSelectionConstraint,
+        SharedQuality, SharedQualityRelation, StaticCondition, StaticDefinition, TargetFilter,
+        TargetRef, TriggerCondition, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -5685,15 +5689,15 @@ pub mod tests {
         // Both triggers should be on the stack
         assert_eq!(state.stack.len(), 2);
 
-        // AP (P0) triggers should be on top of stack (resolve last = placed last)
-        // NAP (P1) triggers should be on bottom (resolve first = placed first)
+        // AP (P0) triggers are placed first, so they are lowest on the stack;
+        // NAP (P1) triggers are placed after them and resolve first.
         let top = &state.stack[state.stack.len() - 1];
         let bottom = &state.stack[0];
-        assert_eq!(top.controller, PlayerId(0), "AP trigger should be on top");
+        assert_eq!(top.controller, PlayerId(1), "NAP trigger should be on top");
         assert_eq!(
             bottom.controller,
-            PlayerId(1),
-            "NAP trigger should be on bottom"
+            PlayerId(0),
+            "AP trigger should be on bottom"
         );
     }
 
@@ -6119,9 +6123,10 @@ pub mod tests {
         process_triggers(&mut state, &events);
 
         assert_eq!(state.stack.len(), 2);
-        // APNAP: AP (P0) on top, NAP (P1) on bottom
-        assert_eq!(state.stack[state.stack.len() - 1].controller, PlayerId(0));
-        assert_eq!(state.stack[0].controller, PlayerId(1));
+        // CR 603.3b: AP triggers are placed first, so they are lower on the
+        // stack; NAP triggers are placed after them and resolve first.
+        assert_eq!(state.stack[state.stack.len() - 1].controller, PlayerId(1));
+        assert_eq!(state.stack[0].controller, PlayerId(0));
     }
 
     #[test]
@@ -6608,7 +6613,7 @@ pub mod tests {
                 AbilityKind::Database,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 3 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             )),
         );
@@ -9239,7 +9244,7 @@ pub mod tests {
                         AbilityKind::Spell,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 2 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .description("When this creature dies, you gain 2 life.".to_string()),
@@ -15075,7 +15080,7 @@ pub mod tests {
                 AbilityKind::Database,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         {
@@ -15140,7 +15145,7 @@ pub mod tests {
                 AbilityKind::Database,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         let obj = state.objects.get_mut(&observer).unwrap();
@@ -15234,7 +15239,7 @@ pub mod tests {
                 AbilityKind::Database,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         let obj = state.objects.get_mut(&observer).unwrap();
@@ -17024,11 +17029,63 @@ mod dedup_regression_tests {
         );
     }
 
+    /// CR 603.3b + CR 101.4: With the active player NOT in seat 0, two
+    /// non-active players' simultaneous triggers must be placed in turn order
+    /// from the active player — not by timestamp. Regression for the binary
+    /// active/non-active sort key that lumped every non-active player into one
+    /// timestamp-ordered bucket: here P0's source is older than P2's, so the old
+    /// key placed P0 before P2 by timestamp, but turn order from active P1 is
+    /// P1, P2, P0, so P2 must be lower on the stack than P0.
+    #[test]
+    fn order_triggers_apnap_two_nonactive_players_use_turn_order() {
+        let mut state = GameState::new(crate::types::format::FormatConfig::commander(), 3, 123);
+        // Active player is P1 (seat 1) — the case the binary key gets wrong.
+        state.active_player = PlayerId(1);
+        state.priority_player = PlayerId(1);
+        state.phase = Phase::Upkeep;
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(1),
+        };
+
+        // One trigger each for two non-active players, so neither is prompted to
+        // order and both reach the stack directly. P0's source is OLDER than
+        // P2's, so a timestamp-based NAP ordering would place P0 first.
+        let p2 = make_phase_trigger_source(&mut state, PlayerId(2), "P2 Source", 1);
+        let p0 = make_phase_trigger_source(&mut state, PlayerId(0), "P0 Source", 1);
+        state.objects.get_mut(&p0).unwrap().entered_battlefield_turn = Some(1);
+        state.objects.get_mut(&p2).unwrap().entered_battlefield_turn = Some(2);
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::PhaseChanged {
+                phase: Phase::Upkeep,
+            }],
+        );
+
+        // Neither player controls 2+ triggers, so there is no ordering prompt.
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }),
+            "single trigger per player must not prompt; got {:?}",
+            state.waiting_for
+        );
+
+        // Turn order from active P1 is P1, P2, P0. The engine stores the stack
+        // bottom-to-top, so P2 is lower and P0 is above it. The old binary key
+        // ordered the two NAPs by timestamp instead, yielding [P0, P2].
+        let stack_sources = stack_source_ids(&state);
+        assert_eq!(stack_sources.len(), 2, "both triggers reach the stack");
+        assert_eq!(
+            stack_sources,
+            vec![p2, p0],
+            "non-active players must be placed by turn order (P2 below P0), not timestamp"
+        );
+    }
+
     /// CR 603.3b + CR 101.4 + CR 405.3: In a 3-player game with both AP and
     /// NAP controlling 2 simultaneous triggers each, the active player is
     /// prompted FIRST (CR 101.4 — APNAP choice order), then each NAP in turn
-    /// order. The final stack reflects the placement order (NAP-first =
-    /// bottom of stack) per CR 405.3.
+    /// order. The final stack reflects the placement order (AP first = bottom
+    /// of stack) per CR 405.3.
     #[test]
     fn order_triggers_apnap_three_players() {
         let mut state = GameState::new(crate::types::format::FormatConfig::commander(), 3, 123);
@@ -17085,23 +17142,23 @@ mod dedup_regression_tests {
         )
         .expect("P1 submits");
 
-        // Now all four triggers must be on the stack; NAP's pair must be
-        // placed FIRST (bottom of stack per CR 405.3 + 603.3b APNAP).
+        // Now all four triggers must be on the stack; AP's pair must be placed
+        // FIRST (bottom of stack per CR 405.3 + 603.3b APNAP).
         let stack_sources = stack_source_ids(&state);
         assert_eq!(stack_sources.len(), 4, "four triggers on the stack");
-        // Bottom two are the NAP (P1)'s pair; top two are AP (P0)'s pair.
+        // Bottom two are the AP (P0)'s pair; top two are the NAP (P1)'s pair.
         let p1_ids = [p1_a, p1_b];
         let p0_ids = [p0_a, p0_b];
         for id in &stack_sources[0..2] {
             assert!(
-                p1_ids.contains(id),
-                "stack bottom must contain NAP triggers (CR 405.3 + 603.3b)"
+                p0_ids.contains(id),
+                "stack bottom must contain AP triggers (CR 405.3 + 603.3b)"
             );
         }
         for id in &stack_sources[2..4] {
             assert!(
-                p0_ids.contains(id),
-                "stack top must contain AP triggers (CR 405.3 + 603.3b)"
+                p1_ids.contains(id),
+                "stack top must contain NAP triggers (CR 405.3 + 603.3b)"
             );
         }
     }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -25,10 +25,9 @@ use crate::parser::oracle_static::{
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, CategoryChooserScope, ChoiceType,
     Chooser, ContinuousModification, ControllerRef, CopyRetargetPermission, Duration, Effect,
-    FilterProp, GainLifePlayer, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool,
-    PaymentCost, PlayerScope, PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr,
-    QuantityRef, SearchSelectionConstraint, StaticDefinition, TargetFilter, TypeFilter,
-    TypedFilter, ZoneOwner,
+    FilterProp, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool, PaymentCost, PlayerScope,
+    PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
+    SearchSelectionConstraint, StaticDefinition, TargetFilter, TypeFilter, TypedFilter, ZoneOwner,
 };
 use crate::types::card_type::CoreType;
 use crate::types::phase::Phase;
@@ -654,7 +653,7 @@ pub(super) fn lower_numeric_imperative_ast(ast: NumericImperativeAst) -> Effect 
         },
         NumericImperativeAst::GainLife { amount } => Effect::GainLife {
             amount,
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
         NumericImperativeAst::LoseLife { amount } => Effect::LoseLife {
             amount,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -86,13 +86,13 @@ use crate::types::ability::{
     BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
     ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard,
     ContinuousModification, ControllerRef, DamageModification, DamageSource,
-    DelayedTriggerCondition, DoubleTarget, Duration, Effect, FilterProp, GainLifePlayer,
-    GameRestriction, IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec,
-    ObjectProperty, ObjectScope, PaymentCost, PlayerFilter, PlayerScope, PreventionAmount,
-    PreventionScope, ProhibitedActivity, QuantityExpr, QuantityRef, ReplacementDefinition,
-    RestrictionExpiry, RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition,
-    StepSkipTarget, SubAbilityLink, TargetFilter, TargetSelectionMode, TriggerCondition,
-    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
+    DelayedTriggerCondition, DoubleTarget, Duration, Effect, FilterProp, GameRestriction,
+    IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty,
+    ObjectScope, PaymentCost, PlayerFilter, PlayerScope, PreventionAmount, PreventionScope,
+    ProhibitedActivity, QuantityExpr, QuantityRef, ReplacementDefinition, RestrictionExpiry,
+    RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition, StepSkipTarget,
+    SubAbilityLink, TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition,
+    TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterType;
@@ -3478,7 +3478,9 @@ fn try_parse_choose_player_to_verb(
 /// `TargetFilter` are left untouched — the surrounding `relative_player_scope`
 /// already binds object-controller anaphora ("a creature they control").
 ///
-/// `GainLife` (recipient is the `GainLifePlayer` enum, not a `TargetFilter`)
+/// `GainLife` (recipient `player` is now a `TargetFilter`, but no current card
+/// pairs "choose a player to gain life" with this verb, so it is not yet wired
+/// into the `rebind` match below)
 /// and `Discard`/`DiscardCard` (no player-recipient `TargetFilter` — `Discard`
 /// is self-scoped, `DiscardCard.filter` selects *what* is discarded, not
 /// *who*) are a deliberate class-boundary deferral: no current card pairs
@@ -6588,10 +6590,10 @@ fn thread_for_each_subject(effect: Effect, original: &str) -> Effect {
         },
         Effect::GainLife {
             amount,
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         } if is_targeted && matches!(target, TargetFilter::Player) => Effect::GainLife {
             amount,
-            player: GainLifePlayer::TargetPlayer,
+            player: TargetFilter::Player,
         },
         other => other,
     }
@@ -8796,7 +8798,7 @@ fn rewrite_recipient_on_link(def: &mut AbilityDefinition, filter: &TargetFilter)
         // Any other effect family is out of scope for compound-subject
         // distribution at this entry point. Returning false keeps the
         // detector tight and prevents silent misparse on bodies whose
-        // recipient binding is encoded differently (GainLifePlayer enum, etc.).
+        // recipient binding is encoded differently (e.g. nested filter props).
         _ => false,
     }
 }
@@ -15822,10 +15824,10 @@ mod tests {
         AbilityCondition, AggregateFunction, BounceSelection, CardTypeSetSource, CastVariantPaid,
         ChoiceType, CombatRelation, CombatRelationSubject, Comparator, ContinuousModification,
         ControllerRef, CopyRetargetPermission, CountScope, DoublePTMode, Duration, FilterProp,
-        GainLifePlayer, LibraryPosition, LinkedExileScope, ManaContribution, ManaProduction,
-        ObjectProperty, ObjectScope, PaymentCost, PermissionGrantee, PtStat, PtValue, PtValueScope,
-        QuantityExpr, QuantityRef, SearchSelectionConstraint, SharedQuality, TargetChoiceTiming,
-        TypeFilter, TypedFilter, ZoneRef,
+        LibraryPosition, LinkedExileScope, ManaContribution, ManaProduction, ObjectProperty,
+        ObjectScope, PaymentCost, PermissionGrantee, PtStat, PtValue, PtValueScope, QuantityExpr,
+        QuantityRef, SearchSelectionConstraint, SharedQuality, TargetChoiceTiming, TypeFilter,
+        TypedFilter, ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::game_state::{DistributionUnit, TargetSelectionConstraint};
@@ -21042,7 +21044,7 @@ mod tests {
                             scope: crate::types::ability::ObjectScope::Target
                         }
                     },
-                    player: GainLifePlayer::TargetedController
+                    player: TargetFilter::ParentTargetController
                 }
             ),
             "Expected TargetPower + TargetedController, got {e:?}"
@@ -21073,7 +21075,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::Target
                     }
                 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }
@@ -21244,7 +21246,7 @@ mod tests {
         assert!(matches!(
             &*gain_life.effect,
             Effect::GainLife {
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
                 amount: QuantityExpr::Fixed { value: 3 },
             }
         ));
@@ -32493,7 +32495,7 @@ mod tests {
                         },
                     }),
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
     }
@@ -32509,7 +32511,7 @@ mod tests {
                         filter: TargetFilter::Typed(TypedFilter::creature()),
                     },
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
     }
@@ -32716,7 +32718,7 @@ mod tests {
                         },
                     }),
                 },
-                player: GainLifePlayer::TargetPlayer,
+                player: TargetFilter::Player,
             },
         );
     }

--- a/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__assembly_gain_life_draw.snap
+++ b/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__assembly_gain_life_draw.snap
@@ -10,8 +10,7 @@ expression: def
     "amount": {
       "type": "Fixed",
       "value": 3
-    },
-    "player": "controller"
+    }
   },
   "cost": null,
   "sub_ability": {

--- a/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__assembly_three_clause_destroy_lose_gain.snap
+++ b/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__assembly_three_clause_destroy_lose_gain.snap
@@ -38,8 +38,7 @@ expression: def
         "amount": {
           "type": "Fixed",
           "value": 2
-        },
-        "player": "controller"
+        }
       },
       "cost": null,
       "sub_ability": null,

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -10,8 +10,8 @@ use super::{resolve_it_pronoun, ParseContext};
 use crate::parser::oracle_ir::ast::*;
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, ContinuousModification, ControllerRef, Duration, Effect,
-    FilterProp, GainLifePlayer, MultiTargetSpec, PlayerFilter, PlayerScope, PtValue, QuantityExpr,
-    QuantityRef, StaticDefinition, TargetFilter, TypedFilter,
+    FilterProp, MultiTargetSpec, PlayerFilter, PlayerScope, PtValue, QuantityExpr, QuantityRef,
+    StaticDefinition, TargetFilter, TypedFilter,
 };
 use crate::types::game_state::DayNight;
 use crate::types::keywords::Keyword;
@@ -2576,7 +2576,7 @@ pub(super) fn try_parse_targeted_controller_gain_life(text: &str) -> Option<Pars
     };
     Some(parsed_clause(Effect::GainLife {
         amount,
-        player: GainLifePlayer::TargetedController,
+        player: TargetFilter::ParentTargetController,
     }))
 }
 
@@ -3285,7 +3285,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::Target
                     }
                 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }
@@ -3305,7 +3305,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::Target
                     }
                 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }
@@ -3325,7 +3325,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::Target
                     }
                 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }
@@ -3339,7 +3339,7 @@ mod tests {
             clause.effect,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
@@ -20,8 +20,7 @@ expression: "&ir"
                   "type": "Anaphoric"
                 }
               }
-            },
-            "player": "controller"
+            }
           },
           "cost": null,
           "sub_ability": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_lowered.snap
@@ -20,8 +20,7 @@ expression: "&lowered"
                 "type": "Anaphoric"
               }
             }
-          },
-          "player": "controller"
+          }
         },
         "cost": null,
         "sub_ability": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
@@ -38,7 +38,9 @@ expression: "&ir"
                 }
               }
             },
-            "player": "targeted_controller"
+            "player": {
+              "type": "ParentTargetController"
+            }
           },
           "cost": null,
           "sub_ability": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_lowered.snap
@@ -37,7 +37,9 @@ expression: "&lowered"
               }
             }
           },
-          "player": "targeted_controller"
+          "player": {
+            "type": "ParentTargetController"
+          }
         },
         "cost": null,
         "sub_ability": null,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -14889,7 +14889,7 @@ mod tests {
                 // subject by a post-hoc `player_scope` override.
                 assert_eq!(
                     player,
-                    &crate::types::ability::GainLifePlayer::Controller,
+                    &crate::types::ability::TargetFilter::Controller,
                     "Exquisite Blood: 'you gain' recipient must be the ability controller"
                 );
             }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -768,35 +768,6 @@ pub enum ZoneRef {
     Hand,
 }
 
-/// Who gains life from a GainLife effect.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum GainLifePlayer {
-    /// The ability's controller (default).
-    #[default]
-    Controller,
-    /// The controller of the targeted permanent.
-    TargetedController,
-    /// CR 115.2 + CR 601.2c + CR 119.3: An announced target player. The
-    /// engine resolves this via `ResolvedAbility::target_player()`, which
-    /// returns the first `TargetRef::Player` from `ability.targets` (and
-    /// falls back to controller when no Player target was announced).
-    /// Set by the parser/converter when the Oracle text is "target player
-    /// gains N life" rather than "you gain N life" or "[permanent's]
-    /// controller gains N life."
-    TargetPlayer,
-}
-
-/// How much life is gained — a fixed amount or derived from the targeted permanent.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type", content = "value")]
-pub enum LifeAmount {
-    /// Gain a specific number of life.
-    Fixed(i32),
-    /// Gain life equal to the targeted permanent's power.
-    TargetPower,
-}
-
 /// CR 701.10d-f: What aspect to double (counters, life total, or mana pool).
 /// Used by `Effect::Double` per locked decision D-05.
 /// DoublePT/DoublePTAll handle CR 701.10a-c (power/toughness) separately.
@@ -5269,9 +5240,12 @@ pub enum Effect {
     GainLife {
         #[serde(default = "default_quantity_one")]
         amount: QuantityExpr,
-        /// Who gains the life.
-        #[serde(default)]
-        player: GainLifePlayer,
+        /// CR 119.3: Who gains the life. Defaults to Controller (omitted from JSON).
+        #[serde(
+            default = "default_target_filter_controller",
+            skip_serializing_if = "is_target_filter_controller"
+        )]
+        player: TargetFilter,
     },
     LoseLife {
         #[serde(default = "default_quantity_one")]
@@ -7080,6 +7054,10 @@ fn default_target_filter_controller() -> TargetFilter {
     TargetFilter::Controller
 }
 
+fn is_target_filter_controller(t: &TargetFilter) -> bool {
+    matches!(t, TargetFilter::Controller)
+}
+
 fn default_target_filter_self_ref() -> TargetFilter {
     TargetFilter::SelfRef
 }
@@ -7588,7 +7566,11 @@ impl Effect {
             Effect::Dig { player, .. }
             | Effect::ExileTop { player, .. }
             | Effect::ExchangeLifeWithStat { player, .. }
-            | Effect::ExileFromTopUntil { player, .. } => Some(player),
+            | Effect::ExileFromTopUntil { player, .. }
+            // CR 119.3: `GainLife.player` is a TargetFilter. `extract_target_filter_from_effect`
+            // drops context-refs (Controller) via `.filter(|t| !t.is_context_ref())`, so the
+            // default "you gain life" still surfaces no target slot.
+            | Effect::GainLife { player, .. } => Some(player),
 
             // CR 115.1a + CR 601.2c: "Create a [Role/Aura] token attached to
             // target creature" targets its host — surface `attach_to` as the
@@ -7629,7 +7611,6 @@ impl Effect {
             Effect::StartYourEngines { .. }
             | Effect::Myriad
             | Effect::ChangeSpeed { .. }
-            | Effect::GainLife { .. }
             | Effect::PumpAll { .. }
             | Effect::DamageAll { .. }
             | Effect::DamageEachPlayer { .. }
@@ -12593,7 +12574,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ))),
             valid_card: Some(TargetFilter::SelfRef),
@@ -13475,7 +13456,7 @@ mod modal_ability_tests {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
         let modal = ModalChoice {

--- a/crates/engine/tests/integration/elemental_spectacle_regression.rs
+++ b/crates/engine/tests/integration/elemental_spectacle_regression.rs
@@ -2,9 +2,7 @@ use engine::game::ability_utils::build_resolved_from_def;
 use engine::game::effects::resolve_ability_chain;
 use engine::game::zones::create_object;
 use engine::parser::parse_oracle_text;
-use engine::types::ability::{
-    Effect, GainLifePlayer, QuantityExpr, QuantityRef, TargetFilter, TypeFilter,
-};
+use engine::types::ability::{Effect, QuantityExpr, QuantityRef, TargetFilter, TypeFilter};
 use engine::types::card_type::CoreType;
 use engine::types::events::GameEvent;
 use engine::types::game_state::GameState;
@@ -80,7 +78,7 @@ fn elemental_spectacle_counts_distinct_controlled_permanent_colors_for_tokens() 
             amount: QuantityExpr::Ref {
                 qty: QuantityRef::ObjectCount { .. },
             },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         }
     ));
 

--- a/crates/engine/tests/integration/exquisite_blood_routing.rs
+++ b/crates/engine/tests/integration/exquisite_blood_routing.rs
@@ -8,7 +8,7 @@
 //! `TriggeringPlayer` whenever the trigger's subject was opponent-scoped. That
 //! ignored the *effect*-level subject ("you"), causing the opponent to gain
 //! life instead of the controller. The fix deletes the rewire and relies on
-//! the effect's own subject (`GainLifePlayer::Controller`) to route correctly.
+//! the effect's own subject (`TargetFilter::Controller`) to route correctly.
 //!
 //! CR 119.3: If an effect causes a player to gain life, that player's life
 //!           total is adjusted accordingly — the recipient is determined by
@@ -18,7 +18,7 @@
 //! the ability controller, regardless of the trigger's subject.
 
 use engine::game::effects;
-use engine::types::ability::{Effect, GainLifePlayer, QuantityExpr, QuantityRef, ResolvedAbility};
+use engine::types::ability::{Effect, QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter};
 use engine::types::events::GameEvent;
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
@@ -46,7 +46,7 @@ fn exquisite_blood_heals_controller_not_triggering_opponent() {
             amount: QuantityExpr::Ref {
                 qty: QuantityRef::EventContextAmount,
             },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
         vec![],
         ObjectId(100), // Exquisite Blood

--- a/crates/engine/tests/integration/riot_control_regression.rs
+++ b/crates/engine/tests/integration/riot_control_regression.rs
@@ -19,8 +19,8 @@
 use engine::game::effects;
 use engine::game::zones::create_object;
 use engine::types::ability::{
-    ControllerRef, Effect, GainLifePlayer, PreventionAmount, PreventionScope, QuantityExpr,
-    QuantityRef, ResolvedAbility, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+    ControllerRef, Effect, PreventionAmount, PreventionScope, QuantityExpr, QuantityRef,
+    ResolvedAbility, TargetFilter, TargetRef, TypeFilter, TypedFilter,
 };
 use engine::types::game_state::GameState;
 use engine::types::identifiers::CardId;
@@ -84,7 +84,7 @@ fn riot_control_chain_gains_life_and_prevents_damage() {
                     }),
                 },
             },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
         vec![],
         riot_control,

--- a/crates/engine/tests/integration/rules/combat.rs
+++ b/crates/engine/tests/integration/rules/combat.rs
@@ -338,7 +338,7 @@ fn dies_trigger_fires_from_combat_damage() {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: engine::types::ability::GainLifePlayer::Controller,
+                player: engine::types::ability::TargetFilter::Controller,
             },
         ))
         .valid_card(TargetFilter::SelfRef)

--- a/crates/engine/tests/integration/ureni_attack_trigger.rs
+++ b/crates/engine/tests/integration/ureni_attack_trigger.rs
@@ -22,8 +22,8 @@
 
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::ability::{
-    AbilityDefinition, AbilityKind, Effect, GainLifePlayer, QuantityExpr, StaticDefinition,
-    TargetFilter, TriggerDefinition, TypedFilter,
+    AbilityDefinition, AbilityKind, Effect, QuantityExpr, StaticDefinition, TargetFilter,
+    TriggerDefinition, TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::game_state::ExtraPhase;
@@ -43,7 +43,7 @@ fn ureni_style_trigger() -> TriggerDefinition {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         ))
         .valid_card(TargetFilter::SelfRef)

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -57,8 +57,7 @@ use engine::game::filter::{matches_target_filter, FilterContext};
 use engine::game::keywords::has_keyword;
 use engine::game::quantity::resolve_quantity;
 use engine::types::ability::{
-    ContinuousModification, Duration, Effect, GainLifePlayer, QuantityExpr, StaticDefinition,
-    TargetFilter,
+    ContinuousModification, Duration, Effect, QuantityExpr, StaticDefinition, TargetFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::game_state::{GameState, TransientContinuousEffect};
@@ -724,15 +723,15 @@ fn tce_matches_pump(
 
 /// Gain-life-when-comfortable: controller's current life ≥
 /// `LIFE_DIMINISHING_RETURNS`, and the life gain is directed at the
-/// controller (the default `GainLifePlayer::Controller`).
+/// controller (the default `TargetFilter::Controller`).
 fn gain_life_redundancy(
     state: &GameState,
     source_id: ObjectId,
     ai_player: PlayerId,
     amount: &QuantityExpr,
-    player: &GainLifePlayer,
+    player: &TargetFilter,
 ) -> Option<(f64, i64, i64)> {
-    if !matches!(player, GainLifePlayer::Controller) {
+    if !matches!(player, TargetFilter::Controller) {
         return None;
     }
     let controller = state
@@ -1091,7 +1090,7 @@ mod tests {
             "Lifegainer",
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
 
@@ -1116,7 +1115,7 @@ mod tests {
             "Lifegainer",
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
 


### PR DESCRIPTION
closes: #1693 

## Summary

- `Effect` had 12 sibling pairs where the only structural axis was **targeting vs. non-targeting scope** — `*All` variants apply the same game action to every matching object, singulars apply it to one player-chosen target. Every resolver, parser, AI policy, and test enumerated both variants in parallel match arms.
- Added `EffectScope { Target, All }` enum (CR 115.1 + CR 601.2c) and merged each pair into the singular variant name with a `scope` field. Removed all 12 `*All` variants.
- 2,178 direct variant references across 94 files updated. Each match arm that previously needed two arms (`Tap` + `TapAll`) now uses one (`Tap { scope }`). Future sweeper/mass-effect cards add zero new variants.

## Pairs merged

| Before (2 variants) | After (1 variant) |
|---|---|
| `Tap { target }` / `TapAll { target }` | `Tap { scope: EffectScope, target }` |
| `Untap { target }` / `UntapAll { target }` | `Untap { scope: EffectScope, target }` |
| `Pump { power, toughness, target }` / `PumpAll { .. }` | `Pump { scope, power, toughness, target }` |
| `Destroy { target, cant_regenerate }` / `DestroyAll { target }` | `Destroy { scope, target, cant_regenerate }` |
| `Counter { target, source_rider }` / `CounterAll { target }` | `Counter { scope, target, source_rider }` |
| `Bounce { target, destination, selection }` / `BounceAll { target, destination, count }` | `Bounce { scope, target, destination, count, selection }` |
| `ChangeZone { … }` / `ChangeZoneAll { origin, destination, target, enter_tapped }` | `ChangeZone { scope, … }` |
| `Explore` (unit) / `ExploreAll { filter }` | `Explore { scope, filter }` |
| `Unattach` (unit) / `UnattachAll { attachment, target }` | `Unattach { scope, attachment, target }` |
| `AddCounter { counter_type, count, target }` / `PutCounterAll { … }` | `AddCounter { scope, counter_type, count, target }` |
| `DoublePT { mode, target }` / `DoublePTAll { mode, target }` | `DoublePT { scope, mode, target }` |
| `Goad { target }` / `GoadAll { target }` | `Goad { scope, target }` |

`DamageAll` has no same-CR-section singular counterpart — left as-is.

## Design notes

- **`EffectKind::*All` retained** — kept for event-tagging continuity. `Effect::Tap { scope: All }` maps to `EffectKind::TapAll` in `EffectKind::from`. Removing `EffectKind` variants would silently change trigger/resolution behavior in `engine_resolution_choices.rs` and `trigger_matchers.rs`.
- **Wire compat** — `scope` field uses `#[serde(default, skip_serializing_if = "EffectScope::is_target")]` so existing card-data JSON (no `scope` key) deserializes as `Target` unchanged. New `All`-scope effects serialize with `"scope": "All"`.
- **Resolver strategy** — dispatch in `effects/mod.rs` branches on `scope` at the call site; existing `resolve_*` / `resolve_*_all` function pairs stay intact internally.

## Stats

| Metric | Value |
|---|---|
| Files changed | 112 |
| Insertions | 2,433 |
| Deletions | 761 |
| Direct variant refs updated | ~2,178 |
| Variants removed from `Effect` | 12 |

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo check -p engine -p mtgish-import -p phase-ai` — 0 errors
- [x] `cargo clippy -p engine -p mtgish-import -p phase-ai -- -D warnings` — clean
- [ ] `cargo test -p engine` — CI should confirm (test suite too large for local iteration)
- [ ] `cargo semantic-audit` — CI should confirm coverage unchanged
