### PR TITLE
fix: mobile interaction for player-attached Auras

### DIFF
--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -7,6 +7,7 @@ import type { PlayerId } from "../../adapter/types.ts";
 import { usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
 import { usePlayerDesignations } from "../../hooks/usePlayerDesignations.ts";
 import { getSeatColor } from "../../hooks/useSeatColor.ts";
+import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { getOpponentDisplayName, useMultiplayerStore } from "../../stores/multiplayerStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
@@ -499,6 +500,7 @@ interface OpponentTabProps {
 
 function OpponentTab({ playerId, isFocused, isEliminated, isTeammate: ally, isValidTarget, isTargeting, legalObjectTargetIds, showMana, incomingAttackerIds, onSelectFocus, onTargetPlayer, onKick }: OpponentTabProps) {
   const { t } = useTranslation("game");
+  const isMobile = useIsMobile();
   const gameState = useGameStore((s) => s.gameState);
   const isTheirTurn = gameState?.active_player === playerId;
   const seatColor = getSeatColor(playerId, gameState?.seat_order);
@@ -865,6 +867,7 @@ function OpponentTab({ playerId, isFocused, isEliminated, isTeammate: ally, isVa
           ref={auraBadgeRef}
           role="button"
           tabIndex={0}
+          data-testid={`opponent-aura-badge-${playerId}`}
           aria-label={t("enchantmentsBadge.ariaLabel", { count: auraIds.length })}
           title={t("enchantmentsBadge.tooltip", { count: auraIds.length })}
           onClick={(e) => {
@@ -878,17 +881,17 @@ function OpponentTab({ playerId, isFocused, isEliminated, isTeammate: ally, isVa
               setEnchantmentsDialogPlayer(playerId);
             }
           }}
-          onMouseEnter={onAuraEnter}
-          onMouseLeave={onAuraLeave}
-          onFocus={onAuraEnter}
-          onBlur={onAuraLeave}
-          className={`absolute -right-1.5 z-10 flex h-5 min-w-5 cursor-pointer items-center justify-center rounded-full bg-gradient-to-b from-violet-500 to-violet-700 px-1 text-[10px] font-bold text-violet-50 shadow ring-2 ring-violet-300/70 transition-all hover:from-violet-400 hover:to-violet-600 ${compact ? "-bottom-5" : "-bottom-1.5"}`}
+          onMouseEnter={isMobile ? undefined : onAuraEnter}
+          onMouseLeave={isMobile ? undefined : onAuraLeave}
+          onFocus={isMobile ? undefined : onAuraEnter}
+          onBlur={isMobile ? undefined : onAuraLeave}
+          className={`absolute -right-1.5 z-10 flex min-w-5 cursor-pointer items-center justify-center rounded-full bg-gradient-to-b from-violet-500 to-violet-700 px-1 text-[10px] font-bold text-violet-50 shadow ring-2 ring-violet-300/70 transition-all hover:from-violet-400 hover:to-violet-600 ${compact ? "-top-1.5 h-6" : "-bottom-1.5 h-5"}`}
         >
           <span aria-hidden className="text-[11px] leading-none">✧</span>
           {auraIds.length > 1 ? <span className="ml-0.5 tabular-nums">×{auraIds.length}</span> : null}
         </span>
       )}
-      {auraHoverOpen && auraBadgeRef.current && (
+      {!isMobile && auraHoverOpen && auraBadgeRef.current && (
         <AurasHoverPreview anchorEl={auraBadgeRef.current} attachmentIds={auraIds} />
       )}
       {hoverPopover === "incoming" && tabRef.current && (

--- a/client/src/components/hud/__tests__/OpponentHud.test.tsx
+++ b/client/src/components/hud/__tests__/OpponentHud.test.tsx
@@ -8,6 +8,16 @@ import { useGameStore } from "../../../stores/gameStore.ts";
 import { useMultiplayerStore } from "../../../stores/multiplayerStore.ts";
 import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
 import { useUiStore } from "../../../stores/uiStore.ts";
+import { buildGameObject } from "../../../test/factories/gameObjectFactory.ts";
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event("resize"));
+}
 
 function createGameState(overrides: Partial<GameState> = {}): GameState {
   return {
@@ -59,6 +69,7 @@ function createGameState(overrides: Partial<GameState> = {}): GameState {
 
 describe("OpponentHud", () => {
   beforeEach(() => {
+    setViewportWidth(1024);
     localStorage.clear();
     useMultiplayerStore.setState({ activePlayerId: 0 });
     usePreferencesStore.setState({ followActiveOpponent: false });
@@ -408,5 +419,32 @@ describe("OpponentHud", () => {
     const badge = screen.getByTestId("opponent-aura-badge-1");
     expect(badge.className).toContain("-top-1.5");
     expect(badge.className).not.toContain("-bottom-5");
+  });
+
+  it("does not open the desktop aura hover preview on mobile", () => {
+    setViewportWidth(500);
+    const gameState = createGameState({
+      objects: {
+        "101": buildGameObject({
+          id: 101,
+          name: "Curse of Test",
+          controller: 1,
+          owner: 1,
+        }),
+      },
+      derived: {
+        auras_attached_to_player: { "1": [101] },
+      },
+    });
+    act(() => {
+      useGameStore.setState({ gameState });
+      useUiStore.setState({ focusedOpponent: 1 });
+    });
+
+    render(<OpponentHud />);
+
+    fireEvent.mouseEnter(screen.getByTestId("opponent-aura-badge-1"));
+
+    expect(screen.queryByLabelText(/Curse of Test/i)).toBeNull();
   });
 });

--- a/client/src/components/hud/__tests__/OpponentHud.test.tsx
+++ b/client/src/components/hud/__tests__/OpponentHud.test.tsx
@@ -370,4 +370,43 @@ describe("OpponentHud", () => {
     expect(screen.getByTitle("Speed: 1")).toHaveAttribute("aria-label", "Speed 1");
     expect(screen.queryByText("Speed")).toBeNull();
   });
+
+  it("opens player enchantments dialog when the opponent aura badge is tapped", async () => {
+    const gameState = createGameState({
+      derived: {
+        auras_attached_to_player: { "1": [101] },
+      },
+    });
+    act(() => {
+      useGameStore.setState({ gameState });
+      useUiStore.setState({ enchantmentsDialogPlayer: null, focusedOpponent: 1 });
+    });
+
+    render(<OpponentHud />);
+
+    fireEvent.click(screen.getByTestId("opponent-aura-badge-1"));
+
+    await waitFor(() => {
+      expect(useUiStore.getState().enchantmentsDialogPlayer).toBe(1);
+    });
+  });
+
+  it("keeps compact-mode aura badge inside the tab for mobile-reachable hit area", () => {
+    const gameState = createGameState({
+      derived: {
+        auras_attached_to_player: { "1": [101] },
+      },
+    });
+    act(() => {
+      usePreferencesStore.setState({ opponentHudDensity: "compact" });
+      useGameStore.setState({ gameState });
+      useUiStore.setState({ focusedOpponent: 1 });
+    });
+
+    render(<OpponentHud />);
+
+    const badge = screen.getByTestId("opponent-aura-badge-1");
+    expect(badge.className).toContain("-top-1.5");
+    expect(badge.className).not.toContain("-bottom-5");
+  });
 });


### PR DESCRIPTION
## Summary
This PR fixes a mobile usability bug where player-attached Aura badges in multiplayer compact opponent tabs were difficult/impossible to tap.  
The badge was positioned outside the tab (`-bottom-5`) in compact mode, which could place it out of practical touch reach on small screens.

The fix keeps the Aura badge in an always-reachable position inside the tab for compact/mobile layouts, and disables hover-only Aura preview behavior on mobile touch devices.
## Related Issue
Closes: #1578 
## Change Type (select all)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX improvement
- [x] Test coverage improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor only (no behavior change)
- [ ] Documentation only

## Root Cause
- In `OpponentHud` compact mode, the opponent Aura badge used a bottom offset (`-bottom-5`) outside the tab bounds.
- On mobile/touch layouts, this caused poor hit targeting and inconsistent accessibility.
- Hover-based preview handlers were desktop-centric and not meaningful on touch devices.

## Real Behavior Proof
### 1) Targeted unit test
Command:
```bash
pnpm vitest run src/components/hud/__tests__/OpponentHud.test.tsx
```
Result:
- `16 passed, 0 failed`
- Includes new tests:
  - opens player enchantments dialog when aura badge is tapped
  - compact-mode aura badge stays in reachable top position

### 2) Type safety
Command:
```bash
pnpm run type-check
```
Result:
- Passed

### 3) Lint
Command:
```bash
pnpm run lint
```
Result:
- No errors
- 2 pre-existing unrelated warnings in:
  - `CubeSetupPanel.tsx`
  - `DialogHost.tsx`

## Checklist
- [x] Reproduced/confirmed issue context from #1578
- [x] Implemented focused UI fix
- [x] Added regression tests for the mobile/compact path
- [x] Ran targeted frontend tests
- [x] Ran type-check
- [x] Ran lint (no new lint errors)
- [x] Verified no breaking interface changes
