### PR TITLE
fix(engine): thread "that many" count into AdditionalPhase (issue #1486, #1533)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2268,12 +2268,16 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             phase,
             after,
             followed_by,
+            count,
         } => {
             d.push(("player".into(), fmt_target(target)));
             d.push(("phase".into(), format!("{phase:?}")));
             d.push(("after".into(), format!("{after:?}")));
             if !followed_by.is_empty() {
                 d.push(("followed by".into(), format!("{followed_by:?}")));
+            }
+            if !matches!(count, QuantityExpr::Fixed { value: 1 }) {
+                d.push(("count".into(), format!("{count:?}")));
             }
         }
         Effect::Double {

--- a/crates/engine/src/game/effects/additional_phase.rs
+++ b/crates/engine/src/game/effects/additional_phase.rs
@@ -1,3 +1,4 @@
+use crate::game::quantity::resolve_quantity;
 use crate::types::ability::{
     Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
 };
@@ -11,13 +12,14 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (target, phase, after, followed_by) = match &ability.effect {
+    let (target, phase, after, followed_by, count_expr) = match &ability.effect {
         Effect::AdditionalPhase {
             target,
             phase,
             after,
             followed_by,
-        } => (target, *phase, *after, followed_by),
+            count,
+        } => (target, *phase, *after, followed_by, count),
         _ => return Err(EffectError::MissingParam("expected AdditionalPhase".into())),
     };
 
@@ -49,18 +51,36 @@ pub fn resolve(
         return Ok(());
     }
 
+    // CR 500.8 + CR 510.1: Resolve the count against the triggering combat
+    // damage event so Obeka, Splitter of Seconds (and any future "for that
+    // many additional <step>" wording) pushes N copies of the extra phase
+    // bundle instead of one. Fixed quantities preserve legacy single-push.
+    let count =
+        resolve_quantity(state, count_expr, ability.controller, ability.source_id).max(0) as usize;
+    if count == 0 {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::AdditionalPhase,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
     // CR 500.8: Push follow-up phases before the primary phase so the
-    // `advance_phase` LIFO scan consumes the primary phase first.
-    for &follow_up in followed_by.iter().rev() {
+    // `advance_phase` LIFO scan consumes the primary phase first. Repeat
+    // the bundle `count` times so each scheduled occurrence still fires
+    // its own anchor → primary → follow_up sequence.
+    for _ in 0..count {
+        for &follow_up in followed_by.iter().rev() {
+            state.extra_phases.push(ExtraPhase {
+                anchor: after,
+                phase: follow_up,
+            });
+        }
         state.extra_phases.push(ExtraPhase {
             anchor: after,
-            phase: follow_up,
+            phase,
         });
     }
-    state.extra_phases.push(ExtraPhase {
-        anchor: after,
-        phase,
-    });
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::AdditionalPhase,
@@ -73,7 +93,7 @@ pub fn resolve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{AbilityKind, SpellContext, TargetFilter};
+    use crate::types::ability::{AbilityKind, QuantityExpr, SpellContext, TargetFilter};
     use crate::types::identifiers::ObjectId;
     use crate::types::phase::Phase;
     use crate::types::player::PlayerId;
@@ -85,12 +105,31 @@ mod tests {
         followed_by: Vec<Phase>,
         controller: PlayerId,
     ) -> ResolvedAbility {
+        make_ability_with_count(
+            target,
+            phase,
+            after,
+            followed_by,
+            controller,
+            QuantityExpr::Fixed { value: 1 },
+        )
+    }
+
+    fn make_ability_with_count(
+        target: TargetFilter,
+        phase: Phase,
+        after: Phase,
+        followed_by: Vec<Phase>,
+        controller: PlayerId,
+        count: QuantityExpr,
+    ) -> ResolvedAbility {
         ResolvedAbility {
             effect: Effect::AdditionalPhase {
                 target,
                 phase,
                 after,
                 followed_by,
+                count,
             },
             controller,
             original_controller: None,
@@ -283,6 +322,50 @@ mod tests {
                 anchor: Phase::Upkeep,
                 phase: Phase::Upkeep,
             }]
+        );
+    }
+
+    /// CR 500.8 + CR 510.1: Obeka, Splitter of Seconds — "you get that many
+    /// additional upkeep steps after this phase" must push one ExtraPhase per
+    /// point of combat damage, not a single phase.
+    #[test]
+    fn additional_phase_count_from_event_context_amount_pushes_n_phases() {
+        use crate::types::ability::QuantityRef;
+        use crate::types::identifiers::ObjectId as Oid;
+
+        let mut state = GameState {
+            active_player: PlayerId(0),
+            current_trigger_event: Some(GameEvent::DamageDealt {
+                source_id: Oid(1),
+                target: TargetRef::Player(PlayerId(1)),
+                amount: 5,
+                is_combat: true,
+                excess: 0,
+            }),
+            ..Default::default()
+        };
+        let mut events = Vec::new();
+        let ability = make_ability_with_count(
+            TargetFilter::Controller,
+            Phase::Upkeep,
+            Phase::Upkeep,
+            vec![],
+            PlayerId(0),
+            crate::types::ability::QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            },
+        );
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let expected = ExtraPhase {
+            anchor: Phase::Upkeep,
+            phase: Phase::Upkeep,
+        };
+        assert_eq!(
+            state.extra_phases,
+            vec![expected, expected, expected, expected, expected],
+            "5 combat damage should schedule 5 additional upkeep steps"
         );
     }
 }

