### PR TITLE
feat: prepared-spell support — mtgish EntersPrepared converter + debug toggle

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1364,6 +1364,7 @@ export type DebugAction =
   | { type: "SetBasePowerToughness"; data: { object_id: ObjectId; power: number | null; toughness: number | null } }
   | { type: "ModifyCounters"; data: { object_id: ObjectId; counter_type: CounterType; delta: number } }
   | { type: "SetTapped"; data: { object_id: ObjectId; tapped: boolean } }
+  | { type: "SetPrepared"; data: { object_id: ObjectId; prepared: boolean } }
   | { type: "SetController"; data: { object_id: ObjectId; controller: PlayerId } }
   | { type: "SetSummoningSickness"; data: { object_id: ObjectId; sick: boolean } }
   | { type: "SetFaceState"; data: { object_id: ObjectId; face_down?: boolean; transformed?: boolean; flipped?: boolean } }

--- a/client/src/components/chrome/DebugObjectActions.tsx
+++ b/client/src/components/chrome/DebugObjectActions.tsx
@@ -243,6 +243,27 @@ function SetTappedForm({ onDispatch }: Props) {
   );
 }
 
+function SetPreparedForm({ onDispatch }: Props) {
+  const [objectId, setObjectId] = useState<ObjectId | null>(null);
+  const [prepared, setPrepared] = useState(true);
+
+  return (
+    <>
+      <ObjectSelect value={objectId} onChange={setObjectId} filter={onBattlefield} />
+      <CheckboxInput checked={prepared} onChange={setPrepared} label="Prepared" />
+      <SubmitButton
+        disabled={objectId == null}
+        onClick={() =>
+          objectId != null &&
+          onDispatch({ type: "SetPrepared", data: { object_id: objectId, prepared } })
+        }
+      >
+        Set Prepared State
+      </SubmitButton>
+    </>
+  );
+}
+
 function SetControllerForm({ onDispatch }: Props) {
   const [objectId, setObjectId] = useState<ObjectId | null>(null);
   const [controller, setController] = useState<PlayerId>(0);
@@ -437,6 +458,9 @@ export function DebugObjectActions({ onDispatch }: Props) {
       </AccordionItem>
       <AccordionItem label="Set Tapped" expanded={expanded === "tapped"} onToggle={() => toggle("tapped")}>
         <SetTappedForm onDispatch={onDispatch} />
+      </AccordionItem>
+      <AccordionItem label="Set Prepared" expanded={expanded === "prepared"} onToggle={() => toggle("prepared")}>
+        <SetPreparedForm onDispatch={onDispatch} />
       </AccordionItem>
       <AccordionItem label="Set Controller" expanded={expanded === "controller"} onToggle={() => toggle("controller")}>
         <SetControllerForm onDispatch={onDispatch} />

--- a/crates/engine/src/game/effects/prepare.rs
+++ b/crates/engine/src/game/effects/prepare.rs
@@ -66,19 +66,7 @@ pub fn resolve_become_prepared(
 ) -> Result<(), EffectError> {
     let target_ids = resolve_object_targets(state, ability);
     for object_id in target_ids {
-        // Biblioplex gate — only creatures with prepare spells can become prepared.
-        if !has_prepare_face(state, object_id) {
-            continue;
-        }
-        let Some(obj) = state.objects.get_mut(&object_id) else {
-            continue;
-        };
-        // Idempotency: no-op if already prepared.
-        if obj.prepared.is_some() {
-            continue;
-        }
-        obj.prepared = Some(PreparedState);
-        events.push(GameEvent::BecamePrepared { object_id });
+        prepare_object(state, object_id, events);
     }
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::BecomePrepared,

--- a/crates/engine/src/game/effects/prepare.rs
+++ b/crates/engine/src/game/effects/prepare.rs
@@ -131,6 +131,29 @@ pub fn unprepare_object(state: &mut GameState, object_id: ObjectId, events: &mut
     events.push(GameEvent::BecameUnprepared { object_id });
 }
 
+/// CR 722.3a: Direct-call variant that gives a specific object the prepared
+/// designation, emitting `BecamePrepared` only when the toggle actually fires.
+/// Mirrors [`unprepare_object`] for the opposite direction. Enforces the same
+/// two gates as `resolve_become_prepared`: the object must have a prepare-spell
+/// face ("A permanent can't gain this designation unless it has a prepare
+/// spell") and must not already be prepared (idempotent). Single authority for
+/// the "become prepared" toggle — used by the become-prepared resolver path and
+/// the debug `SetPrepared` action so neither sets the field directly.
+pub fn prepare_object(state: &mut GameState, object_id: ObjectId, events: &mut Vec<GameEvent>) {
+    // Biblioplex gate — only creatures with prepare spells can become prepared.
+    if !has_prepare_face(state, object_id) {
+        return;
+    }
+    let Some(obj) = state.objects.get_mut(&object_id) else {
+        return;
+    };
+    if obj.prepared.is_some() {
+        return;
+    }
+    obj.prepared = Some(PreparedState);
+    events.push(GameEvent::BecamePrepared { object_id });
+}
+
 /// CR 601.2c / CR 722.3c: After pushing a freshly cast prepare/paradigm copy
 /// to the stack, open target selection via `WaitingFor::CopyRetarget` if the
 /// copy's ability requires targets. The copy is not a copy of an
@@ -612,6 +635,41 @@ mod tests {
         let mut events2 = Vec::new();
         unprepare_object(&mut state, id, &mut events2);
         assert!(events2.is_empty());
+    }
+
+    #[test]
+    fn prepare_object_flips_and_emits_when_prepare_face_present() {
+        let mut state = GameState::new_two_player(42);
+        let id = setup_creature(&mut state);
+        state.objects.get_mut(&id).unwrap().back_face = Some(BackFaceForTest::prepare());
+
+        let mut events = Vec::new();
+        prepare_object(&mut state, id, &mut events);
+
+        assert!(state.objects[&id].prepared.is_some());
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, GameEvent::BecamePrepared { object_id } if *object_id == id)));
+
+        // Idempotency — second call must not re-emit.
+        let mut events2 = Vec::new();
+        prepare_object(&mut state, id, &mut events2);
+        assert!(events2.is_empty());
+    }
+
+    #[test]
+    fn prepare_object_noop_without_prepare_face() {
+        // CR 722.3a Biblioplex gate — an object with no prepare-spell face
+        // can't gain the prepared designation (matches the debug SetPrepared
+        // path's single-authority guarantee).
+        let mut state = GameState::new_two_player(42);
+        let id = setup_creature(&mut state);
+
+        let mut events = Vec::new();
+        prepare_object(&mut state, id, &mut events);
+
+        assert!(state.objects[&id].prepared.is_none());
+        assert!(events.is_empty());
     }
 
     // CR 707.10c: `open_copy_target_selection` detects whether the copy's

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -189,6 +189,21 @@ pub fn apply_debug_action(
             validate_object_mut(state, object_id)?.tapped = tapped;
         }
 
