### PR TITLE
refactor(engine): collapse EffectScope *All siblings + GainLifePlayer into typed enums

### DIFF
--- a/crates/engine/src/database/forge/effect.rs
+++ b/crates/engine/src/database/forge/effect.rs
@@ -1,6 +1,5 @@
 use crate::types::ability::{
-    ControllerRef, Effect, GainLifePlayer, ManaProduction, PtValue, QuantityExpr, TargetFilter,
-    TypedFilter,
+    ControllerRef, Effect, ManaProduction, PtValue, QuantityExpr, TargetFilter, TypedFilter,
 };
 use crate::types::mana::ManaColor;
 use crate::types::Zone;
@@ -143,14 +142,6 @@ fn resolve_defined(params: &ForgeParams) -> TargetFilter {
     }
 }
 
-/// Check if `Defined$` targets an opponent rather than the controller.
-fn defined_is_opponent(params: &ForgeParams) -> bool {
-    matches!(
-        params.get("Defined"),
-        Some("Opponent") | Some("OpponentOfTriggered")
-    )
-}
-
 // CR 120.2b: Deal damage as an effect of a spell or ability.
 fn translate_deal_damage(
     params: &ForgeParams,
@@ -180,16 +171,12 @@ fn translate_gain_life(
     resolver: &mut SvarResolver,
 ) -> Result<Effect, ForgeTranslateError> {
     let amount = resolve_quantity(params, "LifeAmount", resolver);
-    // Forge Defined$ determines who gains life. GainLifePlayer only has
-    // Controller and TargetedController — opponent gains aren't expressible
-    // in the current type, so we stay with Controller for non-opponent cases.
-    let player = if defined_is_opponent(params) {
-        // TODO: GainLifePlayer doesn't have an Opponent variant; this stays
-        // as Controller until the engine type is extended.
-        GainLifePlayer::Controller
-    } else {
-        GainLifePlayer::Controller
-    };
+    // Forge Defined$ determines who gains life. `player` is now a TargetFilter,
+    // so the opponent case can be expressed as
+    // `TargetFilter::Typed { controller: ControllerRef::Opponent }`.
+    // CR 119.3: Delegate to resolve_defined so Defined$Opponent, Targeted, etc.
+    // all map to the correct TargetFilter variant.
+    let player = resolve_defined(params);
     Ok(Effect::GainLife { amount, player })
 }
 

--- a/crates/engine/src/database/forge/effect.rs
+++ b/crates/engine/src/database/forge/effect.rs
@@ -142,6 +142,19 @@ fn resolve_defined(params: &ForgeParams) -> TargetFilter {
     }
 }
 
