### PR TITLE
fix(client): play opponent-owned exiled cards you were granted permission to play

### DIFF
--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -9,7 +9,7 @@ import { useLongPress } from "../../hooks/useLongPress.ts";
 import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
-import { useCanActForWaitingState, usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
+import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
 import { getPlayerZoneIds, getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
 import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.ts";
@@ -41,7 +41,6 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
   const inspectObject = useUiStore((s) => s.inspectObject);
   const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
   const dispatchAction = useGameDispatch();
-  const currentPlayerId = usePerspectivePlayerId();
   const canActForWaitingState = useCanActForWaitingState();
   const zoneIds = useMemo(
     () => getPlayerZoneIds(gameState, zone, playerId),
@@ -53,7 +52,6 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
     return zoneIds.map((id) => objects[id]).filter(Boolean);
   }, [objects, zoneIds]);
 
-  const isMyZone = playerId === currentPlayerId;
   const hasPriority = waitingFor?.type === "Priority" && canActForWaitingState;
 
   const currentLegalTargets = useMemo(() => {
@@ -107,10 +105,17 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
             {cards.map((obj) => {
               // CR 702.81a + CR 702.143a + CR 715.3a + CR 702.62a + CR 702.170d + CR 702.185a:
               // Engine surfaces a CastSpell-family action for every legally
-              // castable owner-viewed graveyard/exile card (Retrace, Adventure,
-              // Foretell, Suspend, Plot, Warp, etc.). The zone viewer surfaces
-              // whatever the engine reports — no per-mechanic permission inspection.
-              const castActions = (zone === "graveyard" || zone === "exile") && isMyZone && hasPriority
+              // castable graveyard/exile card (Retrace, Adventure, Foretell,
+              // Suspend, Plot, Warp, etc.). The zone viewer surfaces whatever
+              // the engine reports — no per-mechanic permission inspection.
+              //
+              // CR 715.3d / CR 400.7i: this includes opponent-OWNED cards in
+              // exile the viewer was granted permission to play (Hostage Taker,
+              // Gonti, Thief of Sanity). Those live in the owner's exile pile,
+              // so castability must NOT be gated on the pile belonging to the
+              // viewer — `legalActionsByObject` (engine authority, keyed to the
+              // player the permission was granted to) is the sole gate.
+              const castActions = (zone === "graveyard" || zone === "exile") && hasPriority
                 ? playOrCastActionsForObject(legalActionsByObject, obj.id)
                 : [];
               const isValidTarget = currentLegalTargets.has(obj.id);

--- a/client/src/components/zone/__tests__/ZoneViewer.test.tsx
+++ b/client/src/components/zone/__tests__/ZoneViewer.test.tsx
@@ -145,4 +145,51 @@ describe("ZoneViewer", () => {
       expect.objectContaining({ type: "CastSpell" }),
     );
   });
+
+  it("dispatches a CastSpell for an opponent-owned exiled card the viewer may play", () => {
+    // Hostage Taker / Gonti / Thief of Sanity: the card is owned by the
+    // opponent (player 1) and sits in their exile pile, but the engine granted
+    // the viewer (player 0) permission to play it — surfaced as a CastSpell in
+    // legalActionsByObject. The viewer must honor the engine's authority even
+    // though the pile is not the viewer's own. Regression guard for the removed
+    // client-side `isMyZone` ownership gate.
+    const object = makeObject({
+      id: 9,
+      owner: 1,
+      controller: 1,
+      zone: "Exile",
+      name: "Gonti, Lord of Luxury",
+      keywords: [],
+      base_keywords: [],
+    });
+    const action = makeCastAction(object.id);
+    const base = makeState(object);
+    const gameState = {
+      ...base,
+      objects: { [object.id]: object },
+      exile: [object.id],
+      players: [
+        { ...base.players[0], graveyard: [] },
+        { ...base.players[1], graveyard: [] },
+      ],
+    } as unknown as GameState;
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [action],
+      legalActionsByObject: { [String(object.id)]: [action] },
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+
+    render(<ZoneViewer zone="exile" playerId={1} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByTestId("card-image"));
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "CastSpell" }),
+    );
+  });
 });


### PR DESCRIPTION
The exile/graveyard ZoneViewer gated cast affordances on `isMyZone`
(the pile belonging to the viewing player), so a card owned by an
opponent that the engine granted you permission to play (Hostage Taker,
Gonti, Thief of Sanity, Captivating Crew) showed no playable affordance
and could not be clicked to cast. Such cards live in the opponent's
exile/graveyard pile, so the ownership gate blocked every grant of this
kind regardless of which effect created it.

Defer entirely to the engine's `legalActionsByObject` authority (keyed
to the player the permission was granted to), as the component's own
comment already declares is the contract. Add a regression test for the
opponent-owned exile case.
