### PR TITLE
fix(engine): fire ETB triggers and grant summoning sickness for conjured permanents (CR 603.6a)

### DIFF
--- a/crates/engine/src/game/effects/conjure.rs
+++ b/crates/engine/src/game/effects/conjure.rs
@@ -81,8 +81,8 @@ pub fn resolve(
                 // conjured object (escalates to Full if it sources effects/etc.).
                 crate::game::layers::mark_layers_entered(state, obj_id);
 
-                // CR 111.1 + CR 603.6a: Conjuring places a card from outside the
-                // game directly onto the battlefield — a zone change from `None`.
+                // CR 603.6a: Conjuring places a card from outside the game
+                // directly onto the battlefield — a zone change from `None`.
                 // Emit `ZoneChanged { from: None, to: Battlefield }` (in addition to
                 // `ObjectConjured`, which animation/logging consumers still read) so
                 // every enters-the-battlefield triggered ability fires through the
@@ -95,6 +95,9 @@ pub fn resolve(
                     .get(&obj_id)
                     .expect("conjured object was just created")
                     .snapshot_for_zone_change(obj_id, None, Zone::Battlefield);
+                state
+                    .zone_changes_this_turn
+                    .push(zone_change_record.clone());
                 events.push(GameEvent::ZoneChanged {
                     object_id: obj_id,
                     from: None,
@@ -116,4 +119,53 @@ pub fn resolve(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ability::{ConjureCard, QuantityExpr};
+    use crate::types::identifiers::ObjectId;
+    use crate::types::player::PlayerId;
+
+    #[test]
+    fn battlefield_conjure_records_zone_change_for_turn_history() {
+        let mut state = GameState::new_two_player(7);
+        let ability = ResolvedAbility::new(
+            Effect::Conjure {
+                cards: vec![ConjureCard {
+                    name: "Verdant Dread".to_string(),
+                    count: QuantityExpr::Fixed { value: 1 },
+                }],
+                destination: Zone::Battlefield,
+                tapped: false,
+            },
+            vec![],
+            ObjectId(99),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let zone_change = events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged {
+                    object_id,
+                    from,
+                    to,
+                    ..
+                } => Some((*object_id, *from, *to)),
+                _ => None,
+            })
+            .expect("conjuring onto the battlefield emits ZoneChanged");
+
+        assert_eq!(zone_change.1, None);
+        assert_eq!(zone_change.2, Zone::Battlefield);
+        assert_eq!(state.zone_changes_this_turn.len(), 1);
+        assert_eq!(state.zone_changes_this_turn[0].object_id, zone_change.0);
+        assert_eq!(state.zone_changes_this_turn[0].from_zone, None);
+        assert_eq!(state.zone_changes_this_turn[0].to_zone, Zone::Battlefield);
+    }
 }

--- a/crates/engine/src/game/effects/conjure.rs
+++ b/crates/engine/src/game/effects/conjure.rs
@@ -56,9 +56,21 @@ pub fn resolve(
                     apply_card_face_to_object(obj, face);
                 }
 
-                // Apply tapped state for "onto the battlefield tapped" patterns.
-                if tapped && destination == Zone::Battlefield {
-                    obj.tapped = true;
+                if destination == Zone::Battlefield {
+                    // CR 302.6: A creature entering the battlefield has summoning
+                    // sickness unless its controller has controlled it continuously
+                    // since their most recent turn began. A conjured permanent is a
+                    // brand-new object, so it must run the same entry reset (summoning
+                    // sickness, marked damage, per-turn activation flags) as any other
+                    // battlefield entry — otherwise a conjured creature could attack or
+                    // tap for {T} costs the turn it appears. Delegate to the single
+                    // authority rather than setting flags ad hoc.
+                    obj.reset_for_battlefield_entry(state.turn_number);
+
+                    // Apply tapped state for "onto the battlefield tapped" patterns.
+                    if tapped {
+                        obj.tapped = true;
+                    }
                 }
             }
 
@@ -68,6 +80,27 @@ pub fn resolve(
                 // Battlefield entry: incremental re-derive candidate for this
                 // conjured object (escalates to Full if it sources effects/etc.).
                 crate::game::layers::mark_layers_entered(state, obj_id);
+
+                // CR 111.1 + CR 603.6a: Conjuring places a card from outside the
+                // game directly onto the battlefield — a zone change from `None`.
+                // Emit `ZoneChanged { from: None, to: Battlefield }` (in addition to
+                // `ObjectConjured`, which animation/logging consumers still read) so
+                // every enters-the-battlefield triggered ability fires through the
+                // same matcher path used for normal entries and token creation
+                // (e.g. Verdant Dread's "another Verdant Dread enters" manifest-dread
+                // trigger, Soul Warden, Panharmonicon). Without this the conjured
+                // permanent enters silently and no ETB ability ever triggers.
+                let zone_change_record = state
+                    .objects
+                    .get(&obj_id)
+                    .expect("conjured object was just created")
+                    .snapshot_for_zone_change(obj_id, None, Zone::Battlefield);
+                events.push(GameEvent::ZoneChanged {
+                    object_id: obj_id,
+                    from: None,
+                    to: Zone::Battlefield,
+                    record: Box::new(zone_change_record),
+                });
             }
 
             events.push(GameEvent::ObjectConjured {


### PR DESCRIPTION
Fixes #1756.

## Summary
`Effect::Conjure` placed a card onto the battlefield via `create_object` plus a bespoke `ObjectConjured` event only. It emitted **no `ZoneChanged`** event — and the ETB trigger matcher (`trigger_matchers.rs::match_changes_zone`) keys exclusively on `ZoneChanged` — so **no enters-the-battlefield triggered ability ever fired** for a conjured permanent. It also never called `reset_for_battlefield_entry`, so a conjured creature had **no summoning sickness** and could attack or pay `{T}` costs the turn it appeared (CR 302.6).

## Fix
Mirror the token-entry path (`effects/token.rs`) for battlefield destinations:
- Call `obj.reset_for_battlefield_entry(state.turn_number)` before applying the `tapped` state (single authority for summoning sickness + per-turn entry flags — CR 302.6).
- After the entry bookkeeping, build a `snapshot_for_zone_change(obj_id, None, Zone::Battlefield)` record and push `GameEvent::ZoneChanged { from: None, to: Battlefield, .. }` **in addition to** `ObjectConjured` (kept for animation/logging) so every ETB triggered ability fires through the same matcher path as normal entries and token creation (CR 603.6a / CR 111.1).

Non-battlefield conjure destinations keep their current behavior (out of CR 603.6a scope), and richer entry-replacement specs beyond `tapped` remain a separate parser-level concern.

## Real-card impact
Verdant Dread's "another Verdant Dread enters → manifest dread" now fires when it conjures one; board-wide ETB watchers (Soul Warden, Panharmonicon, etc.) now see conjured permanents; conjured creatures now have summoning sickness.

## Verification
`cargo clippy -p engine` clean; full engine suite green (9580 unit + 573 integration + 1, **0 failed**); targeted `conjure` / `manifest_dread` tests pass. The fix is isolated to `crates/engine/src/game/effects/conjure.rs`.