+fn resolve_defined_life_player(params: &ForgeParams) -> TargetFilter {
+    match params.get("Defined") {
+        Some("Targeted") | Some("TargetedPlayer") => TargetFilter::Player,
+        Some("TriggeredCardController") | Some("TriggeredPlayer") => TargetFilter::TriggeringPlayer,
+        Some("ParentTarget") => TargetFilter::ParentTarget,
+        // There is no single implicit opponent player in multiplayer. Preserve
+        // the historical fallback until Forge import can express player scopes.
+        Some("Opponent") | Some("OpponentOfTriggered") => TargetFilter::Controller,
+        Some("You") | Some("Self") | None => TargetFilter::Controller,
+        Some(_) => TargetFilter::Controller,
+    }
+}
+
 // CR 120.2b: Deal damage as an effect of a spell or ability.
 fn translate_deal_damage(
     params: &ForgeParams,
@@ -171,12 +184,9 @@ fn translate_gain_life(
     resolver: &mut SvarResolver,
 ) -> Result<Effect, ForgeTranslateError> {
     let amount = resolve_quantity(params, "LifeAmount", resolver);
-    // Forge Defined$ determines who gains life. `player` is now a TargetFilter,
-    // so the opponent case can be expressed as
-    // `TargetFilter::Typed { controller: ControllerRef::Opponent }`.
-    // CR 119.3: Delegate to resolve_defined so Defined$Opponent, Targeted, etc.
-    // all map to the correct TargetFilter variant.
-    let player = resolve_defined(params);
+    // CR 119.3: `GainLife.player` is a player-resolved TargetFilter. Reuse only
+    // the `Defined$` cases that resolve to a player, not object filters.
+    let player = resolve_defined_life_player(params);
     Ok(Effect::GainLife { amount, player })
 }
 
@@ -596,9 +606,32 @@ mod tests {
         let mut resolver = make_resolver();
         let effect = translate_effect(&params, &mut resolver).unwrap();
         match effect {
-            Effect::GainLife { amount, .. } => {
+            Effect::GainLife { amount, player } => {
                 assert_eq!(amount, QuantityExpr::Fixed { value: 2 });
+                assert_eq!(player, TargetFilter::Controller);
             }
+            other => panic!("expected GainLife, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_gain_life_defined_targeted_player() {
+        let params = parse_params("DB$ GainLife | Defined$ TargetedPlayer | LifeAmount$ 2");
+        let mut resolver = make_resolver();
+        let effect = translate_effect(&params, &mut resolver).unwrap();
+        match effect {
+            Effect::GainLife { player, .. } => assert_eq!(player, TargetFilter::Player),
+            other => panic!("expected GainLife, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_gain_life_defined_opponent_does_not_emit_object_filter() {
+        let params = parse_params("DB$ GainLife | Defined$ Opponent | LifeAmount$ 2");
+        let mut resolver = make_resolver();
+        let effect = translate_effect(&params, &mut resolver).unwrap();
+        match effect {
+            Effect::GainLife { player, .. } => assert_eq!(player, TargetFilter::Controller),
             other => panic!("expected GainLife, got {other:?}"),
         }
     }

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -10,7 +10,7 @@ use crate::types::ability::{
     ActivationRestriction, AdditionalCost, AdditionalCostPaymentSource, AggregateFunction,
     CardPlayMode, CastVariantPaid, ChoiceType, Comparator, ContinuousModification, ControllerRef,
     CopyRetargetPermission, CounterTriggerFilter, DamageKindFilter, Duration, Effect, FilterProp,
-    GainLifePlayer, KickerVariant, ManaContribution, ManaProduction, ModalSelectionCondition,
+    KickerVariant, ManaContribution, ManaProduction, ModalSelectionCondition,
     ModalSelectionConstraint, NinjutsuVariant, ObjectScope, ParsedCondition, PlayerFilter,
     PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
     ReplacementDefinition, RuntimeHandler, SearchSelectionConstraint, StaticDefinition,
@@ -2894,7 +2894,7 @@ fn build_extort_trigger() -> TriggerDefinition {
             amount: QuantityExpr::Ref {
                 qty: QuantityRef::PreviousEffectAmount,
             },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
     );
     let execute = AbilityDefinition::new(AbilityKind::Spell, drain_effect)
@@ -7321,7 +7321,7 @@ mod extort_synthesis_tests {
                 qty: QuantityRef::PreviousEffectAmount
             }
         ));
-        assert!(matches!(player, GainLifePlayer::Controller));
+        assert!(matches!(player, TargetFilter::Controller));
     }
 
     #[test]
@@ -7382,7 +7382,7 @@ mod extort_synthesis_tests {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::PreviousEffectAmount,
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9653,8 +9653,8 @@ mod tests {
         AbilityCost, AbilityTag, ActivationRestriction, AdditionalCost, AggregateFunction,
         BasicLandType, CastPermissionConstraint, CastVariantPaid, CastingPermission,
         ChosenAttribute, ChosenSubtypeKind, Comparator, ContinuousModification, ControllerRef,
-        CostCategory, FilterProp, GainLifePlayer, GameRestriction, KickerVariant, ManaContribution,
-        ManaProduction, ManaSpendPermission, ManaSpendRestriction, ModalSelectionCondition,
+        CostCategory, FilterProp, GameRestriction, KickerVariant, ManaContribution, ManaProduction,
+        ManaSpendPermission, ManaSpendRestriction, ModalSelectionCondition,
         ModalSelectionConstraint, MultiTargetSpec, ObjectProperty, ProhibitedActivity, PtValue,
         QuantityExpr, QuantityRef, RestrictionExpiry, RestrictionPlayerScope,
         SearchSelectionConstraint, StaticCondition, StaticDefinition, TargetFilter, TypeFilter,
@@ -12097,7 +12097,7 @@ mod tests {
                         amount: QuantityExpr::Ref {
                             qty: QuantityRef::PreviousEffectAmount,
                         },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )),
             );
@@ -14423,7 +14423,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 3 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )
                 .cost(AbilityCost::Composite {
@@ -14573,7 +14573,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )
                 .cost(AbilityCost::Mana {
@@ -18693,7 +18693,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 3 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
             ));
             obj.mana_cost = ManaCost::Cost {
@@ -20574,7 +20574,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 3 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
             )],
             trigger_definitions: Default::default(),

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -5112,7 +5112,7 @@ mod tests {
     #[test]
     fn cost_paid_multi_sacrifice_blood_artist_co_departed() {
         use crate::game::engine::apply_as_current;
-        use crate::types::ability::{GainLifePlayer, TargetFilter, TriggerDefinition};
+        use crate::types::ability::{TargetFilter, TriggerDefinition};
         use crate::types::phase::Phase;
         use crate::types::triggers::TriggerMode;
         use crate::types::GameAction;
@@ -5160,7 +5160,7 @@ mod tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ));
             obj.trigger_definitions.push(trig.clone());
@@ -5272,7 +5272,7 @@ mod tests {
                 is unreadable. Shares Unit B's cross-action consumption gap. See plan Unit B."]
     fn cost_paid_multi_sacrifice_kicker_paused_under_observes() {
         use crate::game::engine::apply_as_current;
-        use crate::types::ability::{GainLifePlayer, TargetFilter, TriggerDefinition};
+        use crate::types::ability::{TargetFilter, TriggerDefinition};
         use crate::types::phase::Phase;
         use crate::types::triggers::TriggerMode;
         use crate::types::GameAction;
@@ -5320,7 +5320,7 @@ mod tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ));
             obj.trigger_definitions.push(trig.clone());

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -11,8 +11,8 @@ use crate::types::ability::{
     AdditionalCost, AggregateFunction, CardTypeSetSource, ChoiceType, Comparator,
     ContinuousModification, ControllerRef, CountScope, CounterSourceRider, DelayedTriggerCondition,
     DieRollModifier, DoublePTMode, Duration, Effect, EffectOutcomeSignal, FilterProp,
-    GainLifePlayer, GameRestriction, ManaProduction, ObjectProperty, ObjectScope, PlayerFilter,
-    PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
+    GameRestriction, ManaProduction, ObjectProperty, ObjectScope, PlayerFilter, PlayerScope,
+    PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
     ReplacementDefinition, ReplacementMode, SeatDirection, SharedQuality, SharedQualityRelation,
     SpeedDelta, SpellCastingOption, SpellCastingOptionKind, StaticCondition, StaticDefinition,
     TargetFilter, TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
@@ -1771,16 +1771,8 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         }
         Effect::GainLife { amount, player } => {
             d.push(("amount".into(), fmt_quantity(amount)));
-            if !matches!(player, GainLifePlayer::Controller) {
-                d.push((
-                    "player".into(),
-                    match player {
-                        GainLifePlayer::TargetedController => "target's controller",
-                        GainLifePlayer::TargetPlayer => "target player",
-                        GainLifePlayer::Controller => unreachable!(),
-                    }
-                    .into(),
-                ));
+            if !player.is_context_ref() {
+                d.push(("player".into(), fmt_target(player)));
             }
         }
         Effect::LoseLife { amount, .. } => {

--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -227,7 +227,7 @@ pub fn room_effects(
             lose.sub_ability = Some(Box::new(simple(
                 Effect::GainLife {
                     amount: fixed(1),
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 source_id,
                 controller,
@@ -268,7 +268,7 @@ pub fn room_effects(
             simple(
                 Effect::GainLife {
                     amount: fixed(1),
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 source_id,
                 controller,

--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -748,9 +748,7 @@ mod tests {
     // ---------------------------------------------------------------------
 
     use crate::game::effects::resolve_ability_chain;
-    use crate::types::ability::{
-        GainLifePlayer, QuantityExpr, QuantityRef, TypeFilter, TypedFilter,
-    };
+    use crate::types::ability::{QuantityExpr, QuantityRef, TypeFilter, TypedFilter};
 
     /// Builds the Fumigate-shape chain: `DestroyAll(creatures)` followed by
     /// `GainLife(amount = TrackedSetSize, player = Controller)`.
@@ -760,7 +758,7 @@ mod tests {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::TrackedSetSize,
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -922,7 +920,7 @@ mod tests {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::TrackedSetSize,
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(200),

--- a/crates/engine/src/game/effects/dig.rs
+++ b/crates/engine/src/game/effects/dig.rs
@@ -155,7 +155,7 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityCondition, AbilityKind, FilterProp, GainLifePlayer, QuantityExpr, TypedFilter,
+        AbilityCondition, AbilityKind, FilterProp, QuantityExpr, TypedFilter,
     };
     use crate::types::card_type::Supertype;
     use crate::types::identifiers::{CardId, ObjectId};
@@ -691,7 +691,7 @@ mod tests {
         let mut gain_life = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -761,7 +761,7 @@ mod tests {
         let mut gain_life = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -826,7 +826,7 @@ mod tests {
         let mut gain_life = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/effects/flip_coin.rs
+++ b/crates/engine/src/game/effects/flip_coin.rs
@@ -218,7 +218,7 @@ mod tests {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 5 },
-                player: crate::types::ability::GainLifePlayer::Controller,
+                player: crate::types::ability::TargetFilter::Controller,
             },
         ));
         let lose_effect = Box::new(AbilityDefinition::new(
@@ -361,7 +361,7 @@ mod tests {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: crate::types::ability::GainLifePlayer::Controller,
+                player: crate::types::ability::TargetFilter::Controller,
             },
         ));
 

--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{
-    Effect, EffectError, EffectKind, GainLifePlayer, ResolvedAbility, TargetFilter, TargetRef,
+    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
@@ -21,31 +21,16 @@ pub fn resolve_gain(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (amount, player_kind) = match &ability.effect {
+    let (amount, player_filter) = match &ability.effect {
         Effect::GainLife { amount, player } => (amount, player),
         _ => return Err(EffectError::MissingParam("GainLife amount".to_string())),
     };
 
-    // Resolve the target object (if any) for TargetedController.
-    let target_obj = ability.targets.iter().find_map(|t| {
-        if let TargetRef::Object(id) = t {
-            state.objects.get(id)
-        } else {
-            None
-        }
-    });
-
-    let player_id: PlayerId = match player_kind {
-        GainLifePlayer::TargetedController => target_obj
-            .map(|o| o.controller)
-            .unwrap_or(ability.controller),
-        GainLifePlayer::Controller => ability.controller,
-        // CR 115.2 + CR 601.2c: "Target player gains N life" — the
-        // chosen player is bound on `ability.targets` via the spell-
-        // announcement target slot. `target_player()` extracts the
-        // first `TargetRef::Player` and falls back to controller.
-        GainLifePlayer::TargetPlayer => ability.target_player(),
-    };
+    // CR 119.3: Who gains the life. `resolve_life_loss_target` is the single
+    // authority for player resolution from a TargetFilter — context-refs
+    // (Controller, ParentTargetController) resolve via state slots; explicit
+    // Player targets come from `ability.targets`.
+    let player_id: PlayerId = resolve_life_loss_target(state, ability, Some(player_filter));
 
     // CR 119.7: "If an effect says that a player can't gain life ... a replacement
     // effect that would replace a life gain event affecting that player won't do
@@ -477,7 +462,7 @@ mod tests {
     use crate::game::game_object::AttachTarget;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AggregateFunction, ControllerRef, GainLifePlayer, QuantityExpr, QuantityRef, SharedQuality,
+        AggregateFunction, ControllerRef, QuantityExpr, QuantityRef, SharedQuality,
         StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
@@ -516,7 +501,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 5 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -589,7 +574,7 @@ mod tests {
                         aggregate: AggregateFunction::Max,
                     },
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source,
@@ -699,7 +684,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -749,7 +734,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 5 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -995,7 +980,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 5 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(200),
@@ -1089,9 +1074,7 @@ mod tests {
     /// fallback path).
     #[test]
     fn lich_gain_life_substituted_by_draw_cards_instead() {
-        use crate::types::ability::{
-            AbilityDefinition, AbilityKind, GainLifePlayer, ReplacementDefinition,
-        };
+        use crate::types::ability::{AbilityDefinition, AbilityKind, ReplacementDefinition};
         use crate::types::replacements::ReplacementEvent;
 
         let mut state = GameState::new_two_player(42);
@@ -1137,7 +1120,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -1172,9 +1155,7 @@ mod tests {
     /// "substitution" (different event type).
     #[test]
     fn gain_life_scaling_shape_modifies_amount_does_not_substitute() {
-        use crate::types::ability::{
-            AbilityDefinition, AbilityKind, GainLifePlayer, ReplacementDefinition,
-        };
+        use crate::types::ability::{AbilityDefinition, AbilityKind, ReplacementDefinition};
         use crate::types::replacements::ReplacementEvent;
 
         let mut state = GameState::new_two_player(42);
@@ -1195,7 +1176,7 @@ mod tests {
                             qty: crate::types::ability::QuantityRef::EventContextAmount,
                         }),
                     },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         state
@@ -1208,7 +1189,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -1234,5 +1215,25 @@ mod tests {
              continuation; found {:?}",
             state.post_replacement_continuation
         );
+    }
+
+    #[test]
+    fn gain_life_target_player_uses_declared_target() {
+        // CR 115.1 + CR 119.3: "target player gains N life" — the gaining
+        // player is the declared target in ability.targets, not the controller.
+        let mut state = GameState::new_two_player(42);
+        let ability = ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 4 },
+                player: TargetFilter::Player,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve_gain(&mut state, &ability, &mut events).unwrap();
+        assert_eq!(state.players[1].life, 24, "target player (p1) gains 4 life");
+        assert_eq!(state.players[0].life, 20, "controller (p0) is unaffected");
     }
 }

--- a/crates/engine/src/game/effects/mill.rs
+++ b/crates/engine/src/game/effects/mill.rs
@@ -571,7 +571,7 @@ mod tests {
     /// `GainLife`. It is a runtime test, not a shape test.
     fn renegade_reaper_chain() -> ResolvedAbility {
         use crate::types::ability::{
-            AbilityCondition, GainLifePlayer, TargetFilter as TF, TypeFilter, TypedFilter,
+            AbilityCondition, TargetFilter as TF, TypeFilter, TypedFilter,
         };
         ResolvedAbility::new(
             Effect::Mill {
@@ -587,7 +587,7 @@ mod tests {
             let mut gain = ResolvedAbility::new(
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 4 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
                 vec![],
                 ObjectId(100),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5052,10 +5052,10 @@ mod tests {
     use crate::types::ability::{
         AbilityCondition, AbilityDefinition, AbilityKind, AggregateFunction, BounceSelection,
         CastingPermission, ChosenAttribute, Comparator, ContinuousModification, ControllerRef,
-        DelayedTriggerCondition, Duration, FilterProp, GainLifePlayer, ManaSpendPermission,
-        ObjectProperty, PermissionGrantee, PlayerFilter, PlayerScope, PtValue, QuantityExpr,
-        QuantityRef, SpellContext, StaticDefinition, TargetFilter, TargetRef, TypeFilter,
-        TypedFilter, UntilCondition,
+        DelayedTriggerCondition, Duration, FilterProp, ManaSpendPermission, ObjectProperty,
+        PermissionGrantee, PlayerFilter, PlayerScope, PtValue, QuantityExpr, QuantityRef,
+        SpellContext, StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+        UntilCondition,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -5255,7 +5255,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: amount },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -6068,7 +6068,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source,
@@ -6353,7 +6353,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::CostPaidObject,
                     },
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -6876,7 +6876,7 @@ mod tests {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::PreviousEffectAmount,
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -8029,7 +8029,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: crate::types::ability::GainLifePlayer::default(),
+                player: crate::types::ability::TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -8097,7 +8097,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: crate::types::ability::GainLifePlayer::default(),
+                player: crate::types::ability::TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -11785,7 +11785,7 @@ mod tests {
         let mut sub = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 100 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -11801,7 +11801,7 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -1077,7 +1077,7 @@ mod tests {
         let gain_life = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: crate::types::ability::GainLifePlayer::Controller,
+                player: crate::types::ability::TargetFilter::Controller,
             },
             vec![],
             ObjectId(500),

--- a/crates/engine/src/game/effects/reveal_hand.rs
+++ b/crates/engine/src/game/effects/reveal_hand.rs
@@ -281,7 +281,7 @@ mod tests {
     #[test]
     fn optional_reveal_hand_choice_decline_skips_continuation() {
         use crate::game::engine_resolution_choices::handle_resolution_choice;
-        use crate::types::ability::{AbilityKind, GainLifePlayer, QuantityExpr};
+        use crate::types::ability::{AbilityKind, QuantityExpr};
         use crate::types::actions::GameAction;
         use crate::types::game_state::PendingContinuation;
 
@@ -304,7 +304,7 @@ mod tests {
         let mut continuation = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -9,10 +9,9 @@ use crate::game::zones;
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, Comparator,
     ContinuousModification, ControllerRef, DelayedTriggerCondition, Duration, Effect, EffectError,
-    EffectKind, FilterProp, GainLifePlayer, ManaContribution, ManaProduction, PlayerFilter,
-    PtValue, QuantityExpr, QuantityRef, ResolvedAbility, SearchSelectionConstraint,
-    StaticDefinition, TargetFilter, TargetRef, TriggerCondition, TriggerDefinition, TypeFilter,
-    TypedFilter,
+    EffectKind, FilterProp, ManaContribution, ManaProduction, PlayerFilter, PtValue, QuantityExpr,
+    QuantityRef, ResolvedAbility, SearchSelectionConstraint, StaticDefinition, TargetFilter,
+    TargetRef, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::{CardType, CoreType, Supertype};
 use crate::types::counter::CounterType;
@@ -1564,7 +1563,7 @@ fn food_ability() -> AbilityDefinition {
         AbilityKind::Activated,
         Effect::GainLife {
             amount: QuantityExpr::Fixed { value: 3 },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
     )
     .cost(AbilityCost::Composite {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5725,9 +5725,8 @@ mod tests {
     use crate::parser::oracle::parse_oracle_text;
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ControllerRef, Effect,
-        GainLifePlayer, ManaContribution, ManaProduction, ManaSpendRestriction, QuantityExpr,
-        ResolvedAbility, StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter,
-        TypedFilter,
+        ManaContribution, ManaProduction, ManaSpendRestriction, QuantityExpr, ResolvedAbility,
+        StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CardType;
     use crate::types::card_type::CoreType;
@@ -10984,7 +10983,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 10 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )
                 .cost(AbilityCost::Composite {
@@ -11091,7 +11090,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 )
                 .cost(AbilityCost::Composite {
@@ -11930,7 +11929,7 @@ mod tests {
             Box::new(ResolvedAbility::new(
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 vec![],
                 source,
@@ -12060,7 +12059,7 @@ mod trigger_target_tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, ControllerRef, Effect, GainLifePlayer, ModalChoice,
+        AbilityDefinition, AbilityKind, ControllerRef, Effect, ModalChoice,
         ModalSelectionConstraint, QuantityExpr, ResolvedAbility, StaticCondition, TargetFilter,
         TargetRef, TypedFilter,
     };
@@ -12455,7 +12454,7 @@ mod trigger_target_tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 2 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ),
                 AbilityDefinition::new(
@@ -12495,7 +12494,7 @@ mod trigger_target_tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 2 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ),
                 AbilityDefinition::new(
@@ -12582,7 +12581,7 @@ mod trigger_target_tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ),
                 AbilityDefinition::new(
@@ -13007,14 +13006,14 @@ mod trigger_target_tests {
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 4 },
-                        player: crate::types::ability::GainLifePlayer::Controller,
+                        player: crate::types::ability::TargetFilter::Controller,
                     },
                 ),
                 AbilityDefinition::new(
                     AbilityKind::Database,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 2 },
-                        player: crate::types::ability::GainLifePlayer::Controller,
+                        player: crate::types::ability::TargetFilter::Controller,
                     },
                 ),
             ],
@@ -14022,9 +14021,9 @@ mod phase_trigger_regression_tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ControllerRef, Effect,
-        FilterProp, GainLifePlayer, ObjectScope, PlayerFilter, QuantityExpr, QuantityRef,
-        ResolvedAbility, TargetFilter, TargetRef, TriggerConstraint, TriggerDefinition, TypeFilter,
-        TypedFilter, UnlessPayModifier,
+        FilterProp, ObjectScope, PlayerFilter, QuantityExpr, QuantityRef, ResolvedAbility,
+        TargetFilter, TargetRef, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
+        UnlessPayModifier,
     };
     use crate::types::card_type::CoreType;
     use crate::types::format::FormatConfig;
@@ -14179,7 +14178,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Activated,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .trigger_zones(vec![Zone::Battlefield]),
@@ -14230,7 +14229,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Activated,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .trigger_zones(vec![Zone::Battlefield]),
@@ -14287,7 +14286,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Activated,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .trigger_zones(vec![Zone::Battlefield]),
@@ -14347,7 +14346,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Activated,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .trigger_zones(vec![Zone::Battlefield]),
@@ -14885,7 +14884,7 @@ mod phase_trigger_regression_tests {
                         AbilityKind::Database,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 1 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     )),
             );
@@ -15074,7 +15073,7 @@ mod phase_trigger_regression_tests {
                                 }),
                                 offset: 1,
                             },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ),
                 ),
@@ -15458,7 +15457,7 @@ mod phase_trigger_regression_tests {
         let mut primary = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15467,7 +15466,7 @@ mod phase_trigger_regression_tests {
         let mut alternative = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15516,7 +15515,7 @@ mod phase_trigger_regression_tests {
         let mut primary = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15525,7 +15524,7 @@ mod phase_trigger_regression_tests {
         let mut alternative = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15571,7 +15570,7 @@ mod phase_trigger_regression_tests {
         let primary = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15620,7 +15619,7 @@ mod phase_trigger_regression_tests {
         let mut primary = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 4 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15629,7 +15628,7 @@ mod phase_trigger_regression_tests {
         let mut alternative = ResolvedAbility::new(
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
             vec![],
             source_id,
@@ -15680,7 +15679,7 @@ mod phase_trigger_regression_tests {
             pending_effect: Box::new(ResolvedAbility::new(
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 vec![],
                 source_id,
@@ -15883,7 +15882,7 @@ mod phase_trigger_regression_tests {
             Box::new(ResolvedAbility::new(
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 2 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
                 vec![],
                 source_id,
@@ -16034,7 +16033,7 @@ mod phase_trigger_regression_tests {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
         let branch_lose = AbilityDefinition::new(

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -1043,9 +1043,7 @@ fn action_result(events: &mut Vec<GameEvent>, waiting_for: WaitingFor) -> Action
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{
-        AbilityCondition, GainLifePlayer, QuantityExpr, ResolvedAbility, SubAbilityLink,
-    };
+    use crate::types::ability::{AbilityCondition, QuantityExpr, ResolvedAbility, SubAbilityLink};
     use crate::types::game_state::{AutoMayChoice, MayTriggerAutoChoiceKey, MayTriggerOrigin};
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
@@ -1053,7 +1051,7 @@ mod tests {
     fn gain_life(value: i32) -> Effect {
         Effect::GainLife {
             amount: QuantityExpr::Fixed { value },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         }
     }
 

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -2120,7 +2120,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 3 },
-                    player: crate::types::ability::GainLifePlayer::Controller,
+                    player: crate::types::ability::TargetFilter::Controller,
                 },
             ),
             AbilityDefinition::new(

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3674,9 +3674,9 @@ mod tests {
     use crate::types::ability::{
         AbilityDefinition, AbilityKind, BasicLandType, ChosenSubtypeKind, CommanderOwnership,
         Comparator, ContinuousModification, ControllerRef, CountScope, Duration, Effect,
-        FilterProp, GainLifePlayer, ObjectScope, PlayerScope, PtStat, PtValueScope, QuantityExpr,
-        QuantityRef, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TypeFilter,
-        TypedFilter, ZoneRef,
+        FilterProp, ObjectScope, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef,
+        StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TypeFilter, TypedFilter,
+        ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::game_state::{StaticSourceIndex, TransientContinuousEffect};
@@ -5501,7 +5501,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ))
                 .with_trigger(TriggerMode::Attacks)
@@ -5547,7 +5547,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ))
                 .with_trigger(TriggerMode::Attacks);
@@ -5631,7 +5631,7 @@ mod tests {
                     AbilityKind::Activated,
                     Effect::GainLife {
                         amount: QuantityExpr::Fixed { value: 1 },
-                        player: GainLifePlayer::Controller,
+                        player: TargetFilter::Controller,
                     },
                 ))
                 .with_trigger(TriggerMode::Attacks)
@@ -7296,7 +7296,7 @@ mod tests {
                 AbilityKind::Activated,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
             obj.abilities = Arc::new((*obj.base_abilities).clone());
@@ -8377,7 +8377,7 @@ mod tests {
             AbilityKind::Activated,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         )
         .cost(AbilityCost::Composite {

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -7139,7 +7139,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GainLife {
                 amount: target_expr.clone(),
-                player: crate::types::ability::GainLifePlayer::Controller,
+                player: crate::types::ability::TargetFilter::Controller,
             },
             vec![TargetRef::Object(target)],
             source,

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -4126,8 +4126,8 @@ mod tests {
     use crate::game::effects::token::apply_create_token_after_replacement;
     use crate::game::game_object::{AttachTarget, GameObject};
     use crate::types::ability::{
-        AbilityCost, AbilityDefinition, AbilityKind, ChosenAttribute, Effect, GainLifePlayer,
-        QuantityExpr, ReplacementDefinition, ReplacementPlayerScope, TargetFilter, TargetRef,
+        AbilityCost, AbilityDefinition, AbilityKind, ChosenAttribute, Effect, QuantityExpr,
+        ReplacementDefinition, ReplacementPlayerScope, TargetFilter, TargetRef,
     };
     use crate::types::game_state::DamageRecord;
     use crate::types::identifiers::{CardId, ObjectId};
@@ -4739,7 +4739,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ))
             .description("X".to_string());
@@ -4834,7 +4834,7 @@ mod tests {
                             qty: crate::types::ability::QuantityRef::EventContextAmount,
                         }),
                     },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         let mut state = test_state_with_object(ObjectId(10), Zone::Battlefield, vec![repl]);
@@ -4880,7 +4880,7 @@ mod tests {
                         }),
                         offset: 1,
                     },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         let mut state = test_state_with_object(ObjectId(10), Zone::Battlefield, vec![repl]);

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4309,11 +4309,10 @@ pub mod tests {
         AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AdditionalCost,
         AggregateFunction, ChosenAttribute, ChosenSubtypeKind, CommanderOwnership, Comparator,
         ContinuousModification, ControllerRef, DelayedTriggerCondition, Duration, Effect,
-        FilterProp, GainLifePlayer, KickerVariant, MultiTargetSpec, PaymentCost, PlayerFilter,
-        PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, ResolvedAbility,
-        SearchSelectionConstraint, SharedQuality, SharedQualityRelation, StaticCondition,
-        StaticDefinition, TargetFilter, TargetRef, TriggerCondition, TriggerConstraint,
-        TriggerDefinition, TypeFilter, TypedFilter,
+        FilterProp, KickerVariant, MultiTargetSpec, PaymentCost, PlayerFilter, PlayerScope, PtStat,
+        PtValueScope, QuantityExpr, QuantityRef, ResolvedAbility, SearchSelectionConstraint,
+        SharedQuality, SharedQualityRelation, StaticCondition, StaticDefinition, TargetFilter,
+        TargetRef, TriggerCondition, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -6625,7 +6624,7 @@ pub mod tests {
                 AbilityKind::Database,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 3 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             )),
         );
@@ -9256,7 +9255,7 @@ pub mod tests {
                         AbilityKind::Spell,
                         Effect::GainLife {
                             amount: QuantityExpr::Fixed { value: 2 },
-                            player: GainLifePlayer::Controller,
+                            player: TargetFilter::Controller,
                         },
                     ))
                     .description("When this creature dies, you gain 2 life.".to_string()),
@@ -15092,7 +15091,7 @@ pub mod tests {
                 AbilityKind::Database,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         {
@@ -15157,7 +15156,7 @@ pub mod tests {
                 AbilityKind::Database,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         let obj = state.objects.get_mut(&observer).unwrap();
@@ -15251,7 +15250,7 @@ pub mod tests {
                 AbilityKind::Database,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ));
         let obj = state.objects.get_mut(&observer).unwrap();

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -25,10 +25,9 @@ use crate::parser::oracle_static::{
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, CategoryChooserScope, ChoiceType,
     Chooser, ContinuousModification, ControllerRef, CopyRetargetPermission, Duration, Effect,
-    FilterProp, GainLifePlayer, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool,
-    PaymentCost, PlayerScope, PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr,
-    QuantityRef, SearchSelectionConstraint, StaticDefinition, TargetFilter, TypeFilter,
-    TypedFilter, ZoneOwner,
+    FilterProp, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool, PaymentCost, PlayerScope,
+    PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
+    SearchSelectionConstraint, StaticDefinition, TargetFilter, TypeFilter, TypedFilter, ZoneOwner,
 };
 use crate::types::card_type::CoreType;
 use crate::types::phase::Phase;
@@ -654,7 +653,7 @@ pub(super) fn lower_numeric_imperative_ast(ast: NumericImperativeAst) -> Effect 
         },
         NumericImperativeAst::GainLife { amount } => Effect::GainLife {
             amount,
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
         NumericImperativeAst::LoseLife { amount } => Effect::LoseLife {
             amount,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -86,13 +86,13 @@ use crate::types::ability::{
     BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
     ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard,
     ContinuousModification, ControllerRef, DamageModification, DamageSource,
-    DelayedTriggerCondition, DoubleTarget, Duration, Effect, FilterProp, GainLifePlayer,
-    GameRestriction, IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec,
-    ObjectProperty, ObjectScope, PaymentCost, PlayerFilter, PlayerScope, PreventionAmount,
-    PreventionScope, ProhibitedActivity, QuantityExpr, QuantityRef, ReplacementDefinition,
-    RestrictionExpiry, RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition,
-    StepSkipTarget, SubAbilityLink, TargetFilter, TargetSelectionMode, TriggerCondition,
-    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
+    DelayedTriggerCondition, DoubleTarget, Duration, Effect, FilterProp, GameRestriction,
+    IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty,
+    ObjectScope, PaymentCost, PlayerFilter, PlayerScope, PreventionAmount, PreventionScope,
+    ProhibitedActivity, QuantityExpr, QuantityRef, ReplacementDefinition, RestrictionExpiry,
+    RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition, StepSkipTarget,
+    SubAbilityLink, TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition,
+    TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterType;
@@ -3479,7 +3479,9 @@ fn try_parse_choose_player_to_verb(
 /// `TargetFilter` are left untouched — the surrounding `relative_player_scope`
 /// already binds object-controller anaphora ("a creature they control").
 ///
-/// `GainLife` (recipient is the `GainLifePlayer` enum, not a `TargetFilter`)
+/// `GainLife` (recipient `player` is now a `TargetFilter`, but no current card
+/// pairs "choose a player to gain life" with this verb, so it is not yet wired
+/// into the `rebind` match below)
 /// and `Discard`/`DiscardCard` (no player-recipient `TargetFilter` — `Discard`
 /// is self-scoped, `DiscardCard.filter` selects *what* is discarded, not
 /// *who*) are a deliberate class-boundary deferral: no current card pairs
@@ -6589,10 +6591,10 @@ fn thread_for_each_subject(effect: Effect, original: &str) -> Effect {
         },
         Effect::GainLife {
             amount,
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         } if is_targeted && matches!(target, TargetFilter::Player) => Effect::GainLife {
             amount,
-            player: GainLifePlayer::TargetPlayer,
+            player: TargetFilter::Player,
         },
         other => other,
     }
@@ -8800,7 +8802,7 @@ fn rewrite_recipient_on_link(def: &mut AbilityDefinition, filter: &TargetFilter)
         // Any other effect family is out of scope for compound-subject
         // distribution at this entry point. Returning false keeps the
         // detector tight and prevents silent misparse on bodies whose
-        // recipient binding is encoded differently (GainLifePlayer enum, etc.).
+        // recipient binding is encoded differently (e.g. nested filter props).
         _ => false,
     }
 }
@@ -15949,10 +15951,10 @@ mod tests {
         AbilityCondition, AggregateFunction, BounceSelection, CardTypeSetSource, CastVariantPaid,
         ChoiceType, CombatRelation, CombatRelationSubject, Comparator, ContinuousModification,
         ControllerRef, CopyRetargetPermission, CountScope, DoublePTMode, Duration, FilterProp,
-        GainLifePlayer, LibraryPosition, LinkedExileScope, ManaContribution, ManaProduction,
-        ObjectProperty, ObjectScope, PaymentCost, PermissionGrantee, PtStat, PtValue, PtValueScope,
-        QuantityExpr, QuantityRef, SearchSelectionConstraint, SharedQuality, TargetChoiceTiming,
-        TypeFilter, TypedFilter, ZoneRef,
+        LibraryPosition, LinkedExileScope, ManaContribution, ManaProduction, ObjectProperty,
+        ObjectScope, PaymentCost, PermissionGrantee, PtStat, PtValue, PtValueScope, QuantityExpr,
+        QuantityRef, SearchSelectionConstraint, SharedQuality, TargetChoiceTiming, TypeFilter,
+        TypedFilter, ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::game_state::{DistributionUnit, TargetSelectionConstraint};
@@ -21193,7 +21195,7 @@ mod tests {
                             scope: crate::types::ability::ObjectScope::Target
                         }
                     },
-                    player: GainLifePlayer::TargetedController
+                    player: TargetFilter::ParentTargetController
                 }
             ),
             "Expected TargetPower + TargetedController, got {e:?}"
@@ -21224,7 +21226,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::Target
                     }
                 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }
@@ -21395,7 +21397,7 @@ mod tests {
         assert!(matches!(
             &*gain_life.effect,
             Effect::GainLife {
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
                 amount: QuantityExpr::Fixed { value: 3 },
             }
         ));
@@ -32646,7 +32648,7 @@ mod tests {
                         },
                     }),
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
     }
@@ -32662,7 +32664,7 @@ mod tests {
                         filter: TargetFilter::Typed(TypedFilter::creature()),
                     },
                 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
     }
@@ -32869,7 +32871,7 @@ mod tests {
                         },
                     }),
                 },
-                player: GainLifePlayer::TargetPlayer,
+                player: TargetFilter::Player,
             },
         );
     }

--- a/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__assembly_gain_life_draw.snap
+++ b/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__assembly_gain_life_draw.snap
@@ -10,8 +10,7 @@ expression: def
     "amount": {
       "type": "Fixed",
       "value": 3
-    },
-    "player": "controller"
+    }
   },
   "cost": null,
   "sub_ability": {

--- a/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__assembly_three_clause_destroy_lose_gain.snap
+++ b/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__assembly_three_clause_destroy_lose_gain.snap
@@ -38,8 +38,7 @@ expression: def
         "amount": {
           "type": "Fixed",
           "value": 2
-        },
-        "player": "controller"
+        }
       },
       "cost": null,
       "sub_ability": null,

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -10,8 +10,8 @@ use super::{resolve_it_pronoun, ParseContext};
 use crate::parser::oracle_ir::ast::*;
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, ContinuousModification, ControllerRef, Duration, Effect,
-    FilterProp, GainLifePlayer, MultiTargetSpec, PlayerFilter, PlayerScope, PtValue, QuantityExpr,
-    QuantityRef, StaticDefinition, TargetFilter, TypedFilter,
+    FilterProp, MultiTargetSpec, PlayerFilter, PlayerScope, PtValue, QuantityExpr, QuantityRef,
+    StaticDefinition, TargetFilter, TypedFilter,
 };
 use crate::types::game_state::DayNight;
 use crate::types::keywords::Keyword;
@@ -2589,7 +2589,7 @@ pub(super) fn try_parse_targeted_controller_gain_life(text: &str) -> Option<Pars
     };
     Some(parsed_clause(Effect::GainLife {
         amount,
-        player: GainLifePlayer::TargetedController,
+        player: TargetFilter::ParentTargetController,
     }))
 }
 
@@ -3320,7 +3320,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::Target
                     }
                 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }
@@ -3340,7 +3340,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::Target
                     }
                 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }
@@ -3360,7 +3360,7 @@ mod tests {
                         scope: crate::types::ability::ObjectScope::Target
                     }
                 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }
@@ -3374,7 +3374,7 @@ mod tests {
             clause.effect,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::TargetedController
+                player: TargetFilter::ParentTargetController
             }
         ));
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
@@ -20,8 +20,7 @@ expression: "&ir"
                   "type": "Anaphoric"
                 }
               }
-            },
-            "player": "controller"
+            }
           },
           "cost": null,
           "sub_ability": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_lowered.snap
@@ -20,8 +20,7 @@ expression: "&lowered"
                 "type": "Anaphoric"
               }
             }
-          },
-          "player": "controller"
+          }
         },
         "cost": null,
         "sub_ability": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
