### PR TITLE
fix(client): show persisted chosen attributes in card preview

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -487,6 +487,26 @@ export type CounterMatch =
   | { type: "Any" }
   | { type: "OfType"; data: CounterType };
 
+// ── Chosen Attributes ─────────────────────────────────────────────────────
+
+/**
+ * Persistent choices attached to a permanent by the engine
+ * (`serde(tag = "type", content = "value")`), e.g. "chosen card name".
+ */
+export type ChosenAttribute =
+  | { type: "Color"; value: ManaColor }
+  | { type: "CreatureType"; value: string }
+  | { type: "BasicLandType"; value: string }
+  | { type: "CardType"; value: CoreType }
+  | { type: "OddOrEven"; value: "Odd" | "Even" }
+  | { type: "CardName"; value: string }
+  | { type: "Number"; value: number }
+  | { type: "Player"; value: PlayerId }
+  | { type: "TwoColors"; value: [ManaColor, ManaColor] }
+  | { type: "TributeOutcome"; value: "Paid" | "Declined" }
+  | { type: "Keyword"; value: Keyword }
+  | { type: "Label"; value: string };
+
 export type CounterMoveChoice = {
   destination_id: ObjectId;
   counter_type: CounterType;
@@ -680,6 +700,7 @@ export interface GameObject {
   mana_ability_index?: number;
   is_suspected?: boolean;
   case_state?: { is_solved: boolean; solve_condition: unknown } | null;
+  chosen_attributes?: ChosenAttribute[];
   class_level?: number;
   devotion?: number;
   available_mana_pips?: ManaPip[];

--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { GameObject, ManaCost } from "../../adapter/types.ts";
+import type { ChosenAttribute, GameObject, ManaCost } from "../../adapter/types.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import type { SourcePrinting } from "../../hooks/useCardImage.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
@@ -759,6 +759,50 @@ function CardInfoPanel({ obj, altAvailable }: { obj: GameObject; altAvailable: b
   const deref = { objects, transientContinuousEffects };
   const keywordSources = buildGrantedKeywordSources(attribution, obj.id, deref);
   const ptSources = buildPTSources(attribution, obj.id, deref);
+  const chosenAttributes = obj.chosen_attributes ?? [];
+
+  const formatChosenAttribute = (attribute: ChosenAttribute): { label: string; value: string } => {
+    switch (attribute.type) {
+      case "Color":
+        return { label: t("preview.chosen.kind.color"), value: attribute.value };
+      case "CreatureType":
+        return { label: t("preview.chosen.kind.creatureType"), value: attribute.value };
+      case "BasicLandType":
+        return { label: t("preview.chosen.kind.basicLandType"), value: attribute.value };
+      case "CardType":
+        return { label: t("preview.chosen.kind.cardType"), value: attribute.value };
+      case "OddOrEven":
+        return { label: t("preview.chosen.kind.oddOrEven"), value: attribute.value };
+      case "CardName":
+        return { label: t("preview.chosen.kind.cardName"), value: attribute.value };
+      case "Number":
+        return { label: t("preview.chosen.kind.number"), value: String(attribute.value) };
+      case "Player":
+        return {
+          label: t("preview.chosen.kind.player"),
+          value: t("preview.chosen.playerValue", { id: attribute.value }),
+        };
+      case "TwoColors":
+        return {
+          label: t("preview.chosen.kind.twoColors"),
+          value: t("preview.chosen.twoColorsValue", {
+            first: attribute.value[0],
+            second: attribute.value[1],
+          }),
+        };
+      case "TributeOutcome":
+        return { label: t("preview.chosen.kind.tributeOutcome"), value: attribute.value };
+      case "Keyword":
+        return {
+          label: t("preview.chosen.kind.keyword"),
+          value: getKeywordDisplayText(attribute.value),
+        };
+      case "Label":
+        return { label: t("preview.chosen.kind.label"), value: attribute.value };
+      default:
+        return { label: t("preview.chosen.kind.fallback"), value: t("preview.chosen.unknown") };
+    }
+  };
 
   return (
     <div className="relative w-full border-t border-gray-600 bg-gray-900/95 px-3 py-2 text-xs text-gray-200">
@@ -846,6 +890,25 @@ function CardInfoPanel({ obj, altAvailable }: { obj: GameObject; altAvailable: b
       {colorsChanged && (
         <div className="mt-1 text-gray-400">
           {t("preview.colors", { colors: obj.color.length > 0 ? obj.color.join(", ") : t("preview.colorless") })}
+        </div>
+      )}
+
+      {chosenAttributes.length > 0 && (
+        <div className="mt-1 text-gray-400">
+          <div className="font-semibold text-gray-300">{t("preview.chosen.title")}</div>
+          <div className="mt-0.5 space-y-0.5">
+            {chosenAttributes.map((attribute, index) => {
+              const formatted = formatChosenAttribute(attribute);
+              return (
+                <div key={`${attribute.type}-${index}`}>
+                  {t("preview.chosen.entry", {
+                    kind: formatted.label,
+                    value: formatted.value,
+                  })}
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/client/src/components/card/__tests__/CardPreview.test.tsx
+++ b/client/src/components/card/__tests__/CardPreview.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GameObject, GameState } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { CardPreview } from "../CardPreview.tsx";
+
+vi.mock("../../../hooks/useCardImage.ts", () => ({
+  useCardImage: () => ({
+    src: "card.png",
+    isLoading: false,
+    isRotated: false,
+    isFlip: false,
+  }),
+}));
+
+vi.mock("../../../hooks/useEngineCardData.ts", () => ({
+  useEngineCardData: () => null,
+  useCardParseDetails: () => null,
+  useCardRulings: () => [],
+}));
+
+function battlefieldObject(overrides: Partial<GameObject> = {}): GameObject {
+  return {
+    id: 101,
+    card_id: 1,
+    owner: 0,
+    controller: 0,
+    zone: "Battlefield",
+    tapped: false,
+    face_down: false,
+    flipped: false,
+    transformed: false,
+    damage_marked: 0,
+    dealt_deathtouch_damage: false,
+    attached_to: null,
+    attachments: [],
+    counters: {},
+    name: "Pithing Needle",
+    power: null,
+    toughness: null,
+    loyalty: null,
+    card_types: { supertypes: [], core_types: ["Artifact"], subtypes: [] },
+    mana_cost: { type: "Cost", shards: [], generic: 1 },
+    keywords: [],
+    abilities: [],
+    trigger_definitions: [],
+    replacement_definitions: [],
+    static_definitions: [],
+    color: [],
+    base_power: null,
+    base_toughness: null,
+    base_keywords: [],
+    base_color: [],
+    timestamp: 1,
+    entered_battlefield_turn: 1,
+    ...overrides,
+  };
+}
+
+function gameStateWithObject(object: GameObject): GameState {
+  return {
+    turn_number: 1,
+    active_player: 0,
+    phase: "PreCombatMain",
+    players: [],
+    priority_player: 0,
+    objects: { [String(object.id)]: object },
+    next_object_id: 102,
+    battlefield: [object.id],
+    stack: [],
+    exile: [],
+    rng_seed: 1,
+    combat: null,
+    waiting_for: { type: "Priority", data: { player: 0 } },
+    has_pending_cast: false,
+    lands_played_this_turn: 0,
+    max_lands_per_turn: 1,
+    priority_pass_count: 0,
+    pending_replacement: null,
+    layers_dirty: false,
+    next_timestamp: 2,
+  } as GameState;
+}
+
+afterEach(() => {
+  cleanup();
+  useGameStore.setState({ gameState: null, spellCosts: {} });
+  useUiStore.setState({ inspectedObjectId: null, altHeld: false });
+});
+
+describe("CardPreview chosen attributes", () => {
+  it("shows a persisted chosen card name for a battlefield permanent", () => {
+    const object = battlefieldObject({
+      chosen_attributes: [{ type: "CardName", value: "Lightning Bolt" }],
+    });
+    useGameStore.setState({ gameState: gameStateWithObject(object), spellCosts: {} });
+    useUiStore.setState({ inspectedObjectId: object.id, altHeld: false });
+
+    render(<CardPreview cardName="Pithing Needle" position={{ x: 20, y: 20 }} />);
+
+    expect(screen.getByText("Chosen")).toBeInTheDocument();
+    expect(screen.getByText("Card name: Lightning Bolt")).toBeInTheDocument();
+  });
+});

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -31,7 +31,29 @@
     "damage": "Schaden: {{amount}}",
     "ptDeltaFrom": "{{delta}} von {{source}}",
     "colors": "Farben: {{colors}}",
-    "colorless": "Farblos"
+    "colorless": "Farblos",
+    "chosen": {
+      "title": "Gewählt",
+      "entry": "{{kind}}: {{value}}",
+      "playerValue": "Spieler {{id}}",
+      "twoColorsValue": "{{first}}, {{second}}",
+      "unknown": "Unbekannt",
+      "kind": {
+        "color": "Farbe",
+        "creatureType": "Kreaturentyp",
+        "basicLandType": "Standardlandtyp",
+        "cardType": "Kartentyp",
+        "oddOrEven": "Ungerade oder gerade",
+        "cardName": "Kartenname",
+        "number": "Zahl",
+        "player": "Spieler",
+        "twoColors": "Zwei Farben",
+        "tributeOutcome": "Tribut",
+        "keyword": "Schlüsselwort",
+        "label": "Label",
+        "fallback": "Auswahl"
+      }
+    }
   },
   "actionButton": {
     "clearAttackers": "Angreifer löschen",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -31,7 +31,29 @@
     "damage": "Damage: {{amount}}",
     "ptDeltaFrom": "{{delta}} from {{source}}",
     "colors": "Colors: {{colors}}",
-    "colorless": "Colorless"
+    "colorless": "Colorless",
+    "chosen": {
+      "title": "Chosen",
+      "entry": "{{kind}}: {{value}}",
+      "playerValue": "Player {{id}}",
+      "twoColorsValue": "{{first}}, {{second}}",
+      "unknown": "Unknown",
+      "kind": {
+        "color": "Color",
+        "creatureType": "Creature type",
+        "basicLandType": "Basic land type",
+        "cardType": "Card type",
+        "oddOrEven": "Odd or even",
+        "cardName": "Card name",
+        "number": "Number",
+        "player": "Player",
+        "twoColors": "Two colors",
+        "tributeOutcome": "Tribute",
+        "keyword": "Keyword",
+        "label": "Label",
+        "fallback": "Choice"
+      }
+    }
   },
   "actionButton": {
     "clearAttackers": "Clear Attackers",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -31,7 +31,29 @@
     "damage": "Daño: {{amount}}",
     "ptDeltaFrom": "{{delta}} de {{source}}",
     "colors": "Colores: {{colors}}",
-    "colorless": "Incoloro"
+    "colorless": "Incoloro",
+    "chosen": {
+      "title": "Elegido",
+      "entry": "{{kind}}: {{value}}",
+      "playerValue": "Jugador {{id}}",
+      "twoColorsValue": "{{first}}, {{second}}",
+      "unknown": "Desconocido",
+      "kind": {
+        "color": "Color",
+        "creatureType": "Tipo de criatura",
+        "basicLandType": "Tipo de tierra básica",
+        "cardType": "Tipo de carta",
+        "oddOrEven": "Impar o par",
+        "cardName": "Nombre de carta",
+        "number": "Número",
+        "player": "Jugador",
+        "twoColors": "Dos colores",
+        "tributeOutcome": "Tributo",
+        "keyword": "Palabra clave",
+        "label": "Etiqueta",
+        "fallback": "Elección"
+      }
+    }
   },
   "actionButton": {
     "clearAttackers": "Cancelar atacantes",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -31,7 +31,29 @@
     "damage": "Blessures : {{amount}}",
     "ptDeltaFrom": "{{delta}} depuis {{source}}",
     "colors": "Couleurs : {{colors}}",
-    "colorless": "Incolore"
+    "colorless": "Incolore",
+    "chosen": {
+      "title": "Choisi",
+      "entry": "{{kind}} : {{value}}",
+      "playerValue": "Joueur {{id}}",
+      "twoColorsValue": "{{first}}, {{second}}",
+      "unknown": "Inconnu",
+      "kind": {
+        "color": "Couleur",
+        "creatureType": "Type de créature",
+        "basicLandType": "Type de terrain de base",
+        "cardType": "Type de carte",
+        "oddOrEven": "Pair ou impair",
+        "cardName": "Nom de carte",
+        "number": "Nombre",
+        "player": "Joueur",
+        "twoColors": "Deux couleurs",
+        "tributeOutcome": "Tribut",
+        "keyword": "Mot-clé",
+        "label": "Libellé",
+        "fallback": "Choix"
+      }
+    }
   },
   "actionButton": {
     "clearAttackers": "Effacer les attaquants",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -31,7 +31,29 @@
     "damage": "Danno: {{amount}}",
     "ptDeltaFrom": "{{delta}} da {{source}}",
     "colors": "Colori: {{colors}}",
-    "colorless": "Incolore"
+    "colorless": "Incolore",
+    "chosen": {
+      "title": "Scelto",
+      "entry": "{{kind}}: {{value}}",
+      "playerValue": "Giocatore {{id}}",
+      "twoColorsValue": "{{first}}, {{second}}",
+      "unknown": "Sconosciuto",
+      "kind": {
+        "color": "Colore",
+        "creatureType": "Tipo di creatura",
+        "basicLandType": "Tipo di terra base",
+        "cardType": "Tipo di carta",
+        "oddOrEven": "Pari o dispari",
+        "cardName": "Nome carta",
+        "number": "Numero",
+        "player": "Giocatore",
+        "twoColors": "Due colori",
+        "tributeOutcome": "Tributo",
+        "keyword": "Parola chiave",
+        "label": "Etichetta",
+        "fallback": "Scelta"
+      }
+    }
   },
   "actionButton": {
     "clearAttackers": "Cancella attaccanti",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -31,7 +31,29 @@
     "damage": "Obrażenia: {{amount}}",
     "ptDeltaFrom": "{{delta}} od {{source}}",
     "colors": "Kolory: {{colors}}",
-    "colorless": "Bezbarwny"
+    "colorless": "Bezbarwny",
+    "chosen": {
+      "title": "Wybrane",
+      "entry": "{{kind}}: {{value}}",
+      "playerValue": "Gracz {{id}}",
+      "twoColorsValue": "{{first}}, {{second}}",
+      "unknown": "Nieznane",
+      "kind": {
+        "color": "Kolor",
+        "creatureType": "Typ stwora",
+        "basicLandType": "Typ podstawowego lądu",
+        "cardType": "Typ karty",
+        "oddOrEven": "Parzyste lub nieparzyste",
+        "cardName": "Nazwa karty",
+        "number": "Liczba",
+        "player": "Gracz",
+        "twoColors": "Dwa kolory",
+        "tributeOutcome": "Tribute",
+        "keyword": "Słowo kluczowe",
+        "label": "Etykieta",
+        "fallback": "Wybór"
+      }
+    }
   },
   "actionButton": {
     "clearAttackers": "Wyczyść atakujących",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -31,7 +31,29 @@
     "damage": "Dano: {{amount}}",
     "ptDeltaFrom": "{{delta}} de {{source}}",
     "colors": "Cores: {{colors}}",
-    "colorless": "Incolor"
+    "colorless": "Incolor",
+    "chosen": {
+      "title": "Escolhido",
+      "entry": "{{kind}}: {{value}}",
+      "playerValue": "Jogador {{id}}",
+      "twoColorsValue": "{{first}}, {{second}}",
+      "unknown": "Desconhecido",
+      "kind": {
+        "color": "Cor",
+        "creatureType": "Tipo de criatura",
+        "basicLandType": "Tipo de terreno básico",
+        "cardType": "Tipo de carta",
+        "oddOrEven": "Ímpar ou par",
+        "cardName": "Nome da carta",
+        "number": "Número",
+        "player": "Jogador",
+        "twoColors": "Duas cores",
+        "tributeOutcome": "Tributo",
+        "keyword": "Palavra-chave",
+        "label": "Rótulo",
+        "fallback": "Escolha"
+      }
+    }
   },
   "actionButton": {
     "clearAttackers": "Limpar Atacantes",


### PR DESCRIPTION
## Summary
- Add `ChosenAttribute` and optional `chosen_attributes` to frontend `GameObject` types.
- Render a "Chosen" section in the battlefield card preview for persisted choices (e.g. Pithing Needle card name).
- Add English i18n strings for chosen-attribute labels.

## Problem
Fixes #1518 — opponents could not see which card name was chosen for Pithing Needle (and similar "choose a card name" permanents). The engine already persisted the choice on `chosen_attributes`; the UI never displayed it.

## Test plan
- [ ] Play Pithing Needle, choose a card name, have the opponent inspect the Needle on the battlefield.
- [ ] Confirm preview shows **Chosen → Card name: &lt;name&gt;**.
- [ ] Spot-check other chosen-attribute cards (color, creature type, etc.) if available.
- [ ] Run frontend type-check (`pnpm type-check` or Tilt `check-frontend`).