### PR TITLE
fix(engine): mass phase-out keeps attachments indirect (CR 702.26h)

### DIFF
--- a/crates/engine/src/game/effects/phase_out.rs
+++ b/crates/engine/src/game/effects/phase_out.rs
@@ -11,6 +11,8 @@
 //! permanent path (CR 702.26 proper). Player phasing has no formal CR rule
 //! and follows the small set of card Oracle text that says "you phase out".
 
+use std::collections::HashSet;
+
 use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::game_object::PhaseOutCause;
 use crate::game::phasing::{phase_in_object, phase_in_player, phase_out_object, phase_out_player};
@@ -51,7 +53,13 @@ pub fn resolve(
     }
 
     let object_targets = collect_object_targets(state, ability, &target);
+    let target_set: HashSet<ObjectId> = object_targets.iter().copied().collect();
     for oid in object_targets {
+        // CR 702.26h: attachments whose host is also in this mass set phase out
+        // only indirectly via the host's CR 702.26g cascade, not as direct targets.
+        if attachment_host_in_set(state, oid, &target_set) {
+            continue;
+        }
         phase_out_object(state, oid, PhaseOutCause::Directly, events);
     }
 
@@ -164,6 +172,16 @@ fn collect_player_targets(
         }
         _ => Vec::new(),
     }
+}
+
+/// True when `oid` is attached to another permanent that is also in `targets`.
+fn attachment_host_in_set(state: &GameState, oid: ObjectId, targets: &HashSet<ObjectId>) -> bool {
+    state
+        .objects
+        .get(&oid)
+        .and_then(|obj| obj.attached_to.as_ref())
+        .and_then(|t| t.as_object())
+        .is_some_and(|host| targets.contains(&host))
 }
 
 /// Resolve the target object set for a `PhaseOut` effect. Explicit