@@ -38,7 +38,9 @@ expression: "&ir"
                 }
               }
             },
-            "player": "targeted_controller"
+            "player": {
+              "type": "ParentTargetController"
+            }
           },
           "cost": null,
           "sub_ability": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_lowered.snap
@@ -37,7 +37,9 @@ expression: "&lowered"
               }
             }
           },
-          "player": "targeted_controller"
+          "player": {
+            "type": "ParentTargetController"
+          }
         },
         "cost": null,
         "sub_ability": null,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -14935,7 +14935,7 @@ mod tests {
                 // subject by a post-hoc `player_scope` override.
                 assert_eq!(
                     player,
-                    &crate::types::ability::GainLifePlayer::Controller,
+                    &crate::types::ability::TargetFilter::Controller,
                     "Exquisite Blood: 'you gain' recipient must be the ability controller"
                 );
             }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -768,35 +768,6 @@ pub enum ZoneRef {
     Hand,
 }
 
-/// Who gains life from a GainLife effect.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum GainLifePlayer {
-    /// The ability's controller (default).
-    #[default]
-    Controller,
-    /// The controller of the targeted permanent.
-    TargetedController,
-    /// CR 115.2 + CR 601.2c + CR 119.3: An announced target player. The
-    /// engine resolves this via `ResolvedAbility::target_player()`, which
-    /// returns the first `TargetRef::Player` from `ability.targets` (and
-    /// falls back to controller when no Player target was announced).
-    /// Set by the parser/converter when the Oracle text is "target player
-    /// gains N life" rather than "you gain N life" or "[permanent's]
-    /// controller gains N life."
-    TargetPlayer,
-}
-
-/// How much life is gained — a fixed amount or derived from the targeted permanent.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type", content = "value")]
-pub enum LifeAmount {
-    /// Gain a specific number of life.
-    Fixed(i32),
-    /// Gain life equal to the targeted permanent's power.
-    TargetPower,
-}
-
 /// CR 701.10d-f: What aspect to double (counters, life total, or mana pool).
 /// Used by `Effect::Double` per locked decision D-05.
 /// DoublePT/DoublePTAll handle CR 701.10a-c (power/toughness) separately.
