### PR TITLE
fix(engine): roll-a-die "equal to the result" reads the roll, not the trigger event (#1602)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2801,9 +2801,9 @@ pub fn resolve_ability_chain(
         // impossible.
         state.last_vote_ballots = crate::im::Vector::new();
         state.last_effect_amount = None;
-        // CR 706.2 + CR 706.4: Clear the per-resolution die-roll result at depth-0
-        // chain entry so a roll consumed by an inline sub_ability cannot leak into
-        // a later, unrelated resolution's EventContextAmount.
+        // CR 706.4: Clear the per-resolution die-roll result at depth-0 chain
+        // entry so a roll consumed by an inline sub_ability cannot leak into a
+        // later, unrelated resolution's EventContextAmount.
         state.die_result_this_resolution = None;
         state.last_effect_counts_by_player.clear();
         state.exiled_from_hand_this_resolution = 0;

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2801,6 +2801,10 @@ pub fn resolve_ability_chain(
         // impossible.
         state.last_vote_ballots = crate::im::Vector::new();
         state.last_effect_amount = None;
+        // CR 706.2 + CR 706.4: Clear the per-resolution die-roll result at depth-0
+        // chain entry so a roll consumed by an inline sub_ability cannot leak into
+        // a later, unrelated resolution's EventContextAmount.
+        state.die_result_this_resolution = None;
         state.last_effect_counts_by_player.clear();
         state.exiled_from_hand_this_resolution = 0;
         // CR 608.2e: The clause-local equalization snapshot is resolution-

--- a/crates/engine/src/game/effects/roll_die.rs
+++ b/crates/engine/src/game/effects/roll_die.rs
@@ -60,6 +60,15 @@ pub fn resolve(
         result: actual,
     });
 
+    // CR 706.2 + CR 706.4: Record the actual result so an inline "equal to the
+    // result" sub_ability (no results table) reads the roll via
+    // QuantityRef::EventContextAmount instead of the triggering event's amount.
+    // Deliberately NOT cleared at this function's exit: for `results: []` cards
+    // (Ancient Copper/Gold/Silver, Adorable Kitten) the consuming effect is the
+    // RollDie's sub_ability, resolved by the outer resolve_ability_chain at depth+1
+    // AFTER this returns. Clearing here would erase the value before it is read.
+    state.die_result_this_resolution = Some(actual);
+
     // CR 706.2: Find the matching result branch and resolve its effect.
     if let Some(branch) = results.iter().find(|b| actual >= b.min && actual <= b.max) {
         let sub = ResolvedAbility::new(
@@ -560,6 +569,111 @@ mod tests {
             state.players[0].hand.len(),
             2,
             "result ≥ 1 must not fire the guarded Discard"
+        );
+    }
+
+    /// CR 706.2 + CR 706.4: After a RollDie resolves, the actual result is
+    /// stamped into `state.die_result_this_resolution` so an inline "equal to
+    /// the result" sub_ability (no results table) reads the roll via
+    /// `QuantityRef::EventContextAmount`. The stamped value must equal the
+    /// `DieRolled` event's result.
+    #[test]
+    fn roll_die_stamps_die_result_this_resolution() {
+        let mut state = GameState::new_two_player(7);
+        let ability = ResolvedAbility::new(
+            Effect::RollDie {
+                sides: 20,
+                results: vec![],
+                modifier: None,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        let result = events
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::DieRolled { result, .. } => Some(*result),
+                _ => None,
+            })
+            .expect("DieRolled event must be present");
+        assert_eq!(
+            state.die_result_this_resolution,
+            Some(result),
+            "die_result_this_resolution must mirror the actual rolled result"
+        );
+    }
+
+    /// CR 706.2 + CR 706.4 (issue #1602, building-block guard): "roll a d20.
+    /// You create a number of Treasure tokens equal to the result." With a
+    /// triggering combat-damage event of 6 already set, the inline sub_ability
+    /// whose count is `EventContextAmount` must consume the ROLL, not the 6.
+    /// Modeled with a Draw sub_ability (count == EventContextAmount) so we can
+    /// assert exactly `result` cards were drawn.
+    #[test]
+    fn roll_die_subability_reads_roll_not_trigger_event() {
+        use crate::types::ability::{QuantityRef, TargetFilter, TargetRef};
+        let mut state = GameState::new_two_player(7);
+        // Seed enough library cards that any d20 result (≤ 20) can be drawn.
+        for i in 0..20 {
+            crate::game::zones::create_object(
+                &mut state,
+                crate::types::identifiers::CardId(4000 + i as u64),
+                PlayerId(0),
+                format!("Card {i}"),
+                crate::types::zones::Zone::Library,
+            );
+        }
+        // The triggering event carries amount 6 (combat damage). If the cascade
+        // is wrong, the sub_ability would draw 6 instead of the rolled result.
+        state.current_trigger_event = Some(GameEvent::DamageDealt {
+            source_id: ObjectId(1),
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 6,
+            is_combat: true,
+            excess: 0,
+        });
+        let draw = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        let ability = ResolvedAbility::new(
+            Effect::RollDie {
+                sides: 20,
+                results: vec![],
+                modifier: None,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        )
+        .sub_ability(draw);
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        let rolled = events
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::DieRolled { result, .. } => Some(*result as usize),
+                _ => None,
+            })
+            .expect("DieRolled event must be present");
+        assert!(
+            (1..=20).contains(&rolled),
+            "d20 result out of range: {rolled}"
+        );
+        assert_eq!(
+            state.players[0].hand.len(),
+            rolled,
+            "sub_ability must draw cards equal to the rolled result ({rolled}), not the combat damage (6)"
         );
     }
 }

