### PR TITLE
fix(engine): allow X=0 distribute casts; refresh stale anaphoric/Yuriko test guards

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1441,13 +1441,17 @@ pub(crate) fn resolve_multi_target_bounds(
         ));
     }
 
-    let min = resolve_multi_target_min(state, ability, spec);
+    let raw_min = resolve_multi_target_min(state, ability, spec);
     let raw_max = resolve_multi_target_max(state, ability, spec).unwrap_or(legal_target_count);
-    if raw_max < min {
-        return Err(EngineError::ActionNotAllowed(
-            "Multi-target maximum is below its minimum".to_string(),
-        ));
-    }
+    // CR 601.2c: A resolved variable maximum can legitimately fall below the
+    // spec's structural minimum. For "distribute X counters among any number of
+    // target creatures" (Grove's Bounty) the floor of 1 expresses "each chosen
+    // target must receive a counter", but that floor only applies when there is
+    // something to distribute — casting for X=0 distributes nothing, so the
+    // required target count collapses to 0. Clamping `min` to `raw_max` yields
+    // exactly `min(1, X)`: 1 when X >= 1, 0 when X = 0. A genuinely malformed
+    // static spec never reaches here (constructors keep min <= max).
+    let min = raw_min.min(raw_max);
     if legal_target_count < min {
         return Err(EngineError::ActionNotAllowed(
             "Not enough legal targets available".to_string(),

--- a/crates/engine/tests/integration/anaphoric_scope_allowlist_guard.rs
+++ b/crates/engine/tests/integration/anaphoric_scope_allowlist_guard.rs
@@ -149,7 +149,6 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "baneful omen",
     "banewasp affliction",
     "bartz and boko",
-    "be'lakor, the dark master",
     "beastie beatdown",
     "bite down on crime",
     "blood poet",
@@ -161,7 +160,6 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "brightmare",
     "brokers charm",
     "calibrated blast",
-    "captain ripley vance",
     "champion of the path",
     "champion of wits",
     "chastise",
@@ -195,7 +193,6 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "doomgape",
     "durkwood tracker",
     "duskmantle seer",
-    "efteekay, flame of the kav",
     "electrosiphon",
     "electryte",
     "energy tap",
@@ -206,7 +203,6 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "feed the swarm",
     "felling blow",
     "feral encounter",
-    "fiendlash",
     "fiery encore",
     "flamethrower sonata",
     "foot chopper",
@@ -251,19 +247,15 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "kefka, dancing mad",
     "kindle the carnage",
     "knockout maneuver",
-    "laccolith rig",
     "lagonna-band storyteller",
     "lammastide weave",
     "lifeblood hydra",
     "living inferno",
     "lorcan, warlock collector",
-    "lothlórien blade",
     "lozhan, dragons' legacy",
     "lukka, coppercoat outcast",
-    "lukka, wayward bonder",
     "luminate primordial",
     "madame null, power broker",
-    "mage slayer",
     "make yourself useful",
     "mana drain",
     "marshland bloodcaster",
@@ -344,7 +336,6 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "spinal embrace",
     "spirit flare",
     "spoils of the hunt",
-    "stalking vengeance",
     "steadfast armasaur",
     "stronghold arena",
     "summon: kujata",
@@ -386,7 +377,6 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "vivien's invocation",
     "volcanic vision",
     "vraska's stoneglare",
-    "warstorm surge",
     "weed strangle",
     "willow geist",
     "wolverine riders",
@@ -451,17 +441,21 @@ fn anaphoric_scope_set_is_frozen() {
     // both this and ANAPHORIC_SCOPE_CARDS shrink together.
     assert_eq!(
         observed.len(),
-        257,
-        "Expected exactly 257 cards retaining ObjectScope::Anaphoric. PR #1451 \
+        247,
+        "Expected exactly 247 cards retaining ObjectScope::Anaphoric. PR #1451 \
          re-scoped 8 dynamic-quantity 'its power' anaphora off the Anaphoric \
          arm onto typed quantity refs; PR #1522 re-scoped Dead Before Sunrise \
-         through the recipient/subject rewrite. Count moved to {}.",
+         through the recipient/subject rewrite. The category-2 'it deals damage \
+         equal to its power' trigger-subject class (#512) then moved 10 more \
+         cards (Warstorm Surge, Stalking Vengeance, Mage Slayer, et al.) onto \
+         `Power {{ scope: EventSource }}`, dropping 257 -> 247. Count moved to \
+         {}.",
         observed.len()
     );
     assert_eq!(
         ANAPHORIC_SCOPE_CARDS.len(),
-        257,
-        "ANAPHORIC_SCOPE_CARDS must list exactly 257 cards."
+        247,
+        "ANAPHORIC_SCOPE_CARDS must list exactly 247 cards."
     );
 }
 

--- a/crates/engine/tests/integration/yuriko_combat_damage.rs
+++ b/crates/engine/tests/integration/yuriko_combat_damage.rs
@@ -182,6 +182,17 @@ fn yuriko_attacks_loses_opponent_life_equal_to_revealed_card_mana_value() {
 ///
 /// The 16-vs-14 gap proves the chained life-loss reads the revealed card's
 /// CMC and not the attacker's, even when the attacker is not Yuriko herself.
+///
+/// CR 603.3b: Ingenious Infiltrator carries its *own* combat-damage trigger
+/// ("...draw a card"). Both same-controller triggers fire and P0 orders them;
+/// whichever resolves first consumes the top of the library. The library is
+/// therefore seeded with TWO mana-value-2 cards (Counterspell + Negate) so
+/// that Infiltrator's draw and Yuriko's reveal each take a distinct CMC-2 card
+/// regardless of resolution order — Yuriko's reveal always yields mana value 2.
+/// A single library card would let the draw steal it, leaving Yuriko's reveal
+/// empty (no anaphoric referent) and falling through to the trigger-event
+/// source (the attacker, CMC 4) — the 14 bug-value masquerading as a fix
+/// failure.
 #[test]
 fn another_ninja_attacks_yuriko_still_reads_revealed_card_mana_value() {
     let Some(db) = load_db() else {
@@ -191,8 +202,11 @@ fn another_ninja_attacks_yuriko_still_reads_revealed_card_mana_value() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let _yuriko = scenario.add_real_card(P0, "Yuriko, the Tiger's Shadow", Zone::Battlefield, db);
-    // Counterspell is {U}{U} — mana value 2, distinct from Yuriko's 3.
+    // Counterspell {U}{U} and Negate {1}{U} are both mana value 2, distinct
+    // from Yuriko's 3 and Infiltrator's 4. Two cards so Infiltrator's own
+    // "draw a card" trigger and Yuriko's reveal each take a CMC-2 card.
     let revealed = scenario.add_real_card(P0, "Counterspell", Zone::Library, db);
+    let _drawn = scenario.add_real_card(P0, "Negate", Zone::Library, db);
     // Attacker — also a real Ninja so it matches the trigger condition
     // ("Whenever a Ninja you control deals combat damage to a player").
     // Ingenious Infiltrator is a Vedalken Ninja with mana cost {2}{U}{B}


### PR DESCRIPTION
- **fix(engine): allow X=0 distribute-among-any-number casts (CR 601.2c)**
- **test(engine): refresh anaphoric-scope allowlist to 247 after #512 re-scoping**
- **test(engine): harden Yuriko secondary regression against competing draw**
