### PR TITLE
fix(parser): inject target-player into GainLife (issue #1508)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -10028,6 +10028,27 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
                 }
             }
         }
+        // CR 115.2: "Target player gains N life" / "target opponent gains N life"
+        // announces a player target.
+        // CR 601.2c: per-mode target choice for activated abilities.
+        // CR 119.3: the chosen player (not the source's controller) gains the life.
+        // Promote the imperative default `GainLifePlayer::Controller` to
+        // `TargetPlayer` whenever the subject is a player TARGET reference, so
+        // `target_player()` reads the chosen player from the ability's
+        // `TargetRef::Player` slot at resolution (life.rs). Keys on
+        // `subject.target.is_some()` rather than the filter variant — mirrors
+        // the Sacrifice arm above — because "target opponent" parses to
+        // `ControllerRef::Opponent` with the opponent-constraint kept as a
+        // filter on the target slot. Covers Kenrith {2}{W}, Healing Salve,
+        // Healing Leaves, Hope Charm modal, etc.
+        Effect::GainLife {
+            player: gp @ GainLifePlayer::Controller,
+            ..
+        } if subject.target.is_some()
+            && player_filter_as_controller_ref(&subject_filter).is_some() =>
+        {
+            *gp = GainLifePlayer::TargetPlayer;
+        }
         // CR 119.3 + CR 115.1d: "they lose N life" — inject subject's player reference.
         // LoseLife.target is Option<TargetFilter>, unlike other effects' non-optional targets.
         // Guard on is_none() to only inject when no target was explicitly parsed.
@@ -32838,6 +32859,36 @@ mod tests {
                         },
                     }),
                 },
+                player: GainLifePlayer::TargetPlayer,
+            },
+        );
+    }
+
+    // CR 115.2 + CR 601.2c + CR 119.3: "Target player gains N life" announces a
+    // player target; the chosen player (not the controller) gains the life.
+    // Regression for issue #1508 — Kenrith's {2}{W} activated mode and any
+    // plain spell with the same shape (Healing Salve, Healing Leaves, Hope
+    // Charm modal) previously degraded to GainLifePlayer::Controller because
+    // inject_subject_target had no GainLife arm.
+    #[test]
+    fn effect_target_player_gains_fixed_life_uses_target_player() {
+        let e = parse_effect("target player gains 5 life");
+        assert_eq!(
+            e,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 5 },
+                player: GainLifePlayer::TargetPlayer,
+            },
+        );
+    }
+
+    #[test]
+    fn effect_target_opponent_gains_fixed_life_uses_target_player() {
+        let e = parse_effect("target opponent gains 3 life");
+        assert_eq!(
+            e,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 3 },
                 player: GainLifePlayer::TargetPlayer,
             },
         );

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6592,9 +6592,9 @@ fn thread_for_each_subject(effect: Effect, original: &str) -> Effect {
         Effect::GainLife {
             amount,
             player: TargetFilter::Controller,
-        } if is_targeted && matches!(target, TargetFilter::Player) => Effect::GainLife {
+        } if is_targeted && target_filter_can_target_player(&target) => Effect::GainLife {
             amount,
-            player: TargetFilter::Player,
+            player: target,
         },
         other => other,
     }
@@ -10034,26 +10034,14 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
                 }
             }
         }
-        // CR 115.2: "Target player gains N life" / "target opponent gains N life"
-        // announces a player target.
-        // CR 601.2c: per-mode target choice for activated abilities.
-        // CR 119.3: the chosen player (not the source's controller) gains the life.
-        // Promote the imperative default `GainLifePlayer::Controller` to
-        // `TargetPlayer` whenever the subject is a player TARGET reference, so
-        // `target_player()` reads the chosen player from the ability's
-        // `TargetRef::Player` slot at resolution (life.rs). Keys on
-        // `subject.target.is_some()` rather than the filter variant — mirrors
-        // the Sacrifice arm above — because "target opponent" parses to
-        // `ControllerRef::Opponent` with the opponent-constraint kept as a
-        // filter on the target slot. Covers Kenrith {2}{W}, Healing Salve,
-        // Healing Leaves, Hope Charm modal, etc.
+        // CR 115.1c / CR 602.2b + CR 601.2c / CR 119.3: "Target player gains
+        // N life" / "target opponent gains N life" announces a player target;
+        // the chosen player, not the source controller, gains the life.
         Effect::GainLife {
-            player: gp @ GainLifePlayer::Controller,
+            player: player @ TargetFilter::Controller,
             ..
-        } if subject.target.is_some()
-            && player_filter_as_controller_ref(&subject_filter).is_some() =>
-        {
-            *gp = GainLifePlayer::TargetPlayer;
+        } if subject.target.is_some() && target_filter_can_target_player(&subject_filter) => {
+            *player = subject_filter;
         }
         // CR 119.3 + CR 115.1d: "they lose N life" — inject subject's player reference.
         // LoseLife.target is Option<TargetFilter>, unlike other effects' non-optional targets.
