### PR TITLE
refactor(parser): factor cross-product alt() blocks + reject them on push

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6815,27 +6815,23 @@ fn try_parse_attack_if_able(lower: &str) -> Option<ImperativeFamilyAst> {
     let trimmed = lower.trim_end_matches('.');
 
     // First try: bare forms without a player reference.
-    let result: Result<(&str, Duration), nom::Err<OracleError<'_>>> = alt((
-        value(Duration::UntilEndOfTurn, tag("attacks this turn if able")),
-        value(Duration::UntilEndOfTurn, tag("attack this turn if able")),
-        value(
-            Duration::UntilEndOfCombat,
-            tag("attacks this combat if able"),
+    // verb axis × phase axis (PATTERNS.md §8b): factor "attack(s)" out front,
+    // then map the phase clause to its duration.
+    let result: Result<(&str, Duration), nom::Err<OracleError<'_>>> = (
+        alt((tag("attacks"), tag("attack"))),
+        preceded(
+            tag(" "),
+            alt((
+                value(Duration::UntilEndOfTurn, tag("this turn if able")),
+                value(
+                    Duration::UntilEndOfCombat,
+                    alt((tag("this combat if able"), tag("that combat if able"))),
+                ),
+            )),
         ),
-        value(
-            Duration::UntilEndOfCombat,
-            tag("attack this combat if able"),
-        ),
-        value(
-            Duration::UntilEndOfCombat,
-            tag("attacks that combat if able"),
-        ),
-        value(
-            Duration::UntilEndOfCombat,
-            tag("attack that combat if able"),
-        ),
-    ))
-    .parse(trimmed);
+    )
+        .map(|(_, duration)| duration)
+        .parse(trimmed);
 
     if let Ok((_, duration)) = result {
         return Some(ImperativeFamilyAst::GainKeyword(Effect::GenericEffect {

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1956,25 +1956,21 @@ fn try_parse_become_and_attack_if_able(
 }
 
 fn parse_attack_if_able_duration(input: &str) -> OracleResult<'_, Duration> {
-    alt((
-        value(
-            Duration::UntilEndOfTurn,
-            alt((
-                tag("attacks this turn if able"),
-                tag("attack this turn if able"),
-            )),
-        ),
-        value(
-            Duration::UntilEndOfCombat,
-            alt((
-                tag("attacks this combat if able"),
-                tag("attack this combat if able"),
-                tag("attacks that combat if able"),
-                tag("attack that combat if able"),
-            )),
-        ),
-    ))
-    .parse(input)
+    // verb axis × phase axis (PATTERNS.md §8b): factor "attack(s)" out front,
+    // then map the phase clause to its duration ("this turn" → end of turn,
+    // "this/that combat" → end of combat).
+    let (rest, _) = alt((tag("attacks"), tag("attack"))).parse(input)?;
+    preceded(
+        tag(" "),
+        alt((
+            value(Duration::UntilEndOfTurn, tag("this turn if able")),
+            value(
+                Duration::UntilEndOfCombat,
+                alt((tag("this combat if able"), tag("that combat if able"))),
+            ),
+        )),
+    )
+    .parse(rest)
 }
 
 /// CR 119.5: Parse "life total becomes N" into SetLifeTotal effect.

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -2,7 +2,7 @@ use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::combinator::{map, opt, success, value};
-use nom::sequence::{preceded, terminated};
+use nom::sequence::{delimited, preceded, terminated};
 use nom::Parser;
 
 use crate::types::ability::{
@@ -552,13 +552,17 @@ fn parse_modal_specific_kicker_cost_condition(
 }
 
 fn parse_modal_override_count(input: &str) -> nom::IResult<&str, usize, OracleError<'_>> {
-    alt((
-        value(2, tag("choose both instead")),
-        value(2, tag("choose two instead")),
-        value(3, tag("choose three instead")),
-        value(usize::MAX, tag("choose any number instead")),
-        value(usize::MAX, tag("choose one or more instead")),
-    ))
+    // "choose <count> instead" — factor the shared prefix/suffix; only the
+    // count word varies (PATTERNS.md §8b).
+    delimited(
+        tag("choose "),
+        alt((
+            value(2, alt((tag("both"), tag("two")))),
+            value(3, tag("three")),
+            value(usize::MAX, alt((tag("any number"), tag("one or more")))),
+        )),
+        tag(" instead"),
+    )
     .parse(input)
 }
 

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2058,12 +2058,12 @@ fn parse_counter_added_target(input: &str) -> OracleResult<'_, TargetFilter> {
     alt((
         value(
             TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
-            alt((
-                tag("creature under your control"),
-                tag("creature you control"),
-                tag("creatures under your control"),
-                tag("creatures you control"),
-            )),
+            // number axis × controller-phrase axis (PATTERNS.md §8b) — "creatures"
+            // before "creature" since alt() is short-circuit.
+            (
+                alt((tag("creatures"), tag("creature"))),
+                alt((tag(" under your control"), tag(" you control"))),
+            ),
         ),
         value(
             TargetFilter::Typed(TypedFilter::creature()),
@@ -2071,12 +2071,10 @@ fn parse_counter_added_target(input: &str) -> OracleResult<'_, TargetFilter> {
         ),
         value(
             TargetFilter::Typed(TypedFilter::permanent().controller(ControllerRef::You)),
-            alt((
-                tag("permanent under your control"),
-                tag("permanent you control"),
-                tag("permanents under your control"),
-                tag("permanents you control"),
-            )),
+            (
+                alt((tag("permanents"), tag("permanent"))),
+                alt((tag(" under your control"), tag(" you control"))),
+            ),
         ),
         value(
             TargetFilter::Typed(TypedFilter::permanent()),

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2811,34 +2811,25 @@ fn parse_superlative_property_suffix(
     ctx: &mut ParseContext,
 ) -> Option<(FilterProp, usize)> {
     let trimmed = text.trim_start();
-    let (rest, (function, property)) = alt((
+    // "with the <greatest|highest> <property> among " — greatest/highest are
+    // synonyms (both AggregateFunction::Max), property is the second axis.
+    // Factor the 2×3 cross product into two alts (PATTERNS.md §8b).
+    let (rest, (function, property)) = (
+        tag::<_, _, OracleError<'_>>("with the "),
         value(
-            (AggregateFunction::Max, ObjectProperty::Power),
-            tag::<_, _, OracleError<'_>>("with the greatest power among "),
+            AggregateFunction::Max,
+            alt((tag("greatest "), tag("highest "))),
         ),
-        value(
-            (AggregateFunction::Max, ObjectProperty::Power),
-            tag("with the highest power among "),
-        ),
-        value(
-            (AggregateFunction::Max, ObjectProperty::Toughness),
-            tag("with the greatest toughness among "),
-        ),
-        value(
-            (AggregateFunction::Max, ObjectProperty::Toughness),
-            tag("with the highest toughness among "),
-        ),
-        value(
-            (AggregateFunction::Max, ObjectProperty::ManaValue),
-            tag("with the greatest mana value among "),
-        ),
-        value(
-            (AggregateFunction::Max, ObjectProperty::ManaValue),
-            tag("with the highest mana value among "),
-        ),
-    ))
-    .parse(trimmed)
-    .ok()?;
+        alt((
+            value(ObjectProperty::Power, tag("power")),
+            value(ObjectProperty::Toughness, tag("toughness")),
+            value(ObjectProperty::ManaValue, tag("mana value")),
+        )),
+        tag(" among "),
+    )
+        .parse(trimmed)
+        .map(|(rest, (_, function, property, _))| (rest, (function, property)))
+        .ok()?;
     // Delegate the "<type-set> <controller> control(s)" clause to the
     // authoritative type-phrase combinator — it parses the multi-type
     // or/and list, any leading article, and the trailing controller suffix.

--- a/scripts/check-parser-combinators.sh
+++ b/scripts/check-parser-combinators.sh
@@ -6,13 +6,18 @@
 # Existing non-combinator code in the parser is frozen in amber — this check
 # only flags *newly added* offending lines in the diff.
 #
-# Three forbidden pattern families:
+# Four forbidden pattern families:
 #   (A) String-method dispatch: .strip_prefix / .contains("...") / .split_once
 #       / .find("...") / etc. Use nom combinators (tag, alt, take_until) instead.
 #   (B) Match-arm dispatch on string literals: `match expr { "foo" => ..., }`.
 #       Discriminant is parser text; arms are literals. Use alt((tag(...))).
 #   (C) Chained `if let Ok((rest, _)) = tag("…")(input)` blocks (≥2 in one
 #       file). Sequential tag tries should compose into a single alt(()).
+#   (D) Un-factored cross-product alt: a flat `alt` whose ≥4 `tag` arms share a
+#       long common prefix AND suffix (e.g. "in addition to {its,their,...} other
+#       [creature ]types"). Factor each varying axis into its own alt()/opt()
+#       inside a sequence; see PATTERNS.md section 8b. Multi-line structural
+#       check delegated to scripts/lib/detect-cross-product-alts.py.
 #
 # Exempt: lines (or the line immediately above) with
 #     // allow-noncombinator: <reason>
@@ -27,6 +32,9 @@
 # target branch's SHA explicitly.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CROSS_PRODUCT_DETECTOR="$SCRIPT_DIR/lib/detect-cross-product-alts.py"
 
 BASE="${1:-$(git merge-base origin/main HEAD 2>/dev/null || echo HEAD~1)}"
 SCOPE='crates/engine/src/parser'
@@ -64,6 +72,7 @@ FAIL=0
 report_methods=""
 report_match_arm=""
 report_iflet_tag=""
+report_crossprod=""
 
 # Filter a per-file candidate list against the allow-noncombinator escape
 # hatch. Reads candidate lines (each prefixed by '+') on stdin, prints the
@@ -151,6 +160,21 @@ while IFS= read -r file; do
         done <<< "$iflet_clean"
         FAIL=1
     fi
+
+    # (D) Un-factored cross-product alt. Multi-line structural check: feed the
+    # unified=0 diff for this file to the Python detector, which maps added
+    # lines onto post-image `alt` blocks and flags those with >=4 tag arms
+    # sharing a long common prefix AND suffix. Skipped (not failed) if python3
+    # is unavailable, so the gate degrades gracefully outside CI.
+    if command -v python3 >/dev/null 2>&1 && [ -f "$CROSS_PRODUCT_DETECTOR" ]; then
+        crossprod_hits=$(git diff $DIFF_MODE --unified=0 "$BASE" -- "$file" \
+            | python3 "$CROSS_PRODUCT_DETECTOR" "$file" 2>/dev/null || true)
+        if [ -n "$crossprod_hits" ]; then
+            report_crossprod="${report_crossprod}
+${crossprod_hits}"
+            FAIL=1
+        fi
+    fi
 done <<< "$files"
 
 if [ "$FAIL" -eq 1 ]; then
@@ -207,6 +231,24 @@ A single if-let-tag for an optional prefix is fine.
 
 Forbidden in added files (diff vs ${BASE}):
 ${report_iflet_tag}
+
+EOF
+    fi
+
+    if [ -n "$report_crossprod" ]; then
+        cat >&2 <<EOF
+(D) Un-factored cross-product alt — factor each varying axis (PATTERNS.md §8b):
+    alt((                                      ->  recognize((
+        tag("in addition to its other types"),     tag("in addition to "),
+        tag("in addition to their other types"),   alt((tag("its"), tag("their"), ...)),
+        tag("in addition to his other types"),      tag(" other "),
+        ... (8 arms = 4 pronouns x 2 scopes)        opt(tag("creature ")),
+    ))                                              tag("types"),
+                                                ))
+The arm count should be the SUM of per-axis choices, never the PRODUCT.
+
+Flagged blocks (diff vs ${BASE}):
+${report_crossprod}
 
 EOF
     fi

--- a/scripts/lib/detect-cross-product-alts.py
+++ b/scripts/lib/detect-cross-product-alts.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Detect un-factored cross-product `alt((...))` blocks in parser code.
+
+Family (D) of the parser combinator gate (scripts/check-parser-combinators.sh).
+A flat `alt` whose `tag("...")` arms share a long common *prefix AND suffix* is
+a cross product that should be factored into per-axis `alt`/`opt` calls — see
+crates/engine/src/parser/oracle_nom/PATTERNS.md section 8b.
+
+This is a multi-line structural check (the bash gate's line-regex families can't
+see across an `alt` block), so it lives here and is invoked per changed file.
+
+Usage:
+    git diff --unified=0 <base> -- <file> | \
+        python3 scripts/lib/detect-cross-product-alts.py <file>
+
+Reads the unified=0 diff on stdin (to recover the set of added post-image line
+numbers) and the post-image <file> from disk. Prints one report block per
+flagged cross product that *intersects an added line* — pre-existing blocks are
+frozen in amber, matching the rest of the gate. A block is exempt if any of its
+lines (or the line directly above the `alt((`) carries `allow-noncombinator`.
+
+Exit code is always 0; the caller decides pass/fail from whether output is empty.
+"""
+
+import re
+import sys
+
+# Conservative thresholds (see check-parser-combinators.sh family D). A genuine
+# cross product has many arms that are nearly identical — long shared prefix AND
+# suffix, with only a short interior span varying. Distinct-word dispatch
+# (destroy/exile/sacrifice) shares neither and is never flagged.
+MIN_ARMS = 4
+MIN_PREFIX = 6
+MIN_SUFFIX = 5
+
+TAG_RE = re.compile(r'\btag(?:_no_case)?\s*(?:::<[^>]*>)?\s*\(\s*"((?:[^"\\]|\\.)*)"\s*\)')
+ALT_OPEN_RE = re.compile(r'\balt\s*\(\s*\(')
+HUNK_RE = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
+
+
+def added_lines_from_diff(diff_text):
+    """Post-image line numbers added in a unified=0 diff."""
+    added = set()
+    for line in diff_text.splitlines():
+        m = HUNK_RE.match(line)
+        if m:
+            start = int(m.group(1))
+            count = int(m.group(2)) if m.group(2) is not None else 1
+            added.update(range(start, start + count))
+    return added
+
+
+def common_prefix(strings):
+    lo, hi = min(strings), max(strings)
+    i = 0
+    while i < len(lo) and i < len(hi) and lo[i] == hi[i]:
+        i += 1
+    return lo[:i]
+
+
+def common_suffix(strings):
+    return common_prefix([s[::-1] for s in strings])[::-1]
+
+
+def alt_blocks(lines):
+    """Yield (start_idx, end_idx, [tag_literals]) for each `alt((...))`, 0-based
+    inclusive line indices. Nested alts are yielded independently."""
+    n = len(lines)
+    for idx, line in enumerate(lines):
+        if not ALT_OPEN_RE.search(line):
+            continue
+        depth = 0
+        started = False
+        buf = []
+        end = idx
+        for j in range(idx, min(idx + 60, n)):
+            buf.append(lines[j])
+            for ch in lines[j]:
+                if ch == '(':
+                    depth += 1
+                    started = True
+                elif ch == ')':
+                    depth -= 1
+            end = j
+            if started and depth <= 0:
+                break
+        tags = TAG_RE.findall('\n'.join(buf))
+        yield idx, end, tags
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: detect-cross-product-alts.py <file> (diff on stdin)\n")
+        return 0
+    path = sys.argv[1]
+    added = added_lines_from_diff(sys.stdin.read())
+    if not added:
+        return 0
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError:
+        return 0
+
+    for start, end, tags in alt_blocks(lines):
+        uniq = []
+        for t in tags:
+            if t not in uniq:
+                uniq.append(t)
+        if len(uniq) < MIN_ARMS:
+            continue
+        cp, cs = common_prefix(uniq), common_suffix(uniq)
+        minlen = min(len(t) for t in uniq)
+        # Don't let prefix and suffix overlap on short arms (would double-count).
+        if len(cp) + len(cs) > minlen:
+            cs = cs[: max(0, minlen - len(cp))]
+        if len(cp) < MIN_PREFIX or len(cs) < MIN_SUFFIX:
+            continue
+        # Only flag blocks touched by this diff (freeze existing offenders).
+        block_range = range(start + 1, end + 2)  # 1-based, inclusive
+        if not added.intersection(block_range):
+            continue
+        # Escape hatch: allow-noncombinator anywhere in the block or directly above.
+        window = lines[max(0, start - 1): end + 1]
+        if any("allow-noncombinator" in w for w in window):
+            continue
+        print(f"  {path}:{start + 1}  ({len(uniq)} arms, shared prefix {cp!r} + suffix {cs!r})")
+        for t in uniq[:6]:
+            print(f'    tag("{t}")')
+        if len(uniq) > 6:
+            print(f"    ... +{len(uniq) - 6} more")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Follow-up to #1791, which fixed an 8-arm \`alt\` that enumerated a 4×2 cross product (\"in addition to {its,their,his,her} other [creature ]types\"). This PR:

1. **Sweeps the codebase** for the same anti-pattern and factors all six occurrences (commit 1).
2. **Adds a push-gate check** (family D) so the pattern can't return (commit 2).

## Sweep (behavior-preserving)

Each block was a *complete* cross product, so factoring into one \`alt\`/\`opt\` per axis leaves the accepted set unchanged:

| File | Axes |
|---|---|
| \`oracle_nom/quantity.rs\` | {creature(s), permanent(s)} × {under your control, you control} |
| \`oracle_modal.rs\` | \"choose <count> instead\" (only the count word varies) |
| \`oracle_target.rs\` | {greatest, highest} × {power, toughness, mana value} → Max |
| \`oracle_effect/subject.rs\`, \`imperative.rs\` | {attacks, attack} × {this turn, this/that combat} |

## Gate (family D)

A flat \`alt\` with ≥4 \`tag\` arms sharing a long common **prefix AND suffix** is flagged. Multi-line analysis lives in \`scripts/lib/detect-cross-product-alts.py\`; it maps added diff lines onto post-image \`alt\` blocks (pre-existing offenders stay frozen in amber) and honors \`// allow-noncombinator\`. Conservative thresholds (≥4 arms, prefix ≥6, suffix ≥5) avoid false positives on distinct-word dispatch (destroy/exile/sacrifice). Skips gracefully if python3 is absent in a local hook; CI enforces.

Codified in \`PATTERNS.md §8b\` and the \`oracle-parser\` SKILL table (both landed via #1791).

## Verification

- Detector unit-tested: catches the 8-arm block, honors escape hatch, ignores distinct-word dispatch.
- Full gate proven end-to-end: fails on a reintroduced flat block, passes on the factored fixes.
- Parser-combinator pre-commit gate green on both commits.