### PR TITLE
fix(engine): scry choice no longer clobbered by 2+ "whenever you scry" triggers

### DIFF
--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -34,7 +34,19 @@ pub(super) fn run_post_action_pipeline(
             .filter(|event| !matches!(event, GameEvent::PhaseChanged { .. }))
             .cloned()
             .collect();
-        triggers::process_triggers(state, &filtered_events);
+        // CR 603.3b: If the resolution step that just ran paused for a player
+        // resolution-choice (Scry/Surveil/Dig/Search/...), the triggered
+        // abilities it generated (e.g. "whenever you scry, ...") must NOT be
+        // collected and ordered now — doing so overwrites the pending choice's
+        // WaitingFor (the `OrderTriggers` PromptForChoice arm clobbers
+        // `ScryChoice` when 2+ same-controller triggers fire). Park them in
+        // `deferred_triggers`; they are drained below once the action settles
+        // back to Priority. Mirrors `batch_or_drain_observer_triggers`' B2 branch.
+        if super::engine_resolution_choices::handles(&state.waiting_for) {
+            triggers::collect_triggers_into_deferred(state, &filtered_events);
+        } else {
+            triggers::process_triggers(state, &filtered_events);
+        }
     }
 
     // CR 704.3: SBA/trigger loop. SBAs may generate events (e.g., ZoneChanged for
@@ -48,6 +60,22 @@ pub(super) fn run_post_action_pipeline(
             triggers::process_triggers(state, &sba_events);
         } else {
             break;
+        }
+    }
+
+    // CR 603.3b: Triggered abilities parked while a resolution choice was open
+    // (e.g. "whenever you scry, ..." deferred above so it couldn't clobber the
+    // choice's WaitingFor) go on the stack now that the action has settled and a
+    // player is about to receive priority. Gated on `Priority` so it never fires
+    // mid-trigger-pause (where `dispatch_collected_triggers` parks remaining
+    // contexts under a non-Priority WaitingFor and a dedicated site drains them
+    // after the active trigger resolves). A drained trigger that itself needs
+    // input returns its own WaitingFor, handled by the check below.
+    if matches!(state.waiting_for, WaitingFor::Priority { .. })
+        && !state.deferred_triggers.is_empty()
+    {
+        if let Some(wf) = triggers::drain_deferred_trigger_queue(state, events) {
+            state.waiting_for = wf;
         }
     }
 

--- a/crates/engine/tests/scry_choice_not_clobbered_by_triggers.rs
+++ b/crates/engine/tests/scry_choice_not_clobbered_by_triggers.rs
@@ -1,0 +1,109 @@
+//! Regression: a scry that triggers 2+ simultaneous "whenever you scry"
+//! abilities must still surface the `ScryChoice` prompt — and the triggers must
+//! still fire after the choice resolves.
+//!
+//! Reported in-game (Track Down with Matoya, Archon Elder + Elrond, Master of
+//! Healing both on the battlefield): "Scry is now a no-op, the modal never
+//! appeared." Root cause: when a scry effect set `WaitingFor::ScryChoice`
+//! mid-resolution, the post-resolution trigger scan collected the scry-watching
+//! triggers and — with 2+ same-controller triggers — set
+//! `WaitingFor::OrderTriggers`, overwriting the pending `ScryChoice` (CR 603.3b
+//! violation: those triggers must wait until the spell finishes resolving). A
+//! single trigger used the non-ordering dispatch path and didn't clobber, so
+//! the bug only manifested with two or more — which is why plain scry (and Opt
+//! with only one watcher present) appeared to work.
+//!
+//! CR 603.3b: a triggered ability is put on the stack the next time a player
+//! would receive priority — i.e. AFTER the current spell, including its scry
+//! choice, finishes resolving.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::triggers::drain_order_triggers_with_identity;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+/// CR 603.3b + CR 701.22a: With two "whenever you scry" triggers on the
+/// battlefield, casting a scry spell must still pause at `ScryChoice` (the
+/// modal the user picks from), not jump straight into trigger handling.
+#[test]
+fn scry_with_two_watchers_still_prompts_and_fires_triggers() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Two distinct "whenever you scry, draw a card" watchers (the user's board
+    // had Matoya draw + Elrond counters; two draw-watchers make the after-effect
+    // observable as +2 cards without a target-selection step).
+    scenario.add_creature_from_oracle(
+        P0,
+        "Scry Watcher A",
+        2,
+        2,
+        "Whenever you scry, draw a card.",
+    );
+    scenario.add_creature_from_oracle(
+        P0,
+        "Scry Watcher B",
+        2,
+        2,
+        "Whenever you scry, draw a card.",
+    );
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Augury Owl Spell", false, "Scry 2.")
+        .id();
+    for name in ["Lib 1", "Lib 2", "Lib 3", "Lib 4", "Lib 5", "Lib 6"] {
+        scenario.add_card_to_library_top(P0, name);
+    }
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects.get(&spell).unwrap().card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+        })
+        .expect("cast the scry spell");
+    runner.advance_until_stack_empty();
+
+    // The spell left the hand on cast; after it resolves the engine MUST be
+    // paused on the scry choice, not on a trigger-ordering / target prompt.
+    let WaitingFor::ScryChoice { player, cards } = runner.state().waiting_for.clone() else {
+        panic!(
+            "scry must pause at ScryChoice even with two scry-watchers, got {}",
+            runner.waiting_for_kind()
+        );
+    };
+    assert_eq!(player, P0);
+    assert_eq!(cards.len(), 2, "Scry 2 looks at the top two cards");
+
+    let hand_after_cast = runner.state().players[0].hand.len();
+
+    // Submit the scry (keep both on top), then let the now-unparked triggers
+    // resolve through any ordering prompt.
+    runner
+        .act(GameAction::SelectCards { cards })
+        .expect("submit the scry ordering");
+    for _ in 0..8 {
+        if matches!(runner.state().waiting_for, WaitingFor::OrderTriggers { .. }) {
+            drain_order_triggers_with_identity(runner.state_mut());
+        }
+        runner.advance_until_stack_empty();
+        if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+            break;
+        }
+    }
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+        "resolution must settle back to Priority, got {}",
+        runner.waiting_for_kind()
+    );
+    assert_eq!(
+        runner.state().players[0].hand.len(),
+        hand_after_cast + 2,
+        "both 'whenever you scry, draw' triggers must fire after the scry choice"
+    );
+}


### PR DESCRIPTION
When a scry/surveil/etc. effect set WaitingFor::ScryChoice mid-resolution, the
post-resolution trigger scan in run_post_action_pipeline collected the scry-
watching triggered abilities immediately. With 2+ same-controller triggers,
begin_trigger_ordering set state.waiting_for = OrderTriggers, overwriting the
pending ScryChoice — the scry modal never appeared and scry silently no-op'd
(reported in-game: Track Down with Matoya, Archon Elder + Elrond, Master of
Healing both on the battlefield). A single trigger used the non-ordering
dispatch path and didn't clobber, which is why plain scry and single-watcher
boards appeared to work.

CR 603.3b: a triggered ability is put on the stack the next time a player would
receive priority — i.e. AFTER the current spell, including its scry choice,
finishes resolving. Park triggers fired during a resolution choice in
deferred_triggers instead of collecting+ordering them, then drain that queue
once the action settles back to Priority. Covers the whole resolution-choice
class (scry/surveil/dig/search/reveal/...) via the shared
run_post_action_pipeline settle point.

Regression test: scry_choice_not_clobbered_by_triggers.
