### PR TITLE
fix(client): flush buffered P2P messages through the recvQueue

### DIFF
--- a/client/src/network/__tests__/peer.test.ts
+++ b/client/src/network/__tests__/peer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 
 import { createPeerSession } from "../peer";
 import { validateMessage } from "../protocol";
+import type { P2PMessage } from "../protocol";
 import { FakeDataConnection } from "./fakeDataConnection";
 
 function createTestSession(opts?: { onSessionEnd?: () => void }) {
@@ -10,6 +11,10 @@ function createTestSession(opts?: { onSessionEnd?: () => void }) {
   const session = createPeerSession(conn as never, opts);
   return { conn, session };
 }
+
+// Drain all pending microtasks/timers so the recvQueue-chained pending-message
+// flush (scheduled by onMessage) has run.
+const flushAsync = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 describe("P2P Protocol - validateMessage", () => {
   it("accepts valid P2P message types", () => {
@@ -100,9 +105,56 @@ describe("PeerSession", () => {
 
     const handler = vi.fn();
     session.onMessage(handler);
+    await flushAsync();
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith(actionMessage);
+    session.close();
+  });
+
+  it("awaits async pending handlers and dispatches buffered messages before later inbound ones", async () => {
+    const { conn, session } = createTestSession();
+    const order: string[] = [];
+
+    const buffered = {
+      type: "action" as const,
+      senderPlayerId: 0,
+      action: { type: "PassPriority" as const },
+    };
+    // Buffered before any handler is attached.
+    await conn.simulateData(buffered);
+
+    const handler = vi.fn(async (m: P2PMessage) => {
+      await Promise.resolve();
+      order.push(m.type);
+    });
+    session.onMessage(handler);
+    await flushAsync();
+    // A later inbound message must be dispatched only after the buffered one.
+    await conn.simulateData({ type: "concede" });
+
+    expect(order).toEqual(["action", "concede"]);
+    session.close();
+  });
+
+  it("keeps the session alive when a pending-message handler throws", async () => {
+    const { conn, session } = createTestSession();
+    await conn.simulateData({ type: "concede" });
+
+    const received: string[] = [];
+    const handler = vi.fn((m: P2PMessage) => {
+      received.push(m.type);
+      if (received.length === 1) {
+        throw new Error("boom on first pending message");
+      }
+    });
+    session.onMessage(handler);
+    await flushAsync();
+    // The thrown pending handler must not poison recvQueue: later inbound
+    // messages still reach the handler.
+    await conn.simulateData({ type: "concede" });
+
+    expect(received).toEqual(["concede", "concede"]);
     session.close();
   });
 

--- a/client/src/network/peer.ts
+++ b/client/src/network/peer.ts
@@ -267,15 +267,17 @@ export function createPeerSession(
         //    already queued on recvQueue;
         //  - a throwing/rejecting handler is caught here instead of dropping an
         //    unhandled rejection or breaking the chain (matches onData).
-        recvQueue = recvQueue.then(async () => {
-          for (const msg of queued) {
-            try {
-              await handler(msg);
-            } catch (e) {
-              console.warn("[PeerSession] pending message handler threw:", e, msg.type);
+        recvQueue = recvQueue
+          .catch(() => {})
+          .then(async () => {
+            for (const msg of queued) {
+              try {
+                await handler(msg);
+              } catch (e) {
+                console.warn("[PeerSession] pending message handler threw:", e, msg.type);
+              }
             }
-          }
-        });
+          });
       }
 
       return () => {

--- a/client/src/network/peer.ts
+++ b/client/src/network/peer.ts
@@ -258,9 +258,24 @@ export function createPeerSession(
 
       if (pendingMessages.length > 0) {
         const queued = pendingMessages.splice(0);
-        for (const msg of queued) {
-          handler(msg);
-        }
+        // Flush buffered messages through the same serialized recvQueue used by
+        // onData, rather than dispatching them synchronously and un-awaited.
+        // That keeps three guarantees the engine relies on:
+        //  - async handlers are awaited, so a handler-triggered send completes
+        //    before the next inbound message is dispatched (ordering invariant);
+        //  - the buffered messages stay ordered relative to any inbound message
+        //    already queued on recvQueue;
+        //  - a throwing/rejecting handler is caught here instead of dropping an
+        //    unhandled rejection or breaking the chain (matches onData).
+        recvQueue = recvQueue.then(async () => {
+          for (const msg of queued) {
+            try {
+              await handler(msg);
+            } catch (e) {
+              console.warn("[PeerSession] pending message handler threw:", e, msg.type);
+            }
+          }
+        });
       }
 
       return () => {


### PR DESCRIPTION
## Summary

`PeerSession.onMessage` dispatched buffered (pre-subscribe) messages synchronously and un-awaited. For an async handler that dropped its returned promise — errors became unhandled rejections and its work could interleave with later inbound messages, breaking the ordered-dispatch invariant the `recvQueue` exists to guarantee. A throwing pending handler also escaped the per-handler `try/catch` that `onData` uses.

Route the pending flush through the same serialized `recvQueue`: `await` each handler and catch its errors, exactly like `onData`. Updates the buffer/flush test to await the now-async dispatch and adds tests for async ordering and a throwing pending handler.

Closes #1777

## LLM
Model: claude-opus-4-8
Thinking: high
