### PR TITLE
feat(ui): animated 3D dice roll for first-player contest and in-game rolls

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "react-i18next": "^17.0.8",
     "react-router": "^7.13.1",
     "tailwindcss": "^4.2.1",
+    "three": "^0.184.0",
     "vite-plugin-top-level-await": "^1.5.0",
     "vite-plugin-wasm": "^3.4.1",
     "zustand": "^5.0.11"
@@ -54,6 +55,7 @@
     "@types/node": "^25.4.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^4.4.1",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.39.4",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.1
         version: 4.3.0
+      three:
+        specifier: ^0.184.0
+        version: 0.184.0
       vite-plugin-top-level-await:
         specifier: ^1.5.0
         version: 1.6.0(rollup@2.80.0)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1))
@@ -97,6 +100,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      '@types/three':
+        specifier: ^0.184.1
+        version: 0.184.1
       '@vitejs/plugin-react':
         specifier: ^4.4.1
         version: 4.7.0(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1))
@@ -761,6 +767,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -1842,6 +1851,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -1892,11 +1904,20 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
   '@types/symlink-or-copy@1.2.2':
     resolution: {integrity: sha512-MQ1AnmTLOncwEf9IVU+B2e4Hchrku5N67NkgcAHW0p3sdzPe0FNMANxEm6OJUzPniEQGkeT3OROLlCwZJLWFZA==}
 
+  '@types/three@0.184.1':
+    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -3228,6 +3249,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -3821,6 +3845,9 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
 
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
@@ -5056,6 +5083,8 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@dimforge/rapier3d-compat@0.12.0': {}
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
@@ -5837,6 +5866,8 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -5891,9 +5922,22 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/stats.js@0.17.4': {}
+
   '@types/symlink-or-copy@1.2.2': {}
 
+  '@types/three@0.184.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.2
+      meshoptimizer: 1.1.1
+
   '@types/trusted-types@2.0.7': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -7428,6 +7472,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  meshoptimizer@1.1.1: {}
+
   min-indent@1.0.1: {}
 
   miniflare@4.20260507.1:
@@ -8101,6 +8147,8 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
+
+  three@0.184.0: {}
 
   through2@2.0.5:
     dependencies:

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1580,7 +1580,14 @@ export type GameEvent =
   | { type: "InitiativeTaken"; data: { player_id: PlayerId } }
   | { type: "DebugActionUsed"; data: { player_id: PlayerId; description: string } }
   | { type: "DebugPermissionGranted"; data: { host: PlayerId; player_id: PlayerId } }