+        DebugAction::SetPrepared {
+            object_id,
+            prepared,
+        } => {
+            // CR 722.3a/b: Route through the single authority so the
+            // prepare-face gate and Became(Un)Prepared events are honored
+            // instead of writing `obj.prepared` directly.
+            validate_object_mut(state, object_id)?;
+            if prepared {
+                super::effects::prepare::prepare_object(state, object_id, events);
+            } else {
+                super::effects::prepare::unprepare_object(state, object_id, events);
+            }
+        }
+
         DebugAction::SetController {
             object_id,
             controller,

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -615,12 +615,16 @@ fn validate_player(state: &GameState, player_id: PlayerId) -> Result<(), EngineE
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::game_object::BackFaceData;
     use crate::game::zones::create_object;
+    use crate::types::ability::{AbilityDefinition, AbilityKind};
     use crate::types::actions::GameAction;
+    use crate::types::card::LayoutKind;
+    use crate::types::definitions::Definitions;
     use crate::types::format::FormatConfig;
     use crate::types::identifiers::CardId;
     use crate::types::keywords::Keyword;
-    use crate::types::mana::ManaColor;
+    use crate::types::mana::{ManaColor, ManaCost};
     use crate::types::proposed_event::TokenCharacteristics;
     use crate::types::CoreType;
 
@@ -640,6 +644,39 @@ mod tests {
             supertypes: Vec::new(),
             colors: vec![ManaColor::Green],
             keywords: Vec::<Keyword>::new(),
+        }
+    }
+
+    fn prepare_back_face() -> BackFaceData {
+        let mut card_types = crate::types::card_type::CardType::default();
+        card_types.core_types.push(CoreType::Sorcery);
+        BackFaceData {
+            name: "Test Prepare Face".to_string(),
+            power: None,
+            toughness: None,
+            loyalty: None,
+            defense: None,
+            card_types,
+            mana_cost: ManaCost::default(),
+            keywords: Vec::new(),
+            abilities: vec![AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )],
+            trigger_definitions: Definitions::default(),
+            replacement_definitions: Definitions::default(),
+            static_definitions: Definitions::default(),
+            color: Vec::new(),
+            printed_ref: None,
+            modal: None,
+            additional_cost: None,
+            strive_cost: None,
+            casting_restrictions: Vec::new(),
+            casting_options: Vec::new(),
+            layout_kind: Some(LayoutKind::Prepare),
         }
     }
 
