### PR TITLE
fix(engine): implement Mirror Match copy-blocker tokens (#1597)

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -306,11 +306,7 @@ pub fn place_attacking_alongside(
 /// the battlefield blocking does NOT cause "whenever ~ blocks" abilities to
 /// trigger, so no `BlockersDeclared` event is emitted; combat damage reads the
 /// recorded assignments directly. Returns `true` when the block was established.
-pub fn place_blocking(
-    state: &mut GameState,
-    blocker_id: ObjectId,
-    attacker_id: ObjectId,
-) -> bool {
+pub fn place_blocking(state: &mut GameState, blocker_id: ObjectId, attacker_id: ObjectId) -> bool {
     let Some(blocker_controller) = state.objects.get(&blocker_id).map(|o| o.controller) else {
         return false;
     };
@@ -344,7 +340,7 @@ pub fn place_blocking(
         .or_default()
         .push(blocker_id);
     // CR 509.1a tracking: record the blocker for per-turn "blocked this turn" queries.
-    state.creatures_blocked_this_turn.push(blocker_id);
+    state.creatures_blocked_this_turn.insert(blocker_id);
     // CR 506.4 + CR 613.1f: a new blocking creature can satisfy Layer 6
     // `FilterProp::Blocking` grants; re-evaluate continuous effects.
     state.layers_dirty.mark_full();

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -294,6 +294,63 @@ pub fn place_attacking_alongside(
     }
 }
 
+/// CR 509.1g + CR 506.3e + CR 509.1h: Put a permanent onto the battlefield as a
+/// blocking creature for `attacker_id`. Used by effects that create or place a
+/// creature already "blocking that creature" (Mirror Match's copy tokens).
+///
+/// Per CR 506.3e, the creature only becomes a blocking creature if `attacker_id`
+/// is attacking the blocker's controller (or a planeswalker/battle they control,
+/// captured by `AttackerInfo.defending_player`); otherwise the creature is on
+/// the battlefield but is never considered a blocking creature, so this is a
+/// no-op for the combat bookkeeping. Per CR 509.3a/509.3b, a creature put onto
+/// the battlefield blocking does NOT cause "whenever ~ blocks" abilities to
+/// trigger, so no `BlockersDeclared` event is emitted; combat damage reads the
+/// recorded assignments directly. Returns `true` when the block was established.
+pub fn place_blocking(
+    state: &mut GameState,
+    blocker_id: ObjectId,
+    attacker_id: ObjectId,
+) -> bool {
+    let Some(blocker_controller) = state.objects.get(&blocker_id).map(|o| o.controller) else {
+        return false;
+    };
+    let Some(combat) = state.combat.as_mut() else {
+        return false;
+    };
+    // CR 506.3e: the entering creature only blocks an attacker that is attacking
+    // its controller, a planeswalker they control, or a battle they protect —
+    // exactly the side recorded as `AttackerInfo.defending_player`.
+    let Some(info) = combat
+        .attackers
+        .iter_mut()
+        .find(|a| a.object_id == attacker_id)
+    else {
+        return false;
+    };
+    if info.defending_player != blocker_controller {
+        return false;
+    }
+    // CR 509.1h: an attacking creature with one or more blockers becomes blocked.
+    info.blocked = true;
+    // CR 509.1g: the creature becomes a blocking creature for the chosen attacker.
+    combat
+        .blocker_to_attacker
+        .entry(blocker_id)
+        .or_default()
+        .push(attacker_id);
+    combat
+        .blocker_assignments
+        .entry(attacker_id)
+        .or_default()
+        .push(blocker_id);
+    // CR 509.1a tracking: record the blocker for per-turn "blocked this turn" queries.
+    state.creatures_blocked_this_turn.push(blocker_id);
+    // CR 506.4 + CR 613.1f: a new blocking creature can satisfy Layer 6
+    // `FilterProp::Blocking` grants; re-evaluate continuous effects.
+    state.layers_dirty.mark_full();
+    true
+}
+
 /// Validate attacker declarations per CR 508.1.
 pub fn validate_attackers(state: &GameState, attacker_ids: &[ObjectId]) -> Result<(), String> {
     let active = state.active_player;

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2373,6 +2373,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::Learn
         | Effect::SwitchPT { .. }
         | Effect::Myriad
+        | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::Populate
         | Effect::VentureIntoDungeon
         | Effect::VentureInto { .. }

--- a/crates/engine/src/game/effects/copy_token_blocking.rs
+++ b/crates/engine/src/game/effects/copy_token_blocking.rs
@@ -1,0 +1,184 @@
+use crate::game::filter::{matches_target_filter, FilterContext};
+use crate::game::{combat, targeting};
+use crate::types::ability::{
+    Effect, EffectError, EffectKind, QuantityExpr, ResolvedAbility, TargetFilter,
+};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
+use crate::types::zones::Zone;
+
+/// CR 509.1g + CR 506.3e + CR 707.2: Resolve `Effect::CopyTokenBlockingAttacker`.
+///
+/// For each attacking creature matched by `source_filter`, create a token that's
+/// a copy of it (CR 707.2) and put that token onto the battlefield blocking the
+/// attacker it copies (CR 506.3e + CR 509.1g). Mirror Match is the canonical
+/// card. The created token ids are republished to `state.last_created_token_ids`
+/// so a composed delayed trigger can exile "those tokens" at end of combat via
+/// `TargetFilter::LastCreated`.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let (source_filter, owner) = match &ability.effect {
+        Effect::CopyTokenBlockingAttacker {
+            source_filter,
+            owner,
+        } => (source_filter.clone(), owner.clone()),
+        _ => {
+            return Err(EffectError::MissingParam(
+                "CopyTokenBlockingAttacker".to_string(),
+            ))
+        }
+    };
+
+    // CR 508.1: resolve the attackers to copy. Non-targeting — evaluated against
+    // the battlefield (or any zones the filter names) at resolution time, the
+    // same way `Effect::CopyTokenOf`'s `source_filter` branch enumerates its
+    // copy sources.
+    let zones = {
+        let explicit = source_filter.extract_zones();
+        if explicit.is_empty() {
+            vec![Zone::Battlefield]
+        } else {
+            explicit
+        }
+    };
+    let filter_ctx = FilterContext::from_ability(ability);
+    let attacker_ids: Vec<ObjectId> = zones
+        .into_iter()
+        .flat_map(|zone| targeting::zone_object_ids(state, zone))
+        .filter(|id| matches_target_filter(state, *id, &source_filter, &filter_ctx))
+        .collect();
+
+    let mut all_created: Vec<ObjectId> = Vec::new();
+    for attacker_id in attacker_ids {
+        // CR 707.2: create one token copy of this specific attacker, delegating
+        // to the single-authority token-copy resolver so copiable values,
+        // predefined abilities, and ETB events are handled identically to every
+        // other copy-token effect.
+        let copy_effect = Effect::CopyTokenOf {
+            target: TargetFilter::Any,
+            owner: owner.clone(),
+            source_filter: Some(TargetFilter::SpecificObject { id: attacker_id }),
+            enters_attacking: false,
+            tapped: false,
+            count: QuantityExpr::Fixed { value: 1 },
+            extra_keywords: vec![],
+            additional_modifications: vec![],
+        };
+        let copy_ability =
+            ResolvedAbility::new(copy_effect, vec![], ability.source_id, ability.controller);
+        crate::game::effects::token_copy::resolve(state, &copy_ability, events)?;
+
+        // CR 506.3e + CR 509.1g: each fresh copy is put onto the battlefield
+        // blocking the attacker it copied. `last_created_token_ids` holds exactly
+        // this attacker's single copy at this point in the loop.
+        for token_id in state.last_created_token_ids.clone() {
+            combat::place_blocking(state, token_id, attacker_id);
+            all_created.push(token_id);
+        }
+    }
+
+    // CR 603.7c + CR 701.36a: republish the full created-token set so a composed
+    // "exile those tokens at end of combat" delayed trigger snapshots all copies
+    // via `TargetFilter::LastCreated` rather than just the last loop iteration's.
+    state.last_created_token_ids = all_created;
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::CopyTokenOf,
+        source_id: ability.source_id,
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::combat::{AttackTarget, AttackerInfo, CombatState};
+    use crate::game::zones::create_object;
+    use crate::types::ability::{FilterProp, TypedFilter};
+    use crate::types::card_type::{CardType, CoreType};
+    use crate::types::identifiers::CardId;
+    use crate::types::player::PlayerId;
+
+    /// CR 506.3e + CR 509.1g: For each creature attacking the controller, a copy
+    /// token is created and put onto the battlefield blocking that attacker. The
+    /// attacker becomes blocked and the created tokens are published for the
+    /// "those tokens" anaphor.
+    #[test]
+    fn copies_and_blocks_each_attacker() {
+        let mut state = GameState::new_two_player(42);
+        let defender = PlayerId(0); // Mirror Match's controller (defending player).
+        let aggressor = PlayerId(1);
+
+        // Two creatures controlled by the aggressor, attacking the defender.
+        let make_attacker = |state: &mut GameState, name: &str| {
+            let id = create_object(state, CardId(1), aggressor, name.to_string(), Zone::Battlefield);
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec![],
+            };
+            obj.card_types = obj.base_card_types.clone();
+            id
+        };
+        let atk_a = make_attacker(&mut state, "Grizzly Bears");
+        let atk_b = make_attacker(&mut state, "Hill Giant");
+
+        let mut combat = CombatState::default();
+        combat
+            .attackers
+            .push(AttackerInfo::new(atk_a, AttackTarget::Player(defender), defender));
+        combat
+            .attackers
+            .push(AttackerInfo::new(atk_b, AttackTarget::Player(defender), defender));
+        state.combat = Some(combat);
+
+        // Mirror Match: copy + block each creature attacking the controller.
+        let source_filter = TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::AttackingController]),
+        );
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenBlockingAttacker {
+                source_filter,
+                owner: TargetFilter::Controller,
+            },
+            vec![],
+            create_object(&mut state, CardId(2), defender, "Mirror Match".to_string(), Zone::Stack),
+            defender,
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // Two copy tokens were created, controlled by the defender.
+        assert_eq!(state.last_created_token_ids.len(), 2);
+        for token_id in &state.last_created_token_ids {
+            let token = &state.objects[token_id];
+            assert!(token.is_token, "created object is a token");
+            assert_eq!(token.controller, defender, "copy is controlled by Mirror Match's controller");
+            assert!(!token.tapped, "blocking copy is not tapped");
+        }
+
+        // Both attackers are now blocked, each by exactly one created copy.
+        let combat = state.combat.as_ref().unwrap();
+        for atk in [atk_a, atk_b] {
+            let info = combat.attackers.iter().find(|a| a.object_id == atk).unwrap();
+            assert!(info.blocked, "attacker {atk:?} became blocked");
+            assert_eq!(combat.blocker_assignments[&atk].len(), 1, "one blocker per attacker");
+        }
+        // The two blockers are the two created tokens.
+        let blockers: std::collections::HashSet<_> =
+            combat.blocker_to_attacker.keys().copied().collect();
+        let created: std::collections::HashSet<_> =
+            state.last_created_token_ids.iter().copied().collect();
+        assert_eq!(blockers, created, "every created copy is a blocker");
+    }
+}