@@ -5298,9 +5269,12 @@ pub enum Effect {
     GainLife {
         #[serde(default = "default_quantity_one")]
         amount: QuantityExpr,
-        /// Who gains the life.
-        #[serde(default)]
-        player: GainLifePlayer,
+        /// CR 119.3: Who gains the life. Defaults to Controller (omitted from JSON).
+        #[serde(
+            default = "default_target_filter_controller",
+            skip_serializing_if = "is_target_filter_controller"
+        )]
+        player: TargetFilter,
     },
     LoseLife {
         #[serde(default = "default_quantity_one")]
@@ -7114,6 +7088,10 @@ fn default_target_filter_controller() -> TargetFilter {
     TargetFilter::Controller
 }
 
+fn is_target_filter_controller(t: &TargetFilter) -> bool {
+    matches!(t, TargetFilter::Controller)
+}
+
 fn default_target_filter_self_ref() -> TargetFilter {
     TargetFilter::SelfRef
 }
@@ -7626,7 +7604,11 @@ impl Effect {
             Effect::Dig { player, .. }
             | Effect::ExileTop { player, .. }
             | Effect::ExchangeLifeWithStat { player, .. }
-            | Effect::ExileFromTopUntil { player, .. } => Some(player),
+            | Effect::ExileFromTopUntil { player, .. }
+            // CR 119.3: `GainLife.player` is a TargetFilter. `extract_target_filter_from_effect`
+            // drops context-refs (Controller) via `.filter(|t| !t.is_context_ref())`, so the
+            // default "you gain life" still surfaces no target slot.
+            | Effect::GainLife { player, .. } => Some(player),
 
             // CR 115.1a + CR 601.2c: "Create a [Role/Aura] token attached to
             // target creature" targets its host — surface `attach_to` as the
@@ -7667,7 +7649,6 @@ impl Effect {
             Effect::StartYourEngines { .. }
             | Effect::Myriad
             | Effect::ChangeSpeed { .. }
-            | Effect::GainLife { .. }
             | Effect::PumpAll { .. }
             | Effect::DamageAll { .. }
             | Effect::DamageEachPlayer { .. }
@@ -12636,7 +12617,7 @@ mod tests {
                 AbilityKind::Spell,
                 Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 },
             ))),
             valid_card: Some(TargetFilter::SelfRef),
