### PR TITLE
fix: Pyrogoyf ETB Damage Source and Target Parsing

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -9789,6 +9789,29 @@ fn wrap_target_subject_damage(
     subject: &SubjectPhraseAst,
 ) -> Option<ParsedEffectClause> {
     let subject_target = subject.target.as_ref()?;
+    if matches!(subject_target, TargetFilter::TriggeringSource) {
+        match &mut clause.effect {
+            Effect::DealDamage {
+                amount,
+                damage_source,
+                ..
+            } => {
+                rewrite_event_source_power_to_object_power(amount, ObjectScope::EventSource);
+                *damage_source = Some(DamageSource::TriggeringSource);
+            }
+            Effect::DamageAll {
+                amount,
+                damage_source,
+                ..
+            } => {
+                rewrite_event_source_power_to_object_power(amount, ObjectScope::EventSource);
+                *damage_source = Some(DamageSource::TriggeringSource);
+            }
+            _ => return None,
+        }
+        return Some(clause);
+    }
+
     // CR 608.2c + CR 120.1: "target creature deals damage equal to its
     // power..." makes the chosen source object, not the spell card, deal the
     // damage. "Its power" is therefore the first target's current power.
@@ -9876,6 +9899,27 @@ fn parse_subject_exile_top_count(pred_lower: &str) -> QuantityExpr {
 fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
     let subject_filter = subject.target.as_ref().unwrap_or(&subject.affected).clone();
     match effect {
+        // CR 120.1 + CR 608.2c: "that creature/permanent deals damage equal to
+        // its power..." in an ETB trigger makes the triggering object, not the
+        // trigger source permanent, the damage source. Keep the parsed damage
+        // recipient target intact ("to any target") while rebinding both the
+        // source metadata and anaphoric "its power" to the triggering source.
+        Effect::DealDamage {
+            amount,
+            damage_source,
+            ..
+        } if matches!(subject_filter, TargetFilter::TriggeringSource) => {
+            rewrite_event_source_power_to_object_power(amount, ObjectScope::EventSource);
+            *damage_source = Some(DamageSource::TriggeringSource);
+        }
+        Effect::DamageAll {
+            amount,
+            damage_source,
+            ..
+        } if matches!(subject_filter, TargetFilter::TriggeringSource) => {
+            rewrite_event_source_power_to_object_power(amount, ObjectScope::EventSource);
+            *damage_source = Some(DamageSource::TriggeringSource);
+        }
         // CR 601.2c + CR 121.1: "Target player draws ..." — each Draw mode of a
         // modal spell is its own targeting instance. The imperative path emits
         // `target: TargetFilter::Controller` (the no-subject default); when a

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -9729,6 +9729,30 @@ fn rewrite_event_source_power_to_object_power(expr: &mut QuantityExpr, scope: Ob
     }
 }
 
+fn bind_damage_clause_source(
+    effect: &mut Effect,
+    damage_source_ref: DamageSource,
+    power_scope: ObjectScope,
+) -> bool {
+    match effect {
+        Effect::DealDamage {
+            amount,
+            damage_source,
+            ..
+        }
+        | Effect::DamageAll {
+            amount,
+            damage_source,
+            ..
+        } => {
+            rewrite_event_source_power_to_object_power(amount, power_scope);
+            *damage_source = Some(damage_source_ref);
+            true
+        }
+        _ => false,
+    }
+}
+
 fn rewrite_filter_controller(filter: &mut TargetFilter, from: &ControllerRef, to: &ControllerRef) {
     match filter {
         TargetFilter::Typed(tf) if tf.controller.as_ref() == Some(from) => {
@@ -9790,26 +9814,17 @@ fn wrap_target_subject_damage(
 ) -> Option<ParsedEffectClause> {
     let subject_target = subject.target.as_ref()?;
     if matches!(subject_target, TargetFilter::TriggeringSource) {
-        match &mut clause.effect {
-            Effect::DealDamage {
-                amount,
-                damage_source,
-                ..
-            } => {
-                rewrite_event_source_power_to_object_power(amount, ObjectScope::EventSource);
-                *damage_source = Some(DamageSource::TriggeringSource);
-            }
-            Effect::DamageAll {
-                amount,
-                damage_source,
-                ..
-            } => {
-                rewrite_event_source_power_to_object_power(amount, ObjectScope::EventSource);
-                *damage_source = Some(DamageSource::TriggeringSource);
-            }
-            _ => return None,
+        // CR 603.6 + CR 120.1: "that creature deals damage equal to its
+        // power" in a zone-change trigger binds both the damage source and
+        // anaphoric power reference to the moved object.
+        if bind_damage_clause_source(
+            &mut clause.effect,
+            DamageSource::TriggeringSource,
+            ObjectScope::EventSource,
+        ) {
+            return Some(clause);
         }
-        return Some(clause);
+        return None;
     }
 
     // CR 608.2c + CR 120.1: "target creature deals damage equal to its
@@ -9821,24 +9836,12 @@ fn wrap_target_subject_damage(
     // (CR 702.16), wither/infect (CR 120.3b/d), and damage-source replacements
     // (CR 614). The 2015-06-22 Chandra's Ignition rulings codify this for
     // the multi-recipient case (DamageAll).
-    match &mut clause.effect {
-        Effect::DealDamage {
-            amount,
-            damage_source,
-            ..
-        } => {
-            rewrite_event_source_power_to_object_power(amount, ObjectScope::Target);
-            *damage_source = Some(DamageSource::Target);
-        }
-        Effect::DamageAll {
-            amount,
-            damage_source,
-            ..
-        } => {
-            rewrite_event_source_power_to_object_power(amount, ObjectScope::Target);
-            *damage_source = Some(DamageSource::Target);
-        }
-        _ => return None,
+    if !bind_damage_clause_source(
+        &mut clause.effect,
+        DamageSource::Target,
+        ObjectScope::Target,
+    ) {
+        return None;
     }
 
     let mut damage_ability = AbilityDefinition::new(AbilityKind::Spell, clause.effect);
@@ -9898,28 +9901,22 @@ fn parse_subject_exile_top_count(pred_lower: &str) -> QuantityExpr {
 /// the subject's targeting information.
 fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
     let subject_filter = subject.target.as_ref().unwrap_or(&subject.affected).clone();
+    // CR 603.6 + CR 120.1: "that creature/permanent deals damage equal to
+    // its power..." in an ETB trigger makes the triggering object, not the
+    // trigger source permanent, the damage source. Keep the parsed damage
+    // recipient target intact ("to any target") while rebinding both the
+    // source metadata and anaphoric "its power" to the triggering source.
+    if matches!(subject_filter, TargetFilter::TriggeringSource)
+        && bind_damage_clause_source(
+            effect,
+            DamageSource::TriggeringSource,
+            ObjectScope::EventSource,
+        )
+    {
+        return;
+    }
+
     match effect {
-        // CR 120.1 + CR 608.2c: "that creature/permanent deals damage equal to
-        // its power..." in an ETB trigger makes the triggering object, not the
-        // trigger source permanent, the damage source. Keep the parsed damage
-        // recipient target intact ("to any target") while rebinding both the
-        // source metadata and anaphoric "its power" to the triggering source.
-        Effect::DealDamage {
-            amount,
-            damage_source,
-            ..
-        } if matches!(subject_filter, TargetFilter::TriggeringSource) => {
-            rewrite_event_source_power_to_object_power(amount, ObjectScope::EventSource);
-            *damage_source = Some(DamageSource::TriggeringSource);
-        }
-        Effect::DamageAll {
-            amount,
-            damage_source,
-            ..
-        } if matches!(subject_filter, TargetFilter::TriggeringSource) => {
-            rewrite_event_source_power_to_object_power(amount, ObjectScope::EventSource);
-            *damage_source = Some(DamageSource::TriggeringSource);
-        }
         // CR 601.2c + CR 121.1: "Target player draws ..." — each Draw mode of a
         // modal spell is its own targeting instance. The imperative path emits
         // `target: TargetFilter::Controller` (the no-subject default); when a

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -18326,6 +18326,26 @@ mod tests {
         assert_eq!(def.mode, TriggerMode::ChangesZone);
         assert_eq!(def.destination, Some(Zone::Battlefield));
         assert_eq!(def.origin, Some(Zone::Graveyard));
+        let execute = def.execute.as_ref().expect("trigger should have execute");
+        match &*execute.effect {
+            Effect::DealDamage {
+                amount,
+                target,
+                damage_source,
+            } => {
+                assert_eq!(*target, TargetFilter::Any);
+                assert_eq!(*damage_source, Some(DamageSource::TriggeringSource));
+                assert!(matches!(
+                    amount,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Power {
+                            scope: ObjectScope::EventSource,
+                        },
+                    }
+                ));
+            }
+            other => panic!("expected DealDamage, got {other:?}"),
+        }
     }
 
     /// CR 120.1 + CR 603.6: Pyrogoyf's "that creature deals damage equal to

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -10370,7 +10370,7 @@ mod tests {
     use crate::types::ability::{
         AbilityCondition, AbilityCost, AbilityKind, AggregateFunction, BounceSelection,
         CastingPermission, Comparator, ContinuousModification, ControllerRef, CountScope,
-        DamageModification, DelayedTriggerCondition, Duration, Effect, FilterProp,
+        DamageModification, DamageSource, DelayedTriggerCondition, Duration, Effect, FilterProp,
         ManaSpendPermission, ObjectScope, PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope,
         QuantityExpr, QuantityRef, SharedQuality, TargetFilter, TypeFilter, TypedFilter,
     };
@@ -18326,6 +18326,41 @@ mod tests {
         assert_eq!(def.mode, TriggerMode::ChangesZone);
         assert_eq!(def.destination, Some(Zone::Battlefield));
         assert_eq!(def.origin, Some(Zone::Graveyard));
+    }
+
+    /// CR 120.1 + CR 603.6: Pyrogoyf's "that creature deals damage equal to
+    /// its power" trigger must use the entering Lhurgoyf as both the damage
+    /// source and power source, while keeping "any target" as the chosen damage
+    /// recipient.
+    #[test]
+    fn pyrogoyf_etb_damage_uses_entering_lhurgoyf_as_damage_source() {
+        let def = parse_trigger_line(
+            "Whenever this creature or another Lhurgoyf creature you control enters, that creature deals damage equal to its power to any target.",
+            "Pyrogoyf",
+        );
+
+        assert_eq!(def.mode, TriggerMode::ChangesZone);
+        assert_eq!(def.destination, Some(Zone::Battlefield));
+        let execute = def.execute.as_ref().expect("trigger should have execute");
+        match &*execute.effect {
+            Effect::DealDamage {
+                amount,
+                target,
+                damage_source,
+            } => {
+                assert_eq!(*target, TargetFilter::Any);
+                assert_eq!(*damage_source, Some(DamageSource::TriggeringSource));
+                assert!(matches!(
+                    amount,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Power {
+                            scope: ObjectScope::EventSource,
+                        },
+                    }
+                ));
+            }
+            other => panic!("expected DealDamage, got {other:?}"),
+        }
     }
 
     /// CR 603.6 + CR 603.6a — origin extraction for "enters from exile"


### PR DESCRIPTION
## Summary
Fixes #1586: Pyrogoyf’s ETB trigger now correctly parses and resolves the entering creature as the damage source.

Previously, the parser treated “that creature” as the only target wrapper and lost the actual `any target` damage recipient. Now the parser keeps `any target` as the recipient and binds “that creature” / “its power” to the triggering entering object.
## Related Issue
Closes: #1586
## Change Type
- [x] Bug fix
- [x] Parser fix
- [x] Rules behavior fix
- [x] Regression test
- [x] Validation / test coverage

## Real Behavior Proof

Tested Oracle text:

```text
Whenever this creature or another Lhurgoyf creature you control enters, that creature deals damage equal to its power to any target.
```

Verified parsed behavior:

- `TriggerMode::ChangesZone`
- Destination is `Zone::Battlefield`
- Effect is `Effect::DealDamage`
- Damage target remains `TargetFilter::Any`
- Damage source is `DamageSource::TriggeringSource`
- Damage amount uses `QuantityRef::Power { scope: ObjectScope::EventSource }`

This means the entering Pyrogoyf/Lhurgoyf deals damage equal to its own current power to the chosen target.
## Checklist

- [x] Analyzed issue #1586
- [x] Reused existing `DamageSource::TriggeringSource` engine behavior
- [x] Preserved `any target` as the selected damage recipient
- [x] Bound “its power” to the triggering entering object
- [x] Added regression coverage for Pyrogoyf-style ETB damage
- [x] Confirmed full engine tests pass
- [x] Confirmed clippy passes with warnings denied
- [x] Confirmed frontend type check passes
- [x] Confirmed frontend lint has no errors