@@ -765,6 +802,63 @@ mod tests {
         assert_eq!(token.name, "Copy Source");
         assert_eq!(token.power, Some(2));
         assert_eq!(token.toughness, Some(3));
+    }
+
+    #[test]
+    fn debug_set_prepared_routes_through_prepare_gate() {
+        let mut state = sandbox_state();
+        let object_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Test Permanent".to_string(),
+            Zone::Battlefield,
+        );
+
+        let no_face_result = crate::game::engine::apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::Debug(DebugAction::SetPrepared {
+                object_id,
+                prepared: true,
+            }),
+        )
+        .expect("debug SetPrepared should be accepted");
+        assert!(state.objects[&object_id].prepared.is_none());
+        assert!(!no_face_result
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::BecamePrepared { .. })));
+
+        state.objects.get_mut(&object_id).unwrap().back_face = Some(prepare_back_face());
+
+        let prepared_result = crate::game::engine::apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::Debug(DebugAction::SetPrepared {
+                object_id,
+                prepared: true,
+            }),
+        )
+        .expect("debug SetPrepared should prepare eligible object");
+        assert!(state.objects[&object_id].prepared.is_some());
+        assert!(prepared_result.events.iter().any(
+            |event| matches!(event, GameEvent::BecamePrepared { object_id: id } if *id == object_id)
+        ));
+
+        let unprepared_result = crate::game::engine::apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::Debug(DebugAction::SetPrepared {
+                object_id,
+                prepared: false,
+            }),
+        )
+        .expect("debug SetPrepared should unprepare object");
+        assert!(state.objects[&object_id].prepared.is_none());
+        assert!(unprepared_result.events.iter().any(
+            |event| matches!(event, GameEvent::BecameUnprepared { object_id: id } if *id == object_id)
+        ));
     }
 
     /// Issue #464 — CR 110.2 + CR 613.1b: `DebugAction::SetController` must

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -714,6 +714,12 @@ pub enum DebugAction {
     },
     /// Tap or untap an object.
     SetTapped { object_id: ObjectId, tapped: bool },
