### PR TITLE
fix(parser): compose enters-tapped with as-enters color choice

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -7183,6 +7183,49 @@ mod tests {
         );
     }
 
+    /// Issue #1581 — Thriving land cycle. "This land enters tapped. As it
+    /// enters, choose a color other than green." must ENTER TAPPED in addition
+    /// to prompting for the colour. Drives the real PlayLand → ETB replacement
+    /// pipeline (synthesis via `from_oracle_text`) and asserts the land is
+    /// tapped on the battlefield.
+    #[test]
+    fn thriving_grove_enters_tapped_with_color_choice() {
+        use crate::game::scenario::{GameScenario, P0};
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let grove = scenario
+            .add_land_to_hand(P0, "Thriving Grove")
+            .from_oracle_text(
+                "This land enters tapped. As it enters, choose a color other than green.",
+            )
+            .id();
+        let mut runner = scenario.build();
+        {
+            let state = runner.state_mut();
+            state.active_player = PlayerId(0);
+            state.priority_player = PlayerId(0);
+        }
+        let card_id = runner.state().objects[&grove].card_id;
+
+        runner
+            .act(GameAction::PlayLand {
+                object_id: grove,
+                card_id,
+            })
+            .unwrap();
+
+        assert!(
+            runner.state().battlefield.contains(&grove),
+            "Thriving Grove must be on the battlefield after PlayLand"
+        );
+        assert!(
+            runner.state().objects[&grove].tapped,
+            "issue #1581: Thriving Grove must ENTER TAPPED (enter_tapped replacement \
+             applied), not just resolve the colour choice"
+        );
+    }
+
     #[test]
     fn apply_play_land_rejects_non_main_phase() {
         let mut state = setup_game_at_main_phase();

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -7183,11 +7183,11 @@ mod tests {
         );
     }
 