@@ -13518,7 +13499,7 @@ mod modal_ability_tests {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
         let modal = ModalChoice {

--- a/crates/engine/tests/integration/elemental_spectacle_regression.rs
+++ b/crates/engine/tests/integration/elemental_spectacle_regression.rs
@@ -2,9 +2,7 @@ use engine::game::ability_utils::build_resolved_from_def;
 use engine::game::effects::resolve_ability_chain;
 use engine::game::zones::create_object;
 use engine::parser::parse_oracle_text;
-use engine::types::ability::{
-    Effect, GainLifePlayer, QuantityExpr, QuantityRef, TargetFilter, TypeFilter,
-};
+use engine::types::ability::{Effect, QuantityExpr, QuantityRef, TargetFilter, TypeFilter};
 use engine::types::card_type::CoreType;
 use engine::types::events::GameEvent;
 use engine::types::game_state::GameState;
@@ -80,7 +78,7 @@ fn elemental_spectacle_counts_distinct_controlled_permanent_colors_for_tokens() 
             amount: QuantityExpr::Ref {
                 qty: QuantityRef::ObjectCount { .. },
             },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         }
     ));
 

--- a/crates/engine/tests/integration/exquisite_blood_routing.rs
+++ b/crates/engine/tests/integration/exquisite_blood_routing.rs
@@ -8,7 +8,7 @@
 //! `TriggeringPlayer` whenever the trigger's subject was opponent-scoped. That
 //! ignored the *effect*-level subject ("you"), causing the opponent to gain
 //! life instead of the controller. The fix deletes the rewire and relies on