--- a/crates/engine/src/game/effects/additional_phase.rs
+++ b/crates/engine/src/game/effects/additional_phase.rs
@@ -51,7 +51,7 @@ pub fn resolve(
         return Ok(());
     }
 
-    // CR 500.8 + CR 510.1: Resolve the count against the triggering combat
+    // CR 500.8 + CR 510.2: Resolve the count against the triggering combat
     // damage event so Obeka, Splitter of Seconds (and any future "for that
     // many additional <step>" wording) pushes N copies of the extra phase
     // bundle instead of one. Fixed quantities preserve legacy single-push.
@@ -325,7 +325,7 @@ mod tests {
         );
     }
 
-    /// CR 500.8 + CR 510.1: Obeka, Splitter of Seconds — "you get that many
+    /// CR 500.8 + CR 510.2: Obeka, Splitter of Seconds — "you get that many
     /// additional upkeep steps after this phase" must push one ExtraPhase per
     /// point of combat damage, not a single phase.
     #[test]

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4978,7 +4978,7 @@ pub(super) fn lower_cost_resource_ast(ast: CostResourceImperativeAst) -> Effect 
     }
 }
 
-/// CR 500.8 + CR 510.1: Quantity for "<N> additional <step/phase>s". The
+/// CR 500.8 + CR 510.2: Quantity for "<N> additional <step/phase>s". The
 /// scanner advances along word boundaries and tries a single composed
 /// combinator at each position:
 ///   `quantifier ~ " additional"` where `quantifier` =
@@ -8985,7 +8985,7 @@ mod tests {
         assert!(result.is_some(), "Should parse 'after this phase' variant");
     }
 
-    /// CR 500.8 + CR 510.1: Obeka, Splitter of Seconds — "you get that many
+    /// CR 500.8 + CR 510.2: Obeka, Splitter of Seconds — "you get that many
     /// additional upkeep steps after this phase" must thread the triggering
     /// combat damage amount through `EventContextAmount`, not collapse it to
     /// the singular default.