--- a/crates/engine/src/game/effects/copy_token_blocking.rs
+++ b/crates/engine/src/game/effects/copy_token_blocking.rs
@@ -115,7 +115,13 @@ mod tests {
 
         // Two creatures controlled by the aggressor, attacking the defender.
         let make_attacker = |state: &mut GameState, name: &str| {
-            let id = create_object(state, CardId(1), aggressor, name.to_string(), Zone::Battlefield);
+            let id = create_object(
+                state,
+                CardId(1),
+                aggressor,
+                name.to_string(),
+                Zone::Battlefield,
+            );
             let obj = state.objects.get_mut(&id).unwrap();
             obj.base_power = Some(2);
             obj.base_toughness = Some(2);
@@ -133,12 +139,16 @@ mod tests {
         let atk_b = make_attacker(&mut state, "Hill Giant");
 
         let mut combat = CombatState::default();
-        combat
-            .attackers
-            .push(AttackerInfo::new(atk_a, AttackTarget::Player(defender), defender));
-        combat
-            .attackers
-            .push(AttackerInfo::new(atk_b, AttackTarget::Player(defender), defender));
+        combat.attackers.push(AttackerInfo::new(
+            atk_a,
+            AttackTarget::Player(defender),
+            defender,
+        ));
+        combat.attackers.push(AttackerInfo::new(
+            atk_b,
+            AttackTarget::Player(defender),
+            defender,
+        ));
         state.combat = Some(combat);
 
         // Mirror Match: copy + block each creature attacking the controller.
@@ -151,7 +161,13 @@ mod tests {
                 owner: TargetFilter::Controller,
             },
             vec![],
-            create_object(&mut state, CardId(2), defender, "Mirror Match".to_string(), Zone::Stack),
+            create_object(
+                &mut state,
+                CardId(2),
+                defender,
+                "Mirror Match".to_string(),
+                Zone::Stack,
+            ),
             defender,
         );
 
@@ -163,16 +179,27 @@ mod tests {
         for token_id in &state.last_created_token_ids {
             let token = &state.objects[token_id];
             assert!(token.is_token, "created object is a token");
-            assert_eq!(token.controller, defender, "copy is controlled by Mirror Match's controller");
+            assert_eq!(
+                token.controller, defender,
+                "copy is controlled by Mirror Match's controller"
+            );
             assert!(!token.tapped, "blocking copy is not tapped");
         }
 
         // Both attackers are now blocked, each by exactly one created copy.
         let combat = state.combat.as_ref().unwrap();
         for atk in [atk_a, atk_b] {
-            let info = combat.attackers.iter().find(|a| a.object_id == atk).unwrap();
+            let info = combat
+                .attackers
+                .iter()
+                .find(|a| a.object_id == atk)
+                .unwrap();
             assert!(info.blocked, "attacker {atk:?} became blocked");
-            assert_eq!(combat.blocker_assignments[&atk].len(), 1, "one blocker per attacker");
+            assert_eq!(
+                combat.blocker_assignments[&atk].len(),
+                1,
+                "one blocker per attacker"
+            );
         }
         // The two blockers are the two created tokens.
         let blockers: std::collections::HashSet<_> =

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -51,6 +51,7 @@ pub mod conjure;
 pub mod connive;
 pub mod control_next_turn;
 pub mod copy_spell;
+pub mod copy_token_blocking;
 pub mod counter;
 pub mod counters;
 pub mod create_damage_replacement;
@@ -1679,6 +1680,9 @@ pub fn resolve_effect(
         Effect::CastCopyOfCard { .. } => cast_copy_of_card::resolve(state, ability, events),
         Effect::CopyTokenOf { .. } => token_copy::resolve(state, ability, events),
         Effect::Myriad => myriad::resolve(state, ability, events),
+        Effect::CopyTokenBlockingAttacker { .. } => {
+            copy_token_blocking::resolve(state, ability, events)
+        }
         Effect::BecomeCopy { .. } => become_copy::resolve(state, ability, events),
         Effect::ChooseCard { .. } => choose_card::resolve(state, ability, events),
         Effect::PutCounter { .. } => counters::resolve_add(state, ability, events),

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -701,6 +701,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::CastCopyOfCard { .. }
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
+        | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
         | Effect::ChooseCard { .. }
         | Effect::PutCounter { .. }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12756,6 +12756,9 @@ pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
     if let Some(def) = try_parse_return_target_and_same_name_from_your_graveyard(text, kind) {
         return def;
     }
+    if let Some(def) = try_parse_for_each_attacker_copy_blocker(text, kind) {
+        return def;
+    }
     let ir = parse_effect_chain_ir(text, kind, &mut ParseContext::default());
     let mut def = lower_effect_chain_ir(&ir);
     fold_speed_floor_sentences(&mut def);
@@ -12779,10 +12782,135 @@ pub(crate) fn parse_effect_chain_with_context(
     if let Some(def) = try_parse_return_target_and_same_name_from_your_graveyard(text, kind) {
         return def;
     }
+    if let Some(def) = try_parse_for_each_attacker_copy_blocker(text, kind) {
+        return def;
+    }
     let ir = parse_effect_chain_ir(text, kind, ctx);
     let mut def = lower_effect_chain_ir(&ir);
     fold_speed_floor_sentences(&mut def);
     def
+}
+
+/// CR 509.1g + CR 506.3e + CR 707.2 + CR 603.7: Mirror Match's whole-card idiom
+/// — "For each creature attacking you[ or a planeswalker you control], create a
+/// token that's a copy of that creature and that's blocking that creature.
+/// Exile those tokens at end of combat."
+///
+/// Lowers to `Effect::CopyTokenBlockingAttacker` (the copy-and-block half, whose
+/// resolver copies each matched attacker and puts the copy onto the battlefield
+/// blocking it, CR 506.3e) chained via `sub_ability` to a delayed end-of-combat
+/// exile of "those tokens" (`TargetFilter::LastCreated`, snapshotted at
+/// creation by the delayed-trigger resolver, CR 603.7c). The casting
+/// restriction ("only during the declare blockers step") is handled separately
+/// by the casting-line parser; an optional leading copy of that sentence is
+/// stripped here defensively in case it reaches this entry inline.
+///
+/// `FilterProp::AttackingController` matches every attacker whose defending
+/// player is the controller — which the engine records as the controller of an
+/// attacked planeswalker/battle too, so "attacking you" and "or a planeswalker
+/// you control" collapse onto the one predicate.
+fn try_parse_for_each_attacker_copy_blocker(
+    text: &str,
+    kind: AbilityKind,
+) -> Option<AbilityDefinition> {
+    let lower = text.to_ascii_lowercase();
+    // Optional leading casting-restriction sentence, if not pre-stripped.
+    let i = opt(tag::<_, _, OracleError<'_>>(
+        "cast this spell only during the declare blockers step.",
+    ))
+    .parse(lower.as_str())
+    .map(|(rest, _)| rest.trim_start())
+    .unwrap_or(lower.as_str());
+
+    // "for each creature attacking you[ or a planeswalker you control], "
+    let (i, _) = tag::<_, _, OracleError<'_>>("for each creature attacking you")
+        .parse(i)
+        .ok()?;
+    let (i, _) = opt(tag::<_, _, OracleError<'_>>(" or a planeswalker you control"))
+        .parse(i)
+        .ok()?;
+    let (i, _) = tag::<_, _, OracleError<'_>>(", ").parse(i).ok()?;
+
+    // "create a token that's a copy of <anaphor> and that's blocking <anaphor>"
+    let (i, _) = tag::<_, _, OracleError<'_>>("create a token that's a copy of ")
+        .parse(i)
+        .ok()?;
+    let (i, _) = alt((
+        tag::<_, _, OracleError<'_>>("that creature"),
+        tag("it"),
+    ))
+    .parse(i)
+    .ok()?;
+    let (i, _) = tag::<_, _, OracleError<'_>>(" and that's blocking ")
+        .parse(i)
+        .ok()?;
+    let (i, _) = alt((
+        tag::<_, _, OracleError<'_>>("that creature"),
+        tag("it"),
+    ))
+    .parse(i)
+    .ok()?;
+    let (i, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(i).ok()?;
+    let i = i.trim_start();
+
+    // Optional trailing "exile those tokens at end of combat." sentence. When
+    // present, it chains a delayed end-of-combat exile of the created tokens;
+    // when the body ends after the copy clause, the recognizer still matches
+    // (the copy-and-block half alone). Any other trailing text disqualifies the
+    // whole-card match so the generic pipeline can attempt it instead.
+    let exiles_tokens = if i.is_empty() {
+        false
+    } else {
+        let (rest, _) = tag::<_, _, OracleError<'_>>("exile those tokens at end of combat")
+            .parse(i)
+            .ok()?;
+        let (rest, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(rest).ok()?;
+        if !rest.trim().is_empty() {
+            return None;
+        }
+        true
+    };
+
+    let source_filter = TargetFilter::Typed(
+        TypedFilter::creature().properties(vec![FilterProp::AttackingController]),
+    );
+    let mut def = AbilityDefinition::new(
+        kind,
+        Effect::CopyTokenBlockingAttacker {
+            source_filter,
+            owner: TargetFilter::Controller,
+        },
+    );
+    if exiles_tokens {
+        // CR 603.7c + CR 701.36a: "those tokens" → the tokens created above,
+        // snapshotted at delayed-trigger creation via `TargetFilter::LastCreated`.
+        let exile = AbilityDefinition::new(
+            kind,
+            Effect::ChangeZone {
+                origin: Some(Zone::Battlefield),
+                destination: Zone::Exile,
+                target: TargetFilter::LastCreated,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: false,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+            },
+        );
+        def.sub_ability = Some(Box::new(AbilityDefinition::new(
+            kind,
+            Effect::CreateDelayedTrigger {
+                condition: DelayedTriggerCondition::AtNextPhase {
+                    phase: Phase::EndCombat,
+                },
+                effect: Box::new(exile),
+                uses_tracked_set: false,
+            },
+        )));
+    }
+    Some(def)
 }
 
 fn try_parse_return_target_and_same_name_from_your_graveyard(
@@ -20819,6 +20947,52 @@ mod tests {
                     .any(|p| matches!(p, FilterProp::EnteredThisTurn)));
             }
             other => panic!("expected CopyTokenOf with typed source_filter, got {other:?}"),
+        }
+    }
+
+    /// CR 509.1g + CR 506.3e + CR 603.7: Mirror Match lowers to
+    /// `CopyTokenBlockingAttacker` over attackers-against-you plus a delayed
+    /// end-of-combat exile of the created tokens.
+    #[test]
+    fn effect_mirror_match_copy_blockers_and_delayed_exile() {
+        let def = parse_effect_chain(
+            "For each creature attacking you or a planeswalker you control, create a token that's a copy of that creature and that's blocking that creature. Exile those tokens at end of combat.",
+            AbilityKind::Spell,
+        );
+        match &*def.effect {
+            Effect::CopyTokenBlockingAttacker {
+                source_filter: TargetFilter::Typed(tf),
+                owner,
+            } => {
+                assert_eq!(*owner, TargetFilter::Controller);
+                assert!(tf
+                    .properties
+                    .iter()
+                    .any(|p| matches!(p, FilterProp::AttackingController)));
+            }
+            other => panic!("expected CopyTokenBlockingAttacker, got {other:?}"),
+        }
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("delayed end-of-combat exile sub_ability present");
+        match &*sub.effect {
+            Effect::CreateDelayedTrigger {
+                condition: DelayedTriggerCondition::AtNextPhase { phase },
+                effect,
+                ..
+            } => {
+                assert_eq!(*phase, Phase::EndCombat);
+                assert!(matches!(
+                    &*effect.effect,
+                    Effect::ChangeZone {
+                        destination: Zone::Exile,
+                        target: TargetFilter::LastCreated,
+                        ..
+                    }
+                ));
+            }
+            other => panic!("expected delayed exile trigger, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12826,30 +12826,26 @@ fn try_parse_for_each_attacker_copy_blocker(
     let (i, _) = tag::<_, _, OracleError<'_>>("for each creature attacking you")
         .parse(i)
         .ok()?;
-    let (i, _) = opt(tag::<_, _, OracleError<'_>>(" or a planeswalker you control"))
-        .parse(i)
-        .ok()?;
+    let (i, _) = opt(tag::<_, _, OracleError<'_>>(
+        " or a planeswalker you control",
+    ))
+    .parse(i)
+    .ok()?;
     let (i, _) = tag::<_, _, OracleError<'_>>(", ").parse(i).ok()?;
 
     // "create a token that's a copy of <anaphor> and that's blocking <anaphor>"
     let (i, _) = tag::<_, _, OracleError<'_>>("create a token that's a copy of ")
         .parse(i)
         .ok()?;
-    let (i, _) = alt((
-        tag::<_, _, OracleError<'_>>("that creature"),
-        tag("it"),
-    ))
-    .parse(i)
-    .ok()?;
+    let (i, _) = alt((tag::<_, _, OracleError<'_>>("that creature"), tag("it")))
+        .parse(i)
+        .ok()?;
     let (i, _) = tag::<_, _, OracleError<'_>>(" and that's blocking ")
         .parse(i)
         .ok()?;
-    let (i, _) = alt((
-        tag::<_, _, OracleError<'_>>("that creature"),
-        tag("it"),
-    ))
-    .parse(i)
-    .ok()?;
+    let (i, _) = alt((tag::<_, _, OracleError<'_>>("that creature"), tag("it")))
+        .parse(i)
+        .ok()?;
     let (i, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(i).ok()?;
     let i = i.trim_start();
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2794,6 +2794,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::CastCopyOfCard { .. }
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
+        | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
         | Effect::ChooseCard { .. }
         | Effect::PutCounter { .. }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5785,6 +5785,24 @@ pub enum Effect {
     /// opponent other than the defending player for the source creature, then
     /// exiles those tokens at end of combat.
     Myriad,
+    /// CR 509.1g + CR 506.3e + CR 707.2: For each attacking creature matched by
+    /// `source_filter`, create a token that's a copy of it and put that token
+    /// onto the battlefield blocking the attacker it copies. Mirror Match is the
+    /// canonical card ("For each attacking creature, create a token that's a
+    /// copy of that creature. Those tokens block those creatures …"). The
+    /// end-of-combat exile of the created tokens is composed separately as a
+    /// delayed trigger over `TargetFilter::LastCreated` ("those tokens"), so
+    /// this effect only handles the copy-and-block half of the idiom.
+    CopyTokenBlockingAttacker {
+        /// CR 508.1: The attacking creatures to copy and block. Non-targeting —
+        /// resolved against the battlefield at resolution time ("for each").
+        source_filter: TargetFilter,
+        /// CR 109.4: The player who creates (and therefore controls) the copy
+        /// tokens. Defaults to the resolving ability's controller. Mirrors
+        /// `Effect::CopyTokenOf.owner`.
+        #[serde(default = "default_target_filter_controller")]
+        owner: TargetFilter,
+    },
     /// CR 707.2 / CR 613.1a: Become a copy of target permanent.
     /// Sets copiable characteristics at Layer 1.
     BecomeCopy {
@@ -7661,6 +7679,8 @@ impl Effect {
             // These use filters, zone-level operations, or have no targeting at all.
             Effect::StartYourEngines { .. }
             | Effect::Myriad
+            // CR 508.1: copies are chosen by the effect, not declared as targets.
+            | Effect::CopyTokenBlockingAttacker { .. }
             | Effect::ChangeSpeed { .. }
             | Effect::GainLife { .. }
             | Effect::PumpAll { .. }
@@ -7832,6 +7852,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::CastCopyOfCard { .. } => "CastCopyOfCard",
         Effect::CopyTokenOf { .. } => "CopyTokenOf",
         Effect::Myriad => "Myriad",
+        Effect::CopyTokenBlockingAttacker { .. } => "CopyTokenBlockingAttacker",
         Effect::BecomeCopy { .. } => "BecomeCopy",
         Effect::ChooseCard { .. } => "ChooseCard",
         Effect::PutCounter { .. } => "PutCounter",
@@ -8193,6 +8214,9 @@ impl From<&Effect> for EffectKind {
             Effect::CastCopyOfCard { .. } => EffectKind::CastCopyOfCard,
             Effect::CopyTokenOf { .. } => EffectKind::CopyTokenOf,
             Effect::Myriad => EffectKind::Myriad,
+            // CR 707.2: classified as a copy-token effect — the block placement
+            // is bookkeeping layered on top of the same token-copy creation.
+            Effect::CopyTokenBlockingAttacker { .. } => EffectKind::CopyTokenOf,
             Effect::BecomeCopy { .. } => EffectKind::BecomeCopy,
             Effect::ChooseCard { .. } => EffectKind::ChooseCard,
             Effect::PutCounter { .. } => EffectKind::PutCounter,

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -34,10 +34,10 @@ use crate::convert::token;
 use crate::convert::trigger as trigger_mod;
 use crate::schema::types::{
     Action, Actions, CardInExile, CardInGraveyard, CardType, CardsInHand, CounterType,
-    CreatureType, DamageRecipient, DamageToRecipients, DistributedTarget, Distribution,
-    FutureTrigger, GameNumber, GroupFilter, ManaUseModifier, Permanent, Player, Players,
-    ReplacementActionWouldEnter, RevealTheTopNumberCardsOfLibraryAction, Rule, SearchLibraryAction,
-    Spell, Spells, Target, TokenFlag,
+    CreatableToken, CreatureType, DamageRecipient, DamageToRecipients, DistributedTarget,
+    Distribution, FutureTrigger, GameNumber, GroupFilter, ManaUseModifier, Permanent, Player,
+    Players, ReplacementActionWouldEnter, RevealTheTopNumberCardsOfLibraryAction, Rule,
+    SearchLibraryAction, Spell, Spells, Target, TokenCopyEffects, TokenFlag,
 };
 
 /// Modal-choice arity for `ActionsConversion::Modal`. Mirrors the engine's
@@ -3466,6 +3466,66 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
                 });
             };
             apply_token_flags(token::convert(single)?, flags)?
+        }
+
+        // CR 509.1g + CR 506.3e + CR 707.2: "For each attacking creature, create
+        // a token that's a copy of that creature. Those tokens block those
+        // creatures." (Mirror Match.) The only supported shape is a single
+        // copy-of-each-permanent spec carrying just the "enters blocking the
+        // attacker it copies" flag — it lowers to
+        // `Effect::CopyTokenBlockingAttacker`, whose resolver copies each matched
+        // attacker and puts the copy onto the battlefield blocking it. The
+        // end-of-combat exile is a separate `CreateFutureTrigger` action over
+        // "those tokens". Any other token spec, copy-effect, or flag combination
+        // strict-fails until it has a dedicated slot.
+        Action::ForEachPermanentCreateTokensWithFlags(perms, specs, flags) => {
+            let [CreatableToken::TokenCopyOfPermanent(copy_perm, copy_effects)] = specs.as_slice()
+            else {
+                return Err(ConversionGap::MalformedIdiom {
+                    idiom: "Action::ForEachPermanentCreateTokensWithFlags",
+                    path: String::new(),
+                    detail: format!(
+                        "expected single copy-of-each token spec, got {} specs",
+                        specs.len()
+                    ),
+                });
+            };
+            if !matches!(**copy_perm, Permanent::EachablePermanent) {
+                return Err(ConversionGap::MalformedIdiom {
+                    idiom: "Action::ForEachPermanentCreateTokensWithFlags",
+                    path: String::new(),
+                    detail: "copy source is not the iterated EachablePermanent".to_string(),
+                });
+            }
+            // CR 707.2: a plain copy ("a copy of that creature") — copy-effect
+            // overrides on a blocking copy have no engine slot yet.
+            if !matches!(copy_effects, TokenCopyEffects::NoTokenCopyEffects) {
+                return Err(ConversionGap::EnginePrerequisiteMissing {
+                    engine_type: "Effect::CopyTokenBlockingAttacker",
+                    needed_variant: "copy-effects on a for-each blocking copy".to_string(),
+                });
+            }
+            match flags.as_slice() {
+                // CR 506.3e: "that token blocks the attacker it copies." The flag
+                // names the iterated permanent (the copy source) as the blocked
+                // attacker, which the resolver binds per-iteration.
+                [TokenFlag::EntersBlockingAttacker(block_perm)]
+                    if matches!(**block_perm, Permanent::EachablePermanent) =>
+                {
+                    Effect::CopyTokenBlockingAttacker {
+                        source_filter: convert_permanents(perms)?,
+                        owner: TargetFilter::Controller,
+                    }
+                }
+                _ => {
+                    return Err(ConversionGap::EnginePrerequisiteMissing {
+                        engine_type: "Effect::CopyTokenBlockingAttacker",
+                        needed_variant:
+                            "for-each copy-token flags beyond EntersBlockingAttacker(Eachable)"
+                                .to_string(),
+                    });
+                }
+            }
         }
 
         // CR 701.13 + CR 400.7: "Exile the top card of your library." Maps onto

--- a/crates/mtgish-import/src/convert/filter.rs
+++ b/crates/mtgish-import/src/convert/filter.rs
@@ -425,6 +425,35 @@ pub fn convert(p: &Permanents) -> ConvResult<TargetFilter> {
                 });
             }
         },
+        // CR 508.1b + CR 506.3: "attacking you or a planeswalker you control."
+        // `FilterProp::AttackingController` matches any attacker whose recorded
+        // defending side equals the source controller — and the engine records
+        // an attacker's defending player as the controller of the attacked
+        // planeswalker/battle, so the player- and permanent-defended cases both
+        // collapse onto the one predicate. Only the `You` axis is expressible;
+        // an opponent-relative defended axis needs a primitive we don't have.
+        Permanents::IsAttackingAPlayerOrPlaneswalkerTheyControl(players) => {
+            match players_to_controller(players)? {
+                ControllerRef::You => TargetFilter::Typed(
+                    TypedFilter::creature().properties(vec![FilterProp::AttackingController]),
+                ),
+                other => {
+                    return Err(ConversionGap::MalformedIdiom {
+                        idiom: "Permanents/convert",
+                        path: String::new(),
+                        detail: format!(
+                            "IsAttackingAPlayerOrPlaneswalkerTheyControl with non-You axis: {other:?}"
+                        ),
+                    });
+                }
+            }
+        }
+        // CR 111.1 + CR 603.7c: "the created tokens" / "those tokens" anaphor —
+        // the set of tokens created earlier in this same resolution. Maps to
+        // `TargetFilter::LastCreated`, which the engine snapshots at the moment a
+        // composed delayed trigger is built (the exile-at-end-of-combat half of
+        // Mirror Match) so it survives later token creation.
+        Permanents::TheCreatedTokens => TargetFilter::LastCreated,
 
         // "Except for ~" set-difference subject — semantically the
         // complement of the inner filter. mtgish surfaces this distinct from

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -358,6 +358,7 @@ fn redundancy_delta(
         | Effect::CastCopyOfCard { .. }
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
+        | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
         | Effect::ChooseCard { .. }
         | Effect::PutCounter { .. }


### PR DESCRIPTION
## Summary

Fixes #1597 — **Mirror Match** did nothing in-game: the tokens that should copy each attacker and block it were never created, so the attackers connected with the player ("did not make the blockers and save the enemy").

The engine had no way to put a copy token onto the battlefield *blocking* the attacker it copies. This PR adds that primitive and teaches both the native Oracle parser (the runtime card-data source) and the `mtgish-import` converter to produce it.

## What changed

**Engine primitive — `Effect::CopyTokenBlockingAttacker { source_filter, owner }`**
- For each attacking creature matched by `source_filter`, create a token that's a copy of it (delegating to the single-authority `token_copy` resolver) and put that token onto the battlefield blocking the attacker it copies (CR 506.3e + CR 509.1g).
- Republishes the created tokens to `last_created_token_ids` so the composed "exile those tokens at end of combat" delayed trigger (CR 603.7c) snapshots them via `TargetFilter::LastCreated`.

**`combat::place_blocking`** — establishes the block per CR 506.3e (only when the attacker is attacking the blocker's controller, or a planeswalker/battle they control) and CR 509.1h (attacker becomes blocked), without firing "whenever ~ blocks" triggers (CR 509.3a — a creature *put onto the battlefield blocking* doesn't trigger those).

**Native Oracle parser** — a whole-card recognizer in `parse_effect_chain` lowers Mirror Match's text ("For each creature attacking you or a planeswalker you control, create a token that's a copy of that creature and that's blocking that creature. Exile those tokens at end of combat.") to the new effect plus the delayed end-of-combat exile. This is the path that feeds runtime `card-data.json`.

**`mtgish-import` converter** — lowers `ForEachPermanentCreateTokensWithFlags` + `EntersBlockingAttacker`, the `IsAttackingAPlayerOrPlaneswalkerTheyControl` filter, and the `TheCreatedTokens` anaphor, so the second-source-of-truth pipeline covers the card too.

## Rules references
- CR 506.3e — put-onto-battlefield-blocking only blocks an attacker attacking your side
- CR 509.1g / 509.1h — becomes a blocking / blocked creature
- CR 509.3a — no "whenever ~ blocks" trigger when put onto the battlefield blocking
- CR 603.7c — delayed trigger snapshots its referenced objects at creation
- CR 707.2 — token copies copiable characteristics

## Tests
- `copy_token_blocking::tests::copies_and_blocks_each_attacker` — resolver creates one copy per attacker and blocks each.
- `oracle_effect::tests::effect_mirror_match_copy_blockers_and_delayed_exile` — native parser lowers the full card to the effect + delayed exile.
