### PR TITLE
fix(engine): detach attachments when host gains protection or can't-be-attached (CR 702.16c/d, 704.5m/n)

### DIFF
--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -178,46 +178,90 @@ pub fn attach_to(
     old_target
 }
 
+/// CR 702.16c/d + CR 701.3/702.5/702.6: Why a host forbids an attachment,
+/// independent of the Enchant filter and zone. This is the single authority for
+/// the protection ("E" of DEBT) + can't-be-attached legality, shared by the
+/// attach gate (`can_attach_to_object`, applied when attaching) and the
+/// state-based-action re-check (`sba::is_valid_attachment_target`, applied
+/// continuously). Previously the attach path checked the prohibition statics but
+/// not protection, and the SBA path checked neither — so protection (or a
+/// can't-be-enchanted/equipped static) *acquired after* a legal attachment never
+/// detached the attachment (CR 702.16c/d, CR 704.5m/n).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttachIllegality {
+    /// CR 702.16c/d: the host has protection whose quality excludes this
+    /// attachment. Per CR 704.5m an illegal Aura is put into its owner's
+    /// graveyard; per CR 704.5n an illegal Equipment/Fortification becomes
+    /// unattached but stays on the battlefield.
+    Protection,
+    /// CR 701.3/702.5b/702.6e: a `CantBeAttached` (any), `CantBeEnchanted`
+    /// (Auras), or `CantBeEquipped` (Equipment) static on the host forbids it.
+    Prohibited,
+}
+
+/// CR 702.16c/d + CR 701.3: Returns `Some(reason)` when `host` forbids
+/// `attachment` via protection or a can't-be-attached static, else `None`.
+///
+/// Does NOT evaluate the Enchant filter or zone — that legality is applied by
+/// the caller (`is_valid_attachment_target` checks it for the SBA path). The
+/// checks here are purely additive prohibitions that apply equally at attach
+/// time and continuously thereafter, so routing both paths through this resolver
+/// keeps them from drifting.
+pub(crate) fn attachment_illegality(
+    state: &GameState,
+    attachment_id: ObjectId,
+    host_id: ObjectId,
+) -> Option<AttachIllegality> {
+    // CR 701.3: `CantBeAttached` blocks any attachment (Aura / Equipment /
+    // Fortification); `CantBeEnchanted` blocks Auras; `CantBeEquipped` blocks
+    // Equipment.
+    if crate::game::static_abilities::object_has_static_other(state, host_id, "CantBeAttached") {
+        return Some(AttachIllegality::Prohibited);
+    }
+    let (attacher_is_aura, attacher_is_equipment) =
+        state
+            .objects
+            .get(&attachment_id)
+            .map_or((false, false), |obj| {
+                (
+                    obj.card_types.subtypes.iter().any(|s| s == "Aura"),
+                    obj.card_types.subtypes.iter().any(|s| s == "Equipment"),
+                )
+            });
+    if attacher_is_aura
+        && crate::game::static_abilities::object_has_static_other(state, host_id, "CantBeEnchanted")
+    {
+        return Some(AttachIllegality::Prohibited);
+    }
+    if attacher_is_equipment
+        && crate::game::static_abilities::object_has_static_other(state, host_id, "CantBeEquipped")
+    {
+        return Some(AttachIllegality::Prohibited);
+    }
+
+    // CR 702.16c/d: protection by the attachment's quality (color, "from
+    // artifacts", etc.). `protection_prevents_from(host, attachment)` is the
+    // shared DEBT check — the same one targeting/damage use.
+    if let (Some(host), Some(attachment)) = (
+        state.objects.get(&host_id),
+        state.objects.get(&attachment_id),
+    ) {
+        if crate::game::keywords::protection_prevents_from(host, attachment) {
+            return Some(AttachIllegality::Protection);
+        }
+    }
+
+    None
+}
+
 pub(crate) fn can_attach_to_object(
     state: &GameState,
     attachment_id: ObjectId,
     target_id: ObjectId,
 ) -> bool {
-    // CR 701.3, CR 702.5, CR 702.6: Attachment prohibitions on the target.
-    // `CantBeAttached` blocks any attachment (Aura / Equipment / Fortification);
-    // `CantBeEnchanted` blocks Auras specifically; `CantBeEquipped` blocks Equipment.
-    // A blocked attachment is not legal for non-spell Aura entry choices.
-    if crate::game::static_abilities::object_has_static_other(state, target_id, "CantBeAttached") {
-        return false;
-    }
-    let attacher_is_aura = state
-        .objects
-        .get(&attachment_id)
-        .is_some_and(|obj| obj.card_types.subtypes.iter().any(|s| s == "Aura"));
-    let attacher_is_equipment = state
-        .objects
-        .get(&attachment_id)
-        .is_some_and(|obj| obj.card_types.subtypes.iter().any(|s| s == "Equipment"));
-    if attacher_is_aura
-        && crate::game::static_abilities::object_has_static_other(
-            state,
-            target_id,
-            "CantBeEnchanted",
-        )
-    {
-        return false;
-    }
-    if attacher_is_equipment
-        && crate::game::static_abilities::object_has_static_other(
-            state,
-            target_id,
-            "CantBeEquipped",
-        )
-    {
-        return false;
-    }
-
-    true
+    // CR 701.3 + CR 702.16c/d: a blocked attachment (prohibition static or
+    // protection) is not a legal host for an attach / non-spell Aura entry.
+    attachment_illegality(state, attachment_id, target_id).is_none()
 }
 
 /// CR 303.4 + CR 702.5: Attach an Aura to a player (Curse cycle, Faith's