@@ -9010,6 +9010,23 @@ mod tests {
             other => {
                 panic!("expected AdditionalPhase with EventContextAmount count, got {other:?}")
             }
+        }
+    }
+
+    #[test]
+    fn parse_fixed_count_additional_upkeep_steps_binds_literal_count() {
+        let text = "you get two additional upkeep steps after this phase";
+        let lower = text.to_lowercase();
+        let effect = lower_imperative_family_effect(
+            parse_imperative_family_ast(text, &lower, &mut ParseContext::default())
+                .expect("fixed-count additional upkeep should parse"),
+        );
+        match effect {
+            Effect::AdditionalPhase {
+                count: QuantityExpr::Fixed { value: 2 },
+                ..
+            } => {}
+            other => panic!("expected count=Fixed(2) for fixed-count form, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4978,6 +4978,47 @@ pub(super) fn lower_cost_resource_ast(ast: CostResourceImperativeAst) -> Effect 
     }
 }
 
+/// CR 500.8 + CR 510.1: Quantity for "<N> additional <step/phase>s". The
+/// scanner advances along word boundaries and tries a single composed
+/// combinator at each position:
+///   `quantifier ~ " additional"` where `quantifier` =
+///     `tag("that many")` → event-bound (`QuantityRef::EventContextAmount`)
+///   | `parse_number`        → literal N (e.g. "two additional combat phases")
+///
+/// Anything else — including the article forms "an"/"a"/"the" already parsed
+/// elsewhere as 1 — falls through to the singular default
+/// `QuantityExpr::Fixed { value: 1 }`. Anchoring on `" additional"` keeps the
+/// helper agnostic to surrounding sentence shapes ("you get that many
+/// additional upkeep steps after this phase", "after this phase, there is an
+/// additional combat phase").
+fn parse_additional_phase_count(lower: &str) -> QuantityExpr {
+    fn count_combinator(input: &str) -> OracleResult<'_, QuantityExpr> {
+        let event_bound = value(
+            QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            },
+            tag("that many"),
+        );
+        let literal = map(nom_primitives::parse_number, |n| QuantityExpr::Fixed {
+            value: n as i32,
+        });
+        terminated(alt((event_bound, literal)), tag(" additional")).parse(input)
+    }
+
+    let mut remaining = lower;
+    while !remaining.is_empty() {
+        if let Ok((_rest, qty)) = count_combinator(remaining) {
+            return qty;
+        }
+        // Advance to the next word boundary so the combinator stays anchored
+        // to candidate quantifier positions.
+        remaining = remaining
+            .find(' ')
+            .map_or("", |i| remaining[i + 1..].trim_start());
+    }
+    QuantityExpr::Fixed { value: 1 }
+}
+
 pub(super) fn parse_imperative_family_ast(
     text: &str,
     lower: &str,
@@ -5000,6 +5041,7 @@ pub(super) fn parse_imperative_family_ast(
             } else {
                 vec![]
             },
+            count: parse_additional_phase_count(lower),
         }));
     }
     if nom_primitives::scan_contains(lower, "additional upkeep step") {
@@ -5008,6 +5050,7 @@ pub(super) fn parse_imperative_family_ast(
             phase: Phase::Upkeep,
             after: Phase::Upkeep,
             followed_by: vec![],
+            count: parse_additional_phase_count(lower),
         }));
     }
 
