### PR TITLE
fix(multiplayer): route host seat mutations to the active lobby backend

### DIFF
--- a/client/src/components/chrome/HostControlTile.tsx
+++ b/client/src/components/chrome/HostControlTile.tsx
@@ -254,6 +254,9 @@ export function HostControlTile() {
   const playerSlots = useMultiplayerStore((s) => s.playerSlots);
   const hostSession = useMultiplayerStore((s) => s.hostSession);
   const seatMutate = useMultiplayerStore((s) => s.seatMutate);
+  const startLobbyWithCurrentPlayers = useMultiplayerStore(
+    (s) => s.startLobbyWithCurrentPlayers,
+  );
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
@@ -321,27 +324,26 @@ export function HostControlTile() {
     return null;
   }
 
-  const startWithCurrentPlayers = () => {
-    for (const slot of [...waitingSeats].sort((a, b) => b.playerId - a.playerId)) {
-      seatMutate({ type: "Remove", data: { seatIndex: slot.playerId } });
-    }
-    seatMutate({ type: "Start" });
-  };
-
   const fillWithAiAndStart = () => {
     if (!haveAnyDeck) return;
-    for (const slot of waitingSeats) {
-      const deck = pickRandomAiDeck();
-      if (!deck) return;
-      seatMutate({
-        type: "SetKind",
-        data: {
-          seatIndex: slot.playerId,
-          kind: { type: "Ai", data: { difficulty: "Medium", deck } },
-        },
-      });
-    }
-    seatMutate({ type: "Start" });
+    void (async () => {
+      for (const slot of waitingSeats) {
+        const deck = pickRandomAiDeck();
+        if (!deck) return;
+        await useMultiplayerStore.getState().seatMutateAsync({
+          type: "SetKind",
+          data: {
+            seatIndex: slot.playerId,
+            kind: { type: "Ai", data: { difficulty: "Medium", deck } },
+          },
+        });
+      }
+      await useMultiplayerStore.getState().seatMutateAsync({ type: "Start" });
+    })().catch((err) => {
+      useMultiplayerStore.getState().showToast(
+        err instanceof Error ? err.message : String(err),
+      );
+    });
   };
 
   return (
@@ -433,7 +435,13 @@ export function HostControlTile() {
                   {occupiedSeats >= minPlayers && (
                     <button
                       type="button"
-                      onClick={startWithCurrentPlayers}
+                      onClick={() => {
+                        void startLobbyWithCurrentPlayers().catch((err) => {
+                          useMultiplayerStore.getState().showToast(
+                            err instanceof Error ? err.message : String(err),
+                          );
+                        });
+                      }}
                       className="rounded border border-emerald-500/20 px-2 py-1 text-xs font-medium text-emerald-300"
                     >
                       {t("hostControl.startNow")}

--- a/client/src/components/chrome/HostControlTile.tsx
+++ b/client/src/components/chrome/HostControlTile.tsx
@@ -254,9 +254,11 @@ export function HostControlTile() {
   const playerSlots = useMultiplayerStore((s) => s.playerSlots);
   const hostSession = useMultiplayerStore((s) => s.hostSession);
   const seatMutate = useMultiplayerStore((s) => s.seatMutate);
+  const seatMutateAsync = useMultiplayerStore((s) => s.seatMutateAsync);
   const startLobbyWithCurrentPlayers = useMultiplayerStore(
     (s) => s.startLobbyWithCurrentPlayers,
   );
+  const showToast = useMultiplayerStore((s) => s.showToast);
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
@@ -330,7 +332,7 @@ export function HostControlTile() {
       for (const slot of waitingSeats) {
         const deck = pickRandomAiDeck();
         if (!deck) return;
-        await useMultiplayerStore.getState().seatMutateAsync({
+        await seatMutateAsync({
           type: "SetKind",
           data: {
             seatIndex: slot.playerId,
@@ -338,11 +340,9 @@ export function HostControlTile() {
           },
         });
       }
-      await useMultiplayerStore.getState().seatMutateAsync({ type: "Start" });
+      await seatMutateAsync({ type: "Start" });
     })().catch((err) => {
-      useMultiplayerStore.getState().showToast(
-        err instanceof Error ? err.message : String(err),
-      );
+      showToast(err instanceof Error ? err.message : String(err));
     });
   };
 
@@ -437,9 +437,7 @@ export function HostControlTile() {
                       type="button"
                       onClick={() => {
                         void startLobbyWithCurrentPlayers().catch((err) => {
-                          useMultiplayerStore.getState().showToast(
-                            err instanceof Error ? err.message : String(err),
-                          );
+                          showToast(err instanceof Error ? err.message : String(err));
                         });
                       }}
                       className="rounded border border-emerald-500/20 px-2 py-1 text-xs font-medium text-emerald-300"

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -6,6 +6,7 @@ const p2pMocks = vi.hoisted(() => ({
   hostDestroy: vi.fn(),
   initialize: vi.fn(async () => undefined),
   applySeatMutation: vi.fn(async () => undefined),
+  startNow: vi.fn(),
   getPlayerSlots: vi.fn(() => []),
   dispose: vi.fn(),
 }));
@@ -23,6 +24,7 @@ vi.mock("../../adapter/p2p-adapter", () => ({
     onEvent: vi.fn(),
     initialize: p2pMocks.initialize,
     applySeatMutation: p2pMocks.applySeatMutation,
+    startNow: p2pMocks.startNow,
     getPlayerSlots: p2pMocks.getPlayerSlots,
     dispose: p2pMocks.dispose,
   })),

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PlayerSlot } from "../../multiplayer/seatTypes";
 import { useMultiplayerStore } from "../multiplayerStore";
 
 const p2pMocks = vi.hoisted(() => ({
@@ -7,6 +8,7 @@ const p2pMocks = vi.hoisted(() => ({
   initialize: vi.fn(async () => undefined),
   applySeatMutation: vi.fn(async () => undefined),
   startNow: vi.fn(),
+  startPregameGame: vi.fn(async () => undefined),
   getPlayerSlots: vi.fn(() => []),
   dispose: vi.fn(),
 }));
@@ -25,6 +27,7 @@ vi.mock("../../adapter/p2p-adapter", () => ({
     initialize: p2pMocks.initialize,
     applySeatMutation: p2pMocks.applySeatMutation,
     startNow: p2pMocks.startNow,
+    startPregameGame: p2pMocks.startPregameGame,
     getPlayerSlots: p2pMocks.getPlayerSlots,
     dispose: p2pMocks.dispose,
   })),
@@ -126,5 +129,73 @@ describe("multiplayerStore", () => {
         },
       },
     });
+  });
+
+  it("removes open P2P seats in order before starting with current players", async () => {
+    const ok = await useMultiplayerStore.getState().startP2PHostingSession(
+      {
+        displayName: "Host",
+        public: true,
+        password: "",
+        timerSeconds: null,
+        formatConfig: {
+          format: "Commander",
+          starting_life: 40,
+          min_players: 2,
+          max_players: 4,
+          deck_size: 100,
+          singleton: true,
+          command_zone: true,
+          commander_damage_threshold: 21,
+          range_of_influence: null,
+          team_based: false,
+          uses_commander: true,
+          allow_debug_actions: false,
+        },
+        matchType: "Bo1",
+        aiSeats: [],
+        startWhenFull: false,
+        roomName: "Test room",
+      },
+      {
+        main_deck: ["Forest"],
+        sideboard: [],
+        commander: ["Goreclaw, Terror of Qal Sisma"],
+      },
+      { useBroker: false },
+    );
+    expect(ok).toBe(true);
+
+    const slots: PlayerSlot[] = [
+      { playerId: 0, name: "Host", kind: { type: "HostHuman" } },
+      { playerId: 1, name: "", kind: { type: "WaitingHuman" } },
+      { playerId: 2, name: "Guest", kind: { type: "JoinedHuman" } },
+      { playerId: 3, name: "", kind: { type: "WaitingHuman" } },
+    ];
+    useMultiplayerStore.setState({ playerSlots: slots });
+
+    await useMultiplayerStore.getState().startLobbyWithCurrentPlayers();
+
+    expect(p2pMocks.applySeatMutation).toHaveBeenNthCalledWith(1, {
+      type: "Remove",
+      data: { seatIndex: 3 },
+    });
+    expect(p2pMocks.applySeatMutation).toHaveBeenNthCalledWith(2, {
+      type: "Remove",
+      data: { seatIndex: 1 },
+    });
+    expect(p2pMocks.startNow).toHaveBeenCalledOnce();
+    expect(p2pMocks.startPregameGame).toHaveBeenCalledOnce();
+  });
+
+  it("reports a server host connection error instead of falling through to P2P", async () => {
+    useMultiplayerStore.setState({
+      hostingStatus: "waiting",
+      hostGameCode: "ABCDE",
+    });
+
+    await expect(
+      useMultiplayerStore.getState().seatMutateAsync({ type: "Start" }),
+    ).rejects.toThrow("Host connection is not active.");
   });
 });

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -375,13 +375,21 @@ function closeHostWebSocket(): void {
   }
 }
 
-function isServerHostingActive(get: () => MultiplayerState): boolean {
-  return (
-    hostWs != null &&
-    hostWs.readyState === WebSocket.OPEN &&
+function activeServerHostingSocket(get: () => MultiplayerState): WebSocket | null {
+  if (hostWs) {
+    if (hostWs.readyState !== WebSocket.OPEN) {
+      throw new Error("Host connection is not active.");
+    }
+    return hostWs;
+  }
+  if (
     get().hostingStatus === "waiting" &&
-    get().hostGameCode != null
-  );
+    get().hostGameCode != null &&
+    !activeP2PHostAdapter
+  ) {
+    throw new Error("Host connection is not active.");
+  }
+  return null;
 }
 
 async function runP2PSeatMutation(
@@ -1047,8 +1055,9 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       },
 
       seatMutateAsync: async (mutation) => {
-        if (isServerHostingActive(get)) {
-          hostWs!.send(JSON.stringify({
+        const serverSocket = activeServerHostingSocket(get);
+        if (serverSocket) {
+          serverSocket.send(JSON.stringify({
             type: "SeatMutate",
             data: { mutation },
           }));

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -290,6 +290,10 @@ interface MultiplayerActions {
   ) => Promise<boolean>;
   getActiveP2PHost: () => { adapter: P2PHostAdapter; gameId: string } | null;
   seatMutate: (mutation: SeatMutation) => void;
+  /** Like `seatMutate` but awaits P2P work; server sends are still fire-and-forget. */
+  seatMutateAsync: (mutation: SeatMutation) => Promise<void>;
+  /** Remove open seats, then start — mutations run in order (fixes Start-now races). */
+  startLobbyWithCurrentPlayers: () => Promise<void>;
   /**
    * Lazily open the long-lived subscription socket and return the
    * `PhaseSocket`. Idempotent: a second call while an open is in flight
@@ -350,6 +354,51 @@ interface MultiplayerActions {
     serverUrl: string,
     settings: CreateDraftSettings,
   ) => Promise<void>;
+}
+
+function disposeActiveP2PHost(): void {
+  if (activeP2PHostAdapter) {
+    activeP2PHostAdapter.dispose();
+    activeP2PHostAdapter = null;
+    activeP2PHostGameId = null;
+  }
+}
+
+function closeHostWebSocket(): void {
+  if (hostReconnectTimer) {
+    clearTimeout(hostReconnectTimer);
+    hostReconnectTimer = null;
+  }
+  if (hostWs) {
+    hostWs.close();
+    hostWs = null;
+  }
+}
+
+function isServerHostingActive(get: () => MultiplayerState): boolean {
+  return (
+    hostWs != null &&
+    hostWs.readyState === WebSocket.OPEN &&
+    get().hostingStatus === "waiting" &&
+    get().hostGameCode != null
+  );
+}
+
+async function runP2PSeatMutation(
+  mutation: SeatMutation,
+  set: (partial: Partial<MultiplayerState>) => void,
+): Promise<void> {
+  const adapter = activeP2PHostAdapter;
+  if (!adapter) {
+    throw new Error("P2P host is not active.");
+  }
+  if (mutation.type === "Start") {
+    adapter.startNow();
+    await startActiveP2PHostGame(set);
+  } else {
+    await adapter.applySeatMutation(mutation);
+    set({ playerSlots: adapter.getPlayerSlots() });
+  }
 }
 
 async function startActiveP2PHostGame(
@@ -544,14 +593,16 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       setLatency: (ms) => set({ latencyMs: ms }),
 
       startHosting: (settings, deck) => {
-        // Clean up any existing hosting session
-        if (hostWs) {
-          hostWs.close();
-          hostWs = null;
-        }
-        if (hostReconnectTimer) {
-          clearTimeout(hostReconnectTimer);
-          hostReconnectTimer = null;
+        // Clean up any existing hosting session (server or P2P).
+        closeHostWebSocket();
+        disposeActiveP2PHost();
+        if (activeBroker) {
+          if (activeBrokerGameCode) {
+            void activeBroker.unregister(activeBrokerGameCode).catch(() => {});
+          }
+          activeBroker.close();
+          activeBroker = null;
+          activeBrokerGameCode = null;
         }
         clearWsSession();
         gameStartedFired = false;
@@ -627,7 +678,12 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
             const data = msg.data as { message: string };
             console.error("Host error:", data.message);
             get().showToast(data.message || "Failed to create game.");
-            get().cancelHosting();
+            // Keep the pregame lobby open for recoverable errors (failed
+            // Start, seat edits, bracket checks). Only tear down when we
+            // never reached a lobby or the connection itself failed.
+            if (get().hostingStatus !== "waiting") {
+              get().cancelHosting();
+            }
           }
         };
 
@@ -755,19 +811,8 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       },
 
       cancelHosting: () => {
-        if (hostReconnectTimer) {
-          clearTimeout(hostReconnectTimer);
-          hostReconnectTimer = null;
-        }
-        if (hostWs) {
-          hostWs.close();
-          hostWs = null;
-        }
-        if (activeP2PHostAdapter) {
-          activeP2PHostAdapter.dispose();
-          activeP2PHostAdapter = null;
-          activeP2PHostGameId = null;
-        }
+        closeHostWebSocket();
+        disposeActiveP2PHost();
         if (activeBroker) {
           if (activeBrokerGameCode) {
             void activeBroker.unregister(activeBrokerGameCode).catch(() => {});
@@ -823,6 +868,11 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       },
 
       startP2PHostingSession: async (settings, deck, opts) => {
+        closeHostWebSocket();
+        clearWsSession();
+        gameStartedFired = false;
+        hostReconnectAttempt = 0;
+
         const resetFailedHosting = () => {
           set({
             hostIsPublic: false,
@@ -996,34 +1046,37 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
         return null;
       },
 
+      seatMutateAsync: async (mutation) => {
+        if (isServerHostingActive(get)) {
+          hostWs!.send(JSON.stringify({
+            type: "SeatMutate",
+            data: { mutation },
+          }));
+          return;
+        }
+        await runP2PSeatMutation(mutation, set);
+      },
+
       seatMutate: (mutation) => {
-        if (activeP2PHostAdapter) {
-          void (async () => {
-            if (mutation.type === "Start") {
-              await startActiveP2PHostGame(set);
-            } else {
-              await activeP2PHostAdapter.applySeatMutation(mutation);
-              set({ playerSlots: activeP2PHostAdapter.getPlayerSlots() });
-            }
-          })().catch((err) => {
-            // Surface the failure to BOTH the dev console and the in-app
-            // toaster. The toaster can be off-screen or hidden behind the
-            // lobby modal; without the console.error a silent rejection in
-            // startPregameGame / applySeatMutation looks like the button
-            // did nothing at all.
+        void get()
+          .seatMutateAsync(mutation)
+          .catch((err) => {
             console.error("[seatMutate]", mutation.type, err);
             get().showToast(err instanceof Error ? err.message : String(err));
           });
-          return;
+      },
+
+      startLobbyWithCurrentPlayers: async () => {
+        const waiting = get()
+          .playerSlots.filter((slot) => slot.kind.type === "WaitingHuman")
+          .sort((a, b) => b.playerId - a.playerId);
+        for (const slot of waiting) {
+          await get().seatMutateAsync({
+            type: "Remove",
+            data: { seatIndex: slot.playerId },
+          });
         }
-        if (!hostWs || hostWs.readyState !== WebSocket.OPEN) {
-          get().showToast("Host connection is not active.");
-          return;
-        }
-        hostWs.send(JSON.stringify({
-          type: "SeatMutate",
-          data: { mutation },
-        }));
+        await get().seatMutateAsync({ type: "Start" });
       },
 
       ensureSubscriptionSocket: async () => {

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -3622,8 +3622,13 @@ async fn handle_client_message(
                     .collect::<Vec<_>>();
 
                 session.apply_seat_delta(seat_state, &delta, db.as_ref());
+                // Match `seat_reducer::apply_start` — token occupancy alone can
+                // disagree with seat kinds (reservations, mid-mutation slots).
+                let seat_state_after = session.seat_state();
                 let mut started = delta.now_started
-                    || (session.is_full() && session.start_when_full && session.is_pregame());
+                    || (seat_state_after.is_full()
+                        && session.start_when_full
+                        && session.is_pregame());
                 // Collect a bracket-violation message to broadcast after releasing the state lock.
                 // start_game guarantees no mutation on Err, so session state is untouched.
                 let bracket_error: Option<String> = if started {


### PR DESCRIPTION
## Summary

- Route host `seatMutate` to the server WebSocket when a waiting server lobby is active, instead of always preferring a stale P2P adapter left over from an earlier session.
- Clear P2P/broker state when starting server hosting; close the host WebSocket when starting P2P hosting.
- Keep the pregame lobby open on recoverable server errors while `hostingStatus === "waiting"` (failed Start shows a toast instead of calling `cancelHosting()`).
- Add `seatMutateAsync` and `startLobbyWithCurrentPlayers` so P2P "Start now" and "Fill with AI & start" run seat mutations in order.
- On the server, only auto-start after seat mutations when `seat_state.is_full()`, matching manual `Start` and avoiding spurious starts when `start_when_full` is enabled.

Fixes #1506

## Test plan

- [ ] Host a server game (2+ players), fill all seats, click **Start game** — game starts.
- [ ] Trigger a failed start (e.g. lobby not actually full) — toast appears and the host lobby **remains** open.
- [ ] Host P2P, then host a server game without a full reload — **Start** and **Kick** affect the server lobby.
- [ ] P2P lobby with extra empty seats: **Start now** removes open seats and starts; **Fill with AI** works.
- [ ] With **Start when full** enabled, **Kick** does not auto-start; replacing a player with AI on a full lobby still auto-starts when intended.
- [ ] `pnpm exec vitest run src/stores/__tests__/multiplayerStore.test.ts` passes.