-    /// Issue #1581 — Thriving land cycle. "This land enters tapped. As it
-    /// enters, choose a color other than green." must ENTER TAPPED in addition
-    /// to prompting for the colour. Drives the real PlayLand → ETB replacement
-    /// pipeline (synthesis via `from_oracle_text`) and asserts the land is
-    /// tapped on the battlefield.
+    /// CR 614.1c + CR 614.1d: Thriving land text ("This land enters tapped. As
+    /// it enters, choose a color other than green.") must ENTER TAPPED in
+    /// addition to prompting for the colour. Drives the real PlayLand → ETB
+    /// replacement pipeline (synthesis via `from_oracle_text`) and asserts the
+    /// land is tapped on the battlefield.
     #[test]
     fn thriving_grove_enters_tapped_with_color_choice() {
         use crate::game::scenario::{GameScenario, P0};

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -977,17 +977,20 @@ fn parse_shock_land(norm_lower: &str, original_text: &str) -> Option<Replacement
 /// Parse "As ~ enters, choose a [type]" into a Moved replacement with persisted Choose.
 /// Skips lines that also contain shock land markers (handled by parse_shock_land).
 fn parse_as_enters_choose(norm_lower: &str, original_text: &str) -> Option<ReplacementDefinition> {
+    let has_phrase = |phrase: &'static str| {
+        nom_primitives::scan_at_word_boundaries(norm_lower, |input| {
+            tag::<_, _, OracleError<'_>>(phrase).parse(input)
+        })
+        .is_some()
+    };
+
     // Must have "as" + "enters" framing
-    if !nom_primitives::scan_contains(norm_lower, "as")
-        || !nom_primitives::scan_contains(norm_lower, "enters")
-    {
+    if !has_phrase("as ") || !has_phrase("enters") {
         return None;
     }
 
     // Don't match shock lands — they have their own handler
-    if nom_primitives::scan_contains(norm_lower, "you may pay")
-        && nom_primitives::scan_contains(norm_lower, "life")
-    {
+    if has_phrase("you may pay") && has_phrase("life") {
         return None;
     }
 
@@ -1016,10 +1019,10 @@ fn parse_as_enters_choose(norm_lower: &str, original_text: &str) -> Option<Repla
     // already resolves for Vesuva's "enter tapped as a copy"
     // (`Tap { SelfRef }` -> `sub_ability(BecomeCopy)`). The modifier must come
     // first so `EventModifiers` accumulates the tap before reaching the choice.
-    let enters_tapped = (nom_primitives::scan_contains(norm_lower, "enters tapped")
-        || nom_primitives::scan_contains(norm_lower, "enters the battlefield tapped"))
-        && !nom_primitives::scan_contains(norm_lower, "unless")
-        && !nom_primitives::scan_contains(norm_lower, "if you control");
+    let enters_tapped = (has_phrase("enters tapped")
+        || has_phrase("enters the battlefield tapped"))
+        && !has_phrase("unless")
+        && !has_phrase("if you control");
 
     let execute = if enters_tapped {
         AbilityDefinition::new(
@@ -6869,9 +6872,9 @@ mod tests {
 
     #[test]
     fn enters_tapped_then_choose_color_composes_tap_and_choice() {
-        // Issue #1581 — Thriving land cycle. "This land enters tapped. As it
-        // enters, choose a color other than green." must compose BOTH the
-        // enters-tapped modifier AND the colour choice into one Moved
+        // CR 614.1c + CR 614.1d: Thriving land text ("This land enters
+        // tapped. As it enters, choose a color other than green.") must compose
+        // BOTH the enters-tapped modifier AND the colour choice into one Moved
         // replacement: Tap { SelfRef } (modifier) -> sub_ability(Choose).
         let def = parse_replacement_line(
             "This land enters tapped. As it enters, choose a color other than green.",

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -997,15 +997,45 @@ fn parse_as_enters_choose(norm_lower: &str, original_text: &str) -> Option<Repla
     })?;
     let choice_type = try_parse_named_choice(choose_text)?;
 
+    let choose = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Choose {
+            choice_type,
+            persist: true,
+        },
+    );
+
+    // CR 614.1c + CR 614.1d: The Thriving land cycle ("This land enters tapped.
+    // As it enters, choose a color other than <C>.") layers TWO replacement
+    // effects on the same entry event — the enters-tapped modifier AND the
+    // choice. This handler is dispatched BEFORE the unconditional enters-tapped
+    // guard and returns early, so without composing here the tap is silently
+    // dropped (issue #1581). Compose them into one Moved replacement:
+    // `Tap { SelfRef }` (the enter_tapped event-modifier) followed by the
+    // `Choose` as post-replacement "real work" — exactly the shape the engine
+    // already resolves for Vesuva's "enter tapped as a copy"
+    // (`Tap { SelfRef }` -> `sub_ability(BecomeCopy)`). The modifier must come
+    // first so `EventModifiers` accumulates the tap before reaching the choice.
+    let enters_tapped = (nom_primitives::scan_contains(norm_lower, "enters tapped")
+        || nom_primitives::scan_contains(norm_lower, "enters the battlefield tapped"))
+        && !nom_primitives::scan_contains(norm_lower, "unless")
+        && !nom_primitives::scan_contains(norm_lower, "if you control");
+
+    let execute = if enters_tapped {
+        AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Tap {
+                target: TargetFilter::SelfRef,
+            },
+        )
+        .sub_ability(choose)
+    } else {
+        choose
+    };
+
     Some(
         ReplacementDefinition::new(ReplacementEvent::Moved)
-            .execute(AbilityDefinition::new(
-                AbilityKind::Spell,
-                Effect::Choose {
-                    choice_type,
-                    persist: true,
-                },
-            ))
+            .execute(execute)
             .valid_card(TargetFilter::SelfRef)
             .description(original_text.to_string()),
     )
@@ -6835,6 +6865,49 @@ mod tests {
                 persist: true,
             } if excluded.is_empty()
         ));
+    }
+
+    #[test]
+    fn enters_tapped_then_choose_color_composes_tap_and_choice() {
+        // Issue #1581 — Thriving land cycle. "This land enters tapped. As it
+        // enters, choose a color other than green." must compose BOTH the
+        // enters-tapped modifier AND the colour choice into one Moved
+        // replacement: Tap { SelfRef } (modifier) -> sub_ability(Choose).
+        let def = parse_replacement_line(
+            "This land enters tapped. As it enters, choose a color other than green.",
+            "Thriving Grove",
+        )
+        .unwrap();
+        assert_eq!(def.event, ReplacementEvent::Moved);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        let execute = def.execute.as_ref().unwrap();
+        // Primary effect is the enters-tapped event modifier.
+        assert!(
+            matches!(
+                *execute.effect,
+                Effect::Tap {
+                    target: TargetFilter::SelfRef
+                }
+            ),
+            "primary effect must be Tap {{ SelfRef }} (enter_tapped modifier), got {:?}",
+            execute.effect
+        );
+        // The colour choice rides as the sub-ability "real work".
+        let sub = execute
+            .sub_ability
+            .as_ref()
+            .expect("enters-tapped choose-colour must carry the Choose as a sub-ability");
+        assert!(
+            matches!(
+                *sub.effect,
+                Effect::Choose {
+                    choice_type: ChoiceType::Color { ref excluded },
+                    persist: true,
+                } if excluded == &vec![ManaColor::Green]
+            ),
+            "sub-ability must be Choose color (excluding Green), got {:?}",
+            sub.effect
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1581

## Problem
> Thriving Grove — "This land enters tapped. As it enters, choose a color other than green."

After choosing the color, the land entered **untapped**. Affects the whole Thriving land cycle (Grove, Heath, Bluff, Isle, Moor).

## Root cause
In `parse_replacement_line_inner`, `parse_as_enters_choose` is dispatched **before** the unconditional enters-tapped guard and **returns early** with a `Choose`-only replacement. So for "…enters tapped. As it enters, choose a color…" the enters-tapped half was silently dropped.

Confirmed by contrast:
- Tranquil Cove ("…enters tapped.") → replacement effect `Tap{SelfRef}` ✓
- Thriving Grove → replacement effect `Choose` only ✗

## Fix
Both clauses modify the same entry event (CR 614.1c / 614.1d). Compose them into one `Moved` replacement:

```
Tap { SelfRef }            // enter_tapped event-modifier
  └─ sub_ability: Choose   // the colour choice (post-replacement "real work")
```

This is exactly the shape the engine already resolves for Vesuva's "enter tapped as a copy" (`Tap { SelfRef }` →  sub_ability(BecomeCopy)`): `EventModifiers` walks the chain, applies the tap to the entry event, then resolves the choice.
The modifier must come first so the walk records the tap before reaching the choice. Guarded to unconditional enters-tapped (no "unless" / "if you control"), so conditional taplands keep their dedicated handlers.

**Class fix:** all five Thriving lands.

## Tests
- **Parser:** the composed replacement is `Tap{SelfRef}` → `sub(Choose color excluding Green)`.
- **Runtime:** playing Thriving Grove through the real `PlayLand` → ETB replacement pipeline (full `from_oracle_text` synthesis) leaves it **tapped on the battlefield**.

## Verification
- Full engine suite: **9584 passed, 0 failed**.
- `cargo fmt --all --check` clean; `cargo clippy -p engine` clean.

## Scope
- Parser only: `crates/engine/src/parser/oracle_replacement.rs` + tests(`oracle_replacement.rs`, `game/engine.rs`).
- No data committed — `card-data.json` is gitignored and regenerated by CI(which now emits `Tap → Choose` for the Thriving cycle).
