### PR TITLE
fix(parser): expand "repeat this process for [keywords]" for Kathril

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -41,10 +41,10 @@ use super::subject;
 use super::{
     append_to_deepest_sub_ability, apply_player_scope_rewrites,
     attach_alt_cost_to_prior_cast_from_zone, attach_mana_retention_to_prior_mana,
-    attach_same_is_true_keywords, collapse_ephemeral_color_choice_mana,
-    contains_explicit_tracked_set_pronoun, contains_implicit_tracked_set_pronoun,
-    fold_cast_copy_of_card_defs, mark_uses_tracked_set, parse_effect_clause,
-    parse_event_context_ref_with_ctx, parse_for_each_object_copy_parts,
+    attach_repeat_process_keywords, attach_same_is_true_keywords,
+    collapse_ephemeral_color_choice_mana, contains_explicit_tracked_set_pronoun,
+    contains_implicit_tracked_set_pronoun, fold_cast_copy_of_card_defs, mark_uses_tracked_set,
+    parse_effect_clause, parse_event_context_ref_with_ctx, parse_for_each_object_copy_parts,
     publishes_tracked_set_from_resolution, refine_damage_target_remainder,
     rewrite_parent_targets_to_tracked_set, rewrite_rounding_mode, rewrite_that_type_mana_instead,
     scan_contains_phrase, stamp_delayed_returns, target_filter_controller_ref,
@@ -307,6 +307,10 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                     }
                     SpecialClause::SameIsTrueFor(keywords) => {
                         attach_same_is_true_keywords(&mut defs, keywords);
+                        true
+                    }
+                    SpecialClause::RepeatProcessForKeywords(keywords) => {
+                        attach_repeat_process_keywords(&mut defs, keywords);
                         true
                     }
                 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -120,7 +120,7 @@ use self::search::{
 use self::sequence::{
     apply_clause_continuation, clause_is_dig_lookback_transparent, continuation_absorbs_current,
     parse_followup_continuation_ast, parse_intrinsic_continuation_ast, split_clause_sequence,
-    try_parse_same_is_true_continuation,
+    try_parse_repeat_process_for_keywords, try_parse_same_is_true_continuation,
 };
 use self::subject::{try_parse_subject_predicate_ast, try_parse_targeted_controller_gain_life};
 use crate::parser::oracle_ir::ast::*;
@@ -10900,6 +10900,72 @@ fn attach_same_is_true_keywords(defs: &mut [AbilityDefinition], keywords: &[Keyw
     }
 }
 
+/// CR 608.2c: Apply a "Repeat this process for <keyword list>" continuation
+/// (Kathril, Aspect Warper). Walks `defs` from the back for the most recent
+/// conditional keyword-counter placement (`PutCounter { counter_type:
+/// Keyword(..) }` gated by a graveyard-keyword `condition`) and appends one
+/// cloned sibling per listed keyword — swapping both the placed counter's
+/// keyword and the gating condition's keyword. Each clone is an independent
+/// sequential sibling, mirroring the antecedent's structure, so the engine
+/// resolves all keyword counters during the trigger's one resolution. This is
+/// the counters-class analogue of `attach_same_is_true_keywords` (static
+/// grants); it covers the whole "repeat this process for <list>" class.
+fn attach_repeat_process_keywords(defs: &mut Vec<AbilityDefinition>, keywords: &[Keyword]) {
+    let Some(template) = defs
+        .iter()
+        .rev()
+        .find(|d| {
+            matches!(
+                &*d.effect,
+                Effect::PutCounter {
+                    counter_type: CounterType::Keyword(_),
+                    ..
+                }
+            )
+        })
+        .cloned()
+    else {
+        return;
+    };
+    for keyword in keywords {
+        let mut new_def = template.clone();
+        if let Effect::PutCounter { counter_type, .. } = &mut *new_def.effect {
+            *counter_type = CounterType::Keyword(keyword.kind());
+        }
+        if let Some(condition) = &mut new_def.condition {
+            rewrite_ability_condition_keyword(condition, keyword);
+        }
+        // Each replicated counter placement is its own sequential instruction.
+        new_def.sub_link = SubAbilityLink::SequentialSibling;
+        new_def.sub_ability = None;
+        defs.push(new_def);
+    }
+}
+
+/// Swap the gating keyword inside an `AbilityCondition` to `new_keyword`. Used
+/// by `attach_repeat_process_keywords` to rewrite the "if a creature card in
+/// your graveyard has <keyword>" gate of each replicated counter clause.
+fn rewrite_ability_condition_keyword(condition: &mut AbilityCondition, new_keyword: &Keyword) {
+    match condition {
+        AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
+            rewrite_quantity_expr_keyword(lhs, new_keyword);
+            rewrite_quantity_expr_keyword(rhs, new_keyword);
+        }
+        _ => {}
+    }
+}
+
+/// Rewrite the keyword inside any `ObjectCount` filter carried by a
+/// `QuantityExpr` (the count side of a graveyard-keyword condition).
+fn rewrite_quantity_expr_keyword(expr: &mut QuantityExpr, new_keyword: &Keyword) {
+    if let QuantityExpr::Ref {
+        qty: QuantityRef::ObjectCount { filter },
+    } = expr
+    {
+        rewrite_filter_keyword(filter, new_keyword);
+    }
+}
+
 #[tracing::instrument(level = "debug")]
 fn parse_imperative_effect(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause {
     let lower = text.to_lowercase();
@@ -13167,6 +13233,42 @@ pub(crate) fn parse_effect_chain_ir(
                     is_otherwise: false,
                     unless_pay: None,
                     special: Some(SpecialClause::SameIsTrueFor(keywords)),
+                    source_text: normalized_text.to_string(),
+                    target_selection_mode: TargetSelectionMode::Chosen,
+                });
+                continue;
+            }
+        }
+
+        // CR 608.2c: "Repeat this process for <keyword list>." — Kathril, Aspect
+        // Warper. Must precede the generic "repeat this process" directive below,
+        // whose `tag("repeat this process")` would otherwise swallow the prefix
+        // and discard the keyword list. Replicates the antecedent conditional
+        // keyword-counter clause once per listed keyword during lowering.
+        if !clauses.is_empty() {
+            if let Some(keywords) = try_parse_repeat_process_for_keywords(normalized_text) {
+                clauses.push(ClauseIr {
+                    parsed: parsed_clause(Effect::Unimplemented {
+                        name: "repeat_process_for_keywords_placeholder".to_string(),
+                        description: None,
+                    }),
+                    boundary: chunk.boundary_after,
+                    condition: None,
+                    is_optional: false,
+                    opponent_may_scope: None,
+                    repeat_for: None,
+                    player_scope: None,
+                    starting_with: None,
+                    delayed_condition: None,
+                    prefix_delayed_condition: None,
+                    intrinsic_continuation: None,
+                    followup_continuation: None,
+                    absorbed_by_followup: false,
+                    multi_target: None,
+                    where_x_expression: None,
+                    is_otherwise: false,
+                    unless_pay: None,
+                    special: Some(SpecialClause::RepeatProcessForKeywords(keywords)),
                     source_text: normalized_text.to_string(),
                     target_selection_mode: TargetSelectionMode::Chosen,
                 });

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -10946,12 +10946,9 @@ fn attach_repeat_process_keywords(defs: &mut Vec<AbilityDefinition>, keywords: &
 /// by `attach_repeat_process_keywords` to rewrite the "if a creature card in
 /// your graveyard has <keyword>" gate of each replicated counter clause.
 fn rewrite_ability_condition_keyword(condition: &mut AbilityCondition, new_keyword: &Keyword) {
-    match condition {
-        AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
-            rewrite_quantity_expr_keyword(lhs, new_keyword);
-            rewrite_quantity_expr_keyword(rhs, new_keyword);
-        }
-        _ => {}
+    if let AbilityCondition::QuantityCheck { lhs, rhs, .. } = condition {
+        rewrite_quantity_expr_keyword(lhs, new_keyword);
+        rewrite_quantity_expr_keyword(rhs, new_keyword);
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3825,6 +3825,28 @@ pub(super) fn try_parse_same_is_true_continuation(text: &str) -> Option<Vec<Keyw
     }
 }
 
+/// CR 608.2c: Parse "Repeat this process for <keyword list>." — Kathril, Aspect
+/// Warper. Returns the keyword list; the chunk loop wraps it in
+/// `SpecialClause::RepeatProcessForKeywords` and lowering replicates the
+/// antecedent conditional keyword-counter clause once per keyword. Mirrors
+/// `try_parse_same_is_true_continuation`; covers every "repeat this process for
+/// <list>" card, not Kathril alone.
+pub(super) fn try_parse_repeat_process_for_keywords(text: &str) -> Option<Vec<Keyword>> {
+    let lower = text.to_lowercase();
+    let (keywords, rest) = nom_on_lower(text, &lower, |i| {
+        let (i, _) = tag("repeat this process for ").parse(i)?;
+        parse_keyword_list(i)
+    })?;
+    // The sentence must be fully consumed by the keyword list (modulo a trailing
+    // period) — a leftover tail means this is some other "repeat this process …"
+    // form (e.g. "repeat this process any number of times") and must not match.
+    if rest.trim().trim_end_matches('.').is_empty() {
+        Some(keywords)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -77,6 +77,13 @@ pub(crate) enum SpecialClause {
     /// additional `StaticDefinition` cloned from the antecedent grant template,
     /// with both the granted keyword and the gating condition's keyword swapped.
     SameIsTrueFor(Vec<Keyword>),
+    /// CR 608.2c: "Repeat this process for <keyword list>." — Kathril, Aspect
+    /// Warper. Replicates the antecedent conditional keyword-counter clause
+    /// (`PutCounter { counter_type: Keyword(..) }` gated by a graveyard-keyword
+    /// condition) once per listed keyword, swapping both the placed counter's
+    /// keyword and the gating condition's keyword. The counters-class analogue
+    /// of `SameIsTrueFor` (which handles static keyword grants).
+    RepeatProcessForKeywords(Vec<Keyword>),
 }
 
 /// Per-clause IR: captures everything about a single parsed chunk before chain assembly.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -23047,6 +23047,98 @@ mod snapshot_tests {
         insta::assert_json_snapshot!(def);
     }
 
+    /// CR 608.2c (issue #1584): Kathril's "Repeat this process for <10 keywords>"
+    /// must replicate the conditional keyword-counter placement once per keyword
+    /// — each placing that keyword's counter gated on a creature card in the
+    /// graveyard with the SAME keyword — instead of silently dropping the list.
+    #[test]
+    fn kathril_repeats_keyword_counters_across_graveyard_keywords() {
+        use crate::types::ability::{Effect, FilterProp, QuantityExpr, QuantityRef, TargetFilter};
+        use crate::types::counter::CounterType;
+        use crate::types::keywords::{Keyword, KeywordKind};
+
+        fn condition_keyword(cond: &AbilityCondition) -> Option<Keyword> {
+            let AbilityCondition::QuantityCheck { lhs, .. } = cond else {
+                return None;
+            };
+            let QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount { filter },
+            } = lhs
+            else {
+                return None;
+            };
+            let TargetFilter::Typed(typed) = filter else {
+                return None;
+            };
+            typed.properties.iter().find_map(|prop| match prop {
+                FilterProp::WithKeyword { value } => Some(value.clone()),
+                _ => None,
+            })
+        }
+
+        let def = parse_trigger_line(
+            "When Kathril enters, put a flying counter on any creature you control \
+             if a creature card in your graveyard has flying. Repeat this process \
+             for first strike, double strike, deathtouch, hexproof, indestructible, \
+             lifelink, menace, reach, trample, and vigilance. Then put a +1/+1 \
+             counter on Kathril for each counter put on a creature this way.",
+            "Kathril, Aspect Warper",
+        );
+
+        // Walk the execute chain, collecting each keyword counter with the
+        // keyword its graveyard gate checks.
+        let mut node = def.execute.as_deref();
+        let mut keyword_counters: Vec<(KeywordKind, KeywordKind)> = Vec::new();
+        let mut saw_p1p1 = false;
+        while let Some(d) = node {
+            if let Effect::PutCounter { counter_type, .. } = &*d.effect {
+                match counter_type {
+                    CounterType::Keyword(kind) => {
+                        let cond_kw = d
+                            .condition
+                            .as_ref()
+                            .and_then(condition_keyword)
+                            .expect("keyword counter keeps its graveyard-keyword gate");
+                        keyword_counters.push((*kind, cond_kw.kind()));
+                    }
+                    CounterType::Plus1Plus1 => saw_p1p1 = true,
+                    other => panic!("unexpected counter type {other:?}"),
+                }
+            }
+            node = d.sub_ability.as_deref();
+        }
+
+        let expected = [
+            KeywordKind::Flying,
+            KeywordKind::FirstStrike,
+            KeywordKind::DoubleStrike,
+            KeywordKind::Deathtouch,
+            KeywordKind::Hexproof,
+            KeywordKind::Indestructible,
+            KeywordKind::Lifelink,
+            KeywordKind::Menace,
+            KeywordKind::Reach,
+            KeywordKind::Trample,
+            KeywordKind::Vigilance,
+        ];
+        assert_eq!(
+            keyword_counters.len(),
+            expected.len(),
+            "all 11 keyword counters present (flying + the 10 repeated)"
+        );
+        for ((counter_kw, gate_kw), exp) in keyword_counters.iter().zip(expected) {
+            assert_eq!(*counter_kw, exp, "placed counter keyword matches the list");
+            assert_eq!(
+                *gate_kw, exp,
+                "the graveyard gate checks the SAME keyword as the placed counter"
+            );
+        }
+        assert!(
+            saw_p1p1,
+            "the +1/+1-on-Kathril follow-up survives the expansion"
+        );
+    }
+
     #[test]
     fn trigger_conditional_upkeep() {
         let def = parse_trigger_line(


### PR DESCRIPTION
## Summary
- Kathril, Aspect Warper only ever placed the first (flying) keyword counter. Its "Repeat this process for first strike, double strike, … and vigilance" line was silently dropped, so none of the other 10 keyword counters were generated.

## Root Cause
In `oracle_effect/mod.rs` the generic `tag("repeat this process")` directive matched "repeat this process for <list>" as a prefix and discarded the keyword list — the same swallow that affects any "repeat this process for X" card.

## Fix
Add a class-general `SpecialClause::RepeatProcessForKeywords` (the counters analogue of Odric's `SameIsTrueFor`):
- New parser branch `try_parse_repeat_process_for_keywords` runs before the generic directive and parses the keyword list.
- Lowering (`attach_repeat_process_keywords`) finds the antecedent conditional keyword-counter clause and appends one cloned sibling per listed keyword, swapping both the placed counter's keyword and the gating graveyard condition's keyword.

Result: all 11 keyword counters are generated, each gated on a creature card in the graveyard with the matching keyword (CR 608.2c).

Documented follow-ups (pre-existing, separate from this expansion): narrowing the counter target from "any" to "creature you control", and wiring the "+1/+1 for each counter put on a creature this way" count (needs resolution-scoped counting across the interactive per-counter choices).

## Test Plan
- Regression test `kathril_repeats_keyword_counters_across_graveyard_keywords` asserts all 11 keyword counters, each paired with the matching graveyard-keyword gate, plus the +1/+1 follow-up survives.
- Parser sweep `cargo test -p engine -- parser::oracle_effect parser::oracle_trigger parser::oracle_ir` -> 2122 passed (incl. the Odric `SameIsTrueFor` path).

Closes #1584