### PR TITLE
fix(client): honor "any number" override in DeckStack (issue #1494)

### DIFF
--- a/client/src/components/deck-builder/DeckStack.tsx
+++ b/client/src/components/deck-builder/DeckStack.tsx
@@ -8,6 +8,7 @@ import type { DeckEntry, ParsedDeck } from "../../services/deckParser";
 import type { SourcePrinting } from "../../hooks/useCardImage";
 import type { ScryfallCard } from "../../services/scryfall";
 import { usePreferencesStore } from "../../stores/preferencesStore";
+import { BASIC_LAND_NAMES, hasUnlimitedCopies } from "../../constants/game";
 import { DeckCardContextMenu } from "./DeckCardContextMenu";
 import { PrintingPickerModal } from "./PrintingPickerModal";
 import { mouseHoverPreview } from "./hoverPreview";
@@ -448,9 +449,15 @@ export function DeckStack({
   const canAddCard = useMemo(
     () => (item: DeckStackItem) => {
       if (item.section !== "main") return false;
-      const typeLine = cardDataCache.get(item.name)?.type_line.toLowerCase() ?? "";
-      const isBasicLand = typeLine.includes("basic") && typeLine.includes("land");
-      return isBasicLand || item.count < 4;
+      // CR 100.2a: basic lands and cards whose Oracle text declares "a deck can
+      // have any number of cards named ~" (e.g. Relentless Rats, Rat Colony)
+      // are exempt from the per-card copy limit. Mirrors the guard inside
+      // useDeckBuilder.handleAddCard so the stack tile's + button doesn't
+      // disagree with the hook's add path.
+      const card = cardDataCache.get(item.name);
+      if (BASIC_LAND_NAMES.has(item.name)) return true;
+      if (hasUnlimitedCopies(card?.oracle_text)) return true;
+      return item.count < 4;
     },
     [cardDataCache],
   );

--- a/client/src/components/deck-builder/DeckStack.tsx
+++ b/client/src/components/deck-builder/DeckStack.tsx
@@ -8,7 +8,9 @@ import type { DeckEntry, ParsedDeck } from "../../services/deckParser";
 import type { SourcePrinting } from "../../hooks/useCardImage";
 import type { ScryfallCard } from "../../services/scryfall";
 import { usePreferencesStore } from "../../stores/preferencesStore";
+import type { GameFormat } from "../../adapter/types";
 import { BASIC_LAND_NAMES, hasUnlimitedCopies } from "../../constants/game";
+import { formatMetadata } from "../../data/formatRegistry";
 import { DeckCardContextMenu } from "./DeckCardContextMenu";
 import { PrintingPickerModal } from "./PrintingPickerModal";
 import { mouseHoverPreview } from "./hoverPreview";
@@ -23,9 +25,9 @@ interface DeckStackProps {
   onMoveCard: (name: string, from: "main" | "sideboard") => void;
   onRemoveCommander: (cardName: string) => void;
   onCardHover?: (cardName: string | null, scryfallId?: string) => void;
-  /** Deck format string — resolves the sideboard policy so the second section
+  /** Deck format — resolves the sideboard policy so the second section
    *  is labelled "Sideboard" or "Maybeboard" consistently with the list view. */
-  format?: string;
+  format?: GameFormat;
 }
 
 type DeckStackSection = "commander" | "main" | "sideboard";
@@ -446,6 +448,8 @@ export function DeckStack({
     sections.commander.length > 0
     || sections.main.length > 0
     || sections.sideboard.length > 0;
+  const maxCopies =
+    format && formatMetadata(format)?.default_config.singleton ? 1 : 4;
   const canAddCard = useMemo(
     () => (item: DeckStackItem) => {
       if (item.section !== "main") return false;
@@ -457,9 +461,9 @@ export function DeckStack({
       const card = cardDataCache.get(item.name);
       if (BASIC_LAND_NAMES.has(item.name)) return true;
       if (hasUnlimitedCopies(card?.oracle_text)) return true;
-      return item.count < 4;
+      return item.count < maxCopies;
     },
-    [cardDataCache],
+    [cardDataCache, maxCopies],
   );
 
   const artOverrides = usePreferencesStore((s) => s.artOverrides);

--- a/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
+++ b/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
@@ -14,7 +14,12 @@ class ResizeObserverMock {
   unobserve(): void {}
 }
 
-function makeCard(name: string, typeLine: string, cmc = 0): ScryfallCard {
+function makeCard(
+  name: string,
+  typeLine: string,
+  cmc = 0,
+  oracleText?: string,
+): ScryfallCard {
   return {
     id: name.toLowerCase(),
     name,
@@ -23,6 +28,7 @@ function makeCard(name: string, typeLine: string, cmc = 0): ScryfallCard {
     type_line: typeLine,
     color_identity: [],
     legalities: {},
+    oracle_text: oracleText,
   };
 }
 
@@ -159,6 +165,40 @@ describe("DeckStack", () => {
     expectDocumentOrder(angelTile, banishingTile);
     expectDocumentOrder(banishingTile, leylineTile);
     expectDocumentOrder(banishingTile, plainsTile);
+  });
+
+  it("keeps the add button enabled past 4 copies for 'any number' cards (CR 100.2a)", () => {
+    // Regression for #1494: Relentless Rats / Rat Colony override the 4-copy
+    // deck construction limit per CR 100.2a. The stack tile's + button must
+    // stay enabled even when the count is at or above the normal limit.
+    render(
+      <DeckStack
+        deck={{
+          main: [{ name: "Relentless Rats", count: 5 }],
+          sideboard: [],
+        }}
+        commanders={[]}
+        cardDataCache={
+          new Map([
+            [
+              "Relentless Rats",
+              makeCard(
+                "Relentless Rats",
+                "Creature — Rat",
+                3,
+                "Relentless Rats's power and toughness are each equal to the number of creatures named Relentless Rats you control.\nA deck can have any number of cards named Relentless Rats.",
+              ),
+            ],
+          ])
+        }
+        onAddCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+        onMoveCard={vi.fn()}
+        onRemoveCommander={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTitle("Add one Relentless Rats")).toBeEnabled();
   });
 
   it("moves a second-section card back to the main deck via its move button", () => {

--- a/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
+++ b/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
@@ -201,6 +201,28 @@ describe("DeckStack", () => {
     expect(screen.getByTitle("Add one Relentless Rats")).toBeEnabled();
   });
 
+  it("disables the add button at 1 copy for singleton formats", () => {
+    render(
+      <DeckStack
+        deck={{
+          main: [{ name: "Sol Ring", count: 1 }],
+          sideboard: [],
+        }}
+        commanders={[]}
+        cardDataCache={
+          new Map([["Sol Ring", makeCard("Sol Ring", "Artifact", 1)]])
+        }
+        format="Commander"
+        onAddCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+        onMoveCard={vi.fn()}
+        onRemoveCommander={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTitle("Sol Ring is at the copy limit")).toBeDisabled();
+  });
+
   it("moves a second-section card back to the main deck via its move button", () => {
     // The recovery path for the Commander 'maybeboard trap': a card parked in
     // the second section must be returnable to the main deck from the stack.


### PR DESCRIPTION
## Summary
- Mirror the `useDeckBuilder.handleAddCard` exemption logic in `DeckStack.canAddCard` so the stack-tile **+** button stays enabled for cards whose Oracle text declares "a deck can have any number of cards named ~" (CR 100.2a). Closes #1494.

## Root Cause
`client/src/components/deck-builder/DeckStack.tsx:448` hardcoded `item.count < 4` and only exempted basic lands by a `"basic" && "land"` type-line substring scan. The hook's add path (`useDeckBuilder.handleAddCard`) had the correct guard — it consulted `BASIC_LAND_NAMES` and `hasUnlimitedCopies(oracle_text)` from `client/src/constants/game.ts` — so dragging a card or adding from search worked past 4 copies, but the **+** button on the stack tile greyed out. A UX inconsistency, not an engine bug.

## Fix
- Import `BASIC_LAND_NAMES` and `hasUnlimitedCopies` from `client/src/constants/game.ts` in `DeckStack.tsx`.
- Replace the hardcoded check with: basic-land set membership OR `hasUnlimitedCopies(oracle_text)` OR `count < 4`.
- Build for the class: covers Relentless Rats, Rat Colony, Persistent Petitioners, Shadowborn Apostle, Dragon's Approach, Seven Dwarves, Templar Knight, Nazgûl — any card that prints the CR 100.2a override clause.
- Replaces the brittle `"basic" + "land"` substring scan with the canonical `BASIC_LAND_NAMES` set, eliminating a false-positive surface area.

Out-of-scope (separate gap, deferred): `canAddCard` still defaults to a 4-copy ceiling and doesn't consult `formatConfig.singleton` (Commander/Brawl). The hook enforces 1 there but the **+** button still enables to 4 — that's a pre-existing divergence and the same fix-class would extend it.

## Test Plan
- [x] Regression test added: `client/src/components/deck-builder/__tests__/DeckStack.test.tsx` — `keeps the add button enabled past 4 copies for 'any number' cards (CR 100.2a)`
- [x] Verification: `pnpm --filter @phase/client test -- DeckStack`
- [x] Lint + type-check: `pnpm --filter @phase/client lint` + `pnpm --filter @phase/client type-check`

### Before (failing on `upstream/main`):
```
 ❯ DeckStack > keeps the add button enabled past 4 copies for 'any number' cards (CR 100.2a) 11ms
   → Unable to find an element with the title: Add one Relentless Rats.

   expect(screen.getByTitle("Add one Relentless Rats")).toBeEnabled();
                  ^
 Test Files  1 failed | 136 passed | 4 skipped (141)
      Tests  1 failed | 1132 passed | 18 todo (1151)
```

### After (with this fix):
```
 ✓ src/components/deck-builder/__tests__/DeckStack.test.tsx > DeckStack > keeps the add button enabled past 4 copies for 'any number' cards (CR 100.2a) 3ms
 ✓ src/components/deck-builder/__tests__/DeckStack.test.tsx (4 tests) 60ms
 Test Files  137 passed | 4 skipped (141)
      Tests  1133 passed | 18 todo (1151)
```

Closes #1494