@@ -344,6 +388,57 @@ mod tests {
             StaticDefinition::new(StaticMode::Other(mode_name.to_string()))
                 .affected(TargetFilter::SelfRef),
         );
+    }
+
+    #[test]
+    fn attachment_illegality_protection_blocks_aura() {
+        // CR 702.16c: a host with protection from white forbids a white Aura.
+        let mut state = setup();
+        let aura = spawn_with_subtype(&mut state, "Pacifism", "Aura");
+        {
+            let obj = state.objects.get_mut(&aura).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.color.push(crate::types::mana::ManaColor::White);
+        }
+        let creature = spawn_creature(&mut state, "Bear");
+        state.objects.get_mut(&creature).unwrap().keywords.push(
+            crate::types::keywords::Keyword::Protection(
+                crate::types::keywords::ProtectionTarget::Color(
+                    crate::types::mana::ManaColor::White,
+                ),
+            ),
+        );
+
+        assert_eq!(
+            attachment_illegality(&state, aura, creature),
+            Some(AttachIllegality::Protection)
+        );
+        assert!(!can_attach_to_object(&state, aura, creature));
+    }
+
+    #[test]
+    fn attachment_illegality_cant_be_enchanted_blocks_aura() {
+        // CR 702.5b: a `CantBeEnchanted` static forbids an Aura.
+        let mut state = setup();
+        let aura = spawn_with_subtype(&mut state, "Aura", "Aura");
+        let creature = spawn_creature(&mut state, "Bear");
+        apply_static(&mut state, creature, "CantBeEnchanted");
+
+        assert_eq!(
+            attachment_illegality(&state, aura, creature),
+            Some(AttachIllegality::Prohibited)
+        );
+        assert!(!can_attach_to_object(&state, aura, creature));
+    }
+
+    #[test]
+    fn attachment_illegality_none_for_legal_host() {
+        let mut state = setup();
+        let aura = spawn_with_subtype(&mut state, "Aura", "Aura");
+        let creature = spawn_creature(&mut state, "Bear");
+
+        assert_eq!(attachment_illegality(&state, aura, creature), None);
+        assert!(can_attach_to_object(&state, aura, creature));
     }
 
     #[test]

--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -178,29 +178,24 @@ pub fn attach_to(
     old_target
 }
 