@@ -32978,12 +32966,11 @@ mod tests {
         );
     }
 
-    // CR 115.2 + CR 601.2c + CR 119.3: "Target player gains N life" announces a
-    // player target; the chosen player (not the controller) gains the life.
-    // Regression for issue #1508 — Kenrith's {2}{W} activated mode and any
-    // plain spell with the same shape (Healing Salve, Healing Leaves, Hope
-    // Charm modal) previously degraded to GainLifePlayer::Controller because
-    // inject_subject_target had no GainLife arm.
+    // CR 115.1c / CR 602.2b + CR 601.2c / CR 119.3: "Target player gains N life"
+    // announces a player target; the chosen player (not the controller) gains the life.
+    // Regression for issue #1508 — Kenrith's {2}{W} activated mode and any plain
+    // spell with the same shape (Healing Salve, Healing Leaves, Hope Charm modal)
+    // previously degraded to TargetFilter::Controller.
     #[test]
     fn effect_target_player_gains_fixed_life_uses_target_player() {
         let e = parse_effect("target player gains 5 life");
@@ -32991,7 +32978,7 @@ mod tests {
             e,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 5 },
-                player: GainLifePlayer::TargetPlayer,
+                player: TargetFilter::Player,
             },
         );
     }
@@ -33003,7 +32990,30 @@ mod tests {
             e,
             Effect::GainLife {
                 amount: QuantityExpr::Fixed { value: 3 },
-                player: GainLifePlayer::TargetPlayer,
+                player: TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent)
+                ),
+            },
+        );
+    }
+
+    #[test]
+    fn effect_target_opponent_gains_life_for_each_creature_on_the_battlefield() {
+        let e = parse_effect("target opponent gains 2 life for each creature on the battlefield");
+        assert_eq!(
+            e,
+            Effect::GainLife {
+                amount: QuantityExpr::Multiply {
+                    factor: 2,
+                    inner: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(TypedFilter::creature()),
+                        },
+                    }),
+                },
+                player: TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent)
+                ),
             },
         );
     }


### PR DESCRIPTION
## Summary
- `inject_subject_target` now injects a player target into `Effect::GainLife`, so spells/abilities of shape "target player/opponent gains N life" resolve on the chosen player. Closes #1508.

## Root Cause
`crates/engine/src/parser/oracle_effect/mod.rs::inject_subject_target` had arms for `Sacrifice` (with `subject.target.is_some()` → `ControllerRef::TargetPlayer`) and `LoseLife`, but **no arm for `GainLife`**. So the parser left Kenrith's {2}{W} mode (and every "target player gains N life" shape) as `GainLife { player: GainLifePlayer::Controller, .. }`, and `target_player()` at resolution time always returned the source's controller instead of the chosen player.

## Fix
Add a `GainLife` arm in `inject_subject_target` that promotes `GainLifePlayer::Controller` → `GainLifePlayer::TargetPlayer` whenever `subject.target.is_some()` and the subject is a player-scope filter. Keys on the `subject.target` boolean — not the filter variant — mirroring the Sacrifice arm above. That makes "target opponent" (which parses to `ControllerRef::Opponent` with an opponent constraint on the target slot) work identically to "target player".

Class covered: Kenrith {2}{W}, Healing Salve, Healing Leaves, Hope Charm modal — any spell or activated ability whose effect chain ends in "target {player,opponent} gains N life".

## Test Plan
- [x] Regression tests added: `effect_target_player_gains_fixed_life_uses_target_player`, `effect_target_opponent_gains_fixed_life_uses_target_player` (in `crates/engine/src/parser/oracle_effect/mod.rs` test module)
- [x] `cargo fmt --all` — clean
- [x] `./scripts/check-parser-combinators.sh` — clean
- [x] Full `parser::oracle` test suite: **4676 passed; 0 failed**

### Before (failing on `upstream/main`):
```
thread 'parser::oracle_effect::tests::effect_target_opponent_gains_fixed_life_uses_target_player'
panicked at crates/engine/src/parser/oracle_effect/mod.rs:32884:9:
assertion `left == right` failed
  left: {"type":"GainLife","amount":{"type":"Fixed","value":3},"player":"controller"}
 right: {"type":"GainLife","amount":{"type":"Fixed","value":3},"player":"target_player"}
```

### After (with this fix):
```
test parser::oracle_effect::tests::effect_target_player_gains_fixed_life_uses_target_player ... ok
test parser::oracle_effect::tests::effect_target_opponent_gains_fixed_life_uses_target_player ... ok
test result: ok. 4676 passed; 0 failed; 1 ignored; 0 measured; 4897 filtered out
```

Closes #1508
