### PR TITLE
fix(engine): Bucknard's Everfull Purse — die-roll Treasure count + seating-relative control transfer

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -13,9 +13,9 @@ use crate::types::ability::{
     DieRollModifier, DoublePTMode, Duration, Effect, EffectOutcomeSignal, FilterProp,
     GainLifePlayer, GameRestriction, ManaProduction, ObjectProperty, ObjectScope, PlayerFilter,
     PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
-    ReplacementDefinition, ReplacementMode, SharedQuality, SharedQualityRelation, SpeedDelta,
-    SpellCastingOption, SpellCastingOptionKind, StaticCondition, StaticDefinition, TargetFilter,
-    TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
+    ReplacementDefinition, ReplacementMode, SeatDirection, SharedQuality, SharedQualityRelation,
+    SpeedDelta, SpellCastingOption, SpellCastingOptionKind, StaticCondition, StaticDefinition,
+    TargetFilter, TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
@@ -363,6 +363,10 @@ fn fmt_target(filter: &TargetFilter) -> String {
         TargetFilter::PostReplacementDamageTarget => "prevented damage target".into(),
         TargetFilter::SpecificObject { id } => format!("object #{}", id.0),
         TargetFilter::SpecificPlayer { id } => format!("player #{}", id.0),
+        TargetFilter::Neighbor { direction } => match direction {
+            SeatDirection::Left => "player to your left".into(),
+            SeatDirection::Right => "player to your right".into(),
+        },
         TargetFilter::TrackedSet { id } => format!("tracked set #{}", id.0),
         TargetFilter::TrackedSetFiltered { id, filter } => {
             format!("tracked set #{} matching {}", id.0, fmt_target(filter))

--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -124,6 +124,18 @@ fn unique_recipient_from_filter(
             .ok_or_else(|| EffectError::MissingParam("GiveControl recipient".to_string()));
     }
 
+    // CR 613.3 + CR 102.1: "the player to your left/right" resolves to a single
+    // living seating-neighbor (CR 101.4 / CR 103.1). `game::players::neighbor`
+    // already skips eliminated players, so this returns one player and bypasses
+    // the generic ambiguity loop below.
+    if let TargetFilter::Neighbor { direction } = filter {
+        return Ok(crate::game::players::neighbor(
+            state,
+            source_controller,
+            *direction,
+        ));
+    }
+
     let mut matching = state
         .players
         .iter()
@@ -386,6 +398,265 @@ mod tests {
             Err(EffectError::MissingParam(message)) if message == "ambiguous GiveControl recipient"
         ));
         assert!(events.is_empty());
+    }
+
+    /// CR 102.1 + CR 103.1 + CR 613.3: "The player to your right gains control
+    /// of this artifact" (Bucknard's Everfull Purse). Drives the real recipient
+    /// path: `resolve_give` → `unique_recipient_from_filter` →
+    /// `players::neighbor(Right)` = `previous_player`. In a 3-player game with
+    /// seat_order [P0,P1,P2] and controller P0, RIGHT = P2 (previous seat),
+    /// distinct from LEFT = P1 (next seat) — so this discriminates the seat
+    /// direction AND proves the single-recipient (no-ambiguity) resolution.
+    #[test]
+    fn give_control_to_player_to_the_right_targets_previous_seat() {
+        use crate::types::ability::SeatDirection;
+
+        let mut state = GameState::new(FormatConfig::free_for_all(), 3, 42);
+        assert_eq!(
+            state.seat_order,
+            vec![PlayerId(0), PlayerId(1), PlayerId(2)]
+        );
+
+        // The artifact (Bucknard's) controlled by the activator P0.
+        let artifact = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bucknard's Everfull Purse".to_string(),
+            Zone::Battlefield,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::GiveControl {
+                target: TargetFilter::SelfRef,
+                recipient: TargetFilter::Neighbor {
+                    direction: SeatDirection::Right,
+                },
+            },
+            vec![TargetRef::Object(artifact)],
+            artifact,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_give(&mut state, &ability, &mut events).unwrap();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert_eq!(
+            state.objects.get(&artifact).unwrap().controller,
+            PlayerId(2),
+            "player to your right = previous seat (P2), not next seat (P1)"
+        );
+    }
+
+    /// CR 706.2 + CR 102.1 + CR 103.1 + CR 613.3: End-to-end resolution of
+    /// Bucknard's Everfull Purse's activated ability
+    /// (`{1}, {T}: Roll a d4 and create a number of Treasure tokens equal to
+    /// the result. The player to your right gains control of this artifact.`)
+    /// through the REAL chain pipeline. This is the combined-ability test the
+    /// two unit tests (token-count parse + 3/4-player Neighbor{Right} recipient)
+    /// don't cover individually: it drives `RollDie → Token{count:
+    /// EventContextAmount} → GiveControl{recipient: Neighbor{Right}}` through
+    /// `resolve_ability_chain` and asserts both effects on the post-resolution
+    /// state.
+    ///
+    /// (a) CR 706.2: exactly N Treasures are created where N is the d4 result
+    ///     READ FROM the emitted `GameEvent::DieRolled` (not hard-coded), so the
+    ///     `EventContextAmount` count snapshot is proven to flow from the roll.
+    /// (b) CR 102.1 + CR 103.1 + CR 613.3: control of the Purse transfers to the
+    ///     controller's RIGHT neighbor = previous seat. In [P0,P1,P2] with
+    ///     controller P0, RIGHT = P2 (previous seat), distinct from LEFT = P1.
+    #[test]
+    fn bucknards_everfull_purse_full_chain_rolls_treasures_and_passes_right() {
+        use crate::game::players::previous_player;
+        use crate::types::ability::{PtValue, QuantityExpr, QuantityRef, SeatDirection};
+        use crate::types::card_type::CoreType;
+
+        let mut state = GameState::new(FormatConfig::free_for_all(), 3, 42);
+        assert_eq!(
+            state.seat_order,
+            vec![PlayerId(0), PlayerId(1), PlayerId(2)]
+        );
+
+        // Bucknard's Everfull Purse, controlled by the activator P0.
+        let purse = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bucknard's Everfull Purse".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&purse).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+        }
+
+        // Build the resolved ability EXACTLY as the parser produces it:
+        //   RollDie{sides:4}
+        //     └─ Token{name:"Treasure", count: EventContextAmount, owner: Controller}
+        //          └─ GiveControl{target: SelfRef, recipient: Neighbor{Right}}
+        let give_control = ResolvedAbility::new(
+            Effect::GiveControl {
+                target: TargetFilter::SelfRef,
+                recipient: TargetFilter::Neighbor {
+                    direction: SeatDirection::Right,
+                },
+            },
+            vec![TargetRef::Object(purse)],
+            purse,
+            PlayerId(0),
+        );
+        let create_treasures = ResolvedAbility::new(
+            Effect::Token {
+                name: "Treasure".to_string(),
+                power: PtValue::Fixed(0),
+                toughness: PtValue::Fixed(0),
+                types: vec!["Artifact".to_string(), "Treasure".to_string()],
+                colors: vec![],
+                keywords: vec![],
+                tapped: false,
+                // CR 706.2: "a number of Treasure tokens equal to the result"
+                // parses to an EventContextAmount count, snapshotted from the
+                // preceding RollDie's DieRolled event.
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                },
+                owner: TargetFilter::Controller,
+                attach_to: None,
+                enters_attacking: false,
+                supertypes: vec![],
+                static_abilities: vec![],
+                enter_with_counters: vec![],
+            },
+            vec![],
+            purse,
+            PlayerId(0),
+        )
+        .sub_ability(give_control);
+        let ability = ResolvedAbility::new(
+            Effect::RollDie {
+                sides: 4,
+                results: vec![],
+                modifier: None,
+            },
+            vec![],
+            purse,
+            PlayerId(0),
+        )
+        .sub_ability(create_treasures);
+
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        // (a) CR 706.2: read N from the emitted DieRolled event — never hard-coded.
+        let roll = events
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::DieRolled { result, .. } => Some(*result as usize),
+                _ => None,
+            })
+            .expect("RollDie must emit a DieRolled event");
+        assert!((1..=4).contains(&roll), "d4 result out of range: {roll}");
+
+        // Count Treasure tokens controlled by the activator (owner = Controller).
+        // After the GiveControl sub-effect the Purse moves to P2, so filtering on
+        // the Treasure subtype (not all P0-controlled artifacts) isolates the
+        // tokens from the artifact itself.
+        let treasure_count = state
+            .battlefield
+            .iter()
+            .filter_map(|id| state.objects.get(id))
+            .filter(|o| {
+                o.card_types.subtypes.contains(&"Treasure".to_string())
+                    && o.controller == PlayerId(0)
+            })
+            .count();
+        assert_eq!(
+            treasure_count, roll,
+            "must create exactly N={roll} Treasures (the d4 result), not a hard-coded count",
+        );
+        // Treasure tokens are colorless artifacts — sanity-check the type line so
+        // a future Token-shape regression can't silently pass the count check.
+        assert!(
+            state
+                .battlefield
+                .iter()
+                .filter_map(|id| state.objects.get(id))
+                .filter(|o| o.card_types.subtypes.contains(&"Treasure".to_string()))
+                .all(
+                    |o| o.card_types.core_types.contains(&CoreType::Artifact) && o.color.is_empty()
+                ),
+            "Treasure tokens must be colorless artifacts",
+        );
+
+        // (b) CR 102.1 + CR 103.1 + CR 613.3: control passed to the RIGHT
+        // neighbor = previous seat = P2 (distinct from LEFT = P1).
+        assert_eq!(
+            previous_player(&state, PlayerId(0)),
+            PlayerId(2),
+            "right neighbor of P0 in [P0,P1,P2] is the previous seat P2",
+        );
+        assert_eq!(
+            state.objects.get(&purse).unwrap().controller,
+            PlayerId(2),
+            "the Purse must transfer to the player on the controller's right (P2), not the left (P1)",
+        );
+        assert_ne!(
+            state.objects.get(&purse).unwrap().controller,
+            PlayerId(1),
+            "control must NOT go to the LEFT neighbor (next seat P1)",
+        );
+    }
+
+    /// CR 102.1 + CR 800.4b: When the immediate right-neighbor has left the
+    /// game, "the player to your right" skips to the next living seat
+    /// counter-clockwise. In a 4-player game [P0,P1,P2,P3] with controller P0,
+    /// the immediate right is P3; eliminating P3 routes control to P2.
+    #[test]
+    fn give_control_to_the_right_skips_eliminated_neighbor() {
+        use crate::types::ability::SeatDirection;
+
+        let mut state = GameState::new(FormatConfig::free_for_all(), 4, 42);
+        assert_eq!(
+            state.seat_order,
+            vec![PlayerId(0), PlayerId(1), PlayerId(2), PlayerId(3)]
+        );
+        // Eliminate the immediate right neighbor (P3).
+        state
+            .players
+            .iter_mut()
+            .find(|p| p.id == PlayerId(3))
+            .unwrap()
+            .is_eliminated = true;
+
+        let artifact = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bucknard's Everfull Purse".to_string(),
+            Zone::Battlefield,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::GiveControl {
+                target: TargetFilter::SelfRef,
+                recipient: TargetFilter::Neighbor {
+                    direction: SeatDirection::Right,
+                },
+            },
+            vec![TargetRef::Object(artifact)],
+            artifact,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_give(&mut state, &ability, &mut events).unwrap();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert_eq!(
+            state.objects.get(&artifact).unwrap().controller,
+            PlayerId(2),
+            "eliminated right neighbor (P3) is skipped; control passes to P2"
+        );
     }
 
     /// CR 611.2b + CR 110.5d + CR 613.1b: Callous Oppressor regression (issue

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -65,6 +65,7 @@ pub(crate) fn affected_filter_uses_object_population(filter: &TargetFilter) -> b
         | TargetFilter::StackSpell
         | TargetFilter::SpecificObject { .. }
         | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::Neighbor { .. }
         | TargetFilter::ScopedPlayer
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
@@ -243,6 +244,7 @@ pub(crate) fn entered_object_perturbs_affected_filter(
         | TargetFilter::StackSpell
         | TargetFilter::SpecificObject { .. }
         | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::Neighbor { .. }
         | TargetFilter::ScopedPlayer
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
@@ -1121,6 +1123,9 @@ fn filter_inner_for_object(
         TargetFilter::SpecificObject { id: target_id } => object_id == *target_id,
         // SpecificPlayer scopes to players, not objects — no object matches.
         TargetFilter::SpecificPlayer { .. } => false,
+        // CR 102.1 + CR 103.1: Neighbor scopes to a seating-relative player,
+        // not an object — no object matches.
+        TargetFilter::Neighbor { .. } => false,
         TargetFilter::AttachedTo => state
             .objects
             .get(&source_id)
@@ -1377,6 +1382,9 @@ fn zone_change_filter_inner(
         // SpecificPlayer scopes to players, not objects — a zone-change record
         // is always an object transition.
         TargetFilter::SpecificPlayer { .. } => false,
+        // CR 102.1 + CR 103.1: Neighbor scopes to a seating-relative player,
+        // not an object — a zone-change record is always an object transition.
+        TargetFilter::Neighbor { .. } => false,
         // CR 201.2: Zone-change record path mirrors the live-object path —
         // case-insensitive comparison matches the player UI prompt's input.
         TargetFilter::HasChosenName => {
@@ -1628,6 +1636,7 @@ pub fn spell_record_matches_filter(
         | TargetFilter::StackSpell
         | TargetFilter::SpecificObject { .. }
         | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::Neighbor { .. }
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::CostPaidObject
@@ -1861,6 +1870,7 @@ fn spell_object_matches_filter_inner(
         | TargetFilter::StackSpell
         | TargetFilter::SpecificObject { .. }
         | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::Neighbor { .. }
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::CostPaidObject
@@ -3717,6 +3727,12 @@ pub fn player_matches_target_filter(
         TargetFilter::And { filters } => filters
             .iter()
             .all(|f| player_matches_target_filter(f, player_id, source_controller)),
+        // CR 102.1 + CR 103.1: seating-neighbor resolution requires
+        // `state.seat_order`, which is not available in this stateless matcher.
+        // The recipient is resolved upstream at the GainControl recipient path
+        // (`gain_control::unique_recipient_from_filter`). Fail closed here —
+        // mirrors the `TriggeringPlayer` / `TargetPlayer` fail-closed arms.
+        TargetFilter::Neighbor { .. } => false,
         _ => false,
     }
 }

--- a/crates/engine/src/game/players.rs
+++ b/crates/engine/src/game/players.rs
@@ -1,4 +1,4 @@
-use crate::types::ability::{ControllerRef, PlayerRelation};
+use crate::types::ability::{ControllerRef, PlayerRelation, SeatDirection};
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::GameState;
 use crate::types::game_state::LinkedExileSnapshot;
@@ -37,6 +37,47 @@ pub fn next_player(state: &GameState, current: PlayerId) -> PlayerId {
 
     // Only living player (or no living players — shouldn't happen)
     current
+}
+
+/// CR 102.1 / CR 500.1: Previous living player in seat (turn) order.
+///
+/// Returns the previous living player in seat order before `current`, wrapping
+/// around (the seat to `current`'s right, since turn order proceeds to the
+/// left per CR 101.4 / CR 103.1). Skips eliminated players. If `current` is the
+/// only living player, returns `current`.
+pub fn previous_player(state: &GameState, current: PlayerId) -> PlayerId {
+    let seat_order = &state.seat_order;
+    let len = seat_order.len();
+    if len == 0 {
+        return current;
+    }
+
+    let current_idx = seat_order.iter().position(|&id| id == current).unwrap_or(0);
+
+    for offset in 1..=len {
+        // Walk backward through the seat ring (wrapping) by adding `len - offset`.
+        let idx = (current_idx + len - (offset % len)) % len;
+        let candidate = seat_order[idx];
+        if is_alive(state, candidate) {
+            return candidate;
+        }
+    }
+
+    // Only living player (or no living players — shouldn't happen)
+    current
+}
+
+/// CR 102.1 + CR 103.1: Single authority for seating-neighbor resolution.
+///
+/// Resolves the living player seated immediately to `controller`'s left or
+/// right. Turn order proceeds clockwise to the active player's left
+/// (CR 101.4 / CR 103.1), so `Left` walks forward in `seat_order`
+/// (`next_player`) and `Right` walks backward (`previous_player`).
+pub fn neighbor(state: &GameState, controller: PlayerId, direction: SeatDirection) -> PlayerId {
+    match direction {
+        SeatDirection::Left => next_player(state, controller),
+        SeatDirection::Right => previous_player(state, controller),
+    }
 }
 
 /// CR 102.2 / CR 102.3: Opponents in two-player and multiplayer games.
@@ -293,6 +334,62 @@ mod tests {
         let state = make_state(2, FormatConfig::standard());
         assert_eq!(next_player(&state, PlayerId(0)), PlayerId(1));
         assert_eq!(next_player(&state, PlayerId(1)), PlayerId(0));
+    }
+
+    // --- previous_player ---
+
+    #[test]
+    fn previous_player_returns_previous_in_seat_order() {
+        let state = make_state(3, FormatConfig::free_for_all());
+        // seat_order [P0,P1,P2]: previous of P1 is P0, previous of P2 is P1.
+        assert_eq!(previous_player(&state, PlayerId(1)), PlayerId(0));
+        assert_eq!(previous_player(&state, PlayerId(2)), PlayerId(1));
+    }
+
+    #[test]
+    fn previous_player_wraps_around() {
+        let state = make_state(3, FormatConfig::free_for_all());
+        // previous of P0 wraps to the last seat P2.
+        assert_eq!(previous_player(&state, PlayerId(0)), PlayerId(2));
+    }
+
+    #[test]
+    fn previous_player_skips_eliminated() {
+        let mut state = make_state(4, FormatConfig::free_for_all());
+        // seat_order [P0,P1,P2,P3]: immediate previous of P0 is P3; eliminate it.
+        eliminate(&mut state, PlayerId(3));
+        assert_eq!(previous_player(&state, PlayerId(0)), PlayerId(2));
+    }
+
+    #[test]
+    fn previous_player_returns_self_if_only_living() {
+        let mut state = make_state(3, FormatConfig::free_for_all());
+        eliminate(&mut state, PlayerId(1));
+        eliminate(&mut state, PlayerId(2));
+        assert_eq!(previous_player(&state, PlayerId(0)), PlayerId(0));
+    }
+
+    #[test]
+    fn previous_player_two_player_standard() {
+        let state = make_state(2, FormatConfig::standard());
+        assert_eq!(previous_player(&state, PlayerId(0)), PlayerId(1));
+        assert_eq!(previous_player(&state, PlayerId(1)), PlayerId(0));
+    }
+
+    // --- neighbor ---
+
+    #[test]
+    fn neighbor_left_is_next_right_is_previous() {
+        let state = make_state(3, FormatConfig::free_for_all());
+        // seat_order [P0,P1,P2], controller P0: left = next = P1, right = prev = P2.
+        assert_eq!(
+            neighbor(&state, PlayerId(0), SeatDirection::Left),
+            PlayerId(1)
+        );
+        assert_eq!(
+            neighbor(&state, PlayerId(0), SeatDirection::Right),
+            PlayerId(2)
+        );
     }
 
     // --- opponents ---

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -613,6 +613,9 @@ pub(super) fn target_filter_matches_object(
         TargetFilter::ScopedPlayer => false,
         // SpecificPlayer scopes to a player, not an object — never matches an object.
         TargetFilter::SpecificPlayer { .. } => false,
+        // CR 102.1 + CR 103.1: Neighbor scopes to a seating-relative player,
+        // not an object — never matches an object.
+        TargetFilter::Neighbor { .. } => false,
         TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
         | TargetFilter::TriggeringPlayer

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -830,6 +830,19 @@ pub(super) fn parse_subject_application(
             is_optional: false,
         });
     }
+    // CR 102.1 + CR 103.1: "the player to your right/left" as subject — a
+    // seating-relative neighbor (Bucknard's Everfull Purse: "The player to your
+    // right gains control of this artifact"). Delegate to `parse_target`, which
+    // is the single authority for the `Neighbor` mapping. Must precede the bare
+    // "the player" anaphor arm below so the longer seating phrase wins, and the
+    // GainControl→GiveControl rewrite receives `recipient: Neighbor` rather than
+    // a generic `Any`/`TriggeringPlayer`.
+    {
+        let (neighbor_filter, rest) = parse_target(subject);
+        if rest.trim().is_empty() && matches!(neighbor_filter, TargetFilter::Neighbor { .. }) {
+            return subject_filter_application(neighbor_filter, false);
+        }
+    }
     // CR 608.2c + CR 117.3a: "that player" / "the player" as subject,
     // optionally carrying a "may" modal ("that player may pay {2}").
     // In trigger context (`ctx.subject` is Some — set exclusively by
@@ -3141,6 +3154,28 @@ mod tests {
                 mode: StaticMode::CantUntap
             }
         )));
+    }
+
+    /// CR 102.1 + CR 103.1: "the player to your right" as a subject resolves to
+    /// the seating-relative `Neighbor` filter (untargeted), so the
+    /// GainControl→GiveControl rewrite gets `recipient: Neighbor { Right }`
+    /// rather than a generic `Any`. Regression for Bucknard's Everfull Purse.
+    #[test]
+    fn parse_subject_the_player_to_your_right_is_neighbor() {
+        use crate::types::ability::SeatDirection;
+        let mut ctx = ParseContext::default();
+        let app = parse_subject_application("the player to your right", &mut ctx)
+            .expect("seating-neighbor subject should parse");
+        assert_eq!(
+            app.affected,
+            TargetFilter::Neighbor {
+                direction: SeatDirection::Right
+            }
+        );
+        assert!(
+            app.target.is_none(),
+            "neighbor recipient is computed, not a chosen target slot"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -386,7 +386,15 @@ pub(crate) fn parse_token_description(text: &str) -> Option<TokenDescription> {
     if let Some(count_expression) = extract_token_count_expression(suffix) {
         if matches!(&count, QuantityExpr::Ref { qty: QuantityRef::Variable { ref name } } if name == "count")
         {
+            // CR 706.2: "the result" (die roll / coin flip) flows through
+            // `EventContextAmount`, consistent with `oracle_quantity.rs:1176`.
+            // `parse_event_context_quantity` only fires when `parse_cda_quantity`
+            // returns None and itself returns None for unrecognized phrases, so
+            // it strictly widens coverage without disturbing existing matches.
             count = crate::parser::oracle_quantity::parse_cda_quantity(&count_expression)
+                .or_else(|| {
+                    crate::parser::oracle_quantity::parse_event_context_quantity(&count_expression)
+                })
                 .unwrap_or(QuantityExpr::Ref {
                     qty: QuantityRef::Variable {
                         name: count_expression,
@@ -1442,6 +1450,30 @@ mod tests {
             }
             other => panic!("Expected Token effect, got {:?}", other),
         }
+    }
+
+    /// CR 706.2: "create a number of Treasure tokens equal to the result"
+    /// (Bucknard's Everfull Purse). "the result" of the die roll flows through
+    /// `EventContextAmount`, not a `Variable("count")` fallback. Regression for
+    /// the count→0 bug where the count was a stringly-typed Variable.
+    #[test]
+    fn token_count_equal_to_the_result_is_event_context_amount() {
+        let effect = try_parse_token(
+            "create a number of treasure tokens equal to the result",
+            "Create a number of Treasure tokens equal to the result",
+            &mut ParseContext::default(),
+        )
+        .expect("expected Token effect");
+        let Effect::Token { count, .. } = effect else {
+            panic!("expected Token effect, got {effect:?}");
+        };
+        assert_eq!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount
+            },
+            "die-roll result count must resolve to EventContextAmount, not Variable"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -9,8 +9,8 @@ use nom::Parser;
 use crate::types::ability::{
     AggregateFunction, AttachmentKind, CombatRelation, CombatRelationSubject, Comparator,
     ControllerRef, FilterProp, ObjectProperty, ObjectScope, PtStat, PtValueScope, QuantityExpr,
-    QuantityRef, SharedQuality, SharedQualityRelation, TargetFilter, TargetSelectionMode,
-    TypeFilter, TypedFilter,
+    QuantityRef, SeatDirection, SharedQuality, SharedQualityRelation, TargetFilter,
+    TargetSelectionMode, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::{CounterMatch, CounterType};
@@ -796,6 +796,22 @@ pub fn parse_target_with_syntax<'a>(
             value(
                 TargetFilter::ParentTargetSlot { index: 0 },
                 tag("the second player"),
+            ),
+            // CR 102.1 + CR 103.1: "the player to your right/left" —
+            // seating-relative neighbor. Right = previous seat (clockwise turn
+            // order proceeds to the left). Placed before the bare "the player"
+            // arm so the longer phrase wins under longest-match-first dispatch.
+            value(
+                TargetFilter::Neighbor {
+                    direction: SeatDirection::Right,
+                },
+                tag("the player to your right"),
+            ),
+            value(
+                TargetFilter::Neighbor {
+                    direction: SeatDirection::Left,
+                },
+                tag("the player to your left"),
             ),
             value(TargetFilter::ParentTarget, tag("the player")),
             value(TargetFilter::ParentTarget, tag("the creature")),
@@ -9512,6 +9528,33 @@ mod tests {
         assert!(tf.type_filters.contains(&TypeFilter::Artifact));
         assert!(tf.type_filters.contains(&TypeFilter::Creature));
         assert_eq!(tf.controller, Some(ControllerRef::You));
+    }
+
+    /// CR 102.1 + CR 103.1: "the player to your right/left" parses to a
+    /// seating-relative `Neighbor` filter. Right = previous seat (clockwise
+    /// turn order proceeds to the left).
+    #[test]
+    fn parse_target_player_to_your_right_is_neighbor_right() {
+        let (f, rest) = parse_target("the player to your right");
+        assert_eq!(
+            f,
+            TargetFilter::Neighbor {
+                direction: SeatDirection::Right
+            }
+        );
+        assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn parse_target_player_to_your_left_is_neighbor_left() {
+        let (f, rest) = parse_target("the player to your left");
+        assert_eq!(
+            f,
+            TargetFilter::Neighbor {
+                direction: SeatDirection::Left
+            }
+        );
+        assert_eq!(rest, "");
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2492,6 +2492,14 @@ pub enum TargetFilter {
     SpecificPlayer {
         id: PlayerId,
     },
+    /// CR 102.1 + CR 103.1: living player seated immediately to controller's
+    /// left/right; clockwise turn order, right = previous seat; resolved
+    /// against `state.seat_order`. The recipient is computed at the resolver
+    /// (`game::players::neighbor`), never selected as an interactive target
+    /// slot.
+    Neighbor {
+        direction: SeatDirection,
+    },
     /// CR 115.10 + CR 608.2c: The current player being affected by an
     /// "each player/opponent" instruction during resolution. This is not the
     /// ability controller; "you" and "your" still refer to `controller`.
@@ -3343,6 +3351,21 @@ pub enum UntilCondition {
 pub struct CostPaidObjectSnapshot {
     pub object_id: ObjectId,
     pub lki: LKISnapshot,
+}
+
+/// CR 102.1 + CR 103.1: Seating direction relative to a player. The game's
+/// default turn order proceeds clockwise (CR 103.1); the next player in turn
+/// order is seated to the active player's left (CR 101.4). Thus walking
+/// forward through `seat_order` is `Left`, and walking backward is `Right`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum SeatDirection {
+    /// The living player seated immediately to the controller's left — the
+    /// next player in turn order (CR 101.4). Forward through `seat_order`.
+    Left,
+    /// The living player seated immediately to the controller's right — the
+    /// previous player in turn order. Backward through `seat_order`.
+    Right,
 }
 
 /// CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that
@@ -7355,6 +7378,10 @@ impl TargetFilter {
                 | TargetFilter::TriggeringPlayer
                 | TargetFilter::TriggeringSource
                 | TargetFilter::DefendingPlayer
+                // CR 102.1 + CR 103.1: the seating neighbor is computed at the
+                // resolver (`game::players::neighbor`), never declared as a
+                // chosen target slot — so it is a context ref.
+                | TargetFilter::Neighbor { .. }
                 | TargetFilter::AttachedTo
                 | TargetFilter::CostPaidObject
                 | TargetFilter::ParentTarget

--- a/crates/mtgish-import/src/convert/condition.rs
+++ b/crates/mtgish-import/src/convert/condition.rs
@@ -1026,6 +1026,7 @@ fn target_filter_variant_name(f: &TargetFilter) -> &'static str {
         TargetFilter::StackSpell => "StackSpell",
         TargetFilter::SpecificObject { .. } => "SpecificObject",
         TargetFilter::SpecificPlayer { .. } => "SpecificPlayer",
+        TargetFilter::Neighbor { .. } => "Neighbor",
         TargetFilter::AttachedTo => "AttachedTo",
         TargetFilter::LastCreated => "LastCreated",
         TargetFilter::CostPaidObject => "CostPaidObject",

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -25,8 +25,8 @@
     "crates/engine/src/types/attribution.rs",
     "crates/engine/src/types/card_type.rs"
   ],
-  "enum_count": 250,
-  "variant_count": 2785,
+  "enum_count": 251,
+  "variant_count": 2788,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -430,13 +430,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9145,
+      "line": 9172,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 9163,
+          "line": 9190,
           "kind": "struct",
           "field_names": [
             "source",
@@ -454,7 +454,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 9179,
+          "line": 9206,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -465,7 +465,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 9184,
+          "line": 9211,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -479,7 +479,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 9189,
+          "line": 9216,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -489,7 +489,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 9197,
+          "line": 9224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -499,7 +499,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9200,
+          "line": 9227,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -511,7 +511,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9204,
+          "line": 9231,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -524,7 +524,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9207,
+          "line": 9234,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -537,7 +537,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9210,
+          "line": 9237,
           "kind": "struct",
           "field_names": [
             "color",
@@ -551,7 +551,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 9216,
+          "line": 9243,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -564,7 +564,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9224,
+          "line": 9251,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -575,7 +575,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9227,
+          "line": 9254,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -588,7 +588,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 9232,
+          "line": 9259,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -602,7 +602,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 9236,
+          "line": 9263,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -616,7 +616,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 9245,
+          "line": 9272,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -630,7 +630,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9250,
+          "line": 9277,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -640,7 +640,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9252,
+          "line": 9279,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -650,7 +650,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9255,
+          "line": 9282,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -660,7 +660,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 9259,
+          "line": 9286,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -672,7 +672,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 9264,
+          "line": 9291,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -686,7 +686,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9272,
+          "line": 9299,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -698,7 +698,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9277,
+          "line": 9304,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -714,7 +714,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 9289,
+          "line": 9316,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -727,7 +727,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 9293,
+          "line": 9320,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -740,7 +740,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 9297,
+          "line": 9324,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -750,7 +750,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9305,
+          "line": 9332,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -763,7 +763,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9310,
+          "line": 9337,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -776,7 +776,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9315,
+          "line": 9342,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -788,7 +788,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 9321,
+          "line": 9348,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -800,7 +800,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 9325,
+          "line": 9352,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -814,7 +814,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9328,
+          "line": 9355,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -824,7 +824,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 9337,
+          "line": 9364,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -837,7 +837,7 @@
         },
         {
           "name": "And",
-          "line": 9342,
+          "line": 9369,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -849,7 +849,7 @@
         },
         {
           "name": "Or",
-          "line": 9347,
+          "line": 9374,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -861,7 +861,7 @@
         },
         {
           "name": "Not",
-          "line": 9355,
+          "line": 9382,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -873,7 +873,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 9359,
+          "line": 9386,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -883,7 +883,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 9361,
+          "line": 9388,
           "kind": "struct",
           "field_names": [
             "state"
@@ -895,7 +895,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 9371,
+          "line": 9398,
           "kind": "struct",
           "field_names": [
             "n"
@@ -907,7 +907,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 9374,
+          "line": 9401,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -919,7 +919,7 @@
         },
         {
           "name": "ScopedPlayerMatches",
-          "line": 9394,
+          "line": 9421,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -945,13 +945,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4397,
+      "line": 4420,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 4398,
+          "line": 4421,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -961,7 +961,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 4407,
+          "line": 4430,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -974,7 +974,7 @@
         },
         {
           "name": "Tap",
-          "line": 4410,
+          "line": 4433,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -982,7 +982,7 @@
         },
         {
           "name": "Untap",
-          "line": 4411,
+          "line": 4434,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -990,7 +990,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 4412,
+          "line": 4435,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1000,7 +1000,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 4415,
+          "line": 4438,
           "kind": "struct",
           "field_names": [
             "target",
@@ -1011,7 +1011,7 @@
         },
         {
           "name": "PayLife",
-          "line": 4427,
+          "line": 4450,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1023,7 +1023,7 @@
         },
         {
           "name": "Discard",
-          "line": 4430,
+          "line": 4453,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1036,7 +1036,7 @@
         },
         {
           "name": "Exile",
-          "line": 4441,
+          "line": 4464,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1048,7 +1048,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 4450,
+          "line": 4473,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1061,7 +1061,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 4453,
+          "line": 4476,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1072,7 +1072,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 4464,
+          "line": 4487,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1087,7 +1087,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 4470,
+          "line": 4493,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1097,7 +1097,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4474,
+          "line": 4497,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1110,7 +1110,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4482,
+          "line": 4505,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1124,7 +1124,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4491,
+          "line": 4514,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1134,7 +1134,7 @@
         },
         {
           "name": "Mill",
-          "line": 4492,
+          "line": 4515,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1144,7 +1144,7 @@
         },
         {
           "name": "Exert",
-          "line": 4495,
+          "line": 4518,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1152,7 +1152,7 @@
         },
         {
           "name": "Blight",
-          "line": 4498,
+          "line": 4521,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1162,7 +1162,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4501,
+          "line": 4524,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1173,7 +1173,7 @@
         },
         {
           "name": "Behold",
-          "line": 4509,
+          "line": 4532,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1185,7 +1185,7 @@
         },
         {
           "name": "Composite",
-          "line": 4515,
+          "line": 4538,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1195,7 +1195,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4532,
+          "line": 4555,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1208,7 +1208,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4536,
+          "line": 4559,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1218,7 +1218,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4541,
+          "line": 4564,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1231,7 +1231,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4548,
+          "line": 4571,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1243,7 +1243,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4564,
+          "line": 4587,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1257,7 +1257,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4569,
+          "line": 4592,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1270,13 +1270,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8284,
+      "line": 8311,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 8286,
+          "line": 8313,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1284,7 +1284,7 @@
         },
         {
           "name": "Activated",
-          "line": 8287,
+          "line": 8314,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1292,7 +1292,7 @@
         },
         {
           "name": "Database",
-          "line": 8288,
+          "line": 8315,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1300,7 +1300,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 8291,
+          "line": 8318,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1308,7 +1308,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 8297,
+          "line": 8324,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1321,7 +1321,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8438,
+      "line": 8465,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1329,7 +1329,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 8440,
+          "line": 8467,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1339,7 +1339,7 @@
         },
         {
           "name": "Evolve",
-          "line": 8442,
+          "line": 8469,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1349,7 +1349,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 8444,
+          "line": 8471,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1359,7 +1359,7 @@
         },
         {
           "name": "Outlast",
-          "line": 8446,
+          "line": 8473,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1428,13 +1428,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8454,
+      "line": 8481,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8455,
+          "line": 8482,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1442,7 +1442,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 8456,
+          "line": 8483,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1450,7 +1450,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8457,
+          "line": 8484,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1458,7 +1458,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8458,
+          "line": 8485,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1466,7 +1466,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8459,
+          "line": 8486,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1474,7 +1474,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8460,
+          "line": 8487,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1482,7 +1482,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8461,
+          "line": 8488,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1490,7 +1490,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 8462,
+          "line": 8489,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1498,7 +1498,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 8463,
+          "line": 8490,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1506,7 +1506,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 8464,
+          "line": 8491,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1516,7 +1516,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8467,
+          "line": 8494,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1526,7 +1526,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 8471,
+          "line": 8498,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1536,7 +1536,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 8473,
+          "line": 8500,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1548,7 +1548,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 8478,
+          "line": 8505,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1562,7 +1562,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 8489,
+          "line": 8516,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1576,7 +1576,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 8502,
+          "line": 8529,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1589,13 +1589,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4773,
+      "line": 4796,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 4779,
+          "line": 4802,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1606,7 +1606,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4789,
+          "line": 4812,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1622,7 +1622,7 @@
         },
         {
           "name": "Choice",
-          "line": 4796,
+          "line": 4819,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1630,7 +1630,7 @@
         },
         {
           "name": "Required",
-          "line": 4798,
+          "line": 4821,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1641,7 +1641,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4807,
+      "line": 4830,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1649,7 +1649,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 4809,
+          "line": 4832,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1657,7 +1657,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4810,
+          "line": 4833,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1665,7 +1665,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 4811,
+          "line": 4834,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1676,7 +1676,7 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3279,
+      "line": 3287,
       "doc": "CR 107.3e: Aggregate function applied over a set of objects.",
       "cr_refs": [
         "CR 107.3e"
@@ -1684,7 +1684,7 @@
       "variants": [
         {
           "name": "Max",
-          "line": 3280,
+          "line": 3288,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1692,7 +1692,7 @@
         },
         {
           "name": "Min",
-          "line": 3281,
+          "line": 3289,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1700,7 +1700,7 @@
         },
         {
           "name": "Sum",
-          "line": 3282,
+          "line": 3290,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2024,13 +2024,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4389,
+      "line": 4412,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 4390,
+          "line": 4413,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2038,7 +2038,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 4391,
+          "line": 4414,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2148,7 +2148,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5109,
+      "line": 5132,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2156,7 +2156,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 5112,
+          "line": 5135,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2164,7 +2164,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 5114,
+          "line": 5137,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2327,13 +2327,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2759,
+      "line": 2767,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 2761,
+          "line": 2769,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -2347,7 +2347,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2763,
+          "line": 2771,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -2358,7 +2358,7 @@
         },
         {
           "name": "Objects",
-          "line": 2765,
+          "line": 2773,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -2450,7 +2450,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2770,
+      "line": 2778,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -2458,7 +2458,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 2772,
+          "line": 2780,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -2466,7 +2466,7 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 2774,
+          "line": 2782,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
@@ -2477,7 +2477,7 @@
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2780,
+      "line": 2788,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -2486,7 +2486,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 2782,
+          "line": 2790,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -2494,7 +2494,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 2784,
+          "line": 2792,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -2502,7 +2502,7 @@
         },
         {
           "name": "FromSource",
-          "line": 2786,
+          "line": 2794,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -2668,7 +2668,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4363,
+      "line": 4386,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -2677,7 +2677,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 4366,
+          "line": 4389,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -2688,7 +2688,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4325,
+      "line": 4348,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -2699,7 +2699,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4327,
+          "line": 4350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -2710,7 +2710,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4330,
+          "line": 4353,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -2720,7 +2720,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4332,
+          "line": 4355,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -2730,7 +2730,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4334,
+          "line": 4357,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -2740,7 +2740,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4337,
+          "line": 4360,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -2750,7 +2750,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4343,
+          "line": 4366,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -2760,7 +2760,7 @@
         },
         {
           "name": "Escape",
-          "line": 4348,
+          "line": 4371,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -2771,7 +2771,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4351,
+          "line": 4374,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -2781,7 +2781,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4356,
+          "line": 4379,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -2975,13 +2975,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8510,
+      "line": 8537,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8511,
+          "line": 8538,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2989,7 +2989,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8512,
+          "line": 8539,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2997,7 +2997,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 8513,
+          "line": 8540,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3005,7 +3005,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8514,
+          "line": 8541,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3013,7 +3013,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8515,
+          "line": 8542,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3021,7 +3021,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 8516,
+          "line": 8543,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3029,7 +3029,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 8517,
+          "line": 8544,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3037,7 +3037,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 8518,
+          "line": 8545,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3045,7 +3045,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 8519,
+          "line": 8546,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3053,7 +3053,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 8520,
+          "line": 8547,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3061,7 +3061,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 8521,
+          "line": 8548,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3069,7 +3069,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8522,
+          "line": 8549,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3077,7 +3077,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 8523,
+          "line": 8550,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3085,7 +3085,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8524,
+          "line": 8551,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3093,7 +3093,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 8525,
+          "line": 8552,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3101,7 +3101,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8526,
+          "line": 8553,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3892,7 +3892,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10218,
+      "line": 10245,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -3900,7 +3900,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 10219,
+          "line": 10246,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3908,7 +3908,7 @@
         },
         {
           "name": "Lost",
-          "line": 10220,
+          "line": 10247,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3975,7 +3975,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10722,
+      "line": 10749,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -3983,7 +3983,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 10723,
+          "line": 10750,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3991,7 +3991,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 10724,
+          "line": 10751,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4106,7 +4106,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3766,
+      "line": 3789,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -4114,7 +4114,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 3769,
+          "line": 3792,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -4125,7 +4125,7 @@
         },
         {
           "name": "Any",
-          "line": 3773,
+          "line": 3796,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -4229,13 +4229,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3637,
+      "line": 3660,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 3638,
+          "line": 3661,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4243,7 +4243,7 @@
         },
         {
           "name": "LT",
-          "line": 3639,
+          "line": 3662,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4251,7 +4251,7 @@
         },
         {
           "name": "GE",
-          "line": 3640,
+          "line": 3663,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4259,7 +4259,7 @@
         },
         {
           "name": "LE",
-          "line": 3641,
+          "line": 3664,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4267,7 +4267,7 @@
         },
         {
           "name": "EQ",
-          "line": 3642,
+          "line": 3665,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4275,7 +4275,7 @@
         },
         {
           "name": "NE",
-          "line": 3643,
+          "line": 3666,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4286,13 +4286,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11138,
+      "line": 11165,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 11139,
+          "line": 11166,
           "kind": "struct",
           "field_names": [
             "values",
@@ -4303,7 +4303,7 @@
         },
         {
           "name": "SetName",
-          "line": 11154,
+          "line": 11181,
           "kind": "struct",
           "field_names": [
             "name"
@@ -4317,7 +4317,7 @@
         },
         {
           "name": "AddPower",
-          "line": 11157,
+          "line": 11184,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4327,7 +4327,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 11160,
+          "line": 11187,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4337,7 +4337,7 @@
         },
         {
           "name": "SetPower",
-          "line": 11163,
+          "line": 11190,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4347,7 +4347,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 11166,
+          "line": 11193,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4357,7 +4357,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 11169,
+          "line": 11196,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4367,7 +4367,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 11172,
+          "line": 11199,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4377,7 +4377,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 11175,
+          "line": 11202,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4387,7 +4387,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 11182,
+          "line": 11209,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -4399,7 +4399,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 11185,
+          "line": 11212,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4407,7 +4407,7 @@
         },
         {
           "name": "AddType",
-          "line": 11186,
+          "line": 11213,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4417,7 +4417,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 11189,
+          "line": 11216,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4427,7 +4427,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 11192,
+          "line": 11219,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4437,7 +4437,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 11195,
+          "line": 11222,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4447,7 +4447,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 11202,
+          "line": 11229,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4460,7 +4460,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 11208,
+          "line": 11235,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4473,7 +4473,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 11212,
+          "line": 11239,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4483,7 +4483,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 11216,
+          "line": 11243,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4493,7 +4493,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 11223,
+          "line": 11250,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4505,7 +4505,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 11228,
+          "line": 11255,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4517,7 +4517,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 11232,
+          "line": 11259,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4529,7 +4529,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 11236,
+          "line": 11263,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4541,7 +4541,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 11241,
+          "line": 11268,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4554,7 +4554,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 11247,
+          "line": 11274,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4562,7 +4562,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 11250,
+          "line": 11277,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4573,7 +4573,7 @@
         },
         {
           "name": "AddAllLandTypes",
-          "line": 11254,
+          "line": 11281,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.7: grants every land type (all 17 land subtypes) and their mana abilities, additive. Distinct from AddAllBasicLandTypes (CR 305.6, 5 basic types). Omo, Queen of Vesuva. Layer 4.",
@@ -4585,7 +4585,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 11257,
+          "line": 11284,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4595,7 +4595,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 11262,
+          "line": 11289,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4605,7 +4605,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 11269,
+          "line": 11296,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -4616,7 +4616,7 @@
         },
         {
           "name": "SetColor",
-          "line": 11270,
+          "line": 11297,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4626,7 +4626,7 @@
         },
         {
           "name": "AddColor",
-          "line": 11273,
+          "line": 11300,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4636,7 +4636,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 11278,
+          "line": 11305,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4646,7 +4646,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 11292,
+          "line": 11319,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4661,7 +4661,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 11296,
+          "line": 11323,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4671,7 +4671,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 11299,
+          "line": 11326,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -4681,7 +4681,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 11301,
+          "line": 11328,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -4691,7 +4691,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 11303,
+          "line": 11330,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -4701,7 +4701,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 11306,
+          "line": 11333,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -4711,7 +4711,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 11309,
+          "line": 11336,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -4723,7 +4723,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 11323,
+          "line": 11350,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -4735,7 +4735,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 11331,
+          "line": 11358,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4750,7 +4750,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 11340,
+          "line": 11367,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4765,7 +4765,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 11354,
+          "line": 11381,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -4927,7 +4927,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11433,
+      "line": 11460,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -4937,7 +4937,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 11436,
+          "line": 11463,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -4945,7 +4945,7 @@
         },
         {
           "name": "Finalized",
-          "line": 11438,
+          "line": 11465,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -4956,13 +4956,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5053,
+      "line": 5076,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 5054,
+          "line": 5077,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4973,7 +4973,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7054,
+      "line": 7077,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -4982,7 +4982,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 7056,
+          "line": 7079,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -4990,7 +4990,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 7058,
+          "line": 7081,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -5114,7 +5114,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4583,
+      "line": 4606,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -5122,7 +5122,7 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4584,
+          "line": 4607,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5130,7 +5130,7 @@
         },
         {
           "name": "TapsSelf",
-          "line": 4585,
+          "line": 4608,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5138,7 +5138,7 @@
         },
         {
           "name": "UntapsSelf",
-          "line": 4586,
+          "line": 4609,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5146,7 +5146,7 @@
         },
         {
           "name": "SacrificesPermanent",
-          "line": 4587,
+          "line": 4610,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5154,7 +5154,7 @@
         },
         {
           "name": "PaysLife",
-          "line": 4588,
+          "line": 4611,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5162,7 +5162,7 @@
         },
         {
           "name": "PaysLoyalty",
-          "line": 4589,
+          "line": 4612,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5170,7 +5170,7 @@
         },
         {
           "name": "Discards",
-          "line": 4590,
+          "line": 4613,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5178,7 +5178,7 @@
         },
         {
           "name": "ExilesCards",
-          "line": 4591,
+          "line": 4614,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5186,7 +5186,7 @@
         },
         {
           "name": "TapsOtherCreatures",
-          "line": 4592,
+          "line": 4615,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5194,7 +5194,7 @@
         },
         {
           "name": "RemovesCounters",
-          "line": 4593,
+          "line": 4616,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5202,7 +5202,7 @@
         },
         {
           "name": "PaysEnergy",
-          "line": 4594,
+          "line": 4617,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5210,7 +5210,7 @@
         },
         {
           "name": "PaysSpeed",
-          "line": 4595,
+          "line": 4618,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5218,7 +5218,7 @@
         },
         {
           "name": "ReturnsToHand",
-          "line": 4596,
+          "line": 4619,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5226,7 +5226,7 @@
         },
         {
           "name": "Unattaches",
-          "line": 4597,
+          "line": 4620,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5234,7 +5234,7 @@
         },
         {
           "name": "Mills",
-          "line": 4598,
+          "line": 4621,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5242,7 +5242,7 @@
         },
         {
           "name": "PutsCounters",
-          "line": 4599,
+          "line": 4622,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5250,7 +5250,7 @@
         },
         {
           "name": "Reveals",
-          "line": 4600,
+          "line": 4623,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5258,7 +5258,7 @@
         },
         {
           "name": "Exerts",
-          "line": 4601,
+          "line": 4624,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5266,7 +5266,7 @@
         },
         {
           "name": "KeywordCost",
-          "line": 4602,
+          "line": 4625,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5738,7 +5738,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3291,
+      "line": 3299,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -5746,7 +5746,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 3294,
+          "line": 3302,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -5798,7 +5798,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10595,
+      "line": 10622,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -5806,7 +5806,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10597,
+          "line": 10624,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -5814,7 +5814,7 @@
         },
         {
           "name": "Triple",
-          "line": 10599,
+          "line": 10626,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -5822,7 +5822,7 @@
         },
         {
           "name": "Plus",
-          "line": 10601,
+          "line": 10628,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5832,7 +5832,7 @@
         },
         {
           "name": "Minus",
-          "line": 10608,
+          "line": 10635,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5845,7 +5845,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 10612,
+          "line": 10639,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -5855,7 +5855,7 @@
         },
         {
           "name": "SetTo",
-          "line": 10618,
+          "line": 10645,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5867,7 +5867,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 10624,
+          "line": 10651,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -5917,7 +5917,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5034,
+      "line": 5057,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -5925,7 +5925,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 5036,
+          "line": 5059,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -5933,7 +5933,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 5039,
+          "line": 5062,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -5947,7 +5947,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10710,
+      "line": 10737,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -5955,7 +5955,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 10712,
+          "line": 10739,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -5963,7 +5963,7 @@
         },
         {
           "name": "Player",
-          "line": 10714,
+          "line": 10741,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5973,7 +5973,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 10717,
+          "line": 10744,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5986,7 +5986,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10694,
+      "line": 10721,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -5994,7 +5994,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10695,
+          "line": 10722,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6002,7 +6002,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10696,
+          "line": 10723,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6010,7 +6010,7 @@
         },
         {
           "name": "Controller",
-          "line": 10699,
+          "line": 10726,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -6018,7 +6018,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 10703,
+          "line": 10730,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 614.1a: Damage recipient is the player chosen for the replacement source by a linked persisted choice, or a permanent that player controls for `PlayerOrPermanentsControlledBy`.",
@@ -6029,7 +6029,7 @@
         },
         {
           "name": "Specific",
-          "line": 10704,
+          "line": 10731,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6811,13 +6811,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5135,
+      "line": 5158,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 5137,
+          "line": 5160,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -6829,7 +6829,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 5143,
+          "line": 5166,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -6844,7 +6844,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 5154,
+          "line": 5177,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6856,7 +6856,7 @@
         },
         {
           "name": "Draw",
-          "line": 5174,
+          "line": 5197,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6872,7 +6872,7 @@
         },
         {
           "name": "Pump",
-          "line": 5180,
+          "line": 5203,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6884,7 +6884,7 @@
         },
         {
           "name": "PairWith",
-          "line": 5191,
+          "line": 5214,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6897,7 +6897,7 @@
         },
         {
           "name": "Destroy",
-          "line": 5194,
+          "line": 5217,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6908,7 +6908,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 5202,
+          "line": 5225,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6920,7 +6920,7 @@
         },
         {
           "name": "Counter",
-          "line": 5206,
+          "line": 5229,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6931,7 +6931,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 5227,
+          "line": 5250,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6945,7 +6945,7 @@
         },
         {
           "name": "Token",
-          "line": 5231,
+          "line": 5254,
           "kind": "struct",
           "field_names": [
             "name",
@@ -6968,7 +6968,7 @@
         },
         {
           "name": "GainLife",
-          "line": 5269,
+          "line": 5292,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6979,7 +6979,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 5276,
+          "line": 5299,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6990,7 +6990,7 @@
         },
         {
           "name": "Tap",
-          "line": 5283,
+          "line": 5306,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7000,7 +7000,7 @@
         },
         {
           "name": "Untap",
-          "line": 5287,
+          "line": 5310,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7010,7 +7010,7 @@
         },
         {
           "name": "TapAll",
-          "line": 5292,
+          "line": 5315,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7022,7 +7022,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 5297,
+          "line": 5320,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7034,7 +7034,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 5301,
+          "line": 5324,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7046,7 +7046,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 5308,
+          "line": 5331,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7058,7 +7058,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5316,
+          "line": 5339,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7070,7 +7070,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 5337,
+          "line": 5360,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7081,7 +7081,7 @@
         },
         {
           "name": "Mill",
-          "line": 5343,
+          "line": 5366,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7093,7 +7093,7 @@
         },
         {
           "name": "Scry",
-          "line": 5360,
+          "line": 5383,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7108,7 +7108,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 5366,
+          "line": 5389,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7120,7 +7120,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 5380,
+          "line": 5403,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7137,7 +7137,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 5404,
+          "line": 5427,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7150,7 +7150,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 5408,
+          "line": 5431,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7161,7 +7161,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 5415,
+          "line": 5438,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7180,7 +7180,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 5466,
+          "line": 5489,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7193,7 +7193,7 @@
         },
         {
           "name": "Dig",
-          "line": 5479,
+          "line": 5502,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7213,7 +7213,7 @@
         },
         {
           "name": "GainControl",
-          "line": 5505,
+          "line": 5528,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7223,7 +7223,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 5509,
+          "line": 5532,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7234,7 +7234,7 @@
         },
         {
           "name": "Attach",
-          "line": 5515,
+          "line": 5538,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7245,7 +7245,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 5527,
+          "line": 5550,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7258,7 +7258,7 @@
         },
         {
           "name": "Surveil",
-          "line": 5539,
+          "line": 5562,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7273,7 +7273,7 @@
         },
         {
           "name": "Fight",
-          "line": 5545,
+          "line": 5568,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7284,7 +7284,7 @@
         },
         {
           "name": "Bounce",
-          "line": 5553,
+          "line": 5576,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7296,7 +7296,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 5572,
+          "line": 5595,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7311,7 +7311,7 @@
         },
         {
           "name": "Explore",
-          "line": 5580,
+          "line": 5603,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7319,7 +7319,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 5584,
+          "line": 5607,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7331,7 +7331,7 @@
         },
         {
           "name": "Investigate",
-          "line": 5589,
+          "line": 5612,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Investigate — create a Clue token.",
@@ -7341,7 +7341,7 @@
         },
         {
           "name": "Tribute",
-          "line": 5596,
+          "line": 5619,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7354,7 +7354,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 5602,
+          "line": 5625,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -7364,7 +7364,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 5604,
+          "line": 5627,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -7374,7 +7374,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 5605,
+          "line": 5628,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7382,7 +7382,7 @@
         },
         {
           "name": "Populate",
-          "line": 5607,
+          "line": 5630,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -7392,7 +7392,7 @@
         },
         {
           "name": "Clash",
-          "line": 5609,
+          "line": 5632,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -7402,7 +7402,7 @@
         },
         {
           "name": "Vote",
-          "line": 5624,
+          "line": 5647,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7418,7 +7418,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 5668,
+          "line": 5691,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -7438,7 +7438,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 5687,
+          "line": 5710,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7450,7 +7450,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 5691,
+          "line": 5714,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7461,7 +7461,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 5700,
+          "line": 5723,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7474,7 +7474,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 5711,
+          "line": 5734,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7494,7 +7494,7 @@
         },
         {
           "name": "Myriad",
-          "line": 5758,
+          "line": 5781,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -7504,7 +7504,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 5761,
+          "line": 5784,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7520,7 +7520,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 5771,
+          "line": 5794,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7531,7 +7531,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 5777,
+          "line": 5800,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7543,7 +7543,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 5785,
+          "line": 5808,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7557,7 +7557,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 5792,
+          "line": 5815,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7569,7 +7569,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 5800,
+          "line": 5823,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7582,7 +7582,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 5806,
+          "line": 5829,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7595,7 +7595,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 5814,
+          "line": 5837,
           "kind": "struct",
           "field_names": [
             "source",
@@ -7613,7 +7613,7 @@
         },
         {
           "name": "Animate",
-          "line": 5834,
+          "line": 5857,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7628,7 +7628,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 5868,
+          "line": 5891,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -7652,7 +7652,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 5884,
+          "line": 5907,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -7662,7 +7662,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 5888,
+          "line": 5911,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -7674,7 +7674,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 5896,
+          "line": 5919,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -7691,7 +7691,7 @@
         },
         {
           "name": "Mana",
-          "line": 5914,
+          "line": 5937,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -7705,7 +7705,7 @@
         },
         {
           "name": "Discard",
-          "line": 5937,
+          "line": 5960,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7719,7 +7719,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 5959,
+          "line": 5982,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7729,7 +7729,7 @@
         },
         {
           "name": "Transform",
-          "line": 5963,
+          "line": 5986,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7739,7 +7739,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 5969,
+          "line": 5992,
           "kind": "struct",
           "field_names": [
             "source_zones",
@@ -7755,7 +7755,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 6026,
+          "line": 6049,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7773,7 +7773,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 6037,
+          "line": 6060,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7787,7 +7787,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 6061,
+          "line": 6084,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7800,7 +7800,7 @@
         },
         {
           "name": "Reveal",
-          "line": 6072,
+          "line": 6095,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7813,7 +7813,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 6077,
+          "line": 6100,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7826,7 +7826,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 6086,
+          "line": 6109,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7838,7 +7838,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 6109,
+          "line": 6132,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7848,7 +7848,7 @@
         },
         {
           "name": "Choose",
-          "line": 6115,
+          "line": 6138,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -7859,7 +7859,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 6126,
+          "line": 6149,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -7872,7 +7872,7 @@
         },
         {
           "name": "Suspect",
-          "line": 6131,
+          "line": 6154,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7884,7 +7884,7 @@
         },
         {
           "name": "Connive",
-          "line": 6138,
+          "line": 6161,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7898,7 +7898,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 6146,
+          "line": 6169,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7910,7 +7910,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 6153,
+          "line": 6176,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7922,7 +7922,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 6158,
+          "line": 6181,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7934,7 +7934,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 6163,
+          "line": 6186,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -7944,7 +7944,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 6170,
+          "line": 6193,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7956,7 +7956,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 6177,
+          "line": 6200,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7968,7 +7968,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 6182,
+          "line": 6205,
           "kind": "struct",
           "field_names": [
             "level"
@@ -7980,7 +7980,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 6187,
+          "line": 6210,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -7994,7 +7994,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 6217,
+          "line": 6240,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -8008,7 +8008,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 6223,
+          "line": 6246,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -8020,7 +8020,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 6228,
+          "line": 6251,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8033,7 +8033,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 6235,
+          "line": 6258,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -8046,7 +8046,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 6244,
+          "line": 6267,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8059,7 +8059,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 6252,
+          "line": 6275,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -8073,7 +8073,7 @@
         },
         {
           "name": "PayCost",
-          "line": 6262,
+          "line": 6285,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -8086,7 +8086,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 6273,
+          "line": 6296,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8104,7 +8104,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 6303,
+          "line": 6326,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8120,7 +8120,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 6342,
+          "line": 6365,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -8141,7 +8141,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 6372,
+          "line": 6395,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: A player who meets this effect's condition loses the game. The affected player is determined by resolution context (controller's opponent if untargeted, or explicit target if targeted).",
@@ -8151,7 +8151,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 6374,
+          "line": 6397,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: The controller wins the game — all opponents lose.",
@@ -8161,7 +8161,7 @@
         },
         {
           "name": "RollDie",
-          "line": 6379,
+          "line": 6402,
           "kind": "struct",
           "field_names": [
             "sides",
@@ -8176,7 +8176,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 6387,
+          "line": 6410,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -8189,7 +8189,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 6399,
+          "line": 6422,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8203,7 +8203,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 6408,
+          "line": 6431,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -8215,7 +8215,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 6413,
+          "line": 6436,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -8225,7 +8225,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 6416,
+          "line": 6439,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -8235,7 +8235,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 6418,
+          "line": 6441,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -8247,7 +8247,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 6423,
+          "line": 6446,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -8258,7 +8258,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 6426,
+          "line": 6449,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -8268,7 +8268,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 6429,
+          "line": 6452,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -8280,7 +8280,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 6446,
+          "line": 6469,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8299,7 +8299,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 6479,
+          "line": 6502,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8314,7 +8314,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 6492,
+          "line": 6515,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -8330,7 +8330,7 @@
         },
         {
           "name": "Exploit",
-          "line": 6507,
+          "line": 6530,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8342,7 +8342,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 6512,
+          "line": 6535,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8354,7 +8354,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 6517,
+          "line": 6540,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -8369,7 +8369,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 6529,
+          "line": 6552,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8381,7 +8381,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 6541,
+          "line": 6564,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8397,7 +8397,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 6552,
+          "line": 6575,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8415,7 +8415,7 @@
         },
         {
           "name": "Discover",
-          "line": 6586,
+          "line": 6609,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -8427,7 +8427,7 @@
         },
         {
           "name": "Cascade",
-          "line": 6598,
+          "line": 6621,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -8437,7 +8437,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 6602,
+          "line": 6625,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8449,7 +8449,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 6607,
+          "line": 6630,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8461,7 +8461,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 6620,
+          "line": 6643,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8473,7 +8473,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 6629,
+          "line": 6652,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8485,7 +8485,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 6638,
+          "line": 6661,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8495,7 +8495,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 6643,
+          "line": 6666,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -8505,7 +8505,7 @@
         },
         {
           "name": "Goad",
-          "line": 6649,
+          "line": 6672,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8517,7 +8517,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 6656,
+          "line": 6679,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8529,7 +8529,7 @@
         },
         {
           "name": "Detain",
-          "line": 6663,
+          "line": 6686,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8541,7 +8541,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 6674,
+          "line": 6697,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -8555,7 +8555,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 6685,
+          "line": 6708,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8569,7 +8569,7 @@
         },
         {
           "name": "Manifest",
-          "line": 6700,
+          "line": 6723,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8582,7 +8582,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 6706,
+          "line": 6729,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -8592,7 +8592,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 6710,
+          "line": 6733,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8604,7 +8604,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 6724,
+          "line": 6747,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8617,7 +8617,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 6735,
+          "line": 6758,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8630,7 +8630,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 6745,
+          "line": 6768,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8644,7 +8644,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 6757,
+          "line": 6780,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8660,7 +8660,7 @@
         },
         {
           "name": "Double",
-          "line": 6768,
+          "line": 6791,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -8674,7 +8674,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 6776,
+          "line": 6799,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -8686,7 +8686,7 @@
         },
         {
           "name": "Incubate",
-          "line": 6782,
+          "line": 6805,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8698,7 +8698,7 @@
         },
         {
           "name": "Amass",
-          "line": 6790,
+          "line": 6813,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -8711,7 +8711,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 6798,
+          "line": 6821,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8723,7 +8723,7 @@
         },
         {
           "name": "Renown",
-          "line": 6804,
+          "line": 6827,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8735,7 +8735,7 @@
         },
         {
           "name": "Bolster",
-          "line": 6810,
+          "line": 6833,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8747,7 +8747,7 @@
         },
         {
           "name": "Adapt",
-          "line": 6816,
+          "line": 6839,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8759,7 +8759,7 @@
         },
         {
           "name": "Learn",
-          "line": 6822,
+          "line": 6845,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -8769,7 +8769,7 @@
         },
         {
           "name": "Forage",
-          "line": 6824,
+          "line": 6847,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -8779,7 +8779,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6826,
+          "line": 6849,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8791,7 +8791,7 @@
         },
         {
           "name": "Endure",
-          "line": 6833,
+          "line": 6856,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8804,7 +8804,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 6838,
+          "line": 6861,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8816,7 +8816,7 @@
         },
         {
           "name": "Seek",
-          "line": 6843,
+          "line": 6866,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -8830,7 +8830,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 6860,
+          "line": 6883,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8843,7 +8843,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 6875,
+          "line": 6898,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8859,7 +8859,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 6882,
+          "line": 6905,
           "kind": "struct",
           "field_names": [
             "to"
@@ -8871,7 +8871,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 6887,
+          "line": 6910,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8884,7 +8884,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 6896,
+          "line": 6919,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8896,7 +8896,7 @@
         },
         {
           "name": "Conjure",
-          "line": 6903,
+          "line": 6926,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -8908,7 +8908,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 6924,
+          "line": 6947,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8922,7 +8922,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6935,
+          "line": 6958,
           "kind": "struct",
           "field_names": [
             "name",
@@ -9017,13 +9017,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11825,
+      "line": 11852,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 11827,
+          "line": 11854,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9031,7 +9031,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 11829,
+          "line": 11856,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9039,7 +9039,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 11831,
+          "line": 11858,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9047,7 +9047,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 11833,
+          "line": 11860,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9055,7 +9055,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 11835,
+          "line": 11862,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9063,7 +9063,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 11837,
+          "line": 11864,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9074,228 +9074,12 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7926,
+      "line": 7953,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7927,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeSpeed",
-          "line": 7928,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DealDamage",
-          "line": 7929,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Draw",
-          "line": 7930,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Pump",
-          "line": 7931,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PairWith",
-          "line": 7932,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Destroy",
-          "line": 7933,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Counter",
-          "line": 7934,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterAll",
-          "line": 7935,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Token",
-          "line": 7936,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GainLife",
-          "line": 7937,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseLife",
-          "line": 7938,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Tap",
-          "line": 7939,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Untap",
-          "line": 7940,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddCounter",
-          "line": 7941,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RemoveCounter",
-          "line": 7942,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Sacrifice",
-          "line": 7943,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DiscardCard",
-          "line": 7944,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Mill",
-          "line": 7945,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Scry",
-          "line": 7946,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PumpAll",
-          "line": 7947,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DamageAll",
-          "line": 7948,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DamageEachPlayer",
-          "line": 7949,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DestroyAll",
-          "line": 7950,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TapAll",
-          "line": 7951,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "UntapAll",
-          "line": 7952,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeZone",
-          "line": 7953,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeZoneAll",
           "line": 7954,
           "kind": "unit",
           "field_names": [],
@@ -9303,7 +9087,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dig",
+          "name": "ChangeSpeed",
           "line": 7955,
           "kind": "unit",
           "field_names": [],
@@ -9311,7 +9095,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainControl",
+          "name": "DealDamage",
           "line": 7956,
           "kind": "unit",
           "field_names": [],
@@ -9319,7 +9103,7 @@
           "cr_refs": []
         },
         {
-          "name": "ControlNextTurn",
+          "name": "Draw",
           "line": 7957,
           "kind": "unit",
           "field_names": [],
@@ -9327,7 +9111,7 @@
           "cr_refs": []
         },
         {
-          "name": "Attach",
+          "name": "Pump",
           "line": 7958,
           "kind": "unit",
           "field_names": [],
@@ -9335,7 +9119,7 @@
           "cr_refs": []
         },
         {
-          "name": "AttachAll",
+          "name": "PairWith",
           "line": 7959,
           "kind": "unit",
           "field_names": [],
@@ -9343,7 +9127,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnattachAll",
+          "name": "Destroy",
           "line": 7960,
           "kind": "unit",
           "field_names": [],
@@ -9351,7 +9135,7 @@
           "cr_refs": []
         },
         {
-          "name": "Surveil",
+          "name": "Counter",
           "line": 7961,
           "kind": "unit",
           "field_names": [],
@@ -9359,7 +9143,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fight",
+          "name": "CounterAll",
           "line": 7962,
           "kind": "unit",
           "field_names": [],
@@ -9367,7 +9151,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bounce",
+          "name": "Token",
           "line": 7963,
           "kind": "unit",
           "field_names": [],
@@ -9375,7 +9159,7 @@
           "cr_refs": []
         },
         {
-          "name": "BounceAll",
+          "name": "GainLife",
           "line": 7964,
           "kind": "unit",
           "field_names": [],
@@ -9383,7 +9167,7 @@
           "cr_refs": []
         },
         {
-          "name": "Explore",
+          "name": "LoseLife",
           "line": 7965,
           "kind": "unit",
           "field_names": [],
@@ -9391,7 +9175,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExploreAll",
+          "name": "Tap",
           "line": 7966,
           "kind": "unit",
           "field_names": [],
@@ -9399,7 +9183,7 @@
           "cr_refs": []
         },
         {
-          "name": "Investigate",
+          "name": "Untap",
           "line": 7967,
           "kind": "unit",
           "field_names": [],
@@ -9407,7 +9191,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tribute",
+          "name": "AddCounter",
           "line": 7968,
           "kind": "unit",
           "field_names": [],
@@ -9415,7 +9199,7 @@
           "cr_refs": []
         },
         {
-          "name": "TimeTravel",
+          "name": "RemoveCounter",
           "line": 7969,
           "kind": "unit",
           "field_names": [],
@@ -9423,7 +9207,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomeMonarch",
+          "name": "Sacrifice",
           "line": 7970,
           "kind": "unit",
           "field_names": [],
@@ -9431,7 +9215,7 @@
           "cr_refs": []
         },
         {
-          "name": "Proliferate",
+          "name": "DiscardCard",
           "line": 7971,
           "kind": "unit",
           "field_names": [],
@@ -9439,7 +9223,7 @@
           "cr_refs": []
         },
         {
-          "name": "Populate",
+          "name": "Mill",
           "line": 7972,
           "kind": "unit",
           "field_names": [],
@@ -9447,7 +9231,7 @@
           "cr_refs": []
         },
         {
-          "name": "Clash",
+          "name": "Scry",
           "line": 7973,
           "kind": "unit",
           "field_names": [],
@@ -9455,8 +9239,224 @@
           "cr_refs": []
         },
         {
-          "name": "Vote",
+          "name": "PumpAll",
+          "line": 7974,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DamageAll",
           "line": 7975,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DamageEachPlayer",
+          "line": 7976,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DestroyAll",
+          "line": 7977,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TapAll",
+          "line": 7978,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "UntapAll",
+          "line": 7979,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChangeZone",
+          "line": 7980,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChangeZoneAll",
+          "line": 7981,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Dig",
+          "line": 7982,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GainControl",
+          "line": 7983,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ControlNextTurn",
+          "line": 7984,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Attach",
+          "line": 7985,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AttachAll",
+          "line": 7986,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "UnattachAll",
+          "line": 7987,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Surveil",
+          "line": 7988,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Fight",
+          "line": 7989,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Bounce",
+          "line": 7990,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BounceAll",
+          "line": 7991,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Explore",
+          "line": 7992,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExploreAll",
+          "line": 7993,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Investigate",
+          "line": 7994,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Tribute",
+          "line": 7995,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TimeTravel",
+          "line": 7996,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomeMonarch",
+          "line": 7997,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Proliferate",
+          "line": 7998,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Populate",
+          "line": 7999,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Clash",
+          "line": 8000,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Vote",
+          "line": 8002,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -9466,7 +9466,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7977,
+          "line": 8004,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -9476,222 +9476,6 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7978,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopySpell",
-          "line": 7979,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastCopyOfCard",
-          "line": 7980,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopyTokenOf",
-          "line": 7981,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Myriad",
-          "line": 7982,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BecomeCopy",
-          "line": 7983,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseCard",
-          "line": 7984,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutCounter",
-          "line": 7985,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutCounterAll",
-          "line": 7986,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MultiplyCounter",
-          "line": 7987,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DoublePT",
-          "line": 7988,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DoublePTAll",
-          "line": 7989,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MoveCounters",
-          "line": 7990,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Animate",
-          "line": 7991,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReturnAsAura",
-          "line": 7992,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RegisterBending",
-          "line": 7993,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GenericEffect",
-          "line": 7994,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Cleanup",
-          "line": 7995,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Mana",
-          "line": 7996,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Discard",
-          "line": 7997,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Shuffle",
-          "line": 7998,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SearchLibrary",
-          "line": 7999,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SearchOutsideGame",
-          "line": 8000,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ExileTop",
-          "line": 8001,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TargetOnly",
-          "line": 8002,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Choose",
-          "line": 8003,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseDamageSource",
-          "line": 8004,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Suspect",
           "line": 8005,
           "kind": "unit",
           "field_names": [],
@@ -9699,7 +9483,7 @@
           "cr_refs": []
         },
         {
-          "name": "Connive",
+          "name": "CopySpell",
           "line": 8006,
           "kind": "unit",
           "field_names": [],
@@ -9707,7 +9491,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseOut",
+          "name": "CastCopyOfCard",
           "line": 8007,
           "kind": "unit",
           "field_names": [],
@@ -9715,7 +9499,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseIn",
+          "name": "CopyTokenOf",
           "line": 8008,
           "kind": "unit",
           "field_names": [],
@@ -9723,7 +9507,7 @@
           "cr_refs": []
         },
         {
-          "name": "ForceBlock",
+          "name": "Myriad",
           "line": 8009,
           "kind": "unit",
           "field_names": [],
@@ -9731,7 +9515,7 @@
           "cr_refs": []
         },
         {
-          "name": "SolveCase",
+          "name": "BecomeCopy",
           "line": 8010,
           "kind": "unit",
           "field_names": [],
@@ -9739,8 +9523,224 @@
           "cr_refs": []
         },
         {
-          "name": "BecomePrepared",
+          "name": "ChooseCard",
+          "line": 8011,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PutCounter",
           "line": 8012,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PutCounterAll",
+          "line": 8013,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MultiplyCounter",
+          "line": 8014,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DoublePT",
+          "line": 8015,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DoublePTAll",
+          "line": 8016,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MoveCounters",
+          "line": 8017,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Animate",
+          "line": 8018,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ReturnAsAura",
+          "line": 8019,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RegisterBending",
+          "line": 8020,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GenericEffect",
+          "line": 8021,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Cleanup",
+          "line": 8022,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Mana",
+          "line": 8023,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Discard",
+          "line": 8024,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Shuffle",
+          "line": 8025,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SearchLibrary",
+          "line": 8026,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SearchOutsideGame",
+          "line": 8027,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExileTop",
+          "line": 8028,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TargetOnly",
+          "line": 8029,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Choose",
+          "line": 8030,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseDamageSource",
+          "line": 8031,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Suspect",
+          "line": 8032,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Connive",
+          "line": 8033,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseOut",
+          "line": 8034,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhaseIn",
+          "line": 8035,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ForceBlock",
+          "line": 8036,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SolveCase",
+          "line": 8037,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomePrepared",
+          "line": 8039,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -9750,7 +9750,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 8014,
+          "line": 8041,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -9760,222 +9760,6 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 8015,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDelayedTrigger",
-          "line": 8016,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddTargetReplacement",
-          "line": 8017,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddRestriction",
-          "line": 8018,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReduceNextSpellCost",
-          "line": 8019,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantNextSpellAbility",
-          "line": 8020,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddPendingETBCounters",
-          "line": 8021,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateEmblem",
-          "line": 8022,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PayCost",
-          "line": 8023,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastFromZone",
-          "line": 8024,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PreventDamage",
-          "line": 8025,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDamageReplacement",
-          "line": 8026,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Regenerate",
-          "line": 8027,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseTheGame",
-          "line": 8028,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "WinTheGame",
-          "line": 8029,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RollDie",
-          "line": 8030,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoin",
-          "line": 8031,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoins",
-          "line": 8032,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoinUntilLose",
-          "line": 8033,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RingTemptsYou",
-          "line": 8034,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "VentureIntoDungeon",
-          "line": 8035,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "VentureInto",
-          "line": 8036,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TakeTheInitiative",
-          "line": 8037,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ProcessRadCounters",
-          "line": 8038,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantCastingPermission",
-          "line": 8039,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseFromZone",
-          "line": 8040,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseObjectsIntoTrackedSet",
-          "line": 8041,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseAndSacrificeRest",
           "line": 8042,
           "kind": "unit",
           "field_names": [],
@@ -9983,7 +9767,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exploit",
+          "name": "CreateDelayedTrigger",
           "line": 8043,
           "kind": "unit",
           "field_names": [],
@@ -9991,7 +9775,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainEnergy",
+          "name": "AddTargetReplacement",
           "line": 8044,
           "kind": "unit",
           "field_names": [],
@@ -9999,7 +9783,7 @@
           "cr_refs": []
         },
         {
-          "name": "GivePlayerCounter",
+          "name": "AddRestriction",
           "line": 8045,
           "kind": "unit",
           "field_names": [],
@@ -10007,7 +9791,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseAllPlayerCounters",
+          "name": "ReduceNextSpellCost",
           "line": 8046,
           "kind": "unit",
           "field_names": [],
@@ -10015,7 +9799,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileFromTopUntil",
+          "name": "GrantNextSpellAbility",
           "line": 8047,
           "kind": "unit",
           "field_names": [],
@@ -10023,7 +9807,7 @@
           "cr_refs": []
         },
         {
-          "name": "RevealUntil",
+          "name": "AddPendingETBCounters",
           "line": 8048,
           "kind": "unit",
           "field_names": [],
@@ -10031,7 +9815,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discover",
+          "name": "CreateEmblem",
           "line": 8049,
           "kind": "unit",
           "field_names": [],
@@ -10039,7 +9823,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cascade",
+          "name": "PayCost",
           "line": 8050,
           "kind": "unit",
           "field_names": [],
@@ -10047,7 +9831,7 @@
           "cr_refs": []
         },
         {
-          "name": "MiracleCast",
+          "name": "CastFromZone",
           "line": 8051,
           "kind": "unit",
           "field_names": [],
@@ -10055,7 +9839,7 @@
           "cr_refs": []
         },
         {
-          "name": "MadnessCast",
+          "name": "PreventDamage",
           "line": 8052,
           "kind": "unit",
           "field_names": [],
@@ -10063,7 +9847,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutAtLibraryPosition",
+          "name": "CreateDamageReplacement",
           "line": 8053,
           "kind": "unit",
           "field_names": [],
@@ -10071,7 +9855,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDrawnThisTurnPayOrTopdeck",
+          "name": "Regenerate",
           "line": 8054,
           "kind": "unit",
           "field_names": [],
@@ -10079,7 +9863,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutOnTopOrBottom",
+          "name": "LoseTheGame",
           "line": 8055,
           "kind": "unit",
           "field_names": [],
@@ -10087,7 +9871,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiftDelivery",
+          "name": "WinTheGame",
           "line": 8056,
           "kind": "unit",
           "field_names": [],
@@ -10095,7 +9879,7 @@
           "cr_refs": []
         },
         {
-          "name": "Goad",
+          "name": "RollDie",
           "line": 8057,
           "kind": "unit",
           "field_names": [],
@@ -10103,7 +9887,7 @@
           "cr_refs": []
         },
         {
-          "name": "GoadAll",
+          "name": "FlipCoin",
           "line": 8058,
           "kind": "unit",
           "field_names": [],
@@ -10111,7 +9895,7 @@
           "cr_refs": []
         },
         {
-          "name": "Detain",
+          "name": "FlipCoins",
           "line": 8059,
           "kind": "unit",
           "field_names": [],
@@ -10119,7 +9903,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeControl",
+          "name": "FlipCoinUntilLose",
           "line": 8060,
           "kind": "unit",
           "field_names": [],
@@ -10127,7 +9911,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeTargets",
+          "name": "RingTemptsYou",
           "line": 8061,
           "kind": "unit",
           "field_names": [],
@@ -10135,7 +9919,7 @@
           "cr_refs": []
         },
         {
-          "name": "Incubate",
+          "name": "VentureIntoDungeon",
           "line": 8062,
           "kind": "unit",
           "field_names": [],
@@ -10143,7 +9927,7 @@
           "cr_refs": []
         },
         {
-          "name": "Amass",
+          "name": "VentureInto",
           "line": 8063,
           "kind": "unit",
           "field_names": [],
@@ -10151,7 +9935,7 @@
           "cr_refs": []
         },
         {
-          "name": "Monstrosity",
+          "name": "TakeTheInitiative",
           "line": 8064,
           "kind": "unit",
           "field_names": [],
@@ -10159,7 +9943,7 @@
           "cr_refs": []
         },
         {
-          "name": "Renown",
+          "name": "ProcessRadCounters",
           "line": 8065,
           "kind": "unit",
           "field_names": [],
@@ -10167,7 +9951,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bolster",
+          "name": "GrantCastingPermission",
           "line": 8066,
           "kind": "unit",
           "field_names": [],
@@ -10175,7 +9959,7 @@
           "cr_refs": []
         },
         {
-          "name": "Adapt",
+          "name": "ChooseFromZone",
           "line": 8067,
           "kind": "unit",
           "field_names": [],
@@ -10183,7 +9967,7 @@
           "cr_refs": []
         },
         {
-          "name": "Manifest",
+          "name": "ChooseObjectsIntoTrackedSet",
           "line": 8068,
           "kind": "unit",
           "field_names": [],
@@ -10191,7 +9975,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "ChooseAndSacrificeRest",
           "line": 8069,
           "kind": "unit",
           "field_names": [],
@@ -10199,7 +9983,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExtraTurn",
+          "name": "Exploit",
           "line": 8070,
           "kind": "unit",
           "field_names": [],
@@ -10207,7 +9991,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantExtraLoyaltyActivations",
+          "name": "GainEnergy",
           "line": 8071,
           "kind": "unit",
           "field_names": [],
@@ -10215,7 +9999,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextTurn",
+          "name": "GivePlayerCounter",
           "line": 8072,
           "kind": "unit",
           "field_names": [],
@@ -10223,7 +10007,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextStep",
+          "name": "LoseAllPlayerCounters",
           "line": 8073,
           "kind": "unit",
           "field_names": [],
@@ -10231,7 +10015,7 @@
           "cr_refs": []
         },
         {
-          "name": "AdditionalPhase",
+          "name": "ExileFromTopUntil",
           "line": 8074,
           "kind": "unit",
           "field_names": [],
@@ -10239,7 +10023,7 @@
           "cr_refs": []
         },
         {
-          "name": "Double",
+          "name": "RevealUntil",
           "line": 8075,
           "kind": "unit",
           "field_names": [],
@@ -10247,7 +10031,7 @@
           "cr_refs": []
         },
         {
-          "name": "RuntimeHandled",
+          "name": "Discover",
           "line": 8076,
           "kind": "unit",
           "field_names": [],
@@ -10255,7 +10039,7 @@
           "cr_refs": []
         },
         {
-          "name": "Learn",
+          "name": "Cascade",
           "line": 8077,
           "kind": "unit",
           "field_names": [],
@@ -10263,7 +10047,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "MiracleCast",
           "line": 8078,
           "kind": "unit",
           "field_names": [],
@@ -10271,7 +10055,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "MadnessCast",
           "line": 8079,
           "kind": "unit",
           "field_names": [],
@@ -10279,7 +10063,7 @@
           "cr_refs": []
         },
         {
-          "name": "Endure",
+          "name": "PutAtLibraryPosition",
           "line": 8080,
           "kind": "unit",
           "field_names": [],
@@ -10287,7 +10071,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlightEffect",
+          "name": "ChooseDrawnThisTurnPayOrTopdeck",
           "line": 8081,
           "kind": "unit",
           "field_names": [],
@@ -10295,7 +10079,7 @@
           "cr_refs": []
         },
         {
-          "name": "Seek",
+          "name": "PutOnTopOrBottom",
           "line": 8082,
           "kind": "unit",
           "field_names": [],
@@ -10303,7 +10087,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetLifeTotal",
+          "name": "GiftDelivery",
           "line": 8083,
           "kind": "unit",
           "field_names": [],
@@ -10311,7 +10095,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeLifeWithStat",
+          "name": "Goad",
           "line": 8084,
           "kind": "unit",
           "field_names": [],
@@ -10319,7 +10103,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetDayNight",
+          "name": "GoadAll",
           "line": 8085,
           "kind": "unit",
           "field_names": [],
@@ -10327,7 +10111,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveControl",
+          "name": "Detain",
           "line": 8086,
           "kind": "unit",
           "field_names": [],
@@ -10335,7 +10119,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveFromCombat",
+          "name": "ExchangeControl",
           "line": 8087,
           "kind": "unit",
           "field_names": [],
@@ -10343,7 +10127,7 @@
           "cr_refs": []
         },
         {
-          "name": "Conjure",
+          "name": "ChangeTargets",
           "line": 8088,
           "kind": "unit",
           "field_names": [],
@@ -10351,7 +10135,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseOneOf",
+          "name": "Incubate",
           "line": 8089,
           "kind": "unit",
           "field_names": [],
@@ -10359,7 +10143,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unimplemented",
+          "name": "Amass",
           "line": 8090,
           "kind": "unit",
           "field_names": [],
@@ -10367,8 +10151,224 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "Monstrosity",
+          "line": 8091,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Renown",
           "line": 8092,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Bolster",
+          "line": 8093,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Adapt",
+          "line": 8094,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Manifest",
+          "line": 8095,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ManifestDread",
+          "line": 8096,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExtraTurn",
+          "line": 8097,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GrantExtraLoyaltyActivations",
+          "line": 8098,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SkipNextTurn",
+          "line": 8099,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SkipNextStep",
+          "line": 8100,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AdditionalPhase",
+          "line": 8101,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Double",
+          "line": 8102,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RuntimeHandled",
+          "line": 8103,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Learn",
+          "line": 8104,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Forage",
+          "line": 8105,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CollectEvidence",
+          "line": 8106,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Endure",
+          "line": 8107,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BlightEffect",
+          "line": 8108,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Seek",
+          "line": 8109,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetLifeTotal",
+          "line": 8110,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExchangeLifeWithStat",
+          "line": 8111,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetDayNight",
+          "line": 8112,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GiveControl",
+          "line": 8113,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RemoveFromCombat",
+          "line": 8114,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Conjure",
+          "line": 8115,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseOneOf",
+          "line": 8116,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unimplemented",
+          "line": 8117,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 8119,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -10376,7 +10376,7 @@
         },
         {
           "name": "Crew",
-          "line": 8094,
+          "line": 8121,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -10386,7 +10386,7 @@
         },
         {
           "name": "Station",
-          "line": 8096,
+          "line": 8123,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -10396,7 +10396,7 @@
         },
         {
           "name": "Saddle",
-          "line": 8098,
+          "line": 8125,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -10406,7 +10406,7 @@
         },
         {
           "name": "Reveal",
-          "line": 8100,
+          "line": 8127,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -10414,7 +10414,7 @@
         },
         {
           "name": "Transform",
-          "line": 8101,
+          "line": 8128,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10422,7 +10422,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 8102,
+          "line": 8129,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10430,7 +10430,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 8103,
+          "line": 8130,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10530,13 +10530,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9129,
+      "line": 9156,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 9133,
+          "line": 9160,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -10547,7 +10547,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 9136,
+          "line": 9163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -14333,7 +14333,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8923,
+      "line": 8950,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -14342,7 +14342,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 8926,
+          "line": 8953,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -15736,17 +15736,17 @@
         },
         {
           "name": "Backup",
-          "line": 699,
+          "line": 697,
           "kind": "tuple",
           "field_names": [],
-          "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (ETB +1/+1 counters + ability-grant trigger not wired). CR 702.165: Backup N — when this creature enters, put N +1/+1 counters on target creature, which gains this creature's other abilities until EOT.",
+          "doc": "CR 702.165: Backup N — when this creature enters, put N +1/+1 counters on target creature, which gains this creature's other abilities until EOT.",
           "cr_refs": [
             "CR 702.165"
           ]
         },
         {
           "name": "Squad",
-          "line": 706,
+          "line": 704,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (variable additional cost + ETB token-per-payment not wired). CR 702.157: Squad {cost} — as an additional cost to cast, you may pay {cost} any number of times; ETB creates that many tokens.",
@@ -15756,7 +15756,7 @@
         },
         {
           "name": "Typecycling",
-          "line": 710,
+          "line": 708,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -15769,7 +15769,7 @@
         },
         {
           "name": "Firebending",
-          "line": 716,
+          "line": 714,
           "kind": "tuple",
           "field_names": [],
           "doc": "Firebending N — produces N {R} when this creature attacks (Avatar crossover).",
@@ -15777,7 +15777,7 @@
         },
         {
           "name": "Splice",
-          "line": 720,
+          "line": 718,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.46a: Splice onto [type] — reveal from hand and pay splice cost while casting a spell of the specified type to add this card's effects to that spell.",
@@ -15787,7 +15787,7 @@
         },
         {
           "name": "Bargain",
-          "line": 723,
+          "line": 721,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Bargain — you may sacrifice an artifact, enchantment, or token as an additional cost to cast this spell.",
@@ -15797,7 +15797,7 @@
         },
         {
           "name": "Sunburst",
-          "line": 725,
+          "line": 723,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.43a: Sunburst — enters with a counter for each color of mana spent to cast it.",
@@ -15807,7 +15807,7 @@
         },
         {
           "name": "Champion",
-          "line": 728,
+          "line": 726,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.72a: Champion a [type] — exile a creature of the specified type you control when this enters; return it when this leaves.",
@@ -15817,7 +15817,7 @@
         },
         {
           "name": "Training",
-          "line": 731,
+          "line": 729,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.149a: Training — whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.",
@@ -15827,7 +15827,7 @@
         },
         {
           "name": "Assist",
-          "line": 733,
+          "line": 731,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.132a: Assist — another player can help pay the generic mana cost of this spell.",
@@ -15837,7 +15837,7 @@
         },
         {
           "name": "Augment",
-          "line": 737,
+          "line": 735,
           "kind": "unit",
           "field_names": [],
           "doc": "Acorn/Un-set keyword: Augment. Runtime host-combine semantics are not implemented; the keyword identity is used for characteristic filters such as \"a card with augment\".",
@@ -15845,7 +15845,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 741,
+          "line": 739,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Aftermath allows casting this half of a split card only from a graveyard, and exiles the spell any time it leaves the stack if it was cast from a graveyard.",
@@ -15855,7 +15855,7 @@
         },
         {
           "name": "JumpStart",
-          "line": 743,
+          "line": 741,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.133a: Jump-start — cast from graveyard by discarding a card, then exile.",
@@ -15865,7 +15865,7 @@
         },
         {
           "name": "Cipher",
-          "line": 746,
+          "line": 744,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.98a: Cipher — exile this spell encoded on a creature you control; whenever that creature deals combat damage to a player, cast a copy.",
@@ -15875,7 +15875,7 @@
         },
         {
           "name": "Transmute",
-          "line": 749,
+          "line": 747,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.52a: Transmute {cost} — discard this card and pay {cost} to search your library for a card with the same mana value.",
@@ -15885,7 +15885,7 @@
         },
         {
           "name": "Escalate",
-          "line": 752,
+          "line": 750,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.120a: Escalate [cost] — additional cost for each mode chosen beyond the first on a modal spell.",
@@ -15895,7 +15895,7 @@
         },
         {
           "name": "Recover",
-          "line": 756,
+          "line": 754,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.59a: Recover {cost} — triggered ability: when a creature is put into your graveyard from the battlefield, you may pay {cost} to return this card from your graveyard to your hand; otherwise exile it.",
@@ -15905,7 +15905,7 @@
         },
         {
           "name": "Cleave",
-          "line": 758,
+          "line": 756,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.148a: Cleave — alternative cost that removes bracketed text from Oracle text.",
@@ -15915,7 +15915,7 @@
         },
         {
           "name": "Undaunted",
-          "line": 760,
+          "line": 758,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.125a: Undaunted — costs {1} less for each opponent.",
@@ -15925,7 +15925,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 768,
+          "line": 766,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — a keyword on instants/sorceries. Reminder: \"Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile without paying its mana cost at the beginning of each of your first main phases.\" Runtime hooks in `stack.rs` (first-resolution arming) and `turns.rs` (first-main-phase offer) carry the semantics. Assign when WotC publishes SOS CR update.",
@@ -15935,7 +15935,7 @@
         },
         {
           "name": "Station",
-          "line": 776,
+          "line": 774,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Station — \"Tap another untapped creature you control: Put a number of charge counters on this permanent equal to the tapped creature's power. Activate only as a sorcery.\" The keyword is fixed (no parameter) — the full semantics come from the rule text. Runtime activation is handled via `GameAction::ActivateStation`, not through the generic activated-ability dispatch.",
@@ -15945,7 +15945,7 @@
         },
         {
           "name": "Replicate",
-          "line": 788,
+          "line": 786,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (no copy-on-cast hook reads it). CR 702.56a: Replicate {cost} — additional-cost-on-cast copy mechanic. \"As an additional cost to cast this spell, you may pay [cost] any number of times\" + \"When you cast this spell, if a replicate cost was paid for it, copy it for each time its replicate cost was paid. If the spell has any targets, you may choose new targets for any of the copies.\" Carries the per-copy mana cost; runtime semantics are not yet implemented (no copy-on-cast hook reads this keyword).",
@@ -15955,7 +15955,7 @@
         },
         {
           "name": "Awaken",
-          "line": 795,
+          "line": 793,
           "kind": "struct",
           "field_names": [
             "count",
@@ -15968,7 +15968,7 @@
         },
         {
           "name": "ForMirrodin",
-          "line": 804,
+          "line": 802,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.163a: For Mirrodin! — Equipment-only triggered ability. \"When this Equipment enters, create a 2/2 red Rebel creature token, then attach this Equipment to it.\" Bare keyword; ETB trigger semantics are synthesized in `database::synthesis`.",
@@ -15978,7 +15978,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 812,
+          "line": 810,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (alt-cost cast hook not wired). CR 702.162a: More Than Meets the Eye {cost} — alternative cost (Transformers crossover). \"You may cast this card converted by paying [cost] rather than its mana cost.\" Stores the alt mana cost; the runtime alt-cost cast hook is not yet wired.",
@@ -15988,7 +15988,7 @@
         },
         {
           "name": "Freerunning",
-          "line": 823,
+          "line": 821,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (alt-cast hook + combat-damage-this-turn predicate not wired). CR 702.173a: Freerunning {cost} — alternative cost. \"You may pay [cost] rather than pay this spell's mana cost if a player was dealt combat damage this turn by a creature that, at the time it dealt that damage, was an Assassin creature or a commander under your control.\" Stores the alt mana cost; runtime alt-cast hook (combat-damage-this-turn predicate) is not yet wired.",
@@ -15998,7 +15998,7 @@
         },
         {
           "name": "Increment",
-          "line": 833,
+          "line": 831,
           "kind": "unit",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (spell-cast trigger not wired). CR 702.191a: Increment — triggered ability. \"Whenever you cast a spell, if this permanent is a creature and the amount of mana spent to cast that spell is greater than this creature's power or this creature's toughness, put a +1/+1 counter on this creature.\" Bare keyword; ETB / spell-cast trigger is not yet wired.",
@@ -16008,7 +16008,7 @@
         },
         {
           "name": "Specialize",
-          "line": 846,
+          "line": 844,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (choose-color + transform hooks not wired). CR ???: Specialize {cost} — not in CR text (needs manual verification). Strixhaven student-into-mage transformation: activated alt-cast that turns the source into a colour-specific version. Stores the activation mana cost; the choose-color and transform hooks are not yet wired. mtgish encodes activation timing modifiers and from-graveyard variants separately; this keyword carries only the cost (the engine drops the activation modifier and the from-graveyard hint, mirroring how `LevelUp` drops its `Vec<Level>` payload).",
@@ -16016,7 +16016,7 @@
         },
         {
           "name": "Offering",
-          "line": 857,
+          "line": 855,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (cost-reduction + cast-as-instant hooks not wired). CR 702.48a: \"[Quality] offering\" — additional-cost-on-cast that sacrifices a permanent matching `Quality`. \"If you chose to pay the additional cost, this spell's total cost is reduced by the sacrificed permanent's mana cost, and you may cast this spell any time you could cast an instant.\" Carries the canonical subtype string (e.g. \"Spirit\", \"Dragon\"); cost-reduction and cast-as- instant runtime hooks are not yet wired.",
@@ -16026,7 +16026,7 @@
         },
         {
           "name": "Unknown",
-          "line": 860,
+          "line": 858,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized keywords.",
@@ -16037,7 +16037,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11389,
+      "line": 11416,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -16046,7 +16046,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 11391,
+          "line": 11418,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -16059,7 +16059,7 @@
         },
         {
           "name": "Crew",
-          "line": 11397,
+          "line": 11424,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -16072,7 +16072,7 @@
         },
         {
           "name": "Saddle",
-          "line": 11403,
+          "line": 11430,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -16085,7 +16085,7 @@
         },
         {
           "name": "Station",
-          "line": 11411,
+          "line": 11438,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -17196,7 +17196,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9501,
+      "line": 9528,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -17206,7 +17206,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 9503,
+          "line": 9530,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -17216,7 +17216,7 @@
         },
         {
           "name": "Second",
-          "line": 9506,
+          "line": 9533,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -17500,13 +17500,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5020,
+      "line": 5043,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 5021,
+          "line": 5044,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17514,7 +17514,7 @@
         },
         {
           "name": "Bottom",
-          "line": 5022,
+          "line": 5045,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17522,7 +17522,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 5024,
+          "line": 5047,
           "kind": "struct",
           "field_names": [
             "n"
@@ -18399,7 +18399,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10665,
+      "line": 10692,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -18408,7 +18408,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 10668,
+          "line": 10695,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -18420,7 +18420,7 @@
         },
         {
           "name": "Multiply",
-          "line": 10671,
+          "line": 10698,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -18666,7 +18666,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10677,
+      "line": 10704,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -18675,7 +18675,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10680,
+          "line": 10707,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -18683,7 +18683,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 10682,
+          "line": 10709,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -19094,13 +19094,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8363,
+      "line": 8390,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 8365,
+          "line": 8392,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -19112,7 +19112,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8368,
+          "line": 8395,
           "kind": "struct",
           "field_names": [
             "source",
@@ -19131,13 +19131,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8343,
+      "line": 8370,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 8344,
+          "line": 8371,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19145,7 +19145,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 8347,
+          "line": 8374,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -19160,7 +19160,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 8354,
+          "line": 8381,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -19170,7 +19170,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 8357,
+          "line": 8384,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -19260,7 +19260,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4307,
+      "line": 4330,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -19270,7 +19270,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4309,
+          "line": 4332,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -19280,7 +19280,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4311,
+          "line": 4334,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -19293,13 +19293,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3299,
+      "line": 3307,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 3300,
+          "line": 3308,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19307,7 +19307,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3301,
+          "line": 3309,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19315,7 +19315,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 3302,
+          "line": 3310,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19326,13 +19326,13 @@
     },
     "ObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2715,
+      "line": 2723,
       "doc": "Scope selector for object-axis quantities (Round Π-5). Picks WHICH object to read from when a `QuantityRef` (and future per-object conditions) is per-object. Mirrors `PlayerScope` for the player axis.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 2721,
+          "line": 2729,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.7 + CR 113.7a: The source object of the resolving ability — \"this creature\", \"~\", \"it\" (when \"it\" anaphors back to the source). CR 113.7 defines the source as the object that generated the ability; CR 113.7a keeps the ability (and thus its source reference) valid on the stack even after the source leaves its expected zone, via LKI.",
@@ -19343,7 +19343,7 @@
         },
         {
           "name": "Target",
-          "line": 2724,
+          "line": 2732,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The first object target of the resolving ability — \"that creature\", \"the creature\", \"it\" (when \"it\" anaphors back to a target).",
@@ -19353,7 +19353,7 @@
         },
         {
           "name": "Recipient",
-          "line": 2730,
+          "line": 2738,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4c + CR 115.10: The object currently receiving an effect. In layer evaluation this is the per-object recipient. Outside layers, it resolves to the first object target when present, then to the source. Used for recipient-relative \"its colors\" boosts such as Blessing of the Nephilim and Civic Saber.",
@@ -19364,7 +19364,7 @@
         },
         {
           "name": "EventSource",
-          "line": 2732,
+          "line": 2740,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: The object referenced by the current trigger event.",
@@ -19374,7 +19374,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2739,
+          "line": 2747,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: The specific untargeted object previously referred to by this ability's cost OR trigger condition. Resolved (first match wins) via `ResolvedAbility.cost_paid_object` → trigger-event source → `effect_context_object`. Subsumes the former `EventContextSource*` trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger referent are the two enumerated members of CR 608.2k's single clause).",
@@ -19387,7 +19387,7 @@
         },
         {
           "name": "Anaphoric",
-          "line": 2753,
+          "line": 2761,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: A deferred anaphoric pronoun (\"it\" / \"its\") whose object referent is bound at parse time. The parser remaps this to a concrete scope wherever it can — `Source` when the clause subject is the ability source, `Target` when the recipient is \"itself\". For triggered abilities no remap applies and `Anaphoric` survives to runtime, where it resolves identically to `CostPaidObject` (behavior-preserving — these cards parsed to `CostPaidObject` before this variant existed). General rules-correct runtime resolution of triggered-ability anaphora (e.g. \"its mana value\" after a reveal — see issue #511) is separate per-card parser work. Distinguishing this from an explicit cost-paid possessive (\"the sacrificed creature's power\", CR 608.2k -> `CostPaidObject`) is what prevents the subject-injection rewrite from clobbering correctly-scoped possessives.",
@@ -19438,7 +19438,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10150,
+      "line": 10177,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -19448,7 +19448,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10152,
+          "line": 10179,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -19456,7 +19456,7 @@
         },
         {
           "name": "Equals",
-          "line": 10154,
+          "line": 10181,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -19464,7 +19464,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 10157,
+          "line": 10184,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -19472,7 +19472,7 @@
         },
         {
           "name": "OneOf",
-          "line": 10159,
+          "line": 10186,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -19614,7 +19614,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4033,
+      "line": 4056,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -19623,7 +19623,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 4034,
+          "line": 4057,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -19633,7 +19633,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 4038,
+          "line": 4061,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -19643,7 +19643,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 4039,
+          "line": 4062,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19651,7 +19651,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 4041,
+          "line": 4064,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -19661,7 +19661,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 4042,
+          "line": 4065,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19671,7 +19671,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 4045,
+          "line": 4068,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -19682,7 +19682,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 4049,
+          "line": 4072,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -19692,7 +19692,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 4053,
+          "line": 4076,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -19702,7 +19702,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 4055,
+          "line": 4078,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -19712,7 +19712,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 4056,
+          "line": 4079,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19720,7 +19720,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 4057,
+          "line": 4080,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -19730,7 +19730,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 4060,
+          "line": 4083,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -19740,7 +19740,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 4063,
+          "line": 4086,
           "kind": "struct",
           "field_names": [
             "color"
@@ -19750,7 +19750,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 4066,
+          "line": 4089,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19758,7 +19758,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 4067,
+          "line": 4090,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19766,7 +19766,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 4068,
+          "line": 4091,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19774,7 +19774,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 4069,
+          "line": 4092,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19785,7 +19785,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 4073,
+          "line": 4096,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19796,7 +19796,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 4077,
+          "line": 4100,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19808,7 +19808,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 4082,
+          "line": 4105,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19818,7 +19818,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 4085,
+          "line": 4108,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19828,7 +19828,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 4088,
+          "line": 4111,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -19838,7 +19838,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 4093,
+          "line": 4116,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19850,7 +19850,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4102,
+          "line": 4125,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19865,7 +19865,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 4107,
+          "line": 4130,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19875,7 +19875,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 4110,
+          "line": 4133,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -19885,7 +19885,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 4113,
+          "line": 4136,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -19896,7 +19896,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 4117,
+          "line": 4140,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -19907,7 +19907,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 4121,
+          "line": 4144,
           "kind": "struct",
           "field_names": [
             "color",
@@ -19918,7 +19918,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 4125,
+          "line": 4148,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -19928,7 +19928,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 4128,
+          "line": 4151,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19936,7 +19936,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 4129,
+          "line": 4152,
           "kind": "struct",
           "field_names": [
             "name"
@@ -19946,7 +19946,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 4136,
+          "line": 4159,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -19959,7 +19959,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 4140,
+          "line": 4163,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19969,7 +19969,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 4143,
+          "line": 4166,
           "kind": "struct",
           "field_names": [
             "power",
@@ -19980,7 +19980,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 4147,
+          "line": 4170,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19988,7 +19988,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 4148,
+          "line": 4171,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19998,7 +19998,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 4151,
+          "line": 4174,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20008,7 +20008,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 4154,
+          "line": 4177,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20018,7 +20018,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 4157,
+          "line": 4180,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20026,7 +20026,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 4158,
+          "line": 4181,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20034,7 +20034,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 4159,
+          "line": 4182,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20044,7 +20044,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 4165,
+          "line": 4188,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -20052,7 +20052,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 4168,
+          "line": 4191,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -20065,7 +20065,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 4172,
+          "line": 4195,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20073,7 +20073,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 4173,
+          "line": 4196,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20083,7 +20083,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 4176,
+          "line": 4199,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20091,7 +20091,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 4177,
+          "line": 4200,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20099,7 +20099,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 4178,
+          "line": 4201,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20107,7 +20107,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 4179,
+          "line": 4202,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20115,7 +20115,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 4181,
+          "line": 4204,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -20125,7 +20125,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 4182,
+          "line": 4205,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20133,7 +20133,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 4183,
+          "line": 4206,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20141,7 +20141,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 4184,
+          "line": 4207,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20149,7 +20149,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 4185,
+          "line": 4208,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -20160,7 +20160,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 4189,
+          "line": 4212,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20170,7 +20170,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 4194,
+          "line": 4217,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -20183,7 +20183,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4199,
+          "line": 4222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -20193,7 +20193,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 4207,
+          "line": 4230,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -20203,7 +20203,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 4220,
+          "line": 4243,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -20217,7 +20217,7 @@
         },
         {
           "name": "And",
-          "line": 4228,
+          "line": 4251,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -20230,7 +20230,7 @@
         },
         {
           "name": "Or",
-          "line": 4234,
+          "line": 4257,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -20243,7 +20243,7 @@
         },
         {
           "name": "Not",
-          "line": 4241,
+          "line": 4264,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -20488,7 +20488,7 @@
     },
     "PaymentCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4254,
+      "line": 4277,
       "doc": "CR 118.1: A cost paid as part of an effect's resolution. Distinct from AbilityCost (which gates activation before the colon).",
       "cr_refs": [
         "CR 118.1"
@@ -20496,7 +20496,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 4255,
+          "line": 4278,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20506,7 +20506,7 @@
         },
         {
           "name": "Life",
-          "line": 4263,
+          "line": 4286,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20519,7 +20519,7 @@
         },
         {
           "name": "Speed",
-          "line": 4267,
+          "line": 4290,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20532,7 +20532,7 @@
         },
         {
           "name": "Energy",
-          "line": 4272,
+          "line": 4295,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20544,7 +20544,7 @@
         },
         {
           "name": "AbilityCost",
-          "line": 4279,
+          "line": 4302,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20557,7 +20557,7 @@
         },
         {
           "name": "ScaledMana",
-          "line": 4289,
+          "line": 4312,
           "kind": "struct",
           "field_names": [
             "base",
@@ -20895,13 +20895,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3364,
+      "line": 3387,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 3368,
+          "line": 3391,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -20911,7 +20911,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3370,
+          "line": 3393,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -20919,7 +20919,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3372,
+          "line": 3395,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -20929,7 +20929,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 3374,
+          "line": 3397,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -20937,7 +20937,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 3376,
+          "line": 3399,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -20945,7 +20945,7 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 3386,
+          "line": 3409,
           "kind": "struct",
           "field_names": [
             "source"
@@ -20960,7 +20960,7 @@
         },
         {
           "name": "OpponentAttackedThisTurn",
-          "line": 3395,
+          "line": 3418,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.6: A player has \"attacked [a player]\" if they declared one or more creatures attacking that player. Each opponent the controller attacked this turn, resolved against `state.attacked_defenders_this_turn[controller]`. Used by \"the number of opponents you attacked this turn\" (Militant Angel). (CR 508.1b: declare-attackers announcement; CR 506.2: active = attacking player.)",
@@ -20972,7 +20972,7 @@
         },
         {
           "name": "All",
-          "line": 3397,
+          "line": 3420,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -20980,7 +20980,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 3399,
+          "line": 3422,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -20990,7 +20990,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 3402,
+          "line": 3425,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -20998,7 +20998,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 3406,
+          "line": 3429,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -21012,7 +21012,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 3412,
+          "line": 3435,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -21020,7 +21020,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3416,
+          "line": 3439,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -21031,7 +21031,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 3425,
+          "line": 3448,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -21042,7 +21042,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 3436,
+          "line": 3459,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -21055,7 +21055,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3448,
+          "line": 3471,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -21066,7 +21066,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 3469,
+          "line": 3492,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -21082,7 +21082,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 3493,
+          "line": 3516,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -21112,7 +21112,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3352,
+      "line": 3375,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -21122,7 +21122,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 3354,
+          "line": 3377,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -21130,7 +21130,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3356,
+          "line": 3379,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -21138,7 +21138,7 @@
         },
         {
           "name": "All",
-          "line": 3358,
+          "line": 3381,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -21149,7 +21149,7 @@
     },
     "PlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2663,
+      "line": 2671,
       "doc": "CR 102 + CR 119 + CR 402: Player axis for player-scoped quantity references.  Parameterizes the player whose hand size, life total, or other per-player scalar is being read. Replaces sibling enum variants like `LifeTotal` / `TargetLifeTotal` / `OpponentLifeTotal` and `HandSize` / `OpponentHandSize` with a single parameterized form.  Categorical-boundary check (per the \"Parameterize, don't proliferate\" principle): every variant is a player-relativity choice within a single CR section. Aggregate scopes (`Opponent`, `AllPlayers`) compose `AggregateFunction` to express max/min/sum across a population — they do not introduce a new abstraction layer.",
       "cr_refs": [
         "CR 102",
@@ -21159,7 +21159,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 2665,
+          "line": 2673,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 / CR 113.6: The controller of the source ability or effect.",
@@ -21170,7 +21170,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2669,
+          "line": 2677,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This keeps \"their\" quantities separate from \"you\" quantities.",
@@ -21181,7 +21181,7 @@
         },
         {
           "name": "Target",
-          "line": 2672,
+          "line": 2680,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 113.6 + CR 115.1: The first player target of the resolving ability (read from `ability.targets`).",
@@ -21193,7 +21193,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2676,
+          "line": 2684,
           "kind": "struct",
           "field_names": [
             "aggregate"
@@ -21206,7 +21206,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2681,
+          "line": 2689,
           "kind": "struct",
           "field_names": [
             "aggregate",
@@ -21219,7 +21219,7 @@
         },
         {
           "name": "RecipientController",
-          "line": 2695,
+          "line": 2703,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4m + CR 613.4c: The controller of the object currently receiving a layer effect. Used for Aura/Equipment statics such as \"enchanted creature gets +1/+1 for each card in its controller's hand\", where \"its\" refers to the enchanted creature, not the Aura.",
@@ -21230,7 +21230,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2701,
+          "line": 2709,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by attack-trigger intervening-if quantities such as \"no opponent has more life than that player.\"",
@@ -21241,7 +21241,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 2707,
+          "line": 2715,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"that opponent\" anaphoring the controller of a bounced/destroyed creature). The player-scalar-axis analogue of `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -21282,7 +21282,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10783,
+      "line": 10810,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -21291,7 +21291,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 10784,
+          "line": 10811,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21299,7 +21299,7 @@
         },
         {
           "name": "Resolved",
-          "line": 10785,
+          "line": 10812,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21879,7 +21879,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3677,
+      "line": 3700,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -21887,7 +21887,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 3679,
+          "line": 3702,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -21897,7 +21897,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3681,
+          "line": 3704,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -21907,7 +21907,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 3683,
+          "line": 3706,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -21953,7 +21953,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3692,
+      "line": 3715,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -21962,7 +21962,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 3695,
+          "line": 3718,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -21972,7 +21972,7 @@
         },
         {
           "name": "Base",
-          "line": 3698,
+          "line": 3721,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -21985,13 +21985,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3505,
+      "line": 3528,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 3507,
+          "line": 3530,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -22001,7 +22001,7 @@
         },
         {
           "name": "Fixed",
-          "line": 3509,
+          "line": 3532,
           "kind": "struct",
           "field_names": [
             "value"
@@ -22011,7 +22011,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 3513,
+          "line": 3536,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -22025,7 +22025,7 @@
         },
         {
           "name": "Offset",
-          "line": 3520,
+          "line": 3543,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -22038,7 +22038,7 @@
         },
         {
           "name": "Multiply",
-          "line": 3525,
+          "line": 3548,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -22049,7 +22049,7 @@
         },
         {
           "name": "Sum",
-          "line": 3534,
+          "line": 3557,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -22059,7 +22059,7 @@
         },
         {
           "name": "UpTo",
-          "line": 3559,
+          "line": 3582,
           "kind": "struct",
           "field_names": [
             "max"
@@ -22072,7 +22072,7 @@
         },
         {
           "name": "Power",
-          "line": 3565,
+          "line": 3588,
           "kind": "struct",
           "field_names": [
             "base",
@@ -22085,7 +22085,7 @@
         },
         {
           "name": "Difference",
-          "line": 3580,
+          "line": 3603,
           "kind": "struct",
           "field_names": [
             "left",
@@ -22101,7 +22101,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10631,
+      "line": 10658,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -22109,7 +22109,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10633,
+          "line": 10660,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -22117,7 +22117,7 @@
         },
         {
           "name": "Plus",
-          "line": 10635,
+          "line": 10662,
           "kind": "struct",
           "field_names": [
             "value"
@@ -22127,7 +22127,7 @@
         },
         {
           "name": "Minus",
-          "line": 10637,
+          "line": 10664,
           "kind": "struct",
           "field_names": [
             "value"
@@ -22137,7 +22137,7 @@
         },
         {
           "name": "Prevent",
-          "line": 10657,
+          "line": 10684,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -22154,13 +22154,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2792,
+      "line": 2800,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 2796,
+          "line": 2804,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22172,7 +22172,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 2799,
+          "line": 2807,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22184,7 +22184,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 2805,
+          "line": 2813,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22196,7 +22196,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 2808,
+          "line": 2816,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -22204,7 +22204,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 2810,
+          "line": 2818,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -22214,7 +22214,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 2813,
+          "line": 2821,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22224,7 +22224,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 2830,
+          "line": 2838,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22238,7 +22238,7 @@
         },
         {
           "name": "ObjectCountBySharedQuality",
-          "line": 2840,
+          "line": 2848,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22253,7 +22253,7 @@
         },
         {
           "name": "PlayerCount",
-          "line": 2847,
+          "line": 2855,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22263,7 +22263,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 2868,
+          "line": 2876,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22276,7 +22276,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 2877,
+          "line": 2885,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -22289,7 +22289,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 2896,
+          "line": 2904,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -22306,7 +22306,7 @@
         },
         {
           "name": "Variable",
-          "line": 2901,
+          "line": 2909,
           "kind": "struct",
           "field_names": [
             "name"
@@ -22316,7 +22316,7 @@
         },
         {
           "name": "Power",
-          "line": 2908,
+          "line": 2916,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22330,7 +22330,7 @@
         },
         {
           "name": "Toughness",
-          "line": 2913,
+          "line": 2921,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22344,7 +22344,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 2919,
+          "line": 2927,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22357,7 +22357,7 @@
         },
         {
           "name": "ObjectColorCount",
-          "line": 2925,
+          "line": 2933,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22370,7 +22370,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 2930,
+          "line": 2938,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22383,7 +22383,7 @@
         },
         {
           "name": "ManaSymbolsInManaCost",
-          "line": 2937,
+          "line": 2945,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22397,7 +22397,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 2949,
+          "line": 2957,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -22409,7 +22409,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 2951,
+          "line": 2959,
           "kind": "struct",
           "field_names": [
             "function",
@@ -22423,7 +22423,7 @@
         },
         {
           "name": "ControlledByEachPlayer",
-          "line": 2968,
+          "line": 2976,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22437,7 +22437,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 2975,
+          "line": 2983,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22447,7 +22447,7 @@
         },
         {
           "name": "Devotion",
-          "line": 2977,
+          "line": 2985,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -22459,7 +22459,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 2981,
+          "line": 2989,
           "kind": "struct",
           "field_names": [
             "source"
@@ -22471,7 +22471,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 2986,
+          "line": 2994,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -22482,7 +22482,7 @@
         },
         {
           "name": "ZoneCardCount",
-          "line": 2990,
+          "line": 2998,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22496,7 +22496,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 2997,
+          "line": 3005,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -22508,7 +22508,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 3001,
+          "line": 3009,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -22518,7 +22518,7 @@
         },
         {
           "name": "ExiledFromHandThisResolution",
-          "line": 3007,
+          "line": 3015,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -22529,7 +22529,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 3011,
+          "line": 3019,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -22539,7 +22539,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 3026,
+          "line": 3034,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22552,7 +22552,7 @@
         },
         {
           "name": "PartySize",
-          "line": 3035,
+          "line": 3043,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22565,7 +22565,7 @@
         },
         {
           "name": "Speed",
-          "line": 3042,
+          "line": 3050,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22577,7 +22577,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 3045,
+          "line": 3053,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -22587,7 +22587,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 3053,
+          "line": 3061,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -22601,7 +22601,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 3065,
+          "line": 3073,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -22613,7 +22613,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 3068,
+          "line": 3076,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22626,7 +22626,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 3075,
+          "line": 3083,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22636,7 +22636,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 3081,
+          "line": 3089,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22649,7 +22649,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 3086,
+          "line": 3094,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -22659,7 +22659,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 3092,
+          "line": 3100,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22671,7 +22671,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 3097,
+          "line": 3105,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22683,7 +22683,7 @@
         },
         {
           "name": "LandsPlayedThisTurn",
-          "line": 3101,
+          "line": 3109,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22696,7 +22696,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 3104,
+          "line": 3112,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -22706,7 +22706,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 3108,
+          "line": 3116,
           "kind": "struct",
           "field_names": [
             "from",
@@ -22721,7 +22721,7 @@
         },
         {
           "name": "DamageDealtThisTurn",
-          "line": 3128,
+          "line": 3136,
           "kind": "struct",
           "field_names": [
             "source",
@@ -22738,7 +22738,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 3141,
+          "line": 3149,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -22746,7 +22746,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 3145,
+          "line": 3153,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Number of creatures the controller attacked with this turn. Used for \"if you attacked this turn\" and \"for each creature you attacked with this turn\" patterns.",
@@ -22756,7 +22756,7 @@
         },
         {
           "name": "DescendedThisTurn",
-          "line": 3147,
+          "line": 3155,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -22766,7 +22766,7 @@
         },
         {
           "name": "LoyaltyAbilitiesActivatedThisTurn",
-          "line": 3155,
+          "line": 3163,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22780,7 +22780,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 3158,
+          "line": 3166,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -22790,7 +22790,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 3172,
+          "line": 3180,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22804,7 +22804,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 3183,
+          "line": 3191,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -22819,7 +22819,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 3192,
+          "line": 3200,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22832,7 +22832,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 3197,
+          "line": 3205,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22846,7 +22846,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 3205,
+          "line": 3213,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22860,7 +22860,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 3210,
+          "line": 3218,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -22870,7 +22870,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 3217,
+          "line": 3225,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -22880,7 +22880,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 3220,
+          "line": 3228,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -22891,7 +22891,7 @@
         },
         {
           "name": "AdditionalCostPaymentCount",
-          "line": 3224,
+          "line": 3232,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost payments made for the source spell. Used by Squad so its payment count remains distinct from Kicker's CR 702.33 payment model.",
@@ -22903,7 +22903,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 3228,
+          "line": 3236,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -22913,7 +22913,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 3233,
+          "line": 3241,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22927,7 +22927,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 3244,
+          "line": 3252,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -22938,7 +22938,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 3249,
+          "line": 3257,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -22948,7 +22948,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 3256,
+          "line": 3264,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22962,7 +22962,7 @@
         },
         {
           "name": "DistinctCounterKindsAmong",
-          "line": 3265,
+          "line": 3273,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23045,7 +23045,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8908,
+      "line": 8935,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -23054,7 +23054,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 8912,
+          "line": 8939,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -23067,13 +23067,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9938,
+      "line": 9965,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 9941,
+          "line": 9968,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -23085,7 +23085,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 9947,
+          "line": 9974,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -23095,7 +23095,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 9954,
+          "line": 9981,
           "kind": "struct",
           "field_names": [
             "count",
@@ -23108,7 +23108,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 9959,
+          "line": 9986,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23120,7 +23120,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 9964,
+          "line": 9991,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -23133,7 +23133,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 9967,
+          "line": 9994,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -23145,7 +23145,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 9970,
+          "line": 9997,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -23155,7 +23155,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 9973,
+          "line": 10000,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -23166,7 +23166,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 9981,
+          "line": 10008,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -23179,7 +23179,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 9995,
+          "line": 10022,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -23192,7 +23192,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 10004,
+          "line": 10031,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -23203,7 +23203,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 10007,
+          "line": 10034,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -23213,7 +23213,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 10013,
+          "line": 10040,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -23225,7 +23225,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 10018,
+          "line": 10045,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -23237,7 +23237,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 10023,
+          "line": 10050,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -23248,7 +23248,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 10032,
+          "line": 10059,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -23260,7 +23260,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 10039,
+          "line": 10066,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -23274,7 +23274,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 10047,
+          "line": 10074,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -23284,7 +23284,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 10052,
+          "line": 10079,
           "kind": "struct",
           "field_names": [
             "source"
@@ -23298,7 +23298,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 10056,
+          "line": 10083,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -23311,7 +23311,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 10061,
+          "line": 10088,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -23322,7 +23322,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 10072,
+          "line": 10099,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -23335,7 +23335,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 10083,
+          "line": 10110,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -23347,7 +23347,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 10091,
+          "line": 10118,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -23360,7 +23360,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 10101,
+          "line": 10128,
           "kind": "struct",
           "field_names": [
             "level"
@@ -23372,7 +23372,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 10106,
+          "line": 10133,
           "kind": "struct",
           "field_names": [
             "text"
@@ -23776,13 +23776,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10749,
+      "line": 10776,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 10752,
+          "line": 10779,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -23790,7 +23790,7 @@
         },
         {
           "name": "Optional",
-          "line": 10754,
+          "line": 10781,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -23800,7 +23800,7 @@
         },
         {
           "name": "MayCost",
-          "line": 10761,
+          "line": 10788,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -23817,7 +23817,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10737,
+      "line": 10764,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 614.1a"
@@ -23825,7 +23825,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 10739,
+          "line": 10766,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source's controller.",
@@ -23833,7 +23833,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10741,
+          "line": 10768,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source's controller.",
@@ -23841,7 +23841,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 10743,
+          "line": 10770,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -24006,7 +24006,7 @@
     },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3272,
+      "line": 3280,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -24014,7 +24014,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 3273,
+          "line": 3281,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24022,7 +24022,7 @@
         },
         {
           "name": "Down",
-          "line": 3274,
+          "line": 3282,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24033,7 +24033,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4383,
+      "line": 4406,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -24041,7 +24041,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 4385,
+          "line": 4408,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -24104,6 +24104,37 @@
             "CR 701.23a",
             "CR 701.23h"
           ]
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "SeatDirection": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 3362,
+      "doc": "CR 102.1 + CR 103.1: Seating direction relative to a player. The game's default turn order proceeds clockwise (CR 103.1); the next player in turn order is seated to the active player's left (CR 101.4). Thus walking forward through `seat_order` is `Left`, and walking backward is `Right`.",
+      "cr_refs": [
+        "CR 101.4",
+        "CR 102.1",
+        "CR 103.1"
+      ],
+      "variants": [
+        {
+          "name": "Left",
+          "line": 3365,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "The living player seated immediately to the controller's left — the next player in turn order (CR 101.4). Forward through `seat_order`.",
+          "cr_refs": [
+            "CR 101.4"
+          ]
+        },
+        {
+          "name": "Right",
+          "line": 3368,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "The living player seated immediately to the controller's right — the previous player in turn order. Backward through `seat_order`.",
+          "cr_refs": []
         }
       ],
       "sibling_clusters": []
@@ -24395,7 +24426,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3705,
+      "line": 3728,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -24404,7 +24435,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 3707,
+          "line": 3730,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -24416,7 +24447,7 @@
         },
         {
           "name": "Text",
-          "line": 3713,
+          "line": 3736,
           "kind": "struct",
           "field_names": [
             "description"
@@ -24429,7 +24460,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5061,
+      "line": 5084,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -24437,7 +24468,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 5063,
+          "line": 5086,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -24447,7 +24478,7 @@
         },
         {
           "name": "Decrease",
-          "line": 5065,
+          "line": 5088,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -24460,13 +24491,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4870,
+      "line": 4893,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 4871,
+          "line": 4894,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24474,7 +24505,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 4872,
+          "line": 4895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24482,7 +24513,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 4873,
+          "line": 4896,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24490,7 +24521,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 4875,
+          "line": 4898,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -24565,13 +24596,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3779,
+      "line": 3802,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 3780,
+          "line": 3803,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -24582,7 +24613,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 3784,
+          "line": 3807,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24592,7 +24623,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 3790,
+          "line": 3813,
           "kind": "struct",
           "field_names": [
             "color"
@@ -24602,7 +24633,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 3799,
+          "line": 3822,
           "kind": "struct",
           "field_names": [
             "label"
@@ -24615,7 +24646,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3805,
+          "line": 3828,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -24627,7 +24658,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 3811,
+          "line": 3834,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -24637,7 +24668,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 3813,
+          "line": 3836,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -24650,7 +24681,7 @@
         },
         {
           "name": "And",
-          "line": 3817,
+          "line": 3840,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24660,7 +24691,7 @@
         },
         {
           "name": "Or",
-          "line": 3821,
+          "line": 3844,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24670,7 +24701,7 @@
         },
         {
           "name": "Not",
-          "line": 3827,
+          "line": 3850,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -24680,7 +24711,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 3831,
+          "line": 3854,
           "kind": "struct",
           "field_names": [
             "state"
@@ -24692,7 +24723,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 3840,
+          "line": 3863,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24708,7 +24739,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 3851,
+          "line": 3874,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24723,7 +24754,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 3859,
+          "line": 3882,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24735,7 +24766,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 3866,
+          "line": 3889,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24747,7 +24778,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 3870,
+          "line": 3893,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -24757,7 +24788,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3874,
+          "line": 3897,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -24768,7 +24799,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 3878,
+          "line": 3901,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -24779,7 +24810,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3882,
+          "line": 3905,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -24789,7 +24820,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 3884,
+          "line": 3907,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -24799,7 +24830,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 3887,
+          "line": 3910,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -24809,7 +24840,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 3889,
+          "line": 3912,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -24819,7 +24850,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 3892,
+          "line": 3915,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -24829,7 +24860,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 3898,
+          "line": 3921,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -24841,7 +24872,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 3906,
+          "line": 3929,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -24853,7 +24884,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3910,
+          "line": 3933,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24865,7 +24896,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 3935,
+          "line": 3958,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -24883,7 +24914,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 3944,
+          "line": 3967,
           "kind": "struct",
           "field_names": [
             "text"
@@ -24893,7 +24924,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 3947,
+          "line": 3970,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24901,7 +24932,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3950,
+          "line": 3973,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -24911,7 +24942,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 3952,
+          "line": 3975,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -24921,7 +24952,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 3954,
+          "line": 3977,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24933,7 +24964,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 3960,
+          "line": 3983,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -24947,7 +24978,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 3965,
+          "line": 3988,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -24957,7 +24988,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 3972,
+          "line": 3995,
           "kind": "struct",
           "field_names": [
             "player"
@@ -24970,7 +25001,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 3977,
+          "line": 4000,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -24980,7 +25011,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 3981,
+          "line": 4004,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -24990,7 +25021,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 3985,
+          "line": 4008,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -25001,7 +25032,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 3989,
+          "line": 4012,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25013,7 +25044,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 4001,
+          "line": 4024,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25025,7 +25056,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 4005,
+          "line": 4028,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -25035,7 +25066,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 4008,
+          "line": 4031,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -25047,7 +25078,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 4014,
+          "line": 4037,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -25058,7 +25089,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 4019,
+          "line": 4042,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ModifyCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -25069,7 +25100,7 @@
         },
         {
           "name": "None",
-          "line": 4020,
+          "line": 4043,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26082,7 +26113,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5073,
+      "line": 5096,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -26091,7 +26122,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 5074,
+          "line": 5097,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26099,7 +26130,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 5075,
+          "line": 5098,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26110,7 +26141,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8873,
+      "line": 8900,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -26118,7 +26149,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 8881,
+          "line": 8908,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -26126,7 +26157,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 8886,
+          "line": 8913,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -26305,7 +26336,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8543,
+      "line": 8570,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -26315,7 +26346,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 8545,
+          "line": 8572,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26323,7 +26354,7 @@
         },
         {
           "name": "Resolution",
-          "line": 8546,
+          "line": 8573,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26470,8 +26501,21 @@
           ]
         },
         {
+          "name": "Neighbor",
+          "line": 2500,
+          "kind": "struct",
+          "field_names": [
+            "direction"
+          ],
+          "doc": "CR 102.1 + CR 103.1: living player seated immediately to controller's left/right; clockwise turn order, right = previous seat; resolved against `state.seat_order`. The recipient is computed at the resolver (`game::players::neighbor`), never selected as an interactive target slot.",
+          "cr_refs": [
+            "CR 102.1",
+            "CR 103.1"
+          ]
+        },
+        {
           "name": "ScopedPlayer",
-          "line": 2498,
+          "line": 2506,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This is not the ability controller; \"you\" and \"your\" still refer to `controller`.",
@@ -26482,7 +26526,7 @@
         },
         {
           "name": "AttachedTo",
-          "line": 2501,
+          "line": 2509,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches the permanent that the trigger source (Equipment/Aura) is attached to. Used for \"equipped creature\" / \"enchanted creature\" trigger subjects.",
@@ -26490,7 +26534,7 @@
         },
         {
           "name": "LastCreated",
-          "line": 2504,
+          "line": 2512,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the most recently created token(s) from Effect::Token. Used for \"create X and [verb] it\" patterns (e.g. \"create a token and suspect it\").",
@@ -26498,7 +26542,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2508,
+          "line": 2516,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the resolving spell or ability. Used by effects such as \"the exiled card\" after an exile-as-cost clause.",
@@ -26509,7 +26553,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 2511,
+          "line": 2519,
           "kind": "struct",
           "field_names": [
             "id"
@@ -26521,7 +26565,7 @@
         },
         {
           "name": "TrackedSetFiltered",
-          "line": 2526,
+          "line": 2534,
           "kind": "struct",
           "field_names": [
             "id",
@@ -26535,7 +26579,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2532,
+          "line": 2540,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 610.3: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
@@ -26545,7 +26589,7 @@
         },
         {
           "name": "TriggeringSpellController",
-          "line": 2534,
+          "line": 2542,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the controller of the spell/ability that triggered this.",
@@ -26555,7 +26599,7 @@
         },
         {
           "name": "TriggeringSpellOwner",
-          "line": 2536,
+          "line": 2544,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the owner of the spell/ability that triggered this.",
@@ -26565,7 +26609,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 2538,
+          "line": 2546,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the player involved in the triggering event.",
@@ -26575,7 +26619,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 2540,
+          "line": 2548,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the source object of the triggering event.",
@@ -26585,7 +26629,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 2545,
+          "line": 2553,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the same target(s) as the parent ability. Used for anaphoric \"it\"/\"that creature\"/\"that player\" in compound effects (e.g., \"tap target creature and put a stun counter on it\"). At resolution time, the sub_ability chain inherits parent targets automatically.",
@@ -26593,7 +26637,7 @@
         },
         {
           "name": "ParentTargetSlot",
-          "line": 2550,
+          "line": 2558,
           "kind": "struct",
           "field_names": [
             "index"
@@ -26605,7 +26649,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2556,
+          "line": 2564,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Resolves to the controller of the parent ability's target object. Used for \"its controller\" in compound effects (e.g., \"counter target spell. Its controller loses 2 life.\"). At resolution time, looks up the controller of the first parent target.",
@@ -26615,7 +26659,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 2567,
+          "line": 2575,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 608.2c: Resolves to the *owner* of the parent ability's target object. Used for \"its owner\" anaphoric references where the acting player is the owner of a previously-mentioned permanent — e.g., Enslave's \"enchanted creature deals 1 damage to its owner\" or Bomb Squad's \"that creature deals 4 damage to its owner\". Resolution mirrors `ParentTargetController` (parent target slot → trigger-event source → AttachedTo host on source for Aura phase triggers), but returns the resolved object's `owner` rather than `controller` per CR 108.3.  Distinct from `Owner` (which always reads the source object's owner) and `ParentTargetController` (which returns the controller per CR 109.4).",
@@ -26627,7 +26671,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 2572,
+          "line": 2580,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 608.2c: Resolves to the player chosen for the source by a linked persisted choice (\"the chosen player\"). This is not a target slot and is distinct from `ControllerRef::ChosenPlayer`, which is resolution-scoped to the current ability chain.",
@@ -26638,7 +26682,7 @@
         },
         {
           "name": "OriginalController",
-          "line": 2593,
+          "line": 2601,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 + CR 608.2c: Resolves to the ability's *original* controller — the player who put the spell or ability on the stack — even when a surrounding `player_scope` iteration has rebound `ResolvedAbility::controller` to a different player for the current per-player iteration.  At resolution time, returns `ability.original_controller.unwrap_or(ability.controller)`. This mirrors the quantity-layer behavior in `resolve_quantity_with_targets`, where \"you\" / \"your\" quantities always read the original controller.  Used by parser-level distribution of compound subjects like \"you and that player each Y\" — the first half (\"you\") MUST resolve to the printed ability controller, not the iterated voter, even when the parent ability has `player_scope: PlayerFilter::VotedFor` (Master of Ceremonies pattern, CR 800.4g).  Distinct from `Controller` (which resolves to `ability.controller` and is rebound per-iteration by the player_scope driver in `resolve_ability_chain`). Distinct from `ParentTargetController` (parent's target's controller) and `PostReplacementSourceController` (replacement-context source's controller).",
@@ -26650,7 +26694,7 @@
         },
         {
           "name": "PostReplacementSourceController",
-          "line": 2612,
+          "line": 2620,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5 + CR 609.7: Resolves to the controller of the *prevented event's* damage source. Used by prevention follow-up sentences such as \"the source's controller draws cards equal to the damage prevented this way\" (Swans of Bryn Argoll) and \"deals damage to that source's controller\" (Deflecting Palm class). At resolution time, looks up `state.post_replacement_event_source` and returns its controller.  Distinct from `ParentTargetController` (which resolves via the parent ability's target slot) and `TriggeringSpellController` (which resolves via `state.current_trigger_event`, which is `None` during post-replacement resolution). Architectural twin of the quantity-side `last_effect_count` fallback at `replacement.rs:317` — both stash event context that lives outside the trigger window. The parser never emits this variant directly; the prevention follow-up call site rewrites `ParentTargetController` → `PostReplacementSourceController` via `each_target_filter_mut` after `parse_effect_chain` returns, so the surface phrase \"the source's controller\" can stay consolidated in `parse_target` for non-prevention callers.",
@@ -26661,7 +26705,7 @@
         },
         {
           "name": "PostReplacementDamageTarget",
-          "line": 2617,
+          "line": 2625,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5: Resolves to the player or permanent that was the target of the prevented damage event. Used by prevention follow-up sentences such as \"that player exiles that many cards\" where the affected player is the damage recipient, not the replacement source or damage source.",
@@ -26671,7 +26715,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2621,
+          "line": 2629,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Resolves to the defending player for the source attacking creature, looked up per attacker through `combat::defending_player_for_attacker`.",
@@ -26682,7 +26726,7 @@
         },
         {
           "name": "HasChosenName",
-          "line": 2624,
+          "line": 2632,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose name equals the source's ChosenAttribute::CardName. Used for \"card with the chosen name\" patterns.",
@@ -26690,7 +26734,7 @@
         },
         {
           "name": "ChosenDamageSource",
-          "line": 2628,
+          "line": 2636,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.7a: Matches the object stored as the source's chosen damage source. Resolution-time prevention effects should resolve this to `SpecificObject` when the shield is created so global shields do not depend on a live source.",
@@ -26700,7 +26744,7 @@
         },
         {
           "name": "Named",
-          "line": 2631,
+          "line": 2639,
           "kind": "struct",
           "field_names": [
             "name"
@@ -26710,7 +26754,7 @@
         },
         {
           "name": "Owner",
-          "line": 2639,
+          "line": 2647,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.3: Resolves to the owner of the object referenced by `source_id`. Used for \"its owner's library/hand/graveyard\" phrasings where the acting player must be the card's owner, not its current controller (e.g., Nexus of Fate's shuffle-back replacement when the card is under opposing control via Mind Control).",
@@ -26720,7 +26764,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2646,
+          "line": 2654,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.12a: Every player in the game (controller + opponents), polled in APNAP order. The unless-payer population for \"[Effect] unless any player pays ...\" clauses (Cleansing, Rhystic cycle, Soul Strings). Resolution is a sequential poll — the first player to pay prevents the effect — so this variant is only valid as an `UnlessPayModifier.payer`; it is never used as a target or affected filter.",
@@ -26751,13 +26795,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11371,
+      "line": 11398,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 11372,
+          "line": 11399,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26765,7 +26809,7 @@
         },
         {
           "name": "Player",
-          "line": 11373,
+          "line": 11400,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26921,13 +26965,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9633,
+      "line": 9660,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 9636,
+          "line": 9663,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26937,7 +26981,7 @@
         },
         {
           "name": "LostLife",
-          "line": 9638,
+          "line": 9665,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -26945,7 +26989,7 @@
         },
         {
           "name": "Descended",
-          "line": 9640,
+          "line": 9667,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -26953,7 +26997,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 9642,
+          "line": 9669,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26963,7 +27007,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 9644,
+          "line": 9671,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -26973,7 +27017,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 9646,
+          "line": 9673,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -26983,7 +27027,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 9656,
+          "line": 9683,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26996,7 +27040,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9659,
+          "line": 9686,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -27007,7 +27051,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 9662,
+          "line": 9689,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -27017,7 +27061,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 9666,
+          "line": 9693,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -27029,7 +27073,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 9669,
+          "line": 9696,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -27039,7 +27083,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9672,
+          "line": 9699,
           "kind": "struct",
           "field_names": [
             "level"
@@ -27051,7 +27095,7 @@
         },
         {
           "name": "WasCast",
-          "line": 9675,
+          "line": 9702,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -27064,7 +27108,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 9682,
+          "line": 9709,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -27075,7 +27119,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 9687,
+          "line": 9714,
           "kind": "struct",
           "field_names": [
             "source",
@@ -27091,7 +27135,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 9703,
+          "line": 9730,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -27101,7 +27145,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9709,
+          "line": 9736,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -27116,7 +27160,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 9713,
+          "line": 9740,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -27127,7 +27171,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 9717,
+          "line": 9744,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -27138,7 +27182,7 @@
         },
         {
           "name": "WasType",
-          "line": 9722,
+          "line": 9749,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -27151,7 +27195,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 9725,
+          "line": 9752,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -27163,7 +27207,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 9729,
+          "line": 9756,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -27176,7 +27220,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 9733,
+          "line": 9760,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27188,7 +27232,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 9737,
+          "line": 9764,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -27198,7 +27242,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9740,
+          "line": 9767,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -27210,7 +27254,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 9744,
+          "line": 9771,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27222,7 +27266,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 9747,
+          "line": 9774,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -27234,7 +27278,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9753,
+          "line": 9780,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -27244,7 +27288,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9756,
+          "line": 9783,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -27254,7 +27298,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 9759,
+          "line": 9786,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -27264,7 +27308,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9766,
+          "line": 9793,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -27276,7 +27320,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9771,
+          "line": 9798,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -27288,7 +27332,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9775,
+          "line": 9802,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -27298,7 +27342,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 9780,
+          "line": 9807,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -27310,7 +27354,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9786,
+          "line": 9813,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -27320,7 +27364,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 9791,
+          "line": 9818,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -27330,7 +27374,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 9794,
+          "line": 9821,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -27340,7 +27384,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 9797,
+          "line": 9824,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -27350,7 +27394,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 9799,
+          "line": 9826,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -27362,7 +27406,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 9802,
+          "line": 9829,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -27372,7 +27416,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 9806,
+          "line": 9833,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -27382,7 +27426,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 9810,
+          "line": 9837,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27395,7 +27439,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 9813,
+          "line": 9840,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -27405,7 +27449,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9817,
+          "line": 9844,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -27418,7 +27462,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9820,
+          "line": 9847,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -27431,7 +27475,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9822,
+          "line": 9849,
           "kind": "struct",
           "field_names": [
             "color",
@@ -27444,7 +27488,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 9824,
+          "line": 9851,
           "kind": "struct",
           "field_names": [
             "text"
@@ -27456,7 +27500,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 9826,
+          "line": 9853,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -27468,7 +27512,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 9830,
+          "line": 9857,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -27482,7 +27526,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 9832,
+          "line": 9859,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -27492,7 +27536,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 9837,
+          "line": 9864,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -27507,7 +27551,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9848,
+          "line": 9875,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -27523,7 +27567,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 9863,
+          "line": 9890,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -27535,7 +27579,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9866,
+          "line": 9893,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27548,7 +27592,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 9876,
+          "line": 9903,
           "kind": "struct",
           "field_names": [
             "label"
@@ -27562,7 +27606,7 @@
         },
         {
           "name": "AttackersDeclaredMin",
-          "line": 9889,
+          "line": 9916,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27578,7 +27622,7 @@
         },
         {
           "name": "NoneOfAttackersTargetedYou",
-          "line": 9894,
+          "line": 9921,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 603.4: Intervening-if \"if none of those creatures attacked you\". Reads the triggering `AttackersDeclared` event's per-attacker `AttackTarget` tuples (CR 508.1b) and returns true iff no attacker in the batch targeted the trigger's controller directly (`AttackTarget::Player(trigger_controller)`).",
@@ -27590,7 +27634,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9904,
+          "line": 9931,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -27602,7 +27646,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 9915,
+          "line": 9942,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -27614,7 +27658,7 @@
         },
         {
           "name": "And",
-          "line": 9919,
+          "line": 9946,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27624,7 +27668,7 @@
         },
         {
           "name": "Or",
-          "line": 9921,
+          "line": 9948,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27634,7 +27678,7 @@
         },
         {
           "name": "Not",
-          "line": 9931,
+          "line": 9958,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -27650,13 +27694,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10112,
+      "line": 10139,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 10114,
+          "line": 10141,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -27664,7 +27708,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 10116,
+          "line": 10143,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -27672,7 +27716,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 10118,
+          "line": 10145,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -27680,7 +27724,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 10123,
+          "line": 10150,
           "kind": "struct",
           "field_names": [
             "n",
@@ -27691,7 +27735,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 10130,
+          "line": 10157,
           "kind": "struct",
           "field_names": [
             "n"
@@ -27701,7 +27745,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 10132,
+          "line": 10159,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -27709,7 +27753,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 10136,
+          "line": 10163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -27719,7 +27763,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 10138,
+          "line": 10165,
           "kind": "struct",
           "field_names": [
             "level"
@@ -27731,7 +27775,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 10141,
+          "line": 10168,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29986,7 +30030,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3732,
+      "line": 3755,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -29995,7 +30039,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 3734,
+          "line": 3757,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30003,7 +30047,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 3735,
+          "line": 3758,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30011,7 +30055,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 3736,
+          "line": 3759,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -30021,7 +30065,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 3739,
+          "line": 3762,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -30031,7 +30075,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 3751,
+          "line": 3774,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -30047,7 +30091,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3324,
+      "line": 3332,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -30060,7 +30104,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 3328,
+          "line": 3336,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -30073,7 +30117,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 3332,
+          "line": 3340,
           "kind": "struct",
           "field_names": [
             "property",
@@ -30120,7 +30164,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7267,
+      "line": 7290,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -30129,7 +30173,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 7270,
+          "line": 7293,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -30139,7 +30183,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 7274,
+          "line": 7297,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -30149,7 +30193,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 7282,
+          "line": 7305,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",


### PR DESCRIPTION
Two independent root causes left both halves of the ability inert:

1. "create a number of Treasure tokens equal to the result" parsed the
   token count as QuantityRef::Variable("the result"), which resolves to 0
   (quantity.rs last_named_choice fallback) — zero Treasures. The token
   count-expression fallback now chains parse_event_context_quantity before
   the raw Variable fallback, so "the result" maps to EventContextAmount
   (CR 706.2), the same channel RollDie already feeds. Unlocks every
   "create N <token> equal to the result" die/coin card.

2. "The player to your right gains control" had no seating-relative player
   reference, so the recipient parsed as TargetFilter::Any and the resolver
   rejected it as ambiguous — no transfer. Add a parameterized
   TargetFilter::Neighbor { direction: SeatDirection } (CR 102.1 + CR 103.1;
   right = previous seat under clockwise turn order), resolved to a single
   living player via new players::previous_player/neighbor helpers and a
   short-circuit in gain_control::unique_recipient_from_filter. Parser arms
   in oracle_target/subject recognize "the player to your right/left".

Tests drive real resolution: a 3-player end-to-end chain (roll d4 -> N
Treasures read from DieRolled -> control to the right neighbor), a 4-player
eliminated-neighbor skip, and parser/unit coverage. mtgish condition.rs gets
the forced exhaustiveness arm (classifier only, no rules logic).