-/// CR 702.16c/d + CR 701.3/702.5/702.6: Why a host forbids an attachment,
-/// independent of the Enchant filter and zone. This is the single authority for
-/// the protection ("E" of DEBT) + can't-be-attached legality, shared by the
-/// attach gate (`can_attach_to_object`, applied when attaching) and the
-/// state-based-action re-check (`sba::is_valid_attachment_target`, applied
-/// continuously). Previously the attach path checked the prohibition statics but
-/// not protection, and the SBA path checked neither — so protection (or a
-/// can't-be-enchanted/equipped static) *acquired after* a legal attachment never
-/// detached the attachment (CR 702.16c/d, CR 704.5m/n).
+/// Why a host forbids an attachment, independent of the Enchant filter and zone.
+/// This is the single authority for protection ("E" of DEBT) plus
+/// can't-be-attached legality, shared by attach gates and SBA re-checks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AttachIllegality {
-    /// CR 702.16c/d: the host has protection whose quality excludes this
-    /// attachment. Per CR 704.5m an illegal Aura is put into its owner's
-    /// graveyard; per CR 704.5n an illegal Equipment/Fortification becomes
-    /// unattached but stays on the battlefield.
+    /// CR 702.16c: A protected permanent or player can't be enchanted by an
+    /// Aura of the protected quality.
+    /// CR 702.16d: A protected permanent can't be equipped or fortified by an
+    /// attachment of the protected quality.
     Protection,
-    /// CR 701.3/702.5b/702.6e: a `CantBeAttached` (any), `CantBeEnchanted`
-    /// (Auras), or `CantBeEquipped` (Equipment) static on the host forbids it.
+    /// CR 303.4c: Other applicable effects can make an Aura's host illegal.
+    /// CR 701.3a: An attachment can't be attached to something it couldn't
+    /// enchant, equip, or fortify.
     Prohibited,
 }
 
-/// CR 702.16c/d + CR 701.3: Returns `Some(reason)` when `host` forbids
-/// `attachment` via protection or a can't-be-attached static, else `None`.
+/// Returns `Some(reason)` when an object host forbids `attachment` via
+/// protection or a can't-be-attached static, else `None`.
 ///
 /// Does NOT evaluate the Enchant filter or zone — that legality is applied by
 /// the caller (`is_valid_attachment_target` checks it for the SBA path). The
@@ -212,9 +207,8 @@ pub(crate) fn attachment_illegality(
     attachment_id: ObjectId,
     host_id: ObjectId,
 ) -> Option<AttachIllegality> {
-    // CR 701.3: `CantBeAttached` blocks any attachment (Aura / Equipment /
-    // Fortification); `CantBeEnchanted` blocks Auras; `CantBeEquipped` blocks
-    // Equipment.
+    // CR 701.3a: `CantBeAttached` blocks any attachment from being attached to
+    // the host.
     if crate::game::static_abilities::object_has_static_other(state, host_id, "CantBeAttached") {
         return Some(AttachIllegality::Prohibited);
     }
@@ -228,20 +222,23 @@ pub(crate) fn attachment_illegality(
                     obj.card_types.subtypes.iter().any(|s| s == "Equipment"),
                 )
             });
+    // CR 303.4c: Other applicable effects can make an Aura's host illegal.
     if attacher_is_aura
         && crate::game::static_abilities::object_has_static_other(state, host_id, "CantBeEnchanted")
     {
         return Some(AttachIllegality::Prohibited);
     }
+    // CR 701.3a: Equipment can't be attached to an object it can't equip.
     if attacher_is_equipment
         && crate::game::static_abilities::object_has_static_other(state, host_id, "CantBeEquipped")
     {
         return Some(AttachIllegality::Prohibited);
     }
 
