### PR TITLE
fix: Thriving Grove Entering Untapped After Color Choice

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5724,7 +5724,7 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::parser::oracle::parse_oracle_text;
     use crate::types::ability::{
-        AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ControllerRef, Effect,
+        AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ChoiceType, ControllerRef, Effect,
         ManaContribution, ManaProduction, ManaSpendRestriction, QuantityExpr, ResolvedAbility,
         StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter,
     };
@@ -7180,6 +7180,65 @@ mod tests {
             "result.waiting_for={:?}, stack={:?}",
             result.waiting_for,
             state.stack
+        );
+    }
+
+    #[test]
+    fn thriving_grove_play_land_stays_tapped_after_color_choice() {
+        let mut state = setup_game_at_main_phase();
+        let grove = create_object(
+            &mut state,
+            CardId(1581),
+            PlayerId(0),
+            "Thriving Grove".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&grove).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+        }
+        apply_oracle_to_object(
+            &mut state,
+            grove,
+            "Thriving Grove",
+            "This land enters tapped. As it enters, choose a color other than green.\n{T}: Add {G} or one mana of the chosen color.",
+        );
+
+        let result = apply_as_current(
+            &mut state,
+            GameAction::PlayLand {
+                object_id: grove,
+                card_id: CardId(1581),
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(
+            result.waiting_for,
+            WaitingFor::NamedChoice {
+                choice_type: ChoiceType::Color { .. },
+                source_id: Some(id),
+                ..
+            } if id == grove
+        ));
+        assert!(
+            state.objects.get(&grove).unwrap().tapped,
+            "Thriving Grove must enter tapped before the as-enters color choice resolves"
+        );
+
+        apply_as_current(
+            &mut state,
+            GameAction::ChooseOption {
+                choice: "Red".to_string(),
+            },
+        )
+        .unwrap();
+
+        let obj = state.objects.get(&grove).unwrap();
+        assert_eq!(obj.chosen_color(), Some(ManaColor::Red));
+        assert!(
+            obj.tapped,
+            "Thriving Grove must remain tapped after choosing its color"
         );
     }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1,7 +1,10 @@
 use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while};
-use nom::combinator::{all_consuming, opt, value};
+use nom::character::complete::multispace0;
+use nom::combinator::{all_consuming, opt, recognize, value};
+use nom::multi::many1;
+use nom::sequence::{preceded, terminated};
 use nom::Parser;
 use serde::{Deserialize, Serialize};
 
@@ -182,28 +185,35 @@ fn parse_replacement_sentence_sequence(
     line: &str,
     card_name: &str,
 ) -> Option<Vec<ReplacementDefinition>> {
-    let sentences = line
-        .split(". ")
-        .map(str::trim)
-        .filter(|sentence| !sentence.is_empty())
-        .collect::<Vec<_>>();
+    // CR 614.1c: Effects that read "[This permanent] enters with ...",
+    // "As [this permanent] enters ...", or "[This permanent] enters as ..."
+    // are replacement effects.
+    // CR 614.12: Some replacement effects modify how a permanent enters the battlefield.
+    let (_, sentences) = parse_replacement_sentences(line).ok()?;
     if sentences.len() < 2 {
         return None;
     }
 
     let mut replacements = Vec::with_capacity(sentences.len());
     for sentence in sentences {
-        let sentence = if sentence.ends_with('.') {
-            sentence.to_string()
-        } else {
-            format!("{sentence}.")
-        };
         if !is_replacement_pattern(&sentence.to_lowercase()) {
             return None;
         }
-        replacements.push(parse_replacement_line(&sentence, card_name)?);
+        replacements.push(parse_replacement_line(sentence, card_name)?);
     }
     Some(replacements)
+}
+
+fn parse_replacement_sentences(input: &str) -> OracleResult<'_, Vec<&str>> {
+    all_consuming(many1(parse_replacement_sentence)).parse(input)
+}
+
+fn parse_replacement_sentence(input: &str) -> OracleResult<'_, &str> {
+    preceded(
+        multispace0,
+        recognize(terminated(take_until("."), tag("."))),
+    )
+    .parse(input)
 }
 
 // CR 100.2a / CR 903.5b: Deck-construction overrides like "A deck can have
