### PR TITLE
fix(engine): per-recipient count for PutCounterAll

### DIFF
--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -589,7 +589,7 @@ pub fn resolve_add_all(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (counter_type, counter_num, target_filter) = match &ability.effect {
+    let (counter_type, count, counter_num_shared, target_filter) = match &ability.effect {
         Effect::PutCounterAll {
             counter_type,
             count,
@@ -598,7 +598,12 @@ pub fn resolve_add_all(
             let resolved =
                 crate::game::quantity::resolve_quantity_with_targets(state, count, ability).max(0)
                     as u32;
-            (counter_type.clone(), resolved, target.clone())
+            (
+                counter_type.clone(),
+                count.clone(),
+                resolved,
+                target.clone(),
+            )
         }
         _ => return Ok(()),
     };
@@ -673,7 +678,26 @@ pub fn resolve_add_all(
                 .collect()
         };
 
+    // CR 122.1 + CR 613.4c: A per-recipient count ("each other creature you
+    // control equal to THAT CREATURE's toughness" — Canopy Gargantuan) is
+    // re-evaluated against each object; a uniform count (the source's power —
+    // Ouroboroid) is resolved once and shared. Detected via the recipient-
+    // binding scope the parser stamps on per-recipient counts.
+    let count_uses_recipient = crate::game::quantity::quantity_expr_uses_recipient(&count);
+
     for obj_id in matching_ids {
+        let counter_num = if count_uses_recipient {
+            crate::game::quantity::resolve_quantity_with_recipient(
+                state,
+                &count,
+                ability.controller,
+                ability.source_id,
+                obj_id,
+            )
+            .max(0) as u32
+        } else {
+            counter_num_shared
+        };
         add_counter_with_replacement(
             state,
             ability.controller,
@@ -1360,6 +1384,117 @@ mod tests {
             .card_types
             .core_types
             .push(CoreType::Creature);
+    }
+
+    /// Issue #1675 — Canopy Gargantuan: "put a number of +1/+1 counters on each
+    /// other creature you control equal to THAT CREATURE's toughness." Each
+    /// other creature must receive counters equal to ITS OWN toughness (the
+    /// count is re-evaluated per recipient), the source is excluded ("Another"),
+    /// and an opponent's creature receives none ("you control").
+    #[test]
+    fn put_counter_all_per_recipient_toughness() {
+        use crate::types::ability::{ObjectScope, QuantityRef};
+
+        let mut state = GameState::new_two_player(42);
+
+        // Canopy Gargantuan (the source).
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Canopy Gargantuan".to_string(),
+            Zone::Battlefield,
+        );
+        mark_creature(&mut state, source);
+        {
+            let o = state.objects.get_mut(&source).unwrap();
+            o.toughness = Some(7);
+            o.base_toughness = Some(7);
+        }
+
+        // Three OTHER creatures you control with distinct toughness.
+        let others: Vec<(ObjectId, i32)> = [(2u64, 3i32), (3, 5), (4, 1)]
+            .into_iter()
+            .map(|(cid, tough)| {
+                let id = create_object(
+                    &mut state,
+                    CardId(cid),
+                    PlayerId(0),
+                    format!("Creature {cid}"),
+                    Zone::Battlefield,
+                );
+                mark_creature(&mut state, id);
+                let o = state.objects.get_mut(&id).unwrap();
+                o.toughness = Some(tough);
+                o.base_toughness = Some(tough);
+                (id, tough)
+            })
+            .collect();
+
+        // An opponent's creature — must NOT receive counters ("you control").
+        let opp = create_object(
+            &mut state,
+            CardId(9),
+            PlayerId(1),
+            "Opponent Creature".to_string(),
+            Zone::Battlefield,
+        );
+        mark_creature(&mut state, opp);
+        {
+            let o = state.objects.get_mut(&opp).unwrap();
+            o.toughness = Some(4);
+            o.base_toughness = Some(4);
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::PutCounterAll {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::Toughness {
+                        scope: ObjectScope::Recipient,
+                    },
+                },
+                target: TargetFilter::Typed(
+                    TypedFilter::creature()
+                        .controller(ControllerRef::You)
+                        .properties(vec![FilterProp::Another]),
+                ),
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve_add_all(&mut state, &ability, &mut events).unwrap();
+
+        // Each OTHER creature you control gains counters equal to ITS OWN toughness.
+        for (id, tough) in &others {
+            assert_eq!(
+                state.objects[id]
+                    .counters
+                    .get(&CounterType::Plus1Plus1)
+                    .copied()
+                    .unwrap_or(0),
+                *tough as u32,
+                "creature with toughness {tough} must receive {tough} +1/+1 counters"
+            );
+        }
+        // Source ("Another") and the opponent's creature ("you control") get none.
+        assert!(
+            state.objects[&source]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .is_none(),
+            "source must be excluded by Another"
+        );
+        assert!(
+            state.objects[&opp]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .is_none(),
+            "opponent's creature must be excluded by 'you control'"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -678,7 +678,7 @@ pub fn resolve_add_all(
                 .collect()
         };
 
-    // CR 122.1 + CR 613.4c: A per-recipient count ("each other creature you
+    // CR 122.1 + CR 608.2c: A per-recipient count ("each other creature you
     // control equal to THAT CREATURE's toughness" — Canopy Gargantuan) is
     // re-evaluated against each object; a uniform count (the source's power —
     // Ouroboroid) is resolved once and shared. Detected via the recipient-

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6449,6 +6449,76 @@ pub(super) fn counter_placement_is_mass(clause_lower: &str) -> bool {
         || nom_primitives::scan_contains(clause_lower, "on all ")
 }
 
+/// CR 122.1 + CR 613.4c: In a distributive "put a number of +1/+1 counters on
+/// EACH ... equal to THAT CREATURE's <stat>" (Canopy Gargantuan), "that
+/// creature" is the per-iteration recipient — each object receives counters
+/// equal to its OWN stat. The shared `parse_event_context_refs` lowers "that
+/// creature's <stat>" to `ObjectScope::CostPaidObject` (correct in trigger
+/// bodies, where it refers to the triggering object), so for a mass placement
+/// we rebind it to `ObjectScope::Recipient`; `resolve_add_all` then re-evaluates
+/// the count per object. A genuine cost referent ("the SACRIFICED creature's
+/// power") carries a cost/zone-change participle and is left as
+/// `CostPaidObject` — `resolve_add_all` resolves that once and applies it
+/// uniformly, which is correct.
+fn rebind_distributive_recipient_count(count: QuantityExpr, lower: &str) -> QuantityExpr {
+    let is_cost_referent = nom_primitives::scan_contains(lower, "sacrificed")
+        || nom_primitives::scan_contains(lower, "exiled")
+        || nom_primitives::scan_contains(lower, "discarded")
+        || nom_primitives::scan_contains(lower, "milled");
+    if is_cost_referent {
+        return count;
+    }
+    rebind_costpaid_scope_to_recipient(count)
+}
+
+/// Walk a `QuantityExpr` and rebind `ObjectScope::CostPaidObject` on the object
+/// P/T/mana-value leaves to `ObjectScope::Recipient`. Recurses through the
+/// arithmetic wrappers ("that creature's toughness plus 1", "twice that
+/// creature's power") so the whole class composes.
+fn rebind_costpaid_scope_to_recipient(expr: QuantityExpr) -> QuantityExpr {
+    use crate::types::ability::ObjectScope::{CostPaidObject, Recipient};
+    match expr {
+        QuantityExpr::Ref { qty } => QuantityExpr::Ref {
+            qty: match qty {
+                QuantityRef::Power {
+                    scope: CostPaidObject,
+                } => QuantityRef::Power { scope: Recipient },
+                QuantityRef::Toughness {
+                    scope: CostPaidObject,
+                } => QuantityRef::Toughness { scope: Recipient },
+                QuantityRef::ObjectManaValue {
+                    scope: CostPaidObject,
+                } => QuantityRef::ObjectManaValue { scope: Recipient },
+                other => other,
+            },
+        },
+        QuantityExpr::Offset { inner, offset } => QuantityExpr::Offset {
+            inner: Box::new(rebind_costpaid_scope_to_recipient(*inner)),
+            offset,
+        },
+        QuantityExpr::Multiply { factor, inner } => QuantityExpr::Multiply {
+            factor,
+            inner: Box::new(rebind_costpaid_scope_to_recipient(*inner)),
+        },
+        QuantityExpr::DivideRounded {
+            inner,
+            divisor,
+            rounding,
+        } => QuantityExpr::DivideRounded {
+            inner: Box::new(rebind_costpaid_scope_to_recipient(*inner)),
+            divisor,
+            rounding,
+        },
+        QuantityExpr::Sum { exprs } => QuantityExpr::Sum {
+            exprs: exprs
+                .into_iter()
+                .map(rebind_costpaid_scope_to_recipient)
+                .collect(),
+        },
+        other => other,
+    }
+}
+
 pub(super) fn parse_zone_counter_ast(
     text: &str,
     lower: &str,
@@ -6524,7 +6594,7 @@ pub(super) fn parse_zone_counter_ast(
                 if is_all && multi_target.is_none() {
                     Some(ZoneCounterImperativeAst::PutCounterAll {
                         counter_type,
-                        count,
+                        count: rebind_distributive_recipient_count(count, lower),
                         target,
                     })
                 } else {
@@ -10209,6 +10279,73 @@ mod tests {
     }
 
     /// CR 706 + CR 706.2: "Roll a d20" with no modifier parses to a bare RollDie.
+    /// Issue #1675 — Canopy Gargantuan. "Put a number of +1/+1 counters on each
+    /// other creature you control equal to that creature's toughness." rebinds
+    /// the per-recipient "that creature's toughness" count to `Recipient` so the
+    /// resolver re-evaluates it per object.
+    #[test]
+    fn put_counter_all_each_equal_to_that_creatures_toughness_rebinds_to_recipient() {
+        use crate::types::ability::ObjectScope;
+        let def = super::super::parse_effect_chain(
+            "Put a number of +1/+1 counters on each other creature you control equal to that creature's toughness.",
+            AbilityKind::Spell,
+        );
+        match &*def.effect {
+            Effect::PutCounterAll { count, .. } => assert!(
+                matches!(
+                    count,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Toughness {
+                            scope: ObjectScope::Recipient
+                        }
+                    }
+                ),
+                "count must rebind to Recipient, got {count:?}"
+            ),
+            other => panic!("expected PutCounterAll, got {other:?}"),
+        }
+    }
+
+    /// The rebind is gated: a genuine cost referent ("the sacrificed creature's
+    /// power") stays `CostPaidObject` (resolved once, applied uniformly), so the
+    /// rebind does not hijack cost-paid `*All` counts.
+    #[test]
+    fn rebind_distributive_recipient_count_leaves_cost_referent_alone() {
+        use crate::types::ability::ObjectScope;
+        let cost_paid = QuantityExpr::Ref {
+            qty: QuantityRef::Power {
+                scope: ObjectScope::CostPaidObject,
+            },
+        };
+        let out = super::rebind_distributive_recipient_count(
+            cost_paid.clone(),
+            "put a +1/+1 counter on each creature you control equal to the sacrificed creature's power",
+        );
+        assert_eq!(
+            out, cost_paid,
+            "cost-referent count must NOT rebind to Recipient"
+        );
+
+        // And "that creature's power" (no cost participle) DOES rebind.
+        let anaphor = QuantityExpr::Ref {
+            qty: QuantityRef::Power {
+                scope: ObjectScope::CostPaidObject,
+            },
+        };
+        let rebound = super::rebind_distributive_recipient_count(
+            anaphor,
+            "put a +1/+1 counter on each creature you control equal to that creature's power",
+        );
+        assert!(matches!(
+            rebound,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::Recipient
+                }
+            }
+        ));
+    }
+
     #[test]
     fn roll_a_d20_no_modifier_parses_to_roll_die() {
         let def = super::super::parse_effect_chain("Roll a d20.", AbilityKind::Spell);

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6449,7 +6449,7 @@ pub(super) fn counter_placement_is_mass(clause_lower: &str) -> bool {
         || nom_primitives::scan_contains(clause_lower, "on all ")
 }
 
-/// CR 122.1 + CR 613.4c: In a distributive "put a number of +1/+1 counters on
+/// CR 122.1 + CR 608.2c: In a distributive "put a number of +1/+1 counters on
 /// EACH ... equal to THAT CREATURE's <stat>" (Canopy Gargantuan), "that
 /// creature" is the per-iteration recipient — each object receives counters
 /// equal to its OWN stat. The shared `parse_event_context_refs` lowers "that
@@ -6459,7 +6459,7 @@ pub(super) fn counter_placement_is_mass(clause_lower: &str) -> bool {
 /// the count per object. A genuine cost referent ("the SACRIFICED creature's
 /// power") carries a cost/zone-change participle and is left as
 /// `CostPaidObject` — `resolve_add_all` resolves that once and applies it
-/// uniformly, which is correct.
+/// uniformly per CR 608.2k.
 fn rebind_distributive_recipient_count(count: QuantityExpr, lower: &str) -> QuantityExpr {
     let is_cost_referent = nom_primitives::scan_contains(lower, "sacrificed")
         || nom_primitives::scan_contains(lower, "exiled")
@@ -6515,7 +6515,18 @@ fn rebind_costpaid_scope_to_recipient(expr: QuantityExpr) -> QuantityExpr {
                 .map(rebind_costpaid_scope_to_recipient)
                 .collect(),
         },
-        other => other,
+        QuantityExpr::UpTo { max } => QuantityExpr::UpTo {
+            max: Box::new(rebind_costpaid_scope_to_recipient(*max)),
+        },
+        QuantityExpr::Power { base, exponent } => QuantityExpr::Power {
+            base,
+            exponent: Box::new(rebind_costpaid_scope_to_recipient(*exponent)),
+        },
+        QuantityExpr::Difference { left, right } => QuantityExpr::Difference {
+            left: Box::new(rebind_costpaid_scope_to_recipient(*left)),
+            right: Box::new(rebind_costpaid_scope_to_recipient(*right)),
+        },
+        QuantityExpr::Fixed { value } => QuantityExpr::Fixed { value },
     }
 }
 
@@ -10340,6 +10351,61 @@ mod tests {
             rebound,
             QuantityExpr::Ref {
                 qty: QuantityRef::Power {
+                    scope: ObjectScope::Recipient
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn rebind_distributive_recipient_count_walks_all_quantity_wrappers() {
+        use crate::types::ability::ObjectScope;
+
+        let expr = QuantityExpr::Difference {
+            left: Box::new(QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::CostPaidObject,
+                },
+            }),
+            right: Box::new(QuantityExpr::Power {
+                base: 2,
+                exponent: Box::new(QuantityExpr::UpTo {
+                    max: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectManaValue {
+                            scope: ObjectScope::CostPaidObject,
+                        },
+                    }),
+                }),
+            }),
+        };
+
+        let rebound = super::rebind_distributive_recipient_count(
+            expr,
+            "put a number of +1/+1 counters on each creature you control equal to that creature's power",
+        );
+
+        let QuantityExpr::Difference { left, right } = rebound else {
+            panic!("expected Difference, got {rebound:?}");
+        };
+        assert!(matches!(
+            *left,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::Recipient
+                }
+            }
+        ));
+
+        let QuantityExpr::Power { exponent, .. } = *right else {
+            panic!("expected Power, got {right:?}");
+        };
+        let QuantityExpr::UpTo { max } = *exponent else {
+            panic!("expected UpTo, got {exponent:?}");
+        };
+        assert!(matches!(
+            *max,
+            QuantityExpr::Ref {
+                qty: QuantityRef::ObjectManaValue {
                     scope: ObjectScope::Recipient
                 }
             }


### PR DESCRIPTION
Closes #1675

## Problem
> Canopy Gargantuan — "At the beginning of your upkeep, put a number of +1/+1 counters on each other creature you control equal to **that creature's** toughness."

The upkeep trigger fires but places **no** counters — it resolves as a no-op.

## Root cause
This is a "for each matching creature, counters equal to **that creature's** stat" effect — the count must be evaluated **per creature**. Two bugs combined:

1. **Resolver applies one count uniformly.** `resolve_add_all` resolved the count **once** and applied that single number to every matching object — no per-object path.
2. **Parser mis-scopes the count.** "that creature's toughness" lowered to `Toughness { scope: CostPaidObject }`. On a trigger there is no cost-paid object, so it resolves to **0** — every creature received 0 counters.

## Fix
The per-iteration reference already exists in the engine (`ObjectScope::Recipient`, plus `resolve_quantity_with_recipient` /
`quantity_expr_uses_recipient`), so **no new variant is needed** — just wire it through both layers.

- **Parser** (`PutCounterAll` construction): rebind the count's `CostPaidObject` power/toughness/mana-value leaves to `Recipient` for a distributive "on each … equal to that creature's `<stat>`" placement. The shared "that creature's `<stat>`" mapping used by **84 cards** in trigger bodies is untouched; the rebind is local to the mass-placement site and is
  **gated** so a genuine cost referent ("the **sacrificed** creature's power") stays `CostPaidObject` (resolved once, applied uniformly — which is correct).
- **Resolver** (`resolve_add_all`): when the count uses the recipient binding, re-evaluate it against each object in the loop via
  `resolve_quantity_with_recipient`; otherwise keep the resolve-once shared value (so `Source`-scoped counts like Ouroboroid's "equal to Ouroboroid's power" are unchanged).

**Class fix:** any "for each X, counters equal to that X's `<stat>`" effect, not just this card.

## Tests
- **Parser:** the Canopy line rebinds the count to `Recipient`; a cost-referent line ("the sacrificed creature's power") stays `CostPaidObject` (the gate).
- **Runtime:** three other creatures with toughness 3 / 5 / 1 each receive exactly 3 / 5 / 1 counters; the source (`Another`) and an opponent's creature receive none.

## Verification
- Full engine suite: **9675 passed, 0 failed** (`Source`-scoped `PutCounterAll` cards — Ouroboroid, Gruff Triplets, Aerith — unaffected).
- `cargo fmt --all --check` clean; `cargo clippy -p engine` clean.

## Scope
- Two files: `crates/engine/src/game/effects/counters.rs` (resolver) and `crates/engine/src/parser/oracle_effect/imperative.rs` (parser) + tests.
- No data committed — `card-data.json` is gitignored and regenerated by CI (which now emits `Toughness { Recipient }` for the count).
