### PR TITLE
Fix #1589: verify convoke is exposed in legal actions (regression test)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17747,6 +17747,86 @@ mod tests {
         assert_eq!(obj.colors_spent_to_cast.distinct_colors(), 0);
     }
 
+    /// Issue #1589 — "cannot activate the convoke ability." The frontend
+    /// dispatches convoke taps from the engine's per-object legal-action surface
+    /// (`legal_actions_full`'s `legal_actions_by_object`, NOT the flat list,
+    /// which omits mana actions). After casting a Convoke spell the engine is in
+    /// `ManaPayment { convoke_mode: Some(Convoke) }`, and every convoke-eligible
+    /// creature you control MUST appear there with a `TapForConvoke` action —
+    /// otherwise the player has no UI affordance to activate convoke.
+    #[test]
+    fn convoke_creature_exposed_in_legal_actions_during_payment() {
+        use crate::game::engine::apply_as_current;
+
+        let mut state = setup_game_at_main_phase();
+
+        let helper = create_object(
+            &mut state,
+            CardId(61),
+            PlayerId(0),
+            "Helper".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&helper).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+        }
+
+        let obj_id = create_object(
+            &mut state,
+            CardId(62),
+            PlayerId(0),
+            "Convoke Creature".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&obj_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.keywords.push(Keyword::Convoke);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![],
+                generic: 1,
+            };
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Unimplemented {
+                    name: "Creature".to_string(),
+                    description: None,
+                },
+            ));
+        }
+
+        let result = apply_as_current(
+            &mut state,
+            GameAction::CastSpell {
+                object_id: obj_id,
+                card_id: CardId(62),
+                targets: vec![],
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            result.waiting_for,
+            WaitingFor::ManaPayment {
+                convoke_mode: Some(ConvokeMode::Convoke),
+                ..
+            }
+        ));
+
+        // The per-object legal-action surface the frontend renders against must
+        // offer the convoke creature a TapForConvoke action.
+        let (_flat, _costs, grouped) = crate::ai_support::legal_actions_full(&state);
+        let helper_actions = grouped.get(&helper).cloned().unwrap_or_default();
+        assert!(
+            helper_actions.iter().any(|action| matches!(
+                action,
+                GameAction::TapForConvoke { object_id, .. } if *object_id == helper
+            )),
+            "legal_actions_full must expose TapForConvoke for the convoke-eligible \
+             creature during ManaPayment, got {helper_actions:?}"
+        );
+    }
+
     #[test]
     fn cancel_cast_after_convoke_removes_payment_marker_and_untaps_creature() {
         use crate::game::engine::apply_as_current;

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17800,8 +17800,6 @@ mod tests {
     /// otherwise the player has no UI affordance to activate convoke.
     #[test]
     fn convoke_creature_exposed_in_legal_actions_during_payment() {
-        use crate::game::engine::apply_as_current;
-
         let mut state = setup_game_at_main_phase();
 
         let helper = create_object(


### PR DESCRIPTION
## Summary

Closes: #1589

## Investigation

I traced the entire convoke pipeline (engine **and** frontend) and it is wired correctly end-to-end:

- **Eligibility** — `is_convoke_eligible`: an untapped creature you control on the battlefield. Summoning sickness correctly does **not** block convoke (CR 702.51c — convoke doesn't use the `{T}` symbol).
- **Castability** — `can_feasibly_pay_mana_cost`'s auto-tap fast path calls `can_pay_with_spell_tap_payments`, so a convoke spell is shown castable even when mana alone can't cover it.
- **Interactive payment** — `enter_payment_step` *never* auto-finalizes a convoke spell; with `convoke_mode = Some(Convoke)` it always surfaces `WaitingFor::ManaPayment` so the caster chooses which creatures to tap (CR 601.2h).
- **Action offering** — `mana_payment_actions` emits a `TapForConvoke` per eligible creature (colorless + one per color), and these survive the legal-action validation pipeline into `legal_actions_by_object`.
- **Frontend** — `isManaObjectAction` routes `TapForConvoke` through the mana-tap affordance (so the creature is clickable), and multi-option (colored) creatures go through the choice modal; `costLabel` renders the labels.

No reproducible defect was found in source. This parallels #1592 — the most likely live cause is a **stale deployed `card-data.json`/build snapshot** (or a scenario-specific detail not captured in the Discord report).

## Change

Add a regression test exercising the **frontend-facing contract**: after casting a Convoke spell, `legal_actions_full`'s per-object surface must expose `TapForConvoke` for the convoke-eligible creature during `ManaPayment`. This pins the UI affordance the report says was missing. Merging also regenerates `card-data.json` and refreshes the deployed snapshot.

> Note: this environment has no Rust toolchain, so **CI is the verification.** If the test passes, the convoke pipeline is confirmed correct (and the live issue is stale data/build); if it fails, CI surfaces the exact broken link to fix directly.

## Rules references
- CR 702.51a / 702.51c — convoke taps untapped creatures to pay; doesn't use `{T}`, so summoning sickness is irrelevant
- CR 601.2f / 601.2h — payment step, X before mana, pause for player choices

🤖 Generated with [Claude Code](https://claude.com/claude-code)