--- a/crates/engine/src/game/effects/roll_die.rs
+++ b/crates/engine/src/game/effects/roll_die.rs
@@ -60,7 +60,8 @@ pub fn resolve(
         result: actual,
     });
 
-    // CR 706.2 + CR 706.4: Record the actual result so an inline "equal to the
+    // CR 706.2: The stored value is the actual die-roll result.
+    // CR 706.4: Record the actual result so an inline "equal to the
     // result" sub_ability (no results table) reads the roll via
     // QuantityRef::EventContextAmount instead of the triggering event's amount.
     // Deliberately NOT cleared at this function's exit: for `results: []` cards
@@ -572,8 +573,8 @@ mod tests {
         );
     }
 
-    /// CR 706.2 + CR 706.4: After a RollDie resolves, the actual result is
-    /// stamped into `state.die_result_this_resolution` so an inline "equal to
+    /// CR 706.2: After a RollDie resolves, the actual result is stamped into
+    /// `state.die_result_this_resolution` so an inline "equal to
     /// the result" sub_ability (no results table) reads the roll via
     /// `QuantityRef::EventContextAmount`. The stamped value must equal the
     /// `DieRolled` event's result.
@@ -606,8 +607,8 @@ mod tests {
         );
     }
 
-    /// CR 706.2 + CR 706.4 (issue #1602, building-block guard): "roll a d20.
-    /// You create a number of Treasure tokens equal to the result." With a
+    /// CR 706.4 (issue #1602, building-block guard): "roll a d20. You create a
+    /// number of Treasure tokens equal to the result." With a
     /// triggering combat-damage event of 6 already set, the inline sub_ability
     /// whose count is `EventContextAmount` must consume the ROLL, not the 6.
     /// Modeled with a Draw sub_ability (count == EventContextAmount) so we can

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -145,6 +145,7 @@ pub fn apply(
     state.last_effect_count = None;
     state.last_effect_counts_by_player.clear();
     state.exiled_from_hand_this_resolution = 0;
+    state.die_result_this_resolution = None;
     check_actor_authorization(state, actor, &action)?;
     let mut result = apply_action(state, actor, action)?;
     reconcile_terminal_result(state, &mut result);

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1610,18 +1610,27 @@ fn resolve_ref(
         //      "that many" for Ur-Dragon-style batched triggers; without it
         //      the `extract_amount_from_event` cascade below falls through to
         //      0 on `AttackersDeclared` and similar batched events.
-        //   2. `extract_amount_from_event(current_trigger_event)` — scalar
+        //   2. CR 706.2 + CR 706.4: `die_result_this_resolution` — a die rolled
+        //      earlier in THIS resolution (no results table) outranks the
+        //      triggering event's own amount, so "roll a d20. <effect> equal to
+        //      the result" consumes the roll, not the combat damage / life
+        //      change that triggered it.
+        //   3. `extract_amount_from_event(current_trigger_event)` — scalar
         //      events with an inherent amount (damage dealt, life changed,
         //      cards drawn, counters added/removed, die rolls).
-        //   3. `last_effect_counts_by_player` — APNAP per-player counts from
+        //   4. `last_effect_counts_by_player` — APNAP per-player counts from
         //      the preceding effect in the same resolution.
-        //   4. `last_effect_count` / `last_effect_amount` — sub_ability
+        //   5. `last_effect_count` / `last_effect_amount` — sub_ability
         //      continuation fallbacks (e.g. "discard up to N, then draw that
         //      many"; "dealt excess damage this way, add that much {R}").
-        //   5. `0` — undefined.
+        //   6. `0` — undefined.
         QuantityRef::EventContextAmount => state
             .current_trigger_match_count
             .map(u32_to_i32_saturating)
+            // CR 706.2 + CR 706.4: A die rolled earlier in THIS resolution outranks the
+            // triggering event's own amount, so "roll a d20. <effect> equal to the result"
+            // consumes the roll, not the combat damage / life change that triggered it.
+            .or_else(|| state.die_result_this_resolution.map(i32::from))
             .or_else(|| {
                 state
                     .current_trigger_event
@@ -7669,6 +7678,66 @@ mod tests {
             qty: QuantityRef::EventContextAmount,
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 7);
+    }
+
+    /// CR 706.2 + CR 706.4: A die rolled earlier in the resolution outranks the
+    /// triggering event's intrinsic amount, so "roll a d20. <effect> equal to
+    /// the result" consumes the roll (17), not the combat damage (6). This is
+    /// the building-block guard for Ancient Copper/Gold/Silver Dragon and
+    /// Adorable Kitten (issue #1602).
+    #[test]
+    fn resolve_event_context_amount_prefers_die_result_over_event() {
+        let mut state = GameState::new_two_player(42);
+        state.die_result_this_resolution = Some(17);
+        state.current_trigger_event = Some(crate::types::events::GameEvent::DamageDealt {
+            source_id: ObjectId(1),
+            target: TargetRef::Player(PlayerId(0)),
+            amount: 6,
+            is_combat: true,
+            excess: 0,
+        });
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::EventContextAmount,
+        };
+        assert_eq!(
+            resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)),
+            17
+        );
+    }
+
+    /// CR 706.2 + CR 706.4: With no die rolled this resolution, the cascade
+    /// falls through to the triggering event's amount as before — the new slot
+    /// must not regress event-extracted resolution.
+    #[test]
+    fn resolve_event_context_amount_falls_through_when_no_die_result() {
+        let mut state = GameState::new_two_player(42);
+        state.die_result_this_resolution = None;
+        state.current_trigger_event = Some(crate::types::events::GameEvent::DamageDealt {
+            source_id: ObjectId(1),
+            target: TargetRef::Player(PlayerId(0)),
+            amount: 6,
+            is_combat: true,
+            excess: 0,
+        });
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::EventContextAmount,
+        };
+        assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 6);
+    }
+
+    /// CR 603.2c + CR 706.2: The batched-trigger match-count still outranks a
+    /// die result — the die slot is inserted BELOW match-count in the cascade,
+    /// so a "one or more <FILTER>" batched trigger keeps its filtered-subject
+    /// "that many" semantics even when a die was rolled this resolution.
+    #[test]
+    fn resolve_event_context_amount_match_count_outranks_die_result() {
+        let mut state = GameState::new_two_player(42);
+        state.current_trigger_match_count = Some(3);
+        state.die_result_this_resolution = Some(17);
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::EventContextAmount,
+        };
+        assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 3);
     }
 
     #[test]

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1610,7 +1610,7 @@ fn resolve_ref(
         //      "that many" for Ur-Dragon-style batched triggers; without it
         //      the `extract_amount_from_event` cascade below falls through to
         //      0 on `AttackersDeclared` and similar batched events.
-        //   2. CR 706.2 + CR 706.4: `die_result_this_resolution` — a die rolled
+        //   2. CR 706.4: `die_result_this_resolution` — a die rolled
         //      earlier in THIS resolution (no results table) outranks the
         //      triggering event's own amount, so "roll a d20. <effect> equal to
         //      the result" consumes the roll, not the combat damage / life
@@ -1627,7 +1627,7 @@ fn resolve_ref(
         QuantityRef::EventContextAmount => state
             .current_trigger_match_count
             .map(u32_to_i32_saturating)
-            // CR 706.2 + CR 706.4: A die rolled earlier in THIS resolution outranks the
+            // CR 706.4: A die rolled earlier in THIS resolution outranks the
             // triggering event's own amount, so "roll a d20. <effect> equal to the result"
             // consumes the roll, not the combat damage / life change that triggered it.
             .or_else(|| state.die_result_this_resolution.map(i32::from))
@@ -7680,7 +7680,7 @@ mod tests {
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 7);
     }
 
-    /// CR 706.2 + CR 706.4: A die rolled earlier in the resolution outranks the
+    /// CR 706.4: A die rolled earlier in the resolution outranks the
     /// triggering event's intrinsic amount, so "roll a d20. <effect> equal to
     /// the result" consumes the roll (17), not the combat damage (6). This is
     /// the building-block guard for Ancient Copper/Gold/Silver Dragon and
@@ -7705,7 +7705,7 @@ mod tests {
         );
     }
 