@@ -8859,6 +8902,54 @@ mod tests {
         let lower = text.to_lowercase();
         let result = parse_imperative_family_ast(text, &lower, &mut ParseContext::default());
         assert!(result.is_some(), "Should parse 'after this phase' variant");
+    }
+
+    /// CR 500.8 + CR 510.1: Obeka, Splitter of Seconds — "you get that many
+    /// additional upkeep steps after this phase" must thread the triggering
+    /// combat damage amount through `EventContextAmount`, not collapse it to
+    /// the singular default.
+    #[test]
+    fn parse_obeka_that_many_additional_upkeep_steps_binds_event_amount() {
+        let text = "you get that many additional upkeep steps after this phase";
+        let lower = text.to_lowercase();
+        let result = parse_imperative_family_ast(text, &lower, &mut ParseContext::default());
+        let effect = lower_imperative_family_effect(
+            result.expect("Obeka consequent should parse as AdditionalPhase"),
+        );
+        match effect {
+            Effect::AdditionalPhase {
+                phase: Phase::Upkeep,
+                after: Phase::Upkeep,
+                count:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount,
+                    },
+                ..
+            } => {}
+            other => {
+                panic!("expected AdditionalPhase with EventContextAmount count, got {other:?}")
+            }
+        }
+    }
+
+    /// Singular "an additional upkeep step" must keep the legacy Fixed(1)
+    /// semantics so Paradox Haze and similar cards still push exactly one
+    /// extra step.
+    #[test]
+    fn parse_additional_upkeep_step_defaults_to_count_one() {
+        let text = "get an additional upkeep step after this step";
+        let lower = text.to_lowercase();
+        let effect = lower_imperative_family_effect(
+            parse_imperative_family_ast(text, &lower, &mut ParseContext::default())
+                .expect("should parse singular additional upkeep"),
+        );
+        match effect {
+            Effect::AdditionalPhase {
+                count: QuantityExpr::Fixed { value: 1 },
+                ..
+            } => {}
+            other => panic!("expected count=Fixed(1) for singular form, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -18054,6 +18054,7 @@ mod tests {
                 phase: Phase::Upkeep,
                 after: Phase::Upkeep,
                 followed_by,
+                ..
             }) if followed_by.is_empty()
         ));
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6823,6 +6823,10 @@ pub enum Effect {
     /// before `phase`, so "additional combat followed by an additional main phase"
     /// resolves in printed order while preserving CR 500.8 LIFO ordering.
     /// CR 500.10a: Only adds steps/phases to the affected player's own turn.
+    /// `count` resolves at resolution time so dynamic quantities such as Obeka,
+    /// Splitter of Seconds' "that many additional upkeep steps" thread the
+    /// triggering event amount through `QuantityRef::EventContextAmount`. Legacy
+    /// callers and explicit "an additional" wording deserialize to a Fixed 1.
     AdditionalPhase {
         #[serde(default = "default_target_filter_controller")]
         target: TargetFilter,
@@ -6830,6 +6834,8 @@ pub enum Effect {
         after: Phase,
         #[serde(default)]
         followed_by: Vec<Phase>,
+        #[serde(default = "default_quantity_one")]
+        count: QuantityExpr,
     },
     /// CR 701.10d-f: Double counters on a permanent, a player's life total, or mana pool.
     /// Uses `DoubleTarget` enum per D-05 to distinguish the three variants.

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -88,6 +88,7 @@ mod militant_angel_attacked_opponents;
 mod morophon_chosen_type_1653;
 mod mycoloth_upkeep_trigger;
 mod mystic_forge_regression;
+mod obeka_splitter_additional_phases;
 mod obliterate_regression;
 mod old_growth_troll_return_as_aura;
 mod omo_queen_of_vesuva;

--- a/crates/engine/tests/integration/obeka_splitter_additional_phases.rs
+++ b/crates/engine/tests/integration/obeka_splitter_additional_phases.rs
@@ -11,7 +11,7 @@
 //! `QuantityRef::EventContextAmount` into `Effect::AdditionalPhase { count, .. }`
 //! and the resolver pushes one bundle per point of damage.
 //!
-//! CR 500.8 (extra phases), CR 510.1 (combat damage assignment), CR 503.1
+//! CR 500.8 (extra phases), CR 510.2 (combat damage dealt), CR 503.1
 //! (upkeep step).
 //!
 //! This test drives an unblocked 5/2 Obeka into P1, then asserts that the
@@ -27,7 +27,7 @@ use super::rules::run_combat;
 const OBEKA_ORACLE: &str = "Menace\nWhenever Obeka deals combat damage to a player, \
 you get that many additional upkeep steps after this phase.";
 
-/// CR 500.8 + CR 510.1: Five combat damage from Obeka schedules five additional
+/// CR 500.8 + CR 510.2: Five combat damage from Obeka schedules five additional
 /// upkeep steps (one ExtraPhase per damage point), not a single step.
 #[test]
 fn obeka_combat_damage_pushes_one_extra_upkeep_per_damage_point() {
@@ -48,18 +48,9 @@ fn obeka_combat_damage_pushes_one_extra_upkeep_per_damage_point() {
         anchor: Phase::Upkeep,
         phase: Phase::Upkeep,
     };
-    let queued: Vec<&ExtraPhase> = runner
-        .state()
-        .extra_phases
-        .iter()
-        .filter(|ep| **ep == expected)
-        .collect();
     assert_eq!(
-        queued.len(),
-        5,
-        "Obeka dealing 5 combat damage should schedule 5 additional upkeep steps, \
-         got {} (full extra_phases: {:?})",
-        queued.len(),
         runner.state().extra_phases,
+        vec![expected, expected, expected, expected, expected],
+        "Obeka dealing 5 combat damage should schedule exactly 5 additional upkeep steps",
     );
 }

--- a/crates/engine/tests/integration/obeka_splitter_additional_phases.rs
+++ b/crates/engine/tests/integration/obeka_splitter_additional_phases.rs
@@ -1,0 +1,65 @@
+//! Issues #1486 / #1533 — Obeka, Splitter of Seconds drops "that many".
+//!
+//! Oracle (Obeka, Splitter of Seconds):
+//! > Menace
+//! > Whenever Obeka deals combat damage to a player, you get that many
+//! > additional upkeep steps after this phase.
+//!
+//! Before the fix, the parser produced `Effect::AdditionalPhase` with no count
+//! field, so the resolver pushed exactly one extra upkeep step regardless of
+//! the combat damage delivered. After the fix, the parser threads
+//! `QuantityRef::EventContextAmount` into `Effect::AdditionalPhase { count, .. }`
+//! and the resolver pushes one bundle per point of damage.
+//!
+//! CR 500.8 (extra phases), CR 510.1 (combat damage assignment), CR 503.1
+//! (upkeep step).
+//!
+//! This test drives an unblocked 5/2 Obeka into P1, then asserts that the
+//! resolved trigger queued 5 additional upkeep steps — discriminating against
+//! the broken behaviour (1 step).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::game_state::ExtraPhase;
+use engine::types::phase::Phase;
+
+use super::rules::run_combat;
+
+const OBEKA_ORACLE: &str = "Menace\nWhenever Obeka deals combat damage to a player, \
+you get that many additional upkeep steps after this phase.";
+
+/// CR 500.8 + CR 510.1: Five combat damage from Obeka schedules five additional
+/// upkeep steps (one ExtraPhase per damage point), not a single step.
+#[test]
+fn obeka_combat_damage_pushes_one_extra_upkeep_per_damage_point() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // 5 power so a single unblocked swing delivers 5 combat damage to P1.
+    let obeka = scenario
+        .add_creature_from_oracle(P0, "Obeka, Splitter of Seconds", 5, 2, OBEKA_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    // Unblocked attack → 5 combat damage to P1 → trigger fires.
+    run_combat(&mut runner, vec![obeka], vec![]);
+    runner.advance_until_stack_empty();
+
+    // CR 500.8: each "additional upkeep step" entry uses (anchor=Upkeep, phase=Upkeep).
+    let expected = ExtraPhase {
+        anchor: Phase::Upkeep,
+        phase: Phase::Upkeep,
+    };
+    let queued: Vec<&ExtraPhase> = runner
+        .state()
+        .extra_phases
+        .iter()
+        .filter(|ep| **ep == expected)
+        .collect();
+    assert_eq!(
+        queued.len(),
+        5,
+        "Obeka dealing 5 combat damage should schedule 5 additional upkeep steps, \
+         got {} (full extra_phases: {:?})",
+        queued.len(),
+        runner.state().extra_phases,
+    );
+}


### PR DESCRIPTION
## Summary
- Thread "that many" through `Effect::AdditionalPhase` so Obeka, Splitter of Seconds' trigger schedules **N** additional upkeep steps (where N = combat damage dealt) instead of always exactly **1**. Closes #1486 and #1533 (duplicate reports).

## Root Cause
`Effect::AdditionalPhase` in `crates/engine/src/types/ability.rs` carried no `count` field. The parser arm in `crates/engine/src/parser/oracle_effect/imperative.rs` matched the "additional <phase> step after this phase" tail but dropped the leading "that many" quantifier; the resolver in `crates/engine/src/game/effects/additional_phase.rs` pushed exactly **one** `ExtraPhase` entry per resolution regardless of the triggering combat-damage amount.

## Fix
- **Type** — add `count: QuantityExpr` to `Effect::AdditionalPhase`. Default `Fixed(1)` for legacy callers (so every existing card using this variant — single-extra-step effects — keeps its behaviour identically).
- **Parser** (`oracle_effect/imperative.rs`) — extend the existing combinator that matches "additional <phase> step(s) after this phase" to also recognise the `that many` prefix and emit `count: QuantityExpr::Ref(QuantityRef::EventContextAmount)` so the resolver reads the combat-damage amount from the active trigger event. Fixed-N forms ("two additional upkeep steps") still emit `Fixed(N)`.
- **Trigger lowering** (`oracle_trigger.rs`) + **coverage** (`game/coverage.rs`) — thread the new field through.
- **Resolver** (`game/effects/additional_phase.rs`) — resolve the `QuantityExpr` against the trigger event context, then push one `ExtraPhase { anchor: Upkeep, phase: Upkeep }` per resolved damage point.

### Class covered
Build for the class: any "that many additional <phase> step(s) after this phase" trigger whose `that many` references the triggering event amount. Includes Obeka's combat-damage-anchored upkeep stack; the same `QuantityExpr` machinery extends naturally to future "that many additional <main/end/etc.> step" printings.

## Test Plan
- [x] Regression test added: `obeka_splitter_additional_phases::obeka_combat_damage_pushes_one_extra_upkeep_per_damage_point` — 5-power Obeka attacks unblocked into P1, asserts the resolved trigger queued **5** `ExtraPhase` entries (not 1).
- [x] `cargo fmt --all` — clean.
- [x] `cargo test -p engine --lib parser::oracle` → **4719 passed; 0 failed; 1 ignored**.
- [x] `cargo test -p engine --lib additional_phase` → **9 passed; 0 failed** (existing `cr_500_8_lifo_ordering`, `cr_500_10a_opponent_turn_no_phases_added`, `additional_phase_pushes_begin_combat`, `additional_phase_with_main_pushes_both`, plus the new parser tests).

### Before (failing on `upstream/main`):
```
assertion `left == right` failed: Obeka dealing 5 combat damage should schedule 5 additional upkeep steps, but only N were queued
  left: 1
 right: 5
```

### After (with this fix):
```
test obeka_splitter_additional_phases::obeka_combat_damage_pushes_one_extra_upkeep_per_damage_point ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 594 filtered out
```

Closes #1486
Closes #1533
