### PR TITLE
fix(deck-builder): Doctor's Companion dual-commander pairing for Amy pond

### DIFF
--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -32,6 +32,7 @@ import {
 } from "./commanderUtils";
 import {
   commanderPartnerCandidates,
+  ensureCardDatabase,
   isCardCommanderEligibleForFormat,
 } from "../../services/engineRuntime";
 
@@ -475,11 +476,16 @@ export function useDeckBuilder({
       // pairing decision is queried on demand (authoritative at click time) so a
       // stale precomputed value can never misclassify an add as a swap.
       void (async () => {
+        try {
+          await ensureCardDatabase();
+        } catch {
+          return;
+        }
         const isPartnerAdd =
           commanders.length === 1 &&
-          (
-            await commanderPartnerCandidates(commanders[0], [cardName])
-          ).includes(cardName);
+          (await commanderPartnerCandidates(commanders[0], [cardName])).includes(
+            cardName,
+          );
         setDirty(true);
         const displaced =
           isPartnerAdd || commanders.length === 0 ? [] : commanders;

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -32,7 +32,6 @@ import {
 } from "./commanderUtils";
 import {
   commanderPartnerCandidates,
-  ensureCardDatabase,
   isCardCommanderEligibleForFormat,
 } from "../../services/engineRuntime";
 
@@ -476,16 +475,16 @@ export function useDeckBuilder({
       // pairing decision is queried on demand (authoritative at click time) so a
       // stale precomputed value can never misclassify an add as a swap.
       void (async () => {
-        try {
-          await ensureCardDatabase();
-        } catch {
-          return;
+        let isPartnerAdd = false;
+        if (commanders.length === 1) {
+          try {
+            isPartnerAdd = (await commanderPartnerCandidates(commanders[0], [cardName])).includes(
+              cardName,
+            );
+          } catch {
+            return;
+          }
         }
-        const isPartnerAdd =
-          commanders.length === 1 &&
-          (await commanderPartnerCandidates(commanders[0], [cardName])).includes(
-            cardName,
-          );
         setDirty(true);
         const displaced =
           isPartnerAdd || commanders.length === 0 ? [] : commanders;

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -302,6 +302,13 @@ impl CardDatabase {
         if let Some(alias) = self.name_alias_index.get(&fold_card_name_key(name)) {
             return alias.clone();
         }
+        // Deck lists often omit the leading article ("Eleventh Doctor").
+        if !lower.starts_with("the ") {
+            let with_the = format!("the {lower}");
+            if self.face_index.contains_key(&with_the) || self.cards.contains_key(&with_the) {
+                return with_the;
+            }
+        }
         if let Some((front, _)) = lower.split_once("//") {
             let front = front.trim();
             if self.face_index.contains_key(front) || self.cards.contains_key(front) {
@@ -369,6 +376,21 @@ pub(crate) fn build_name_alias_index<'a>(
                 }
             })
             .or_insert_with(|| Some(key.clone()));
+
+        // Deck imports often drop the leading article ("Eleventh Doctor" vs
+        // "The Eleventh Doctor"). Register the stripped form when unambiguous.
+        if let Some(stripped) = key.strip_prefix("the ") {
+            if !stripped.is_empty() {
+                aliases
+                    .entry(stripped.to_string())
+                    .and_modify(|existing| {
+                        if existing.as_deref() != Some(key.as_str()) {
+                            *existing = None;
+                        }
+                    })
+                    .or_insert_with(|| Some(key.clone()));
+            }
+        }
     }
     aliases
         .into_iter()
@@ -688,6 +710,31 @@ mod tests {
             db.get_face_by_name("Brigid, Clachan's Heart // Brigid, Doun's Mind")
                 .map(|face| face.name.as_str()),
             Some("Brigid, Clachan's Heart")
+        );
+    }
+
+    #[test]
+    fn name_lookup_resolves_card_names_without_leading_the() {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "the eleventh doctor".to_string(),
+            serde_json::json!({
+                "name": "The Eleventh Doctor",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": ["Legendary"], "core_types": ["Creature"], "subtypes": ["Time Lord", "Doctor"] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": null, "scryfall_oracle_id": null, "legalities": {}
+            }),
+        );
+        let json = serde_json::Value::Object(map).to_string();
+        let db = CardDatabase::from_json_str(&json).unwrap();
+
+        assert_eq!(
+            db.get_face_by_name("Eleventh Doctor")
+                .map(|face| face.name.as_str()),
+            Some("The Eleventh Doctor")
         );
     }
 

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -302,13 +302,6 @@ impl CardDatabase {
         if let Some(alias) = self.name_alias_index.get(&fold_card_name_key(name)) {
             return alias.clone();
         }
-        // Deck lists often omit the leading article ("Eleventh Doctor").
-        if !lower.starts_with("the ") {
-            let with_the = format!("the {lower}");
-            if self.face_index.contains_key(&with_the) || self.cards.contains_key(&with_the) {
-                return with_the;
-            }
-        }
         if let Some((front, _)) = lower.split_once("//") {
             let front = front.trim();
             if self.face_index.contains_key(front) || self.cards.contains_key(front) {
@@ -364,32 +357,26 @@ pub(crate) fn build_name_alias_index<'a>(
 ) -> HashMap<String, String> {
     let mut aliases: HashMap<String, Option<String>> = HashMap::new();
     for key in keys {
+        let mut register_alias = |alias: String| {
+            aliases
+                .entry(alias)
+                .and_modify(|existing| {
+                    if existing.as_deref() != Some(key.as_str()) {
+                        *existing = None;
+                    }
+                })
+                .or_insert_with(|| Some(key.clone()));
+        };
+
         let folded = fold_card_name_key(key);
-        if folded == *key {
-            continue;
+        if folded != *key {
+            register_alias(folded);
         }
-        aliases
-            .entry(folded)
-            .and_modify(|existing| {
-                if existing.as_deref() != Some(key.as_str()) {
-                    *existing = None;
-                }
-            })
-            .or_insert_with(|| Some(key.clone()));
 
         // Deck imports often drop the leading article ("Eleventh Doctor" vs
         // "The Eleventh Doctor"). Register the stripped form when unambiguous.
-        if let Some(stripped) = key.strip_prefix("the ") {
-            if !stripped.is_empty() {
-                aliases
-                    .entry(stripped.to_string())
-                    .and_modify(|existing| {
-                        if existing.as_deref() != Some(key.as_str()) {
-                            *existing = None;
-                        }
-                    })
-                    .or_insert_with(|| Some(key.clone()));
-            }
+        if let Some(stripped) = key.strip_prefix("the ").filter(|s| !s.is_empty()) {
+            register_alias(fold_card_name_key(stripped));
         }
     }
     aliases
@@ -728,6 +715,18 @@ mod tests {
                 "color_override": null, "scryfall_oracle_id": null, "legalities": {}
             }),
         );
+        map.insert(
+            "the séance doctor".to_string(),
+            serde_json::json!({
+                "name": "The Séance Doctor",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": ["Legendary"], "core_types": ["Creature"], "subtypes": ["Time Lord", "Doctor"] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": null, "scryfall_oracle_id": null, "legalities": {}
+            }),
+        );
         let json = serde_json::Value::Object(map).to_string();
         let db = CardDatabase::from_json_str(&json).unwrap();
 
@@ -735,6 +734,11 @@ mod tests {
             db.get_face_by_name("Eleventh Doctor")
                 .map(|face| face.name.as_str()),
             Some("The Eleventh Doctor")
+        );
+        assert_eq!(
+            db.get_face_by_name("Seance Doctor")
+                .map(|face| face.name.as_str()),
+            Some("The Séance Doctor")
         );
     }
 

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -1974,9 +1974,14 @@ fn partner_types_compatible(
     }
 }
 
-/// CR 903.3 + WHO release notes: a Doctor's Companion pairs with a legendary
-/// creature that is a Time Lord Doctor and has no other creature types.
+/// CR 702.124m: Doctor's companion pairs with a legendary Time Lord Doctor
+/// creature card that has no other creature types.
 fn is_time_lord_doctor_commander(face: &CardFace) -> bool {
+    if !face.card_type.supertypes.contains(&Supertype::Legendary)
+        || !face.card_type.core_types.contains(&CoreType::Creature)
+    {
+        return false;
+    }
     if !is_commander_eligible(face) {
         return false;
     }
@@ -1989,18 +1994,14 @@ fn is_time_lord_doctor_commander(face: &CardFace) -> bool {
         return subtypes.len() == 1;
     }
     subtypes.len() == 2
+        && subtypes.iter().any(|s| s.eq_ignore_ascii_case("Doctor"))
+        && subtypes.iter().any(|s| s.eq_ignore_ascii_case("Time Lord"))
         && subtypes
             .iter()
-            .any(|s| s.eq_ignore_ascii_case("Doctor"))
-        && subtypes
-            .iter()
-            .any(|s| s.eq_ignore_ascii_case("Time Lord"))
-        && subtypes.iter().all(|s| {
-            s.eq_ignore_ascii_case("Doctor") || s.eq_ignore_ascii_case("Time Lord")
-        })
+            .all(|s| s.eq_ignore_ascii_case("Doctor") || s.eq_ignore_ascii_case("Time Lord"))
 }
 
-/// CR 702.124: Check if a partner type matches the other face by subtype.
+/// CR 702.124k + CR 702.124m: Check if a partner type matches the other face by subtype.
 /// Doctor's Companion pairs with a Time Lord Doctor commander; Choose a Background
 /// pairs with any Background.
 fn subtype_partner_match(
@@ -2023,6 +2024,11 @@ fn subtype_partner_match(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+
+    use crate::database::mtgjson::load_atomic_cards;
+    use crate::database::synthesis::build_oracle_face;
+    use crate::types::keywords::PartnerType;
 
     fn test_db_json() -> String {
         serde_json::json!({
@@ -3565,11 +3571,7 @@ mod tests {
             vec![],
         );
         // Can pair with a Doctor
-        let doctor = partner_face(
-            "The Thirteenth Doctor",
-            vec![],
-            vec!["Time Lord", "Doctor"],
-        );
+        let doctor = partner_face("The Thirteenth Doctor", vec![], vec!["Time Lord", "Doctor"]);
         assert!(are_valid_partners(&amy, &doctor));
 
         // Can pair with Rory Williams
@@ -3628,12 +3630,6 @@ mod tests {
     /// synthesis and pair with a Time Lord Doctor commander.
     #[test]
     fn amy_pond_pairs_with_eleventh_doctor_from_mtgjson() {
-        use std::path::Path;
-
-        use crate::database::mtgjson::load_atomic_cards;
-        use crate::database::synthesis::build_oracle_face;
-        use crate::types::keywords::PartnerType;
-
         let path =
             Path::new(env!("CARGO_MANIFEST_DIR")).join("../../data/mtgjson/AtomicCards.json");
         if !path.exists() {
@@ -3681,7 +3677,6 @@ mod tests {
 
     #[test]
     fn doctors_companion_rejects_non_doctor_subtypes() {
-        use crate::types::keywords::PartnerType;
         let companion = partner_face(
             "Amy Pond",
             vec![Keyword::Partner(PartnerType::DoctorsCompanion)],
@@ -3689,6 +3684,18 @@ mod tests {
         );
         let human_doctor = partner_face("Not A Real Doctor", vec![], vec!["Human", "Doctor"]);
         assert!(!are_valid_partners(&companion, &human_doctor));
+
+        let non_creature_doctor = CardFace {
+            name: "Noncreature Doctor".to_string(),
+            is_commander: true,
+            card_type: crate::types::card_type::CardType {
+                supertypes: vec![Supertype::Legendary],
+                core_types: vec![CoreType::Artifact],
+                subtypes: vec!["Time Lord".to_string(), "Doctor".to_string()],
+            },
+            ..CardFace::default()
+        };
+        assert!(!are_valid_partners(&companion, &non_creature_doctor));
 
         let unified = partner_face("The Eleventh Doctor", vec![], vec!["Time Lord Doctor"]);
         assert!(are_valid_partners(&companion, &unified));

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -1989,15 +1989,11 @@ fn is_time_lord_doctor_commander(face: &CardFace) -> bool {
         return subtypes.len() == 1;
     }
     subtypes.len() == 2
+        && subtypes.iter().any(|s| s.eq_ignore_ascii_case("Doctor"))
+        && subtypes.iter().any(|s| s.eq_ignore_ascii_case("Time Lord"))
         && subtypes
             .iter()
-            .any(|s| s.eq_ignore_ascii_case("Doctor"))
-        && subtypes
-            .iter()
-            .any(|s| s.eq_ignore_ascii_case("Time Lord"))
-        && subtypes.iter().all(|s| {
-            s.eq_ignore_ascii_case("Doctor") || s.eq_ignore_ascii_case("Time Lord")
-        })
+            .all(|s| s.eq_ignore_ascii_case("Doctor") || s.eq_ignore_ascii_case("Time Lord"))
 }
 
 /// CR 702.124: Check if a partner type matches the other face by subtype.
@@ -3565,11 +3561,7 @@ mod tests {
             vec![],
         );
         // Can pair with a Doctor
-        let doctor = partner_face(
-            "The Thirteenth Doctor",
-            vec![],
-            vec!["Time Lord", "Doctor"],
-        );
+        let doctor = partner_face("The Thirteenth Doctor", vec![], vec!["Time Lord", "Doctor"]);
         assert!(are_valid_partners(&amy, &doctor));
 
         // Can pair with Rory Williams

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -1974,8 +1974,35 @@ fn partner_types_compatible(
     }
 }
 
+/// CR 903.3 + WHO release notes: a Doctor's Companion pairs with a legendary
+/// creature that is a Time Lord Doctor and has no other creature types.
+fn is_time_lord_doctor_commander(face: &CardFace) -> bool {
+    if !is_commander_eligible(face) {
+        return false;
+    }
+    let subtypes = &face.card_type.subtypes;
+    // MTGJSON may emit the single two-word subtype or the split pair.
+    if subtypes
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case("Time Lord Doctor"))
+    {
+        return subtypes.len() == 1;
+    }
+    subtypes.len() == 2
+        && subtypes
+            .iter()
+            .any(|s| s.eq_ignore_ascii_case("Doctor"))
+        && subtypes
+            .iter()
+            .any(|s| s.eq_ignore_ascii_case("Time Lord"))
+        && subtypes.iter().all(|s| {
+            s.eq_ignore_ascii_case("Doctor") || s.eq_ignore_ascii_case("Time Lord")
+        })
+}
+
 /// CR 702.124: Check if a partner type matches the other face by subtype.
-/// Doctor's Companion pairs with any Doctor; Choose a Background pairs with any Background.
+/// Doctor's Companion pairs with a Time Lord Doctor commander; Choose a Background
+/// pairs with any Background.
 fn subtype_partner_match(
     partner_type: &crate::types::keywords::PartnerType,
     other_face: &CardFace,
@@ -1983,11 +2010,7 @@ fn subtype_partner_match(
     use crate::types::keywords::PartnerType;
 
     match partner_type {
-        PartnerType::DoctorsCompanion => other_face
-            .card_type
-            .subtypes
-            .iter()
-            .any(|s| s.eq_ignore_ascii_case("Doctor")),
+        PartnerType::DoctorsCompanion => is_time_lord_doctor_commander(other_face),
         PartnerType::ChooseABackground => other_face
             .card_type
             .subtypes
@@ -3542,7 +3565,11 @@ mod tests {
             vec![],
         );
         // Can pair with a Doctor
-        let doctor = partner_face("The Thirteenth Doctor", vec![], vec!["Doctor"]);
+        let doctor = partner_face(
+            "The Thirteenth Doctor",
+            vec![],
+            vec!["Time Lord", "Doctor"],
+        );
         assert!(are_valid_partners(&amy, &doctor));
 
         // Can pair with Rory Williams
@@ -3595,6 +3622,76 @@ mod tests {
         assert!(can_pair_commanders(&db, "The Eleventh Doctor", "Amy Pond"));
         // Unknown names resolve to no pairing rather than panicking.
         assert!(!can_pair_commanders(&db, "Amy Pond", "Nonexistent Card"));
+    }
+
+    /// Regression for issue #1500: Doctor's Companion must survive MTGJSON
+    /// synthesis and pair with a Time Lord Doctor commander.
+    #[test]
+    fn amy_pond_pairs_with_eleventh_doctor_from_mtgjson() {
+        use std::path::Path;
+
+        use crate::database::mtgjson::load_atomic_cards;
+        use crate::database::synthesis::build_oracle_face;
+        use crate::types::keywords::PartnerType;
+
+        let path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../data/mtgjson/AtomicCards.json");
+        if !path.exists() {
+            return;
+        }
+        let atomic = load_atomic_cards(&path).expect("AtomicCards.json should load");
+        let amy_json = atomic
+            .data
+            .get("Amy Pond")
+            .and_then(|faces| faces.first())
+            .expect("Amy Pond should exist in MTGJSON");
+        let doctor_json = atomic
+            .data
+            .get("The Eleventh Doctor")
+            .and_then(|faces| faces.first())
+            .expect("The Eleventh Doctor should exist in MTGJSON");
+
+        let amy = build_oracle_face(amy_json, None);
+        let doctor = build_oracle_face(doctor_json, None);
+
+        assert!(
+            amy.keywords
+                .iter()
+                .any(|kw| matches!(kw, Keyword::Partner(PartnerType::DoctorsCompanion))),
+            "Amy Pond should carry Doctor's Companion after synthesis; got {:?}",
+            amy.keywords
+        );
+        assert!(
+            are_valid_partners(&amy, &doctor),
+            "Amy Pond and The Eleventh Doctor should form a legal co-commander pair \
+             (doctor subtypes: {:?})",
+            doctor.card_type.subtypes
+        );
+
+        let db = CardDatabase::from_mtgjson(&path).expect("db load");
+        assert!(
+            can_pair_commanders(&db, "Amy Pond", "The Eleventh Doctor"),
+            "full MTGJSON database load must agree on Doctor's Companion pairing"
+        );
+        assert!(
+            can_pair_commanders(&db, "Amy Pond", "Eleventh Doctor"),
+            "deck lists that omit the leading article must still pair"
+        );
+    }
+
+    #[test]
+    fn doctors_companion_rejects_non_doctor_subtypes() {
+        use crate::types::keywords::PartnerType;
+        let companion = partner_face(
+            "Amy Pond",
+            vec![Keyword::Partner(PartnerType::DoctorsCompanion)],
+            vec![],
+        );
+        let human_doctor = partner_face("Not A Real Doctor", vec![], vec!["Human", "Doctor"]);
+        assert!(!are_valid_partners(&companion, &human_doctor));
+
+        let unified = partner_face("The Eleventh Doctor", vec![], vec!["Time Lord Doctor"]);
+        assert!(are_valid_partners(&companion, &unified));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes [#1500](https://github.com/phase-rs/phase/issues/1500): Amy Pond and The Eleventh Doctor could not be assigned as co-commanders in the deck builder.
- **Engine:** Doctor's Companion now pairs only with a commander-eligible **Time Lord Doctor** (Gatherer/WHO rules), not any creature with a `Doctor` subtype.
- **Engine:** Card lookup accepts names without a leading article (`Eleventh Doctor` → `The Eleventh Doctor`) so imports and deck lists still resolve and pair correctly.
- **Deck builder:** `handleSetCommander` awaits `ensureCardDatabase()` before `commanderPartnerCandidates`, avoiding a silent swap when card-data is not loaded yet.

Amy Pond and The Eleventh Doctor are separate cards that pair via Doctor's Companion (not a DFC). PR #1410 already routed pairing through the engine; this change hardens matching, name resolution, and load timing.

## Test plan

- [ ] `cargo test -p engine amy_pond`
- [ ] `cargo test -p engine doctors_companion_rejects`
- [ ] `cargo test -p engine name_lookup_resolves_card_names_without`
- [ ] Deck builder (Commander): add Amy Pond and The Eleventh Doctor to main, crown Amy, then crown the Doctor — both appear as commanders (no swap)
- [ ] Import or paste a list using `Eleventh Doctor` (no `The`) — pairing and commander eligibility still work
- [ ] `Invalid partner pairing` does not appear for Amy + Eleventh Doctor in compatibility check