### PR TITLE
fix(client): hold who-goes-first dice roll until player dismisses it

### DIFF
--- a/client/src/components/animation/DiceRollOverlay.tsx
+++ b/client/src/components/animation/DiceRollOverlay.tsx
@@ -82,6 +82,14 @@ export function DiceRollOverlay() {
     void import("./dice3d/Coin3D.tsx");
   }, [shouldReduceMotion]);
 
+  // CR 103.1 contest holds for input, so its hint reads "tap to continue"; an
+  // ability roll auto-advances, so tapping early just skips it. The copy tracks
+  // the same `context` axis that decides whether the roll auto-advances (see
+  // `scheduleDiceAdvance` in uiStore), so affordance and behaviour stay in sync.
+  const dismissHint = t(
+    diceRoll?.context === "startingPlayer" ? "diceRoll.continue" : "diceRoll.skip",
+  );
+
   return (
     <AnimatePresence>
       {diceRoll && (
@@ -99,7 +107,7 @@ export function DiceRollOverlay() {
               itself stays pointer-events-none so it never traps board input. */}
           <button
             type="button"
-            aria-label={t("diceRoll.skip")}
+            aria-label={dismissHint}
             onClick={skipDiceRoll}
             className="absolute inset-0 cursor-pointer bg-[radial-gradient(circle_at_center,rgba(2,6,23,0.55),rgba(2,6,23,0.86)_70%)] backdrop-blur-[2px] pointer-events-auto"
           />
@@ -116,7 +124,7 @@ export function DiceRollOverlay() {
             animate={{ opacity: 1 }}
             transition={{ delay: 1, duration: 0.5 }}
           >
-            {t("diceRoll.skip")}
+            {dismissHint}
           </motion.span>
         </motion.div>
       )}

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -203,6 +203,7 @@
     "rollingForFirst": "Auswürfeln, wer beginnt",
     "versus": "VS",
     "skip": "Zum Überspringen tippen",
+    "continue": "Zum Fortfahren tippen",
     "you": "Du",
     "youPlayFirst": "Du beginnst",
     "playerPlaysFirst": "{{name}} beginnt",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -203,6 +203,7 @@
     "rollingForFirst": "Rolling for first player",
     "versus": "VS",
     "skip": "Tap to skip",
+    "continue": "Tap to continue",
     "you": "You",
     "youPlayFirst": "You play first",
     "playerPlaysFirst": "{{name}} plays first",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -203,6 +203,7 @@
     "rollingForFirst": "Tirada para ver quién empieza",
     "versus": "VS",
     "skip": "Toca para omitir",
+    "continue": "Toca para continuar",
     "you": "Tú",
     "youPlayFirst": "Juegas primero",
     "playerPlaysFirst": "{{name}} juega primero",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -203,6 +203,7 @@
     "rollingForFirst": "Tirage pour savoir qui commence",
     "versus": "VS",
     "skip": "Toucher pour passer",
+    "continue": "Toucher pour continuer",
     "you": "Vous",
     "youPlayFirst": "Vous jouez en premier",
     "playerPlaysFirst": "{{name}} joue en premier",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -203,6 +203,7 @@
     "rollingForFirst": "Tiro per stabilire chi inizia",
     "versus": "VS",
     "skip": "Tocca per saltare",
+    "continue": "Tocca per continuare",
     "you": "Tu",
     "youPlayFirst": "Giochi per primo",
     "playerPlaysFirst": "{{name}} gioca per primo",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -203,6 +203,7 @@
     "rollingForFirst": "Rzut o pierwszego gracza",
     "versus": "VS",
     "skip": "Dotknij, aby pominąć",
+    "continue": "Dotknij, aby kontynuować",
     "you": "Ty",
     "youPlayFirst": "Zaczynasz",
     "playerPlaysFirst": "{{name}} zaczyna",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -203,6 +203,7 @@
     "rollingForFirst": "Rolagem para ver quem começa",
     "versus": "VS",
     "skip": "Toque para pular",
+    "continue": "Toque para continuar",
     "you": "Você",
     "youPlayFirst": "Você joga primeiro",
     "playerPlaysFirst": "{{name}} joga primeiro",

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -53,6 +53,33 @@ if (typeof window !== "undefined") {
 // payload; `diceRollQueue` holds the pending ones. Distinct from the board-event
 // step queue (animationStore) — that coordinates spatial per-object effects.
 let diceAdvanceTimer: ReturnType<typeof setTimeout> | null = null;
+
+// CR 103.1: the starting-player contest determines who's on the play — a moment
+// the player should acknowledge, not one that flashes by. It holds on screen
+// until the player dismisses it (backdrop tap / Escape, both via `skipDiceRoll`).
+// In-game ability rolls (planar die, "roll a dN") keep their timer so a run of
+// them advances hands-free. Keyed on the payload's own `context`, so a queue
+// that mixes kinds is handled correctly whatever the order.
+function autoAdvances(payload: DiceRollPayload): boolean {
+  return payload.context !== "startingPlayer";
+}
+
+// Arm (or deliberately withhold) the auto-advance timer for the now-active roll.
+// Single authority for the timer lifecycle: both the initial show (`flashDiceRoll`)
+// and each FIFO step (`advanceDiceQueue`) route through here so the
+// hold-for-input rule is applied in exactly one place.
+function scheduleDiceAdvance(payload: DiceRollPayload): void {
+  if (diceAdvanceTimer) {
+    clearTimeout(diceAdvanceTimer);
+    diceAdvanceTimer = null;
+  }
+  if (!autoAdvances(payload)) return;
+  // Re-read speed each step so a live Animation Speed change (incl. switching to
+  // instant) takes effect for the remaining queued rolls.
+  const speed = usePreferencesStore.getState().animationSpeedMultiplier;
+  diceAdvanceTimer = setTimeout(advanceDiceQueue, DICE_ROLL_DURATION_MS * Math.max(speed, 0));
+}
+
 function advanceDiceQueue(): void {
   const queue = useUiStore.getState().diceRollQueue;
   if (queue.length === 0) {
@@ -60,11 +87,9 @@ function advanceDiceQueue(): void {
     diceAdvanceTimer = null;
     return;
   }
-  useUiStore.setState({ diceRoll: queue[0], diceRollQueue: queue.slice(1) });
-  // Re-read speed each step so a live Animation Speed change (incl. switching to
-  // instant) takes effect for the remaining queued rolls.
-  const speed = usePreferencesStore.getState().animationSpeedMultiplier;
-  diceAdvanceTimer = setTimeout(advanceDiceQueue, DICE_ROLL_DURATION_MS * Math.max(speed, 0));
+  const next = queue[0];
+  useUiStore.setState({ diceRoll: next, diceRollQueue: queue.slice(1) });
+  scheduleDiceAdvance(next);
 }
 
 interface UiStoreState {
@@ -410,18 +435,17 @@ export const useUiStore = create<UiStore>()((set, get) => ({
     setTimeout(() => set({ showTurnBanner: false }), duration);
   },
   flashDiceRoll: (payload) => {
-    // Instant speed (0) skips the overlay entirely. The visible window scales
-    // with the global Animation Speed ONLY — not the Banner pacing category —
-    // because the 3D die's own tumble+settle duration scales by the same
-    // `speed`, so the die always settles before the overlay advances and the
-    // result caption reveals. When a roll is already showing, queue this one so
-    // simultaneous/back-to-back rolls play serially instead of clobbering.
+    // Instant speed (0) skips the overlay entirely. When a roll is already
+    // showing, queue this one so simultaneous/back-to-back rolls play serially
+    // instead of clobbering. `scheduleDiceAdvance` owns how long the active roll
+    // stays up: ability rolls auto-advance on the speed-scaled timer (the 3D
+    // die's tumble+settle scales by the same `speed`, so it settles before the
+    // overlay advances); the starting-player contest holds for player input.
     const speed = usePreferencesStore.getState().animationSpeedMultiplier;
     if (speed <= 0) return;
     if (get().diceRoll === null) {
       set({ diceRoll: payload });
-      if (diceAdvanceTimer) clearTimeout(diceAdvanceTimer);
-      diceAdvanceTimer = setTimeout(advanceDiceQueue, DICE_ROLL_DURATION_MS * speed);
+      scheduleDiceAdvance(payload);
     } else {
       set({ diceRollQueue: [...get().diceRollQueue, payload] });
     }


### PR DESCRIPTION
The starting-player d20 contest (CR 103.1) auto-dismissed after a 2400ms
timer, racing the player's tap and often closing before it could be read.
Route the auto-advance timer through a single scheduleDiceAdvance authority
that withholds the timer for context=="startingPlayer" rolls, so the
contest holds on screen until the player taps/clicks/Escapes (all via the
existing skipDiceRoll path). In-game ability rolls keep auto-advancing.

The mulligan gate (GamePage startingContestActive) already keys off the
same context, so holding the roll naturally holds the mulligan UI back
until dismissal, matching CR 103.1 ordering.

Surface a context-aware dismiss hint: "Tap to continue" for the contest
(the tap is required) vs "Tap to skip" for ability rolls, with a new
diceRoll.continue key added across all 7 locales.