--- a/crates/engine/src/game/phasing.rs
+++ b/crates/engine/src/game/phasing.rs
@@ -48,13 +48,20 @@ pub fn phase_out_object(
         let Some(obj) = state.objects.get_mut(&id) else {
             continue;
         };
-        // Already phased out: CR 702.26h — direct-over-indirect preference
-        // handled by not downgrading an existing direct phase-out to indirect.
+        // CR 702.26h: if an object would phase out directly and indirectly at
+        // the same time, it phases out indirectly — never promote indirect to
+        // direct when a later pass reaches the same object.
         if obj.is_phased_out() {
-            if matches!(this_cause, PhaseOutCause::Directly) {
-                // Upgrade indirect → direct per CR 702.26h.
+            if matches!(this_cause, PhaseOutCause::Indirectly)
+                && matches!(
+                    obj.phase_status,
+                    PhaseStatus::PhasedOut {
+                        cause: PhaseOutCause::Directly
+                    }
+                )
+            {
                 obj.phase_status = PhaseStatus::PhasedOut {
-                    cause: PhaseOutCause::Directly,
+                    cause: PhaseOutCause::Indirectly,
                 };
             }
             continue;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -78,6 +78,7 @@ mod lurking_predators_1604_repro;
 mod madame_null_integration;
 mod magnetic_mountain_choose_and_pay;
 mod mana_drain_refund;
+mod mass_phase_out_1792_repro;
 mod master_of_ceremonies;
 mod militant_angel_attacked_opponents;
 mod morophon_chosen_type_1653;

--- a/crates/engine/tests/integration/mass_phase_out_1792_repro.rs
+++ b/crates/engine/tests/integration/mass_phase_out_1792_repro.rs
@@ -1,0 +1,153 @@
+//! [#1792](https://github.com/phase-rs/phase/issues/1792): mass phase-out must mark
+//! attached Equipment as indirectly phased out when its host is in the target set.
+
+use engine::game::effects::phase_out::resolve;
+use engine::game::game_object::{PhaseOutCause, PhaseStatus};
+use engine::game::phasing::{execute_untap_step_phasing, phase_out_object};
+use engine::game::zones::create_object;
+use engine::types::ability::{ControllerRef, Effect, ResolvedAbility, TargetFilter, TypedFilter};
+use engine::types::card_type::CoreType;
+use engine::types::events::GameEvent;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+fn setup_creature(state: &mut GameState, name: &str, controller: PlayerId) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(1),
+        controller,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    if let Some(obj) = state.objects.get_mut(&id) {
+        obj.card_types.core_types = vec![CoreType::Creature];
+    }
+    id
+}
+
+fn setup_equipment(
+    state: &mut GameState,
+    name: &str,
+    controller: PlayerId,
+    host: ObjectId,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(2),
+        controller,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    if let Some(obj) = state.objects.get_mut(&id) {
+        obj.card_types.core_types = vec![CoreType::Artifact];
+        obj.card_types.subtypes = vec!["Equipment".to_string()];
+        obj.attached_to = Some(host.into());
+    }
+    if let Some(host_obj) = state.objects.get_mut(&host) {
+        host_obj.attachments.push(id);
+    }
+    id
+}
+
+#[test]
+fn mass_phase_out_leaves_equipment_indirect_when_host_in_set() {
+    let mut state = GameState::new_two_player(42);
+    let creature = setup_creature(&mut state, "Bear", PlayerId(0));
+    let equipment = setup_equipment(&mut state, "Bonesplitter", PlayerId(0), creature);
+    let source = create_object(
+        &mut state,
+        CardId(9),
+        PlayerId(0),
+        "Teferi".to_string(),
+        Zone::Battlefield,
+    );
+
+    let ability = ResolvedAbility::new(
+        Effect::PhaseOut {
+            target: TargetFilter::Typed(TypedFilter::permanent().controller(ControllerRef::You)),
+        },
+        vec![],
+        source,
+        PlayerId(0),
+    );
+
+    let mut events = Vec::new();
+    resolve(&mut state, &ability, &mut events).expect("mass phase out");
+
+    assert!(matches!(
+        state.objects[&creature].phase_status,
+        PhaseStatus::PhasedOut {
+            cause: PhaseOutCause::Directly
+        }
+    ));
+    assert!(
+        matches!(
+            state.objects[&equipment].phase_status,
+            PhaseStatus::PhasedOut {
+                cause: PhaseOutCause::Indirectly
+            }
+        ),
+        "equipment must be indirectly phased (CR 702.26h), got {:?}",
+        state.objects[&equipment].phase_status
+    );
+}
+
+#[test]
+fn direct_pass_after_indirect_does_not_promote_attachment_to_direct() {
+    let mut state = GameState::new_two_player(42);
+    let creature = setup_creature(&mut state, "Bear", PlayerId(0));
+    let equipment = setup_equipment(&mut state, "Bonesplitter", PlayerId(0), creature);
+    let mut events = Vec::new();
+
+    phase_out_object(&mut state, equipment, PhaseOutCause::Directly, &mut events);
+    phase_out_object(&mut state, creature, PhaseOutCause::Directly, &mut events);
+
+    assert!(matches!(
+        state.objects[&equipment].phase_status,
+        PhaseStatus::PhasedOut {
+            cause: PhaseOutCause::Indirectly
+        }
+    ));
+}
+
+#[test]
+fn indirect_equipment_phases_in_with_host_on_untap() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+    let creature = setup_creature(&mut state, "Bear", PlayerId(0));
+    let equipment = setup_equipment(&mut state, "Bonesplitter", PlayerId(0), creature);
+    let source = create_object(
+        &mut state,
+        CardId(10),
+        PlayerId(0),
+        "Teferi".to_string(),
+        Zone::Battlefield,
+    );
+
+    let ability = ResolvedAbility::new(
+        Effect::PhaseOut {
+            target: TargetFilter::Typed(TypedFilter::permanent().controller(ControllerRef::You)),
+        },
+        vec![],
+        source,
+        PlayerId(0),
+    );
+
+    let mut events = Vec::new();
+    resolve(&mut state, &ability, &mut events).expect("mass phase out");
+    events.clear();
+
+    execute_untap_step_phasing(&mut state, &mut events);
+
+    assert!(state.objects[&creature].is_phased_in());
+    assert!(
+        state.objects[&equipment].is_phased_in(),
+        "equipment must phase in with host (CR 702.26i)"
+    );
+    assert!(events.iter().any(|e| matches!(
+        e,
+        GameEvent::PermanentPhasedIn { object_id } if *object_id == equipment
+    )));
+}


### PR DESCRIPTION
## Summary
Fixes #1792. Mass `Effect::PhaseOut` was marking attached Equipment/Auras as directly phased out when their host was also in the mass set, instead of indirectly per CR 702.26h.
## Changes
- Skip attachment targets whose host is in the same mass set; cascade marks them `Indirectly`.
- Stop promoting indirect phase-out to direct in `phase_out_object`.
## Test plan
- [x] `cargo test -p engine --test integration mass_phase_out_1792`
- [x] `cargo check -p engine`