### PR TITLE
fix(engine): surface orphaned same-controller combat-damage trigger ordering (turn-18 hang)

### DIFF
--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -114,6 +114,17 @@ pub fn resolve_combat_damage(
 
         // CR 510.4: SBAs and triggers run between first-strike and regular damage sub-steps.
         process_combat_damage_triggers(state, &damage_events, events);
+
+        // CR 510.4 + CR 603.3b: if the first-strike sub-step produced a same-
+        // controller trigger-ordering prompt, surface it now — before the regular
+        // sub-step's own trigger processing clobbers/orphans it. Returning here
+        // leaves `regular_damage_done == false`; the mandatory second (regular)
+        // combat-damage sub-step is resumed by the priority-pass completeness gate
+        // in priority.rs, which re-enters this function once the order is submitted
+        // and the resulting triggers resolve.
+        if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
+            return Some(state.waiting_for.clone());
+        }
     }
 
     // --- Regular damage sub-step ---

--- a/crates/engine/src/game/priority.rs
+++ b/crates/engine/src/game/priority.rs
@@ -40,9 +40,31 @@ pub fn handle_priority_pass(
         state.priority_pass_count = 0;
 
         if state.stack.is_empty() {
-            // CR 117.4: Empty stack — advance to next phase.
-            turns::advance_phase(state, events);
-            turns::auto_advance(state, events)
+            // CR 510.4: The combat damage step's turn-based action runs in two
+            // sub-steps when a first-strike/double-strike creature is present. If
+            // the first-strike sub-step paused on a CR 603.3b trigger-ordering
+            // prompt (combat_damage.rs), `resolve_combat_damage` returned before
+            // the MANDATORY second (regular) sub-step ran (`regular_damage_done ==
+            // false`). Those ordered triggers have now resolved and all players
+            // passed with an empty stack, but combat damage is INCOMPLETE — re-enter
+            // the combat-damage turn-based action (auto_advance re-calls
+            // resolve_combat_damage, which runs only the regular sub-step) instead
+            // of advancing to end of combat (which would silently skip the regular
+            // damage, violating CR 510.4). `regular_damage_done` is set true before
+            // the regular sub-step's own trigger processing, so the gate fires at
+            // most once and then advances normally — no infinite loop.
+            let combat_damage_incomplete = state.phase == crate::types::phase::Phase::CombatDamage
+                && state
+                    .combat
+                    .as_ref()
+                    .is_some_and(|c| !c.regular_damage_done);
+            if combat_damage_incomplete {
+                turns::auto_advance(state, events)
+            } else {
+                // CR 117.4: Empty stack — advance to next phase.
+                turns::advance_phase(state, events);
+                turns::auto_advance(state, events)
+            }
         } else {
             // CR 117.4: Non-empty stack — resolve the next object. A batch-safe
             // run of identical token triggers collapses into one step that

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -594,6 +594,27 @@ fn player_matches_filter(
     }
 }
 
+/// CR 120.3 + CR 102.2: True when a damage-recipient `valid_target` names a
+/// *player* and therefore can never be satisfied by an object recipient.
+///
+/// Covers the player-scope filters the parser emits for "deals [combat] damage
+/// to a player / to an opponent / to you": `Player`, `Controller`, and the
+/// controller-only `Typed` scope (empty `type_filters` and `properties`, only a
+/// `controller` set) that `player_matches_filter` treats as "you"/"an opponent".
+/// A `Typed` filter carrying any type constraint or property is a genuine object
+/// filter (e.g. "to a creature an opponent controls") and is excluded here.
+fn is_player_scope_damage_filter(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Player | TargetFilter::Controller => true,
+        TargetFilter::Typed(TypedFilter {
+            type_filters,
+            controller: Some(_),
+            properties,
+        }) => type_filters.is_empty() && properties.is_empty(),
+        _ => false,
+    }
+}
+
 /// Basic runtime matching of a TargetFilter against a game object.
 /// Handles the common filter patterns used in triggers.
 pub(super) fn target_filter_matches_object(
@@ -989,6 +1010,19 @@ pub(super) fn match_damage_done(
                     }
                 }
                 TargetRef::Object(oid) => {
+                    // CR 120.3 + CR 102.2: "deals [combat] damage to a player /
+                    // to an opponent" names a *player* recipient — an opponent is
+                    // by definition a player. The parser encodes "an opponent" as
+                    // a controller-only `Typed` scope (empty type_filters and
+                    // properties), the same player-scope convention
+                    // `player_matches_filter` honors. Damage dealt to an *object*
+                    // an opponent controls is not "damage to an opponent", so a
+                    // player-scope `valid_target` must reject every object
+                    // recipient — otherwise e.g. Coastal Piracy mis-fires on
+                    // combat damage to the opponent's creatures.
+                    if is_player_scope_damage_filter(vt) {
+                        return false;
+                    }
                     if !target_filter_matches_object(state, *oid, vt, source_id) {
                         return false;
                     }
@@ -7761,6 +7795,64 @@ mod tests {
             excess: 0,
         };
         assert!(match_damage_done(&event_opp, &trigger, source_id, &state));
+    }
+
+    /// CR 120.3 + CR 102.2: "deals combat damage to an opponent" names a *player*
+    /// recipient. A controller-only `Typed` opponent scope must reject combat
+    /// damage dealt to an *object* an opponent controls (their creature /
+    /// planeswalker) — otherwise Coastal Piracy ("Whenever a creature you control
+    /// deals combat damage to an opponent, you may draw a card") mis-fires on
+    /// blocked combat damage, spawning spurious same-controller triggers.
+    #[test]
+    fn damage_done_opponent_player_scope_rejects_object_recipient() {
+        let mut state = setup();
+        // Source: a creature PlayerId(0) controls (the Coastal Piracy attacker).
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            String::new(),
+            Zone::Battlefield,
+        );
+        // Opponent's creature — a valid combat-damage *object* recipient.
+        let opp_creature = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opponent Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::DamageDone);
+        trigger.damage_kind = DamageKindFilter::CombatOnly;
+        trigger.valid_target = Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::Opponent),
+        ));
+
+        // Combat damage to the opponent's creature — must NOT match.
+        let to_object = GameEvent::DamageDealt {
+            source_id,
+            target: TargetRef::Object(opp_creature),
+            amount: 4,
+            is_combat: true,
+            excess: 0,
+        };
+        assert!(
+            !match_damage_done(&to_object, &trigger, source_id, &state),
+            "combat damage to an opponent's creature is not 'damage to an opponent'"
+        );
+
+        // Combat damage to the opponent *player* — must still match.
+        let to_player = GameEvent::DamageDealt {
+            source_id,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 4,
+            is_combat: true,
+            excess: 0,
+        };
+        assert!(
+            match_damage_done(&to_player, &trigger, source_id, &state),
+            "combat damage to the opponent player must still fire the trigger"
+        );
     }
 
     // ── damage_amount threshold (CR 603.2 + CR 120.1) ─────────────

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1315,18 +1315,27 @@ fn add_lore_counters_to_sagas(state: &mut GameState, events: &mut Vec<GameEvent>
 ///   `state.waiting_for`. Returning `Priority` here would overwrite the prompt
 ///   and strand the queued triggers in `pending_trigger_order` forever (they
 ///   never reach the stack). Single-trigger steps take the `NoChoiceNeeded`
-///   path with no prompt and fall through to the normal priority grant.
+///   path with no prompt and fall through to the normal priority grant. The
+///   prompt is rebuilt from the AUTHORITATIVE `pending_trigger_order` state via
+///   `build_next_order_triggers_prompt_public`, not cloned from
+///   `state.waiting_for` — so a stale `waiting_for` left by an upstream
+///   phase-advance can't re-surface and hang, and already-corrupted saves
+///   recover by surfacing the real ordering prompt.
 fn process_phase_triggers(state: &mut GameState) -> (bool, Option<WaitingFor>) {
     let phase_event = [GameEvent::PhaseChanged { phase: state.phase }];
     let stack_before = state.stack.len();
     super::triggers::process_triggers(state, &phase_event);
     // CR 603.3b: an unresolved ordering pass keeps its triggers in
-    // `pending_trigger_order` (not on the stack, not in `pending_trigger`), so
-    // it must count toward `fired` and surface its prompt.
-    let ordering_prompt = state
-        .pending_trigger_order
-        .is_some()
-        .then(|| state.waiting_for.clone());
+    // `pending_trigger_order` (not on the stack, not in `pending_trigger`), so it
+    // must count toward `fired` and surface its prompt. Reconstruct the prompt
+    // from the AUTHORITATIVE source (`pending_trigger_order`) rather than cloning
+    // `state.waiting_for`: if an upstream phase-advance orphaned the pass and left
+    // `waiting_for` stale, cloning it would re-surface the stale state and hang.
+    // Reading the canonical pending state also RECOVERS already-corrupted saves by
+    // surfacing the real ordering prompt. Note `pending_trigger_order.is_some()` no
+    // longer blindly implies `waiting_for == OrderTriggers`, which is exactly why
+    // the prior `.then(|| clone)` idiom was unsafe.
+    let ordering_prompt = super::triggers::build_next_order_triggers_prompt_public(state);
     let fired = state.stack.len() > stack_before
         || state.pending_trigger.is_some()
         || ordering_prompt.is_some();
@@ -1535,6 +1544,23 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 if let Some(waiting) = combat_damage::resolve_combat_damage(state, events) {
                     state.waiting_for = waiting.clone();
                     return waiting;
+                }
+                // CR 603.3b: combat-damage triggers ran inside resolve_combat_damage
+                // (process_combat_damage_triggers -> process_triggers). If 2+ triggers
+                // controlled by the same player fired simultaneously, process_triggers
+                // populated `pending_trigger_order` and set `waiting_for` to the
+                // OrderTriggers prompt. Those triggers sit in `pending_trigger_order`, NOT
+                // on the stack, so the `!state.stack.is_empty()` guard below would advance
+                // past the prompt and strand them forever (the turn-18 hang). Surface the
+                // ordering prompt now, mirroring finish_declare_attackers (engine_combat.rs).
+                // NOTE: a first-strike sub-step OrderTriggers prompt is surfaced earlier,
+                // via the `Some(waiting)` return from resolve_combat_damage above (CR 510.4
+                // Part A in combat_damage.rs); the mandatory regular sub-step is then resumed
+                // by the empty-stack completeness gate in priority.rs. This guard handles the
+                // regular-step case, where resolve_combat_damage returns None but set
+                // `waiting_for` to the OrderTriggers prompt internally.
+                if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
+                    return state.waiting_for.clone();
                 }
                 // CR 704.3 / CR 800.4: SBAs may have ended the game during combat damage.
                 if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {

--- a/crates/engine/tests/integration/combat_damage_order_triggers_no_hang.rs
+++ b/crates/engine/tests/integration/combat_damage_order_triggers_no_hang.rs
@@ -1,0 +1,343 @@
+//! Regression: same-controller combat-damage triggers must surface their
+//! CR 603.3b ordering prompt instead of being stranded in
+//! `pending_trigger_order` (the turn-18 Coastal Piracy hang).
+//!
+//! Bug: when 2+ triggers controlled by the same player fired simultaneously in
+//! the combat damage step, `combat_damage::resolve_combat_damage` ran
+//! `process_triggers`, which populated `state.pending_trigger_order` and set
+//! `state.waiting_for` to `WaitingFor::OrderTriggers`. The `Phase::CombatDamage`
+//! arm of `auto_advance` then checked `!state.stack.is_empty()` — but the
+//! queued triggers live in `pending_trigger_order`, NOT on the stack — found an
+//! empty stack, and called `advance_phase`, silently discarding the ordering
+//! prompt. The triggers never reached the stack and the game hung waiting for an
+//! ordering choice it had thrown away.
+//!
+//! Fix (Edit 1, `turns.rs`): the `CombatDamage` arm now surfaces a live
+//! `WaitingFor::OrderTriggers` prompt (mirroring `finish_declare_attackers` in
+//! `engine_combat.rs`) before the `!state.stack.is_empty()` guard can advance
+//! past it.
+//!
+//! Fix (Edit 2, `turns.rs::process_phase_triggers`): the ordering prompt is now
+//! reconstructed from the AUTHORITATIVE `pending_trigger_order` state rather than
+//! cloned from a possibly-stale `state.waiting_for`.
+//!
+//! CR references (verified against `docs/MagicCompRules.txt`):
+//!   - CR 603.3b: when multiple abilities trigger before a player would receive
+//!     priority, each player orders their own simultaneous triggers (the
+//!     OrderTriggers prompt) before they go on the stack.
+//!   - CR 510.1b / CR 510.2: an unblocked creature deals combat damage equal to
+//!     its power to the player it is attacking, in the combat damage step.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+use super::rules::run_combat;
+
+/// "Whenever this creature deals combat damage to a player, you may draw a
+/// card." — a per-creature combat-damage trigger. Two creatures with the same
+/// controller carrying this trigger fire two simultaneous, same-controller
+/// triggers when both connect, which is the exact CR 603.3b ordering case.
+const DRAW_ON_COMBAT_DAMAGE: &str =
+    "Whenever this creature deals combat damage to a player, you may draw a card.";
+
+/// Mandatory variant (no "you may") for the first-strike re-entry test. A
+/// per-creature combat-damage trigger with NO optional choice: it resolves with
+/// no `OptionalEffectChoice` prompt, so the two ordered triggers drain fully off
+/// the stack and the test can reach the empty-stack priority pass that resumes
+/// the CR 510.4 regular sub-step. The optional `DRAW_ON_COMBAT_DAMAGE` would
+/// surface a draw-or-not prompt mid-resolution that the stack-drain helper cannot
+/// satisfy, stalling before the re-entry under test.
+const DRAW_ON_COMBAT_DAMAGE_MANDATORY: &str =
+    "Whenever this creature deals combat damage to a player, draw a card.";
+
+/// Primary regression — two same-controller creatures with combat-damage
+/// triggers attack unblocked, both deal combat damage to P1, and the resulting
+/// two simultaneous same-controller triggers MUST surface a CR 603.3b
+/// `WaitingFor::OrderTriggers` prompt for P0 instead of hanging.
+#[test]
+fn two_same_controller_combat_damage_triggers_surface_order_prompt_then_progress() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Two attackers, both P0-controlled, each with the draw-on-combat-damage
+    // trigger. Distinct names so the harness can disambiguate.
+    let bear_a = scenario
+        .add_creature_from_oracle(P0, "Tide Raider A", 2, 2, DRAW_ON_COMBAT_DAMAGE)
+        .id();
+    let bear_b = scenario
+        .add_creature_from_oracle(P0, "Tide Raider B", 2, 2, DRAW_ON_COMBAT_DAMAGE)
+        .id();
+
+    // Stock P0's library so the optional draws (if taken later) are observable
+    // and never trigger a draw-from-empty loss.
+    for name in ["Lib 1", "Lib 2", "Lib 3", "Lib 4"] {
+        scenario.add_card_to_library_top(P0, name);
+    }
+
+    let mut runner = scenario.build();
+    let life_before_p1 = runner.life(P1);
+
+    // Both creatures attack P1 unblocked → 2 simultaneous, same-controller
+    // combat-damage triggers fire inside `resolve_combat_damage`.
+    run_combat(&mut runner, vec![bear_a, bear_b], vec![]);
+
+    // CR 510.1b / CR 510.2: both 2/2s connected — P1 took 4 combat damage. This
+    // proves combat actually reached the damage step (not skipped).
+    assert_eq!(
+        runner.life(P1),
+        life_before_p1 - 4,
+        "CR 510.1b: two unblocked 2/2s deal 4 combat damage to P1"
+    );
+
+    // THE FIX: the two same-controller combat-damage triggers surface a
+    // CR 603.3b ordering prompt for P0 — they are NOT stranded in
+    // `pending_trigger_order` with the phase advanced past them (the hang).
+    match &runner.state().waiting_for {
+        WaitingFor::OrderTriggers { player, triggers } => {
+            assert_eq!(
+                *player, P0,
+                "CR 603.3b: P0 controls both combat-damage triggers and must order them"
+            );
+            assert_eq!(
+                triggers.len(),
+                2,
+                "CR 603.3b: both same-controller combat-damage triggers are awaiting ordering"
+            );
+        }
+        other => panic!(
+            "expected CR 603.3b OrderTriggers prompt after combat damage, got {other:?} \
+             (the turn-18 hang: triggers stranded in pending_trigger_order, phase advanced)"
+        ),
+    }
+
+    // The ordering pass is genuinely live in the authoritative source.
+    assert!(
+        runner.state().pending_trigger_order.is_some(),
+        "the ordering pass must be live in pending_trigger_order while the prompt is up"
+    );
+
+    // Drain the prompt by submitting an order, then resolve the two triggers.
+    // The turn MUST progress out of combat — not loop back to DeclareAttackers.
+    runner
+        .act(GameAction::OrderTriggers { order: vec![0, 1] })
+        .expect("submitting the CR 603.3b trigger order should succeed");
+    runner.advance_until_stack_empty();
+
+    assert!(
+        runner.state().pending_trigger_order.is_none(),
+        "after ordering and resolving, the ordering pass must be cleared"
+    );
+    assert_ne!(
+        runner.state().phase,
+        Phase::DeclareAttackers,
+        "the turn must progress past combat after the triggers resolve — not re-enter \
+         DeclareAttackers (a symptom of the stranded-prompt hang)"
+    );
+}
+
+/// Shape / recovery pin (Edit 2) — the surfaced CR 603.3b prompt is rebuilt
+/// from the AUTHORITATIVE `pending_trigger_order` state, so its contents match
+/// that source exactly (same controller, same trigger count). This is the
+/// property `process_phase_triggers` now relies on:
+/// `build_next_order_triggers_prompt_public(state)` reads `pending_trigger_order`
+/// directly instead of cloning `state.waiting_for`, which is what lets it
+/// recover a stale/orphaned `waiting_for` and surface the real prompt.
+///
+/// This is a SHAPE test: it pins the prompt-vs-pending-state correspondence,
+/// not a fault-injected corruption scenario. A full corruption-injection
+/// recovery test (seed `pending_trigger_order` with a stale `waiting_for` and
+/// re-enter `process_phase_triggers`) is not expressible from the integration
+/// test crate — `build_next_order_triggers_prompt_public` is `pub(crate)` and
+/// `PendingTriggerOrder` cannot be hand-constructed without engine-internal
+/// access to `PendingTrigger`/`ResolvedAbility`.
+#[test]
+fn order_prompt_contents_track_pending_trigger_order_state() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let bear_a = scenario
+        .add_creature_from_oracle(P0, "Tide Raider A", 2, 2, DRAW_ON_COMBAT_DAMAGE)
+        .id();
+    let bear_b = scenario
+        .add_creature_from_oracle(P0, "Tide Raider B", 2, 2, DRAW_ON_COMBAT_DAMAGE)
+        .id();
+    for name in ["Lib 1", "Lib 2", "Lib 3", "Lib 4"] {
+        scenario.add_card_to_library_top(P0, name);
+    }
+
+    let mut runner = scenario.build();
+    run_combat(&mut runner, vec![bear_a, bear_b], vec![]);
+
+    let WaitingFor::OrderTriggers {
+        player: prompt_player,
+        triggers: prompt_triggers,
+    } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "expected a CR 603.3b OrderTriggers prompt, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+
+    let order = runner
+        .state()
+        .pending_trigger_order
+        .as_ref()
+        .expect("a live ordering pass must back the prompt");
+    let unordered_group = order
+        .groups
+        .iter()
+        .find(|g| !g.ordered)
+        .expect("the prompt corresponds to the first unordered group");
+
+    // The surfaced prompt is a faithful projection of the authoritative
+    // `pending_trigger_order` group, not a clone of a stale `waiting_for`.
+    assert_eq!(
+        prompt_player, unordered_group.controller,
+        "the prompt's player is the unordered group's controller (rebuilt from pending state)"
+    );
+    assert_eq!(
+        prompt_triggers.len(),
+        unordered_group.triggers.len(),
+        "the prompt's trigger count matches the pending group (rebuilt, not cloned)"
+    );
+    assert_eq!(
+        prompt_player, P0,
+        "both combat-damage triggers belong to P0"
+    );
+}
+
+/// CR 510.4 + CR 603.3b mixed-combat regression — the first-strike sub-step's
+/// trigger-ordering prompt must NOT cause the mandatory regular (second)
+/// combat-damage sub-step to be skipped.
+///
+/// Pre-fix bug: P0's two first-strike creatures each carry a combat-damage
+/// trigger, so the first-strike sub-step paused on a CR 603.3b OrderTriggers
+/// prompt with `regular_damage_done == false`. When that ordering pass resolved
+/// and all players passed with an empty stack, `handle_priority_pass` saw the
+/// empty stack and called `advance_phase`, moving CombatDamage -> EndCombat
+/// WITHOUT running the regular sub-step — so the non-first-strike 3/3 attacker
+/// dealt no combat damage, silently violating CR 510.4 (after the first-strike
+/// step the phase MUST get a second combat-damage step for the remaining
+/// attackers). The fix: the empty-stack branch re-enters the combat-damage
+/// turn-based action while `regular_damage_done == false` instead of advancing.
+#[test]
+fn first_strike_order_prompt_does_not_skip_regular_combat_damage_substep() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Two P0 first-strike 2/2s, each with the combat-damage trigger → the
+    // first-strike sub-step produces a CR 603.3b ordering prompt. The builder
+    // borrows `&mut state`, so each creature must be built in its own scope
+    // (a fluent `.first_strike().id()` chain or multiple live builders won't
+    // compile).
+    let fs_a = {
+        let mut b = scenario.add_creature_from_oracle(
+            P0,
+            "FS Raider A",
+            2,
+            2,
+            DRAW_ON_COMBAT_DAMAGE_MANDATORY,
+        );
+        b.first_strike();
+        b.id()
+    };
+    let fs_b = {
+        let mut b = scenario.add_creature_from_oracle(
+            P0,
+            "FS Raider B",
+            2,
+            2,
+            DRAW_ON_COMBAT_DAMAGE_MANDATORY,
+        );
+        b.first_strike();
+        b.id()
+    };
+    // One P0 NON-first-strike 3/3 — it deals its damage only in the regular
+    // (second) sub-step, which is exactly what the pre-fix bug skipped.
+    let regular = scenario.add_creature(P0, "Regular Attacker", 3, 3).id();
+
+    // Stock P0's library so the optional draws never cause a draw-from-empty loss.
+    for name in ["Lib 1", "Lib 2", "Lib 3", "Lib 4", "Lib 5", "Lib 6"] {
+        scenario.add_card_to_library_top(P0, name);
+    }
+
+    let mut runner = scenario.build();
+    let life_before = runner.life(P1);
+
+    // All three attack P1 unblocked.
+    run_combat(&mut runner, vec![fs_a, fs_b, regular], vec![]);
+
+    // The first-strike sub-step paused on the CR 603.3b ordering prompt, BEFORE
+    // the regular sub-step ran.
+    match &runner.state().waiting_for {
+        WaitingFor::OrderTriggers { player, triggers } => {
+            assert_eq!(
+                *player, P0,
+                "CR 603.3b: P0 controls both first-strike combat-damage triggers"
+            );
+            assert_eq!(
+                triggers.len(),
+                2,
+                "CR 603.3b: both first-strike combat-damage triggers await ordering"
+            );
+        }
+        other => panic!(
+            "expected CR 603.3b OrderTriggers prompt after first-strike damage, got {other:?}"
+        ),
+    }
+
+    // Discriminator: the regular sub-step has NOT run yet, so only the two
+    // first-strike 2/2s have dealt damage (2 + 2 = 4); the 3/3 has not hit.
+    assert!(
+        !runner
+            .state()
+            .combat
+            .as_ref()
+            .expect("combat is still in progress at the first-strike pause")
+            .regular_damage_done,
+        "CR 510.4: regular combat-damage sub-step must not have run while the first-strike \
+         ordering prompt is up"
+    );
+    assert_eq!(
+        runner.life(P1),
+        life_before - 4,
+        "CR 510.4: only the two first-strike 2/2s have dealt damage so far (the 3/3 hits in \
+         the regular sub-step)"
+    );
+
+    // Submit the ordering and resolve the two first-strike triggers off the stack.
+    // `advance_until_stack_empty` stops the instant the stack is empty — it does NOT
+    // pass priority over the empty stack — so on its own it cannot drive a turn-based
+    // action that resumes AFTER the stack drains (CR 510.4's regular sub-step). The
+    // triggers are mandatory (no "you may"), so they drain cleanly without surfacing
+    // an OptionalEffectChoice the helper could not satisfy.
+    runner
+        .act(GameAction::OrderTriggers { order: vec![0, 1] })
+        .expect("submitting the CR 603.3b trigger order should succeed");
+    runner.advance_until_stack_empty();
+
+    // The two first-strike triggers have resolved and the stack is empty, but the
+    // CombatDamage step's turn-based action is incomplete (regular_damage_done ==
+    // false). Passing priority on the empty stack drives the CR 510.4 completeness
+    // gate, which re-enters the regular sub-step instead of advancing to end of
+    // combat — this is the precise pass the pre-fix bug skipped.
+    runner.pass_both_players();
+
+    // Authoritative proof the CR 510.4 second (regular) sub-step ran: the 3/3
+    // dealt its 3 combat damage (4 + 3 = 7 total).
+    assert_eq!(
+        runner.life(P1),
+        life_before - 7,
+        "CR 510.4: the regular sub-step ran — the non-first-strike 3/3 dealt its 3 damage"
+    );
+
+    // Combat has ended (or, at minimum, the regular sub-step completed).
+    assert!(
+        runner.state().combat.is_none()
+            || runner.state().combat.as_ref().unwrap().regular_damage_done,
+        "CR 510.4: combat ended or the regular combat-damage sub-step completed"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -28,6 +28,7 @@ mod cleave_text_changing_cost;
 mod cloud_key_chosen_type_cost;
 mod coalition_relic_integration;
 mod combat_celebrant_exert;
+mod combat_damage_order_triggers_no_hang;
 mod council_of_four_nth_per_turn;
 mod cr_annotations;
 mod crossway_troublemakers_attacking_keywords;


### PR DESCRIPTION
A game hung at turn 18 when Coastal Piracy fired multiple simultaneous
same-controller combat-damage triggers. Three compounding defects:

- Layer 1 (trigger_matchers.rs): the "deals combat damage to an opponent"
  matcher matched object recipients (creatures), not only the opponent
  player. CR 120.3 + CR 102.2: a player-scope damage filter can never be
  satisfied by an object recipient.

- Layer 2 (turns.rs): the CombatDamage auto_advance arm advanced the phase
  past a same-controller OrderTriggers prompt living in pending_trigger_order
  (not on the stack), stranding the triggers forever (CR 603.3b).

- Layer 3 (turns.rs::process_phase_triggers): the ordering prompt was cloned
  from a possibly-stale waiting_for instead of rebuilt from the authoritative
  pending_trigger_order.

Also fixes a related CR 510.4 first-strike gap: a trigger-ordering prompt
raised during the first-strike combat-damage sub-step now surfaces and then
re-enters the mandatory regular sub-step (combat_damage.rs Part A +
priority.rs empty-stack completeness gate) instead of skipping the second
damage step.

Verified: clippy + test-engine (590 passed) green; combat_loop_repro on the
saved turn-18 state surfaces OrderTriggers with no cycle.