-//! the effect's own subject (`GainLifePlayer::Controller`) to route correctly.
+//! the effect's own subject (`TargetFilter::Controller`) to route correctly.
 //!
 //! CR 119.3: If an effect causes a player to gain life, that player's life
 //!           total is adjusted accordingly — the recipient is determined by
@@ -18,7 +18,7 @@
 //! the ability controller, regardless of the trigger's subject.
 
 use engine::game::effects;
-use engine::types::ability::{Effect, GainLifePlayer, QuantityExpr, QuantityRef, ResolvedAbility};
+use engine::types::ability::{Effect, QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter};
 use engine::types::events::GameEvent;
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
@@ -46,7 +46,7 @@ fn exquisite_blood_heals_controller_not_triggering_opponent() {
             amount: QuantityExpr::Ref {
                 qty: QuantityRef::EventContextAmount,
             },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
         vec![],
         ObjectId(100), // Exquisite Blood

--- a/crates/engine/tests/integration/riot_control_regression.rs
+++ b/crates/engine/tests/integration/riot_control_regression.rs
@@ -19,8 +19,8 @@
 use engine::game::effects;
 use engine::game::zones::create_object;
 use engine::types::ability::{
-    ControllerRef, Effect, GainLifePlayer, PreventionAmount, PreventionScope, QuantityExpr,
-    QuantityRef, ResolvedAbility, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+    ControllerRef, Effect, PreventionAmount, PreventionScope, QuantityExpr, QuantityRef,
+    ResolvedAbility, TargetFilter, TargetRef, TypeFilter, TypedFilter,
 };
 use engine::types::game_state::GameState;
 use engine::types::identifiers::CardId;
@@ -84,7 +84,7 @@ fn riot_control_chain_gains_life_and_prevents_damage() {
                     }),
                 },
             },
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
         vec![],
         riot_control,

