### PR TITLE
fix(parser): split "draws X cards and loses X life" siblings (issue #1587)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17357,6 +17357,46 @@ mod tests {
         );
     }
 
+    /// CR 121.1 + CR 119.3 + CR 608.2c: Rankle class — the elided second
+    /// player-action sibling may use an article count ("draws a card"), not
+    /// only digits or X. The split predicate must still carry the prior player
+    /// subject so each player both loses life and draws.
+    #[test]
+    fn article_count_draws_card_splits_after_loses_life_sibling() {
+        let chain = parse_effect_chain(
+            "each player loses 1 life and draws a card",
+            AbilityKind::Spell,
+        );
+        assert_eq!(chain.player_scope, Some(PlayerFilter::All));
+        assert!(
+            matches!(
+                &*chain.effect,
+                Effect::LoseLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    ..
+                }
+            ),
+            "expected first sibling to be LoseLife(1), got {:?}",
+            chain.effect,
+        );
+
+        let sub = chain
+            .sub_ability
+            .as_ref()
+            .expect("expected Draw sub_ability after LoseLife");
+        assert!(
+            matches!(
+                &*sub.effect,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    ..
+                }
+            ),
+            "expected second sibling to be Draw(1), got {:?}",
+            sub.effect,
+        );
+    }
+
     #[test]
     fn effect_lightning_bolt() {
         let e = parse_effect("Lightning Bolt deals 3 damage to any target");

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17309,6 +17309,47 @@ mod tests {
         );
     }
 
+    /// CR 107.3i + CR 121.1 + CR 119.3: Pact of the Serpent class — a single
+    /// "where X is …" defining clause must bind X for BOTH sibling sub-effects
+    /// of "target player draws X cards and loses X life". The shared-X
+    /// resolver must reach the LoseLife sub-effect via the chained
+    /// `sub_ability` traversal so the chosen-type creature count substitutes
+    /// into both `count` and `amount` operands. Issue #1587.
+    #[test]
+    fn shared_where_x_binds_draws_and_loses_life_siblings() {
+        let chain = parse_effect_chain(
+            "target player draws X cards and loses X life, where X is the number of creatures they control of the chosen type",
+            AbilityKind::Spell,
+        );
+        // First sibling: Draw with shared QuantityExpr.
+        let draw_count = match &*chain.effect {
+            Effect::Draw { count, .. } => count.clone(),
+            other => panic!("expected Effect::Draw as first sibling, got {other:?}"),
+        };
+        assert!(
+            !matches!(
+                &draw_count,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable { name },
+                } if name == "X"
+            ),
+            "draw count must be rewritten from bare X to the where-X binding, got {draw_count:?}"
+        );
+        // Second sibling: LoseLife with the SAME QuantityExpr.
+        let sub = chain
+            .sub_ability
+            .as_ref()
+            .expect("expected LoseLife sub_ability after Draw");
+        let lose_amount = match &*sub.effect {
+            Effect::LoseLife { amount, .. } => amount.clone(),
+            other => panic!("expected Effect::LoseLife as second sibling, got {other:?}"),
+        };
+        assert_eq!(
+            lose_amount, draw_count,
+            "draw count and lose-life amount must share the same where-X binding"
+        );
+    }
+
     #[test]
     fn effect_lightning_bolt() {
         let e = parse_effect("Lightning Bolt deals 3 damage to any target");

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1381,6 +1381,33 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
             return true;
         }
     }