-    /// CR 706.2 + CR 706.4: With no die rolled this resolution, the cascade
+    /// CR 706.4: With no die rolled this resolution, the cascade
     /// falls through to the triggering event's amount as before — the new slot
     /// must not regress event-extracted resolution.
     #[test]

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4716,6 +4716,19 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_effect_amount: Option<i32>,
 
+    /// CR 706.2 + CR 706.4: The actual result (natural + modifiers, clamped at 0)
+    /// of the most recent die roll within the current ability resolution. Set by
+    /// `roll_die::resolve` immediately after emitting `GameEvent::DieRolled`, read by
+    /// `QuantityRef::EventContextAmount` so an inline "equal to the result" sub_ability
+    /// (CR 706.4 — no results table) consumes the rolled value rather than the
+    /// numeric amount of the triggering event (e.g. combat damage). Resolution-scoped:
+    /// cleared at `apply()` entry and at every depth-0 chain entry, so it is `Some`
+    /// only between the roll and the sub_ability that reads it. Follows the
+    /// `last_effect_amount` PartialEq-OMISSION pattern: NOT compared in the
+    /// hand-written `PartialEq` (safe — always cleared at comparison boundaries).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub die_result_this_resolution: Option<u8>,
+
     /// Count from the most recent interactive effect resolution (e.g., number of cards
     /// actually discarded in a DiscardChoice). Used as fallback for EventContextAmount
     /// in sub_ability continuations where current_trigger_event has no amount.