-  | { type: "DebugPermissionRevoked"; data: { host: PlayerId; player_id: PlayerId } };
+  | { type: "DebugPermissionRevoked"; data: { host: PlayerId; player_id: PlayerId } }
+  // CR 706: a die was rolled. Animated by DiceRollOverlay. `sides`/`result` are
+  // the engine's authoritative roll (1..=sides after modifiers).
+  | { type: "DieRolled"; data: { player_id: PlayerId; sides: number; result: number } }
+  // CR 705: a coin was flipped. `won` is whether the flipping player won the flip
+  // (relative to that player) — there is no engine-named face; the heads/tails
+  // depiction is a presentation choice.
+  | { type: "CoinFlipped"; data: { player_id: PlayerId; won: boolean } };
 
 // ── Game State ───────────────────────────────────────────────────────────
 

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -110,6 +110,10 @@ export class WebSocketAdapter implements EngineAdapter {
   private pendingReject: ((error: Error) => void) | null = null;
   private initResolve: (() => void) | null = null;
   private initReject: ((error: Error) => void) | null = null;
+  /** Starting-player contest DieRolled batch captured from the initial
+   *  GameStarted message, handed back by `initializeGame()` so the dice overlay
+   *  animates it. Empty on reconnects (the server drains it after first send). */
+  private initStartEvents: GameEvent[] = [];
   private listeners: WsAdapterEventListener[] = [];
   private reconnectAttempt = 0;
   private readonly maxReconnectAttempts = 8;
@@ -175,8 +179,13 @@ export class WebSocketAdapter implements EngineAdapter {
     _matchConfig?: unknown,
     _firstPlayer?: number,
   ): Promise<SubmitResult> {
-    // Server handles deck data via WebSocket protocol during initialize()
-    return { events: [] };
+    // Server handles deck data via WebSocket protocol during initialize().
+    // The starting-player contest events (if any) were captured from the
+    // initial GameStarted message; hand them back so gameStore.initGame routes
+    // them to the dice overlay, then clear so they're consumed once.
+    const events = this.initStartEvents;
+    this.initStartEvents = [];
+    return { events };
   }
 
   async initialize(): Promise<void> {
@@ -565,7 +574,7 @@ export class WebSocketAdapter implements EngineAdapter {
       }
 
       case "GameStarted": {
-        const data = msg.data as { state: GameState; your_player: PlayerId; opponent_name?: string; player_names?: string[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; derived?: GameState["derived"]; player_token?: string };
+        const data = msg.data as { state: GameState; your_player: PlayerId; opponent_name?: string; player_names?: string[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; derived?: GameState["derived"]; player_token?: string; events?: GameEvent[] };
         if (this.reconnectInFlight) {
           this.reconnectInFlight = false;
           this.reconnectAttempt = 0;
@@ -604,6 +613,12 @@ export class WebSocketAdapter implements EngineAdapter {
           ...(playerNames === undefined ? {} : { playerNames }),
         });
         if (this.initResolve) {
+          // CR 103.1: the server sends the starting-player contest DieRolled
+          // batch only on the initial GameStarted (drained server-side, so
+          // reconnects carry none). Stash it for initializeGame() to return,
+          // routing it through the same gameStore.initGame contest path as
+          // local games.
+          this.initStartEvents = data.events ?? [];
           this.initResolve();
           this.initResolve = null;
           this.initReject = null;

--- a/client/src/animation/eventNormalizer.ts
+++ b/client/src/animation/eventNormalizer.ts
@@ -29,6 +29,10 @@ const NON_VISUAL_EVENTS = new Set([
   "Regenerated",
   "AttackersDeclared",
   "BlockersDeclared",
+  // Dice/coin are presented out-of-band by DiceRollOverlay (via flashDiceRoll),
+  // not as queued animation steps — same pattern as TurnStarted → the turn banner.
+  "DieRolled",
+  "CoinFlipped",
 ]);
 
 /** Events that always begin a new step, regardless of context. */

--- a/client/src/animation/types.ts
+++ b/client/src/animation/types.ts
@@ -77,3 +77,8 @@ export const CARD_SLAM_FLIGHT_MS = 200;
 /** Base "your turn / opponent's turn" banner display duration, before any
  *  pacing multipliers apply. */
 export const TURN_BANNER_DURATION_MS = 1500;
+
+/** Base dice-roll overlay display duration (the 3D tumble + settle + a beat to
+ *  read the result), before pacing multipliers. The tumble itself is ~1.6s
+ *  inside Dice3D; this is the total time the overlay stays mounted. */
+export const DICE_ROLL_DURATION_MS = 2400;

--- a/client/src/components/animation/DiceRollOverlay.tsx
+++ b/client/src/components/animation/DiceRollOverlay.tsx
@@ -1,0 +1,199 @@
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+
+import { getPlayerId } from "../../hooks/usePlayerId";
+import { getOpponentDisplayName } from "../../stores/multiplayerStore";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+import { useUiStore } from "../../stores/uiStore";
+import type { DiceRollPayload } from "../../stores/uiStore";
+
+// Code-split the WebGL renderer: `three` only loads when a die is actually
+// rolled, keeping it out of the main bundle.
+const Dice3D = lazy(() => import("./dice3d/Dice3D.tsx").then((m) => ({ default: m.Dice3D })));
+const Coin3D = lazy(() => import("./dice3d/Coin3D.tsx").then((m) => ({ default: m.Coin3D })));
+
+const DIE_SIZE = 132;
+
+/** Cached WebGL-availability probe. The dice overlay is the first component in
+ *  the app that needs WebGL, so it must degrade gracefully where it's absent. */
+let webglSupported: boolean | null = null;
+function hasWebGL(): boolean {
+  if (webglSupported !== null) return webglSupported;
+  try {
+    const canvas = document.createElement("canvas");
+    webglSupported = Boolean(canvas.getContext("webgl2") ?? canvas.getContext("webgl"));
+  } catch {
+    webglSupported = false;
+  }
+  return webglSupported;
+}
+
+/**
+ * Full-screen dice-roll / coin-flip moment. Gated on `uiStore.diceRoll` (set by
+ * `flashDiceRoll`), it animates the engine's already-known result in real 3D.
+ * Mirrors the TurnBanner pattern: `fixed inset-0 z-50`, AnimatePresence,
+ * pointer-events-none. Falls back to a static result under reduced-motion or
+ * when WebGL is unavailable — the roll is cosmetic, so degrading is safe.
+ */
+export function DiceRollOverlay() {
+  const diceRoll = useUiStore((s) => s.diceRoll);
+  const shouldReduceMotion = useReducedMotion();
+
+  // Clear any active/queued roll and its advance timer when leaving the game.
+  // The store is a module singleton that outlives this mount, so without this an
+  // in-flight roll could pop into the next game.
+  useEffect(() => () => useUiStore.getState().resetDiceRoll(), []);
+
+  return (
+    <AnimatePresence>
+      {diceRoll && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+          role="status"
+          aria-live="polite"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.25 }}
+        >
+          <div className="absolute inset-0 bg-black/55" />
+          {/* Keyed by payload identity so each roll the FIFO advances to gets a
+              fresh component instance (resets `settled`, re-runs the 3D mount). */}
+          <DiceRollContent
+            key={diceRollKey(diceRoll)}
+            payload={diceRoll}
+            animate={!shouldReduceMotion && hasWebGL()}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+/** Stable identity for a payload so the FIFO advancing from one roll to the next
+ *  remounts `DiceRollContent` instead of reconciling stale `settled` state. */
+function diceRollKey(payload: DiceRollPayload): string {
+  return payload.kind === "coin"
+    ? `coin-${payload.context}-${payload.playerId}-${payload.won}`
+    : `die-${payload.context}-${payload.rolls.map((r) => `${r.playerId}:${r.value}`).join(",")}`;
+}
+
+function DiceRollContent({ payload, animate }: { payload: DiceRollPayload; animate: boolean }) {
+  const { t } = useTranslation();
+  const speedMultiplier = usePreferencesStore((s) => s.animationSpeedMultiplier);
+  const [settled, setSettled] = useState(false);
+  const onSettle = useCallback(() => setSettled(true), []);
+
+  const playerLabel = (playerId: number): string =>
+    playerId === getPlayerId() ? t("diceRoll.you") : getOpponentDisplayName(playerId);
+
+  if (payload.kind === "coin") {
+    // No engine-named face: `won` (relative to the flipping player) maps to a
+    // heads/tails depiction. We show "heads" on a win — a pure display choice.
+    const face = payload.won ? "heads" : "tails";
+    return (
+      <div className="relative flex flex-col items-center gap-6 select-none">
+        <span className="text-2xl font-bold tracking-wider uppercase text-slate-200">
+          {playerLabel(payload.playerId)}
+        </span>
+        {animate ? (
+          <Suspense fallback={<DiePlaceholder label="" />}>
+            <Coin3D
+              face={face}
+              speedMultiplier={speedMultiplier}
+              onSettle={onSettle}
+              size={DIE_SIZE}
+              labels={{ heads: t("diceRoll.heads"), tails: t("diceRoll.tails") }}
+            />
+          </Suspense>
+        ) : (
+          <DiePlaceholder label={t(`diceRoll.${face}`)} />
+        )}
+      </div>
+    );
+  }
+
+  // Dice: one per roll. The starting-player contest highlights the engine's
+  // winner and captions who plays first; in-game rolls just show the value(s).
+  const isContest = payload.context === "startingPlayer";
+  const winnerIsYou = payload.winner === getPlayerId();
+  const caption =
+    isContest && payload.winner != null
+      ? winnerIsYou
+        ? t("diceRoll.youPlayFirst")
+        : t("diceRoll.playerPlaysFirst", { name: getOpponentDisplayName(payload.winner) })
+      : null;
+
+  return (
+    <div className="relative flex flex-col items-center gap-7 select-none">
+      <div className="flex items-end justify-center gap-10">
+        {payload.rolls.map((roll, i) => {
+          const isWinner = isContest && roll.playerId === payload.winner;
+          return (
+            <div key={i} className="flex flex-col items-center gap-3">
+              {isContest && (
+                <span
+                  className="text-lg font-bold tracking-wide uppercase"
+                  style={{ color: isWinner ? "#fbbf24" : "#94a3b8" }}
+                >
+                  {playerLabel(roll.playerId)}
+                </span>
+              )}
+              <div
+                className="rounded-2xl"
+                style={
+                  isWinner
+                    ? { boxShadow: "0 0 28px rgba(251,191,36,0.55)", outline: "2px solid rgba(251,191,36,0.7)" }
+                    : undefined
+                }
+              >
+                {animate ? (
+                  <Suspense fallback={<DiePlaceholder label={String(roll.value)} />}>
+                    <Dice3D
+                      sides={payload.sides}
+                      result={roll.value}
+                      speedMultiplier={speedMultiplier}
+                      onSettle={i === 0 ? onSettle : undefined}
+                      size={DIE_SIZE}
+                    />
+                  </Suspense>
+                ) : (
+                  <DiePlaceholder label={String(roll.value)} />
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {caption && (
+        <motion.span
+          className="text-4xl font-extrabold tracking-wider uppercase"
+          style={{
+            color: "#fbbf24",
+            textShadow: "0 0 20px rgba(251,191,36,0.6), 0 2px 4px rgba(0,0,0,0.5)",
+          }}
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={animate && !settled ? { opacity: 0 } : { opacity: 1, scale: 1 }}
+          transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        >
+          {caption}
+        </motion.span>
+      )}
+    </div>
+  );
+}
+
+/** Static stand-in for the 3D die: the result face as plain text. Used as the
+ *  Suspense fallback while `three` loads, and as the reduced-motion / no-WebGL
+ *  presentation. */
+function DiePlaceholder({ label }: { label: string }) {
+  return (
+    <div
+      className="flex items-center justify-center rounded-2xl bg-slate-800/90 font-extrabold text-slate-100"
+      style={{ width: DIE_SIZE, height: DIE_SIZE, fontSize: DIE_SIZE * 0.42 }}
+    >
+      {label}
+    </div>
+  );
+}

--- a/client/src/components/animation/DiceRollOverlay.tsx
+++ b/client/src/components/animation/DiceRollOverlay.tsx
@@ -48,12 +48,29 @@ function hasWebGL(): boolean {
  */
 export function DiceRollOverlay() {
   const diceRoll = useUiStore((s) => s.diceRoll);
+  const skipDiceRoll = useUiStore((s) => s.skipDiceRoll);
   const shouldReduceMotion = useReducedMotion();
+  const { t } = useTranslation();
 
   // Clear any active/queued roll and its advance timer when leaving the game.
   // The store is a module singleton that outlives this mount, so without this an
   // in-flight roll could pop into the next game.
   useEffect(() => () => useUiStore.getState().resetDiceRoll(), []);
+
+  // Tap-to-skip via keyboard: Escape dismisses the current roll (advancing to
+  // the next queued one, or clearing the overlay). Bound only while a roll is
+  // showing so it never shadows Escape elsewhere.
+  useEffect(() => {
+    if (!diceRoll) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        skipDiceRoll();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [diceRoll, skipDiceRoll]);
 
   // Prefetch the code-split 3D chunk on mount. Every game opens with the
   // starting-player contest (CR 103.1), so `three` is needed within seconds —
@@ -77,8 +94,15 @@ export function DiceRollOverlay() {
           exit={{ opacity: 0 }}
           transition={{ duration: 0.25 }}
         >
-          {/* Vignette backdrop: darker at the edges, focusing the eye centrally. */}
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(2,6,23,0.55),rgba(2,6,23,0.86)_70%)] backdrop-blur-[2px]" />
+          {/* Vignette backdrop: darker at the edges, focusing the eye centrally.
+              Clickable (pointer-events re-enabled) to skip the roll — the overlay
+              itself stays pointer-events-none so it never traps board input. */}
+          <button
+            type="button"
+            aria-label={t("diceRoll.skip")}
+            onClick={skipDiceRoll}
+            className="absolute inset-0 cursor-pointer bg-[radial-gradient(circle_at_center,rgba(2,6,23,0.55),rgba(2,6,23,0.86)_70%)] backdrop-blur-[2px] pointer-events-auto"
+          />
           {/* Keyed by payload identity so each roll the FIFO advances to gets a
               fresh component instance (resets settle state, re-runs the 3D mount). */}
           <DiceRollContent
@@ -86,6 +110,14 @@ export function DiceRollOverlay() {
             payload={diceRoll}
             animate={!shouldReduceMotion && hasWebGL()}
           />
+          <motion.span
+            className="pointer-events-none absolute bottom-8 text-xs font-medium uppercase tracking-[0.2em] text-slate-400/70"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 1, duration: 0.5 }}
+          >
+            {t("diceRoll.skip")}
+          </motion.span>
         </motion.div>
       )}
     </AnimatePresence>

--- a/client/src/components/animation/DiceRollOverlay.tsx
+++ b/client/src/components/animation/DiceRollOverlay.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState, type ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
@@ -14,6 +14,10 @@ const Dice3D = lazy(() => import("./dice3d/Dice3D.tsx").then((m) => ({ default: 
 const Coin3D = lazy(() => import("./dice3d/Coin3D.tsx").then((m) => ({ default: m.Coin3D })));
 
 const DIE_SIZE = 132;
+
+// Accent RGB triples (sans `rgb(...)`) so they compose into rgba()/gradients.
+const GOLD = "251,191,36"; // amber-400 — the winner / emphasis accent
+const NEUTRAL = "148,163,184"; // slate-400 — a non-decisive die
 
 /** Cached WebGL-availability probe. The dice overlay is the first component in
  *  the app that needs WebGL, so it must degrade gracefully where it's absent. */
@@ -32,9 +36,15 @@ function hasWebGL(): boolean {
 /**
  * Full-screen dice-roll / coin-flip moment. Gated on `uiStore.diceRoll` (set by
  * `flashDiceRoll`), it animates the engine's already-known result in real 3D.
- * Mirrors the TurnBanner pattern: `fixed inset-0 z-50`, AnimatePresence,
+ * Mirrors the TurnBanner pattern: `fixed inset-0`, AnimatePresence,
  * pointer-events-none. Falls back to a static result under reduced-motion or
  * when WebGL is unavailable — the roll is cosmetic, so degrading is safe.
+ *
+ * Sits at `z-[55]` — above the `z-50` board overlays (turn banner, mulligan) so
+ * the roll is never occluded mid-animation. The starting-player contest is also
+ * sequenced ahead of the mulligan UI in `GamePage` (CR 103.1 before CR 103.5),
+ * so the two never compete; the raised z-index is defense-in-depth for in-game
+ * rolls that can fire while other overlays are up.
  */
 export function DiceRollOverlay() {
   const diceRoll = useUiStore((s) => s.diceRoll);
@@ -45,11 +55,21 @@ export function DiceRollOverlay() {
   // in-flight roll could pop into the next game.
   useEffect(() => () => useUiStore.getState().resetDiceRoll(), []);
 
+  // Prefetch the code-split 3D chunk on mount. Every game opens with the
+  // starting-player contest (CR 103.1), so `three` is needed within seconds —
+  // warming it here means the first roll animates instead of flashing the static
+  // fallback while the chunk downloads. Skipped where we'd never animate.
+  useEffect(() => {
+    if (shouldReduceMotion || !hasWebGL()) return;
+    void import("./dice3d/Dice3D.tsx");
+    void import("./dice3d/Coin3D.tsx");
+  }, [shouldReduceMotion]);
+
   return (
     <AnimatePresence>
       {diceRoll && (
         <motion.div
-          className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
+          className="fixed inset-0 z-[55] flex items-center justify-center pointer-events-none"
           role="status"
           aria-live="polite"
           initial={{ opacity: 0 }}
@@ -57,9 +77,10 @@ export function DiceRollOverlay() {
           exit={{ opacity: 0 }}
           transition={{ duration: 0.25 }}
         >
-          <div className="absolute inset-0 bg-black/55" />
+          {/* Vignette backdrop: darker at the edges, focusing the eye centrally. */}
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(2,6,23,0.55),rgba(2,6,23,0.86)_70%)] backdrop-blur-[2px]" />
           {/* Keyed by payload identity so each roll the FIFO advances to gets a
-              fresh component instance (resets `settled`, re-runs the 3D mount). */}
+              fresh component instance (resets settle state, re-runs the 3D mount). */}
           <DiceRollContent
             key={diceRollKey(diceRoll)}
             payload={diceRoll}
@@ -72,7 +93,7 @@ export function DiceRollOverlay() {
 }
 
 /** Stable identity for a payload so the FIFO advancing from one roll to the next
- *  remounts `DiceRollContent` instead of reconciling stale `settled` state. */
+ *  remounts `DiceRollContent` instead of reconciling stale settle state. */
 function diceRollKey(payload: DiceRollPayload): string {
   return payload.kind === "coin"
     ? `coin-${payload.context}-${payload.playerId}-${payload.won}`
@@ -82,8 +103,6 @@ function diceRollKey(payload: DiceRollPayload): string {
 function DiceRollContent({ payload, animate }: { payload: DiceRollPayload; animate: boolean }) {
   const { t } = useTranslation();
   const speedMultiplier = usePreferencesStore((s) => s.animationSpeedMultiplier);
-  const [settled, setSettled] = useState(false);
-  const onSettle = useCallback(() => setSettled(true), []);
 
   const playerLabel = (playerId: number): string =>
     playerId === getPlayerId() ? t("diceRoll.you") : getOpponentDisplayName(playerId);
@@ -97,90 +116,305 @@ function DiceRollContent({ payload, animate }: { payload: DiceRollPayload; anima
         <span className="text-2xl font-bold tracking-wider uppercase text-slate-200">
           {playerLabel(payload.playerId)}
         </span>
-        {animate ? (
-          <Suspense fallback={<DiePlaceholder label="" />}>
-            <Coin3D
-              face={face}
-              speedMultiplier={speedMultiplier}
-              onSettle={onSettle}
-              size={DIE_SIZE}
-              labels={{ heads: t("diceRoll.heads"), tails: t("diceRoll.tails") }}
-            />
-          </Suspense>
-        ) : (
-          <DiePlaceholder label={t(`diceRoll.${face}`)} />
-        )}
+        <DieFace animate={animate} accent={NEUTRAL}>
+          {(handleSettle) =>
+            animate ? (
+              <Suspense fallback={<DiePlaceholder label="" />}>
+                <Coin3D
+                  face={face}
+                  speedMultiplier={speedMultiplier}
+                  onSettle={handleSettle}
+                  size={DIE_SIZE}
+                  labels={{ heads: t("diceRoll.heads"), tails: t("diceRoll.tails") }}
+                />
+              </Suspense>
+            ) : (
+              <DiePlaceholder label={t(`diceRoll.${face}`)} />
+            )
+          }
+        </DieFace>
       </div>
     );
   }
 
-  // Dice: one per roll. The starting-player contest highlights the engine's
-  // winner and captions who plays first; in-game rolls just show the value(s).
-  const isContest = payload.context === "startingPlayer";
-  const winnerIsYou = payload.winner === getPlayerId();
+  return payload.context === "startingPlayer" ? (
+    <ContestDice
+      payload={payload}
+      animate={animate}
+      speedMultiplier={speedMultiplier}
+      playerLabel={playerLabel}
+    />
+  ) : (
+    <InGameDice payload={payload} animate={animate} speedMultiplier={speedMultiplier} />
+  );
+}
+
+/**
+ * Starting-player contest (CR 103.1): one die per seat, a VS framing for the
+ * two-player case, then a winner reveal once every die has settled — the
+ * winner's panel lifts and glows gold, the others dim, and the caption resolves.
+ * `winner` is the engine's authoritative pick, never recomputed here.
+ */
+function ContestDice({
+  payload,
+  animate,
+  speedMultiplier,
+  playerLabel,
+}: {
+  payload: Extract<DiceRollPayload, { kind: "die" }>;
+  animate: boolean;
+  speedMultiplier: number;
+  playerLabel: (playerId: number) => string;
+}) {
+  const { t } = useTranslation();
+  const [settledCount, setSettledCount] = useState(0);
+  const onDieSettle = useCallback(() => setSettledCount((c) => c + 1), []);
+  // Without animation the result is shown immediately, so treat it as settled.
+  const allSettled = !animate || settledCount >= payload.rolls.length;
+
+  const winner = payload.winner;
+  const winnerIsYou = winner === getPlayerId();
   const caption =
-    isContest && payload.winner != null
+    winner != null
       ? winnerIsYou
         ? t("diceRoll.youPlayFirst")
-        : t("diceRoll.playerPlaysFirst", { name: getOpponentDisplayName(payload.winner) })
+        : t("diceRoll.playerPlaysFirst", { name: getOpponentDisplayName(winner) })
       : null;
 
   return (
-    <div className="relative flex flex-col items-center gap-7 select-none">
-      <div className="flex items-end justify-center gap-10">
+    <div className="relative flex flex-col items-center gap-8 select-none">
+      <motion.span
+        className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400"
+        initial={{ opacity: 0, y: -8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        {t("diceRoll.rollingForFirst")}
+      </motion.span>
+
+      <div className="flex items-center justify-center gap-8">
         {payload.rolls.map((roll, i) => {
-          const isWinner = isContest && roll.playerId === payload.winner;
+          const isWinner = roll.playerId === winner;
+          const revealed = allSettled && winner != null;
           return (
-            <div key={i} className="flex flex-col items-center gap-3">
-              {isContest && (
+            <div key={roll.playerId} className="contents">
+              {/* `VS` separator between two contestants. */}
+              {i > 0 && (
+                <motion.span
+                  className="text-xl font-black italic tracking-tight text-slate-500"
+                  initial={{ opacity: 0, scale: 0.6 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ delay: 0.2, duration: 0.3 }}
+                >
+                  {t("diceRoll.versus")}
+                </motion.span>
+              )}
+              <motion.div
+                className="flex flex-col items-center gap-3"
+                animate={{
+                  scale: revealed ? (isWinner ? 1.06 : 0.94) : 1,
+                  opacity: revealed && !isWinner ? 0.45 : 1,
+                }}
+                transition={{ type: "spring", stiffness: 260, damping: 22 }}
+              >
                 <span
-                  className="text-lg font-bold tracking-wide uppercase"
-                  style={{ color: isWinner ? "#fbbf24" : "#94a3b8" }}
+                  className="text-base font-bold uppercase tracking-wide transition-colors"
+                  style={{ color: revealed && isWinner ? `rgb(${GOLD})` : "#cbd5e1" }}
                 >
                   {playerLabel(roll.playerId)}
                 </span>
-              )}
-              <div
-                className="rounded-2xl"
-                style={
-                  isWinner
-                    ? { boxShadow: "0 0 28px rgba(251,191,36,0.55)", outline: "2px solid rgba(251,191,36,0.7)" }
-                    : undefined
-                }
-              >
-                {animate ? (
-                  <Suspense fallback={<DiePlaceholder label={String(roll.value)} />}>
-                    <Dice3D
-                      sides={payload.sides}
-                      result={roll.value}
-                      speedMultiplier={speedMultiplier}
-                      onSettle={i === 0 ? onSettle : undefined}
-                      size={DIE_SIZE}
-                    />
-                  </Suspense>
-                ) : (
-                  <DiePlaceholder label={String(roll.value)} />
-                )}
-              </div>
+                <DieFace
+                  animate={animate}
+                  accent={isWinner ? GOLD : NEUTRAL}
+                  emphasize={revealed && isWinner}
+                  value={roll.value}
+                  onSettle={onDieSettle}
+                >
+                  {(handleSettle) =>
+                    animate ? (
+                      <Suspense fallback={<DiePlaceholder label={String(roll.value)} />}>
+                        <Dice3D
+                          sides={payload.sides}
+                          result={roll.value}
+                          speedMultiplier={speedMultiplier}
+                          size={DIE_SIZE}
+                          onSettle={handleSettle}
+                        />
+                      </Suspense>
+                    ) : (
+                      <DiePlaceholder label={String(roll.value)} />
+                    )
+                  }
+                </DieFace>
+              </motion.div>
             </div>
           );
         })}
       </div>
-      {caption && (
-        <motion.span
-          className="text-4xl font-extrabold tracking-wider uppercase"
-          style={{
-            color: "#fbbf24",
-            textShadow: "0 0 20px rgba(251,191,36,0.6), 0 2px 4px rgba(0,0,0,0.5)",
-          }}
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={animate && !settled ? { opacity: 0 } : { opacity: 1, scale: 1 }}
-          transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
-        >
-          {caption}
-        </motion.span>
-      )}
+
+      <div className="flex h-10 items-center">
+        <AnimatePresence>
+          {allSettled && caption && (
+            <motion.span
+              className="text-4xl font-extrabold uppercase tracking-wider"
+              style={{
+                color: `rgb(${GOLD})`,
+                textShadow: `0 0 22px rgba(${GOLD},0.6), 0 2px 4px rgba(0,0,0,0.5)`,
+              }}
+              initial={{ opacity: 0, scale: 0.85, y: 6 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+            >
+              {caption}
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </div>
     </div>
+  );
+}
+
+/**
+ * In-game rolls (CR 705 / dN rolls): one die per result, grouped (e.g. a
+ * Krark's-Thumb double), with the same landing flourish but no winner framing.
+ */
+function InGameDice({
+  payload,
+  animate,
+  speedMultiplier,
+}: {
+  payload: Extract<DiceRollPayload, { kind: "die" }>;
+  animate: boolean;
+  speedMultiplier: number;
+}) {
+  return (
+    <div className="relative flex items-end justify-center gap-10 select-none">
+      {payload.rolls.map((roll, i) => (
+        <DieFace key={i} animate={animate} accent={NEUTRAL} value={roll.value}>
+          {(handleSettle) =>
+            animate ? (
+              <Suspense fallback={<DiePlaceholder label={String(roll.value)} />}>
+                <Dice3D
+                  sides={payload.sides}
+                  result={roll.value}
+                  speedMultiplier={speedMultiplier}
+                  size={DIE_SIZE}
+                  onSettle={handleSettle}
+                />
+              </Suspense>
+            ) : (
+              <DiePlaceholder label={String(roll.value)} />
+            )
+          }
+        </DieFace>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Wraps a single die/coin and plays a landing flourish the moment it settles: a
+ * scale "pop", an expanding accent ring, and a soft radial flash. `emphasize`
+ * adds a lingering glow for the contest winner. The die is supplied as a render
+ * prop so the wrapper can hand its settle callback to whichever 3D child (Dice3D
+ * / Coin3D) it renders; the static fallback settles on mount instead.
+ */
+function DieFace({
+  children,
+  animate,
+  accent,
+  emphasize = false,
+  value,
+  onSettle,
+}: {
+  children: (handleSettle: () => void) => ReactNode;
+  animate: boolean;
+  accent: string;
+  emphasize?: boolean;
+  /** When set, a numeric result badge pops in below the die as it lands. */
+  value?: number;
+  onSettle?: () => void;
+}) {
+  // Static fallbacks never fire a 3D `onSettle`, so they start settled.
+  const [settled, setSettled] = useState(!animate);
+  const handleSettle = useCallback(() => {
+    setSettled(true);
+    onSettle?.();
+  }, [onSettle]);
+
+  // The static fallback has no settle event of its own — register it once so a
+  // parent counting settles (the contest winner reveal) still reaches its total.
+  useEffect(() => {
+    if (!animate) onSettle?.();
+  }, [animate, onSettle]);
+
+  return (
+    <motion.div
+      className="relative flex flex-col items-center gap-2"
+      animate={settled ? { scale: [1, 1.14, 1] } : { scale: 1 }}
+      transition={{ duration: 0.36, ease: [0.34, 1.56, 0.64, 1] }}
+    >
+      <div className="relative rounded-2xl" style={{ width: DIE_SIZE, height: DIE_SIZE }}>
+        {/* Lingering glow for the emphasized (winner) die. */}
+        {emphasize && (
+          <motion.div
+            className="absolute -inset-1 rounded-2xl pointer-events-none"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.4 }}
+            style={{
+              boxShadow: `0 0 30px 6px rgba(${accent},0.55)`,
+              outline: `2px solid rgba(${accent},0.7)`,
+            }}
+          />
+        )}
+
+        {/* Settle flourish: expanding ring + radial flash, one-shot. */}
+        {settled && animate && (
+          <>
+            <motion.div
+              className="absolute inset-0 rounded-2xl pointer-events-none"
+              initial={{ opacity: 0.85, scale: 0.65 }}
+              animate={{ opacity: 0, scale: 1.7 }}
+              transition={{ duration: 0.6, ease: "easeOut" }}
+              style={{ border: `2px solid rgba(${accent},0.8)` }}
+            />
+            <motion.div
+              className="absolute inset-0 rounded-2xl pointer-events-none"
+              initial={{ opacity: 0.55, scale: 0.8 }}
+              animate={{ opacity: 0, scale: 1.35 }}
+              transition={{ duration: 0.45, ease: "easeOut" }}
+              style={{ background: `radial-gradient(circle, rgba(${accent},0.5), transparent 70%)` }}
+            />
+          </>
+        )}
+
+        <div className="relative h-full w-full">{children(handleSettle)}</div>
+      </div>
+
+      {/* Result badge: the engine's rolled value, revealed as the die lands so
+          the outcome is legible without reading the cluttered polyhedron face. */}
+      {value != null && (
+        <AnimatePresence>
+          {settled && (
+            <motion.span
+              className="min-w-9 rounded-md px-2 py-0.5 text-center text-xl font-extrabold tabular-nums"
+              initial={{ opacity: 0, scale: 0.6, y: -4 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0 }}
+              transition={{ type: "spring", stiffness: 320, damping: 18 }}
+              style={{
+                color: `rgb(${accent})`,
+                backgroundColor: `rgba(${accent},0.12)`,
+                border: `1px solid rgba(${accent},0.4)`,
+              }}
+            >
+              {value}
+            </motion.span>
+          )}
+        </AnimatePresence>
+      )}
+    </motion.div>
   );
 }
 
@@ -190,8 +424,8 @@ function DiceRollContent({ payload, animate }: { payload: DiceRollPayload; anima
 function DiePlaceholder({ label }: { label: string }) {
   return (
     <div
-      className="flex items-center justify-center rounded-2xl bg-slate-800/90 font-extrabold text-slate-100"
-      style={{ width: DIE_SIZE, height: DIE_SIZE, fontSize: DIE_SIZE * 0.42 }}
+      className="flex h-full w-full items-center justify-center rounded-2xl bg-slate-800/90 font-extrabold text-slate-100"
+      style={{ fontSize: DIE_SIZE * 0.42 }}
     >
       {label}
     </div>

--- a/client/src/components/animation/dice3d/Coin3D.tsx
+++ b/client/src/components/animation/dice3d/Coin3D.tsx
@@ -1,0 +1,214 @@
+// ─── Coin3D ───
+// Imperative three.js coin flip, mounted into its own <canvas>. Same mount /
+// rAF / dispose discipline as Dice3D and DeathShatter.
+//
+// A flattened cylinder (disc) flips about a horizontal axis with decaying
+// angular velocity, then settles showing the requested `face`. Heads and tails
+// each get a labelled CanvasTexture. `onSettle` fires once at rest.
+
+import { useEffect, useRef } from "react";
+import {
+  AmbientLight,
+  CanvasTexture,
+  CylinderGeometry,
+  DirectionalLight,
+  Mesh,
+  MeshStandardMaterial,
+  PerspectiveCamera,
+  Scene,
+  Vector3,
+  WebGLRenderer,
+} from "three";
+
+interface Coin3DProps {
+  /** Which face to land on after the flip. */
+  face: "heads" | "tails";
+  /** Scales animation duration (default 1). */
+  speedMultiplier?: number;
+  /** Fired once when the coin finishes settling. */
+  onSettle?: () => void;
+  /** Render size in px (the component owns its own <canvas>). */
+  size?: number;
+  /** Display text per face (caller supplies, may be i18n'd). */
+  labels?: { heads: string; tails: string };
+}
+
+const DEFAULT_SIZE = 120;
+const TOTAL_MS = 1500;
+const FACE_TEXTURE_PX = 256;
+const DEFAULT_LABELS = { heads: "H", tails: "T" } as const;
+
+// The flip axis: a horizontal axis (X). The coin's flat faces point along ±Y
+// in local space (CylinderGeometry's axis is Y), so flipping about X swaps
+// which flat face points toward the camera.
+const FLIP_AXIS = new Vector3(1, 0, 0);
+
+/** Quadratic ease-out. */
+function easeOutQuad(t: number): number {
+  return 1 - (1 - t) * (1 - t);
+}
+
+/** Draw a coin face label onto a CanvasTexture. */
+function makeFaceTexture(label: string, accent: string): CanvasTexture {
+  const canvas = document.createElement("canvas");
+  canvas.width = FACE_TEXTURE_PX;
+  canvas.height = FACE_TEXTURE_PX;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    const half = FACE_TEXTURE_PX / 2;
+    const grad = ctx.createRadialGradient(half, half, half * 0.1, half, half, half);
+    grad.addColorStop(0, accent);
+    grad.addColorStop(1, "#b8860b");
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.arc(half, half, half, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = "#1a1a2e";
+    ctx.font = `bold ${FACE_TEXTURE_PX * 0.4}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(label, half, half);
+  }
+  const texture = new CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+}
+
+export function Coin3D({
+  face,
+  speedMultiplier = 1,
+  onSettle,
+  size = DEFAULT_SIZE,
+  labels = DEFAULT_LABELS,
+}: Coin3DProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const settledRef = useRef(false);
+  const onSettleRef = useRef(onSettle);
+  onSettleRef.current = onSettle;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    settledRef.current = false;
+    let disposed = false;
+    let rafId = 0;
+
+    // ─── Scene / camera / renderer ───
+    const scene = new Scene();
+    const camera = new PerspectiveCamera(40, 1, 0.1, 100);
+    camera.position.set(0, 0, 4.5);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new WebGLRenderer({ alpha: true, antialias: true });
+    renderer.setSize(size, size);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    container.appendChild(renderer.domElement);
+
+    scene.add(new AmbientLight(0xffffff, 0.7));
+    const dirLight = new DirectionalLight(0xffffff, 0.9);
+    dirLight.position.set(2, 3, 4);
+    scene.add(dirLight);
+
+    // ─── Coin mesh: flattened cylinder ───
+    // Material group order for CylinderGeometry: [side, top (+Y), bottom (-Y)].
+    const headsTexture = makeFaceTexture(labels.heads, "#ffd700");
+    const tailsTexture = makeFaceTexture(labels.tails, "#e0c060");
+    const sideMaterial = new MeshStandardMaterial({
+      color: 0xc9a227,
+      roughness: 0.5,
+      metalness: 0.3,
+    });
+    const headsMaterial = new MeshStandardMaterial({
+      map: headsTexture,
+      roughness: 0.4,
+      metalness: 0.3,
+    });
+    const tailsMaterial = new MeshStandardMaterial({
+      map: tailsTexture,
+      roughness: 0.4,
+      metalness: 0.3,
+    });
+
+    const geometry = new CylinderGeometry(1, 1, 0.18, 48);
+    const mesh = new Mesh(geometry, [sideMaterial, headsMaterial, tailsMaterial]);
+
+    // Orient the coin so its flat faces face the camera at rest. The cylinder's
+    // top (+Y, heads) must point toward +Z (camera). Rotate +90° about X maps
+    // local +Y → +Z, showing heads; rotate -90° about X shows tails (local -Y
+    // → +Z).
+    const headsRest = Math.PI / 2;
+    const tailsRest = -Math.PI / 2;
+    const restAngle = face === "heads" ? headsRest : tailsRest;
+
+    scene.add(mesh);
+
+    // ─── Animation ───
+    // Flip several full turns, decaying to the rest angle showing `face`.
+    const totalMs = TOTAL_MS * speedMultiplier;
+    const flipTurns = 5;
+    // Final accumulated angle must equal restAngle modulo 2π so the chosen face
+    // ends pointing at the camera. We interpolate angle from 0 → target where
+    // target = flipTurns * 2π + restAngle.
+    const targetAngle = flipTurns * Math.PI * 2 + restAngle;
+
+    const start = performance.now();
+
+    const tick = (now: number) => {
+      if (disposed) return;
+
+      const elapsed = now - start;
+      const t = Math.min(elapsed / totalMs, 1);
+      const eased = easeOutQuad(t);
+      const angle = eased * targetAngle;
+
+      mesh.quaternion.setFromAxisAngle(FLIP_AXIS, angle);
+      // A small vertical hop for liveliness.
+      mesh.position.y = Math.sin(t * Math.PI) * 0.5;
+
+      renderer.render(scene, camera);
+
+      if (t >= 1) {
+        mesh.quaternion.setFromAxisAngle(FLIP_AXIS, targetAngle);
+        mesh.position.y = 0;
+        renderer.render(scene, camera);
+        if (!settledRef.current) {
+          settledRef.current = true;
+          onSettleRef.current?.();
+        }
+        return;
+      }
+
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(rafId);
+      geometry.dispose();
+      sideMaterial.dispose();
+      headsMaterial.dispose();
+      tailsMaterial.dispose();
+      headsTexture.dispose();
+      tailsTexture.dispose();
+      renderer.dispose();
+      if (renderer.domElement.parentNode === container) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, [face, speedMultiplier, size, labels.heads, labels.tails]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: size,
+        height: size,
+        pointerEvents: "none",
+      }}
+    />
+  );
+}

--- a/client/src/components/animation/dice3d/Dice3D.tsx
+++ b/client/src/components/animation/dice3d/Dice3D.tsx
@@ -1,0 +1,303 @@
+// ─── Dice3D ───
+// Imperative three.js die roll, mounted into its own <canvas>. Mirrors the
+// rAF + cleanup/dispose idiom of DeathShatter.tsx, swapping the 2D context for
+// a WebGLRenderer.
+//
+// The die tumbles with decaying angular velocity about a deterministic axis
+// (derived from `result` + `sides`, never Math.random — so the same roll looks
+// identical across re-renders), then slerps to the orientation that shows
+// `result` facing CAMERA_UP. `onSettle` fires exactly once when it comes to
+// rest.
+
+import { useEffect, useRef } from "react";
+import {
+  AmbientLight,
+  BoxGeometry,
+  CanvasTexture,
+  Color,
+  DirectionalLight,
+  Mesh,
+  MeshStandardMaterial,
+  PerspectiveCamera,
+  Quaternion,
+  Scene,
+  Sprite,
+  SpriteMaterial,
+  Vector3,
+  WebGLRenderer,
+} from "three";
+
+import { dieDescriptor } from "./dieGeometry.ts";
+
+interface Dice3DProps {
+  sides: number;
+  /** The engine's rolled value — the die MUST settle showing this. */
+  result: number;
+  /** Scales animation duration (default 1). */
+  speedMultiplier?: number;
+  /** Fired once when the die finishes settling. */
+  onSettle?: () => void;
+  /** Render size in px (the component owns its own <canvas>). */
+  size?: number;
+}
+
+const DEFAULT_SIZE = 120;
+const TOTAL_MS = 1600; // base roll duration (before speedMultiplier)
+const TUMBLE_FRACTION = 0.6; // first 60% tumbles, last 40% settles
+const FACE_TEXTURE_PX = 128;
+
+/** Quadratic ease-out, matching CardSlamAnimation's return easing. */
+function easeOutQuad(t: number): number {
+  return 1 - (1 - t) * (1 - t);
+}
+
+/**
+ * Deterministic pseudo-random unit axis from integer inputs. A small integer
+ * hash spread across three components, normalized — stable per (result, sides)
+ * so a given roll always tumbles the same way without touching Math.random.
+ */
+function deterministicAxis(result: number, sides: number): Vector3 {
+  const seed = (result * 73856093) ^ (sides * 19349663);
+  const x = ((seed & 0xff) / 255) * 2 - 1;
+  const y = (((seed >> 8) & 0xff) / 255) * 2 - 1;
+  const z = (((seed >> 16) & 0xff) / 255) * 2 - 1;
+  const axis = new Vector3(x, y, z);
+  if (axis.lengthSq() < 1e-6) axis.set(1, 1, 1);
+  return axis.normalize();
+}
+
+/** Draw a die face number onto a square CanvasTexture. */
+function makeNumberTexture(value: number): CanvasTexture {
+  const canvas = document.createElement("canvas");
+  canvas.width = FACE_TEXTURE_PX;
+  canvas.height = FACE_TEXTURE_PX;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    ctx.fillStyle = "#f5f1e6";
+    ctx.fillRect(0, 0, FACE_TEXTURE_PX, FACE_TEXTURE_PX);
+    ctx.fillStyle = "#1a1a2e";
+    ctx.font = `bold ${FACE_TEXTURE_PX * 0.55}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(String(value), FACE_TEXTURE_PX / 2, FACE_TEXTURE_PX / 2);
+  }
+  const texture = new CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+}
+
+/** Transparent sprite texture showing a number (for non-box polyhedra). */
+function makeSpriteTexture(value: number): CanvasTexture {
+  const canvas = document.createElement("canvas");
+  canvas.width = FACE_TEXTURE_PX;
+  canvas.height = FACE_TEXTURE_PX;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    ctx.clearRect(0, 0, FACE_TEXTURE_PX, FACE_TEXTURE_PX);
+    ctx.fillStyle = "#1a1a2e";
+    ctx.font = `bold ${FACE_TEXTURE_PX * 0.6}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(String(value), FACE_TEXTURE_PX / 2, FACE_TEXTURE_PX / 2);
+  }
+  const texture = new CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+}
+
+export function Dice3D({
+  sides,
+  result,
+  speedMultiplier = 1,
+  onSettle,
+  size = DEFAULT_SIZE,
+}: Dice3DProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const settledRef = useRef(false);
+  const onSettleRef = useRef(onSettle);
+  onSettleRef.current = onSettle;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    settledRef.current = false;
+    let disposed = false;
+    let rafId = 0;
+
+    const descriptor = dieDescriptor(sides);
+
+    // ─── Scene / camera / renderer ───
+    const scene = new Scene();
+    const camera = new PerspectiveCamera(40, 1, 0.1, 100);
+    camera.position.set(0, 1.4, 4.2);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new WebGLRenderer({ alpha: true, antialias: true });
+    renderer.setSize(size, size);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    container.appendChild(renderer.domElement);
+
+    scene.add(new AmbientLight(0xffffff, 0.7));
+    const dirLight = new DirectionalLight(0xffffff, 0.9);
+    dirLight.position.set(2, 4, 3);
+    scene.add(dirLight);
+
+    // ─── Geometry, materials, number labels ───
+    const geometry = descriptor.geometry();
+    const isBox = geometry instanceof BoxGeometry;
+
+    // Track everything that needs disposal.
+    const textures: CanvasTexture[] = [];
+    const materials: MeshStandardMaterial[] = [];
+    const spriteMaterials: SpriteMaterial[] = [];
+
+    let mesh: Mesh;
+    if (isBox) {
+      // BoxGeometry exposes 6 material groups in the order
+      // +X, -X, +Y, -Y, +Z, -Z. Map each to the descriptor's face value by
+      // matching that side's outward normal to a derived face normal.
+      const boxNormals: Vector3[] = [
+        new Vector3(1, 0, 0),
+        new Vector3(-1, 0, 0),
+        new Vector3(0, 1, 0),
+        new Vector3(0, -1, 0),
+        new Vector3(0, 0, 1),
+        new Vector3(0, 0, -1),
+      ];
+      const boxMaterials = boxNormals.map((normal) => {
+        // Find the descriptor face whose normal best matches this box side.
+        let bestFace = 0;
+        let bestDot = -Infinity;
+        for (let i = 0; i < descriptor.faceValue.length; i++) {
+          const d = descriptor.faceNormal(i).dot(normal);
+          if (d > bestDot) {
+            bestDot = d;
+            bestFace = i;
+          }
+        }
+        const value = descriptor.faceValue[bestFace];
+        const texture = makeNumberTexture(value);
+        textures.push(texture);
+        const material = new MeshStandardMaterial({
+          map: texture,
+          roughness: 0.4,
+          metalness: 0.05,
+        });
+        materials.push(material);
+        return material;
+      });
+      mesh = new Mesh(geometry, boxMaterials);
+    } else {
+      // Non-box polyhedron: single body material, number Sprites at centroids.
+      const body = new MeshStandardMaterial({
+        color: new Color(0xf5f1e6),
+        roughness: 0.4,
+        metalness: 0.05,
+      });
+      materials.push(body);
+      mesh = new Mesh(geometry, body);
+
+      for (let i = 0; i < descriptor.faceValue.length; i++) {
+        const value = descriptor.faceValue[i];
+        const texture = makeSpriteTexture(value);
+        textures.push(texture);
+        const spriteMaterial = new SpriteMaterial({
+          map: texture,
+          transparent: true,
+          depthTest: false,
+        });
+        spriteMaterials.push(spriteMaterial);
+        const sprite = new Sprite(spriteMaterial);
+        // Park the label just outside the face along its normal so it sits on
+        // the facet. Parented to the mesh, it inherits all roll rotation.
+        const normal = descriptor.faceNormal(i);
+        sprite.position.copy(normal.multiplyScalar(0.62));
+        sprite.scale.setScalar(0.5);
+        mesh.add(sprite);
+      }
+    }
+
+    scene.add(mesh);
+
+    // ─── Orientation targets ───
+    const settleQuat = descriptor.orientationFor(result);
+    const tumbleAxis = deterministicAxis(result, sides);
+    // Total tumble revolutions: a few full spins for a satisfying roll.
+    const tumbleTurns = 4 + (Math.abs(result) % 3);
+    const totalMs = TOTAL_MS * speedMultiplier;
+    const tumbleMs = totalMs * TUMBLE_FRACTION;
+    const settleMs = totalMs - tumbleMs;
+
+    // Orientation captured at the tumble→settle handoff, so the slerp starts
+    // from wherever the tumble left the die.
+    let handoffQuat: Quaternion | null = null;
+    const baseQuat = new Quaternion();
+    const tumbleQuat = new Quaternion();
+
+    const start = performance.now();
+
+    const tick = (now: number) => {
+      if (disposed) return;
+
+      const elapsed = now - start;
+
+      if (elapsed < tumbleMs) {
+        // Tumble: decaying angular velocity → angle eases out toward its max.
+        const t = elapsed / tumbleMs;
+        const angle = easeOutQuad(t) * tumbleTurns * Math.PI * 2;
+        tumbleQuat.setFromAxisAngle(tumbleAxis, angle);
+        mesh.quaternion.copy(baseQuat).multiply(tumbleQuat);
+
+        // Vertical bounce arc (quad ease), purely visual.
+        const bounce = Math.sin(t * Math.PI) * 0.4;
+        mesh.position.y = bounce;
+      } else if (elapsed < totalMs) {
+        // Settle: slerp from the handoff pose to the result-showing pose.
+        if (!handoffQuat) handoffQuat = mesh.quaternion.clone();
+        const t = (elapsed - tumbleMs) / settleMs;
+        const eased = easeOutQuad(t);
+        mesh.quaternion.copy(handoffQuat).slerp(settleQuat, eased);
+        mesh.position.y = (1 - eased) * 0.15;
+      } else {
+        mesh.quaternion.copy(settleQuat);
+        mesh.position.y = 0;
+        renderer.render(scene, camera);
+        if (!settledRef.current) {
+          settledRef.current = true;
+          onSettleRef.current?.();
+        }
+        return;
+      }
+
+      renderer.render(scene, camera);
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(rafId);
+      geometry.dispose();
+      for (const m of materials) m.dispose();
+      for (const m of spriteMaterials) m.dispose();
+      for (const t of textures) t.dispose();
+      renderer.dispose();
+      if (renderer.domElement.parentNode === container) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, [sides, result, speedMultiplier, size]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: size,
+        height: size,
+        pointerEvents: "none",
+      }}
+    />
+  );
+}

--- a/client/src/components/animation/dice3d/Dice3D.tsx
+++ b/client/src/components/animation/dice3d/Dice3D.tsx
@@ -3,11 +3,11 @@
 // rAF + cleanup/dispose idiom of DeathShatter.tsx, swapping the 2D context for
 // a WebGLRenderer.
 //
-// The die tumbles with decaying angular velocity about a deterministic axis
+// The die tumbles with decaying angular velocity about deterministic axes
 // (derived from `result` + `sides`, never Math.random — so the same roll looks
-// identical across re-renders), then slerps to the orientation that shows
-// `result` facing CAMERA_UP. `onSettle` fires exactly once when it comes to
-// rest.
+// identical across re-renders), then slerps to the orientation that turns the
+// `result` face toward the camera (RESULT_FACING) so the number reads head-on.
+// `onSettle` fires exactly once when it comes to rest.
 
 import { useEffect, useRef } from "react";
 import {
@@ -27,7 +27,7 @@ import {
   WebGLRenderer,
 } from "three";
 
-import { dieDescriptor } from "./dieGeometry.ts";
+import { CAMERA_UP, dieDescriptor } from "./dieGeometry.ts";
 
 interface Dice3DProps {
   sides: number;
@@ -45,6 +45,10 @@ const DEFAULT_SIZE = 120;
 const TOTAL_MS = 1600; // base roll duration (before speedMultiplier)
 const TUMBLE_FRACTION = 0.6; // first 60% tumbles, last 40% settles
 const FACE_TEXTURE_PX = 128;
+// Camera offset from the die center — a slightly-raised 3/4 view. The result
+// face is settled to point straight at this position (see `viewFacingQuat`), so
+// the rolled number reads head-on while the die keeps its dramatic angle.
+const CAMERA_OFFSET = new Vector3(0, 1.4, 4.2);
 
 /** Quadratic ease-out, matching CardSlamAnimation's return easing. */
 function easeOutQuad(t: number): number {
@@ -130,7 +134,7 @@ export function Dice3D({
     // ─── Scene / camera / renderer ───
     const scene = new Scene();
     const camera = new PerspectiveCamera(40, 1, 0.1, 100);
-    camera.position.set(0, 1.4, 4.2);
+    camera.position.copy(CAMERA_OFFSET);
     camera.lookAt(0, 0, 0);
 
     const renderer = new WebGLRenderer({ alpha: true, antialias: true });
@@ -189,7 +193,7 @@ export function Dice3D({
       });
       mesh = new Mesh(geometry, boxMaterials);
     } else {
-      // Non-box polyhedron: single body material, number Sprites at centroids.
+      // Non-box polyhedron: single body material, number Sprites on each facet.
       const body = new MeshStandardMaterial({
         color: new Color(0xf5f1e6),
         roughness: 0.4,
@@ -198,21 +202,42 @@ export function Dice3D({
       materials.push(body);
       mesh = new Mesh(geometry, body);
 
+      // A face's plane distance from the center is the max projection of any
+      // vertex onto that face's outward normal. Computed from the geometry's
+      // own vertices, this is correct for every die type (the inscribed radius
+      // differs per solid — d4 ≈ 0.33, d20 ≈ 0.79 of the circumradius), so the
+      // label always sits ON the facet rather than buried inside the body.
+      const posAttr = geometry.getAttribute("position");
+      const vtx = new Vector3();
+      const faceDistance = (normal: Vector3): number => {
+        let max = -Infinity;
+        for (let k = 0; k < posAttr.count; k++) {
+          vtx.fromBufferAttribute(posAttr, k);
+          max = Math.max(max, vtx.dot(normal));
+        }
+        return max;
+      };
+
       for (let i = 0; i < descriptor.faceValue.length; i++) {
         const value = descriptor.faceValue[i];
         const texture = makeSpriteTexture(value);
         textures.push(texture);
+        // `depthTest: true` lets the opaque body occlude labels on faces turned
+        // away from the camera — so only the numbers on the visible facets show,
+        // like a real die. (`depthTest: false` painted all N faces at once.)
         const spriteMaterial = new SpriteMaterial({
           map: texture,
           transparent: true,
-          depthTest: false,
+          depthTest: true,
+          depthWrite: false,
         });
         spriteMaterials.push(spriteMaterial);
         const sprite = new Sprite(spriteMaterial);
-        // Park the label just outside the face along its normal so it sits on
-        // the facet. Parented to the mesh, it inherits all roll rotation.
+        // Float the label a hair outside the facet plane along its normal, so it
+        // reads cleanly when front-facing and is hidden by the body when behind.
+        // Parented to the mesh, it inherits all roll rotation.
         const normal = descriptor.faceNormal(i);
-        sprite.position.copy(normal.multiplyScalar(0.62));
+        sprite.position.copy(normal.clone().multiplyScalar(faceDistance(normal) + 0.06));
         sprite.scale.setScalar(0.5);
         mesh.add(sprite);
       }
@@ -221,10 +246,20 @@ export function Dice3D({
     scene.add(mesh);
 
     // ─── Orientation targets ───
-    const settleQuat = descriptor.orientationFor(result);
+    // `orientationFor` turns the result face to the geometry's canonical up
+    // (CAMERA_UP, +Y). Compose a view-facing rotation that carries +Y onto the
+    // camera direction, so the result face ends up pointing straight at the
+    // (oblique) camera and the number reads head-on instead of edge-on. The
+    // camera concern lives here, not in the camera-agnostic geometry module.
+    const cameraDir = CAMERA_OFFSET.clone().normalize();
+    const viewFacingQuat = new Quaternion().setFromUnitVectors(CAMERA_UP, cameraDir);
+    const settleQuat = viewFacingQuat.multiply(descriptor.orientationFor(result));
+    // Tumble around TWO distinct axes at different rates so the die actually
+    // tumbles (end over end + spin) rather than spinning flatly about one axis.
     const tumbleAxis = deterministicAxis(result, sides);
-    // Total tumble revolutions: a few full spins for a satisfying roll.
+    const tumbleAxis2 = deterministicAxis(result + 7, sides + 3);
     const tumbleTurns = 4 + (Math.abs(result) % 3);
+    const tumbleTurns2 = 3 + (Math.abs(result * 2 + 1) % 3);
     const totalMs = TOTAL_MS * speedMultiplier;
     const tumbleMs = totalMs * TUMBLE_FRACTION;
     const settleMs = totalMs - tumbleMs;
@@ -233,7 +268,8 @@ export function Dice3D({
     // from wherever the tumble left the die.
     let handoffQuat: Quaternion | null = null;
     const baseQuat = new Quaternion();
-    const tumbleQuat = new Quaternion();
+    const spinQuat = new Quaternion();
+    const flipQuat = new Quaternion();
 
     const start = performance.now();
 
@@ -244,13 +280,15 @@ export function Dice3D({
 
       if (elapsed < tumbleMs) {
         // Tumble: decaying angular velocity → angle eases out toward its max.
+        // Two superimposed rotations give a chaotic, end-over-end tumble.
         const t = elapsed / tumbleMs;
-        const angle = easeOutQuad(t) * tumbleTurns * Math.PI * 2;
-        tumbleQuat.setFromAxisAngle(tumbleAxis, angle);
-        mesh.quaternion.copy(baseQuat).multiply(tumbleQuat);
+        const eased = easeOutQuad(t);
+        spinQuat.setFromAxisAngle(tumbleAxis, eased * tumbleTurns * Math.PI * 2);
+        flipQuat.setFromAxisAngle(tumbleAxis2, eased * tumbleTurns2 * Math.PI * 2);
+        mesh.quaternion.copy(baseQuat).multiply(spinQuat).multiply(flipQuat);
 
-        // Vertical bounce arc (quad ease), purely visual.
-        const bounce = Math.sin(t * Math.PI) * 0.4;
+        // Vertical bounce arc (quad ease), purely visual — a pronounced toss.
+        const bounce = Math.sin(t * Math.PI) * 0.7;
         mesh.position.y = bounce;
       } else if (elapsed < totalMs) {
         // Settle: slerp from the handoff pose to the result-showing pose.

--- a/client/src/components/animation/dice3d/__tests__/dieGeometry.test.ts
+++ b/client/src/components/animation/dice3d/__tests__/dieGeometry.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { Quaternion, Vector3 } from "three";
+
+import {
+  CAMERA_UP,
+  dieDescriptor,
+  SUPPORTED_DIE_SIDES,
+} from "../dieGeometry.ts";
+
+const EPS = 1e-4;
+
+function quaternionHasNaN(q: Quaternion): boolean {
+  return (
+    Number.isNaN(q.x) ||
+    Number.isNaN(q.y) ||
+    Number.isNaN(q.z) ||
+    Number.isNaN(q.w)
+  );
+}
+
+describe("dieGeometry — orientationFor brings the requested face to CAMERA_UP", () => {
+  for (const sides of SUPPORTED_DIE_SIDES) {
+    describe(`d${sides}`, () => {
+      const descriptor = dieDescriptor(sides);
+
+      it(`has exactly ${sides} faces numbered 1..${sides}`, () => {
+        expect(descriptor.faceValue).toHaveLength(sides);
+        const sorted = [...descriptor.faceValue].sort((a, b) => a - b);
+        expect(sorted).toEqual(
+          Array.from({ length: sides }, (_, i) => i + 1),
+        );
+      });
+
+      for (let value = 1; value <= sides; value++) {
+        it(`orientationFor(${value}) points face ${value} at CAMERA_UP`, () => {
+          const faceIndex = descriptor.faceValue.indexOf(value);
+          expect(faceIndex).toBeGreaterThanOrEqual(0);
+
+          const normal = descriptor.faceNormal(faceIndex);
+          const q = descriptor.orientationFor(value);
+          expect(quaternionHasNaN(q)).toBe(false);
+
+          const rotated = normal.clone().applyQuaternion(q);
+          // The rotated face normal must coincide with CAMERA_UP.
+          expect(rotated.dot(CAMERA_UP)).toBeGreaterThan(1 - EPS);
+        });
+      }
+    });
+  }
+});
+
+describe("dieGeometry — antipodal degeneracy guard", () => {
+  it("never returns a NaN quaternion even when a face normal opposes CAMERA_UP", () => {
+    // Walk every supported die and every face; the down-pointing face (normal
+    // ≈ -CAMERA_UP) is the antipodal case setFromUnitVectors cannot handle.
+    for (const sides of SUPPORTED_DIE_SIDES) {
+      const descriptor = dieDescriptor(sides);
+      for (const value of descriptor.faceValue) {
+        const q = descriptor.orientationFor(value);
+        expect(quaternionHasNaN(q)).toBe(false);
+      }
+    }
+  });
+
+  it("d6 explicitly handles a face whose normal is exactly -CAMERA_UP", () => {
+    const descriptor = dieDescriptor(6);
+    // The box has an axis-aligned face at -Y. Find the value on it.
+    const downIndex = descriptor.faceValue.findIndex(
+      (_, i) =>
+        descriptor.faceNormal(i).dot(CAMERA_UP) < -0.999,
+    );
+    expect(downIndex).toBeGreaterThanOrEqual(0);
+
+    const value = descriptor.faceValue[downIndex];
+    const normal = descriptor.faceNormal(downIndex);
+    const q = descriptor.orientationFor(value);
+    expect(quaternionHasNaN(q)).toBe(false);
+
+    const rotated = normal.clone().applyQuaternion(q);
+    expect(rotated.dot(CAMERA_UP)).toBeGreaterThan(1 - EPS);
+  });
+});
+
+describe("dieGeometry — unsupported sides fall back gracefully", () => {
+  it("dieDescriptor(10) returns a non-throwing fallback", () => {
+    const descriptor = dieDescriptor(10);
+    expect(descriptor.sides).toBe(10);
+    expect(descriptor.faceValue.length).toBeGreaterThan(0);
+    expect(() => descriptor.geometry().dispose()).not.toThrow();
+    const q = descriptor.orientationFor(7);
+    expect(quaternionHasNaN(q)).toBe(false);
+    // Identity orientation for the fallback.
+    expect(q.equals(new Quaternion())).toBe(true);
+  });
+
+  it("dieDescriptor(100) returns a non-throwing fallback", () => {
+    const descriptor = dieDescriptor(100);
+    expect(descriptor.sides).toBe(100);
+    expect(descriptor.faceValue.length).toBeGreaterThan(0);
+    expect(() => descriptor.geometry().dispose()).not.toThrow();
+    const normal = descriptor.faceNormal(0);
+    expect(normal).toBeInstanceOf(Vector3);
+    expect(quaternionHasNaN(descriptor.orientationFor(1))).toBe(false);
+  });
+});

--- a/client/src/components/animation/dice3d/dieGeometry.ts
+++ b/client/src/components/animation/dice3d/dieGeometry.ts
@@ -1,0 +1,229 @@
+// ─── 3D Die Geometry Registry ───
+// PURE module: no WebGL context, no DOM. Depends only on `three` math/geometry
+// classes so it is unit-testable under happy-dom without a GPU.
+//
+// Each supported die type maps to a `DieDescriptor` that knows:
+//   - how to build a fresh geometry instance,
+//   - the outward unit normal of each face (in the geometry's local space),
+//   - which number is printed on each face,
+//   - the quaternion that brings the face showing a requested value to CAMERA_UP.
+//
+// Supported v1 dice: d4, d6, d8, d12, d20 (three.js built-in polyhedra).
+// d10 / d100 (pentagonal trapezohedron) are OUT OF SCOPE — `dieDescriptor`
+// returns a graceful fallback descriptor for any unsupported side count.
+
+import {
+  BoxGeometry,
+  BufferGeometry,
+  DodecahedronGeometry,
+  IcosahedronGeometry,
+  OctahedronGeometry,
+  Quaternion,
+  SphereGeometry,
+  TetrahedronGeometry,
+  Vector3,
+} from "three";
+
+/**
+ * The direction a settled die's top (showing) face points after the roll
+ * resolves. We use +Y: the scene camera looks slightly down the -Z/-Y diagonal,
+ * so a face whose outward normal is +Y reads as the "top" of the die. All
+ * `orientationFor` results rotate the labelled face's normal onto this vector.
+ */
+export const CAMERA_UP: Vector3 = new Vector3(0, 1, 0);
+
+/** Squared-cosine threshold for treating two normals as antipodal. */
+const ANTIPODAL_DOT = -0.999999;
+
+/** Cosine tolerance for grouping coplanar triangles onto the same face. */
+const FACE_NORMAL_EPS = 1e-3;
+
+export interface DieDescriptor {
+  sides: number;
+  /** Build a fresh geometry instance (caller owns disposal). */
+  geometry(): BufferGeometry;
+  /** Number shown on each face: `faceValue[i]` is the pip count on face `i`. */
+  faceValue: number[];
+  /** Outward unit normal of face `i`, in the geometry's local space. */
+  faceNormal(faceIndex: number): Vector3;
+  /** Quaternion rotating the mesh so the face showing `value` points at CAMERA_UP. */
+  orientationFor(value: number): Quaternion;
+  /** How many physical dice represent one rolled value (1 for all v1 dice). */
+  renderCount: number;
+}
+
+/**
+ * Derive one outward unit normal per geometric face from a (non-indexed)
+ * geometry's position attribute.
+ *
+ * Each triangle contributes its geometric normal (the normalized cross product
+ * of two edges). Coplanar triangles of the same flat face share that normal
+ * exactly, so the box's two triangles per square side and the dodecahedron's
+ * three triangles per pentagon collapse into one face normal. (A centroid-
+ * direction heuristic does NOT work here: a square/pentagon split into
+ * triangles produces triangle centroids that do not lie on the face's outward
+ * ray, so the box reports 12 and the dodecahedron 36 spurious faces.)
+ *
+ * For the origin-centered convex polyhedra used as dice, three.js emits
+ * triangle vertices counter-clockwise when viewed from outside, so the cross
+ * product already points outward — no centroid-sign correction is needed.
+ *
+ * Faces are returned sorted by a stable lexicographic key on the rounded
+ * normal components, giving a deterministic 1..N numbering across runs.
+ */
+function deriveFaceNormals(geometry: BufferGeometry): Vector3[] {
+  const nonIndexed = geometry.index ? geometry.toNonIndexed() : geometry;
+  const pos = nonIndexed.getAttribute("position");
+  const triCount = pos.count / 3;
+
+  const groups: Vector3[] = [];
+  const a = new Vector3();
+  const b = new Vector3();
+  const c = new Vector3();
+  const edge1 = new Vector3();
+  const edge2 = new Vector3();
+  const normal = new Vector3();
+
+  for (let t = 0; t < triCount; t++) {
+    a.fromBufferAttribute(pos, t * 3 + 0);
+    b.fromBufferAttribute(pos, t * 3 + 1);
+    c.fromBufferAttribute(pos, t * 3 + 2);
+    edge1.subVectors(b, a);
+    edge2.subVectors(c, a);
+    normal.crossVectors(edge1, edge2);
+
+    // Skip degenerate triangles (zero-area, no defined normal).
+    if (normal.lengthSq() === 0) continue;
+    const dir = normal.clone().normalize();
+
+    const existing = groups.find((g) => g.dot(dir) > 1 - FACE_NORMAL_EPS);
+    if (!existing) groups.push(dir);
+  }
+
+  // If we created a non-indexed copy, free it — the source geometry is the
+  // caller's to keep; the copy was a transient working buffer.
+  if (nonIndexed !== geometry) nonIndexed.dispose();
+
+  // Deterministic ordering so face numbering is stable across runs.
+  groups.sort((u, v) => {
+    const ku = `${u.x.toFixed(4)},${u.y.toFixed(4)},${u.z.toFixed(4)}`;
+    const kv = `${v.x.toFixed(4)},${v.y.toFixed(4)},${v.z.toFixed(4)}`;
+    return ku < kv ? -1 : ku > kv ? 1 : 0;
+  });
+
+  return groups;
+}
+
+/**
+ * Quaternion that rotates `from` onto `to`, guarding the antipodal degeneracy
+ * where `Quaternion.setFromUnitVectors` is undefined (the two vectors are
+ * exactly opposite). In that case we rotate 180° about any axis perpendicular
+ * to `to`, which sends `from` onto `to` without producing a NaN quaternion.
+ */
+function rotationBetween(from: Vector3, to: Vector3): Quaternion {
+  const dot = from.dot(to);
+  if (dot < ANTIPODAL_DOT) {
+    // Pick an axis perpendicular to `to`. Cross with a non-parallel basis
+    // vector; fall back to a second basis vector if the first is parallel.
+    let axis = new Vector3(1, 0, 0).cross(to);
+    if (axis.lengthSq() < 1e-6) axis = new Vector3(0, 0, 1).cross(to);
+    axis.normalize();
+    return new Quaternion().setFromAxisAngle(axis, Math.PI);
+  }
+  return new Quaternion().setFromUnitVectors(from, to);
+}
+
+/**
+ * Build a descriptor for a geometry whose faces are derived generically from
+ * its triangle data. `valueForFace` assigns the printed number for face `i`
+ * (default: `i + 1`, i.e. faces labelled 1..N in deterministic normal order).
+ */
+function buildDescriptor(
+  sides: number,
+  makeGeometry: () => BufferGeometry,
+  valueForFace: (faceIndex: number, total: number) => number = (i) => i + 1,
+): DieDescriptor {
+  // Derive normals once from a throwaway geometry instance.
+  const probe = makeGeometry();
+  const normals = deriveFaceNormals(probe);
+  probe.dispose();
+
+  const faceValue = normals.map((_, i) => valueForFace(i, normals.length));
+
+  return {
+    sides,
+    geometry: makeGeometry,
+    faceValue,
+    renderCount: 1,
+    faceNormal(faceIndex: number): Vector3 {
+      return normals[faceIndex].clone();
+    },
+    orientationFor(value: number): Quaternion {
+      const faceIndex = faceValue.indexOf(value);
+      // Unknown value: identity (no NaN, die simply keeps its tumble pose).
+      if (faceIndex === -1) return new Quaternion();
+      return rotationBetween(normals[faceIndex].clone(), CAMERA_UP);
+    },
+  };
+}
+
+// ─── Supported die registry ───
+// `radius` arguments are arbitrary unit scales; orientation correctness is
+// scale-invariant, and the renderer normalizes display size separately.
+
+const DIE_BUILDERS: Record<number, () => DieDescriptor> = {
+  4: () => buildDescriptor(4, () => new TetrahedronGeometry(1)),
+  6: () => buildDescriptor(6, () => new BoxGeometry(1, 1, 1)),
+  8: () => buildDescriptor(8, () => new OctahedronGeometry(1)),
+  12: () => buildDescriptor(12, () => new DodecahedronGeometry(1)),
+  20: () => buildDescriptor(20, () => new IcosahedronGeometry(1)),
+};
+
+const registry = new Map<number, DieDescriptor>();
+
+/**
+ * Fallback descriptor for unsupported side counts (d10, d100, exotic dice).
+ * Backed by a sphere so it never crashes the renderer; it spins and the
+ * integration's text overlay shows the actual value. `faceValue` covers
+ * 1..min(sides, 6) and `orientationFor` returns identity (the sphere has no
+ * canonical "up" face — the value is communicated by the overlay, not a facet).
+ */
+function fallbackDescriptor(sides: number): DieDescriptor {
+  const count = Math.max(1, Math.min(sides, 6));
+  const faceValue = Array.from({ length: count }, (_, i) => i + 1);
+  // A single representative up-normal so faceNormal is well-defined and
+  // non-degenerate for any index.
+  const upNormal = new Vector3(0, 1, 0);
+
+  return {
+    sides,
+    geometry: () => new SphereGeometry(1, 24, 16),
+    faceValue,
+    renderCount: 1,
+    faceNormal(): Vector3 {
+      return upNormal.clone();
+    },
+    orientationFor(): Quaternion {
+      return new Quaternion();
+    },
+  };
+}
+
+/**
+ * Resolve the descriptor for a die with `sides` faces. Supported v1 dice
+ * (4, 6, 8, 12, 20) return a fully-derived descriptor; any other side count
+ * returns a non-throwing fallback so the integration never crashes on an
+ * exotic die.
+ */
+export function dieDescriptor(sides: number): DieDescriptor {
+  const cached = registry.get(sides);
+  if (cached) return cached;
+
+  const builder = DIE_BUILDERS[sides];
+  const descriptor = builder ? builder() : fallbackDescriptor(sides);
+  registry.set(sides, descriptor);
+  return descriptor;
+}
+
+/** Side counts with a fully-derived (non-fallback) descriptor. */
+export const SUPPORTED_DIE_SIDES: readonly number[] = [4, 6, 8, 12, 20];

--- a/client/src/components/animation/dice3d/dieGeometry.ts
+++ b/client/src/components/animation/dice3d/dieGeometry.ts
@@ -25,10 +25,12 @@ import {
 } from "three";
 
 /**
- * The direction a settled die's top (showing) face points after the roll
- * resolves. We use +Y: the scene camera looks slightly down the -Z/-Y diagonal,
- * so a face whose outward normal is +Y reads as the "top" of the die. All
- * `orientationFor` results rotate the labelled face's normal onto this vector.
+ * The canonical "up" a settled die's result face points to after the roll
+ * resolves, in the die's own (camera-agnostic) space. We use +Y. `Dice3D` then
+ * composes a further view-facing rotation so the result face turns toward its
+ * (oblique) camera and the number reads head-on — keeping this module free of
+ * any camera knowledge. All `orientationFor` results rotate the labelled face's
+ * normal onto this vector.
  */
 export const CAMERA_UP: Vector3 = new Vector3(0, 1, 0);
 

--- a/client/src/game/__tests__/diceContest.test.ts
+++ b/client/src/game/__tests__/diceContest.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameEvent } from "../../adapter/types";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+import { useUiStore } from "../../stores/uiStore";
+import { flashInGameRolls, flashStartingPlayerContest } from "../diceContest";
+
+const die = (player_id: number, sides: number, result: number): GameEvent => ({
+  type: "DieRolled",
+  data: { player_id, sides, result },
+});
+const coin = (player_id: number, won: boolean): GameEvent => ({
+  type: "CoinFlipped",
+  data: { player_id, won },
+});
+const gameStarted: GameEvent = { type: "GameStarted" };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  usePreferencesStore.setState({ animationSpeedMultiplier: 1 });
+  useUiStore.setState({ diceRoll: null, diceRollQueue: [] });
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("flashStartingPlayerContest", () => {
+  it("builds a startingPlayer die payload using the engine's winner", () => {
+    flashStartingPlayerContest([die(0, 20, 17), die(1, 20, 9), gameStarted], 0);
+    const d = useUiStore.getState().diceRoll;
+    expect(d).toMatchObject({ kind: "die", sides: 20, context: "startingPlayer", winner: 0 });
+    expect(d?.kind === "die" && d.rolls).toEqual([
+      { playerId: 0, value: 17 },
+      { playerId: 1, value: 9 },
+    ]);
+  });
+
+  it("shows each player's FINAL roll after tie rerolls", () => {
+    // Round 1 ties at 11; round 2 decides. The overlay should show the decisive
+    // values (18 vs 4), not the tied first round.
+    flashStartingPlayerContest(
+      [die(0, 20, 11), die(1, 20, 11), die(0, 20, 18), die(1, 20, 4), gameStarted],
+      0,
+    );
+    const d = useUiStore.getState().diceRoll;
+    expect(d?.kind === "die" && d.rolls).toEqual([
+      { playerId: 0, value: 18 },
+      { playerId: 1, value: 4 },
+    ]);
+  });
+
+  it("honors the engine winner even when it isn't the highest shown roll (lowest-seat fallback)", () => {
+    // Engine's all-tied-at-cap fallback picks the lowest seat; the winner is
+    // passed in, never recomputed from the rolls.
+    flashStartingPlayerContest([die(0, 20, 7), die(1, 20, 7), gameStarted], 0);
+    expect(useUiStore.getState().diceRoll).toMatchObject({ winner: 0 });
+  });
+
+  it("no-ops when the starter was chosen explicitly (no leading DieRolled)", () => {
+    flashStartingPlayerContest([gameStarted], 1);
+    expect(useUiStore.getState().diceRoll).toBeNull();
+  });
+
+  it("respects instant animation speed (0): no overlay", () => {
+    usePreferencesStore.setState({ animationSpeedMultiplier: 0 });
+    flashStartingPlayerContest([die(0, 20, 5)], 0);
+    expect(useUiStore.getState().diceRoll).toBeNull();
+  });
+});
+
+describe("flashInGameRolls", () => {
+  it("groups consecutive dice into one ability payload (e.g. Krark's Thumb double)", () => {
+    flashInGameRolls([die(0, 6, 3), die(0, 6, 5)]);
+    const d = useUiStore.getState().diceRoll;
+    expect(d).toMatchObject({ kind: "die", sides: 6, context: "ability" });
+    expect(d?.kind === "die" && d.rolls.length).toBe(2);
+  });
+
+  it("shows a coin flip when the batch has no dice", () => {
+    flashInGameRolls([coin(1, true)]);
+    expect(useUiStore.getState().diceRoll).toMatchObject({
+      kind: "coin",
+      playerId: 1,
+      won: true,
+      context: "ability",
+    });
+  });
+
+  it("no-ops on a batch containing neither dice nor coins", () => {
+    flashInGameRolls([gameStarted]);
+    expect(useUiStore.getState().diceRoll).toBeNull();
+  });
+
+  it("queues a co-occurring coin behind the dice instead of dropping it", () => {
+    flashInGameRolls([die(0, 20, 12), coin(0, true)]);
+    const s = useUiStore.getState();
+    expect(s.diceRoll).toMatchObject({ kind: "die" });
+    expect(s.diceRollQueue).toEqual([
+      { kind: "coin", playerId: 0, won: true, context: "ability" },
+    ]);
+  });
+
+  it("plays queued rolls serially: dice → coin → idle", () => {
+    flashInGameRolls([die(0, 20, 12), coin(0, true)]);
+    expect(useUiStore.getState().diceRoll?.kind).toBe("die");
+    vi.advanceTimersByTime(2400); // one DICE_ROLL_DURATION_MS at speed 1
+    expect(useUiStore.getState().diceRoll).toMatchObject({ kind: "coin" });
+    vi.advanceTimersByTime(2400);
+    expect(useUiStore.getState().diceRoll).toBeNull();
+  });
+});

--- a/client/src/game/diceContest.ts
+++ b/client/src/game/diceContest.ts
@@ -1,0 +1,77 @@
+import type { GameEvent, PlayerId } from "../adapter/types";
+import { useUiStore } from "../stores/uiStore";
+
+type DieRolledEvent = Extract<GameEvent, { type: "DieRolled" }>;
+type CoinFlippedEvent = Extract<GameEvent, { type: "CoinFlipped" }>;
+
+/**
+ * The leading run of consecutive `DieRolled` events — the starting-player
+ * contest the engine emits before `GameStarted` (CR 103.1). Empty when the
+ * starter was chosen explicitly (play/draw in setup), so callers no-op.
+ */
+function leadingDieRolls(events: GameEvent[]): DieRolledEvent[] {
+  const out: DieRolledEvent[] = [];
+  for (const e of events) {
+    if (e.type !== "DieRolled") break;
+    out.push(e);
+  }
+  return out;
+}
+
+/**
+ * The last roll per player — the decisive round after any tie rerolls — in
+ * first-seen seat order. The engine emits every reroll round; for display we
+ * show each player's final value.
+ */
+function finalRollPerPlayer(rolls: DieRolledEvent[]): { playerId: PlayerId; value: number }[] {
+  const byPlayer = new Map<PlayerId, number>();
+  for (const r of rolls) byPlayer.set(r.data.player_id, r.data.result);
+  return [...byPlayer.entries()].map(([playerId, value]) => ({ playerId, value }));
+}
+
+/**
+ * Fire the starting-player contest overlay from a game-start event batch.
+ *
+ * `startingPlayer` is the engine's authoritative choice (the player taking turn
+ * 1) — never recomputed on the frontend, so the highlighted winner always
+ * matches engine state even in the all-tied-at-cap → lowest-seat fallback. The
+ * `context` is supplied here (this code path IS the contest), not inferred from
+ * event ordering. No-ops on an empty contest (explicit play/draw choice).
+ */
+export function flashStartingPlayerContest(events: GameEvent[], startingPlayer: PlayerId): void {
+  const rolls = leadingDieRolls(events);
+  if (rolls.length === 0) return;
+  useUiStore.getState().flashDiceRoll({
+    kind: "die",
+    sides: rolls[0].data.sides,
+    rolls: finalRollPerPlayer(rolls),
+    context: "startingPlayer",
+    winner: startingPlayer,
+  });
+}
+
+/**
+ * Fire the in-game roll overlay for an action's event batch. Groups all
+ * `DieRolled` into one die overlay (e.g. a Krark's Thumb double) and otherwise
+ * shows the first `CoinFlipped`. Always `context: "ability"`. No-ops when the
+ * batch contains neither.
+ */
+export function flashInGameRolls(events: GameEvent[]): void {
+  const dice = events.filter((e): e is DieRolledEvent => e.type === "DieRolled");
+  const coin = events.find((e): e is CoinFlippedEvent => e.type === "CoinFlipped");
+  const flash = useUiStore.getState().flashDiceRoll;
+  // All dice in the batch group into one overlay (e.g. a Krark's Thumb double);
+  // a co-occurring coin queues behind them and plays after (the overlay FIFO
+  // serializes both rather than dropping either).
+  if (dice.length > 0) {
+    flash({
+      kind: "die",
+      sides: dice[0].data.sides,
+      rolls: dice.map((e) => ({ playerId: e.data.player_id, value: e.data.result })),
+      context: "ability",
+    });
+  }
+  if (coin) {
+    flash({ kind: "coin", playerId: coin.data.player_id, won: coin.data.won, context: "ability" });
+  }
+}

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -7,6 +7,7 @@ import type { AnimationStep } from "../animation/types";
 import { audioManager } from "../audio/AudioManager";
 import { MAX_UNDO_HISTORY, UNDOABLE_ACTIONS } from "../constants/game";
 import { debugLog } from "./debugLog";
+import { flashInGameRolls } from "./diceContest";
 import { useAnimationStore } from "../stores/animationStore";
 import { isMultiplayerMode, useGameStore, legalResultState, saveGame, saveCheckpoints } from "../stores/gameStore";
 import { getOpponentDisplayName } from "../stores/multiplayerStore";
@@ -229,6 +230,11 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
     const turnNumber = newState.players[turnPlayerId]?.turns_taken ?? 1;
     useUiStore.getState().flashTurnBanner(bannerText, turnNumber);
   }
+
+  // 5b. Surface in-game dice/coin rolls out-of-band (DiceRollOverlay), the same
+  // way the turn banner bypasses the animation queue. These events are marked
+  // NON_VISUAL so normalizeEvents skips them below.
+  flashInGameRolls(events);
 
   // 6. Normalize events into animation steps
   const pacingMultipliers = usePreferencesStore.getState().pacingMultipliers;

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -199,6 +199,13 @@
   "turnBanner": {
     "turn": "Zug {{number}}"
   },
+  "diceRoll": {
+    "you": "Du",
+    "youPlayFirst": "Du beginnst",
+    "playerPlaysFirst": "{{name}} beginnt",
+    "heads": "Kopf",
+    "tails": "Zahl"
+  },
   "chrome": {
     "back": "Zurück",
     "settings": "Einstellungen",

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -200,6 +200,8 @@
     "turn": "Zug {{number}}"
   },
   "diceRoll": {
+    "rollingForFirst": "Auswürfeln, wer beginnt",
+    "versus": "VS",
     "you": "Du",
     "youPlayFirst": "Du beginnst",
     "playerPlaysFirst": "{{name}} beginnt",

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -202,6 +202,7 @@
   "diceRoll": {
     "rollingForFirst": "Auswürfeln, wer beginnt",
     "versus": "VS",
+    "skip": "Zum Überspringen tippen",
     "you": "Du",
     "youPlayFirst": "Du beginnst",
     "playerPlaysFirst": "{{name}} beginnt",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -200,6 +200,8 @@
     "turn": "Turn {{number}}"
   },
   "diceRoll": {
+    "rollingForFirst": "Rolling for first player",
+    "versus": "VS",
     "you": "You",
     "youPlayFirst": "You play first",
     "playerPlaysFirst": "{{name}} plays first",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -202,6 +202,7 @@
   "diceRoll": {
     "rollingForFirst": "Rolling for first player",
     "versus": "VS",
+    "skip": "Tap to skip",
     "you": "You",
     "youPlayFirst": "You play first",
     "playerPlaysFirst": "{{name}} plays first",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -199,6 +199,13 @@
   "turnBanner": {
     "turn": "Turn {{number}}"
   },
+  "diceRoll": {
+    "you": "You",
+    "youPlayFirst": "You play first",
+    "playerPlaysFirst": "{{name}} plays first",
+    "heads": "Heads",
+    "tails": "Tails"
+  },
   "chrome": {
     "back": "Back",
     "settings": "Settings",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -200,6 +200,8 @@
     "turn": "Turno {{number}}"
   },
   "diceRoll": {
+    "rollingForFirst": "Tirada para ver quién empieza",
+    "versus": "VS",
     "you": "Tú",
     "youPlayFirst": "Juegas primero",
     "playerPlaysFirst": "{{name}} juega primero",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -202,6 +202,7 @@
   "diceRoll": {
     "rollingForFirst": "Tirada para ver quién empieza",
     "versus": "VS",
+    "skip": "Toca para omitir",
     "you": "Tú",
     "youPlayFirst": "Juegas primero",
     "playerPlaysFirst": "{{name}} juega primero",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -199,6 +199,13 @@
   "turnBanner": {
     "turn": "Turno {{number}}"
   },
+  "diceRoll": {
+    "you": "Tú",
+    "youPlayFirst": "Juegas primero",
+    "playerPlaysFirst": "{{name}} juega primero",
+    "heads": "Cara",
+    "tails": "Cruz"
+  },
   "chrome": {
     "back": "Atrás",
     "settings": "Ajustes",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -200,6 +200,8 @@
     "turn": "Tour {{number}}"
   },
   "diceRoll": {
+    "rollingForFirst": "Tirage pour savoir qui commence",
+    "versus": "VS",
     "you": "Vous",
     "youPlayFirst": "Vous jouez en premier",
     "playerPlaysFirst": "{{name}} joue en premier",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -202,6 +202,7 @@
   "diceRoll": {
     "rollingForFirst": "Tirage pour savoir qui commence",
     "versus": "VS",
+    "skip": "Toucher pour passer",
     "you": "Vous",
     "youPlayFirst": "Vous jouez en premier",
     "playerPlaysFirst": "{{name}} joue en premier",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -199,6 +199,13 @@
   "turnBanner": {
     "turn": "Tour {{number}}"
   },
+  "diceRoll": {
+    "you": "Vous",
+    "youPlayFirst": "Vous jouez en premier",
+    "playerPlaysFirst": "{{name}} joue en premier",
+    "heads": "Face",
+    "tails": "Pile"
+  },
   "chrome": {
     "back": "Retour",
     "settings": "Paramètres",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -202,6 +202,7 @@
   "diceRoll": {
     "rollingForFirst": "Tiro per stabilire chi inizia",
     "versus": "VS",
+    "skip": "Tocca per saltare",
     "you": "Tu",
     "youPlayFirst": "Giochi per primo",
     "playerPlaysFirst": "{{name}} gioca per primo",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -199,6 +199,13 @@
   "turnBanner": {
     "turn": "Turno {{number}}"
   },
+  "diceRoll": {
+    "you": "Tu",
+    "youPlayFirst": "Giochi per primo",
+    "playerPlaysFirst": "{{name}} gioca per primo",
+    "heads": "Testa",
+    "tails": "Croce"
+  },
   "chrome": {
     "back": "Indietro",
     "settings": "Impostazioni",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -200,6 +200,8 @@
     "turn": "Turno {{number}}"
   },
   "diceRoll": {
+    "rollingForFirst": "Tiro per stabilire chi inizia",
+    "versus": "VS",
     "you": "Tu",
     "youPlayFirst": "Giochi per primo",
     "playerPlaysFirst": "{{name}} gioca per primo",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -202,6 +202,7 @@
   "diceRoll": {
     "rollingForFirst": "Rzut o pierwszego gracza",
     "versus": "VS",
+    "skip": "Dotknij, aby pominąć",
     "you": "Ty",
     "youPlayFirst": "Zaczynasz",
     "playerPlaysFirst": "{{name}} zaczyna",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -199,6 +199,13 @@
   "turnBanner": {
     "turn": "Tura {{number}}"
   },
+  "diceRoll": {
+    "you": "Ty",
+    "youPlayFirst": "Zaczynasz",
+    "playerPlaysFirst": "{{name}} zaczyna",
+    "heads": "Orzeł",
+    "tails": "Reszka"
+  },
   "chrome": {
     "back": "Wstecz",
     "settings": "Ustawienia",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -200,6 +200,8 @@
     "turn": "Tura {{number}}"
   },
   "diceRoll": {
+    "rollingForFirst": "Rzut o pierwszego gracza",
+    "versus": "VS",
     "you": "Ty",
     "youPlayFirst": "Zaczynasz",
     "playerPlaysFirst": "{{name}} zaczyna",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -199,6 +199,13 @@
   "turnBanner": {
     "turn": "Turno {{number}}"
   },
+  "diceRoll": {
+    "you": "Você",
+    "youPlayFirst": "Você joga primeiro",
+    "playerPlaysFirst": "{{name}} joga primeiro",
+    "heads": "Cara",
+    "tails": "Coroa"
+  },
   "chrome": {
     "back": "Voltar",
     "settings": "Configurações",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -202,6 +202,7 @@
   "diceRoll": {
     "rollingForFirst": "Rolagem para ver quem começa",
     "versus": "VS",
+    "skip": "Toque para pular",
     "you": "Você",
     "youPlayFirst": "Você joga primeiro",
     "playerPlaysFirst": "{{name}} joga primeiro",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -200,6 +200,8 @@
     "turn": "Turno {{number}}"
   },
   "diceRoll": {
+    "rollingForFirst": "Rolagem para ver quem começa",
+    "versus": "VS",
     "you": "Você",
     "youPlayFirst": "Você joga primeiro",
     "playerPlaysFirst": "{{name}} joga primeiro",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -22,6 +22,8 @@ import { audioManager } from "../audio/AudioManager.ts";
 import { useAudioContext } from "../audio/useAudioContext.ts";
 import { AnimationOverlay } from "../components/animation/AnimationOverlay.tsx";
 import { TurnBanner } from "../components/animation/TurnBanner.tsx";
+import { DiceRollOverlay } from "../components/animation/DiceRollOverlay.tsx";
+import { flashStartingPlayerContest } from "../game/diceContest.ts";
 import { BattlefieldBackground } from "../components/board/BattlefieldBackground.tsx";
 import { BoardContextMenu } from "../components/board/BoardContextMenu.tsx";
 import { DebugCardContextMenu } from "../components/chrome/DebugCardContextMenu.tsx";
@@ -701,6 +703,20 @@ function GamePageContent({
   const isSandboxGame = useGameStore(
     (s) => s.gameState?.format_config?.allow_debug_actions === true,
   );
+
+  // CR 103.1: present the starting-player d20 contest once on game load. The
+  // store holds it as pure data; this presentation-layer effect drives the dice
+  // overlay with the engine's authoritative winner and clears the carrier. The
+  // identity-ref latch makes the consume idempotent under React StrictMode's
+  // double-invoke and after the clear (the re-run sees `null`).
+  const startingContest = useGameStore((s) => s.startingContest);
+  const consumedContestRef = useRef<typeof startingContest>(null);
+  useEffect(() => {
+    if (!startingContest || consumedContestRef.current === startingContest) return;
+    consumedContestRef.current = startingContest;
+    flashStartingPlayerContest(startingContest.events, startingContest.startingPlayer);
+    useGameStore.getState().clearStartingContest();
+  }, [startingContest]);
   const [showAiHand, setShowAiHand] = useState(false);
   const [showDebugBounds, setShowDebugBounds] = useState(false);
   const [viewingZone, setViewingZone] = useState<{
@@ -1321,6 +1337,7 @@ function GamePageContent({
       {/* Animation overlay (above board, below modals) */}
       <AnimationOverlay containerRef={containerRef} />
       <TurnBanner />
+      <DiceRollOverlay />
 
       {/* Combat SVG overlays: blocker assignments + attack target arrows */}
       <BlockAssignmentLines />

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -717,6 +717,16 @@ function GamePageContent({
     flashStartingPlayerContest(startingContest.events, startingContest.startingPlayer);
     useGameStore.getState().clearStartingContest();
   }, [startingContest]);
+  // CR 103.1 before CR 103.5: the starting-player contest must finish before the
+  // mulligan UI appears (the roll determines who's on the play, which precedes
+  // drawing opening hands). True from `initGame` setting the carrier through the
+  // dice overlay's full life — the store hands `startingContest` off to
+  // `uiStore.diceRoll` atomically, so there's no gap. Degrades to `false`
+  // immediately for instant speed and explicit play/draw (no contest).
+  const startingContestDiceActive = useUiStore(
+    (s) => s.diceRoll?.context === "startingPlayer",
+  );
+  const startingContestActive = startingContest !== null || startingContestDiceActive;
   const [showAiHand, setShowAiHand] = useState(false);
   const [showDebugBounds, setShowDebugBounds] = useState(false);
   const [viewingZone, setViewingZone] = useState<{
@@ -1459,8 +1469,11 @@ function GamePageContent({
         )}
 
       {/* CR 103.5: Simultaneous mulligan — render this player's modal iff
-          they are in the pending set. Each player decides independently. */}
+          they are in the pending set. Each player decides independently.
+          Held back until the CR 103.1 starting-player contest finishes so the
+          dice aren't hidden behind this modal. */}
       {waitingFor?.type === "MulliganDecision" &&
+        !startingContestActive &&
         (() => {
           const entry = waitingFor.data.pending.find(
             (e) => e.player === playerId,
@@ -1477,6 +1490,7 @@ function GamePageContent({
         })()}
 
       {waitingFor?.type === "MulliganDecision" &&
+        !startingContestActive &&
         !waitingFor.data.pending.some((e) => e.player === playerId) && (
           <div className="fixed inset-0 z-50 flex items-center justify-center">
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(31,41,55,0.55),rgba(2,6,23,0.92)_58%,rgba(2,6,23,0.98))]" />

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -10,6 +10,7 @@ import type {
   LegalActionsResult,
   ManaCost,
   MatchConfig,
+  PlayerId,
   WaitingFor,
 } from "../adapter/types";
 import { MAX_UNDO_HISTORY, UNDOABLE_ACTIONS } from "../constants/game";
@@ -89,6 +90,15 @@ interface GameStoreState {
    * `resolved`/`total` are engine-provided counts, never frontend-derived.
    */
   resolutionProgress: { resolved: number; total: number } | null;
+  /**
+   * Pure-data carrier for the starting-player d20 contest (CR 103.1): the
+   * game-start `DieRolled` batch plus the engine's authoritative starting
+   * player. Set once by `initGame` (null when the starter was chosen
+   * explicitly). A GamePage effect consumes it to drive the dice overlay and
+   * clears it via `clearStartingContest`. The store holds only data — it never
+   * calls the UI store, keeping the layer boundary clean.
+   */
+  startingContest: { events: GameEvent[]; startingPlayer: PlayerId } | null;
 }
 
 interface GameStoreActions {
@@ -120,6 +130,8 @@ interface GameStoreActions {
   setGameMode: (mode: GameMode) => void;
   setLobbyProgress: (progress: { joined: number; total: number } | null) => void;
   setResolutionProgress: (progress: { resolved: number; total: number } | null) => void;
+  /** Clear the starting-player contest after the overlay has consumed it. */
+  clearStartingContest: () => void;
 }
 
 export type GameStore = GameStoreState & GameStoreActions;
@@ -142,6 +154,7 @@ const initialState: GameStoreState = {
   turnCheckpoints: [],
   lobbyProgress: null,
   resolutionProgress: null,
+  startingContest: null,
 };
 
 export const useGameStore = create<GameStore>()(
@@ -157,6 +170,19 @@ export const useGameStore = create<GameStore>()(
         ...entry,
         seq: i,
       }));
+      // CR 103.1: capture the starting-player d20 contest as pure data so the
+      // dice overlay can animate the engine's authoritative result. Present only
+      // when the engine rolled (random starter); empty for an explicit
+      // play/draw choice. `current_starting_player` is the engine's pick — never
+      // recomputed from the rolls on the frontend.
+      const initEvents = initResult.events ?? [];
+      const rolledStart = initEvents[0]?.type === "DieRolled";
+      const startingContest = rolledStart
+        ? {
+            events: initEvents,
+            startingPlayer: state.current_starting_player ?? state.active_player,
+          }
+        : null;
       set({
         gameId,
         adapter,
@@ -169,6 +195,7 @@ export const useGameStore = create<GameStore>()(
         nextLogSeq: initLogEntries.length,
         stateHistory: [],
         turnCheckpoints: [],
+        startingContest,
       });
       saveGame(gameId, state);
     },
@@ -328,6 +355,10 @@ export const useGameStore = create<GameStore>()(
 
     setResolutionProgress: (progress) => {
       set({ resolutionProgress: progress });
+    },
+
+    clearStartingContest: () => {
+      set({ startingContest: null });
     },
   })),
 );

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -2,9 +2,36 @@ import { create } from "zustand";
 import type {
   GameAction,
   ObjectId,
+  PlayerId,
 } from "../adapter/types";
-import { TURN_BANNER_DURATION_MS } from "../animation/types";
+import { DICE_ROLL_DURATION_MS, TURN_BANNER_DURATION_MS } from "../animation/types";
 import { usePreferencesStore } from "./preferencesStore";
+
+/**
+ * A dice-roll / coin-flip moment to animate, surfaced from engine-authored
+ * `DieRolled` / `CoinFlipped` events. `context` is supplied by the delivering
+ * code path (the starting-player contest hand-off vs. an in-game roll), never
+ * inferred from event ordering. The engine owns the result; this is display.
+ */
+export type DiceRollPayload =
+  | {
+      kind: "die";
+      /** d-sides (e.g. 20 for the first-player contest, dN for card rolls). */
+      sides: number;
+      /** One entry per physical die shown — one per player for the contest. */
+      rolls: { playerId: PlayerId; value: number }[];
+      context: "startingPlayer" | "ability";
+      /** Starting-player contest: the high roller who takes the first turn. */
+      winner?: PlayerId;
+    }
+  | {
+      kind: "coin";
+      playerId: PlayerId;
+      /** The engine `won` flag (relative to the flipping player); the overlay
+       *  maps it to a heads/tails face (presentation choice, not engine data). */
+      won: boolean;
+      context: "startingPlayer" | "ability";
+    };
 
 // Guard against spurious mouseleave events caused by Framer Motion layout
 // recalculations or pointer-events-auto overlays stealing focus from the card.
@@ -18,6 +45,26 @@ let pendingShowTimer: ReturnType<typeof setTimeout> | null = null;
 let lastPointer = { x: 0, y: 0 };
 if (typeof window !== "undefined") {
   window.addEventListener("pointermove", (e) => { lastPointer = { x: e.clientX, y: e.clientY }; }, { passive: true });
+}
+
+// Serial FIFO for dice/coin overlays. Full-screen "moment" overlays are mutually
+// exclusive (you can't show two rolls at once), so simultaneous/back-to-back
+// rolls play one after another rather than clobbering. `diceRoll` is the active
+// payload; `diceRollQueue` holds the pending ones. Distinct from the board-event
+// step queue (animationStore) — that coordinates spatial per-object effects.
+let diceAdvanceTimer: ReturnType<typeof setTimeout> | null = null;
+function advanceDiceQueue(): void {
+  const queue = useUiStore.getState().diceRollQueue;
+  if (queue.length === 0) {
+    useUiStore.setState({ diceRoll: null });
+    diceAdvanceTimer = null;
+    return;
+  }
+  useUiStore.setState({ diceRoll: queue[0], diceRollQueue: queue.slice(1) });
+  // Re-read speed each step so a live Animation Speed change (incl. switching to
+  // instant) takes effect for the remaining queued rolls.
+  const speed = usePreferencesStore.getState().animationSpeedMultiplier;
+  diceAdvanceTimer = setTimeout(advanceDiceQueue, DICE_ROLL_DURATION_MS * Math.max(speed, 0));
 }
 
 interface UiStoreState {
@@ -42,6 +89,12 @@ interface UiStoreState {
   showTurnBanner: boolean;
   turnBannerText: string;
   turnBannerNumber: number | null;
+  /** Active dice-roll / coin-flip overlay payload, or null when idle. Set by
+   *  `flashDiceRoll`, auto-advanced through `diceRollQueue`, then cleared. */
+  diceRoll: DiceRollPayload | null;
+  /** Pending dice/coin overlays behind the active one. Simultaneous or
+   *  back-to-back rolls play serially instead of clobbering. */
+  diceRollQueue: DiceRollPayload[];
   focusedOpponent: number | null;
   pendingAbilityChoice: { objectId: ObjectId; actions: GameAction[] } | null;
   /** When non-null, the AttachmentsDialog is open showing every Aura
@@ -99,6 +152,12 @@ interface UiStoreActions {
   setPreviewSticky: (sticky: boolean) => void;
   setDragging: (dragging: boolean) => void;
   flashTurnBanner: (text: string, turnNumber: number) => void;
+  /** Show the dice-roll / coin-flip overlay for the engine's already-known
+   *  result. No-ops when animation speed is "instant" (0). */
+  flashDiceRoll: (payload: DiceRollPayload) => void;
+  /** Clear the active dice overlay, pending queue, and advance timer. Called on
+   *  DiceRollOverlay unmount so rolls can't leak across games. */
+  resetDiceRoll: () => void;
   setFocusedOpponent: (id: number | null) => void;
   setPendingAbilityChoice: (choice: { objectId: ObjectId; actions: GameAction[] } | null) => void;
   setEnchantmentsDialogPlayer: (id: number | null) => void;
@@ -141,6 +200,8 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   showTurnBanner: false,
   turnBannerText: "",
   turnBannerNumber: null,
+  diceRoll: null,
+  diceRollQueue: [],
   focusedOpponent: null,
   pendingAbilityChoice: null,
   enchantmentsDialogPlayer: null,
@@ -344,6 +405,34 @@ export const useUiStore = create<UiStore>()((set, get) => ({
     const duration = TURN_BANNER_DURATION_MS * speed * banner;
     set({ showTurnBanner: true, turnBannerText: text, turnBannerNumber: turnNumber });
     setTimeout(() => set({ showTurnBanner: false }), duration);
+  },
+  flashDiceRoll: (payload) => {
+    // Instant speed (0) skips the overlay entirely. The visible window scales
+    // with the global Animation Speed ONLY — not the Banner pacing category —
+    // because the 3D die's own tumble+settle duration scales by the same
+    // `speed`, so the die always settles before the overlay advances and the
+    // result caption reveals. When a roll is already showing, queue this one so
+    // simultaneous/back-to-back rolls play serially instead of clobbering.
+    const speed = usePreferencesStore.getState().animationSpeedMultiplier;
+    if (speed <= 0) return;
+    if (get().diceRoll === null) {
+      set({ diceRoll: payload });
+      if (diceAdvanceTimer) clearTimeout(diceAdvanceTimer);
+      diceAdvanceTimer = setTimeout(advanceDiceQueue, DICE_ROLL_DURATION_MS * speed);
+    } else {
+      set({ diceRollQueue: [...get().diceRollQueue, payload] });
+    }
+  },
+  resetDiceRoll: () => {
+    // Clears the active overlay, the pending queue, AND the module-level timer.
+    // Called from DiceRollOverlay's unmount cleanup so an in-flight roll can't
+    // leak across games (the store is a module singleton that outlives the
+    // GamePage mount).
+    if (diceAdvanceTimer) {
+      clearTimeout(diceAdvanceTimer);
+      diceAdvanceTimer = null;
+    }
+    set({ diceRoll: null, diceRollQueue: [] });
   },
   setFocusedOpponent: (id) => set({ focusedOpponent: id }),
   setPendingAbilityChoice: (choice) => set({ pendingAbilityChoice: choice }),

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -158,6 +158,9 @@ interface UiStoreActions {
   /** Clear the active dice overlay, pending queue, and advance timer. Called on
    *  DiceRollOverlay unmount so rolls can't leak across games. */
   resetDiceRoll: () => void;
+  /** Dismiss the current dice/coin overlay immediately (user tap-to-skip),
+   *  advancing to the next queued roll if any. */
+  skipDiceRoll: () => void;
   setFocusedOpponent: (id: number | null) => void;
   setPendingAbilityChoice: (choice: { objectId: ObjectId; actions: GameAction[] } | null) => void;
   setEnchantmentsDialogPlayer: (id: number | null) => void;
@@ -433,6 +436,17 @@ export const useUiStore = create<UiStore>()((set, get) => ({
       diceAdvanceTimer = null;
     }
     set({ diceRoll: null, diceRollQueue: [] });
+  },
+  skipDiceRoll: () => {
+    // User tap-to-skip: cancel the pending auto-advance and advance now, so the
+    // next queued roll plays immediately or the overlay clears. Reuses the same
+    // FIFO drain as the timer, so a skipped roll hands off to the next exactly
+    // as a timed one would (and the GamePage mulligan gate releases on schedule).
+    if (diceAdvanceTimer) {
+      clearTimeout(diceAdvanceTimer);
+      diceAdvanceTimer = null;
+    }
+    advanceDiceQueue();
   },
   setFocusedOpponent: (id) => set({ focusedOpponent: id }),
   setPendingAbilityChoice: (choice) => set({ pendingAbilityChoice: choice }),

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5549,22 +5549,106 @@ pub fn new_game(seed: u64) -> GameState {
     GameState::new_two_player(seed)
 }
 
+/// Maximum number of tie-break reroll rounds in the first-player contest.
+///
+/// Load-bearing safety cap: if every tied seat re-rolls the same value, the
+/// tied group does not shrink, so an unbounded "reroll the tied group" loop
+/// could spin forever on a degenerate RNG. After this many rounds the tie is
+/// broken deterministically by lowest seat index (see `start_game`).
+const FIRST_PLAYER_CONTEST_MAX_ROUNDS: usize = 16;
+
 /// Start game with mulligan flow. If no cards in libraries, skips mulligan.
 ///
-/// CR 103.1: The starting player of game 1 is chosen at random. Subsequent games
-/// in a multi-game match route through `match_flow::start_next_game`, which uses
-/// `next_game_chooser` instead, so this function is always the game-1 path.
+/// CR 103.1: At the start of game 1 of a match the players determine who takes
+/// the first turn "using any mutually agreeable method (flipping a coin,
+/// rolling dice, etc.)". This engine models that determination as an
+/// authoritative d20 high-roll contest — one d20 per seat using the game's
+/// seeded RNG (CR 706, rolling a die) — with ties rerolled among the tied top
+/// group. NOTE ON FIDELITY: the literal CR 103.1 sequence is "contest winner
+/// *chooses* who takes the first turn"; this engine collapses that to "contest
+/// winner *becomes* the starting player" (it does not present a play/draw
+/// choice here), an existing, accepted simplification — the annotation does not
+/// claim the choose-step is implemented. Subsequent games in a multi-game match
+/// route through `match_flow::start_next_game`, which uses `next_game_chooser`
+/// instead, so this function is always the game-1 path.
+///
+/// DETERMINISM: the contest draws only from `state.rng` (the seeded
+/// `ChaCha20Rng`), never thread/global RNG, so replays and AI search stay
+/// deterministic. This consumes a different number of RNG draws than the
+/// previous single `random_range(0..len)` pick, so a given seed now produces a
+/// different downstream sequence — an intentional, accepted determinism shift
+/// (verified: no in-repo test or replay fixture pins exact post-start RNG
+/// state).
 ///
 /// Callers that need a deterministic starter (tests, fixed scenarios) must use
-/// `start_game_with_starting_player` directly.
+/// `start_game_with_starting_player` directly — that path runs no contest and
+/// emits no `DieRolled` events.
 pub fn start_game(state: &mut GameState) -> ActionResult {
-    let starting_player = if state.seat_order.is_empty() {
-        PlayerId(0)
-    } else {
-        let idx = state.rng.random_range(0..state.seat_order.len());
-        state.seat_order[idx]
-    };
-    start_game_with_starting_player(state, starting_player)
+    if state.seat_order.is_empty() {
+        return start_game_with_starting_player(state, PlayerId(0));
+    }
+
+    // CR 103.1 / CR 706: roll one d20 per seat; the high roller becomes the
+    // starting player. Emit a DieRolled event for every roll (including reroll
+    // rounds) so the contest can be surfaced/animated downstream.
+    let mut dice_events: Vec<GameEvent> = Vec::new();
+
+    let roll_for =
+        |state: &mut GameState, dice_events: &mut Vec<GameEvent>, seat: PlayerId| -> u8 {
+            let result = state.rng.random_range(1..=20u8);
+            dice_events.push(GameEvent::DieRolled {
+                player_id: seat,
+                sides: 20,
+                result,
+            });
+            result
+        };
+
+    // `contenders` is the set of seats still in the running. It starts as every
+    // seat and, after each tie, narrows to the tied top group only.
+    let mut contenders: Vec<PlayerId> = state.seat_order.clone();
+    let mut starting_player: Option<PlayerId> = None;
+
+    // BOUNDED tie loop. Each iteration rolls every contender; a unique high
+    // roller wins. On a tie, `contenders` narrows to the tied top group and we
+    // reroll just them. INVARIANT: if every tied seat re-rolls the same value
+    // the group does NOT shrink, so this loop is bounded by
+    // FIRST_PLAYER_CONTEST_MAX_ROUNDS rather than relying on the group ever
+    // shrinking. If the cap is reached while still tied, the tie is broken
+    // deterministically by lowest seat index below — the engine can never hang.
+    for _round in 0..FIRST_PLAYER_CONTEST_MAX_ROUNDS {
+        let rolls: Vec<(PlayerId, u8)> = contenders
+            .iter()
+            .map(|&seat| (seat, roll_for(state, &mut dice_events, seat)))
+            .collect();
+        let max_roll = rolls.iter().map(|&(_, r)| r).max().expect("non-empty");
+        let top: Vec<PlayerId> = rolls
+            .iter()
+            .filter(|&&(_, r)| r == max_roll)
+            .map(|&(seat, _)| seat)
+            .collect();
+        if top.len() == 1 {
+            starting_player = Some(top[0]);
+            break;
+        }
+        // Tie: reroll only the tied top group on the next round.
+        contenders = top;
+    }
+
+    // Deterministic fallback: still tied at the cap → lowest seat index wins.
+    let starting_player = starting_player.unwrap_or_else(|| {
+        contenders
+            .iter()
+            .copied()
+            .min()
+            .expect("contenders is always non-empty")
+    });
+
+    let mut result = start_game_with_starting_player(state, starting_player);
+    // Sequence: all DieRolled (every round) → GameStarted → TurnStarted.
+    dice_events.extend(result.events.drain(..));
+    result.events = dice_events;
+    result
 }
 
 /// Start game with a specific player taking the first turn.
@@ -20367,6 +20451,7 @@ mod mdfc_land_tests {
     use crate::game::zones::create_object;
     use crate::types::card::LayoutKind;
     use crate::types::card_type::{CardType, CoreType};
+    use crate::types::format::FormatConfig;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::mana::ManaCost;
 
@@ -21093,5 +21178,211 @@ mod mdfc_land_tests {
             state.debug_permitted.contains(&PlayerId(0)),
             "host permission must remain on rejection"
         );
+    }
+
+    // --- First-player d20 contest (start_game) -------------------------------
+
+    /// Collect the d20 contest rolls (seat → result) from an ActionResult's
+    /// leading `DieRolled` batch, preserving emission order.
+    fn contest_rolls(result: &ActionResult) -> Vec<(PlayerId, u8)> {
+        result
+            .events
+            .iter()
+            .filter_map(|e| match e {
+                GameEvent::DieRolled {
+                    player_id,
+                    sides: 20,
+                    result,
+                } => Some((*player_id, *result)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// CR 103.1 / CR 706: a seeded contest emits one d20 `DieRolled` per seat
+    /// (when there is no tie) and the high roller becomes the starting player.
+    #[test]
+    fn start_game_contest_emits_d20_per_seat_and_picks_high_roller() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 7);
+        let result = start_game(&mut state);
+        let rolls = contest_rolls(&result);
+
+        // No tie at this seed → exactly one roll per seat.
+        assert_eq!(rolls.len(), 2, "no tie → one roll per seat");
+        assert_ne!(rolls[0].1, rolls[1].1, "seed 7 should not tie");
+        let max_roll = rolls.iter().map(|&(_, r)| r).max().unwrap();
+        // The winner is the seat that rolled the max.
+        let winner = rolls.iter().find(|&&(_, r)| r == max_roll).unwrap().0;
+        assert_eq!(
+            state.current_starting_player, winner,
+            "high roller becomes the starting player"
+        );
+        // All d20 rolls are in range.
+        assert!(rolls.iter().all(|&(_, r)| (1..=20).contains(&r)));
+    }
+
+    /// Event sequencing: all `DieRolled` precede `GameStarted`, which precedes
+    /// `TurnStarted`.
+    #[test]
+    fn start_game_contest_sequences_dice_before_game_started() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 7);
+        let result = start_game(&mut state);
+        let first_game_started = result
+            .events
+            .iter()
+            .position(|e| matches!(e, GameEvent::GameStarted))
+            .expect("GameStarted present");
+        let first_turn_started = result
+            .events
+            .iter()
+            .position(|e| matches!(e, GameEvent::TurnStarted { .. }))
+            .expect("TurnStarted present");
+        let last_die = result
+            .events
+            .iter()
+            .rposition(|e| matches!(e, GameEvent::DieRolled { .. }))
+            .expect("DieRolled present");
+        assert!(
+            last_die < first_game_started,
+            "all DieRolled must precede GameStarted"
+        );
+        assert!(
+            first_game_started < first_turn_started,
+            "GameStarted must precede TurnStarted"
+        );
+    }
+
+    /// Tie path: when the first round ties, a reroll occurs (more rolls than
+    /// seats) and the contest still resolves to a unique starting player.
+    #[test]
+    fn start_game_contest_tie_triggers_reroll_and_resolves() {
+        // Scan seeds for one whose first round of two d20s ties, forcing a
+        // reroll. This proves the reroll branch is exercised end-to-end.
+        let mut tie_seed = None;
+        for seed in 0..2000u64 {
+            let mut probe = GameState::new(FormatConfig::standard(), 2, seed);
+            let result = start_game(&mut probe);
+            let rolls = contest_rolls(&result);
+            // A tie on the first round means seat 0 and seat 1 rolled equal,
+            // producing a third (reroll) DieRolled event.
+            if rolls.len() > 2 {
+                tie_seed = Some(seed);
+                break;
+            }
+        }
+        let seed = tie_seed.expect("a tie within 2000 seeds (P(tie) = 1/20)");
+        let mut state = GameState::new(FormatConfig::standard(), 2, seed);
+        let result = start_game(&mut state);
+        let rolls = contest_rolls(&result);
+        assert!(
+            rolls.len() > 2,
+            "tie seed must produce reroll events beyond the two initial rolls"
+        );
+        // Resolves to exactly one starting player that is a valid seat.
+        assert!(
+            state.seat_order.contains(&state.current_starting_player),
+            "starting player is a valid seat after a reroll"
+        );
+        exactly_one_game_started(&result);
+    }
+
+    /// N-seat (3–4 player) contest picks the global max roller.
+    #[test]
+    fn start_game_contest_three_and_four_seats_pick_global_max() {
+        for player_count in [3u8, 4] {
+            let mut state = GameState::new(FormatConfig::commander(), player_count, 11);
+            let result = start_game(&mut state);
+            let rolls = contest_rolls(&result);
+            assert!(
+                rolls.len() >= player_count as usize,
+                "at least one roll per seat"
+            );
+            // The first `player_count` rolls are the opening round (one per seat).
+            let opening = &rolls[..player_count as usize];
+            let max_roll = opening.iter().map(|&(_, r)| r).max().unwrap();
+            // Count how many seats tied at the opening max.
+            let top: Vec<PlayerId> = opening
+                .iter()
+                .filter(|&&(_, r)| r == max_roll)
+                .map(|&(s, _)| s)
+                .collect();
+            if top.len() == 1 {
+                // Clean win: starting player is the unique opening max roller.
+                assert_eq!(
+                    state.current_starting_player, top[0],
+                    "global max roller wins when there is no opening tie"
+                );
+            } else {
+                // Opening tie → reroll happened; winner is still a valid seat.
+                assert!(rolls.len() > player_count as usize, "tie forced a reroll");
+                assert!(state.seat_order.contains(&state.current_starting_player));
+            }
+        }
+    }
+
+    /// The tie loop is BOUNDED: it can roll at most one initial round plus
+    /// FIRST_PLAYER_CONTEST_MAX_ROUNDS reroll rounds before falling back to the
+    /// lowest seat index. With at most `seats` rolls per round, the total
+    /// `DieRolled` count can never exceed `seats * (MAX_ROUNDS + 1)` — so the
+    /// engine can never hang at game start. (Forcing a *true* all-tie out of
+    /// ChaCha20 is impractical, so this asserts the structural bound that makes
+    /// the lowest-seat fallback reachable rather than the fallback firing.)
+    #[test]
+    fn start_game_contest_is_bounded_no_hang() {
+        for seed in 0..200u64 {
+            for player_count in [2u8, 3, 4] {
+                let mut state = GameState::new(FormatConfig::commander(), player_count, seed);
+                let result = start_game(&mut state);
+                let rolls = contest_rolls(&result);
+                let upper = player_count as usize * (FIRST_PLAYER_CONTEST_MAX_ROUNDS + 1);
+                assert!(
+                    rolls.len() <= upper,
+                    "contest must terminate within the bounded reroll cap (got {} rolls, cap {upper})",
+                    rolls.len()
+                );
+                assert!(state.seat_order.contains(&state.current_starting_player));
+            }
+        }
+    }
+
+    /// Explicit `start_game_with_starting_player` runs no contest and emits NO
+    /// `DieRolled` events.
+    #[test]
+    fn start_game_with_explicit_player_emits_no_dice() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 7);
+        let result = start_game_with_starting_player(&mut state, PlayerId(1));
+        assert!(
+            !result
+                .events
+                .iter()
+                .any(|e| matches!(e, GameEvent::DieRolled { .. })),
+            "explicit starting player path must emit no contest dice"
+        );
+        assert_eq!(state.current_starting_player, PlayerId(1));
+    }
+
+    /// Empty seat order keeps the PlayerId(0) fast path and emits no dice.
+    #[test]
+    fn start_game_empty_seat_order_no_contest() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 7);
+        state.seat_order.clear();
+        let result = start_game(&mut state);
+        assert!(
+            !result
+                .events
+                .iter()
+                .any(|e| matches!(e, GameEvent::DieRolled { .. })),
+            "empty seat order must not roll any dice"
+        );
+        assert_eq!(state.current_starting_player, PlayerId(0));
+    }
+
+    fn exactly_one_game_started(result: &ActionResult) {
+        let count = result
+            .events
+            .iter()
+            .filter(|e| matches!(e, GameEvent::GameStarted))
+            .count();
+        assert_eq!(count, 1, "exactly one GameStarted event");
     }
 }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5646,7 +5646,7 @@ pub fn start_game(state: &mut GameState) -> ActionResult {
 
     let mut result = start_game_with_starting_player(state, starting_player);
     // Sequence: all DieRolled (every round) → GameStarted → TurnStarted.
-    dice_events.extend(result.events.drain(..));
+    dice_events.append(&mut result.events);
     result.events = dice_events;
     result
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -21,6 +21,7 @@ use engine::ai_support::{
 use engine::database::CardDatabase;
 use engine::game::derived_views::derive_views;
 use engine::game::validate_name_deck_for_format;
+use engine::types::events::GameEvent;
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
 use http::HeaderValue;
@@ -67,10 +68,20 @@ type SharedDraftSpectators = Arc<
     >,
 >;
 
+/// Build the `GameStarted` message for a single seat.
+///
+/// `events` carries the engine's start-of-game events (the d20 first-player
+/// contest's `DieRolled` batch). Only the INITIAL post-start fan-out
+/// (`build_game_started_messages`) passes a non-empty batch; late joiners and
+/// reconnects pass an empty `Vec` so they never re-see the contest dice. The
+/// full batch goes to every seat unchanged — rolls are public (no
+/// `visibility.rs` redaction), so this deliberately does NOT apply the
+/// `is_actor` gating used for `legal_actions`.
 fn build_game_started_message(
     session: &GameSession,
     player: PlayerId,
     player_token: Option<String>,
+    events: Vec<GameEvent>,
 ) -> ServerMessage {
     let (legal_actions, spell_costs_all, by_object_all) = engine_legal_actions_full(&session.state);
     let auto_pass = engine_auto_pass(&session.state, &legal_actions);
@@ -107,14 +118,25 @@ fn build_game_started_message(
         },
         derived,
         player_token,
+        events,
     }
 }
 
-fn build_game_started_messages(session: &GameSession) -> Vec<(PlayerId, ServerMessage)> {
+/// Initial post-start fan-out. DRAINS `session.start_events` so the first-player
+/// contest dice are sent exactly once — every subsequent `GameStarted` build
+/// (late joiners, reconnects) sees an empty batch and never re-shows the dice.
+/// Every seat receives the full contest batch (public; not actor-gated).
+fn build_game_started_messages(session: &mut GameSession) -> Vec<(PlayerId, ServerMessage)> {
+    let start_events = std::mem::take(&mut session.start_events);
     (0..session.player_count)
         .map(PlayerId)
         .filter(|player| !session.ai_seats.contains(player))
-        .map(|player| (player, build_game_started_message(session, player, None)))
+        .map(|player| {
+            (
+                player,
+                build_game_started_message(session, player, None, start_events.clone()),
+            )
+        })
         .collect()
 }
 
@@ -2047,10 +2069,18 @@ async fn handle_client_message(
                     let started_messages = if session.is_full() {
                         session.run_ai();
                         persist_session_async(game_db, &game_code, session);
-                        Some((
-                            build_game_started_message(session, joiner, Some(player_token.clone())),
-                            build_game_started_messages(session),
-                        ))
+                        // The joiner is excluded from the fan-out send below
+                        // (`pid != joiner`), so it receives the contest dice via
+                        // its own message here. Snapshot the events before the
+                        // fan-out drains `start_events`.
+                        let joiner_events = session.start_events.clone();
+                        let joiner_msg = build_game_started_message(
+                            session,
+                            joiner,
+                            Some(player_token.clone()),
+                            joiner_events,
+                        );
+                        Some((joiner_msg, build_game_started_messages(session)))
                     } else {
                         None
                     };
@@ -2376,8 +2406,10 @@ async fn handle_client_message(
                             if ai_result.is_some() {
                                 persist_session_async(game_db, &game_code, session);
                             }
+                            // Reconnect: no contest dice (the player must not
+                            // re-see the first-player roll).
                             let game_started_msg =
-                                build_game_started_message(session, player, None);
+                                build_game_started_message(session, player, None, Vec::new());
                             ReconnectOutcome::InGame {
                                 player,
                                 game_started_msg: Box::new(game_started_msg),
@@ -2674,7 +2706,12 @@ async fn handle_client_message(
 
                     let session = mgr.sessions.get_mut(&game_code).unwrap();
                     session.run_ai();
-                    let game_started_msg = build_game_started_message(session, PlayerId(0), None);
+                    // Initial start of a Play-vs-AI game: the human seat sees
+                    // the first-player contest dice. Drain so they are not
+                    // re-sent on reconnect.
+                    let start_events = std::mem::take(&mut session.start_events);
+                    let game_started_msg =
+                        build_game_started_message(session, PlayerId(0), None, start_events);
 
                     // Persist the AI game session
                     persist_session_async(game_db, &game_code, session);

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -285,6 +285,14 @@ pub enum ServerMessage {
         /// Omitted (None) for hosts (who get it via GameCreated) and reconnects.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         player_token: Option<String>,
+        /// Engine events produced by `start_game` — currently the d20
+        /// first-player contest (`DieRolled`) batch. Populated ONLY on the
+        /// initial post-start broadcast; empty for late joiners and reconnects
+        /// (a reconnecting player must not re-see the contest dice). Rolls are
+        /// public (no `visibility.rs` redaction), so the full batch goes to
+        /// every seat. `serde(default)` keeps this back-compat for older clients.
+        #[serde(default)]
+        events: Vec<GameEvent>,
     },
     StateUpdate {
         state: GameState,
@@ -727,6 +735,7 @@ mod tests {
             legal_actions_by_object: HashMap::new(),
             derived: Default::default(),
             player_token: None,
+            events: vec![],
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerMessage = serde_json::from_str(&json).unwrap();
@@ -761,6 +770,7 @@ mod tests {
             legal_actions_by_object: HashMap::new(),
             derived: Default::default(),
             player_token: None,
+            events: vec![],
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerMessage = serde_json::from_str(&json).unwrap();

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -113,6 +113,12 @@ pub struct GameSession {
     /// Host preference: start automatically when every configured seat is
     /// occupied by a joined human or AI.
     pub start_when_full: bool,
+    /// Engine events produced by `start_game` (the d20 first-player contest's
+    /// `DieRolled` batch). Captured here so the INITIAL post-start broadcast can
+    /// surface them to clients; cleared after that broadcast so late joiners and
+    /// reconnects do not re-receive the contest dice. Empty when the game has
+    /// not started or the events have already been broadcast.
+    pub start_events: Vec<GameEvent>,
 }
 
 impl GameSession {
@@ -456,7 +462,11 @@ impl GameSession {
             Some(db),
         );
         self.state.log_player_names = self.display_names.clone();
-        let _ = start_game(&mut self.state);
+        // Capture the d20 first-player contest events so the initial broadcast
+        // can surface them; the broadcaster clears `start_events` afterward so
+        // joiners/reconnects do not re-see the dice.
+        let result = start_game(&mut self.state);
+        self.start_events = result.events;
         self.game_started = true;
         self.lobby_meta = None;
         Ok(())
@@ -575,6 +585,7 @@ impl GameSession {
             lobby_meta: ps.lobby_meta,
             game_started: ps.game_started,
             start_when_full: ps.start_when_full,
+            start_events: Vec::new(),
         }
     }
 }
@@ -681,6 +692,7 @@ impl SessionManager {
             lobby_meta: None,
             game_started: false,
             start_when_full: true,
+            start_events: Vec::new(),
         };
 
         self.token_to_game
@@ -1814,6 +1826,7 @@ mod tests {
             lobby_meta: None,
             game_started: false,
             start_when_full: true,
+            start_events: Vec::new(),
         };
 
         let game_started_before = session.game_started;


### PR DESCRIPTION
Engine: start_game runs a seeded d20 high-roll contest to choose the starting
player (CR 103.1 / CR 706), emitting DieRolled events before GameStarted;
bounded tie-reroll with a deterministic lowest-seat fallback.

Server: ServerMessage::GameStarted carries the contest DieRolled batch, drained
once to every seat on the initial broadcast (never replayed on reconnect/join).

Frontend: surface DieRolled/CoinFlipped to the GameEvent union and animate them
in a real-3D (three.js, code-split) DiceRollOverlay with reduced-motion and
no-WebGL static fallbacks. A serial FIFO plays simultaneous/back-to-back rolls
one at a time. The starting-player contest and in-game card rolls route through
the same engine-authoritative path (winner = engine's current_starting_player,
never recomputed). i18n keys added across all 7 locales.