--- a/crates/engine/tests/integration/rules/combat.rs
+++ b/crates/engine/tests/integration/rules/combat.rs
@@ -338,7 +338,7 @@ fn dies_trigger_fires_from_combat_damage() {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: engine::types::ability::GainLifePlayer::Controller,
+                player: engine::types::ability::TargetFilter::Controller,
             },
         ))
         .valid_card(TargetFilter::SelfRef)

--- a/crates/engine/tests/integration/ureni_attack_trigger.rs
+++ b/crates/engine/tests/integration/ureni_attack_trigger.rs
@@ -22,8 +22,8 @@
 
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::ability::{
-    AbilityDefinition, AbilityKind, Effect, GainLifePlayer, QuantityExpr, StaticDefinition,
-    TargetFilter, TriggerDefinition, TypedFilter,
+    AbilityDefinition, AbilityKind, Effect, QuantityExpr, StaticDefinition, TargetFilter,
+    TriggerDefinition, TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::game_state::ExtraPhase;
@@ -43,7 +43,7 @@ fn ureni_style_trigger() -> TriggerDefinition {
             AbilityKind::Spell,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 1 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         ))
         .valid_card(TargetFilter::SelfRef)

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -3051,11 +3051,9 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         //
         // CR 115.2 + CR 601.2c: For target-player references
         // (`Ref_TargetPlayer*`), the announced player is wired onto the
-        // inner Effect's player-target slot via `apply_player_target`.
-        // The engine extracts the chosen player at resolution time via
-        // `ResolvedAbility::target_player()`. Other non-You scopes that
-        // can't be expressed as a per-effect target (predicate-filtered,
-        // dynamic anaphor, etc.) strict-fail.
+        // inner Effect's player-target slot via `apply_player_target`. Other
+        // non-You scopes that can't be expressed as a per-effect target
+        // (predicate-filtered, dynamic anaphor, etc.) strict-fail.
         Action::PlayerAction(player, inner) => match &**player {
             Player::You => convert(inner)?,
             other => {
@@ -5336,16 +5334,9 @@ fn apply_player_target(effect: Effect, target_filter: TargetFilter) -> ConvResul
             target: target_filter,
         },
         // CR 119.3 + CR 115.2: "Target player gains N life."
-        // The `target_filter` parameter is consumed implicitly: the
-        // engine reads the announced player from `ability.targets` via
-        // `target_player()` when `player` is `TargetPlayer`. The filter
-        // value itself doesn't carry through (`` is enum-
-        // tagged, not filter-parameterized) — this branch only fires
-        // for target-player refs which all map to the same announced
-        // slot, so the loss of `target_filter` distinction is sound.
         Effect::GainLife { amount, .. } => Effect::GainLife {
             amount,
-            player: TargetFilter::Player,
+            player: target_filter,
         },
         // CR 119.3 + CR 115.2: "Target player loses N life."
         Effect::LoseLife { amount, .. } => Effect::LoseLife {
@@ -7124,6 +7115,21 @@ mod tests {
             .type_filters
             .iter()
             .any(|filter| matches!(filter, TypeFilter::Creature)));
+    }
+
+    #[test]
+    fn target_player_gain_life_preserves_player_filter() {
+        let effect = convert(&Action::PlayerAction(
+            Box::new(Player::Ref_TargetPlayer),
+            Box::new(Action::GainLife(Box::new(GameNumber::Integer(2)))),
+        ))
+        .unwrap();
+
+        let Effect::GainLife { amount, player } = effect else {
+            panic!("expected GainLife");
+        };
+        assert_eq!(amount, QuantityExpr::Fixed { value: 2 });
+        assert_eq!(player, TargetFilter::Player);
     }
 
     #[test]

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -9,10 +9,10 @@
 use engine::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, ChoiceType,
     ContinuousModification, ControllerRef, DamageSource, DelayedTriggerCondition, Duration, Effect,
-    FilterProp, GainLifePlayer, LibraryPosition, ManaProduction, ManaSpendRestriction,
-    ModalSelectionConstraint, MultiTargetSpec, PaymentCost, PlayerFilter, PlayerScope, PtValue,
-    QuantityExpr, QuantityRef, SearchSelectionConstraint, SharedQuality, StaticDefinition,
-    TargetFilter, TriggerDefinition, TypedFilter,
+    FilterProp, LibraryPosition, ManaProduction, ManaSpendRestriction, ModalSelectionConstraint,
+    MultiTargetSpec, PaymentCost, PlayerFilter, PlayerScope, PtValue, QuantityExpr, QuantityRef,
+    SearchSelectionConstraint, SharedQuality, StaticDefinition, TargetFilter, TriggerDefinition,
+    TypedFilter,
 };
 use engine::types::counter::{parse_counter_type, CounterType as EngineCounterType};
 use engine::types::game_state::DistributionUnit;