@@ -5200,6 +5213,7 @@ impl GameState {
             last_vote_ballots: im::Vector::new(),
             player_actions_this_way: HashSet::new(),
             last_effect_amount: None,
+            die_result_this_resolution: None,
             last_effect_count: None,
             last_effect_counts_by_player: HashMap::new(),
             clause_minimum_snapshot: None,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4716,8 +4716,8 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_effect_amount: Option<i32>,
 
-    /// CR 706.2 + CR 706.4: The actual result (natural + modifiers, clamped at 0)
-    /// of the most recent die roll within the current ability resolution. Set by
+    /// CR 706.2: The actual result (natural + modifiers, clamped at 0) of the
+    /// most recent die roll within the current ability resolution. Set by
     /// `roll_die::resolve` immediately after emitting `GameEvent::DieRolled`, read by
     /// `QuantityRef::EventContextAmount` so an inline "equal to the result" sub_ability
     /// (CR 706.4 — no results table) consumes the rolled value rather than the

--- a/crates/engine/tests/integration/ancient_copper_dragon_roll_d20.rs
+++ b/crates/engine/tests/integration/ancient_copper_dragon_roll_d20.rs
@@ -1,0 +1,88 @@
+//! Reproduction for issue #1602 — Ancient Dragons' combat-damage roll triggers.
+//!
+//! Oracle (Ancient Copper Dragon):
+//! > Flying
+//! > Whenever this creature deals combat damage to a player, roll a d20. You
+//! > create a number of Treasure tokens equal to the result.
+//!
+//! The report: the trigger appears not to fire / no tokens are created. This
+//! test drives real combat (unblocked 6/5 flyer → 6 combat damage to P1) and
+//! then resolves the resulting roll-a-d20 trigger, asserting the controller
+//! ends up with a number of Treasure tokens equal to the d20 result (1..=20),
+//! NOT equal to the combat damage dealt.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+use super::rules::run_combat;
+
+const ANCIENT_COPPER_DRAGON_ORACLE: &str = "Flying\nWhenever this creature deals combat damage \
+to a player, roll a d20. You create a number of Treasure tokens equal to the result.";
+
+fn treasure_count(runner: &GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .battlefield
+        .iter()
+        .filter_map(|id| runner.state().objects.get(id))
+        .filter(|obj| obj.owner == player)
+        .filter(|obj| obj.name.eq_ignore_ascii_case("Treasure"))
+        .count()
+}
+
+#[test]
+fn ancient_copper_dragon_creates_treasures_equal_to_d20_result() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let dragon = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Ancient Copper Dragon",
+            6,
+            5,
+            ANCIENT_COPPER_DRAGON_ORACLE,
+        )
+        .id();
+    let mut runner = scenario.build();
+
+    // Unblocked flyer → 6 combat damage to P1.
+    run_combat(&mut runner, vec![dragon], vec![]);
+
+    // Resolve the roll-a-d20 trigger sitting on the stack, collecting the
+    // emitted events so we can read the actual d20 result.
+    let mut all_events: Vec<GameEvent> = Vec::new();
+    for _ in 0..30 {
+        if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+            match runner.act(GameAction::PassPriority) {
+                Ok(result) => all_events.extend(result.events),
+                Err(_) => break,
+            }
+        } else {
+            break;
+        }
+    }
+
+    let rolled = all_events.iter().find_map(|e| match e {
+        GameEvent::DieRolled {
+            result, sides: 20, ..
+        } => Some(*result as usize),
+        _ => None,
+    });
+
+    let treasures = treasure_count(&runner, P0);
+    eprintln!("d20 roll = {rolled:?}, treasures created = {treasures}");
+
+    let rolled = rolled.expect("Ancient Copper Dragon should roll a d20 on combat damage");
+    assert!(
+        (1..=20).contains(&rolled),
+        "d20 result out of range: {rolled}"
+    );
+    assert_eq!(
+        treasures, rolled,
+        "should create Treasures equal to the d20 result ({rolled}), not the combat damage (6)"
+    );
+}