+    /// CR 722.3a: Give or remove the "prepared" designation on an object so a
+    /// preparation card's prepare spell can be cast for testing. Routes through
+    /// the `game::effects::prepare` single authority, so setting `prepared`
+    /// no-ops on objects without a prepare-spell face and emits the
+    /// `BecamePrepared` / `BecameUnprepared` events.
+    SetPrepared { object_id: ObjectId, prepared: bool },
     /// Change an object's controller. Marks layers dirty.
     SetController {
         object_id: ObjectId,
@@ -951,6 +957,14 @@ impl DebugAction {
                 "SetTapped ({} → {})",
                 obj(*object_id),
                 if *tapped { "tapped" } else { "untapped" }
+            ),
+            DebugAction::SetPrepared {
+                object_id,
+                prepared,
+            } => format!(
+                "SetPrepared ({} → {})",
+                obj(*object_id),
+                if *prepared { "prepared" } else { "unprepared" }
             ),
             DebugAction::SetController {
                 object_id,

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -3242,6 +3242,19 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
             target: convert_permanents(filter)?,
         },
 
+        // CR 122.1: Mass counter placement with an explicit count — "Put N
+        // [counter] on each [filter]." Numbered sibling of
+        // `PutACounterOfTypeOnEachPermanent`; same multi-match `TargetFilter`
+        // semantics, with the count lowered through `quantity::convert` so
+        // X-quantities (e.g. Oracle's Gift: "put X +1/+1 counters on each
+        // Fractal you control") become `QuantityRef::Variable { "X" }` and
+        // resolve from the spell's paid X at resolution.
+        Action::PutNumberCountersOfTypeOnEachPermanent(g, ct, filter) => Effect::AddCounter {
+            counter_type: counter_type_name(ct),
+            count: quantity::convert(g)?,
+            target: convert_permanents(filter)?,
+        },
+
         // CR 701.23 + CR 701.24: SearchLibrary is intrinsically multi-effect
         // — it expands to `SearchLibrary → ChangeZone → [Shuffle]`. Single-
         // effect callers cannot consume it; route through `convert_many` /
@@ -6662,6 +6675,29 @@ mod tests {
         assert_eq!(*payer, TargetFilter::ParentTargetController);
         let sub = ability.sub_ability.as_ref().expect("expected paid body");
         assert!(matches!(sub.effect.as_ref(), Effect::Draw { .. }));
+    }
+
+    #[test]
+    fn put_number_counters_on_each_permanent_lowers_to_add_counter_with_x() {
+        // CR 122.1 + CR 107.1b: "Put X +1/+1 counters on each [filter]"
+        // (Oracle's Gift, Jadzi's prepare spell) lowers to a multi-match
+        // AddCounter whose count is the spell's paid X.
+        let effect = convert(&Action::PutNumberCountersOfTypeOnEachPermanent(
+            Box::new(GameNumber::ValueX),
+            CounterType::PTCounter(1, 1),
+            Box::new(Permanents::IsCardtype(CardType::Creature)),
+        ))
+        .unwrap();
+
+        let Effect::AddCounter { count, .. } = effect else {
+            panic!("expected AddCounter, got {effect:?}");
+        };
+        assert!(matches!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Variable { name }
+            } if name == "X"
+        ));
     }
 
     #[test]

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -1588,6 +1588,17 @@ fn build_replacement_exec(
                 target: target.clone(),
             }
         }
+        // CR 722.3a: Prepare (Strixhaven preparation cards) — "As this enters,
+        // it's prepared." The engine prerequisite EXISTS: `Effect::BecomePrepared`
+        // resolved through this ETB ChangeZone replacement (engine
+        // `game/effects/prepare.rs::resolve_become_prepared`). The runtime
+        // `has_prepare_face` gate ensures only cards with a prepare-spell back
+        // face actually gain the designation, matching the CR 722.3a clause
+        // "A permanent can't gain this designation unless it has a prepare spell."
+        // `target` is the replacement's `valid_card` (SelfRef for ThisPermanent).
+        A::EntersPrepared => Effect::BecomePrepared {
+            target: target.clone(),
+        },
         // CR 614.12 + CR 110.2a: "Enters under [opponent / a player]'s
         // control." `Effect::ChangeZone` carries `enters_under`,
         // but the engine has no slot for "under SOME OTHER player's
@@ -1600,18 +1611,17 @@ fn build_replacement_exec(
                 needed_variant: "ETB action: enters under another player's control".into(),
             });
         }
-        // CR 122.1 (counter-of-choice / EntersPrepared / per-each /
-        // for-each-kind / different-counters / etc.) — these need new
-        // engine ETB action shapes (player picks counter type, "ready"
-        // counter primitive, dynamic per-each-quantity, etc.).
+        // CR 122.1 (counter-of-choice / per-each / for-each-kind /
+        // different-counters / etc.) — these need new engine ETB action
+        // shapes (player picks counter type, "ready" counter primitive,
+        // dynamic per-each-quantity, etc.).
         A::EntersWithACounterOfChoice(_)
         | A::EntersWithNumberDifferentCountersOfChoice(_, _)
         | A::EntersWithNumberCombinationCountersOfChoice(_, _)
         | A::EntersWithACounterOfTypeForEachKindOfCounterOnPermanent(_)
         | A::EntersWithAnAbilityCounterForEachAbilityOnACardDiscardedThisWay(_)
         | A::EntersWithNotedCounters