+    // CR 119.3 + CR 121.1 + CR 608.2c: Conjugated third-person-singular player
+    // action verb + count argument. When the prior conjunct established a
+    // targeted player subject ("Target player draws X cards and loses X life"
+    // — Pact of the Serpent; "Target player draws a card and loses 1 life" —
+    // Shadrix Silverquill mode), the second conjunct's verb appears in the
+    // singular conjugation with the player subject elided. The verb axis is
+    // restricted to player-only actions: "draws N cards" (CR 121.1), "loses
+    // N life" (CR 119.3), "gains N life" (CR 119.3). These verbs never apply
+    // to non-player subjects in Magic — life is a player-only attribute (CR
+    // 119) and drawing is a player-only action (CR 121) — so the split is
+    // safe regardless of prior subject. The count discriminator (digits or
+    // X) keeps conjugated continuous-modifier forms ("gains flying", "loses
+    // all abilities") on the un-split path: those are never followed by a
+    // bare count token. Sibling-clause X-binding (`compute_sentence_where_x`)
+    // and player-subject inheritance (`carried_targeted_player_subject`)
+    // handle the rest once both chunks reach the chain loop.
+    if let Ok((rest, _)) = alt((
+        tag::<_, _, OracleError<'_>>("draws "),
+        tag("loses "),
+        tag("gains "),
+    ))
+    .parse(s)
+    {
+        if next_token_is_count(rest) {
+            return true;
+        }
+    }
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("get ").parse(s) {
         let rest = rest.trim_start();
         if alt((

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1391,12 +1391,13 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // N life" (CR 119.3), "gains N life" (CR 119.3). These verbs never apply
     // to non-player subjects in Magic — life is a player-only attribute (CR
     // 119) and drawing is a player-only action (CR 121) — so the split is
-    // safe regardless of prior subject. The count discriminator (digits or
-    // X) keeps conjugated continuous-modifier forms ("gains flying", "loses
-    // all abilities") on the un-split path: those are never followed by a
-    // bare count token. Sibling-clause X-binding (`compute_sentence_where_x`)
-    // and player-subject inheritance (`carried_targeted_player_subject`)
-    // handle the rest once both chunks reach the chain loop.
+    // safe regardless of prior subject. The count+noun discriminator keeps
+    // conjugated continuous-modifier forms ("gains flying", "loses all
+    // abilities") on the un-split path: those are never followed by a player
+    // action count such as "a card" or "1 life". Sibling-clause X-binding
+    // (`compute_sentence_where_x`) and player-subject inheritance
+    // (`carried_targeted_player_subject`) handle the rest once both chunks
+    // reach the chain loop.
     if let Ok((rest, _)) = alt((
         tag::<_, _, OracleError<'_>>("draws "),
         tag("loses "),
@@ -1404,7 +1405,7 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     ))
     .parse(s)
     {
-        if next_token_is_count(rest) {
+        if next_token_is_player_action_count(rest) {
             return true;
         }
     }
@@ -1535,6 +1536,20 @@ fn next_token_is_count(s: &str) -> bool {
         return next.map(|c| !c.is_alphanumeric()).unwrap_or(true);
     }
     false
+}
+
+/// CR 121.1 / CR 119.3: Returns true when a conjugated player-action verb is
+/// followed by a count plus the matching player-action noun (`card(s)` or
+/// `life`). Unlike the imperative `gain`/`lose` heuristic above, this accepts
+/// article counts ("draws a card") without false-splitting continuous keyword
+/// grants such as "gains flying" or "loses all abilities".
+fn next_token_is_player_action_count(s: &str) -> bool {
+    let count = alt((
+        value((), nom_primitives::parse_number),
+        value((), tag::<_, _, OracleError<'_>>("x")),
+    ));
+    let noun = alt((tag("cards"), tag("card"), tag("life")));
+    (count, multispace1, noun).parse(s.trim_start()).is_ok()
 }
 
 /// Checks if text starts with a subject-prefixed damage verb.


### PR DESCRIPTION
## Summary
- Extend `starts_bare_and_clause_lower` (parser sequence splitter) to recognize the conjugated player-action verbs `draws|loses|gains` followed by a count token, so "Target player draws X cards **and** loses X life" actually splits into two sibling clauses and both sub-effects reach the chain loop. Closes #1587.

## Root Cause
For Pact of the Serpent — *"Choose a creature type. Target player draws X cards and loses X life, where X is the number of creatures they control of the chosen type"* — the chain produced only a `DrawCards` sub-effect and silently dropped the `LoseLife` sibling.

`split_clause_sequence` in `crates/engine/src/parser/oracle_effect/sequence.rs` never split the bare " and " between sibling sub-effects of this shape. `starts_bare_and_clause_lower` only accepted **imperative** bare verbs (`gain N`, `lose N`) and explicitly rejected conjugated forms (`gains`, `loses`, `draws`). For "target player draws X cards and loses X life" the elided second subject ("[that player] loses X life") never matched any clause-start, so the splitter returned a single chunk and the chain loop never saw the `LoseLife` clause.

## Fix
Add a third arm to `starts_bare_and_clause_lower` recognising `draws|loses|gains` followed by a count token (digits or `X`).

These verbs are player-only (CR 119.3 lose/gain life, CR 121.1 draw cards), so the split is safe regardless of the prior subject. The count discriminator keeps continuous-modifier conjugations (`gains flying`, `loses all abilities`) on the un-split path — those are never followed by a bare count token.

Once both chunks reach the chain loop, the existing infrastructure does the rest:
- `carried_targeted_player_subject` (CR 608.2c) inherits the "target player" subject onto sibling 2.
- `compute_sentence_where_x` (CR 107.3i) propagates the shared `where X is …` binding to both `Effect::Draw.count` and `Effect::LoseLife.amount`.

### Class covered
Any card whose effect is shaped *"target player {draws/loses/gains} N {cards/life} and {draws/loses/gains} N {cards/life}"* with an optional shared `where X is …` binding. Includes **Pact of the Serpent**, the **Shadrix Silverquill** "draws a card and loses 1 life" mode, and any future printing with this form.

## Test Plan
- [x] Regression test added: `parser::oracle_effect::tests::shared_where_x_binds_draws_and_loses_life_siblings` in `crates/engine/src/parser/oracle_effect/mod.rs`. Verifies both `Effect::Draw` and `Effect::LoseLife` siblings appear in the chain AND share the same `QuantityExpr` (the `where X is …` binding).
- [x] `cargo fmt --all` — clean
- [x] `./scripts/check-parser-combinators.sh` — clean (uses nom `alt`/`tag` only)
- [x] `cargo test -p engine --lib parser::oracle` — **4675 passed; 0 failed; 1 ignored**

### Before (failing on `upstream/main`):
```
panicked at crates/engine/src/parser/oracle_effect/mod.rs:17343:
expected LoseLife sub_ability after Draw
```
(`chain.sub_ability` was `None` — splitter kept "draws X cards and loses X life" as one chunk, only `Draw` was emitted.)

### After (with this fix):
```
test parser::oracle_effect::tests::shared_where_x_binds_draws_and_loses_life_siblings ... ok
test result: ok. 4675 passed; 0 failed; 1 ignored; 0 measured; 4900 filtered out
```

Closes #1587