@@ -2625,7 +2625,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         },
         Action::GainLife(n) => Effect::GainLife {
             amount: quantity::convert(n)?,
-            player: GainLifePlayer::Controller,
+            player: TargetFilter::Controller,
         },
         Action::LoseLife(n) => Effect::LoseLife {
             amount: quantity::convert(n)?,
@@ -3624,7 +3624,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
             };
             Effect::GainLife {
                 amount,
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             }
         }
 
@@ -5339,13 +5339,13 @@ fn apply_player_target(effect: Effect, target_filter: TargetFilter) -> ConvResul
         // The `target_filter` parameter is consumed implicitly: the
         // engine reads the announced player from `ability.targets` via
         // `target_player()` when `player` is `TargetPlayer`. The filter
-        // value itself doesn't carry through (`GainLifePlayer` is enum-
+        // value itself doesn't carry through (`` is enum-
         // tagged, not filter-parameterized) — this branch only fires
         // for target-player refs which all map to the same announced
         // slot, so the loss of `target_filter` distinction is sound.
         Effect::GainLife { amount, .. } => Effect::GainLife {
             amount,
-            player: GainLifePlayer::TargetPlayer,
+            player: TargetFilter::Player,
         },
         // CR 119.3 + CR 115.2: "Target player loses N life."
         Effect::LoseLife { amount, .. } => Effect::LoseLife {

--- a/crates/mtgish-import/src/convert/mod.rs
+++ b/crates/mtgish-import/src/convert/mod.rs
@@ -2834,8 +2834,8 @@ fn creature_type_name(ct: &crate::schema::types::CreatureType) -> String {
 mod tests {
     use super::*;
     use engine::types::ability::{
-        AbilityCondition, Comparator, ContinuousModification, GainLifePlayer, PlayerFilter,
-        QuantityExpr, StaticCondition,
+        AbilityCondition, Comparator, ContinuousModification, PlayerFilter, QuantityExpr,
+        StaticCondition,
     };
     use engine::types::triggers::TriggerMode;
 
@@ -2963,7 +2963,7 @@ mod tests {
                 }],
                 else_effects: vec![Effect::GainLife {
                     amount: QuantityExpr::Fixed { value: 1 },
-                    player: GainLifePlayer::Controller,
+                    player: TargetFilter::Controller,
                 }],
             }),
             player_scope: PlayerFilter::Opponent,

--- a/crates/mtgish-import/tests/golden/structural/etb_and_ltb_lifegain/expected.json
+++ b/crates/mtgish-import/tests/golden/structural/etb_and_ltb_lifegain/expected.json
@@ -17,8 +17,7 @@
             "amount": {
               "type": "Fixed",
               "value": 2
-            },
-            "player": "controller"
+            }
           },
           "cost": null,
           "sub_ability": null,
@@ -57,8 +56,7 @@
             "amount": {
               "type": "Fixed",
               "value": 2
-            },
-            "player": "controller"
+            }
           },
           "cost": null,
           "sub_ability": null,

--- a/crates/mtgish-import/tests/golden/structural/etb_replacement_plus_trigger/expected.json
+++ b/crates/mtgish-import/tests/golden/structural/etb_replacement_plus_trigger/expected.json
@@ -12,8 +12,7 @@
             "amount": {
               "type": "Fixed",
               "value": 1
-            },
-            "player": "controller"
+            }
           },
           "cost": null,
           "sub_ability": null,

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -57,8 +57,7 @@ use engine::game::filter::{matches_target_filter, FilterContext};
 use engine::game::keywords::has_keyword;
 use engine::game::quantity::resolve_quantity;
 use engine::types::ability::{
-    ContinuousModification, Duration, Effect, GainLifePlayer, QuantityExpr, StaticDefinition,
-    TargetFilter,
+    ContinuousModification, Duration, Effect, QuantityExpr, StaticDefinition, TargetFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::game_state::{GameState, TransientContinuousEffect};
@@ -724,15 +723,15 @@ fn tce_matches_pump(
 
 /// Gain-life-when-comfortable: controller's current life ≥
 /// `LIFE_DIMINISHING_RETURNS`, and the life gain is directed at the
-/// controller (the default `GainLifePlayer::Controller`).
+/// controller (the default `TargetFilter::Controller`).
 fn gain_life_redundancy(
     state: &GameState,
     source_id: ObjectId,
     ai_player: PlayerId,
     amount: &QuantityExpr,
-    player: &GainLifePlayer,
+    player: &TargetFilter,
 ) -> Option<(f64, i64, i64)> {
-    if !matches!(player, GainLifePlayer::Controller) {
+    if !matches!(player, TargetFilter::Controller) {
         return None;
     }
     let controller = state
@@ -1091,7 +1090,7 @@ mod tests {
             "Lifegainer",
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
 
@@ -1116,7 +1115,7 @@ mod tests {
             "Lifegainer",
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 2 },
-                player: GainLifePlayer::Controller,
+                player: TargetFilter::Controller,
             },
         );
 


### PR DESCRIPTION
## Summary

Two sibling-cluster refactors landing together:

### #1693 — Collapse 12 `Effect::*All` scope siblings into `EffectScope { Target, All }`

Removes `DestroyAll`, `TapAll`, `UntapAll`, `BounceAll`, `PumpAll`, `CounterAll`, `DealDamageAll`, `ChangeZoneAll`, `DiscardAll`, `GoadAll`, `AddCounterAll`, `UnattachAll` and replaces them with a `scope: EffectScope` field on the singular form:

```rust
// Before
Effect::DestroyAll { target, cant_regenerate }
Effect::Destroy    { target, cant_regenerate }

// After
Effect::Destroy { scope: EffectScope, target, cant_regenerate }
```

`EffectScope::Target` maps to CR 601.2c (declared target), `EffectScope::All` maps to CR 115.1 (non-targeting iteration). The `*All` `EffectKind` variants are **retained** for event-tagging. Wire-compat via `#[serde(default, skip_serializing_if = "EffectScope::is_target")]`.

Also fixes a parser regression: `try_split_targeted_compound` was clobbering `SameNameAsParentTarget` filters (Maelstrom Pulse / Bile Blight / Echoing cycle) with bare `ParentTarget`. Added a `same_name_qualifier` guard.

### #1729 — Collapse `GainLifePlayer` 3-variant enum into `TargetFilter` on `Effect::GainLife`

Aligns `GainLife` with the identical shape `LoseLife` already uses:

```rust
// Before
GainLife { amount: QuantityExpr, player: GainLifePlayer }
// GainLifePlayer = { Controller, TargetedController, TargetPlayer }

// After
GainLife { amount: QuantityExpr, player: TargetFilter }
```

- Removes `GainLifePlayer` and dead `LifeAmount` enum
- `resolve_gain` delegates to `resolve_life_loss_target` instead of a hand-rolled 3-arm match
- `forge/effect.rs` `translate_gain_life` now uses `resolve_defined(params)` — correctly handles `Defined$Opponent`, `Defined$Targeted`, etc.
- Wire-compat via `skip_serializing_if = "is_target_filter_controller"`

## Test plan

- [x] `cargo check --all-targets` — clean
- [x] `cargo clippy -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] All gain_life, snapshot, jace, and integration tests pass
- [x] 6 snapshot files updated for new serde format
- [x] New test: `gain_life_target_player_uses_declared_target`