-        | A::EntersWithNumberCountersForEach(_, _, _)
-        | A::EntersPrepared => {
+        | A::EntersWithNumberCountersForEach(_, _, _) => {
             return Err(ConversionGap::EnginePrerequisiteMissing {
                 engine_type: "Effect",
                 needed_variant: format!("ETB counter-action shape ({})", variant_tag(act)),
@@ -3008,6 +3018,29 @@ mod tests {
             ConversionGap::EnginePrerequisiteMissing {
                 engine_type: "ReplacementDefinition",
                 ..
+            }
+        ));
+    }
+
+    #[test]
+    fn as_enters_prepared_lowers_to_self_targeted_become_prepared() {
+        // CR 722.3a: "As this enters, it's prepared." (e.g. Jadzi, Steward of
+        // Fate) must lower to a self-targeted `BecomePrepared` ETB replacement,
+        // not strict-fail — the engine prerequisite exists.
+        let defs = convert_as_enters(
+            &Permanent::ThisPermanent,
+            &[ReplacementActionWouldEnter::EntersPrepared],
+        )
+        .unwrap();
+
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(defs[0].event, ReplacementEvent::ChangeZone);
+        let execute = defs[0].execute.as_ref().expect("prepared execute");
+        assert!(matches!(
+            &*execute.effect,
+            Effect::BecomePrepared {
+                target: TargetFilter::SelfRef
             }
         ));
     }


### PR DESCRIPTION
## Summary

Makes Strixhaven-style **preparation cards** (e.g. Jadzi, Steward of Fate) actually playable, and adds a debug control to test the mechanic.

The engine runtime for Prepare (the `prepared` designation, `CastPreparedCopy`, copy synthesis, `BecomePrepared` events) was already complete and tested — but two upstream gaps meant a preparation card never gained the designation, so its prepare spell was never offered for casting.

## Changes

**1. `fix(mtgish-import)`: convert `EntersPrepared` and numbered counters-on-each**

The mtgish→engine converter strict-fails the whole card if any rule fails. Preparation cards hit two unconverted rules:

- `EntersPrepared` ("As this enters, it's prepared") was mis-bucketed with counter-of-choice ETB shapes and rejected as `EnginePrerequisiteMissing` — even though `Effect::BecomePrepared` already exists and is wired in the runtime (`game/effects/prepare.rs`). Now lowered to a self-targeted `Effect::BecomePrepared` (CR 722.3a), gated at runtime by `has_prepare_face`.
- `PutNumberCountersOfTypeOnEachPermanent` (Jadzi's prepare spell *Oracle's Gift*: "put X +1/+1 counters on each Fractal you control") had no converter arm. Added the numbered sibling of the existing `PutACounterOfTypeOnEachPermanent` arm → `Effect::AddCounter` with a multi-match filter and X-resolving count (CR 122.1 + CR 107.1b).

Unblocks **24 cards** (the whole preparation-card class) in the conversion report.

**2. `feat(debug)`: add `SetPrepared` debug action**

A "Set Prepared" control in the debug console's per-object actions, so preparation cards can be toggled into the prepared designation on demand for testing.

- New `DebugAction::SetPrepared { object_id, prepared }` (CR 722.3a), mirroring `SetTapped`, with a `describe` arm for the action log.
- Routes through the `game::effects::prepare` single authority: a new `prepare_object` setter (symmetric with `unprepare_object`) that enforces the prepare-face gate and emits `BecamePrepared`. No direct field writes — setting "prepared" on a card without a prepare spell is a rules-correct no-op (CR 722.3a).
- Frontend: `SetPrepared` added to the `DebugAction` union and a `SetPreparedForm` accordion item.

## Tests / verification

- New unit tests for both converter arms and the `prepare_object` building block (flips + emits with a prepare face; no-ops without one).
- `mtgish-import`: 115 unit + 11 structural golden + manifest tests pass.
- `engine`: `cargo check`/`clippy` clean; prepare-module tests pass.
- Frontend: `tsc -b --noEmit` and `eslint` clean.
- Both commits cherry-pick cleanly onto latest `main` and compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)