--- a/crates/engine/tests/integration/ancient_copper_dragon_roll_d20.rs
+++ b/crates/engine/tests/integration/ancient_copper_dragon_roll_d20.rs
@@ -29,7 +29,7 @@ fn treasure_count(runner: &GameRunner, player: PlayerId) -> usize {
         .battlefield
         .iter()
         .filter_map(|id| runner.state().objects.get(id))
-        .filter(|obj| obj.owner == player)
+        .filter(|obj| obj.controller == player)
         .filter(|obj| obj.name.eq_ignore_ascii_case("Treasure"))
         .count()
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -5,6 +5,7 @@ mod advanced_reconstruction_regression;
 mod ajani_nacatl_pariah_transform;
 mod amphin_mutineer_regression;
 mod anaphoric_scope_allowlist_guard;
+mod ancient_copper_dragon_roll_d20;
 mod armored_kincaller_or_condition;
 mod ashaya_nontoken_lands;
 mod aura_on_player;


### PR DESCRIPTION
## Summary
Fixes #1602. The CLB Ancient Dragon cycle and similar cards ("roll a d20, [effect] equal to the result") created a quantity equal to the **triggering event's amount** (combat damage = the creature's power) instead of the **rolled result**. For Ancient Copper Dragon the failing repro showed a d20 roll of 17 producing only 6 Treasures.

**Root cause:** the `QuantityRef::EventContextAmount` resolution cascade read `extract_amount_from_event(current_trigger_event)` — still the combat-damage event for a "deals combat damage, roll a d20" trigger — *ahead of* the rolled value. The d20 was computed correctly but out-ranked in the cascade.

**Fix:** record the actual die result in a resolution-scoped `GameState::die_result_this_resolution` (`Option<u8>`, stamped by `roll_die::resolve` right after emitting `GameEvent::DieRolled`) and insert it into the `EventContextAmount` cascade just below `current_trigger_match_count` and above the triggering-event amount. The field is cleared at `apply()` entry and at depth-0 chain entry (mirroring `last_effect_amount`'s lifecycle) and is omitted from the hand-written `PartialEq` (always `None` at comparison boundaries, so AI-search/replay determinism is unaffected).

This fixes the whole **class** — "roll a die with no results table → inline sub_ability effect *equal to the result*" — not a single card: **Ancient Copper / Gold / Silver Dragon, Adorable Kitten**, and future printings of the shape.

## Out of scope (follow-up)
**Ancient Brass & Ancient Bronze Dragon** are intentionally **not** fixed here. They use reflexive "when you do … where X is the result" triggers that round-trip the stack, plus separate parser gaps (Bronze's count parses as `Variable("the result")`; Brass's "creature cards with total mana value X or less from graveyards" target filter is dropped at the parser). They need their own parser + reflexive-result-plumbing change and are tracked as follow-up. No test was added for them (a test would pin currently-broken behavior).

## Files changed
- `crates/engine/src/types/game_state.rs` — new `die_result_this_resolution: Option<u8>` field + constructor init (omitted from `PartialEq`)
- `crates/engine/src/game/effects/roll_die.rs` — stamp the actual result after `DieRolled`; unit tests
- `crates/engine/src/game/quantity.rs` — new `EventContextAmount` cascade slot; precedence unit tests
- `crates/engine/src/game/engine.rs`, `crates/engine/src/game/effects/mod.rs` — clear the field at the two resolution boundaries
- `crates/engine/tests/integration/ancient_copper_dragon_roll_d20.rs` (+ `main.rs`) — combat-driven regression test

## CR references
- CR 706.2 — after modifiers, the final number is the *result* of the die roll
- CR 706.4 — abilities with no results table indicate how to use the result

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine --all-targets` — clean
- `cargo test -p engine --lib` — 9583 passed / 0 failed
- `cargo test -p engine --test integration` — 574 passed / 0 failed
- Repro `ancient_copper_dragon_roll_d20.rs` — was 6 (fail), now d20=17 → 17 Treasures (pass); independently confirmed discriminating (reverting only the cascade slot reproduces the 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)