### PR TITLE
fix(mtgish-import): Ovika triggers on noncreature spell casts (#1718)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -6505,6 +6505,74 @@ pub mod tests {
         );
     }
 
+    /// Issue #1718: SpellCast triggers with `valid_target` (caster) and
+    /// `valid_card` (noncreature) must fire — Ovika's mtgish import was missing
+    /// these filters before `spell_cast_trigger` lowered them.
+    #[test]
+    fn spell_cast_trigger_with_caster_and_noncreature_filter_fires() {
+        use crate::types::ability::{AbilityDefinition, AbilityKind, ControllerRef, TypeFilter};
+
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+
+        let ovika = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Ovika, Enigma Goliath".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let trigger = TriggerDefinition::new(TriggerMode::SpellCast)
+                .valid_target(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                ))
+                .valid_card(TargetFilter::Typed(TypedFilter::new(TypeFilter::Non(
+                    Box::new(TypeFilter::Creature),
+                ))))
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Database,
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Controller,
+                    },
+                ));
+            let obj = state.objects.get_mut(&ovika).unwrap();
+            obj.trigger_definitions.push(trigger.clone());
+            std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trigger);
+        }
+
+        let spell = create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(0),
+            "Lightning Bolt".to_string(),
+            Zone::Stack,
+        );
+        state
+            .objects
+            .get_mut(&spell)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Instant);
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::SpellCast {
+                card_id: CardId(10),
+                controller: PlayerId(0),
+                object_id: spell,
+            }],
+        );
+
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "noncreature spell cast by controller should trigger Ovika-style ability"
+        );
+    }
+
     #[test]
     fn prowess_does_not_trigger_on_creature_spell() {
         use crate::types::keywords::Keyword;

--- a/crates/mtgish-import/src/convert/filter.rs
+++ b/crates/mtgish-import/src/convert/filter.rs
@@ -453,7 +453,9 @@ pub fn convert(p: &Permanents) -> ConvResult<TargetFilter> {
         // `TargetFilter::LastCreated`, which the engine snapshots at the moment a
         // composed delayed trigger is built (the exile-at-end-of-combat half of
         // Mirror Match) so it survives later token creation.
-        Permanents::TheCreatedTokens => TargetFilter::LastCreated,
+        Permanents::TheCreatedTokens | Permanents::TheTokensCreatedThisWay => {
+            TargetFilter::LastCreated
+        }
 
         // "Except for ~" set-difference subject — semantically the
         // complement of the inner filter. mtgish surfaces this distinct from
@@ -2029,6 +2031,14 @@ mod tests {
             ChoiceType::Color {
                 excluded: vec![ManaColor::White],
             }
+        );
+    }
+
+    #[test]
+    fn the_tokens_created_this_way_maps_to_last_created() {
+        assert_eq!(
+            convert(&Permanents::TheTokensCreatedThisWay).expect("convert tokens created this way"),
+            TargetFilter::LastCreated
         );
     }
 }

--- a/crates/mtgish-import/src/convert/trigger.rs
+++ b/crates/mtgish-import/src/convert/trigger.rs
@@ -505,9 +505,9 @@ pub fn convert(t: &Trigger) -> ConvResult<TriggerDefinition> {
         Trigger::WhenAPlayerDrawsACard(_players) => TriggerDefinition::new(TriggerMode::Drawn),
 
         // CR 601.2i: Spell cast.
-        Trigger::WhenASpellIsCast(_spells) => TriggerDefinition::new(TriggerMode::SpellCast),
-        Trigger::WhenAPlayerCastsASpell(_players, _spells) => {
-            TriggerDefinition::new(TriggerMode::SpellCast)
+        Trigger::WhenASpellIsCast(spells) => spell_cast_trigger(None, spells)?,
+        Trigger::WhenAPlayerCastsASpell(players, spells) => {
+            spell_cast_trigger(Some(players.as_ref()), spells)?
         }
 
         // CR 119.4 / CR 119.3: Life triggers.
@@ -823,6 +823,29 @@ fn nth_count_from_comparison(comparison: &Comparison, idiom: &'static str) -> Co
 ///   Rift family) and lowers to `valid_card: TargetFilter::SelfRef`.
 /// - Other card predicates (specific card-type filters) have no engine
 ///   slot today and strict-fail.
+/// CR 601.2i + CR 603.6a: "Whenever [a player] casts [a spell]" — lower the
+/// player axis to `valid_target` and the spell predicate to `valid_card`, mirroring
+/// the native oracle_trigger parser (e.g. Ovika's noncreature-spell trigger).
+fn spell_cast_trigger(
+    players: Option<&Players>,
+    spells: &crate::schema::types::Spells,
+) -> ConvResult<TriggerDefinition> {
+    use crate::schema::types::Spells as S;
+
+    let mut def = TriggerDefinition::new(TriggerMode::SpellCast);
+    if let Some(players) = players {
+        if !matches!(players, Players::AnyPlayer) {
+            def.valid_target = Some(TargetFilter::Typed(
+                TypedFilter::default().controller(players_to_controller(players)?),
+            ));
+        }
+    }
+    if !matches!(spells, S::AnySpell) {
+        def.valid_card = Some(spells_to_filter(spells)?);
+    }
+    Ok(def)
+}
+
 fn cycled_trigger(
     players: &Players,
     cards: &CardsInHand,
@@ -849,4 +872,36 @@ fn cycled_trigger(
         }
     }
     Ok(def)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::types::{CardType, Player, Players, Spells};
+    use engine::types::ability::{ControllerRef, TypeFilter};
+
+    #[test]
+    fn when_you_cast_noncreature_spell_sets_caster_and_spell_filters() {
+        let def = convert(&Trigger::WhenAPlayerCastsASpell(
+            Box::new(Players::SinglePlayer(Box::new(Player::You))),
+            Box::new(Spells::IsNonCardtype(CardType::Creature)),
+        ))
+        .expect("convert player spell cast trigger");
+
+        assert_eq!(def.mode, TriggerMode::SpellCast);
+        let Some(TargetFilter::Typed(tf)) = &def.valid_target else {
+            panic!("expected caster filter, got {:?}", def.valid_target);
+        };
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+
+        let Some(TargetFilter::Typed(tf)) = &def.valid_card else {
+            panic!("expected spell filter, got {:?}", def.valid_card);
+        };
+        assert!(
+            tf.type_filters
+                .contains(&TypeFilter::Non(Box::new(TypeFilter::Creature))),
+            "expected Non(Creature), got {:?}",
+            tf.type_filters
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1718. Ovika's `WhenAPlayerCastsASpell` import dropped the caster and noncreature spell filters, so the trigger never matched.

## Changes

- Lower player/spell axes in `spell_cast_trigger` for `WhenASpellIsCast` / `WhenAPlayerCastsASpell`.
- Map `TheTokensCreatedThisWay` to `LastCreated` for haste on created tokens.
- Engine regression test for filtered SpellCast triggers.

## Test plan

- [x] `cargo test -p mtgish-import --lib when_you_cast`
- [x] `cargo test -p mtgish-import --lib the_tokens_created_this_way`
- [x] `cargo test -p engine spell_cast_trigger_with_caster`