-    // CR 702.16c/d: protection by the attachment's quality (color, "from
-    // artifacts", etc.). `protection_prevents_from(host, attachment)` is the
-    // shared DEBT check — the same one targeting/damage use.
+    // CR 702.16c: Protection from a quality prevents Auras of that quality from
+    // being attached to the protected permanent.
+    // CR 702.16d: Protection from a quality prevents Equipment or Fortifications
+    // of that quality from being attached to the protected permanent.
     if let (Some(host), Some(attachment)) = (
         state.objects.get(&host_id),
         state.objects.get(&attachment_id),
@@ -254,38 +251,71 @@ pub(crate) fn attachment_illegality(
     None
 }
 
+/// Returns `Some(reason)` when a player host forbids `attachment` via
+/// player-scoped protection, else `None`.
+pub(crate) fn player_attachment_illegality(
+    state: &GameState,
+    attachment_id: ObjectId,
+    host: PlayerId,
+) -> Option<AttachIllegality> {
+    // CR 702.16c: A player with protection can't be enchanted by an Aura of the
+    // protected quality.
+    if crate::game::static_abilities::player_protection_from(state, host, Some(attachment_id)) {
+        return Some(AttachIllegality::Protection);
+    }
+    None
+}
+
 pub(crate) fn can_attach_to_object(
     state: &GameState,
     attachment_id: ObjectId,
     target_id: ObjectId,
 ) -> bool {
-    // CR 701.3 + CR 702.16c/d: a blocked attachment (prohibition static or
-    // protection) is not a legal host for an attach / non-spell Aura entry.
+    // CR 701.3a: A blocked attachment is not a legal host for an attach effect.
     attachment_illegality(state, attachment_id, target_id).is_none()
 }
 
-/// CR 303.4 + CR 702.5: Attach an Aura to a player (Curse cycle, Faith's
-/// Fetters-class). Mirrors `attach_to`'s "detach from previous host" cleanup
-/// for Object hosts, but no host-side `attachments` list is touched (a player
-/// is not a `GameObject` and has no such field).
+pub(crate) fn can_attach_to_player(
+    state: &GameState,
+    attachment_id: ObjectId,
+    target_player: PlayerId,
+) -> bool {
+    // CR 303.4c: A player who has left the game is an illegal Aura host.
+    if !state
+        .players
+        .get(target_player.0 as usize)
+        .is_some_and(|p| !p.is_eliminated)
+    {
+        return false;
+    }
+    // CR 702.16c: Protection from a quality prevents Auras of that quality from
+    // being attached to the protected player.
+    player_attachment_illegality(state, attachment_id, target_player).is_none()
+}
+
+/// CR 303.4: Attach an Aura to a player (Curse cycle, Faith's Fetters-class).
+/// Mirrors `attach_to`'s "detach from previous host" cleanup for Object hosts,
+/// but no host-side `attachments` list is touched (a player is not a
+/// `GameObject` and has no such field).
 ///
-/// CR 301.5 + CR 303.4i: Equipment / Fortification cannot legally be attached
-/// to a player. Mirroring `attach_to`'s silent-no-op gating pattern, an
-/// illegal Aura/Equipment pairing here is a no-op rather than an error: a
-/// caller that has already validated the source (the cast pipeline, the
-/// debug spawn-attached path) sees no change in state, and a buggy caller
+/// CR 303.4i: An Aura can't enter attached to a player it can't legally
+/// enchant.
+/// CR 301.5: Equipment can't legally be attached to a player.
+/// Mirroring `attach_to`'s silent-no-op gating pattern, an illegal
+/// Aura/Equipment pairing here is a no-op rather than an error: a caller that
+/// has already validated the source sees no change in state, and a buggy caller
 /// that hasn't validated cannot drive the engine into an illegal state.
 pub fn attach_to_player(
     state: &mut GameState,
     attachment_id: ObjectId,
     target_player: PlayerId,
 ) -> Option<TargetRef> {
-    // CR 301.5: Equipment / Fortification cannot attach to a player.
+    // CR 301.5: Equipment or Fortification cannot attach to a player.
     // CR 303.4: Only Auras may have a player host. Any non-Aura attachment is
     // silently rejected here so the only paths into a `Player` `attached_to`
     // value are legitimate Aura attachments. The Equipment/Fortification check
     // is redundant given the Aura whitelist but is named explicitly so future
-    // attachment subtypes (CR 702.6 / CR 702.114) cannot slip through by
+    // attachment subtypes cannot slip through by
     // accident — the contract is "Auras only", not "anything that isn't
     // currently equipment".
     let is_aura = state
@@ -293,6 +323,9 @@ pub fn attach_to_player(
         .get(&attachment_id)
         .is_some_and(|obj| obj.card_types.subtypes.iter().any(|s| s == "Aura"));
     if !is_aura {
+        return None;
+    }
+    if !can_attach_to_player(state, attachment_id, target_player) {
         return None;
     }
 
@@ -418,7 +451,7 @@ mod tests {
 
     #[test]
     fn attachment_illegality_cant_be_enchanted_blocks_aura() {
-        // CR 702.5b: a `CantBeEnchanted` static forbids an Aura.
+        // CR 303.4c: other applicable effects can make an Aura's host illegal.
         let mut state = setup();
         let aura = spawn_with_subtype(&mut state, "Aura", "Aura");
         let creature = spawn_creature(&mut state, "Bear");
@@ -429,6 +462,32 @@ mod tests {
             Some(AttachIllegality::Prohibited)
         );
         assert!(!can_attach_to_object(&state, aura, creature));
+    }
+
+    #[test]
+    fn player_attachment_illegality_protection_blocks_aura() {
+        // CR 702.16c: a player with protection from everything can't be
+        // enchanted by an Aura.
+        let mut state = setup();
+        let aura = spawn_with_subtype(&mut state, "Curse", "Aura");
+        state.add_transient_continuous_effect(
+            aura,
+            PlayerId(0),
+            crate::types::ability::Duration::UntilEndOfTurn,
+            TargetFilter::SpecificPlayer { id: PlayerId(1) },
+            vec![crate::types::ability::ContinuousModification::AddKeyword {
+                keyword: crate::types::keywords::Keyword::Protection(
+                    crate::types::keywords::ProtectionTarget::Everything,
+                ),
+            }],
+            None,
+        );
+
+        assert_eq!(
+            player_attachment_illegality(&state, aura, PlayerId(1)),
+            Some(AttachIllegality::Protection)
+        );
+        assert!(!can_attach_to_player(&state, aura, PlayerId(1)));
     }
 
     #[test]

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -226,24 +226,29 @@ pub fn source_matches_card_type(source: &GameObject, type_name: &str) -> bool {
     use crate::types::card_type::CoreType;
 
     let core = &source.card_types.core_types;
-    match type_name {
-        "artifacts" | "artifact" => core.contains(&CoreType::Artifact),
-        "creatures" | "creature" => core.contains(&CoreType::Creature),
-        "enchantments" | "enchantment" => core.contains(&CoreType::Enchantment),
-        "instants" | "instant" => core.contains(&CoreType::Instant),
-        "sorceries" | "sorcery" => core.contains(&CoreType::Sorcery),
-        "planeswalkers" | "planeswalker" => core.contains(&CoreType::Planeswalker),
-        "lands" | "land" => core.contains(&CoreType::Land),
-        // CR 702.16a + CR 205.3m: "protection from [creature subtype]" —
-        // sources like "assassins" or "elves" are stored as CardType by the
-        // parser but must match via the creature-subtype list.
-        _ => {
-            let quality = type_name.to_ascii_lowercase();
-            source.card_types.subtypes.iter().any(|st| {
-                source_subtype_matches_protection_quality(&st.to_ascii_lowercase(), &quality)
-            })
+    for (core_type, singular, plural) in [
+        (CoreType::Artifact, "artifact", "artifacts"),
+        (CoreType::Creature, "creature", "creatures"),
+        (CoreType::Enchantment, "enchantment", "enchantments"),
+        (CoreType::Instant, "instant", "instants"),
+        (CoreType::Sorcery, "sorcery", "sorceries"),
+        (CoreType::Planeswalker, "planeswalker", "planeswalkers"),
+        (CoreType::Land, "land", "lands"),
+    ] {
+        if type_name.eq_ignore_ascii_case(singular) || type_name.eq_ignore_ascii_case(plural) {
+            return core.contains(&core_type);
         }
     }
+
+    // CR 702.16a + CR 205.3m: "protection from [creature subtype]" —
+    // sources like "assassins" or "elves" are stored as CardType by the
+    // parser but must match via the creature-subtype list.
+    let quality = type_name.to_ascii_lowercase();
+    source
+        .card_types
+        .subtypes
+        .iter()
+        .any(|st| source_subtype_matches_protection_quality(&st.to_ascii_lowercase(), &quality))
 }
 
 fn source_subtype_matches_protection_quality(source_subtype: &str, quality: &str) -> bool {
@@ -843,6 +848,24 @@ mod tests {
             .card_types
             .core_types
             .push(crate::types::card_type::CoreType::Instant);
+
+        assert!(protection_prevents_from(&protected, &source));
+    }
+
+    #[test]
+    fn protection_from_display_case_artifact_matches_artifact_source() {
+        let mut protected = make_obj();
+        protected
+            .keywords
+            .push(Keyword::Protection(ProtectionTarget::CardType(
+                "Artifact".to_string(),
+            )));
+
+        let mut source = make_obj();
+        source
+            .card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Artifact);
 
         assert!(protection_prevents_from(&protected, &source));
     }

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1314,6 +1314,16 @@ fn is_valid_attachment_target(
     let Some(target) = state.objects.get(&target_id) else {
         return false;
     };
+    // CR 702.16c/d + CR 701.3: protection acquired by the host, or a
+    // `CantBeAttached`/`CantBeEnchanted`/`CantBeEquipped` static, makes the host
+    // an illegal attachment target — the attachment must detach as an SBA even
+    // though the Enchant filter / zone below may still match. This is the "E" of
+    // DEBT for the continuously-acquired case (Mother of Runes freeing a
+    // creature from an opponent's Pacifism).
+    if crate::game::effects::attach::attachment_illegality(state, attacher_id, target_id).is_some()
+    {
+        return false;
+    }
     let enchant_filter = attacher.keywords.iter().find_map(|k| match k {
         crate::types::keywords::Keyword::Enchant(f) => Some(f),
         _ => None,
@@ -1912,6 +1922,145 @@ mod tests {
         // Equipment should still be on battlefield but unattached
         assert!(state.battlefield.contains(&equip_id));
         assert_eq!(state.objects.get(&equip_id).unwrap().attached_to, None);
+    }
+
+    #[test]
+    fn sba_aura_detaches_when_host_gains_protection() {
+        // CR 702.16c + CR 704.5m: a creature enchanted by an opponent's white
+        // Aura (Pacifism) that gains protection from white (Mother of Runes) →
+        // the Aura is put into its owner's graveyard as a state-based action.
+        let mut state = setup();
+        let creature = create_creature(&mut state, CardId(1), PlayerId(0), "Bear", 2, 2);
+        let aura = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Pacifism".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&aura).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Enchantment);
+            obj.card_types.subtypes.push("Aura".to_string());
+            obj.color.push(crate::types::mana::ManaColor::White);
+            obj.attached_to = Some(creature.into());
+        }
+        state
+            .objects
+            .get_mut(&creature)
+            .unwrap()
+            .attachments
+            .push(aura);
+        // Host gains protection from white.
+        state.objects.get_mut(&creature).unwrap().keywords.push(
+            crate::types::keywords::Keyword::Protection(
+                crate::types::keywords::ProtectionTarget::Color(
+                    crate::types::mana::ManaColor::White,
+                ),
+            ),
+        );
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        // CR 704.5m: the now-illegal Aura leaves the battlefield (to graveyard).
+        assert!(
+            !state.battlefield.contains(&aura),
+            "an Aura on a host that gained protection must detach (CR 702.16c / 704.5m)"
+        );
+    }
+
+    #[test]
+    fn sba_equipment_unattaches_when_host_gains_protection_from_artifacts() {
+        // CR 702.16d + CR 704.5n: an equipped creature that gains protection
+        // from artifacts → the Equipment unattaches but stays on the battlefield.
+        let mut state = setup();
+        let creature = create_creature(&mut state, CardId(1), PlayerId(0), "Bear", 2, 2);
+        let equip = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Sword".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&equip).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Artifact);
+            obj.card_types.subtypes.push("Equipment".to_string());
+            obj.attached_to = Some(creature.into());
+        }
+        state
+            .objects
+            .get_mut(&creature)
+            .unwrap()
+            .attachments
+            .push(equip);
+        state.objects.get_mut(&creature).unwrap().keywords.push(
+            crate::types::keywords::Keyword::Protection(
+                // `source_matches_card_type` matches the lowercase type word
+                // (the form the parser stores for "protection from artifacts").
+                crate::types::keywords::ProtectionTarget::CardType("artifact".to_string()),
+            ),
+        );
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        // CR 704.5n: Equipment stays on the battlefield, but unattached.
+        assert!(
+            state.battlefield.contains(&equip),
+            "Equipment stays on the battlefield (CR 704.5n)"
+        );
+        assert_eq!(
+            state.objects.get(&equip).unwrap().attached_to,
+            None,
+            "Equipment must unattach from a host that gained protection from artifacts"
+        );
+    }
+
+    #[test]
+    fn sba_legal_aura_stays_attached() {
+        // Regression guard: an Aura on a legal host (no protection / prohibition)
+        // is not detached by the SBA re-check.
+        let mut state = setup();
+        let creature = create_creature(&mut state, CardId(1), PlayerId(0), "Bear", 2, 2);
+        let aura = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Aura".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&aura).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Enchantment);
+            obj.card_types.subtypes.push("Aura".to_string());
+            obj.attached_to = Some(creature.into());
+        }
+        state
+            .objects
+            .get_mut(&creature)
+            .unwrap()
+            .attachments
+            .push(aura);
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            state.battlefield.contains(&aura),
+            "a legal Aura must remain attached"
+        );
+        assert_eq!(
+            state.objects.get(&aura).unwrap().attached_to,
+            Some(creature.into())
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -698,7 +698,7 @@ fn check_unattached_auras(
                     !is_valid_attachment_target(state, id, t)
                 }
                 Some(crate::game::game_object::AttachTarget::Player(pid)) => {
-                    !is_player_in_game(state, pid)
+                    !crate::game::effects::attach::can_attach_to_player(state, id, pid)
                 }
                 None => true,
             };
@@ -1265,8 +1265,8 @@ fn check_token_cease_to_exist(state: &mut GameState, any_performed: &mut bool) {
 /// Spellweaver Volute, Don't Worry About It), that zone IS the legal host
 /// zone and the battlefield default is suspended.
 ///
-/// CR 301.5 + CR 702.6: Equipment carries no `Keyword::Enchant`, so legality
-/// reduces to the printed "on the battlefield" requirement.
+/// CR 301.5: Equipment carries no `Keyword::Enchant`, so legality reduces to
+/// the printed "on the battlefield" requirement.
 fn is_valid_attachment_target(
     state: &GameState,
     attacher_id: crate::types::identifiers::ObjectId,
@@ -1278,12 +1278,12 @@ fn is_valid_attachment_target(
     let Some(target) = state.objects.get(&target_id) else {
         return false;
     };
-    // CR 702.16c/d + CR 701.3: protection acquired by the host, or a
-    // `CantBeAttached`/`CantBeEnchanted`/`CantBeEquipped` static, makes the host
-    // an illegal attachment target — the attachment must detach as an SBA even
-    // though the Enchant filter / zone below may still match. This is the "E" of
-    // DEBT for the continuously-acquired case (Mother of Runes freeing a
-    // creature from an opponent's Pacifism).
+    // CR 704.5m: An Aura attached to an illegal object is put into its owner's
+    // graveyard.
+    // CR 704.5n: Equipment attached to an illegal permanent becomes unattached.
+    // Protection acquired by the host, or a prohibition static, makes the host
+    // an illegal attachment target even though the Enchant filter / zone below
+    // may still match.
     if crate::game::effects::attach::attachment_illegality(state, attacher_id, target_id).is_some()
     {
         return false;
@@ -1337,16 +1337,6 @@ fn explicit_enchant_zones(filter: &crate::types::ability::TargetFilter) -> Vec<Z
         TargetFilter::Not { filter } => explicit_enchant_zones(filter),
         _ => vec![],
     }
-}
-
-/// CR 303.4c: A player has "left the game" when they are eliminated. Multiplayer
-/// exits flip the same flag (CR 800.4a). Out-of-range PlayerIds (defensive) are
-/// treated as not in game so the Aura SBA cleans up the dangling reference.
-fn is_player_in_game(state: &GameState, player_id: crate::types::player::PlayerId) -> bool {
-    state
-        .players
-        .get(player_id.0 as usize)
-        .is_some_and(|p| !p.is_eliminated)
 }
 
 /// CR 704.5t: If a player's venture marker is on the bottommost room of a dungeon card,
@@ -1890,9 +1880,10 @@ mod tests {
 
     #[test]
     fn sba_aura_detaches_when_host_gains_protection() {
-        // CR 702.16c + CR 704.5m: a creature enchanted by an opponent's white
+        // CR 702.16c: a creature enchanted by an opponent's white
         // Aura (Pacifism) that gains protection from white (Mother of Runes) →
         // the Aura is put into its owner's graveyard as a state-based action.
+        // CR 704.5m: An illegal Aura is put into its owner's graveyard.
         let mut state = setup();
         let creature = create_creature(&mut state, CardId(1), PlayerId(0), "Bear", 2, 2);
         let aura = create_object(
@@ -1929,17 +1920,64 @@ mod tests {
         let mut events = Vec::new();
         check_state_based_actions(&mut state, &mut events);
 
-        // CR 704.5m: the now-illegal Aura leaves the battlefield (to graveyard).
+        // CR 704.5m: the now-illegal Aura goes to its owner's graveyard.
         assert!(
             !state.battlefield.contains(&aura),
-            "an Aura on a host that gained protection must detach (CR 702.16c / 704.5m)"
+            "an Aura on a host that gained protection must detach"
+        );
+        assert!(
+            state.players[1].graveyard.contains(&aura),
+            "the illegal Aura must move to its owner's graveyard"
         );
     }
 
     #[test]
+    fn sba_player_aura_detaches_when_player_gains_protection() {
+        // CR 702.16c: a player with protection from everything can't be
+        // enchanted by an Aura.
+        // CR 704.5m: An Aura attached to an illegal player is put into its
+        // owner's graveyard.
+        let mut state = setup();
+        let aura = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Curse".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&aura).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Enchantment);
+            obj.card_types.subtypes.push("Aura".to_string());
+            obj.attached_to = Some(crate::game::game_object::AttachTarget::Player(PlayerId(0)));
+        }
+        state.add_transient_continuous_effect(
+            aura,
+            PlayerId(0),
+            crate::types::ability::Duration::UntilEndOfTurn,
+            TargetFilter::SpecificPlayer { id: PlayerId(0) },
+            vec![crate::types::ability::ContinuousModification::AddKeyword {
+                keyword: crate::types::keywords::Keyword::Protection(
+                    crate::types::keywords::ProtectionTarget::Everything,
+                ),
+            }],
+            None,
+        );
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(!state.battlefield.contains(&aura));
+        assert!(state.players[1].graveyard.contains(&aura));
+    }
+
+    #[test]
     fn sba_equipment_unattaches_when_host_gains_protection_from_artifacts() {
-        // CR 702.16d + CR 704.5n: an equipped creature that gains protection
-        // from artifacts → the Equipment unattaches but stays on the battlefield.
+        // CR 702.16d: an equipped creature that gains protection from artifacts
+        // can't be equipped by artifact Equipment.
+        // CR 704.5n: Illegal Equipment unattaches but stays on the battlefield.
         let mut state = setup();
         let creature = create_creature(&mut state, CardId(1), PlayerId(0), "Bear", 2, 2);
         let equip = create_object(


### PR DESCRIPTION
Fixes a CR 702.16c/d + 704.5m/n bug: continuously-acquired attachment illegality (the "E" of DEBT) was unmodeled.

When a permanent **gains** protection (Mother of Runes) or a "can't be enchanted/equipped/attached" static *after* an Aura/Equipment is already attached, the engine never detached it. The SBA re-check (`is_valid_attachment_target`) re-validated only the Enchant filter + zone; the resolve-time gate (`can_attach_to_object`) checked the prohibition statics but not protection - so neither path enforced protection on an existing attachment. An opponent's Pacifism stayed on a creature that gained protection from white, locking it forever.

**Fix:** a single typed authority `attachment_illegality(state, attachment, host) -> Option<AttachIllegality>` (`Protection` / `Prohibited`) folding the `CantBeAttached`/`CantBeEnchanted`/`CantBeEquipped` statics and `keywords::protection_prevents_from`. `can_attach_to_object` delegates to it, and the SBA re-check now calls it before the filter/zone check - so it flows into both `check_unattached_auras` (Aura ? owner's graveyard, CR 704.5m) and `check_unattached_equipment` (Equipment ? unattached, stays on battlefield, CR 704.5n). The resolver is purely additive (protection + prohibition only; filter/zone unchanged), so it never blocks an otherwise-legal attach. Adds 6 tests (3 unit + 3 SBA integration: protected host detaches its Aura to graveyard; protection-from-artifacts unattaches Equipment in place; legal attachments unaffected).

Closes #1776