@@ -2520,12 +2530,13 @@ pub(crate) fn parse_oracle_ir(
 
         // Priority 8: Replacement patterns
         if is_replacement_pattern(&lower) {
-            // CR 614.1c + CR 614.12: A single Oracle paragraph can contain
-            // multiple independent ETB replacement sentences, such as "This
-            // land enters tapped. As it enters, choose a color." Parse each
-            // replacement sentence instead of letting the first successful
-            // replacement parser consume the paragraph and drop sibling ETB
-            // modifiers.
+            // CR 614.1c: Effects that read "[This permanent] enters with ...",
+            // "As [this permanent] enters ...", or "[This permanent] enters as ..."
+            // are replacement effects.
+            // CR 614.12: Some replacement effects modify how a permanent enters the battlefield.
+            // A single Oracle paragraph can contain multiple independent ETB
+            // replacement sentences. Parse each replacement sentence instead of
+            // letting the first successful parser drop sibling modifiers.
             if let Some(rep_defs) = parse_replacement_sentence_sequence(&line, card_name) {
                 result.replacements.extend(rep_defs);
                 i += 1;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -178,6 +178,34 @@ pub(crate) fn is_commander_permission_sentence(line: &str) -> bool {
     parsed
 }
 
+fn parse_replacement_sentence_sequence(
+    line: &str,
+    card_name: &str,
+) -> Option<Vec<ReplacementDefinition>> {
+    let sentences = line
+        .split(". ")
+        .map(str::trim)
+        .filter(|sentence| !sentence.is_empty())
+        .collect::<Vec<_>>();
+    if sentences.len() < 2 {
+        return None;
+    }
+
+    let mut replacements = Vec::with_capacity(sentences.len());
+    for sentence in sentences {
+        let sentence = if sentence.ends_with('.') {
+            sentence.to_string()
+        } else {
+            format!("{sentence}.")
+        };
+        if !is_replacement_pattern(&sentence.to_lowercase()) {
+            return None;
+        }
+        replacements.push(parse_replacement_line(&sentence, card_name)?);
+    }
+    Some(replacements)
+}
+
 // CR 100.2a / CR 903.5b: Deck-construction overrides like "A deck can have
 // any number of cards named X." (Tempest Hawk, Rat Colony, Relentless Rats,
 // Persistent Petitioners, Shadowborn Apostle, etc.) are deck-construction
@@ -2492,6 +2520,17 @@ pub(crate) fn parse_oracle_ir(
 
         // Priority 8: Replacement patterns
         if is_replacement_pattern(&lower) {
+            // CR 614.1c + CR 614.12: A single Oracle paragraph can contain
+            // multiple independent ETB replacement sentences, such as "This
+            // land enters tapped. As it enters, choose a color." Parse each
+            // replacement sentence instead of letting the first successful
+            // replacement parser consume the paragraph and drop sibling ETB
+            // modifiers.
+            if let Some(rep_defs) = parse_replacement_sentence_sequence(&line, card_name) {
+                result.replacements.extend(rep_defs);
+                i += 1;
+                continue;
+            }
             if let Some(rep_def) = parse_replacement_line(&line, card_name) {
                 result.replacements.push(rep_def);
                 i += 1;


### PR DESCRIPTION
## Summary

Fixes issue #1581: Thriving Grove now correctly enters the battlefield tapped and remains tapped after choosing a color.

The bug happened because the Oracle parser dropped one replacement effect when multiple replacement sentences appeared in the same paragraph:

- `This land enters tapped.`
- `As it enters, choose a color other than green.`

The parser now preserves both replacement effects instead of only applying the color-choice replacement.
## Related Issue
Closes: #1581 
## Change Type

- [x] Bug fix
- [x] Parser fix
- [x] Engine behavior fix
- [x] Regression test
- [x] Rules-correct replacement effect handling
- [x] Validation / test coverage

## Real Behavior Proof

Added regression coverage for Thriving Grove.

Verified behavior:

- [x] Playing Thriving Grove prompts the player to choose a color.
- [x] Thriving Grove is tapped before the color choice resolves.
- [x] Choosing a color stores the selected color correctly.
- [x] Thriving Grove remains tapped after the color choice resolves.

Regression test:

```bash
cargo test -p engine thriving_grove_play_land_stays_tapped_after_color_choice -- --nocapture
```

Result:

```text
test result: ok
```
## Checklist
- [x] Analyzed GitHub issue #1581
- [x] Reproduced the incorrect behavior with a regression test
- [x] Found root cause in Oracle replacement parsing
- [x] Implemented a general parser fix for multiple replacement sentences
- [x] Avoided card-specific special casing
- [x] Verified MTG Comprehensive Rules references
- [x] Added regression test proving Thriving Grove stays tapped
- [x] Ran project validation commands
- [x] Confirmed the fix resolves the reported behavior