### PR TITLE
feat(engine): typed per-card deck copy-limit (DeckCopyLimit) for "deck can have N cards named X"

### DIFF
--- a/client/src/components/deck-builder/CommanderPanel.tsx
+++ b/client/src/components/deck-builder/CommanderPanel.tsx
@@ -28,6 +28,8 @@ interface CommanderPanelProps {
   onSetCommander: (cardName: string) => void;
   onRemoveCommander: (cardName: string) => void;
   onCardHover?: (cardName: string | null) => void;
+  /** CR 100.2a / CR 903.5b: engine-backed per-card copy cap resolver. */
+  getEffectiveCap: (name: string) => number;
 }
 
 
@@ -40,11 +42,12 @@ export function CommanderPanel({
   onSetCommander,
   onRemoveCommander,
   onCardHover,
+  getEffectiveCap,
 }: CommanderPanelProps) {
   const { t } = useTranslation("deck-builder");
   const identity = getCombinedColorIdentity(commanders, cardDataCache);
   const colorViolations = getColorIdentityViolations(deck, commanders, cardDataCache);
-  const singletonViolations = getSingletonViolations(deck, cardDataCache);
+  const singletonViolations = getSingletonViolations(deck, cardDataCache, getEffectiveCap);
   const totalCards = deck.reduce((sum, e) => sum + e.count, 0) + commanders.length;
 
   // Cards in deck that could become a commander. The handler decides whether

--- a/client/src/components/deck-builder/DeckBuilder.tsx
+++ b/client/src/components/deck-builder/DeckBuilder.tsx
@@ -90,6 +90,7 @@ export function DeckBuilder({
     handleSetCommander,
     isCommanderEligible,
     handleRemoveCommander,
+    effectiveCap,
   } = useDeckBuilder({ format, onFormatChange, initialDeckName, searchFilters });
   const { t } = useTranslation("deck-builder");
 
@@ -407,6 +408,7 @@ export function DeckBuilder({
                       onRemoveCommander={handleRemoveCommander}
                       onCardHover={onCardHover}
                       format={format}
+                      getEffectiveCap={effectiveCap}
                     />
                   )}
                 </div>
@@ -433,6 +435,7 @@ export function DeckBuilder({
                 onSetCommander={handleSetCommander}
                 onRemoveCommander={handleRemoveCommander}
                 onCardHover={onCardHover}
+                getEffectiveCap={effectiveCap}
               />
             )}
             <StatsPanel

--- a/client/src/components/deck-builder/DeckStack.tsx
+++ b/client/src/components/deck-builder/DeckStack.tsx
@@ -9,8 +9,7 @@ import type { SourcePrinting } from "../../hooks/useCardImage";
 import type { ScryfallCard } from "../../services/scryfall";
 import { usePreferencesStore } from "../../stores/preferencesStore";
 import type { GameFormat } from "../../adapter/types";
-import { BASIC_LAND_NAMES, hasUnlimitedCopies } from "../../constants/game";
-import { formatMetadata } from "../../data/formatRegistry";
+import { BASIC_LAND_NAMES } from "../../constants/game";
 import { DeckCardContextMenu } from "./DeckCardContextMenu";
 import { PrintingPickerModal } from "./PrintingPickerModal";
 import { mouseHoverPreview } from "./hoverPreview";
@@ -28,6 +27,9 @@ interface DeckStackProps {
   /** Deck format — resolves the sideboard policy so the second section
    *  is labelled "Sideboard" or "Maybeboard" consistently with the list view. */
   format?: GameFormat;
+  /** CR 100.2a / CR 903.5b: engine-backed per-card copy cap resolver. Returns
+   *  the format default (4 / 1) unless the card prints an override. */
+  getEffectiveCap: (name: string) => number;
 }
 
 type DeckStackSection = "commander" | "main" | "sideboard";
@@ -435,6 +437,7 @@ export function DeckStack({
   onRemoveCommander,
   onCardHover,
   format,
+  getEffectiveCap,
 }: DeckStackProps) {
   const { t } = useTranslation("deck-builder");
   const isMaybeboard = isMaybeboardPolicy(useSideboardPolicy(format));
@@ -448,22 +451,18 @@ export function DeckStack({
     sections.commander.length > 0
     || sections.main.length > 0
     || sections.sideboard.length > 0;
-  const maxCopies =
-    format && formatMetadata(format)?.default_config.singleton ? 1 : 4;
   const canAddCard = useMemo(
     () => (item: DeckStackItem) => {
       if (item.section !== "main") return false;
-      // CR 100.2a: basic lands and cards whose Oracle text declares "a deck can
-      // have any number of cards named ~" (e.g. Relentless Rats, Rat Colony)
-      // are exempt from the per-card copy limit. Mirrors the guard inside
+      // CR 100.2a / CR 903.5b: basic lands are always addable; every other card
+      // is capped at its engine-resolved effective limit (4 / 1 default, raised
+      // by "any number" / "up to N" overrides). Mirrors the guard inside
       // useDeckBuilder.handleAddCard so the stack tile's + button doesn't
       // disagree with the hook's add path.
-      const card = cardDataCache.get(item.name);
       if (BASIC_LAND_NAMES.has(item.name)) return true;
-      if (hasUnlimitedCopies(card?.oracle_text)) return true;
-      return item.count < maxCopies;
+      return item.count < getEffectiveCap(item.name);
     },
-    [cardDataCache, maxCopies],
+    [getEffectiveCap],
   );
 
   const artOverrides = usePreferencesStore((s) => s.artOverrides);

--- a/client/src/components/deck-builder/__tests__/CommanderPanel.test.tsx
+++ b/client/src/components/deck-builder/__tests__/CommanderPanel.test.tsx
@@ -37,6 +37,7 @@ describe("CommanderPanel", () => {
         isCommanderEligible={() => true}
         onSetCommander={vi.fn()}
         onRemoveCommander={vi.fn()}
+        getEffectiveCap={() => 1}
       />,
     );
 

--- a/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
+++ b/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
@@ -90,6 +90,7 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
+        getEffectiveCap={() => 4}
       />,
     );
 
@@ -141,6 +142,7 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
+        getEffectiveCap={() => 4}
       />,
     );
 
@@ -169,8 +171,8 @@ describe("DeckStack", () => {
 
   it("keeps the add button enabled past 4 copies for 'any number' cards (CR 100.2a)", () => {
     // Regression for #1494: Relentless Rats / Rat Colony override the 4-copy
-    // deck construction limit per CR 100.2a. The stack tile's + button must
-    // stay enabled even when the count is at or above the normal limit.
+    // deck construction limit per CR 100.2a. The engine resolves the override to
+    // an unbounded cap (Infinity); the tile's + button must stay enabled.
     render(
       <DeckStack
         deck={{
@@ -180,25 +182,56 @@ describe("DeckStack", () => {
         commanders={[]}
         cardDataCache={
           new Map([
-            [
-              "Relentless Rats",
-              makeCard(
-                "Relentless Rats",
-                "Creature — Rat",
-                3,
-                "Relentless Rats's power and toughness are each equal to the number of creatures named Relentless Rats you control.\nA deck can have any number of cards named Relentless Rats.",
-              ),
-            ],
+            ["Relentless Rats", makeCard("Relentless Rats", "Creature — Rat", 3)],
           ])
         }
         onAddCard={vi.fn()}
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
+        getEffectiveCap={(name) => (name === "Relentless Rats" ? Infinity : 4)}
       />,
     );
 
     expect(screen.getByTitle("Add one Relentless Rats")).toBeEnabled();
+  });
+
+  it("respects a bounded 'up to N' override cap (CR 100.2a)", () => {
+    // Seven Dwarves overrides to UpTo(7). At 6 copies the + button is enabled;
+    // at 7 it is disabled.
+    const { rerender } = render(
+      <DeckStack
+        deck={{ main: [{ name: "Seven Dwarves", count: 6 }], sideboard: [] }}
+        commanders={[]}
+        cardDataCache={
+          new Map([["Seven Dwarves", makeCard("Seven Dwarves", "Creature — Dwarf", 4)]])
+        }
+        onAddCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+        onMoveCard={vi.fn()}
+        onRemoveCommander={vi.fn()}
+        getEffectiveCap={(name) => (name === "Seven Dwarves" ? 7 : 4)}
+      />,
+    );
+    expect(screen.getByTitle("Add one Seven Dwarves")).toBeEnabled();
+
+    rerender(
+      <DeckStack
+        deck={{ main: [{ name: "Seven Dwarves", count: 7 }], sideboard: [] }}
+        commanders={[]}
+        cardDataCache={
+          new Map([["Seven Dwarves", makeCard("Seven Dwarves", "Creature — Dwarf", 4)]])
+        }
+        onAddCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+        onMoveCard={vi.fn()}
+        onRemoveCommander={vi.fn()}
+        getEffectiveCap={(name) => (name === "Seven Dwarves" ? 7 : 4)}
+      />,
+    );
+    expect(
+      screen.getByTitle("Seven Dwarves is at the copy limit"),
+    ).toBeDisabled();
   });
 
   it("disables the add button at 1 copy for singleton formats", () => {
@@ -217,6 +250,7 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
+        getEffectiveCap={() => 1}
       />,
     );
 
@@ -244,6 +278,7 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={onMoveCard}
         onRemoveCommander={vi.fn()}
+        getEffectiveCap={() => 4}
       />,
     );
 

--- a/client/src/components/deck-builder/commanderUtils.ts
+++ b/client/src/components/deck-builder/commanderUtils.ts
@@ -1,6 +1,6 @@
 import type { ScryfallCard } from "../../services/scryfall";
 import type { DeckEntry } from "../../services/deckParser";
-import { BASIC_LAND_NAMES, hasUnlimitedCopies } from "../../constants/game";
+import { BASIC_LAND_NAMES } from "../../constants/game";
 
 const WUBRG_COLORS = ["W", "U", "B", "R", "G"] as const;
 
@@ -47,11 +47,18 @@ export function getColorIdentityViolations(
   return violations;
 }
 
+/**
+ * CR 903.5b: Names appearing above their effective copy cap in a singleton
+ * (Commander) deck, excluding basic lands. The cap comes from the engine-backed
+ * `getEffectiveCap` resolver (1 by default; raised for "up to N" override cards
+ * like Nazgûl → 9) — never inferred from Oracle text client-side.
+ */
 export function getSingletonViolations(
   deck: DeckEntry[],
-  cardDataCache: Map<string, ScryfallCard>,
+  _cardDataCache: Map<string, ScryfallCard>,
+  getEffectiveCap: (name: string) => number,
 ): string[] {
   return deck
-    .filter((e) => e.count > 1 && !BASIC_LAND_NAMES.has(e.name) && !hasUnlimitedCopies(cardDataCache.get(e.name)?.oracle_text))
+    .filter((e) => e.count > getEffectiveCap(e.name) && !BASIC_LAND_NAMES.has(e.name))
     .map((e) => e.name);
 }

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -14,7 +14,7 @@ import {
   removeDeckMeta,
   stampDeckMeta,
 } from "../../constants/storage";
-import { BASIC_LAND_NAMES, hasUnlimitedCopies } from "../../constants/game";
+import { BASIC_LAND_NAMES } from "../../constants/game";
 import { loadPreconDeckMap } from "../../hooks/useDecks";
 import { preconDeckEntryToParsedDeck } from "../../services/preconDecks";
 import { useDeckCardData } from "../../hooks/useDeckCardData";
@@ -32,6 +32,7 @@ import {
 } from "./commanderUtils";
 import {
   commanderPartnerCandidates,
+  deckCopyLimit,
   isCardCommanderEligibleForFormat,
 } from "../../services/engineRuntime";
 
@@ -87,6 +88,10 @@ export function useDeckBuilder({
 
   const [compatibility, setCompatibility] = useState<DeckCompatibilityResult | null>(null);
   const [commanderEligibleNames, setCommanderEligibleNames] = useState<Set<string>>(new Set());
+  // CR 100.2a / CR 903.5b: per-card deck-construction copy-limit overrides, keyed
+  // by card name. `Infinity` = "any number"; a finite cap = "up to N" / singleton.
+  // Populated from the engine — never inferred from Oracle text client-side.
+  const [deckCopyLimits, setDeckCopyLimits] = useState<Map<string, number>>(new Map());
 
   const artOverrides = usePreferencesStore((s) => s.artOverrides);
   const clearArtOverride = usePreferencesStore((s) => s.clearArtOverride);
@@ -185,6 +190,48 @@ export function useDeckBuilder({
     };
   }, [deck.main, format, isCommander]);
 
+  // CR 100.2a / CR 903.5b: resolve per-card copy-limit overrides for every card
+  // referenced anywhere in the deck. The engine is the single authority — the
+  // frontend never re-parses Oracle text. Mirrors the commander-eligibility
+  // effect's union-of-names keying and cancellation guard.
+  useEffect(() => {
+    const names = Array.from(
+      new Set([
+        ...deck.main.map((e) => e.name),
+        ...deck.sideboard.map((e) => e.name),
+        ...commanders,
+      ]),
+    );
+    if (names.length === 0) {
+      setDeckCopyLimits(new Map());
+      return;
+    }
+    let cancelled = false;
+    Promise.all(
+      names.map(async (name) => [name, await deckCopyLimit(name)] as const),
+    ).then((results) => {
+      if (cancelled) return;
+      const next = new Map<string, number>();
+      for (const [name, limit] of results) {
+        if (!limit) continue;
+        next.set(name, limit.type === "Unlimited" ? Infinity : limit.data);
+      }
+      setDeckCopyLimits(next);
+    }).catch(() => {
+      if (!cancelled) setDeckCopyLimits(new Map());
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [deck.main, deck.sideboard, commanders]);
+
+  // Synchronous per-card effective copy cap: the override when present, else the
+  // format default (4 constructed / 1 singleton).
+  const effectiveCap = useCallback(
+    (name: string) => deckCopyLimits.get(name) ?? maxCopies,
+    [deckCopyLimits, maxCopies],
+  );
+
   const { estimate, unsupported: bracketUnsupported } = useBracketEstimate({
     deck,
     commanders,
@@ -241,7 +288,7 @@ export function useDeckBuilder({
 
     setDeck((prev) => {
       const existing = prev.main.find((e) => e.name === card.name);
-      if (existing && existing.count >= maxCopies && !BASIC_LAND_NAMES.has(card.name) && !hasUnlimitedCopies(card.oracle_text)) {
+      if (existing && existing.count >= effectiveCap(card.name) && !BASIC_LAND_NAMES.has(card.name)) {
         return prev;
       }
 
@@ -258,7 +305,7 @@ export function useDeckBuilder({
         main: [...prev.main, { count: 1, name: card.name }],
       };
     });
-  }, [cacheCards, maxCopies]);
+  }, [cacheCards, effectiveCap]);
 
   const handleAddCardByName = useCallback((name: string) => {
     const card = cardDataCache.get(name);
@@ -305,9 +352,8 @@ export function useDeckBuilder({
         if (
           to === "main" &&
           targetEntry &&
-          targetEntry.count >= maxCopies &&
-          !BASIC_LAND_NAMES.has(name) &&
-          !hasUnlimitedCopies(cardDataCache.get(name)?.oracle_text)
+          targetEntry.count >= effectiveCap(name) &&
+          !BASIC_LAND_NAMES.has(name)
         ) {
           return prev;
         }
@@ -332,7 +378,7 @@ export function useDeckBuilder({
         };
       });
     },
-    [maxCopies, cardDataCache],
+    [effectiveCap],
   );
 
   const applyDeckToEditor = useCallback((next: ParsedDeck) => {
@@ -557,7 +603,7 @@ export function useDeckBuilder({
     if (totalCards > 0 && totalCards !== expectedDeckSize) {
       warnings.push(t("warnings.commanderCount", { count: totalCards, expected: expectedDeckSize }));
     }
-    for (const name of getSingletonViolations(deck.main, cardDataCache)) {
+    for (const name of getSingletonViolations(deck.main, cardDataCache, effectiveCap)) {
       warnings.push(t("warnings.singleton", { name }));
     }
     for (const name of getColorIdentityViolations(deck.main, commanders, cardDataCache)) {
@@ -569,7 +615,7 @@ export function useDeckBuilder({
       warnings.push(t("warnings.minimumCount", { count: mainTotal }));
     }
     for (const entry of deck.main) {
-      if (entry.count > 4 && !BASIC_LAND_NAMES.has(entry.name) && !hasUnlimitedCopies(cardDataCache.get(entry.name)?.oracle_text)) {
+      if (entry.count > effectiveCap(entry.name) && !BASIC_LAND_NAMES.has(entry.name)) {
         warnings.push(t("warnings.maxCopies", { name: entry.name, count: entry.count }));
       }
     }
@@ -632,5 +678,6 @@ export function useDeckBuilder({
     handleSetCommander,
     isCommanderEligible,
     handleRemoveCommander,
+    effectiveCap,
   };
 }

--- a/client/src/constants/game.ts
+++ b/client/src/constants/game.ts
@@ -16,16 +16,6 @@ export const BASIC_LAND_NAMES = new Set([
   "Snow-Covered Forest",
 ]);
 
-/**
- * CR 100.2a: Certain cards override the 4-copy deck construction limit
- * via Oracle text "a deck can have any number of cards named ~".
- * This is a UI convenience check — real validation goes through the engine.
- */
-export function hasUnlimitedCopies(oracleText: string | undefined): boolean {
-  if (!oracleText) return false;
-  return oracleText.toLowerCase().includes("a deck can have any number of cards named");
-}
-
 /** Action types that don't reveal hidden information and are safe to undo. */
 export const UNDOABLE_ACTIONS = new Set([
   "PassPriority",

--- a/client/src/services/engineRuntime.ts
+++ b/client/src/services/engineRuntime.ts
@@ -232,6 +232,28 @@ export async function commanderPartnerCandidates(
 }
 
 /**
+ * CR 100.2a / CR 903.5b: A card's per-card deck-construction copy-limit override
+ * as a discriminated union, or `null` when the default four-of / singleton limit
+ * applies. `Unlimited` is a unit variant with no `data` field — switch on `type`,
+ * never destructure `data` unconditionally. The engine is the single authority;
+ * the frontend never re-parses Oracle text.
+ */
+export type DeckCopyLimit =
+  | { type: "Unlimited" }
+  | { type: "UpTo"; data: number };
+
+/**
+ * Query the engine for a card's deck-construction copy-limit override. Returns
+ * `null` when the format-default limit applies. The frontend must not infer
+ * this from Oracle text — the engine owns the rule.
+ */
+export async function deckCopyLimit(name: string): Promise<DeckCopyLimit | null> {
+  await ensureCardDatabase();
+  const engine = await loadEngineModule();
+  return engine.deckCopyLimit(name) as DeckCopyLimit | null;
+}
+
+/**
  * CR 100.4a: Per-format sideboard policy as a discriminated union.
  *
  * `Forbidden` and `Unlimited` are unit variants and do not carry a `data`

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -44,6 +44,15 @@ export function commanderPartnerCandidates(first_commander: string, candidates: 
 export function create_initial_state(): any;
 
 /**
+ * CR 100.2a / CR 903.5b: The named card's per-card deck-construction copy-limit
+ * override, or `null` when the default four-of / singleton limit applies.
+ * Serialized as the `DeckCopyLimit` tagged union (`{"type":"Unlimited"}` or
+ * `{"type":"UpTo","data":N}`); the frontend must switch on `.type`. The engine
+ * is the single authority — the frontend never re-parses Oracle text.
+ */
+export function deckCopyLimit(name: string): any;
+
+/**
  * Estimates a Commander deck's bracket without touching `GAME_STATE`.
  * Reads `CARD_DB` for bracket signals. Returns `null` (via serde) when the
  * deck has no commander or the card database is not loaded.
@@ -323,6 +332,7 @@ export interface InitOutput {
     readonly apply_seat_mutation: (a: number, b: number, c: number, d: number) => [number, number, number];
     readonly classify_deck_js: (a: any) => [number, number, number];
     readonly commanderPartnerCandidates: (a: number, b: number, c: any) => [number, number, number];
+    readonly deckCopyLimit: (a: number, b: number) => any;
     readonly estimate_bracket_for_deck: (a: any) => [number, number, number];
     readonly evaluate_deck_compatibility_js: (a: any) => [number, number, number];
     readonly export_game_state_json: () => [number, number, number, number];

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -10,11 +10,12 @@ use engine::database::legality::{any_ai_difficulty_is_cedh, validate_cedh_bracke
 use engine::database::{CardDatabase, CardSearchQuery};
 use engine::game::engine::apply;
 use engine::game::{
-    can_pair_commanders, estimate_bracket, evaluate_deck_compatibility, filter_state_for_viewer,
-    finalize_public_state, is_brawl_commander_eligible, is_commander_eligible,
-    is_tiny_leader_eligible, load_and_hydrate_decks, rehydrate_game_from_card_db,
-    resolve_deck_list, start_game, start_game_with_starting_player, validate_name_deck_for_format,
-    BracketEstimate, DeckCompatibilityRequest, DeckList, PlayerDeckList,
+    can_pair_commanders, deck_copy_limit_for, estimate_bracket, evaluate_deck_compatibility,
+    filter_state_for_viewer, finalize_public_state, is_brawl_commander_eligible,
+    is_commander_eligible, is_tiny_leader_eligible, load_and_hydrate_decks,
+    rehydrate_game_from_card_db, resolve_deck_list, start_game, start_game_with_starting_player,
+    validate_name_deck_for_format, BracketEstimate, DeckCompatibilityRequest, DeckList,
+    PlayerDeckList,
 };
 use engine::types::format::{FormatConfig, GameFormat};
 use engine::types::identifiers::ObjectId;
@@ -281,6 +282,22 @@ pub fn is_card_commander_eligible(name: &str) -> bool {
             return false;
         };
         db.get_face_by_name(name).is_some_and(is_commander_eligible)
+    })
+}
+
+/// CR 100.2a / CR 903.5b: The named card's per-card deck-construction copy-limit
+/// override, or `null` when the default four-of / singleton limit applies.
+/// Serialized as the `DeckCopyLimit` tagged union (`{"type":"Unlimited"}` or
+/// `{"type":"UpTo","data":N}`); the frontend must switch on `.type`. The engine
+/// is the single authority — the frontend never re-parses Oracle text.
+#[wasm_bindgen(js_name = deckCopyLimit)]
+pub fn deck_copy_limit(name: &str) -> JsValue {
+    CARD_DB.with(|cell| {
+        let db = cell.borrow();
+        let Some(db) = db.as_ref() else {
+            return JsValue::NULL;
+        };
+        to_js(&deck_copy_limit_for(db, name))
     })
 }
 
@@ -1540,6 +1557,7 @@ mod tests {
             strive_cost: None,
             brawl_commander: false,
             is_commander: false,
+            deck_copy_limit: None,
             metadata: Default::default(),
         }
     }

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -517,6 +517,7 @@ mod tests {
             parse_warnings: vec![],
             brawl_commander: false,
             is_commander: false,
+            deck_copy_limit: None,
             metadata: Default::default(),
             rarities: Default::default(),
         }

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -2,7 +2,9 @@ use std::str::FromStr;
 
 use crate::database::mtgjson::{parse_mtgjson_mana_cost, AtomicCard};
 use crate::game::printed_cards::derive_colors_from_mana_cost;
-use crate::parser::oracle::{oracle_text_allows_commander, parse_oracle_text};
+use crate::parser::oracle::{
+    compute_deck_copy_limit_from_text, oracle_text_allows_commander, parse_oracle_text,
+};
 use crate::parser::oracle_keyword::{keyword_display_name, parse_keyword_from_oracle};
 use crate::parser::oracle_util::{apply_bracket_mode, strip_reminder_text, BracketMode};
 use crate::types::ability::{
@@ -20,6 +22,7 @@ use crate::types::ability::{
 use crate::types::card::{CardFace, CardLayout, CleaveVariant};
 use crate::types::card_type::{CardType, CoreType, Supertype};
 use crate::types::counter::{CounterMatch, CounterType};
+use crate::types::format::DeckCopyLimit;
 use crate::types::keywords::{BloodthirstValue, BuybackCost, CyclingCost, Keyword, PartnerType};
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use crate::types::phase::Phase;
@@ -1176,6 +1179,16 @@ pub fn compute_commander(mtgjson: &super::mtgjson::AtomicCard, face: &CardFace) 
     // Source 2: type-line analysis — mirrors crate::game::deck_validation logic
     // so this function is the single authority for commander eligibility.
     mtgjson_says || type_line_commander_eligible(face)
+}
+
+/// CR 100.2a / CR 903.5b: determine a card's deck-construction copy-limit
+/// override from its Oracle text (including reminder-text bodies). `None` means
+/// the default four-of (constructed) / singleton (Commander) limit applies.
+/// Delegates to the parser so the recognizer and the validator agree.
+pub fn compute_deck_copy_limit(face: &CardFace) -> Option<DeckCopyLimit> {
+    face.oracle_text
+        .as_deref()
+        .and_then(compute_deck_copy_limit_from_text)
 }
 
 /// CR 903.3 type-line analysis (excludes MTGJSON skill data). Public for use by
@@ -5155,12 +5168,17 @@ fn build_oracle_face_inner(
         parse_warnings: parsed.parse_warnings,
         brawl_commander: false,
         is_commander: false,
+        deck_copy_limit: None,
         metadata: Default::default(),
         rarities: Default::default(),
     };
 
     face.brawl_commander = compute_brawl_commander(mtgjson, &face);
     face.is_commander = compute_commander(mtgjson, &face);
+    // CR 100.2a / CR 903.5b: per-card deck-construction copy-limit override.
+    // `face.oracle_text` retains reminder text + DCI prefix, so reminder-only
+    // limits (Vazal, the Compleat's Megalegendary) are still discovered.
+    face.deck_copy_limit = compute_deck_copy_limit(&face);
     synthesize_all(&mut face);
     face
 }

--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -1409,6 +1409,7 @@ mod tests {
             parse_warnings: vec![],
             brawl_commander: false,
             is_commander: true,
+            deck_copy_limit: None,
             metadata: Default::default(),
             rarities: Default::default(),
         };

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -8378,6 +8378,7 @@ mod tests {
             parse_warnings: vec![],
             brawl_commander: false,
             is_commander: false,
+            deck_copy_limit: None,
             metadata: Default::default(),
             rarities: Default::default(),
         }

--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -469,6 +469,7 @@ mod tests {
             parse_warnings: vec![],
             brawl_commander: false,
             is_commander: false,
+            deck_copy_limit: None,
             metadata: Default::default(),
             rarities: Default::default(),
         }
@@ -518,6 +519,7 @@ mod tests {
             parse_warnings: vec![],
             brawl_commander: false,
             is_commander: false,
+            deck_copy_limit: None,
             metadata: Default::default(),
             rarities: Default::default(),
         }

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::database::legality::{LegalityFormat, LegalityStatus};
 use crate::database::CardDatabase;
-use crate::parser::oracle::oracle_text_allows_commander;
+use crate::parser::oracle::{compute_deck_copy_limit_from_text, oracle_text_allows_commander};
 use crate::types::card::{CardFace, CardRules, PrintedCardRef};
 use crate::types::card_type::{CoreType, Supertype};
-use crate::types::format::{GameFormat, SideboardPolicy};
+use crate::types::format::{DeckCopyLimit, GameFormat, SideboardPolicy};
 use crate::types::keywords::Keyword;
 use crate::types::mana::{ManaColor, ManaCost};
 use crate::types::match_config::MatchType;
@@ -1744,14 +1744,10 @@ fn combined_copy_counts(
 
 /// CR 100.2a: Flag card names whose combined count exceeds `max_copies`,
 /// excluding basic lands and cards whose Oracle text grants a per-card deck-limit
-/// override (e.g. Relentless Rats, Shadowborn Apostle, Rat Colony, Persistent
-/// Petitioners — all printed with "A deck can have any number of cards named ...").
-///
-/// Seven Dwarves / Nazgûl have finite caps printed on the card (7 and 9
-/// respectively) via "A deck can have up to <N> cards named ..."; their phrasing
-/// does not match the "any number" override, so they currently fall through to
-/// the default 4-per-name limit. That's a known gap — supporting arbitrary N-caps
-/// requires parsing the printed number, which is out of scope for this pass.
+/// override (e.g. Relentless Rats — "any number"; Seven Dwarves → 7, Nazgûl → 9
+/// via "up to N"; Vazal singleton → 1). The typed override is resolved from
+/// `face.deck_copy_limit`, falling back to a live Oracle-text parse for faces
+/// loaded without synthesis (test fixtures, `from_json_str`).
 ///
 /// Input counts must be keyed by canonical (DFC-resolved, lowercased) names —
 /// use `combined_copy_counts`.
@@ -1762,21 +1758,25 @@ fn copy_limit_violations(
 ) -> BTreeSet<String> {
     let mut violations = BTreeSet::new();
     for (canonical_name, count) in counts {
-        if *count <= max_copies {
-            continue;
-        }
-        // CR 100.2a + CR 205.3i: Basic lands are exempt from copy limits.
-        // "Basic" is a supertype (covering Plains/Island/Swamp/Mountain/Forest,
-        // Snow-Covered variants, Wastes, and any future basic), not a fixed
-        // name allowlist — trust the MTGJSON-populated supertype field.
+        // CR 100.2a + CR 205.4c: Basic lands are exempt from copy limits
+        // regardless of any other override. "Basic" is a supertype (covering
+        // Plains/Island/Swamp/Mountain/Forest, Snow-Covered variants, Wastes,
+        // and any future basic), not a fixed name allowlist — trust the
+        // MTGJSON-populated supertype field. Checked FIRST so basics never flag.
         if db
             .get_face_by_name(canonical_name)
             .is_some_and(|face| face.card_type.supertypes.contains(&Supertype::Basic))
         {
             continue;
         }
-        if has_deck_limit_override(db, canonical_name) {
-            continue;
+        // CR 100.2a / CR 903.5b: apply the per-card override when present,
+        // otherwise the format-default `max_copies` (4 constructed, 1 singleton).
+        match deck_copy_limit_for(db, canonical_name) {
+            Some(DeckCopyLimit::Unlimited) => continue,
+            Some(DeckCopyLimit::UpTo(n)) if *count <= n => continue,
+            Some(DeckCopyLimit::UpTo(_)) => {} // override cap exceeded — flag
+            None if *count <= max_copies => continue,
+            None => {} // default limit exceeded — flag
         }
         // Prefer the database's canonical display casing for error messages;
         // fall back to the lowercased key if the face is missing (e.g. for
@@ -1797,6 +1797,10 @@ fn copy_limit_violations(
 /// `restricted_canonical` is the set of canonical (DFC-resolved, lowercased)
 /// names that the legality table marks as `Restricted` for the active format;
 /// `counts` is the combined main+sideboard map produced by `combined_copy_counts`.
+///
+/// Note: this hardcodes the `<= 1` Restricted ceiling and does NOT consult any
+/// per-card `DeckCopyLimit` override — no override card is currently
+/// Vintage-Restricted, so the interaction is out of scope.
 fn restricted_copy_violations(
     db: &CardDatabase,
     counts: &HashMap<String, u32>,
@@ -1819,19 +1823,17 @@ fn restricted_copy_violations(
     violations
 }
 
-/// CR 100.2a exception: a card's Oracle text may read
-/// "A deck can have any number of cards named <Name>." When present, the
-/// 4-per-name constructed limit and the 1-per-name singleton limit do not
-/// apply to that card. Class-level Oracle text detection — covers Relentless
-/// Rats, Shadowborn Apostle, Rat Colony, Persistent Petitioners, and any
-/// future card printed with the same phrasing.
-fn has_deck_limit_override(db: &CardDatabase, canonical_name: &str) -> bool {
-    db.get_face_by_name(canonical_name)
-        .and_then(|face| face.oracle_text.as_deref())
-        .is_some_and(|text| {
-            text.to_ascii_lowercase()
-                .contains("a deck can have any number of cards named")
-        })
+/// CR 100.2a / CR 903.5b: Resolve a card's deck-construction copy-limit override.
+/// Reads the precomputed `face.deck_copy_limit` field; falls back to a live
+/// Oracle-text parse for faces loaded without synthesis (test fixtures and
+/// `CardDatabase::from_json_str` / `from_export_entries`, which skip synthesis).
+/// Mirrors `is_commander_eligible`'s synthesized-field-with-live-fallback shape.
+pub fn deck_copy_limit_for(db: &CardDatabase, canonical_name: &str) -> Option<DeckCopyLimit> {
+    let face = db.get_face_by_name(canonical_name)?;
+    if let Some(limit) = face.deck_copy_limit {
+        return Some(limit);
+    }
+    compute_deck_copy_limit_from_text(face.oracle_text.as_deref()?)
 }
 
 /// Resolves a card name to the key used in the database. For DFC names like "Front // Back",
@@ -2326,6 +2328,49 @@ mod tests {
                     "standard": "legal",
                     "commander": "legal"
                 }
+            },
+            "mountain": {
+                "name": "Mountain",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": ["Basic"], "core_types": ["Land"], "subtypes": ["Mountain"] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": null, "color_identity": ["Red"], "scryfall_oracle_id": null,
+                "legalities": { "standard": "legal", "commander": "legal" }
+            },
+            "relentless rats": {
+                "name": "Relentless Rats",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": ["Rat"] },
+                "power": "2", "toughness": "2", "loyalty": null, "defense": null,
+                "oracle_text": "This creature gets +1/+1 for each other creature on the battlefield named Relentless Rats.\nA deck can have any number of cards named Relentless Rats.",
+                "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": null, "color_identity": ["Black"], "scryfall_oracle_id": null,
+                "legalities": { "standard": "legal", "commander": "legal" }
+            },
+            "seven dwarves": {
+                "name": "Seven Dwarves",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": ["Dwarf"] },
+                "power": "3", "toughness": "3", "loyalty": null, "defense": null,
+                "oracle_text": "This creature gets +1/+1 for each other creature named Seven Dwarves you control.\nA deck can have up to seven cards named Seven Dwarves.",
+                "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": null, "color_identity": ["Red"], "scryfall_oracle_id": null,
+                "legalities": { "standard": "legal", "commander": "legal" }
+            },
+            "nazgûl": {
+                "name": "Nazgûl",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": ["Wraith"] },
+                "power": "3", "toughness": "3", "loyalty": null, "defense": null,
+                "oracle_text": "Deathtouch\nA deck can have up to nine cards named Nazgûl.",
+                "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": null, "color_identity": ["Black"], "scryfall_oracle_id": null,
+                "legalities": { "standard": "legal", "commander": "legal" }
             }
         })
         .to_string()
@@ -2497,6 +2542,51 @@ mod tests {
             .reasons
             .iter()
             .any(|r| r.contains("Not Standard")));
+    }
+
+    // CR 100.2a / CR 903.5b: per-card copy-limit overrides drive
+    // `copy_limit_violations`. Faces loaded via `from_json_str` skip synthesis,
+    // so the limit is resolved through the live Oracle-text fallback in
+    // `deck_copy_limit_for`. Helpers below build the canonical count map the way
+    // the production callers do.
+    fn counts_of(pairs: &[(&str, u32)]) -> HashMap<String, u32> {
+        pairs
+            .iter()
+            .map(|(name, n)| (name.to_ascii_lowercase(), *n))
+            .collect()
+    }
+
+    #[test]
+    fn copy_limit_respects_typed_overrides_constructed() {
+        let db = CardDatabase::from_json_str(&test_db_json()).unwrap();
+
+        // Seven Dwarves: UpTo(7) — 7 legal, 8 illegal.
+        assert!(copy_limit_violations(&db, &counts_of(&[("Seven Dwarves", 7)]), 4).is_empty());
+        assert!(!copy_limit_violations(&db, &counts_of(&[("Seven Dwarves", 8)]), 4).is_empty());
+
+        // Nazgûl: UpTo(9) — 8 legal, 10 illegal.
+        assert!(copy_limit_violations(&db, &counts_of(&[("Nazgûl", 8)]), 4).is_empty());
+        assert!(!copy_limit_violations(&db, &counts_of(&[("Nazgûl", 10)]), 4).is_empty());
+
+        // Relentless Rats: Unlimited — 5 legal.
+        assert!(copy_limit_violations(&db, &counts_of(&[("Relentless Rats", 5)]), 4).is_empty());
+
+        // Mountain: basic-land exemption — 30 legal.
+        assert!(copy_limit_violations(&db, &counts_of(&[("Mountain", 30)]), 4).is_empty());
+
+        // A normal card with no override is still flagged at 5.
+        let violations = copy_limit_violations(&db, &counts_of(&[("Red Card", 5)]), 4);
+        assert!(violations.iter().any(|v| v.contains("Red Card")));
+    }
+
+    #[test]
+    fn copy_limit_override_fires_before_commander_singleton() {
+        // CR 903.5b: in a singleton (Commander) context max_copies = 1, but
+        // Nazgûl's UpTo(9) override must raise the cap so 9 copies are legal.
+        let db = CardDatabase::from_json_str(&test_db_json()).unwrap();
+        assert!(copy_limit_violations(&db, &counts_of(&[("Nazgûl", 9)]), 1).is_empty());
+        // A normal card is still singleton-restricted to 1.
+        assert!(!copy_limit_violations(&db, &counts_of(&[("Red Card", 2)]), 1).is_empty());
     }
 
     #[test]

--- a/crates/engine/src/game/match_flow.rs
+++ b/crates/engine/src/game/match_flow.rs
@@ -329,6 +329,7 @@ mod tests {
             parse_warnings: vec![],
             brawl_commander: false,
             is_commander: false,
+            deck_copy_limit: None,
             metadata: Default::default(),
             rarities: Default::default(),
         }

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -88,10 +88,10 @@ pub use deck_loading::{
     resolve_deck_list, resolve_player_deck_list, DeckEntry, DeckList, DeckPayload, PlayerDeckList,
 };
 pub use deck_validation::{
-    can_pair_commanders, evaluate_deck_compatibility, is_brawl_commander_eligible,
-    is_commander_eligible, is_tiny_leader_eligible, validate_deck_for_format,
-    validate_name_deck_for_format, CompatibilityCheck, DeckCompatibilityRequest,
-    DeckCompatibilityResult, DeckCoverage, UnsupportedCard,
+    can_pair_commanders, deck_copy_limit_for, evaluate_deck_compatibility,
+    is_brawl_commander_eligible, is_commander_eligible, is_tiny_leader_eligible,
+    validate_deck_for_format, validate_name_deck_for_format, CompatibilityCheck,
+    DeckCompatibilityRequest, DeckCompatibilityResult, DeckCoverage, UnsupportedCard,
 };
 pub use engine::{
     apply, apply_as_current, new_game, start_game, start_game_skip_mulligan,

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1215,6 +1215,7 @@ mod tests {
             parse_warnings: vec![],
             brawl_commander: false,
             is_commander: false,
+            deck_copy_limit: None,
             metadata: Default::default(),
             rarities: Default::default(),
         }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -16,6 +16,7 @@ use crate::types::ability::{
     SpellCastingOption, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition,
     TriggerDefinition, TypedFilter,
 };
+use crate::types::format::DeckCopyLimit;
 use crate::types::keywords::{ActivationCadence, FlashbackCost, Keyword, KeywordKind};
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
@@ -25,6 +26,7 @@ use crate::types::zones::Zone;
 
 use super::oracle_nom::bridge::{nom_on_lower, split_once_on_lower};
 use super::oracle_nom::condition::parse_inner_condition;
+use super::oracle_nom::primitives::parse_number as nom_parse_number;
 use super::oracle_nom::primitives::scan_contains;
 
 use super::oracle_casting::{
@@ -218,14 +220,21 @@ fn parse_replacement_sentence(input: &str) -> OracleResult<'_, &str> {
 
 // CR 100.2a / CR 903.5b: Deck-construction overrides like "A deck can have
 // any number of cards named X." (Tempest Hawk, Rat Colony, Relentless Rats,
-// Persistent Petitioners, Shadowborn Apostle, etc.) are deck-construction
-// metadata that override CR 100.2a's four-of limit and the CR 903.5b
-// Commander singleton rule. They have no runtime effect to resolve. The
-// recognizer matches this exact phrase shape to avoid false-positives
-// against legitimate "up to N cards named ..." patterns (e.g. Seven Dwarves).
-fn parse_deck_can_have_any_number_sentence(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
-    let (input, _) = tag("a deck can have any number of cards named ").parse(input)?;
-    let (input, subject) = take_while(|c: char| {
+// Persistent Petitioners, Shadowborn Apostle, etc.) and bounded variants like
+// "A deck can have up to seven cards named Seven Dwarves." (also Nazgûl → 9)
+// are deck-construction metadata that override CR 100.2a's four-of limit and
+// the CR 903.5b Commander singleton rule. They have no runtime effect to
+// resolve. The same combinator both extracts the typed `DeckCopyLimit` (for
+// deck validation) and recognizes the line so it does not fall through to
+// `Effect::Unimplemented { name: "static_structure", .. }`.
+
+/// Consume the trailing card-name subject of a deck-construction sentence.
+///
+/// Rejects an empty subject so "... named ." cannot match. The predicate
+/// accepts the raw card name, the engine's normalized self-reference "~", and
+/// Unicode letters (Rust `char::is_alphanumeric` accepts "û" in "Nazgûl").
+fn parse_deck_limit_subject(input: &str) -> OracleResult<'_, &str> {
+    let (rest, subject) = take_while(|c: char| {
         c.is_alphanumeric() || c == ' ' || c == '\'' || c == ',' || c == '-' || c == '~'
     })
     .parse(input)?;
@@ -235,19 +244,104 @@ fn parse_deck_can_have_any_number_sentence(input: &str) -> nom::IResult<&str, ()
             nom::error::ErrorKind::Fail,
         )));
     }
-    let (input, _) = opt(tag(".")).parse(input)?;
-    Ok((input, ()))
+    Ok((rest, subject))
 }
 
-/// Recognizer for "A deck can have any number of cards named X." —
-/// deck-construction text consumed silently by the parser so it does not
-/// fall through to `Effect::Unimplemented { name: "static_structure", .. }`.
-pub(crate) fn is_deck_construction_any_number_sentence(line: &str) -> bool {
+/// Consume " card named " / " cards named " (plural tried first; `tag` is
+/// all-or-nothing so the singular cannot shadow the plural).
+fn parse_card_s_named(input: &str) -> OracleResult<'_, ()> {
+    value((), alt((tag(" cards named "), tag(" card named ")))).parse(input)
+}
+
+/// CR 100.2a / CR 903.5b: Parse a single deck-construction copy-limit sentence
+/// into a typed [`DeckCopyLimit`]. Accepts the optional "DCI ruling — " /
+/// "DCI ruling - " prefix (Once More with Feeling). The caller wraps this in
+/// `all_consuming` so the subject must be fully consumed (no trailing remainder
+/// regresses the card to Unimplemented).
+fn parse_deck_copy_limit(input: &str) -> OracleResult<'_, DeckCopyLimit> {
+    let (input, _) = opt(alt((tag("dci ruling \u{2014} "), tag("dci ruling - ")))).parse(input)?;
+    let (input, limit) = alt((
+        // Variant 1: "a deck can have any number of cards named X" — Unlimited.
+        (
+            tag("a deck can have any number of cards named "),
+            parse_deck_limit_subject,
+        )
+            .map(|_| DeckCopyLimit::Unlimited),
+        // Variants 2/3/4: "a deck can have {up to|only} N card(s) named X" — UpTo(N).
+        preceded(
+            tag("a deck can have "),
+            (
+                alt((value((), tag("up to ")), value((), tag("only ")))),
+                nom_parse_number,
+                parse_card_s_named,
+                parse_deck_limit_subject,
+            ),
+        )
+        .map(|(_, n, _, _)| DeckCopyLimit::UpTo(n)),
+        // Variant 5: Megalegendary reminder body — singleton, no subject.
+        value(
+            DeckCopyLimit::UpTo(1),
+            tag("your deck can have only one copy of this card"),
+        ),
+    ))
+    .parse(input)?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+    Ok((input, limit))
+}
+
+/// CR 100.2a / CR 903.5b: Run the copy-limit combinator over a single
+/// lowercased fragment, tolerating leading prose by trying each sentence within
+/// it. The deck-limit sentence is sometimes its own line ("...\nA deck can
+/// have...") and sometimes the tail sentence of a multi-sentence line
+/// ("...you control. A deck can have..."), so both must be reachable.
+fn copy_limit_from_fragment(fragment: &str) -> Option<DeckCopyLimit> {
+    let lower = fragment.trim().to_ascii_lowercase();
+    // Each ". "-separated sentence is a candidate; the combinator's trailing
+    // `opt(".")` absorbs a present period and tolerates its absence.
+    for sentence in lower.split(". ") {
+        if let Ok((_, limit)) =
+            all_consuming(parse_deck_copy_limit).parse(sentence.trim_end_matches('.').trim())
+        {
+            return Some(limit);
+        }
+    }
+    None
+}
+
+/// CR 100.2a / CR 903.5b: Extract the deck-construction copy limit from a card's
+/// full Oracle text, scanning each line AND each parenthesized reminder-text
+/// body (Vazal, the Compleat's Megalegendary limit lives only in the reminder
+/// body). The first match wins.
+pub(crate) fn compute_deck_copy_limit_from_text(text: &str) -> Option<DeckCopyLimit> {
+    for line in text.lines() {
+        if let Some(limit) = copy_limit_from_fragment(line) {
+            return Some(limit);
+        }
+        // Reminder-text bodies, e.g. "Megalegendary (Your deck can have ...)".
+        let mut rest = line;
+        while let Some(open) = rest.find('(') {
+            let after = &rest[open + 1..];
+            let Some(close) = after.find(')') else { break };
+            if let Some(limit) = copy_limit_from_fragment(&after[..close]) {
+                return Some(limit);
+            }
+            rest = &after[close + 1..];
+        }
+    }
+    None
+}
+
+/// Recognizer for deck-construction copy-limit sentences — deck-construction
+/// text consumed silently by the parser so it does not fall through to
+/// `Effect::Unimplemented { name: "static_structure", .. }`. Also matches the
+/// bare "Megalegendary" keyword line, whose copy limit lives in the reminder
+/// body of the same logical line (handled by `compute_deck_copy_limit_from_text`).
+pub(crate) fn is_deck_construction_copy_limit_sentence(line: &str) -> bool {
     let lower = line.trim().to_ascii_lowercase();
-    let parsed = all_consuming(parse_deck_can_have_any_number_sentence)
+    all_consuming(parse_deck_copy_limit)
         .parse(lower.as_str())
-        .is_ok();
-    parsed
+        .is_ok()
+        || lower.trim() == "megalegendary"
 }
 
 /// Whether Oracle text explicitly permits this card to be a commander.
@@ -936,7 +1030,7 @@ fn is_spell_resolution_instruction_line(
     let is_loyalty = try_parse_loyalty_line(line, ctx).is_some();
     ctx.diagnostics.truncate(loyalty_snap);
     if is_commander_permission_sentence(line)
-        || is_deck_construction_any_number_sentence(line)
+        || is_deck_construction_copy_limit_sentence(line)
         || is_loyalty
     {
         return false;
@@ -1879,7 +1973,7 @@ pub(crate) fn parse_oracle_ir(
             continue;
         }
 
-        if is_deck_construction_any_number_sentence(&line) {
+        if is_deck_construction_copy_limit_sentence(&line) {
             i += 1;
             continue;
         }
@@ -5296,48 +5390,125 @@ mod tests {
         assert!(r.replacements.is_empty());
     }
 
-    // CR 100.2a / CR 903.5b: "A deck can have any number of cards named X."
-    // is deck-construction metadata, not an in-game ability. The recognizer
-    // must accept the raw card name, the engine's normalized self-reference
-    // "~", and reject "up to N" patterns (Seven Dwarves).
+    // CR 100.2a / CR 903.5b: deck-construction copy-limit sentences parse into a
+    // typed `DeckCopyLimit`. The combinator both extracts the value (for deck
+    // validation) and recognizes the line so it does not fall through to
+    // `Effect::Unimplemented`. Tested over all five real phrase shapes, with the
+    // trailing period present (the real Oracle text always carries it).
     #[test]
-    fn deck_construction_any_number_sentence_positive_cases() {
-        assert!(is_deck_construction_any_number_sentence(
-            "A deck can have any number of cards named Tempest Hawk."
-        ));
-        assert!(is_deck_construction_any_number_sentence(
-            "A deck can have any number of cards named Relentless Rats."
-        ));
-        // After normalize_self_refs_for_static rewrites the card name to "~".
-        assert!(is_deck_construction_any_number_sentence(
-            "A deck can have any number of cards named ~."
-        ));
-        // Trailing period is optional.
-        assert!(is_deck_construction_any_number_sentence(
-            "A deck can have any number of cards named Tempest Hawk"
-        ));
+    fn parse_deck_copy_limit_all_phrase_shapes() {
+        // Variant 1: "any number" → Unlimited (Relentless Rats).
+        assert_eq!(
+            all_consuming(parse_deck_copy_limit)
+                .parse("a deck can have any number of cards named relentless rats.")
+                .unwrap()
+                .1,
+            DeckCopyLimit::Unlimited
+        );
+        // Variant 2: "up to seven" → UpTo(7) (Seven Dwarves).
+        assert_eq!(
+            all_consuming(parse_deck_copy_limit)
+                .parse("a deck can have up to seven cards named seven dwarves.")
+                .unwrap()
+                .1,
+            DeckCopyLimit::UpTo(7)
+        );
+        // Variant 3: "up to nine" → UpTo(9) (Nazgûl — Unicode subject).
+        assert_eq!(
+            all_consuming(parse_deck_copy_limit)
+                .parse("a deck can have up to nine cards named nazgûl.")
+                .unwrap()
+                .1,
+            DeckCopyLimit::UpTo(9)
+        );
+        // Variant 4: "only one card named" with DCI em-dash prefix → UpTo(1)
+        // (Once More with Feeling). Exercises the singular "card named" matcher.
+        assert_eq!(
+            all_consuming(parse_deck_copy_limit)
+                .parse(
+                    "dci ruling \u{2014} a deck can have only one card named once more with feeling."
+                )
+                .unwrap()
+                .1,
+            DeckCopyLimit::UpTo(1)
+        );
+        // Shared singular/plural matcher proof: "up to one card named".
+        assert_eq!(
+            all_consuming(parse_deck_copy_limit)
+                .parse("a deck can have up to one card named x.")
+                .unwrap()
+                .1,
+            DeckCopyLimit::UpTo(1)
+        );
+        // Variant 5: Megalegendary reminder body → UpTo(1) (Vazal). No subject.
+        assert_eq!(
+            all_consuming(parse_deck_copy_limit)
+                .parse("your deck can have only one copy of this card.")
+                .unwrap()
+                .1,
+            DeckCopyLimit::UpTo(1)
+        );
     }
 
     #[test]
-    fn deck_construction_any_number_sentence_negative_cases() {
-        // Wrong determiner — must be "A deck", not "Your deck".
-        assert!(!is_deck_construction_any_number_sentence(
-            "Your deck can have any number of cards named X."
+    fn vazal_copy_limit_extracted_from_reminder_body() {
+        // Vazal's limit lives only inside the Megalegendary reminder body, so the
+        // line scanner must descend into parenthesized text.
+        assert_eq!(
+            compute_deck_copy_limit_from_text(
+                "Megalegendary (Your deck can have only one copy of this card.)"
+            ),
+            Some(DeckCopyLimit::UpTo(1))
+        );
+    }
+
+    #[test]
+    fn deck_construction_copy_limit_sentence_positive_cases() {
+        // All five variants are recognized (consumed silently, not Unimplemented).
+        assert!(is_deck_construction_copy_limit_sentence(
+            "A deck can have any number of cards named Tempest Hawk."
         ));
-        // "Up to seven" is a different deck-construction pattern (Seven Dwarves).
-        // It must NOT be silently consumed by this recognizer.
-        assert!(!is_deck_construction_any_number_sentence(
+        // Engine's normalized self-reference "~".
+        assert!(is_deck_construction_copy_limit_sentence(
+            "A deck can have any number of cards named ~."
+        ));
+        // Trailing period is optional.
+        assert!(is_deck_construction_copy_limit_sentence(
+            "A deck can have any number of cards named Tempest Hawk"
+        ));
+        // "up to N" is now ACCEPTED (was rejected before typed-limit support).
+        assert!(is_deck_construction_copy_limit_sentence(
             "A deck can have up to seven cards named Seven Dwarves."
         ));
+        assert!(is_deck_construction_copy_limit_sentence(
+            "A deck can have up to nine cards named Nazgûl."
+        ));
+        // DCI singleton and the bare Megalegendary keyword line.
+        assert!(is_deck_construction_copy_limit_sentence(
+            "DCI ruling \u{2014} A deck can have only one card named Once More with Feeling."
+        ));
+        assert!(is_deck_construction_copy_limit_sentence("Megalegendary"));
+    }
+
+    #[test]
+    fn deck_construction_copy_limit_sentence_negative_cases() {
+        // Wrong determiner — "Your deck ... cards named" is not a supported shape.
+        assert!(!is_deck_construction_copy_limit_sentence(
+            "Your deck can have any number of cards named X."
+        ));
+        // "can contain" is a different (unsupported) phrasing — out of scope.
+        assert!(!is_deck_construction_copy_limit_sentence(
+            "A deck can contain any number of cards named X."
+        ));
         // Unrelated static lines must not match.
-        assert!(!is_deck_construction_any_number_sentence(
+        assert!(!is_deck_construction_copy_limit_sentence(
             "Creatures you control get +1/+1."
         ));
         // Empty subject after the "named " prefix.
-        assert!(!is_deck_construction_any_number_sentence(
+        assert!(!is_deck_construction_copy_limit_sentence(
             "A deck can have any number of cards named ."
         ));
-        assert!(!is_deck_construction_any_number_sentence(
+        assert!(!is_deck_construction_copy_limit_sentence(
             "A deck can have any number of cards named"
         ));
     }
@@ -5378,6 +5549,39 @@ mod tests {
             static_unimplemented
         );
     }
+
+    #[test]
+    fn vazal_megalegendary_line_consumed_and_limit_extracted() {
+        // CR 100.2a / CR 903.5b: Vazal's "Megalegendary (Your deck can have only
+        // one copy of this card.)" line must not surface as Unimplemented, and
+        // its UpTo(1) limit must be extractable from the full Oracle text (the
+        // limit lives only in the reminder body).
+        let vazal_text = "Megalegendary (Your deck can have only one copy of this card.)\n\
+             Vigilance, trample\n\
+             Vazal, the Compleat has the activated abilities of all other permanents on the battlefield.";
+        let r = parse(
+            vazal_text,
+            "Vazal, the Compleat",
+            &[Keyword::Vigilance, Keyword::Trample],
+            &["Creature"],
+            &["Phyrexian", "Praetor"],
+        );
+        let megalegendary_unimplemented = r.abilities.iter().any(|a| {
+            matches!(
+                &*a.effect,
+                Effect::Unimplemented { name, .. } if name.eq_ignore_ascii_case("megalegendary")
+            )
+        });
+        assert!(
+            !megalegendary_unimplemented,
+            "Megalegendary line must be consumed silently, not Unimplemented"
+        );
+        assert_eq!(
+            compute_deck_copy_limit_from_text(vazal_text),
+            Some(DeckCopyLimit::UpTo(1))
+        );
+    }
+
     #[test]
     fn oracle_text_allows_commander_uses_commander_permission_parser() {
         assert!(oracle_text_allows_commander(

--- a/crates/engine/src/types/card.rs
+++ b/crates/engine/src/types/card.rs
@@ -7,6 +7,7 @@ use super::ability::{
     ReplacementDefinition, SolveCondition, SpellCastingOption, StaticDefinition, TriggerDefinition,
 };
 use super::card_type::CardType;
+use super::format::DeckCopyLimit;
 use super::keywords::Keyword;
 use super::mana::{ManaColor, ManaCost};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
@@ -167,6 +168,13 @@ pub struct CardFace {
     /// `brawl_commander` so we stay correct when MTGJSON is missing or stale.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_commander: bool,
+    /// CR 100.2a / CR 903.5b: Per-card override to the default constructed copy
+    /// limit, parsed from deck-construction Oracle text ("A deck can have any
+    /// number of cards named ~." / "A deck can have up to N cards named ~." /
+    /// the singleton override). `None` means the default four-of (or Commander
+    /// singleton) limit applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deck_copy_limit: Option<DeckCopyLimit>,
     /// Parser diagnostic warnings — silent fallbacks, ignored remainders, bare filters.
     /// Populated at build time by the Oracle parser warning accumulator.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -70,6 +70,27 @@ pub enum SideboardPolicy {
     Unlimited,
 }
 
+/// Per-card override to the default constructed copy limit.
+///
+/// CR 100.2a sets the default constructed limit to four of any card with a
+/// particular English name (basic lands excepted). A handful of cards print an
+/// explicit deck-construction override in their rules text:
+///
+/// - `Unlimited`: "A deck can have any number of cards named ~." (Relentless
+///   Rats, Shadowborn Apostle, etc.) — no upper bound on copies.
+/// - `UpTo(n)`: "A deck can have up to <n> cards named ~." (Seven Dwarves → 7,
+///   Nazgûl → 9) and the Commander/companion singleton override "Your deck can
+///   have only one copy of this card" (Vazal, the Compleat → `UpTo(1)`).
+///
+/// CR 903.5b's Commander singleton rule exempts basic lands; an `UpTo(n>1)`
+/// override likewise raises the cap above the format default for that card.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum DeckCopyLimit {
+    Unlimited,
+    UpTo(u32),
+}
+
 /// Configuration for a game format, describing player counts, starting life, deck rules, etc.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FormatConfig {
@@ -751,6 +772,24 @@ mod tests {
         // Tuple variant carries the cap in `data`.
         let limited = serde_json::to_string(&SideboardPolicy::Limited(15)).unwrap();
         assert_eq!(limited, r#"{"type":"Limited","data":15}"#);
+    }
+
+    #[test]
+    fn deck_copy_limit_serializes_as_tagged_union() {
+        // Unit variant emits {"type": "..."} with no "data" field; the frontend
+        // must switch on `.type`, never destructure `.data` unconditionally.
+        let unlimited = serde_json::to_string(&DeckCopyLimit::Unlimited).unwrap();
+        assert_eq!(unlimited, r#"{"type":"Unlimited"}"#);
+
+        // Tuple variant carries the cap in `data`.
+        let up_to = serde_json::to_string(&DeckCopyLimit::UpTo(7)).unwrap();
+        assert_eq!(up_to, r#"{"type":"UpTo","data":7}"#);
+
+        // Round-trips both directions.
+        let parsed: DeckCopyLimit = serde_json::from_str(r#"{"type":"Unlimited"}"#).unwrap();
+        assert_eq!(parsed, DeckCopyLimit::Unlimited);
+        let parsed: DeckCopyLimit = serde_json::from_str(r#"{"type":"UpTo","data":9}"#).unwrap();
+        assert_eq!(parsed, DeckCopyLimit::UpTo(9));
     }
 
     #[test]

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -36,7 +36,7 @@ pub use card_type::{is_land_subtype, CardType, CoreType, Supertype};
 pub use counter::{parse_counter_type, CounterMatch, CounterType};
 pub use definitions::Definitions;
 pub use events::GameEvent;
-pub use format::{FormatConfig, GameFormat};
+pub use format::{DeckCopyLimit, FormatConfig, GameFormat};
 pub use game_state::{
     ActionResult, BattlefieldEntryRecord, CommanderDamageEntry, CostResume, GameState, LKISnapshot,
     NextSpellModifier, PayCostKind, PendingNextSpellModifier, PendingReplacement,

--- a/crates/server-core/src/filter.rs
+++ b/crates/server-core/src/filter.rs
@@ -188,6 +188,7 @@ mod tests {
                 parse_warnings: vec![],
                 brawl_commander: false,
                 is_commander: false,
+                deck_copy_limit: None,
                 metadata: Default::default(),
                 rarities: Default::default(),
             },

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -1298,6 +1298,7 @@ mod tests {
                     parse_warnings: vec![],
                     brawl_commander: false,
                     is_commander: false,
+                    deck_copy_limit: None,
                     metadata: Default::default(),
                     rarities: Default::default(),
                 },

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -25,8 +25,8 @@
     "crates/engine/src/types/attribution.rs",
     "crates/engine/src/types/card_type.rs"
   ],
-  "enum_count": 249,
-  "variant_count": 2787,
+  "enum_count": 251,
+  "variant_count": 2797,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -430,13 +430,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9184,
+      "line": 9236,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 9202,
+          "line": 9254,
           "kind": "struct",
           "field_names": [
             "source",
@@ -454,7 +454,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 9218,
+          "line": 9270,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -464,8 +464,19 @@
           ]
         },
         {
+          "name": "AlternativeManaCostPaid",
+          "line": 9274,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 118.9 + CR 608.2c: \"If the {COST} cost was paid\" on spells with an alternative *mana* cost (e.g. Baleful Mastery). Evaluates against `SpellContext.alternative_mana_cost_paid`, not `additional_cost_paid`.",
+          "cr_refs": [
+            "CR 118.9",
+            "CR 608.2c"
+          ]
+        },
+        {
           "name": "EffectOutcome",
-          "line": 9223,
+          "line": 9279,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -479,7 +490,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 9228,
+          "line": 9284,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -489,7 +500,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 9236,
+          "line": 9292,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -499,7 +510,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9239,
+          "line": 9295,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -511,7 +522,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9243,
+          "line": 9299,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -524,7 +535,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9246,
+          "line": 9302,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -537,7 +548,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9249,
+          "line": 9305,
           "kind": "struct",
           "field_names": [
             "color",
@@ -551,7 +562,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 9255,
+          "line": 9311,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -564,7 +575,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9263,
+          "line": 9319,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -575,7 +586,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9266,
+          "line": 9322,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -588,7 +599,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 9271,
+          "line": 9327,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -602,7 +613,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 9275,
+          "line": 9331,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -616,7 +627,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 9284,
+          "line": 9340,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -630,7 +641,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9289,
+          "line": 9345,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -640,7 +651,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9291,
+          "line": 9347,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -650,7 +661,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9294,
+          "line": 9350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -660,7 +671,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 9298,
+          "line": 9354,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -672,7 +683,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 9303,
+          "line": 9359,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -686,7 +697,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9311,
+          "line": 9367,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -698,7 +709,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9316,
+          "line": 9372,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -714,7 +725,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 9328,
+          "line": 9384,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -727,7 +738,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 9332,
+          "line": 9388,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -740,7 +751,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 9336,
+          "line": 9392,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -750,7 +761,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9344,
+          "line": 9400,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -763,7 +774,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9349,
+          "line": 9405,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -776,7 +787,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9354,
+          "line": 9410,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -788,7 +799,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 9360,
+          "line": 9416,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -800,7 +811,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 9364,
+          "line": 9420,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -814,7 +825,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9367,
+          "line": 9423,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -824,7 +835,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 9376,
+          "line": 9432,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -837,7 +848,7 @@
         },
         {
           "name": "And",
-          "line": 9381,
+          "line": 9437,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -849,7 +860,7 @@
         },
         {
           "name": "Or",
-          "line": 9386,
+          "line": 9442,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -861,7 +872,7 @@
         },
         {
           "name": "Not",
-          "line": 9394,
+          "line": 9450,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -873,7 +884,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 9398,
+          "line": 9454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -883,7 +894,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 9400,
+          "line": 9456,
           "kind": "struct",
           "field_names": [
             "state"
@@ -895,7 +906,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 9410,
+          "line": 9466,
           "kind": "struct",
           "field_names": [
             "n"
@@ -907,7 +918,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 9413,
+          "line": 9469,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -919,7 +930,7 @@
         },
         {
           "name": "ScopedPlayerMatches",
-          "line": 9433,
+          "line": 9489,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -945,13 +956,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4412,
+      "line": 4440,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 4413,
+          "line": 4441,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -961,7 +972,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 4422,
+          "line": 4450,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -974,7 +985,7 @@
         },
         {
           "name": "Tap",
-          "line": 4425,
+          "line": 4453,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -982,7 +993,7 @@
         },
         {
           "name": "Untap",
-          "line": 4426,
+          "line": 4454,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -990,7 +1001,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 4427,
+          "line": 4455,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1000,7 +1011,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 4430,
+          "line": 4458,
           "kind": "struct",
           "field_names": [
             "target",
@@ -1011,7 +1022,7 @@
         },
         {
           "name": "PayLife",
-          "line": 4442,
+          "line": 4470,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1023,7 +1034,7 @@
         },
         {
           "name": "Discard",
-          "line": 4445,
+          "line": 4473,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1036,7 +1047,7 @@
         },
         {
           "name": "Exile",
-          "line": 4456,
+          "line": 4484,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1048,7 +1059,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 4465,
+          "line": 4493,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1061,7 +1072,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 4468,
+          "line": 4496,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1072,7 +1083,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 4479,
+          "line": 4507,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1087,7 +1098,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 4485,
+          "line": 4513,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1097,7 +1108,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4489,
+          "line": 4517,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1110,7 +1121,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4497,
+          "line": 4525,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1124,7 +1135,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4506,
+          "line": 4534,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1134,7 +1145,7 @@
         },
         {
           "name": "Mill",
-          "line": 4507,
+          "line": 4535,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1144,7 +1155,7 @@
         },
         {
           "name": "Exert",
-          "line": 4510,
+          "line": 4538,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1152,7 +1163,7 @@
         },
         {
           "name": "Blight",
-          "line": 4513,
+          "line": 4541,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1162,7 +1173,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4516,
+          "line": 4544,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1173,7 +1184,7 @@
         },
         {
           "name": "Behold",
-          "line": 4524,
+          "line": 4552,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1185,7 +1196,7 @@
         },
         {
           "name": "Composite",
-          "line": 4530,
+          "line": 4558,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1195,7 +1206,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4547,
+          "line": 4575,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1208,7 +1219,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4551,
+          "line": 4579,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1218,7 +1229,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4556,
+          "line": 4584,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1231,7 +1242,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4563,
+          "line": 4591,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1243,7 +1254,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4579,
+          "line": 4607,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1257,7 +1268,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4584,
+          "line": 4612,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1270,13 +1281,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8318,
+      "line": 8370,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 8320,
+          "line": 8372,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1284,7 +1295,7 @@
         },
         {
           "name": "Activated",
-          "line": 8321,
+          "line": 8373,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1292,7 +1303,7 @@
         },
         {
           "name": "Database",
-          "line": 8322,
+          "line": 8374,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1300,7 +1311,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 8325,
+          "line": 8377,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1308,7 +1319,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 8331,
+          "line": 8383,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1321,7 +1332,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8472,
+      "line": 8524,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1329,7 +1340,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 8474,
+          "line": 8526,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1339,7 +1350,7 @@
         },
         {
           "name": "Evolve",
-          "line": 8476,
+          "line": 8528,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1349,7 +1360,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 8478,
+          "line": 8530,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1359,7 +1370,7 @@
         },
         {
           "name": "Outlast",
-          "line": 8480,
+          "line": 8532,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1369,7 +1380,7 @@
         },
         {
           "name": "Cycling",
-          "line": 8485,
+          "line": 8537,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29a + CR 702.29e: This ability originated from a Cycling (or Typecycling) keyword definition. Used so the activation pipeline can emit a `GameEvent::Cycled` (CR 702.29c) that \"When you cycle this card\" triggers match.",
@@ -1440,13 +1451,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8493,
+      "line": 8545,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8494,
+          "line": 8546,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1454,7 +1465,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 8495,
+          "line": 8547,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1462,7 +1473,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8496,
+          "line": 8548,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1470,7 +1481,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8497,
+          "line": 8549,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1478,7 +1489,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8498,
+          "line": 8550,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1486,7 +1497,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8499,
+          "line": 8551,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1494,7 +1505,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8500,
+          "line": 8552,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1502,7 +1513,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 8501,
+          "line": 8553,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1510,7 +1521,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 8502,
+          "line": 8554,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1518,7 +1529,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 8503,
+          "line": 8555,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1528,7 +1539,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8506,
+          "line": 8558,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1538,7 +1549,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 8510,
+          "line": 8562,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1548,7 +1559,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 8512,
+          "line": 8564,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1560,7 +1571,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 8517,
+          "line": 8569,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1574,7 +1585,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 8528,
+          "line": 8580,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1588,7 +1599,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 8541,
+          "line": 8593,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1601,13 +1612,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4788,
+      "line": 4816,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 4794,
+          "line": 4822,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1618,7 +1629,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4804,
+          "line": 4832,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1634,7 +1645,7 @@
         },
         {
           "name": "Choice",
-          "line": 4811,
+          "line": 4839,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1642,7 +1653,7 @@
         },
         {
           "name": "Required",
-          "line": 4813,
+          "line": 4841,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1653,7 +1664,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4822,
+      "line": 4850,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1661,7 +1672,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 4824,
+          "line": 4852,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1669,7 +1680,7 @@
         },
         {
           "name": "Kicker",
-          "line": 4825,
+          "line": 4853,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1677,7 +1688,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 4826,
+          "line": 4854,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1688,7 +1699,7 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3268,
+      "line": 3296,
       "doc": "CR 107.3e: Aggregate function applied over a set of objects.",
       "cr_refs": [
         "CR 107.3e"
@@ -1696,7 +1707,7 @@
       "variants": [
         {
           "name": "Max",
-          "line": 3269,
+          "line": 3297,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1704,7 +1715,7 @@
         },
         {
           "name": "Min",
-          "line": 3270,
+          "line": 3298,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1712,7 +1723,7 @@
         },
         {
           "name": "Sum",
-          "line": 3271,
+          "line": 3299,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1723,7 +1734,7 @@
     },
     "AlternativeCastDecision": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 72,
+      "line": 73,
       "doc": "CR 118.9: Player decision at a `WaitingFor::AlternativeCastChoice` prompt — pay the spell's printed mana cost or the keyword-granted alternative cost. Typed enum (not `bool`, per the no-bool-flags rule) so the action serializes self-describingly and survives future expansion (e.g., a third \"Decline\" path) without breaking exhaustive matches. The specific keyword whose alternative cost is in play lives on the `WaitingFor::AlternativeCastChoice` state, not on this action — the decision is structurally identical across keywords; only post-payment semantics diverge (per CR 702.74a Evoke, CR 702.96a Overload, CR 702.103a Bestow, and the custom Warp keyword).",
       "cr_refs": [
         "CR 118.9",
@@ -1734,7 +1745,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 74,
+          "line": 75,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay the spell's printed mana cost. Resolution proceeds normally.",
@@ -1742,7 +1753,7 @@
         },
         {
           "name": "Alternative",
-          "line": 79,
+          "line": 80,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay the keyword-granted alternative cost. Resolution applies the keyword's post-payment effects (Overload's target→each text change per CR 702.96b-c, Evoke's ETB-sacrifice trigger per CR 702.74b, Bestow's Aura transformation per CR 702.103b, Warp's exile-at-end-step rider).",
@@ -1827,13 +1838,24 @@
             "CR 612",
             "CR 702.148a"
           ]
+        },
+        {
+          "name": "MoreThanMeetsTheEye",
+          "line": 1621,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.162a: Cast converted (back face up, CR 712.14a) for the MTMTE cost.",
+          "cr_refs": [
+            "CR 702.162a",
+            "CR 712.14a"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "AttachmentKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1844,
+      "line": 1867,
       "doc": "CR 301 / CR 303: Kinds of attachments to permanents. Used by `FilterProp::HasAttachment` and `QuantityRef::AttachmentsOnLeavingObject` to parameterize attachment-predicate checks.",
       "cr_refs": [
         "CR 301",
@@ -1842,7 +1864,7 @@
       "variants": [
         {
           "name": "Aura",
-          "line": 1846,
+          "line": 1869,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4: Aura — enchantment subtype that attaches via Enchant ability.",
@@ -1852,7 +1874,7 @@
         },
         {
           "name": "Equipment",
-          "line": 1848,
+          "line": 1871,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5: Equipment — artifact subtype that attaches via Equip ability.",
@@ -1933,13 +1955,13 @@
     },
     "AutoPassMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3369,
+      "line": 3388,
       "doc": "What the engine stores for auto-pass (includes captured state).",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3372,
+          "line": 3391,
           "kind": "struct",
           "field_names": [
             "initial_stack_len"
@@ -1949,7 +1971,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3376,
+          "line": 3395,
           "kind": "unit",
           "field_names": [],
           "doc": "Auto-pass through priority/combat stops until the flagged player's next turn starts. Interrupted by opponent stack activity (MTGA-style) or when the current phase matches the player's entry in `GameState::phase_stops`.",
@@ -1960,13 +1982,13 @@
     },
     "AutoPassRequest": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3361,
+      "line": 3380,
       "doc": "What the frontend requests for auto-pass (no internal state).  Phase stops that should interrupt `UntilEndOfTurn` are a separate per-player preference on `GameState::phase_stops`, managed via `GameAction::SetPhaseStops`. Keeping them out of the request preserves a single source of truth and lets the preference change mid-session without requiring a new auto-pass request.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3362,
+          "line": 3381,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1974,7 +1996,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3363,
+          "line": 3382,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2036,13 +2058,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4404,
+      "line": 4432,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 4405,
+          "line": 4433,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2050,7 +2072,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 4406,
+          "line": 4434,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2160,7 +2182,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5124,
+      "line": 5152,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2168,7 +2190,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 5127,
+          "line": 5155,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2176,7 +2198,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 5129,
+          "line": 5157,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2216,13 +2238,13 @@
     },
     "CardLayout": {
       "file": "crates/engine/src/types/card.rs",
-      "line": 207,
+      "line": 215,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Single",
-          "line": 208,
+          "line": 216,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2230,7 +2252,7 @@
         },
         {
           "name": "Split",
-          "line": 209,
+          "line": 217,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2238,7 +2260,7 @@
         },
         {
           "name": "Flip",
-          "line": 210,
+          "line": 218,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2246,7 +2268,7 @@
         },
         {
           "name": "Transform",
-          "line": 211,
+          "line": 219,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2254,7 +2276,7 @@
         },
         {
           "name": "Meld",
-          "line": 212,
+          "line": 220,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2262,7 +2284,7 @@
         },
         {
           "name": "Adventure",
-          "line": 213,
+          "line": 221,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2270,7 +2292,7 @@
         },
         {
           "name": "Modal",
-          "line": 214,
+          "line": 222,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2278,7 +2300,7 @@
         },
         {
           "name": "Omen",
-          "line": 215,
+          "line": 223,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2286,7 +2308,7 @@
         },
         {
           "name": "Prepare",
-          "line": 220,
+          "line": 228,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — face `a` is the creature, face `b` is the prepare-spell (Sorcery/Instant). When the creature is prepared, its controller may cast a copy of face `b`. Assign when WotC publishes SOS CR update.",
@@ -2296,7 +2318,7 @@
         },
         {
           "name": "Specialize",
-          "line": 221,
+          "line": 229,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2339,13 +2361,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2748,
+      "line": 2771,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 2750,
+          "line": 2773,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -2359,7 +2381,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2752,
+          "line": 2775,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -2370,7 +2392,7 @@
         },
         {
           "name": "Objects",
-          "line": 2754,
+          "line": 2777,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -2394,10 +2416,10 @@
       "variants": [
         {
           "name": "Cast",
-          "line": 31,
+          "line": 32,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 701.57a + CR 702.85a: Cast the offered card without paying its mana cost. The cast pipeline still enforces target legality, alternative constraints (e.g., `CascadeResultingMvBelow`), and other CR 601.2 checks.",
+          "doc": "CR 701.57a + CR 702.85a: Cast the offered card without paying its mana cost. The cast pipeline still enforces target legality, the cast-during-resolution resulting-MV constraint (`ManaValue` carried on the `ExileWithAltCost` permission with `resolution_cleanup`), and other CR 601.2 checks.",
           "cr_refs": [
             "CR 601.2",
             "CR 701.57a",
@@ -2406,7 +2428,7 @@
         },
         {
           "name": "Decline",
-          "line": 35,
+          "line": 36,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.57a + CR 702.85a: Decline the offer. For Discover the card goes to hand; for Cascade the card joins the misses on the bottom of the library in a random order.",
@@ -2462,7 +2484,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2759,
+      "line": 2782,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -2470,7 +2492,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 2761,
+          "line": 2784,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -2478,7 +2500,7 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 2763,
+          "line": 2786,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
@@ -2489,7 +2511,7 @@
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2769,
+      "line": 2792,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -2498,7 +2520,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 2771,
+          "line": 2794,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -2506,7 +2528,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 2773,
+          "line": 2796,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -2514,7 +2536,7 @@
         },
         {
           "name": "FromSource",
-          "line": 2775,
+          "line": 2798,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -2527,13 +2549,13 @@
     },
     "CastOfferKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1677,
+      "line": 1679,
       "doc": "The specific kind of cast offer being presented to the player. Parameterizes `WaitingFor::CastOffer` — all variants share `player: PlayerId` at the outer level; the kind-specific payload lives here.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Adventure",
-          "line": 1679,
+          "line": 1681,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -2547,7 +2569,7 @@
         },
         {
           "name": "Miracle",
-          "line": 1686,
+          "line": 1688,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -2560,7 +2582,7 @@
         },
         {
           "name": "Madness",
-          "line": 1691,
+          "line": 1693,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -2573,7 +2595,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 1696,
+          "line": 1698,
           "kind": "struct",
           "field_names": [
             "offers"
@@ -2585,7 +2607,7 @@
         },
         {
           "name": "Cascade",
-          "line": 1698,
+          "line": 1700,
           "kind": "struct",
           "field_names": [
             "hit_card",
@@ -2599,11 +2621,12 @@
         },
         {
           "name": "Discover",
-          "line": 1704,
+          "line": 1706,
           "kind": "struct",
           "field_names": [
             "hit_card",
-            "exiled_misses"
+            "exiled_misses",
+            "discover_value"
           ],
           "doc": "CR 701.57a: Discover — cast the discovered card or put it to hand.",
           "cr_refs": [
@@ -2642,28 +2665,15 @@
     },
     "CastPermissionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1593,
+      "line": 1604,
       "doc": "CR 702.85a: Typed cast-time predicates attached to an `ExileWithAltCost` permission. Extend this enum when future mechanics need cast-time gating that cannot be evaluated at permission-grant time (e.g., X-cost spells whose mana value is only known after the caster chooses X).",
       "cr_refs": [
         "CR 702.85a"
       ],
       "variants": [
         {
-          "name": "CascadeResultingMvBelow",
-          "line": 1604,
-          "kind": "struct",
-          "field_names": [
-            "source_mv",
-            "exiled_misses"
-          ],
-          "doc": "CR 702.85a: Cascade — \"You may cast that card without paying its mana cost if the resulting spell's mana value is less than this spell's mana value.\" The resulting mana value is only determined after X, Kicker, and similar choices, so this check must run at cast finalization, not at offer time.  `exiled_misses` is rejection-cleanup state: when the cast-time check fails, the original `WaitingFor::CastOffer` (Cascade) has already been cleared, so the misses ride inside the permission so the bottom-shuffle step can still reach them.",
-          "cr_refs": [
-            "CR 702.85a"
-          ]
-        },
-        {
           "name": "ManaValue",
-          "line": 1610,
+          "line": 1607,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -2680,7 +2690,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4378,
+      "line": 4406,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -2689,7 +2699,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 4381,
+          "line": 4409,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -2700,7 +2710,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4340,
+      "line": 4368,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -2711,7 +2721,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4342,
+          "line": 4370,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -2722,7 +2732,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4345,
+          "line": 4373,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -2732,7 +2742,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4347,
+          "line": 4375,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -2742,7 +2752,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4349,
+          "line": 4377,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -2752,7 +2762,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4352,
+          "line": 4380,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -2762,7 +2772,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4358,
+          "line": 4386,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -2772,7 +2782,7 @@
         },
         {
           "name": "Escape",
-          "line": 4363,
+          "line": 4391,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -2783,7 +2793,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4366,
+          "line": 4394,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -2793,7 +2803,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4371,
+          "line": 4399,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -2829,7 +2839,8 @@
             "cost",
             "cast_transformed",
             "constraint",
-            "granted_to"
+            "granted_to",
+            "resolution_cleanup"
           ],
           "doc": "Card may be cast from exile for the specified cost by its owner. Building block for Airbending, Suspend, and similar \"cast from exile\" mechanics. `cast_transformed` causes the spell to resolve to its back face (CR 712.14a); used by Siege victory triggers (CR 310.11b: \"cast it transformed without paying its mana cost\").",
           "cr_refs": [
@@ -2839,7 +2850,7 @@
         },
         {
           "name": "PlayFromExile",
-          "line": 1474,
+          "line": 1485,
           "kind": "struct",
           "field_names": [
             "duration",
@@ -2858,7 +2869,7 @@
         },
         {
           "name": "ExileWithEnergyCost",
-          "line": 1500,
+          "line": 1511,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.3: Cast from exile by paying {E} equal to the card's mana value. Building block for Amped Raptor and similar energy-based casting mechanics.",
@@ -2868,7 +2879,7 @@
         },
         {
           "name": "ExileWithAltAbilityCost",
-          "line": 1509,
+          "line": 1520,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -2883,7 +2894,7 @@
         },
         {
           "name": "WarpExile",
-          "line": 1527,
+          "line": 1538,
           "kind": "struct",
           "field_names": [
             "castable_after_turn"
@@ -2895,7 +2906,7 @@
         },
         {
           "name": "Plotted",
-          "line": 1537,
+          "line": 1548,
           "kind": "struct",
           "field_names": [
             "turn_plotted"
@@ -2908,7 +2919,7 @@
         },
         {
           "name": "Foretold",
-          "line": 1543,
+          "line": 1554,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -2987,13 +2998,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8549,
+      "line": 8601,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 8550,
+          "line": 8602,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3001,7 +3012,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 8551,
+          "line": 8603,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3009,7 +3020,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 8552,
+          "line": 8604,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3017,7 +3028,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 8553,
+          "line": 8605,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3025,7 +3036,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 8554,
+          "line": 8606,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3033,7 +3044,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 8555,
+          "line": 8607,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3041,7 +3052,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 8556,
+          "line": 8608,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3049,7 +3060,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 8557,
+          "line": 8609,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3057,7 +3068,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 8558,
+          "line": 8610,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3065,7 +3076,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 8559,
+          "line": 8611,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3073,7 +3084,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 8560,
+          "line": 8612,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3081,7 +3092,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 8561,
+          "line": 8613,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3089,7 +3100,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 8562,
+          "line": 8614,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3097,7 +3108,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 8563,
+          "line": 8615,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3105,7 +3116,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 8564,
+          "line": 8616,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3113,7 +3124,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 8565,
+          "line": 8617,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3126,13 +3137,13 @@
     },
     "CastingVariant": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3454,
+      "line": 3473,
       "doc": "How a spell was cast — determines zone routing and post-resolution behavior. Replaces individual boolean flags (cast_as_adventure, cast_as_warp) with a single enum that captures the casting context.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Normal",
-          "line": 3457,
+          "line": 3476,
           "kind": "unit",
           "field_names": [],
           "doc": "Normal spell cast — no special resolution behavior.",
@@ -3140,7 +3151,7 @@
         },
         {
           "name": "Adventure",
-          "line": 3460,
+          "line": 3479,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.4: Cast as the Adventure half. On resolution, exiled with AdventureCreature permission and creature face restored.",
@@ -3150,7 +3161,7 @@
         },
         {
           "name": "Omen",
-          "line": 3463,
+          "line": 3482,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 720.3d / CR 720.4: Cast as the Omen half. On resolution, shuffled into its owner's library with normal characteristics restored.",
@@ -3161,7 +3172,7 @@
         },
         {
           "name": "Warp",
-          "line": 3466,
+          "line": 3485,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.185a: Cast via Warp alternative cost from hand. On resolution, creates a delayed trigger to exile at end step with WarpExile permission.",
@@ -3171,7 +3182,7 @@
         },
         {
           "name": "Escape",
-          "line": 3469,
+          "line": 3488,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138: Cast from graveyard via Escape. On resolution, goes to appropriate zone normally (unlike Flashback which exiles).",
@@ -3181,7 +3192,7 @@
         },
         {
           "name": "Retrace",
-          "line": 3472,
+          "line": 3491,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.81a: Cast from graveyard via Retrace by discarding a land card as an additional cost. Resolution uses normal spell routing.",
@@ -3191,7 +3202,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 3475,
+          "line": 3494,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.180a: Cast from graveyard for harmonize cost. On resolution, exiled instead of going anywhere else (unlike Escape which returns to graveyard).",
@@ -3201,7 +3212,7 @@
         },
         {
           "name": "Flashback",
-          "line": 3478,
+          "line": 3497,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34a: Cast from graveyard for flashback cost. On resolution (or whenever leaving the stack for any reason), exiled instead of going anywhere else.",
@@ -3211,7 +3222,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 3481,
+          "line": 3500,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Cast an aftermath half of a split card from a graveyard. If it was cast from a graveyard, exile it any time it leaves the stack.",
@@ -3221,7 +3232,7 @@
         },
         {
           "name": "GraveyardPermission",
-          "line": 3485,
+          "line": 3504,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3237,7 +3248,7 @@
         },
         {
           "name": "HandPermission",
-          "line": 3511,
+          "line": 3530,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3252,7 +3263,7 @@
         },
         {
           "name": "ExilePermission",
-          "line": 3527,
+          "line": 3546,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3268,7 +3279,7 @@
         },
         {
           "name": "Sneak",
-          "line": 3544,
+          "line": 3563,
           "kind": "struct",
           "field_names": [
             "returned_creature",
@@ -3282,7 +3293,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 3553,
+          "line": 3572,
           "kind": "struct",
           "field_names": [
             "returned_creature"
@@ -3294,7 +3305,7 @@
         },
         {
           "name": "Miracle",
-          "line": 3560,
+          "line": 3579,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94a: Cast from hand via Miracle's alternative cost after revealing the card as the first card drawn this turn. The granting keyword carries the miracle mana cost, which `prepare_spell_cast_with_variant_override` substitutes for the printed mana cost. The keyword's `ManaCost` payload is read at preparation time rather than stored here because `prepare_spell_cast` already reads `obj.keywords` for analogous paths.",
@@ -3304,7 +3315,7 @@
         },
         {
           "name": "Madness",
-          "line": 3563,
+          "line": 3582,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.35a: Cast from exile via Madness after the discard replacement exiled the card and its madness triggered ability resolved.",
@@ -3314,7 +3325,7 @@
         },
         {
           "name": "Evoke",
-          "line": 3567,
+          "line": 3586,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Cast from hand via Evoke's alternative cost. On resolution, the permanent enters tagged with `CastVariantPaid::Evoke`, which fires the synthesized intervening-if ETB sacrifice trigger.",
@@ -3324,7 +3335,7 @@
         },
         {
           "name": "Suspend",
-          "line": 3574,
+          "line": 3593,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast from exile via Suspend's \"play it without paying its mana cost\" trigger after the last time counter was removed. On resolution of the resulting permanent, the stack handler tags `CastVariantPaid::Suspend` and — for creature spells — installs a transient continuous \"has haste\" effect that lasts as long as the resolution-time controller still controls the permanent.",
@@ -3334,7 +3345,7 @@
         },
         {
           "name": "Plot",
-          "line": 3581,
+          "line": 3600,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.170d: Cast from exile via the Plot \"cast without paying its mana cost\" permission during the owner's main phase on a turn after the card was plotted. Detected at cast preparation when the exile-zone source has a `CastingPermission::Plotted { turn_plotted }` and the current turn is strictly greater than `turn_plotted`. Zeroes the mana cost and routes through the normal cast pipeline; no special resolution-time behavior.",
@@ -3344,7 +3355,7 @@
         },
         {
           "name": "Foretell",
-          "line": 3588,
+          "line": 3607,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143a-c: Cast from exile via a foretold card's foretell cost on a turn after it was foretold. Detected at cast preparation when the exile-zone source has a `CastingPermission::Foretold { .. }`. The permission supplies the alternative mana cost; stack finalization tags the source with `CastVariantPaid::Foretell` so \"if this spell was foretold\" clauses can evaluate while the spell resolves.",
@@ -3354,7 +3365,7 @@
         },
         {
           "name": "Overload",
-          "line": 3598,
+          "line": 3617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a-c: Cast from hand via Overload's alternative cost. The printed mana cost is replaced by `Keyword::Overload(cost)` at cast preparation (mirrors `Evoke`/`Warp`). Per CR 702.96b, every \"target\" in the spell's text is replaced by \"each\" — applied as a cast-time transformation of the spell's ability tree (`Destroy`→`DestroyAll`, `Pump`→`PumpAll`, `DealDamage`→`DamageAll`, `Tap`→`TapAll`, `Bounce`→`ChangeZoneAll`). Per CR 702.96c, the resulting spell has no targets, so target selection is naturally skipped because the transformed effects carry no `TargetRef` slots.",
@@ -3366,7 +3377,7 @@
         },
         {
           "name": "Bestow",
-          "line": 3613,
+          "line": 3632,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a-b: Cast from hand via Bestow's alternative cost. The printed mana cost is replaced by `Keyword::Bestow(cost)` at cast preparation; the spell becomes an Aura with `enchant creature` while on the stack and as the resulting permanent (until it becomes unattached, per CR 702.103f). The type-changing mutation is applied directly to the stack object (mirroring `swap_to_alternative_spell_face` for Adventure/Omen) — Layers cannot be used here because they only apply to battlefield/hand objects, not stack objects.  Per CR 702.103e: if the target is illegal at resolution, the type-changing effect ends and the spell resolves as a creature spell. Per CR 702.103f: when a bestowed Aura becomes unattached on the battlefield, the type-changing effect ends — it remains as an enchantment creature (overrides CR 704.5m for bestow Auras).",
@@ -3379,7 +3390,7 @@
         },
         {
           "name": "Awaken",
-          "line": 3624,
+          "line": 3643,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: Cast from hand via Awaken's alternative cost. The printed mana cost is replaced by `Keyword::Awaken { cost }` at cast preparation (mirrors `Overload`). A resolution rider is appended to the tail of the spell's ability tree (`effects::awaken::append_awaken_rider`): the printed effect resolves first, then \"put N +1/+1 counters on target land you control; that land becomes a 0/0 Elemental creature with haste; it's still a land.\" Per CR 702.113b, the land target only exists on the awaken variant — a normal cast appends no rider and requests no land target. CR 702.113a: the spell goes to the graveyard normally, so this variant is deliberately absent from `exiles_when_leaving_stack_for_any_reason`.",
@@ -3390,7 +3401,7 @@
         },
         {
           "name": "Cleave",
-          "line": 3635,
+          "line": 3654,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Cast from hand via Cleave's alternative cost (CR 118.9). The printed mana cost is replaced by `Keyword::Cleave(cost)` at cast preparation (mirrors `Evoke`/`Overload`). Per CR 702.148a, paying the cleave cost is a text-changing effect (CR 612) that removes every square-bracketed span from the spell's rules text. The bracket-removed ability set is parsed at build time into `CardFace::cleave_variant` and swapped onto the stack object before preparation (mirroring the Bestow object-mutation-before-prepare seam). Resolution routing matches a normal spell — there is no on-resolve special behavior, so the spell goes to its owner's graveyard like any instant/sorcery.",
@@ -3398,6 +3409,18 @@
             "CR 118.9",
             "CR 612",
             "CR 702.148a"
+          ]
+        },
+        {
+          "name": "MoreThanMeetsTheEye",
+          "line": 3661,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.162a + CR 712.14a: Cast from any castable zone via the More Than Meets the Eye alternative cost. The printed mana cost is replaced by the `Keyword::MoreThanMeetsTheEye(cost)` payload at cast preparation (mirrors Overload). On resolution the spell is cast CONVERTED — the resulting permanent enters the battlefield transformed (back face up) via the existing `enter_transformed` ZoneChange seed. CR 701.28 (Convert).",
+          "cr_refs": [
+            "CR 701.28",
+            "CR 702.162a",
+            "CR 712.14a"
           ]
         }
       ],
@@ -3904,7 +3927,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10257,
+      "line": 10318,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -3912,7 +3935,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 10258,
+          "line": 10319,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3920,7 +3943,7 @@
         },
         {
           "name": "Lost",
-          "line": 10259,
+          "line": 10320,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3960,7 +3983,7 @@
     },
     "CombatDamageAssignmentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3015,
+      "line": 3033,
       "doc": "CR 510.1c: Optional combat-damage assignment mode for attackers with text like \"you may have this creature assign its combat damage as though it weren't blocked.\"",
       "cr_refs": [
         "CR 510.1c"
@@ -3968,7 +3991,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 3017,
+          "line": 3035,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3976,7 +3999,7 @@
         },
         {
           "name": "AsThoughUnblocked",
-          "line": 3018,
+          "line": 3036,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3987,7 +4010,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10761,
+      "line": 10822,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -3995,7 +4018,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 10762,
+          "line": 10823,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4003,7 +4026,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 10763,
+          "line": 10824,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4014,13 +4037,13 @@
     },
     "CombatRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1886,
+      "line": 1909,
       "doc": "Combat relationship required by `FilterProp::CombatRelation`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "BlockingOrBlockedBy",
-          "line": 1888,
+          "line": 1911,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g/509.1h: Candidate is blocking the subject or is blocked by it.",
@@ -4033,13 +4056,13 @@
     },
     "CombatRelationSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1893,
+      "line": 1916,
       "doc": "Context object for a combat relationship filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 1895,
+          "line": 1918,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object of the resolving spell or ability.",
@@ -4047,7 +4070,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 1897,
+          "line": 1920,
           "kind": "unit",
           "field_names": [],
           "doc": "The first selected object target of the resolving spell or ability.",
@@ -4118,7 +4141,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3775,
+      "line": 3803,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -4126,7 +4149,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 3778,
+          "line": 3806,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -4137,7 +4160,7 @@
         },
         {
           "name": "Any",
-          "line": 3782,
+          "line": 3810,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -4241,13 +4264,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3646,
+      "line": 3674,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 3647,
+          "line": 3675,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4255,7 +4278,7 @@
         },
         {
           "name": "LT",
-          "line": 3648,
+          "line": 3676,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4263,7 +4286,7 @@
         },
         {
           "name": "GE",
-          "line": 3649,
+          "line": 3677,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4271,7 +4294,7 @@
         },
         {
           "name": "LE",
-          "line": 3650,
+          "line": 3678,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4279,7 +4302,7 @@
         },
         {
           "name": "EQ",
-          "line": 3651,
+          "line": 3679,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4287,7 +4310,7 @@
         },
         {
           "name": "NE",
-          "line": 3652,
+          "line": 3680,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4298,13 +4321,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11177,
+      "line": 11238,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 11178,
+          "line": 11239,
           "kind": "struct",
           "field_names": [
             "values",
@@ -4315,7 +4338,7 @@
         },
         {
           "name": "SetName",
-          "line": 11193,
+          "line": 11254,
           "kind": "struct",
           "field_names": [
             "name"
@@ -4329,7 +4352,7 @@
         },
         {
           "name": "AddPower",
-          "line": 11196,
+          "line": 11257,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4339,7 +4362,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 11199,
+          "line": 11260,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4349,7 +4372,7 @@
         },
         {
           "name": "SetPower",
-          "line": 11202,
+          "line": 11263,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4359,7 +4382,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 11205,
+          "line": 11266,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4369,7 +4392,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 11208,
+          "line": 11269,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4379,7 +4402,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 11211,
+          "line": 11272,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4389,7 +4412,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 11214,
+          "line": 11275,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4399,7 +4422,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 11221,
+          "line": 11282,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -4411,7 +4434,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 11224,
+          "line": 11285,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4419,7 +4442,7 @@
         },
         {
           "name": "AddType",
-          "line": 11225,
+          "line": 11286,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4429,7 +4452,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 11228,
+          "line": 11289,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4439,7 +4462,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 11231,
+          "line": 11292,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4449,7 +4472,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 11234,
+          "line": 11295,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4459,7 +4482,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 11241,
+          "line": 11302,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4472,7 +4495,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 11247,
+          "line": 11308,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4485,7 +4508,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 11251,
+          "line": 11312,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4495,7 +4518,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 11255,
+          "line": 11316,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4505,7 +4528,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 11262,
+          "line": 11323,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4517,7 +4540,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 11267,
+          "line": 11328,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4529,7 +4552,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 11271,
+          "line": 11332,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4541,7 +4564,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 11275,
+          "line": 11336,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4553,7 +4576,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 11280,
+          "line": 11341,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4566,7 +4589,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 11286,
+          "line": 11347,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4574,7 +4597,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 11289,
+          "line": 11350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4585,7 +4608,7 @@
         },
         {
           "name": "AddAllLandTypes",
-          "line": 11293,
+          "line": 11354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.7: grants every land type (all 17 land subtypes) and their mana abilities, additive. Distinct from AddAllBasicLandTypes (CR 305.6, 5 basic types). Omo, Queen of Vesuva. Layer 4.",
@@ -4597,7 +4620,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 11296,
+          "line": 11357,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4607,7 +4630,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 11301,
+          "line": 11362,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4617,7 +4640,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 11308,
+          "line": 11369,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -4628,7 +4651,7 @@
         },
         {
           "name": "SetColor",
-          "line": 11309,
+          "line": 11370,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4638,7 +4661,7 @@
         },
         {
           "name": "AddColor",
-          "line": 11312,
+          "line": 11373,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4648,7 +4671,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 11317,
+          "line": 11378,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4658,7 +4681,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 11331,
+          "line": 11392,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4673,7 +4696,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 11335,
+          "line": 11396,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4683,7 +4706,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 11338,
+          "line": 11399,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -4693,7 +4716,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 11340,
+          "line": 11401,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -4703,7 +4726,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 11342,
+          "line": 11403,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -4713,7 +4736,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 11345,
+          "line": 11406,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -4723,7 +4746,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 11348,
+          "line": 11409,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -4735,7 +4758,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 11362,
+          "line": 11423,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -4747,7 +4770,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 11370,
+          "line": 11431,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4762,7 +4785,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 11379,
+          "line": 11440,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -4777,7 +4800,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 11393,
+          "line": 11454,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -4795,13 +4818,13 @@
     },
     "ControllerRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1796,
+      "line": 1819,
       "doc": "Controller reference for filter matching.",
       "cr_refs": [],
       "variants": [
         {
           "name": "You",
-          "line": 1797,
+          "line": 1820,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4809,7 +4832,7 @@
         },
         {
           "name": "Opponent",
-          "line": 1798,
+          "line": 1821,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4817,7 +4840,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 1801,
+          "line": 1824,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: Filter controller is the current player being affected by an \"each player/opponent\" instruction during resolution.",
@@ -4828,7 +4851,7 @@
         },
         {
           "name": "TargetPlayer",
-          "line": 1808,
+          "line": 1831,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 115.1: Filter controller is the player chosen as a target of the enclosing ability (e.g., \"each creature target player controls\"). At resolution time, `filter_inner` reads the first `TargetRef::Player` from `ability.targets`. At target-selection time, `collect_target_slots` surfaces a companion `TargetFilter::Player` slot so the player is chosen as part of CR 601.2c / CR 603.3d target declaration.",
@@ -4841,7 +4864,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 1812,
+          "line": 1835,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 109.4: Filter controller is the controller of the parent object target inherited by this chained effect (\"that permanent's controller may sacrifice a land\").",
@@ -4852,7 +4875,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 1817,
+          "line": 1840,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Filter controller is the defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by intervening-if quantity checks such as \"defending player controls more lands than you.\"",
@@ -4863,7 +4886,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 1828,
+          "line": 1851,
           "kind": "struct",
           "field_names": [
             "index"
@@ -4876,7 +4899,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 1837,
+          "line": 1860,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 109.4: Filter controller is the player identified by the triggering event (the drawer, life-gainer, attacker, etc.). Resolved against `state.current_trigger_event` via `extract_player_from_event`. Mirrors `PlayerFilter::TriggeringPlayer` and `TargetFilter::TriggeringPlayer`. Used by control-relative trigger restrictions (\"an opponent who controls F draws a card\").",
@@ -4939,7 +4962,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11472,
+      "line": 11533,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -4949,7 +4972,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 11475,
+          "line": 11536,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -4957,7 +4980,7 @@
         },
         {
           "name": "Finalized",
-          "line": 11477,
+          "line": 11538,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -4968,13 +4991,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5068,
+      "line": 5096,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 5069,
+          "line": 5097,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4985,7 +5008,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7077,
+      "line": 7123,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -4994,7 +5017,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 7079,
+          "line": 7125,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -5002,7 +5025,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 7081,
+          "line": 7127,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -5126,7 +5149,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4598,
+      "line": 4626,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -5134,7 +5157,7 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4599,
+          "line": 4627,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5142,7 +5165,7 @@
         },
         {
           "name": "TapsSelf",
-          "line": 4600,
+          "line": 4628,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5150,7 +5173,7 @@
         },
         {
           "name": "UntapsSelf",
-          "line": 4601,
+          "line": 4629,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5158,7 +5181,7 @@
         },
         {
           "name": "SacrificesPermanent",
-          "line": 4602,
+          "line": 4630,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5166,7 +5189,7 @@
         },
         {
           "name": "PaysLife",
-          "line": 4603,
+          "line": 4631,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5174,7 +5197,7 @@
         },
         {
           "name": "PaysLoyalty",
-          "line": 4604,
+          "line": 4632,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5182,7 +5205,7 @@
         },
         {
           "name": "Discards",
-          "line": 4605,
+          "line": 4633,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5190,7 +5213,7 @@
         },
         {
           "name": "ExilesCards",
-          "line": 4606,
+          "line": 4634,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5198,7 +5221,7 @@
         },
         {
           "name": "TapsOtherCreatures",
-          "line": 4607,
+          "line": 4635,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5206,7 +5229,7 @@
         },
         {
           "name": "RemovesCounters",
-          "line": 4608,
+          "line": 4636,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5214,7 +5237,7 @@
         },
         {
           "name": "PaysEnergy",
-          "line": 4609,
+          "line": 4637,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5222,7 +5245,7 @@
         },
         {
           "name": "PaysSpeed",
-          "line": 4610,
+          "line": 4638,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5230,7 +5253,7 @@
         },
         {
           "name": "ReturnsToHand",
-          "line": 4611,
+          "line": 4639,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5238,7 +5261,7 @@
         },
         {
           "name": "Unattaches",
-          "line": 4612,
+          "line": 4640,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5246,7 +5269,7 @@
         },
         {
           "name": "Mills",
-          "line": 4613,
+          "line": 4641,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5254,7 +5277,7 @@
         },
         {
           "name": "PutsCounters",
-          "line": 4614,
+          "line": 4642,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5262,7 +5285,7 @@
         },
         {
           "name": "Reveals",
-          "line": 4615,
+          "line": 4643,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5270,7 +5293,7 @@
         },
         {
           "name": "Exerts",
-          "line": 4616,
+          "line": 4644,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5278,7 +5301,7 @@
         },
         {
           "name": "KeywordCost",
-          "line": 4617,
+          "line": 4645,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5358,7 +5381,7 @@
     },
     "CostResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1661,
+      "line": 1663,
       "doc": "CR 601.2b + CR 605.3b: Resumption context after a PayCost choice completes. Determines whether the engine re-enters the spell-casting pipeline or the mana-ability pipeline.",
       "cr_refs": [
         "CR 601.2b",
@@ -5367,7 +5390,7 @@
       "variants": [
         {
           "name": "Spell",
-          "line": 1662,
+          "line": 1664,
           "kind": "struct",
           "field_names": [
             "spell"
@@ -5377,7 +5400,7 @@
         },
         {
           "name": "ManaAbility",
-          "line": 1666,
+          "line": 1668,
           "kind": "struct",
           "field_names": [
             "mana_ability"
@@ -5750,7 +5773,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3280,
+      "line": 3308,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -5758,7 +5781,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 3283,
+          "line": 3311,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -5771,7 +5794,7 @@
     },
     "DamageKindFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1784,
+      "line": 1807,
       "doc": "Filter for damage type on trigger definitions. CR 120.3: Combat damage is dealt during the combat damage step; all other damage is noncombat.",
       "cr_refs": [
         "CR 120.3"
@@ -5779,7 +5802,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 1787,
+          "line": 1810,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches both combat and noncombat damage.",
@@ -5787,7 +5810,7 @@
         },
         {
           "name": "CombatOnly",
-          "line": 1789,
+          "line": 1812,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2a: Only combat damage (dealt as a result of combat).",
@@ -5797,7 +5820,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 1791,
+          "line": 1814,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2b: Only noncombat damage (dealt as an effect of a spell or ability).",
@@ -5810,7 +5833,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10634,
+      "line": 10695,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -5818,7 +5841,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10636,
+          "line": 10697,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -5826,7 +5849,7 @@
         },
         {
           "name": "Triple",
-          "line": 10638,
+          "line": 10699,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -5834,7 +5857,7 @@
         },
         {
           "name": "Plus",
-          "line": 10640,
+          "line": 10701,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5844,7 +5867,7 @@
         },
         {
           "name": "Minus",
-          "line": 10647,
+          "line": 10708,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5857,7 +5880,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 10651,
+          "line": 10712,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -5867,7 +5890,7 @@
         },
         {
           "name": "SetTo",
-          "line": 10657,
+          "line": 10718,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5879,7 +5902,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 10663,
+          "line": 10724,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -5929,7 +5952,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5049,
+      "line": 5077,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -5937,7 +5960,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 5051,
+          "line": 5079,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -5945,7 +5968,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 5054,
+          "line": 5082,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -5959,7 +5982,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10749,
+      "line": 10810,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -5967,7 +5990,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 10751,
+          "line": 10812,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -5975,7 +5998,7 @@
         },
         {
           "name": "Player",
-          "line": 10753,
+          "line": 10814,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5985,7 +6008,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 10756,
+          "line": 10817,
           "kind": "struct",
           "field_names": [
             "player"
@@ -5998,7 +6021,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10733,
+      "line": 10794,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -6006,7 +6029,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10734,
+          "line": 10795,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6014,7 +6037,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10735,
+          "line": 10796,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6022,7 +6045,7 @@
         },
         {
           "name": "Controller",
-          "line": 10738,
+          "line": 10799,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -6030,7 +6053,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 10742,
+          "line": 10803,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 614.1a: Damage recipient is the player chosen for the replacement source by a linked persisted choice, or a permanent that player controls for `PlayerOrPermanentsControlledBy`.",
@@ -6041,7 +6064,7 @@
         },
         {
           "name": "Specific",
-          "line": 10743,
+          "line": 10804,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6079,13 +6102,13 @@
     },
     "DebugAction": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 654,
+      "line": 661,
       "doc": "Direct game-state manipulation actions for debugging, testing, and remediation. Bypasses `WaitingFor` validation — fires from any game state without disrupting the current prompt. Gated on `GameState::debug_mode`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MoveToZone",
-          "line": 659,
+          "line": 666,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6098,7 +6121,7 @@
         },
         {
           "name": "CreateCard",
-          "line": 674,
+          "line": 681,
           "kind": "struct",
           "field_names": [
             "card_name",
@@ -6113,7 +6136,7 @@
         },
         {
           "name": "RemoveObject",
-          "line": 682,
+          "line": 689,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -6123,7 +6146,7 @@
         },
         {
           "name": "DrawCards",
-          "line": 685,
+          "line": 692,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6136,7 +6159,7 @@
         },
         {
           "name": "Mill",
-          "line": 687,
+          "line": 694,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6147,7 +6170,7 @@
         },
         {
           "name": "ShuffleLibrary",
-          "line": 689,
+          "line": 696,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -6157,7 +6180,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 692,
+          "line": 699,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -6169,7 +6192,7 @@
         },
         {
           "name": "SetBasePowerToughness",
-          "line": 696,
+          "line": 703,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6181,7 +6204,7 @@
         },
         {
           "name": "ModifyCounters",
-          "line": 703,
+          "line": 710,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6193,7 +6216,7 @@
         },
         {
           "name": "SetTapped",
-          "line": 709,
+          "line": 716,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6204,7 +6227,7 @@
         },
         {
           "name": "SetController",
-          "line": 711,
+          "line": 718,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6215,7 +6238,7 @@
         },
         {
           "name": "SetSummoningSickness",
-          "line": 716,
+          "line": 723,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6226,7 +6249,7 @@
         },
         {
           "name": "SetFaceState",
-          "line": 718,
+          "line": 725,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6239,7 +6262,7 @@
         },
         {
           "name": "Attach",
-          "line": 728,
+          "line": 735,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6253,7 +6276,7 @@
         },
         {
           "name": "Detach",
-          "line": 733,
+          "line": 740,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -6263,7 +6286,7 @@
         },
         {
           "name": "GrantKeyword",
-          "line": 735,
+          "line": 742,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6274,7 +6297,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 740,
+          "line": 747,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6285,7 +6308,7 @@
         },
         {
           "name": "SetLife",
-          "line": 747,
+          "line": 754,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6296,7 +6319,7 @@
         },
         {
           "name": "ModifyPlayerCounters",
-          "line": 749,
+          "line": 756,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6308,7 +6331,7 @@
         },
         {
           "name": "ModifyEnergy",
-          "line": 755,
+          "line": 762,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6319,7 +6342,7 @@
         },
         {
           "name": "AddMana",
-          "line": 757,
+          "line": 764,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6330,7 +6353,7 @@
         },
         {
           "name": "SetPhase",
-          "line": 764,
+          "line": 771,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -6341,7 +6364,7 @@
         },
         {
           "name": "RunStateBasedActions",
-          "line": 769,
+          "line": 776,
           "kind": "unit",
           "field_names": [],
           "doc": "Explicitly run state-based actions. Use after a batch of raw mutations.",
@@ -6349,7 +6372,7 @@
         },
         {
           "name": "CreateToken",
-          "line": 782,
+          "line": 789,
           "kind": "struct",
           "field_names": [
             "request"
@@ -6363,7 +6386,7 @@
         },
         {
           "name": "CreateTokenCopy",
-          "line": 785,
+          "line": 792,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -6379,13 +6402,13 @@
     },
     "DebugTokenRequest": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 793,
+      "line": 800,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Preset",
-          "line": 794,
+          "line": 801,
           "kind": "struct",
           "field_names": [
             "preset_id",
@@ -6397,7 +6420,7 @@
         },
         {
           "name": "Custom",
-          "line": 800,
+          "line": 807,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -6410,9 +6433,37 @@
       ],
       "sibling_clusters": []
     },
+    "DeckCopyLimit": {
+      "file": "crates/engine/src/types/format.rs",
+      "line": 89,
+      "doc": "Per-card override to the default constructed copy limit.  CR 100.2a sets the default constructed limit to four of any card with a particular English name (basic lands excepted). A handful of cards print an explicit deck-construction override in their rules text:  - `Unlimited`: \"A deck can have any number of cards named ~.\" (Relentless   Rats, Shadowborn Apostle, etc.) — no upper bound on copies. - `UpTo(n)`: \"A deck can have up to <n> cards named ~.\" (Seven Dwarves → 7,   Nazgûl → 9) and the Commander/companion singleton override \"Your deck can   have only one copy of this card\" (Vazal, the Compleat → `UpTo(1)`).  CR 903.5b's Commander singleton rule exempts basic lands; an `UpTo(n>1)` override likewise raises the cap above the format default for that card.",
+      "cr_refs": [
+        "CR 100.2a",
+        "CR 903.5b"
+      ],
+      "variants": [
+        {
+          "name": "Unlimited",
+          "line": 90,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "UpTo",
+          "line": 91,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
     "DelayedTriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1619,
+      "line": 1642,
       "doc": "When a delayed triggered ability fires (CR 603.7).",
       "cr_refs": [
         "CR 603.7"
@@ -6420,7 +6471,7 @@
       "variants": [
         {
           "name": "AtNextPhase",
-          "line": 1622,
+          "line": 1645,
           "kind": "struct",
           "field_names": [
             "phase"
@@ -6432,7 +6483,7 @@
         },
         {
           "name": "AtNextPhaseForPlayer",
-          "line": 1625,
+          "line": 1648,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -6443,7 +6494,7 @@
         },
         {
           "name": "WhenLeavesPlay",
-          "line": 1627,
+          "line": 1650,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -6453,7 +6504,7 @@
         },
         {
           "name": "WhenDies",
-          "line": 1633,
+          "line": 1656,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6465,7 +6516,7 @@
         },
         {
           "name": "WhenLeavesPlayFiltered",
-          "line": 1636,
+          "line": 1659,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6477,7 +6528,7 @@
         },
         {
           "name": "WhenEntersBattlefield",
-          "line": 1639,
+          "line": 1662,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6489,7 +6540,7 @@
         },
         {
           "name": "WhenDiesOrExiled",
-          "line": 1642,
+          "line": 1665,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -6499,7 +6550,7 @@
         },
         {
           "name": "WheneverEvent",
-          "line": 1647,
+          "line": 1670,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -6511,7 +6562,7 @@
         },
         {
           "name": "WhenNextEvent",
-          "line": 1651,
+          "line": 1674,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -6584,7 +6635,7 @@
     },
     "DistributionUnit": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3034,
+      "line": 3052,
       "doc": "CR 601.2d: What is being distributed (damage, counters, life).",
       "cr_refs": [
         "CR 601.2d"
@@ -6592,7 +6643,7 @@
       "variants": [
         {
           "name": "Damage",
-          "line": 3035,
+          "line": 3053,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6600,7 +6651,7 @@
         },
         {
           "name": "EvenSplitDamage",
-          "line": 3038,
+          "line": 3056,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2d: Even split — engine auto-computes `total / num_targets` (rounded down). No player choice needed; bypasses `WaitingFor::DistributeAmong`.",
@@ -6610,7 +6661,7 @@
         },
         {
           "name": "Counters",
-          "line": 3039,
+          "line": 3057,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6618,7 +6669,7 @@
         },
         {
           "name": "Life",
-          "line": 3040,
+          "line": 3058,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6835,13 +6886,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5150,
+      "line": 5178,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 5152,
+          "line": 5180,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -6853,7 +6904,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 5158,
+          "line": 5186,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -6868,7 +6919,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 5169,
+          "line": 5197,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -6880,7 +6931,7 @@
         },
         {
           "name": "Draw",
-          "line": 5189,
+          "line": 5217,
           "kind": "struct",
           "field_names": [
             "count",
@@ -6896,7 +6947,7 @@
         },
         {
           "name": "Pump",
-          "line": 5195,
+          "line": 5223,
           "kind": "struct",
           "field_names": [
             "power",
@@ -6908,7 +6959,7 @@
         },
         {
           "name": "PairWith",
-          "line": 5206,
+          "line": 5234,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6921,7 +6972,7 @@
         },
         {
           "name": "Destroy",
-          "line": 5209,
+          "line": 5237,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6932,7 +6983,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 5217,
+          "line": 5245,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6944,7 +6995,7 @@
         },
         {
           "name": "Counter",
-          "line": 5221,
+          "line": 5249,
           "kind": "struct",
           "field_names": [
             "target",
@@ -6955,7 +7006,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 5242,
+          "line": 5270,
           "kind": "struct",
           "field_names": [
             "target"
@@ -6969,7 +7020,7 @@
         },
         {
           "name": "Token",
-          "line": 5246,
+          "line": 5274,
           "kind": "struct",
           "field_names": [
             "name",
@@ -6992,7 +7043,7 @@
         },
         {
           "name": "GainLife",
-          "line": 5284,
+          "line": 5312,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7003,7 +7054,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 5294,
+          "line": 5322,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7014,7 +7065,7 @@
         },
         {
           "name": "Tap",
-          "line": 5301,
+          "line": 5329,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7024,7 +7075,7 @@
         },
         {
           "name": "Untap",
-          "line": 5305,
+          "line": 5333,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7034,7 +7085,7 @@
         },
         {
           "name": "TapAll",
-          "line": 5310,
+          "line": 5338,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7046,7 +7097,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 5315,
+          "line": 5343,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7058,7 +7109,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 5319,
+          "line": 5347,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7070,7 +7121,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 5326,
+          "line": 5354,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7082,7 +7133,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5334,
+          "line": 5362,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7094,7 +7145,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 5355,
+          "line": 5383,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7105,7 +7156,7 @@
         },
         {
           "name": "Mill",
-          "line": 5361,
+          "line": 5389,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7117,7 +7168,7 @@
         },
         {
           "name": "Scry",
-          "line": 5378,
+          "line": 5406,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7132,7 +7183,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 5384,
+          "line": 5412,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7144,7 +7195,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 5398,
+          "line": 5426,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7161,7 +7212,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 5422,
+          "line": 5450,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7174,7 +7225,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 5426,
+          "line": 5454,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7185,7 +7236,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 5433,
+          "line": 5461,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7204,7 +7255,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 5484,
+          "line": 5512,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7218,7 +7269,7 @@
         },
         {
           "name": "Dig",
-          "line": 5502,
+          "line": 5530,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7238,7 +7289,7 @@
         },
         {
           "name": "GainControl",
-          "line": 5528,
+          "line": 5556,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7248,7 +7299,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 5532,
+          "line": 5560,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7259,7 +7310,7 @@
         },
         {
           "name": "Attach",
-          "line": 5538,
+          "line": 5566,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7270,7 +7321,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 5550,
+          "line": 5578,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7283,7 +7334,7 @@
         },
         {
           "name": "Surveil",
-          "line": 5562,
+          "line": 5590,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7298,7 +7349,7 @@
         },
         {
           "name": "Fight",
-          "line": 5568,
+          "line": 5596,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7309,7 +7360,7 @@
         },
         {
           "name": "Bounce",
-          "line": 5576,
+          "line": 5604,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7321,7 +7372,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 5595,
+          "line": 5623,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7336,7 +7387,7 @@
         },
         {
           "name": "Explore",
-          "line": 5603,
+          "line": 5631,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7344,7 +7395,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 5607,
+          "line": 5635,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7356,7 +7407,7 @@
         },
         {
           "name": "Investigate",
-          "line": 5612,
+          "line": 5640,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Investigate — create a Clue token.",
@@ -7366,7 +7417,7 @@
         },
         {
           "name": "Tribute",
-          "line": 5619,
+          "line": 5647,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7379,7 +7430,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 5625,
+          "line": 5653,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -7389,7 +7440,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 5627,
+          "line": 5655,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -7399,7 +7450,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 5628,
+          "line": 5656,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7407,7 +7458,7 @@
         },
         {
           "name": "Populate",
-          "line": 5630,
+          "line": 5658,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -7417,7 +7468,7 @@
         },
         {
           "name": "Clash",
-          "line": 5632,
+          "line": 5660,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -7427,7 +7478,7 @@
         },
         {
           "name": "Vote",
-          "line": 5647,
+          "line": 5675,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7443,7 +7494,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 5691,
+          "line": 5719,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -7463,7 +7514,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 5710,
+          "line": 5738,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7475,7 +7526,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 5714,
+          "line": 5742,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7486,7 +7537,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 5723,
+          "line": 5751,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7499,7 +7550,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 5734,
+          "line": 5762,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7519,7 +7570,7 @@
         },
         {
           "name": "Myriad",
-          "line": 5781,
+          "line": 5809,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -7528,8 +7579,23 @@
           ]
         },
         {
+          "name": "CopyTokenBlockingAttacker",
+          "line": 5818,
+          "kind": "struct",
+          "field_names": [
+            "source_filter",
+            "owner"
+          ],
+          "doc": "CR 509.1g + CR 506.3e + CR 707.2: For each attacking creature matched by `source_filter`, create a token that's a copy of it and put that token onto the battlefield blocking the attacker it copies. Mirror Match is the canonical card (\"For each attacking creature, create a token that's a copy of that creature. Those tokens block those creatures …\"). The end-of-combat exile of the created tokens is composed separately as a delayed trigger over `TargetFilter::LastCreated` (\"those tokens\"), so this effect only handles the copy-and-block half of the idiom.",
+          "cr_refs": [
+            "CR 506.3e",
+            "CR 509.1g",
+            "CR 707.2"
+          ]
+        },
+        {
           "name": "BecomeCopy",
-          "line": 5784,
+          "line": 5830,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7545,7 +7611,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 5794,
+          "line": 5840,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7556,7 +7622,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 5800,
+          "line": 5846,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7568,7 +7634,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 5808,
+          "line": 5854,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7582,7 +7648,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 5815,
+          "line": 5861,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7594,7 +7660,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 5823,
+          "line": 5869,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7607,7 +7673,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 5829,
+          "line": 5875,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -7620,7 +7686,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 5837,
+          "line": 5883,
           "kind": "struct",
           "field_names": [
             "source",
@@ -7638,7 +7704,7 @@
         },
         {
           "name": "Animate",
-          "line": 5857,
+          "line": 5903,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7653,7 +7719,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 5891,
+          "line": 5937,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -7677,7 +7743,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 5907,
+          "line": 5953,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -7687,7 +7753,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 5911,
+          "line": 5957,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -7699,7 +7765,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 5919,
+          "line": 5965,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -7716,7 +7782,7 @@
         },
         {
           "name": "Mana",
-          "line": 5937,
+          "line": 5983,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -7730,7 +7796,7 @@
         },
         {
           "name": "Discard",
-          "line": 5960,
+          "line": 6006,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7744,7 +7810,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 5982,
+          "line": 6028,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7754,7 +7820,7 @@
         },
         {
           "name": "Transform",
-          "line": 5986,
+          "line": 6032,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7764,7 +7830,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 5992,
+          "line": 6038,
           "kind": "struct",
           "field_names": [
             "source_zones",
@@ -7780,7 +7846,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 6049,
+          "line": 6095,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7798,7 +7864,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 6060,
+          "line": 6106,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7812,7 +7878,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 6084,
+          "line": 6130,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -7825,7 +7891,7 @@
         },
         {
           "name": "Reveal",
-          "line": 6095,
+          "line": 6141,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7838,7 +7904,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 6100,
+          "line": 6146,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7851,7 +7917,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 6109,
+          "line": 6155,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7863,7 +7929,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 6132,
+          "line": 6178,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7873,7 +7939,7 @@
         },
         {
           "name": "Choose",
-          "line": 6138,
+          "line": 6184,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -7884,7 +7950,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 6149,
+          "line": 6195,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -7897,7 +7963,7 @@
         },
         {
           "name": "Suspect",
-          "line": 6154,
+          "line": 6200,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7909,7 +7975,7 @@
         },
         {
           "name": "Connive",
-          "line": 6161,
+          "line": 6207,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7923,7 +7989,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 6169,
+          "line": 6215,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7935,7 +8001,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 6176,
+          "line": 6222,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7947,7 +8013,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 6181,
+          "line": 6227,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7959,7 +8025,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 6186,
+          "line": 6232,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -7969,7 +8035,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 6193,
+          "line": 6239,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7981,7 +8047,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 6200,
+          "line": 6246,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7993,7 +8059,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 6205,
+          "line": 6251,
           "kind": "struct",
           "field_names": [
             "level"
@@ -8005,7 +8071,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 6210,
+          "line": 6256,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -8019,7 +8085,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 6240,
+          "line": 6286,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -8033,7 +8099,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 6246,
+          "line": 6292,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -8045,7 +8111,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 6251,
+          "line": 6297,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8058,7 +8124,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 6258,
+          "line": 6304,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -8071,7 +8137,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 6267,
+          "line": 6313,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8084,7 +8150,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 6275,
+          "line": 6321,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -8098,7 +8164,7 @@
         },
         {
           "name": "PayCost",
-          "line": 6285,
+          "line": 6331,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -8111,7 +8177,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 6296,
+          "line": 6342,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8129,7 +8195,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 6326,
+          "line": 6372,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8145,7 +8211,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 6365,
+          "line": 6411,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -8166,7 +8232,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 6395,
+          "line": 6441,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: A player who meets this effect's condition loses the game. The affected player is determined by resolution context (controller's opponent if untargeted, or explicit target if targeted).",
@@ -8176,7 +8242,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 6397,
+          "line": 6443,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: The controller wins the game — all opponents lose.",
@@ -8186,7 +8252,7 @@
         },
         {
           "name": "RollDie",
-          "line": 6402,
+          "line": 6448,
           "kind": "struct",
           "field_names": [
             "sides",
@@ -8201,7 +8267,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 6410,
+          "line": 6456,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -8214,7 +8280,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 6422,
+          "line": 6468,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8228,7 +8294,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 6431,
+          "line": 6477,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -8240,7 +8306,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 6436,
+          "line": 6482,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -8250,7 +8316,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 6439,
+          "line": 6485,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -8260,7 +8326,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 6441,
+          "line": 6487,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -8272,7 +8338,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 6446,
+          "line": 6492,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -8283,7 +8349,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 6449,
+          "line": 6495,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -8293,7 +8359,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 6452,
+          "line": 6498,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -8305,7 +8371,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 6469,
+          "line": 6515,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8324,7 +8390,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 6502,
+          "line": 6548,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8339,7 +8405,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 6515,
+          "line": 6561,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -8355,7 +8421,7 @@
         },
         {
           "name": "Exploit",
-          "line": 6530,
+          "line": 6576,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8367,7 +8433,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 6535,
+          "line": 6581,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8379,7 +8445,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 6540,
+          "line": 6586,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -8394,7 +8460,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 6552,
+          "line": 6598,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8406,7 +8472,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 6564,
+          "line": 6610,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8422,7 +8488,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 6575,
+          "line": 6621,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8440,7 +8506,7 @@
         },
         {
           "name": "Discover",
-          "line": 6609,
+          "line": 6655,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -8452,7 +8518,7 @@
         },
         {
           "name": "Cascade",
-          "line": 6621,
+          "line": 6667,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -8462,7 +8528,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 6625,
+          "line": 6671,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8474,7 +8540,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 6630,
+          "line": 6676,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -8486,7 +8552,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 6643,
+          "line": 6689,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8498,7 +8564,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 6652,
+          "line": 6698,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8510,7 +8576,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 6661,
+          "line": 6707,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8520,7 +8586,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 6666,
+          "line": 6712,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -8530,7 +8596,7 @@
         },
         {
           "name": "Goad",
-          "line": 6672,
+          "line": 6718,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8542,7 +8608,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 6679,
+          "line": 6725,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8554,7 +8620,7 @@
         },
         {
           "name": "Detain",
-          "line": 6686,
+          "line": 6732,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8566,7 +8632,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 6697,
+          "line": 6743,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -8580,7 +8646,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 6708,
+          "line": 6754,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8594,7 +8660,7 @@
         },
         {
           "name": "Manifest",
-          "line": 6723,
+          "line": 6769,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8607,7 +8673,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 6729,
+          "line": 6775,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -8617,7 +8683,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 6733,
+          "line": 6779,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8629,7 +8695,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 6747,
+          "line": 6793,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8642,7 +8708,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 6758,
+          "line": 6804,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8655,7 +8721,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 6768,
+          "line": 6814,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8669,7 +8735,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 6780,
+          "line": 6826,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8685,7 +8751,7 @@
         },
         {
           "name": "Double",
-          "line": 6791,
+          "line": 6837,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -8699,7 +8765,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 6799,
+          "line": 6845,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -8711,7 +8777,7 @@
         },
         {
           "name": "Incubate",
-          "line": 6805,
+          "line": 6851,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8723,7 +8789,7 @@
         },
         {
           "name": "Amass",
-          "line": 6813,
+          "line": 6859,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -8736,7 +8802,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 6821,
+          "line": 6867,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8748,7 +8814,7 @@
         },
         {
           "name": "Renown",
-          "line": 6827,
+          "line": 6873,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8760,7 +8826,7 @@
         },
         {
           "name": "Bolster",
-          "line": 6833,
+          "line": 6879,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8772,7 +8838,7 @@
         },
         {
           "name": "Adapt",
-          "line": 6839,
+          "line": 6885,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8784,7 +8850,7 @@
         },
         {
           "name": "Learn",
-          "line": 6845,
+          "line": 6891,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -8794,7 +8860,7 @@
         },
         {
           "name": "Forage",
-          "line": 6847,
+          "line": 6893,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -8804,7 +8870,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6849,
+          "line": 6895,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8816,7 +8882,7 @@
         },
         {
           "name": "Endure",
-          "line": 6856,
+          "line": 6902,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8829,7 +8895,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 6861,
+          "line": 6907,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8841,7 +8907,7 @@
         },
         {
           "name": "Seek",
-          "line": 6866,
+          "line": 6912,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -8855,7 +8921,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 6883,
+          "line": 6929,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8868,7 +8934,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 6898,
+          "line": 6944,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8884,7 +8950,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 6905,
+          "line": 6951,
           "kind": "struct",
           "field_names": [
             "to"
@@ -8896,7 +8962,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 6910,
+          "line": 6956,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8909,7 +8975,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 6919,
+          "line": 6965,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8921,7 +8987,7 @@
         },
         {
           "name": "Conjure",
-          "line": 6926,
+          "line": 6972,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -8933,7 +8999,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 6947,
+          "line": 6993,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8947,7 +9013,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6958,
+          "line": 7004,
           "kind": "struct",
           "field_names": [
             "name",
@@ -9042,13 +9108,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11864,
+      "line": 11925,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 11866,
+          "line": 11927,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9056,7 +9122,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 11868,
+          "line": 11929,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9064,7 +9130,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 11870,
+          "line": 11931,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9072,7 +9138,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 11872,
+          "line": 11933,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9080,7 +9146,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 11874,
+          "line": 11935,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9088,7 +9154,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 11876,
+          "line": 11937,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9099,13 +9165,13 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7960,
+      "line": 8009,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7961,
+          "line": 8010,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9113,7 +9179,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 7962,
+          "line": 8011,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9121,7 +9187,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 7963,
+          "line": 8012,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9129,7 +9195,7 @@
         },
         {
           "name": "Draw",
-          "line": 7964,
+          "line": 8013,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9137,7 +9203,7 @@
         },
         {
           "name": "Pump",
-          "line": 7965,
+          "line": 8014,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9145,7 +9211,7 @@
         },
         {
           "name": "PairWith",
-          "line": 7966,
+          "line": 8015,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9153,7 +9219,7 @@
         },
         {
           "name": "Destroy",
-          "line": 7967,
+          "line": 8016,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9161,7 +9227,7 @@
         },
         {
           "name": "Counter",
-          "line": 7968,
+          "line": 8017,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9169,7 +9235,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 7969,
+          "line": 8018,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9177,7 +9243,7 @@
         },
         {
           "name": "Token",
-          "line": 7970,
+          "line": 8019,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9185,7 +9251,7 @@
         },
         {
           "name": "GainLife",
-          "line": 7971,
+          "line": 8020,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9193,7 +9259,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 7972,
+          "line": 8021,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9201,7 +9267,7 @@
         },
         {
           "name": "Tap",
-          "line": 7973,
+          "line": 8022,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9209,7 +9275,7 @@
         },
         {
           "name": "Untap",
-          "line": 7974,
+          "line": 8023,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9217,7 +9283,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 7975,
+          "line": 8024,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9225,7 +9291,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 7976,
+          "line": 8025,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9233,7 +9299,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 7977,
+          "line": 8026,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9241,7 +9307,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 7978,
+          "line": 8027,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9249,7 +9315,7 @@
         },
         {
           "name": "Mill",
-          "line": 7979,
+          "line": 8028,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9257,7 +9323,7 @@
         },
         {
           "name": "Scry",
-          "line": 7980,
+          "line": 8029,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9265,7 +9331,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 7981,
+          "line": 8030,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9273,7 +9339,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 7982,
+          "line": 8031,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9281,7 +9347,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 7983,
+          "line": 8032,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9289,7 +9355,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 7984,
+          "line": 8033,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9297,7 +9363,7 @@
         },
         {
           "name": "TapAll",
-          "line": 7985,
+          "line": 8034,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9305,7 +9371,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 7986,
+          "line": 8035,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9313,7 +9379,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 7987,
+          "line": 8036,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9321,7 +9387,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 7988,
+          "line": 8037,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9329,7 +9395,7 @@
         },
         {
           "name": "Dig",
-          "line": 7989,
+          "line": 8038,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9337,7 +9403,7 @@
         },
         {
           "name": "GainControl",
-          "line": 7990,
+          "line": 8039,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9345,7 +9411,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 7991,
+          "line": 8040,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9353,7 +9419,7 @@
         },
         {
           "name": "Attach",
-          "line": 7992,
+          "line": 8041,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9361,7 +9427,7 @@
         },
         {
           "name": "AttachAll",
-          "line": 7993,
+          "line": 8042,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9369,7 +9435,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 7994,
+          "line": 8043,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9377,7 +9443,7 @@
         },
         {
           "name": "Surveil",
-          "line": 7995,
+          "line": 8044,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9385,7 +9451,7 @@
         },
         {
           "name": "Fight",
-          "line": 7996,
+          "line": 8045,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9393,7 +9459,7 @@
         },
         {
           "name": "Bounce",
-          "line": 7997,
+          "line": 8046,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9401,7 +9467,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 7998,
+          "line": 8047,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9409,7 +9475,7 @@
         },
         {
           "name": "Explore",
-          "line": 7999,
+          "line": 8048,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9417,7 +9483,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 8000,
+          "line": 8049,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9425,7 +9491,7 @@
         },
         {
           "name": "Investigate",
-          "line": 8001,
+          "line": 8050,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9433,7 +9499,7 @@
         },
         {
           "name": "Tribute",
-          "line": 8002,
+          "line": 8051,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9441,7 +9507,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 8003,
+          "line": 8052,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9449,7 +9515,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 8004,
+          "line": 8053,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9457,7 +9523,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 8005,
+          "line": 8054,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9465,7 +9531,7 @@
         },
         {
           "name": "Populate",
-          "line": 8006,
+          "line": 8055,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9473,7 +9539,7 @@
         },
         {
           "name": "Clash",
-          "line": 8007,
+          "line": 8056,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9481,7 +9547,7 @@
         },
         {
           "name": "Vote",
-          "line": 8009,
+          "line": 8058,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -9491,7 +9557,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 8011,
+          "line": 8060,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -9501,7 +9567,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 8012,
+          "line": 8061,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9509,7 +9575,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 8013,
+          "line": 8062,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9517,7 +9583,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 8014,
+          "line": 8063,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9525,7 +9591,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 8015,
+          "line": 8064,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9533,7 +9599,7 @@
         },
         {
           "name": "Myriad",
-          "line": 8016,
+          "line": 8065,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9541,7 +9607,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 8017,
+          "line": 8066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9549,7 +9615,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 8018,
+          "line": 8067,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9557,7 +9623,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 8019,
+          "line": 8068,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9565,7 +9631,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 8020,
+          "line": 8069,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9573,7 +9639,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 8021,
+          "line": 8070,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9581,7 +9647,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 8022,
+          "line": 8071,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9589,7 +9655,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 8023,
+          "line": 8072,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9597,7 +9663,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 8024,
+          "line": 8073,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9605,7 +9671,7 @@
         },
         {
           "name": "Animate",
-          "line": 8025,
+          "line": 8074,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9613,7 +9679,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 8026,
+          "line": 8075,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9621,7 +9687,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 8027,
+          "line": 8076,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9629,7 +9695,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 8028,
+          "line": 8077,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9637,7 +9703,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 8029,
+          "line": 8078,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9645,7 +9711,7 @@
         },
         {
           "name": "Mana",
-          "line": 8030,
+          "line": 8079,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9653,7 +9719,7 @@
         },
         {
           "name": "Discard",
-          "line": 8031,
+          "line": 8080,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9661,7 +9727,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 8032,
+          "line": 8081,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9669,7 +9735,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 8033,
+          "line": 8082,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9677,7 +9743,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 8034,
+          "line": 8083,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9685,7 +9751,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 8035,
+          "line": 8084,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9693,7 +9759,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 8036,
+          "line": 8085,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9701,7 +9767,7 @@
         },
         {
           "name": "Choose",
-          "line": 8037,
+          "line": 8086,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9709,7 +9775,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 8038,
+          "line": 8087,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9717,7 +9783,7 @@
         },
         {
           "name": "Suspect",
-          "line": 8039,
+          "line": 8088,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9725,7 +9791,7 @@
         },
         {
           "name": "Connive",
-          "line": 8040,
+          "line": 8089,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9733,7 +9799,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 8041,
+          "line": 8090,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9741,7 +9807,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 8042,
+          "line": 8091,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9749,7 +9815,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 8043,
+          "line": 8092,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9757,7 +9823,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 8044,
+          "line": 8093,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9765,7 +9831,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 8046,
+          "line": 8095,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -9775,7 +9841,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 8048,
+          "line": 8097,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -9785,398 +9851,6 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 8049,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDelayedTrigger",
-          "line": 8050,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddTargetReplacement",
-          "line": 8051,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddRestriction",
-          "line": 8052,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReduceNextSpellCost",
-          "line": 8053,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantNextSpellAbility",
-          "line": 8054,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddPendingETBCounters",
-          "line": 8055,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateEmblem",
-          "line": 8056,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PayCost",
-          "line": 8057,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastFromZone",
-          "line": 8058,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PreventDamage",
-          "line": 8059,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDamageReplacement",
-          "line": 8060,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Regenerate",
-          "line": 8061,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseTheGame",
-          "line": 8062,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "WinTheGame",
-          "line": 8063,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RollDie",
-          "line": 8064,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoin",
-          "line": 8065,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoins",
-          "line": 8066,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlipCoinUntilLose",
-          "line": 8067,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RingTemptsYou",
-          "line": 8068,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "VentureIntoDungeon",
-          "line": 8069,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "VentureInto",
-          "line": 8070,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TakeTheInitiative",
-          "line": 8071,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ProcessRadCounters",
-          "line": 8072,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantCastingPermission",
-          "line": 8073,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseFromZone",
-          "line": 8074,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseObjectsIntoTrackedSet",
-          "line": 8075,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseAndSacrificeRest",
-          "line": 8076,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Exploit",
-          "line": 8077,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GainEnergy",
-          "line": 8078,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GivePlayerCounter",
-          "line": 8079,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LoseAllPlayerCounters",
-          "line": 8080,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ExileFromTopUntil",
-          "line": 8081,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RevealUntil",
-          "line": 8082,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Discover",
-          "line": 8083,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Cascade",
-          "line": 8084,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MiracleCast",
-          "line": 8085,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "MadnessCast",
-          "line": 8086,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutAtLibraryPosition",
-          "line": 8087,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 8088,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PutOnTopOrBottom",
-          "line": 8089,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GiftDelivery",
-          "line": 8090,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Goad",
-          "line": 8091,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GoadAll",
-          "line": 8092,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Detain",
-          "line": 8093,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ExchangeControl",
-          "line": 8094,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeTargets",
-          "line": 8095,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Incubate",
-          "line": 8096,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Amass",
-          "line": 8097,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Monstrosity",
           "line": 8098,
           "kind": "unit",
           "field_names": [],
@@ -10184,7 +9858,7 @@
           "cr_refs": []
         },
         {
-          "name": "Renown",
+          "name": "CreateDelayedTrigger",
           "line": 8099,
           "kind": "unit",
           "field_names": [],
@@ -10192,7 +9866,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bolster",
+          "name": "AddTargetReplacement",
           "line": 8100,
           "kind": "unit",
           "field_names": [],
@@ -10200,7 +9874,7 @@
           "cr_refs": []
         },
         {
-          "name": "Adapt",
+          "name": "AddRestriction",
           "line": 8101,
           "kind": "unit",
           "field_names": [],
@@ -10208,7 +9882,7 @@
           "cr_refs": []
         },
         {
-          "name": "Manifest",
+          "name": "ReduceNextSpellCost",
           "line": 8102,
           "kind": "unit",
           "field_names": [],
@@ -10216,7 +9890,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "GrantNextSpellAbility",
           "line": 8103,
           "kind": "unit",
           "field_names": [],
@@ -10224,7 +9898,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExtraTurn",
+          "name": "AddPendingETBCounters",
           "line": 8104,
           "kind": "unit",
           "field_names": [],
@@ -10232,7 +9906,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantExtraLoyaltyActivations",
+          "name": "CreateEmblem",
           "line": 8105,
           "kind": "unit",
           "field_names": [],
@@ -10240,7 +9914,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextTurn",
+          "name": "PayCost",
           "line": 8106,
           "kind": "unit",
           "field_names": [],
@@ -10248,7 +9922,7 @@
           "cr_refs": []
         },
         {
-          "name": "SkipNextStep",
+          "name": "CastFromZone",
           "line": 8107,
           "kind": "unit",
           "field_names": [],
@@ -10256,7 +9930,7 @@
           "cr_refs": []
         },
         {
-          "name": "AdditionalPhase",
+          "name": "PreventDamage",
           "line": 8108,
           "kind": "unit",
           "field_names": [],
@@ -10264,7 +9938,7 @@
           "cr_refs": []
         },
         {
-          "name": "Double",
+          "name": "CreateDamageReplacement",
           "line": 8109,
           "kind": "unit",
           "field_names": [],
@@ -10272,7 +9946,7 @@
           "cr_refs": []
         },
         {
-          "name": "RuntimeHandled",
+          "name": "Regenerate",
           "line": 8110,
           "kind": "unit",
           "field_names": [],
@@ -10280,7 +9954,7 @@
           "cr_refs": []
         },
         {
-          "name": "Learn",
+          "name": "LoseTheGame",
           "line": 8111,
           "kind": "unit",
           "field_names": [],
@@ -10288,7 +9962,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "WinTheGame",
           "line": 8112,
           "kind": "unit",
           "field_names": [],
@@ -10296,7 +9970,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "RollDie",
           "line": 8113,
           "kind": "unit",
           "field_names": [],
@@ -10304,7 +9978,7 @@
           "cr_refs": []
         },
         {
-          "name": "Endure",
+          "name": "FlipCoin",
           "line": 8114,
           "kind": "unit",
           "field_names": [],
@@ -10312,7 +9986,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlightEffect",
+          "name": "FlipCoins",
           "line": 8115,
           "kind": "unit",
           "field_names": [],
@@ -10320,7 +9994,7 @@
           "cr_refs": []
         },
         {
-          "name": "Seek",
+          "name": "FlipCoinUntilLose",
           "line": 8116,
           "kind": "unit",
           "field_names": [],
@@ -10328,7 +10002,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetLifeTotal",
+          "name": "RingTemptsYou",
           "line": 8117,
           "kind": "unit",
           "field_names": [],
@@ -10336,7 +10010,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeLifeWithStat",
+          "name": "VentureIntoDungeon",
           "line": 8118,
           "kind": "unit",
           "field_names": [],
@@ -10344,7 +10018,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetDayNight",
+          "name": "VentureInto",
           "line": 8119,
           "kind": "unit",
           "field_names": [],
@@ -10352,7 +10026,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveControl",
+          "name": "TakeTheInitiative",
           "line": 8120,
           "kind": "unit",
           "field_names": [],
@@ -10360,7 +10034,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveFromCombat",
+          "name": "ProcessRadCounters",
           "line": 8121,
           "kind": "unit",
           "field_names": [],
@@ -10368,7 +10042,7 @@
           "cr_refs": []
         },
         {
-          "name": "Conjure",
+          "name": "GrantCastingPermission",
           "line": 8122,
           "kind": "unit",
           "field_names": [],
@@ -10376,7 +10050,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseOneOf",
+          "name": "ChooseFromZone",
           "line": 8123,
           "kind": "unit",
           "field_names": [],
@@ -10384,7 +10058,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unimplemented",
+          "name": "ChooseObjectsIntoTrackedSet",
           "line": 8124,
           "kind": "unit",
           "field_names": [],
@@ -10392,8 +10066,400 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "ChooseAndSacrificeRest",
+          "line": 8125,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Exploit",
           "line": 8126,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GainEnergy",
+          "line": 8127,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GivePlayerCounter",
+          "line": 8128,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "LoseAllPlayerCounters",
+          "line": 8129,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExileFromTopUntil",
+          "line": 8130,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RevealUntil",
+          "line": 8131,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Discover",
+          "line": 8132,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Cascade",
+          "line": 8133,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MiracleCast",
+          "line": 8134,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MadnessCast",
+          "line": 8135,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PutAtLibraryPosition",
+          "line": 8136,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseDrawnThisTurnPayOrTopdeck",
+          "line": 8137,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PutOnTopOrBottom",
+          "line": 8138,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GiftDelivery",
+          "line": 8139,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Goad",
+          "line": 8140,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GoadAll",
+          "line": 8141,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Detain",
+          "line": 8142,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExchangeControl",
+          "line": 8143,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChangeTargets",
+          "line": 8144,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Incubate",
+          "line": 8145,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Amass",
+          "line": 8146,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Monstrosity",
+          "line": 8147,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Renown",
+          "line": 8148,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Bolster",
+          "line": 8149,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Adapt",
+          "line": 8150,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Manifest",
+          "line": 8151,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ManifestDread",
+          "line": 8152,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExtraTurn",
+          "line": 8153,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GrantExtraLoyaltyActivations",
+          "line": 8154,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SkipNextTurn",
+          "line": 8155,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SkipNextStep",
+          "line": 8156,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AdditionalPhase",
+          "line": 8157,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Double",
+          "line": 8158,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RuntimeHandled",
+          "line": 8159,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Learn",
+          "line": 8160,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Forage",
+          "line": 8161,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CollectEvidence",
+          "line": 8162,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Endure",
+          "line": 8163,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BlightEffect",
+          "line": 8164,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Seek",
+          "line": 8165,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetLifeTotal",
+          "line": 8166,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExchangeLifeWithStat",
+          "line": 8167,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetDayNight",
+          "line": 8168,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GiveControl",
+          "line": 8169,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RemoveFromCombat",
+          "line": 8170,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Conjure",
+          "line": 8171,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseOneOf",
+          "line": 8172,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unimplemented",
+          "line": 8173,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 8175,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -10401,7 +10467,7 @@
         },
         {
           "name": "Crew",
-          "line": 8128,
+          "line": 8177,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -10411,7 +10477,7 @@
         },
         {
           "name": "Station",
-          "line": 8130,
+          "line": 8179,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -10421,7 +10487,7 @@
         },
         {
           "name": "Saddle",
-          "line": 8132,
+          "line": 8181,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -10431,7 +10497,7 @@
         },
         {
           "name": "Reveal",
-          "line": 8134,
+          "line": 8183,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -10439,7 +10505,7 @@
         },
         {
           "name": "Transform",
-          "line": 8135,
+          "line": 8184,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10447,7 +10513,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 8136,
+          "line": 8185,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10455,7 +10521,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 8137,
+          "line": 8186,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10555,13 +10621,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9168,
+      "line": 9220,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 9172,
+          "line": 9224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -10572,7 +10638,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 9175,
+          "line": 9227,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -10792,13 +10858,13 @@
     },
     "FilterProp": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1903,
+      "line": 1926,
       "doc": "Individual filter properties that can be combined in a Typed filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Token",
-          "line": 1905,
+          "line": 1928,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are tokens.",
@@ -10808,7 +10874,7 @@
         },
         {
           "name": "NonToken",
-          "line": 1907,
+          "line": 1930,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are not tokens.",
@@ -10818,7 +10884,7 @@
         },
         {
           "name": "Attacking",
-          "line": 1908,
+          "line": 1931,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10826,7 +10892,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1910,
+          "line": 1933,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Matches creatures that are blocking.",
@@ -10836,7 +10902,7 @@
         },
         {
           "name": "BlockingSource",
-          "line": 1913,
+          "line": 1936,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g: Matches creatures currently blocking the filter source. Used for \"creature(s) blocking it\" source-relative quantities and filters.",
@@ -10846,7 +10912,7 @@
         },
         {
           "name": "CombatRelation",
-          "line": 1916,
+          "line": 1939,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -10859,7 +10925,7 @@
         },
         {
           "name": "Unblocked",
-          "line": 1921,
+          "line": 1944,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Matches attacking creatures with no blockers assigned.",
@@ -10869,7 +10935,7 @@
         },
         {
           "name": "Tapped",
-          "line": 1922,
+          "line": 1945,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10877,7 +10943,7 @@
         },
         {
           "name": "Untapped",
-          "line": 1924,
+          "line": 1947,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 / CR 110.5: Untapped status as targeting qualifier.",
@@ -10888,7 +10954,7 @@
         },
         {
           "name": "WithKeyword",
-          "line": 1925,
+          "line": 1948,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10898,7 +10964,7 @@
         },
         {
           "name": "HasKeywordKind",
-          "line": 1928,
+          "line": 1951,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10908,7 +10974,7 @@
         },
         {
           "name": "WithoutKeyword",
-          "line": 1933,
+          "line": 1956,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10920,7 +10986,7 @@
         },
         {
           "name": "WithoutKeywordKind",
-          "line": 1936,
+          "line": 1959,
           "kind": "struct",
           "field_names": [
             "value"
@@ -10930,7 +10996,7 @@
         },
         {
           "name": "CanEnchant",
-          "line": 1944,
+          "line": 1967,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10943,7 +11009,7 @@
         },
         {
           "name": "Counters",
-          "line": 1954,
+          "line": 1977,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -10957,7 +11023,7 @@
         },
         {
           "name": "Cmc",
-          "line": 1964,
+          "line": 1987,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -10970,7 +11036,7 @@
         },
         {
           "name": "ManaCostIn",
-          "line": 1971,
+          "line": 1994,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -10983,7 +11049,7 @@
         },
         {
           "name": "InZone",
-          "line": 1974,
+          "line": 1997,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -10993,7 +11059,7 @@
         },
         {
           "name": "Owned",
-          "line": 1977,
+          "line": 2000,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -11003,7 +11069,7 @@
         },
         {
           "name": "Foretold",
-          "line": 1983,
+          "line": 2006,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c-d: Matches cards in exile that have the foretold designation. This is a status of the exiled card, not equivalent to having the Foretell keyword or a generic exile casting permission.",
@@ -11013,7 +11079,7 @@
         },
         {
           "name": "EnchantedBy",
-          "line": 1984,
+          "line": 2007,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11021,7 +11087,7 @@
         },
         {
           "name": "EquippedBy",
-          "line": 1985,
+          "line": 2008,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11029,7 +11095,7 @@
         },
         {
           "name": "AttachedToSource",
-          "line": 1991,
+          "line": 2014,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the matched object's `attached_to` field equals the filter source's object ID. Inverse of `EnchantedBy`/`EquippedBy`, which check whether the source has an attachment. Used for \"Aura and Equipment attached to ~\" quantity clauses (Kellan, the Fae-Blooded) and for any compound filter whose subject is \"attached to <self>\".",
@@ -11040,7 +11106,7 @@
         },
         {
           "name": "AttachedToRecipient",
-          "line": 2005,
+          "line": 2028,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4 + CR 613.4c: True when the matched object's `attached_to` field equals the *recipient* of the resolving effect (the per-object `id` in a layer's affected list). Distinct from `AttachedToSource` — for an Aura/Equipment static \"Enchanted/Equipped creature gets +N/+M for each X attached to it\", the pronoun \"it\" refers to the affected creature, not to the static's source object. The recipient is supplied through `FilterContext::recipient_id`; when recipient is unknown (no per-recipient context), this prop evaluates to false. Covers ~25 cards: Strong Back, Mantle of the Ancients, Auramancer's Guise, Champion of the Flame, Bruenor Battlehammer's \"Each creature you control gets +2/+0 for each Equipment attached to it\", and the broader \"<subject> gets +N/+M for each Aura/Equipment attached to it\" family.",
@@ -11052,7 +11118,7 @@
         },
         {
           "name": "HasAttachment",
-          "line": 2017,
+          "line": 2040,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -11066,7 +11132,7 @@
         },
         {
           "name": "HasAnyAttachmentOf",
-          "line": 2028,
+          "line": 2051,
           "kind": "struct",
           "field_names": [
             "kinds",
@@ -11080,7 +11146,7 @@
         },
         {
           "name": "Another",
-          "line": 2034,
+          "line": 2057,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches any object that is NOT the trigger source (for \"another creature\" triggers).",
@@ -11088,7 +11154,7 @@
         },
         {
           "name": "Unpaired",
-          "line": 2036,
+          "line": 2059,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Matches objects that are not paired with another creature.",
@@ -11098,7 +11164,7 @@
         },
         {
           "name": "OtherThanTriggerObject",
-          "line": 2045,
+          "line": 2068,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 109.3: Matches any object that is NOT the object that caused the currently-evaluating trigger to fire (the \"triggering object\"). Distinct from `Another`, which excludes the *ability source*. Used for intervening-if count predicates like Valakut, the Molten Pinnacle's \"if you control at least five other Mountains\" — here \"other\" means \"other than the newly- entered Mountain,\" not \"other than Valakut.\" Resolves against `FilterContext::triggering_object_id`, populated at trigger-condition evaluation from the current `GameEvent`.",
@@ -11109,7 +11175,7 @@
         },
         {
           "name": "HasColor",
-          "line": 2047,
+          "line": 2070,
           "kind": "struct",
           "field_names": [
             "color"
@@ -11119,7 +11185,7 @@
         },
         {
           "name": "PtComparison",
-          "line": 2074,
+          "line": 2097,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -11137,7 +11203,7 @@
         },
         {
           "name": "PowerGTSource",
-          "line": 2083,
+          "line": 2106,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: Matches objects whose power is strictly greater than the source object's power. Used for \"creatures with greater power\" blocking restrictions (relative comparison).",
@@ -11147,7 +11213,7 @@
         },
         {
           "name": "ColorCount",
-          "line": 2087,
+          "line": 2110,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -11160,7 +11226,7 @@
         },
         {
           "name": "HasSupertype",
-          "line": 2092,
+          "line": 2115,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11170,7 +11236,7 @@
         },
         {
           "name": "IsChosenCreatureType",
-          "line": 2097,
+          "line": 2120,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose subtypes include the source object's chosen creature type. Used for \"of the chosen type\" patterns (Cavern of Souls, Metallic Mimic).",
@@ -11178,7 +11244,7 @@
         },
         {
           "name": "MostPrevalentCreatureTypeIn",
-          "line": 2110,
+          "line": 2133,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -11192,7 +11258,7 @@
         },
         {
           "name": "IsChosenColor",
-          "line": 2119,
+          "line": 2142,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose colors include the source object's chosen color. Used for \"of the chosen color\" patterns (Hall of Triumph, Runed Stalactite). Reads `ChosenAttribute::Color` from the source permanent.",
@@ -11200,7 +11266,7 @@
         },
         {
           "name": "IsChosenCardType",
-          "line": 2123,
+          "line": 2146,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose core type includes the source object's chosen card type. Used for \"spells of the chosen type\" patterns (Archon of Valor's Reach). Reads `ChosenAttribute::CardType` from the source permanent.",
@@ -11208,7 +11274,7 @@
         },
         {
           "name": "IsChosenLandOrNonlandKind",
-          "line": 2128,
+          "line": 2151,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.2 + CR 608.2c: Matches objects by the transient \"land or nonland\" choice made earlier in the same resolving instruction sequence. Used by \"of the chosen kind\" library filters, where \"Land\" means cards with the land card type and \"Nonland\" means cards without it.",
@@ -11219,7 +11285,7 @@
         },
         {
           "name": "HasSingleTarget",
-          "line": 2131,
+          "line": 2154,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.7: Matches stack entries that have exactly one target. Used for \"with a single target\" qualifiers on retarget effects.",
@@ -11229,7 +11295,7 @@
         },
         {
           "name": "NotColor",
-          "line": 2134,
+          "line": 2157,
           "kind": "struct",
           "field_names": [
             "color"
@@ -11241,7 +11307,7 @@
         },
         {
           "name": "NotSupertype",
-          "line": 2139,
+          "line": 2162,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11253,7 +11319,7 @@
         },
         {
           "name": "Suspected",
-          "line": 2143,
+          "line": 2166,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.60b: Matches suspected creatures.",
@@ -11263,7 +11329,7 @@
         },
         {
           "name": "Renowned",
-          "line": 2145,
+          "line": 2168,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112b: Matches permanents with the renowned designation.",
@@ -11273,7 +11339,7 @@
         },
         {
           "name": "ToughnessGTPower",
-          "line": 2147,
+          "line": 2170,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: Matches creatures whose toughness is greater than their power.",
@@ -11283,7 +11349,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 2154,
+          "line": 2177,
           "kind": "struct",
           "field_names": [
             "props"
@@ -11293,7 +11359,7 @@
         },
         {
           "name": "Modified",
-          "line": 2166,
+          "line": 2189,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.9: A permanent is modified if it has one or more counters on it (CR 122), if it is equipped (CR 301.5), or if it is enchanted by an Aura that is controlled by that permanent's controller (CR 303.4).  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.9 names \"modified\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Modified` for \"modified creature(s)\" subjects, analogous to how `FilterProp::Suspected` models CR 701.60b's \"suspected\" status.",
@@ -11307,7 +11373,7 @@
         },
         {
           "name": "Historic",
-          "line": 2176,
+          "line": 2199,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: An object is historic if it has the legendary supertype, the artifact card type, or the Saga subtype.  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.6 names \"historic\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Historic` for \"historic permanent\" / \"historic spell\" / \"historic card\" subjects, mirroring `FilterProp::Modified` for CR 700.9's \"modified\" predicate.",
@@ -11318,7 +11384,7 @@
         },
         {
           "name": "DifferentNameFrom",
-          "line": 2180,
+          "line": 2203,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -11328,7 +11394,7 @@
         },
         {
           "name": "InAnyZone",
-          "line": 2185,
+          "line": 2208,
           "kind": "struct",
           "field_names": [
             "zones"
@@ -11340,7 +11406,7 @@
         },
         {
           "name": "SharesQuality",
-          "line": 2191,
+          "line": 2214,
           "kind": "struct",
           "field_names": [
             "quality",
@@ -11352,7 +11418,7 @@
         },
         {
           "name": "WasDealtDamageThisTurn",
-          "line": 2200,
+          "line": 2223,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1: Object was dealt damage during this turn. Checks `damage_marked > 0` (damage persists until cleanup step).",
@@ -11362,7 +11428,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2203,
+          "line": 2226,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: Object entered the battlefield during this turn. Checks `entered_battlefield_turn == Some(current_turn)`.",
@@ -11372,7 +11438,7 @@
         },
         {
           "name": "ZoneChangedThisTurn",
-          "line": 2208,
+          "line": 2231,
           "kind": "struct",
           "field_names": [
             "from",
@@ -11386,7 +11452,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 2216,
+          "line": 2239,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Creature was declared as an attacker this turn. Checks `creatures_attacked_this_turn` tracking set on GameState.",
@@ -11396,7 +11462,7 @@
         },
         {
           "name": "BlockedThisTurn",
-          "line": 2219,
+          "line": 2242,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Creature was declared as a blocker this turn. Checks `creatures_blocked_this_turn` tracking set on GameState.",
@@ -11406,7 +11472,7 @@
         },
         {
           "name": "AttackedOrBlockedThisTurn",
-          "line": 2222,
+          "line": 2245,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a + CR 509.1a: Creature attacked or blocked this turn. Compound check used by \"that attacked or blocked this turn\" Oracle text.",
@@ -11417,7 +11483,7 @@
         },
         {
           "name": "FaceDown",
-          "line": 2225,
+          "line": 2248,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.2: Matches face-down objects on the battlefield. Used for \"face-down creature\" trigger subjects.",
@@ -11427,7 +11493,7 @@
         },
         {
           "name": "TargetsOnly",
-          "line": 2230,
+          "line": 2253,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -11439,7 +11505,7 @@
         },
         {
           "name": "Targets",
-          "line": 2236,
+          "line": 2259,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -11452,7 +11518,7 @@
         },
         {
           "name": "HasXInManaCost",
-          "line": 2245,
+          "line": 2268,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 202.1: Matches spells/objects whose printed mana cost contains an `{X}` shard. Used for \"spell with {X} in its mana cost\" qualifier on spell-cast triggers (Lattice Library, Nev the Practical Dean, Owlin Spiralmancer, Brass Infiniscope, Elementalist's Palette). Evaluated against `SpellCastRecord.has_x_in_cost` in the spell-history filter path and against `cost_has_x(&obj.mana_cost)` for live objects.",
@@ -11463,7 +11529,7 @@
         },
         {
           "name": "HasManaAbility",
-          "line": 2249,
+          "line": 2272,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1: Matches objects that have at least one ability classified as a mana ability by the engine's authoritative mana-ability classifier. Used for library filters such as \"artifact card with a mana ability\".",
@@ -11473,7 +11539,7 @@
         },
         {
           "name": "HasNoAbilities",
-          "line": 2253,
+          "line": 2276,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.1 + CR 113.3: Matches objects that currently have no abilities: no keyword, activated, triggered, replacement, or static abilities. Used for library filters such as \"creature card with no abilities\".",
@@ -11484,7 +11550,7 @@
         },
         {
           "name": "Named",
-          "line": 2257,
+          "line": 2280,
           "kind": "struct",
           "field_names": [
             "name"
@@ -11497,7 +11563,7 @@
         },
         {
           "name": "SameName",
-          "line": 2262,
+          "line": 2285,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects with the same name as a previously-referenced card. Used for \"search your library for a card with that name\" patterns.",
@@ -11505,7 +11571,7 @@
         },
         {
           "name": "SameNameAsParentTarget",
-          "line": 2275,
+          "line": 2298,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: Matches objects whose name equals the name of the resolving ability's first object target. Used by chained sub-abilities where a prior step targeted/exiled a card and the next step references \"cards with that name\" — e.g., Deadly Cover-Up's \"search ... for any number of cards with that name and exile them\" (the \"that name\" is the name of the card exiled by the immediately preceding effect, which is inherited as the first target via `TargetFilter::ParentTarget`).  Differs from `SameName` (which reads the source object's name): this reads from `ability.targets[0]` when that target is `TargetRef::Object`, looking up the name from `state.objects` (or `lki_cache` if the target has already left its zone).",
@@ -11515,7 +11581,7 @@
         },
         {
           "name": "NameMatchesAnyPermanent",
-          "line": 2282,
+          "line": 2305,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -11528,7 +11594,7 @@
         },
         {
           "name": "AttackingController",
-          "line": 2288,
+          "line": 2311,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1b: Matches attacking creatures whose defending player equals the filter's source controller (\"creatures attacking you\"). Distinct from `Attacking`, which matches any attacker regardless of defender.",
@@ -11538,7 +11604,7 @@
         },
         {
           "name": "IsCommander",
-          "line": 2295,
+          "line": 2318,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 903.3d: Matches permanents on the battlefield that are a commander. Reads `GameObject::is_commander`, set during deck construction per CR 903.3 (the legendary card designated as that deck's commander). Used for \"commander(s) you control\", \"your commander\" subject phrases and for \"target commander\" in commander-format effects (Codsworth, Falthis, Anara, Champions of Archery, etc.).",
@@ -11549,7 +11615,7 @@
         },
         {
           "name": "Other",
-          "line": 2296,
+          "line": 2319,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11647,13 +11713,13 @@
     },
     "GameAction": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 109,
+      "line": 110,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "PassPriority",
-          "line": 110,
+          "line": 111,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11661,7 +11727,7 @@
         },
         {
           "name": "PlayLand",
-          "line": 111,
+          "line": 112,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11672,7 +11738,7 @@
         },
         {
           "name": "CastSpell",
-          "line": 115,
+          "line": 116,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11684,7 +11750,7 @@
         },
         {
           "name": "CastSpellWithPaymentMode",
-          "line": 120,
+          "line": 121,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11697,7 +11763,7 @@
         },
         {
           "name": "Foretell",
-          "line": 130,
+          "line": 131,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11710,7 +11776,7 @@
         },
         {
           "name": "ActivateAbility",
-          "line": 134,
+          "line": 135,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -11721,7 +11787,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 138,
+          "line": 139,
           "kind": "struct",
           "field_names": [
             "attacks"
@@ -11731,7 +11797,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 141,
+          "line": 142,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -11741,7 +11807,7 @@
         },
         {
           "name": "ChooseUntap",
-          "line": 146,
+          "line": 147,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11754,7 +11820,7 @@
         },
         {
           "name": "ChooseExert",
-          "line": 153,
+          "line": 154,
           "kind": "struct",
           "field_names": [
             "exert"
@@ -11766,8 +11832,20 @@
           ]
         },
         {
+          "name": "ChooseClashOpponent",
+          "line": 160,
+          "kind": "struct",
+          "field_names": [
+            "opponent"
+          ],
+          "doc": "CR 701.30b: The clashing player's choice of which opponent to clash with, answering a pending `WaitingFor::ClashChooseOpponent`. `opponent` must be one of that prompt's `candidates`.",
+          "cr_refs": [
+            "CR 701.30b"
+          ]
+        },
+        {
           "name": "MulliganDecision",
-          "line": 158,
+          "line": 165,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -11779,7 +11857,7 @@
         },
         {
           "name": "ReorderHand",
-          "line": 170,
+          "line": 177,
           "kind": "struct",
           "field_names": [
             "order"
@@ -11791,7 +11869,7 @@
         },
         {
           "name": "TapLandForMana",
-          "line": 173,
+          "line": 180,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -11801,7 +11879,7 @@
         },
         {
           "name": "UntapLandForMana",
-          "line": 178,
+          "line": 185,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -11813,7 +11891,7 @@
         },
         {
           "name": "SelectCards",
-          "line": 181,
+          "line": 188,
           "kind": "struct",
           "field_names": [
             "cards"
@@ -11823,7 +11901,7 @@
         },
         {
           "name": "ChooseOutsideGameCards",
-          "line": 187,
+          "line": 194,
           "kind": "struct",
           "field_names": [
             "selections"
@@ -11836,7 +11914,7 @@
         },
         {
           "name": "SelectTargets",
-          "line": 190,
+          "line": 197,
           "kind": "struct",
           "field_names": [
             "targets"
@@ -11846,7 +11924,7 @@
         },
         {
           "name": "ChooseTarget",
-          "line": 193,
+          "line": 200,
           "kind": "struct",
           "field_names": [
             "target"
@@ -11856,7 +11934,7 @@
         },
         {
           "name": "ChooseReplacement",
-          "line": 196,
+          "line": 203,
           "kind": "struct",
           "field_names": [
             "index"
@@ -11866,7 +11944,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 203,
+          "line": 210,
           "kind": "struct",
           "field_names": [
             "order"
@@ -11879,7 +11957,7 @@
         },
         {
           "name": "CancelCast",
-          "line": 206,
+          "line": 213,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11887,7 +11965,7 @@
         },
         {
           "name": "Equip",
-          "line": 207,
+          "line": 214,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -11898,7 +11976,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 214,
+          "line": 221,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -11911,7 +11989,7 @@
         },
         {
           "name": "ActivateStation",
-          "line": 222,
+          "line": 229,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -11924,7 +12002,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 231,
+          "line": 238,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -11937,7 +12015,7 @@
         },
         {
           "name": "Transform",
-          "line": 235,
+          "line": 242,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -11947,7 +12025,7 @@
         },
         {
           "name": "PlayFaceDown",
-          "line": 238,
+          "line": 245,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -11958,7 +12036,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 242,
+          "line": 249,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -11968,7 +12046,7 @@
         },
         {
           "name": "SubmitSideboard",
-          "line": 245,
+          "line": 252,
           "kind": "struct",
           "field_names": [
             "main",
@@ -11979,7 +12057,7 @@
         },
         {
           "name": "ChoosePlayDraw",
-          "line": 249,
+          "line": 256,
           "kind": "struct",
           "field_names": [
             "play_first"
@@ -11989,7 +12067,7 @@
         },
         {
           "name": "ChooseOption",
-          "line": 252,
+          "line": 259,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -11999,7 +12077,7 @@
         },
         {
           "name": "SubmitPilePartition",
-          "line": 261,
+          "line": 268,
           "kind": "struct",
           "field_names": [
             "pile_a"
@@ -12013,7 +12091,7 @@
         },
         {
           "name": "ChoosePile",
-          "line": 268,
+          "line": 275,
           "kind": "struct",
           "field_names": [
             "pile"
@@ -12025,7 +12103,7 @@
         },
         {
           "name": "ChooseBranch",
-          "line": 272,
+          "line": 279,
           "kind": "struct",
           "field_names": [
             "index"
@@ -12037,7 +12115,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 276,
+          "line": 283,
           "kind": "struct",
           "field_names": [
             "source"
@@ -12049,7 +12127,7 @@
         },
         {
           "name": "SelectModes",
-          "line": 279,
+          "line": 286,
           "kind": "struct",
           "field_names": [
             "indices"
@@ -12059,7 +12137,7 @@
         },
         {
           "name": "DecideOptionalCost",
-          "line": 282,
+          "line": 289,
           "kind": "struct",
           "field_names": [
             "pay"
@@ -12069,7 +12147,7 @@
         },
         {
           "name": "ChooseAdventureFace",
-          "line": 286,
+          "line": 293,
           "kind": "struct",
           "field_names": [
             "creature"
@@ -12081,7 +12159,7 @@
         },
         {
           "name": "ChooseModalFace",
-          "line": 290,
+          "line": 297,
           "kind": "struct",
           "field_names": [
             "back_face"
@@ -12093,7 +12171,7 @@
         },
         {
           "name": "ChooseAlternativeCast",
-          "line": 300,
+          "line": 307,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -12108,7 +12186,7 @@
         },
         {
           "name": "ChooseCastingVariant",
-          "line": 305,
+          "line": 312,
           "kind": "struct",
           "field_names": [
             "index"
@@ -12120,7 +12198,7 @@
         },
         {
           "name": "KeepAllCopyTargets",
-          "line": 311,
+          "line": 318,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.10c: Resolve a `WaitingFor::CopyRetarget` by leaving every remaining slot's target unchanged. Single action so the UI can offer \"Keep Current Targets\" without N round-trips through `ChooseTarget`.",
@@ -12130,7 +12208,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 314,
+          "line": 321,
           "kind": "struct",
           "field_names": [
             "slot"
@@ -12142,7 +12220,7 @@
         },
         {
           "name": "ActivateNinjutsu",
-          "line": 318,
+          "line": 325,
           "kind": "struct",
           "field_names": [
             "ninjutsu_object_id",
@@ -12155,7 +12233,7 @@
         },
         {
           "name": "CastSpellAsSneak",
-          "line": 336,
+          "line": 343,
           "kind": "struct",
           "field_names": [
             "hand_object",
@@ -12170,7 +12248,7 @@
         },
         {
           "name": "CastSpellAsSneakWithPaymentMode",
-          "line": 341,
+          "line": 348,
           "kind": "struct",
           "field_names": [
             "hand_object",
@@ -12183,7 +12261,7 @@
         },
         {
           "name": "CastSpellAsWebSlinging",
-          "line": 349,
+          "line": 356,
           "kind": "struct",
           "field_names": [
             "hand_object",
@@ -12197,7 +12275,7 @@
         },
         {
           "name": "CastSpellAsWebSlingingWithPaymentMode",
-          "line": 354,
+          "line": 361,
           "kind": "struct",
           "field_names": [
             "hand_object",
@@ -12210,7 +12288,7 @@
         },
         {
           "name": "CastSpellForFree",
-          "line": 370,
+          "line": 377,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12225,7 +12303,7 @@
         },
         {
           "name": "CastSpellForFreeWithPaymentMode",
-          "line": 375,
+          "line": 382,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12238,7 +12316,7 @@
         },
         {
           "name": "CastSpellAsMiracle",
-          "line": 386,
+          "line": 393,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12252,7 +12330,7 @@
         },
         {
           "name": "CastSpellAsMiracleWithPaymentMode",
-          "line": 390,
+          "line": 397,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12264,7 +12342,7 @@
         },
         {
           "name": "CastSpellAsMadness",
-          "line": 398,
+          "line": 405,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12277,7 +12355,7 @@
         },
         {
           "name": "CastSpellAsMadnessWithPaymentMode",
-          "line": 402,
+          "line": 409,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12289,7 +12367,7 @@
         },
         {
           "name": "DecideOptionalEffect",
-          "line": 408,
+          "line": 415,
           "kind": "struct",
           "field_names": [
             "accept"
@@ -12301,7 +12379,7 @@
         },
         {
           "name": "DecideOptionalEffectAndRemember",
-          "line": 411,
+          "line": 418,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -12311,7 +12389,7 @@
         },
         {
           "name": "PayUnlessCost",
-          "line": 415,
+          "line": 422,
           "kind": "struct",
           "field_names": [
             "pay"
@@ -12323,7 +12401,7 @@
         },
         {
           "name": "ChooseUnlessCostBranch",
-          "line": 423,
+          "line": 430,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -12335,7 +12413,7 @@
         },
         {
           "name": "ChooseActivationCostBranch",
-          "line": 427,
+          "line": 434,
           "kind": "struct",
           "field_names": [
             "index"
@@ -12347,7 +12425,7 @@
         },
         {
           "name": "PayCombatTax",
-          "line": 435,
+          "line": 442,
           "kind": "struct",
           "field_names": [
             "accept"
@@ -12362,7 +12440,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 439,
+          "line": 446,
           "kind": "struct",
           "field_names": [
             "target"
@@ -12374,7 +12452,7 @@
         },
         {
           "name": "ChoosePair",
-          "line": 444,
+          "line": 451,
           "kind": "struct",
           "field_names": [
             "partner"
@@ -12387,7 +12465,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 448,
+          "line": 455,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -12399,7 +12477,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 452,
+          "line": 459,
           "kind": "struct",
           "field_names": [
             "room_index"
@@ -12411,7 +12489,7 @@
         },
         {
           "name": "UnlockRoomDoor",
-          "line": 456,
+          "line": 463,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12424,7 +12502,7 @@
         },
         {
           "name": "TapForConvoke",
-          "line": 462,
+          "line": 469,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -12438,7 +12516,7 @@
         },
         {
           "name": "HarmonizeTap",
-          "line": 468,
+          "line": 475,
           "kind": "struct",
           "field_names": [
             "creature_id"
@@ -12450,7 +12528,7 @@
         },
         {
           "name": "DeclareCompanion",
-          "line": 472,
+          "line": 479,
           "kind": "struct",
           "field_names": [
             "card_index"
@@ -12462,7 +12540,7 @@
         },
         {
           "name": "CompanionToHand",
-          "line": 477,
+          "line": 484,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.139a: Pay {3} to put companion into hand (special action, see rule 116.2g).",
@@ -12472,7 +12550,7 @@
         },
         {
           "name": "DiscoverChoice",
-          "line": 479,
+          "line": 486,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -12484,7 +12562,7 @@
         },
         {
           "name": "CascadeChoice",
-          "line": 483,
+          "line": 490,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -12496,7 +12574,7 @@
         },
         {
           "name": "ChooseTopOrBottom",
-          "line": 487,
+          "line": 494,
           "kind": "struct",
           "field_names": [
             "top"
@@ -12508,7 +12586,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 491,
+          "line": 498,
           "kind": "struct",
           "field_names": [
             "keep"
@@ -12520,7 +12598,7 @@
         },
         {
           "name": "ChooseBattleProtector",
-          "line": 496,
+          "line": 503,
           "kind": "struct",
           "field_names": [
             "protector"
@@ -12534,7 +12612,7 @@
         },
         {
           "name": "SetAutoPass",
-          "line": 500,
+          "line": 507,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -12546,7 +12624,7 @@
         },
         {
           "name": "CancelAutoPass",
-          "line": 504,
+          "line": 511,
           "kind": "unit",
           "field_names": [],
           "doc": "Cancel any active auto-pass for the acting player.",
@@ -12554,7 +12632,7 @@
         },
         {
           "name": "SetPhaseStops",
-          "line": 509,
+          "line": 516,
           "kind": "struct",
           "field_names": [
             "stops"
@@ -12564,7 +12642,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 514,
+          "line": 521,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -12579,7 +12657,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 524,
+          "line": 531,
           "kind": "struct",
           "field_names": [
             "distribution"
@@ -12591,7 +12669,7 @@
         },
         {
           "name": "ChooseCounterMoveDistribution",
-          "line": 528,
+          "line": 535,
           "kind": "struct",
           "field_names": [
             "selections"
@@ -12604,7 +12682,7 @@
         },
         {
           "name": "SubmitPayAmount",
-          "line": 534,
+          "line": 541,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -12617,7 +12695,7 @@
         },
         {
           "name": "RetargetSpell",
-          "line": 538,
+          "line": 545,
           "kind": "struct",
           "field_names": [
             "new_targets"
@@ -12629,7 +12707,7 @@
         },
         {
           "name": "LearnDecision",
-          "line": 542,
+          "line": 549,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -12641,7 +12719,7 @@
         },
         {
           "name": "SelectCategoryPermanents",
-          "line": 548,
+          "line": 555,
           "kind": "struct",
           "field_names": [
             "choices"
@@ -12654,7 +12732,7 @@
         },
         {
           "name": "ChooseX",
-          "line": 554,
+          "line": 561,
           "kind": "struct",
           "field_names": [
             "value"
@@ -12667,7 +12745,7 @@
         },
         {
           "name": "SubmitPhyrexianChoices",
-          "line": 560,
+          "line": 567,
           "kind": "struct",
           "field_names": [
             "choices"
@@ -12680,7 +12758,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 574,
+          "line": 581,
           "kind": "struct",
           "field_names": [
             "choice",
@@ -12695,7 +12773,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 584,
+          "line": 591,
           "kind": "struct",
           "field_names": [
             "payment"
@@ -12709,7 +12787,7 @@
         },
         {
           "name": "CastPreparedCopy",
-          "line": 593,
+          "line": 600,
           "kind": "struct",
           "field_names": [
             "source"
@@ -12721,7 +12799,7 @@
         },
         {
           "name": "CastParadigmCopy",
-          "line": 600,
+          "line": 607,
           "kind": "struct",
           "field_names": [
             "source"
@@ -12733,7 +12811,7 @@
         },
         {
           "name": "PassParadigmOffer",
-          "line": 607,
+          "line": 614,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — decline the turn-based offer during `WaitingFor::CastOffer` (Paradigm). The exiled source stays in exile and may be offered again next turn. Assign when WotC publishes SOS CR update.",
@@ -12743,7 +12821,7 @@
         },
         {
           "name": "Debug",
-          "line": 611,
+          "line": 618,
           "kind": "tuple",
           "field_names": [],
           "doc": "Debug/remediation action — bypasses WaitingFor validation (like Concede). Gated on `GameState::debug_mode`. Rejected in multiplayer at both the WASM and server-core layers.",
@@ -12751,7 +12829,7 @@
         },
         {
           "name": "GrantDebugPermission",
-          "line": 617,
+          "line": 624,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12761,7 +12839,7 @@
         },
         {
           "name": "RevokeDebugPermission",
-          "line": 623,
+          "line": 630,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -12771,7 +12849,7 @@
         },
         {
           "name": "Concede",
-          "line": 634,
+          "line": 641,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -14321,7 +14399,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8962,
+      "line": 9014,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -14330,7 +14408,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 8965,
+          "line": 9017,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -16025,7 +16103,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11428,
+      "line": 11489,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -16034,7 +16112,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 11430,
+          "line": 11491,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -16047,7 +16125,7 @@
         },
         {
           "name": "Crew",
-          "line": 11436,
+          "line": 11497,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -16060,7 +16138,7 @@
         },
         {
           "name": "Saddle",
-          "line": 11442,
+          "line": 11503,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -16073,7 +16151,7 @@
         },
         {
           "name": "Station",
-          "line": 11450,
+          "line": 11511,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -17184,7 +17262,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9540,
+      "line": 9596,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -17194,7 +17272,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 9542,
+          "line": 9598,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -17204,7 +17282,7 @@
         },
         {
           "name": "Second",
-          "line": 9545,
+          "line": 9601,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -17374,7 +17452,7 @@
     },
     "LayoutKind": {
       "file": "crates/engine/src/types/card.rs",
-      "line": 190,
+      "line": 198,
       "doc": "Runtime layout discriminant for double-faced cards.  Stored on `BackFaceData` so the engine can distinguish Modal DFCs (which allow face-choice per CR 712.12) from Transform DFCs at runtime. Intentionally separate from `database::synthesis::LayoutKind` which is a build-pipeline type without serialization derives.",
       "cr_refs": [
         "CR 712.12"
@@ -17382,7 +17460,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 191,
+          "line": 199,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17390,7 +17468,7 @@
         },
         {
           "name": "Split",
-          "line": 192,
+          "line": 200,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17398,7 +17476,7 @@
         },
         {
           "name": "Flip",
-          "line": 193,
+          "line": 201,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17406,7 +17484,7 @@
         },
         {
           "name": "Transform",
-          "line": 194,
+          "line": 202,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17414,7 +17492,7 @@
         },
         {
           "name": "Meld",
-          "line": 195,
+          "line": 203,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17422,7 +17500,7 @@
         },
         {
           "name": "Adventure",
-          "line": 196,
+          "line": 204,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17430,7 +17508,7 @@
         },
         {
           "name": "Modal",
-          "line": 197,
+          "line": 205,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17438,7 +17516,7 @@
         },
         {
           "name": "Omen",
-          "line": 198,
+          "line": 206,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17446,7 +17524,7 @@
         },
         {
           "name": "Prepare",
-          "line": 203,
+          "line": 211,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) frame mechanic — a two-face card whose face `b` is a \"prepare spell\" (Sorcery/Instant). When face `a` is prepared, a copy of face `b` can be cast. Structurally an Adventure analog. Assign when WotC publishes SOS CR update.",
@@ -17459,7 +17537,7 @@
     },
     "LearnOption": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 642,
+      "line": 649,
       "doc": "CR 701.48a: Learn choice — rummage a specific card, or skip entirely.",
       "cr_refs": [
         "CR 701.48a"
@@ -17467,7 +17545,7 @@
       "variants": [
         {
           "name": "Rummage",
-          "line": 644,
+          "line": 651,
           "kind": "struct",
           "field_names": [
             "card_id"
@@ -17477,7 +17555,7 @@
         },
         {
           "name": "Skip",
-          "line": 646,
+          "line": 653,
           "kind": "unit",
           "field_names": [],
           "doc": "Decline to learn (skip).",
@@ -17488,13 +17566,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5035,
+      "line": 5063,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 5036,
+          "line": 5064,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17502,7 +17580,7 @@
         },
         {
           "name": "Bottom",
-          "line": 5037,
+          "line": 5065,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17510,7 +17588,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 5039,
+          "line": 5067,
           "kind": "struct",
           "field_names": [
             "n"
@@ -18362,7 +18440,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10704,
+      "line": 10765,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -18371,7 +18449,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 10707,
+          "line": 10768,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -18383,7 +18461,7 @@
         },
         {
           "name": "Multiply",
-          "line": 10710,
+          "line": 10771,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -18629,7 +18707,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10716,
+      "line": 10777,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -18638,7 +18716,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10719,
+          "line": 10780,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -18646,7 +18724,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 10721,
+          "line": 10782,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -18775,7 +18853,7 @@
     },
     "ManaSpendPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1548,
+      "line": 1559,
       "doc": "CR 609.4b: Permission modifying how mana may be spent to pay a cost.",
       "cr_refs": [
         "CR 609.4b"
@@ -18783,7 +18861,7 @@
       "variants": [
         {
           "name": "AnyTypeOrColor",
-          "line": 1552,
+          "line": 1563,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana may be spent as though it were mana of any type or color for this payment. This preserves the Oracle distinction without changing the actual mana spent.",
@@ -19057,13 +19135,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8397,
+      "line": 8449,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 8399,
+          "line": 8451,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -19075,7 +19153,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8402,
+          "line": 8454,
           "kind": "struct",
           "field_names": [
             "source",
@@ -19094,13 +19172,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8377,
+      "line": 8429,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 8378,
+          "line": 8430,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19108,7 +19186,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 8381,
+          "line": 8433,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -19123,7 +19201,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 8388,
+          "line": 8440,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -19133,7 +19211,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 8391,
+          "line": 8443,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -19146,7 +19224,7 @@
     },
     "MulliganChoice": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 51,
+      "line": 52,
       "doc": "CR 103.5 + Serum Powder Oracle text: Player decision at a `MulliganDecision` prompt. The three branches correspond to the three actions a player can take while still pending in the mulligan-decision phase: - `Keep` — lock in the current opening hand (CR 103.5). - `Mulligan` — shuffle the hand back, redraw the starting hand size, and   remain pending (CR 103.5). - `UseSerumPowder` — exile every card in hand and redraw the same number,   without taking a mulligan and without incrementing the mulligan counter.   Only available when `object_id` references a card named \"Serum Powder\" in   the actor's hand (CR 103.5b and Serum Powder Oracle text). The player   remains pending and may keep, mulligan, or use another Serum Powder next.",
       "cr_refs": [
         "CR 103.5",
@@ -19155,14 +19233,6 @@
       "variants": [
         {
           "name": "Keep",
-          "line": 52,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Mulligan",
           "line": 53,
           "kind": "unit",
           "field_names": [],
@@ -19170,8 +19240,16 @@
           "cr_refs": []
         },
         {
+          "name": "Mulligan",
+          "line": 54,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "UseSerumPowder",
-          "line": 56,
+          "line": 57,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -19223,7 +19301,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4322,
+      "line": 4350,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -19233,7 +19311,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4324,
+          "line": 4352,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -19243,7 +19321,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4326,
+          "line": 4354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -19256,13 +19334,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3288,
+      "line": 3316,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 3289,
+          "line": 3317,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19270,7 +19348,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3290,
+          "line": 3318,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19278,7 +19356,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 3291,
+          "line": 3319,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19289,13 +19367,13 @@
     },
     "ObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2704,
+      "line": 2727,
       "doc": "Scope selector for object-axis quantities (Round Π-5). Picks WHICH object to read from when a `QuantityRef` (and future per-object conditions) is per-object. Mirrors `PlayerScope` for the player axis.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 2710,
+          "line": 2733,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.7 + CR 113.7a: The source object of the resolving ability — \"this creature\", \"~\", \"it\" (when \"it\" anaphors back to the source). CR 113.7 defines the source as the object that generated the ability; CR 113.7a keeps the ability (and thus its source reference) valid on the stack even after the source leaves its expected zone, via LKI.",
@@ -19306,7 +19384,7 @@
         },
         {
           "name": "Target",
-          "line": 2713,
+          "line": 2736,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The first object target of the resolving ability — \"that creature\", \"the creature\", \"it\" (when \"it\" anaphors back to a target).",
@@ -19316,7 +19394,7 @@
         },
         {
           "name": "Recipient",
-          "line": 2719,
+          "line": 2742,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4c + CR 115.10: The object currently receiving an effect. In layer evaluation this is the per-object recipient. Outside layers, it resolves to the first object target when present, then to the source. Used for recipient-relative \"its colors\" boosts such as Blessing of the Nephilim and Civic Saber.",
@@ -19327,7 +19405,7 @@
         },
         {
           "name": "EventSource",
-          "line": 2721,
+          "line": 2744,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: The object referenced by the current trigger event.",
@@ -19337,7 +19415,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2728,
+          "line": 2751,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: The specific untargeted object previously referred to by this ability's cost OR trigger condition. Resolved (first match wins) via `ResolvedAbility.cost_paid_object` → trigger-event source → `effect_context_object`. Subsumes the former `EventContextSource*` trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger referent are the two enumerated members of CR 608.2k's single clause).",
@@ -19350,7 +19428,7 @@
         },
         {
           "name": "Anaphoric",
-          "line": 2742,
+          "line": 2765,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: A deferred anaphoric pronoun (\"it\" / \"its\") whose object referent is bound at parse time. The parser remaps this to a concrete scope wherever it can — `Source` when the clause subject is the ability source, `Target` when the recipient is \"itself\". For triggered abilities no remap applies and `Anaphoric` survives to runtime, where it resolves identically to `CostPaidObject` (behavior-preserving — these cards parsed to `CostPaidObject` before this variant existed). General rules-correct runtime resolution of triggered-ability anaphora (e.g. \"its mana value\" after a reveal — see issue #511) is separate per-card parser work. Distinguishing this from an explicit cost-paid possessive (\"the sacrificed creature's power\", CR 608.2k -> `CostPaidObject`) is what prevents the subject-injection rewrite from clobbering correctly-scoped possessives.",
@@ -19401,7 +19479,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10189,
+      "line": 10250,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -19411,7 +19489,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10191,
+          "line": 10252,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -19419,7 +19497,7 @@
         },
         {
           "name": "Equals",
-          "line": 10193,
+          "line": 10254,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -19427,7 +19505,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 10196,
+          "line": 10257,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -19435,7 +19513,7 @@
         },
         {
           "name": "OneOf",
-          "line": 10198,
+          "line": 10259,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -19483,7 +19561,7 @@
     },
     "OutsideGameSelection": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 100,
+      "line": 101,
       "doc": "CR 400.11 + CR 406.3: One discriminated selection committed for an outside-game choice. The two source pools (sideboard and face-up exile) are expressed as parallel variants so the action wire format is uniform.",
       "cr_refs": [
         "CR 400.11",
@@ -19492,7 +19570,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 102,
+          "line": 103,
           "kind": "struct",
           "field_names": [
             "sideboard_index"
@@ -19504,7 +19582,7 @@
         },
         {
           "name": "FaceUpExile",
-          "line": 104,
+          "line": 105,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -19577,7 +19655,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4042,
+      "line": 4070,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -19586,7 +19664,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 4043,
+          "line": 4071,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -19596,7 +19674,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 4047,
+          "line": 4075,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -19606,7 +19684,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 4048,
+          "line": 4076,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19614,7 +19692,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 4050,
+          "line": 4078,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -19624,7 +19702,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 4051,
+          "line": 4079,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19634,7 +19712,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 4054,
+          "line": 4082,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -19645,7 +19723,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 4058,
+          "line": 4086,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -19655,7 +19733,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 4062,
+          "line": 4090,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -19665,7 +19743,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 4064,
+          "line": 4092,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -19675,7 +19753,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 4065,
+          "line": 4093,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19683,7 +19761,7 @@
         },
         {
           "name": "SourceAttachedTo",
-          "line": 4069,
+          "line": 4097,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -19696,7 +19774,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 4072,
+          "line": 4100,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -19706,7 +19784,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 4075,
+          "line": 4103,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -19716,7 +19794,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 4078,
+          "line": 4106,
           "kind": "struct",
           "field_names": [
             "color"
@@ -19726,7 +19804,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 4081,
+          "line": 4109,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19734,7 +19812,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 4082,
+          "line": 4110,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19742,7 +19820,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 4083,
+          "line": 4111,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19750,7 +19828,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 4084,
+          "line": 4112,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19761,7 +19839,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 4088,
+          "line": 4116,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19772,7 +19850,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 4092,
+          "line": 4120,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -19784,7 +19862,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 4097,
+          "line": 4125,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19794,7 +19872,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 4100,
+          "line": 4128,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19804,7 +19882,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 4103,
+          "line": 4131,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -19814,7 +19892,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 4108,
+          "line": 4136,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19826,7 +19904,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4117,
+          "line": 4145,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -19841,7 +19919,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 4122,
+          "line": 4150,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19851,7 +19929,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 4125,
+          "line": 4153,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -19861,7 +19939,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 4128,
+          "line": 4156,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -19872,7 +19950,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 4132,
+          "line": 4160,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -19883,7 +19961,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 4136,
+          "line": 4164,
           "kind": "struct",
           "field_names": [
             "color",
@@ -19894,7 +19972,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 4140,
+          "line": 4168,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -19904,7 +19982,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 4143,
+          "line": 4171,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19912,7 +19990,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 4144,
+          "line": 4172,
           "kind": "struct",
           "field_names": [
             "name"
@@ -19922,7 +20000,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 4151,
+          "line": 4179,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -19935,7 +20013,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 4155,
+          "line": 4183,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -19945,7 +20023,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 4158,
+          "line": 4186,
           "kind": "struct",
           "field_names": [
             "power",
@@ -19956,7 +20034,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 4162,
+          "line": 4190,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19964,7 +20042,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 4163,
+          "line": 4191,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19974,7 +20052,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 4166,
+          "line": 4194,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19984,7 +20062,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 4169,
+          "line": 4197,
           "kind": "struct",
           "field_names": [
             "count"
@@ -19994,7 +20072,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 4172,
+          "line": 4200,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20002,7 +20080,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 4173,
+          "line": 4201,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20010,7 +20088,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 4174,
+          "line": 4202,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20020,7 +20098,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 4180,
+          "line": 4208,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -20028,7 +20106,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 4183,
+          "line": 4211,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -20041,7 +20119,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 4187,
+          "line": 4215,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20049,7 +20127,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 4188,
+          "line": 4216,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20059,7 +20137,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 4191,
+          "line": 4219,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20067,7 +20145,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 4192,
+          "line": 4220,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20075,7 +20153,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 4193,
+          "line": 4221,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20083,7 +20161,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 4194,
+          "line": 4222,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20091,7 +20169,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 4196,
+          "line": 4224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -20101,7 +20179,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 4197,
+          "line": 4225,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20109,7 +20187,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 4198,
+          "line": 4226,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20117,7 +20195,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 4199,
+          "line": 4227,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20125,7 +20203,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 4200,
+          "line": 4228,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -20136,7 +20214,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 4204,
+          "line": 4232,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20146,7 +20224,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 4209,
+          "line": 4237,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -20159,7 +20237,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4214,
+          "line": 4242,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -20169,7 +20247,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 4222,
+          "line": 4250,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -20179,7 +20257,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 4235,
+          "line": 4263,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -20193,7 +20271,7 @@
         },
         {
           "name": "And",
-          "line": 4243,
+          "line": 4271,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -20206,7 +20284,7 @@
         },
         {
           "name": "Or",
-          "line": 4249,
+          "line": 4277,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -20219,7 +20297,7 @@
         },
         {
           "name": "Not",
-          "line": 4256,
+          "line": 4284,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -20306,7 +20384,7 @@
     },
     "PayCostKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1635,
+      "line": 1637,
       "doc": "CR 118.3 + CR 601.2b + CR 605.3b: Identifies the specific action to take on the objects a player selects while paying a cost.",
       "cr_refs": [
         "CR 118.3",
@@ -20316,22 +20394,6 @@
       "variants": [
         {
           "name": "Discard",
-          "line": 1636,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Sacrifice",
-          "line": 1637,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReturnToHand",
           "line": 1638,
           "kind": "unit",
           "field_names": [],
@@ -20339,8 +20401,24 @@
           "cr_refs": []
         },
         {
-          "name": "ExileFromZone",
+          "name": "Sacrifice",
+          "line": 1639,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ReturnToHand",
           "line": 1640,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExileFromZone",
+          "line": 1642,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -20350,7 +20428,7 @@
         },
         {
           "name": "ExileFromManaZone",
-          "line": 1644,
+          "line": 1646,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -20360,7 +20438,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 1647,
+          "line": 1649,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -20370,7 +20448,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 1650,
+          "line": 1652,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20378,7 +20456,7 @@
         },
         {
           "name": "Behold",
-          "line": 1651,
+          "line": 1653,
           "kind": "struct",
           "field_names": [
             "action"
@@ -20391,7 +20469,7 @@
     },
     "PayableResource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3048,
+      "line": 3066,
       "doc": "CR 107.14 + CR 118.8: Resource that can be paid in a \"pay any amount of X\" prompt. Typed so the same `WaitingFor::PayAmountChoice` variant generalizes to future classes (energy, life, mana) without re-introducing boolean flags.",
       "cr_refs": [
         "CR 107.14",
@@ -20400,7 +20478,7 @@
       "variants": [
         {
           "name": "Energy",
-          "line": 3050,
+          "line": 3068,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.",
@@ -20410,7 +20488,7 @@
         },
         {
           "name": "ManaGeneric",
-          "line": 3052,
+          "line": 3070,
           "kind": "struct",
           "field_names": [
             "per_x"
@@ -20464,7 +20542,7 @@
     },
     "PaymentCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4269,
+      "line": 4297,
       "doc": "CR 118.1: A cost paid as part of an effect's resolution. Distinct from AbilityCost (which gates activation before the colon).",
       "cr_refs": [
         "CR 118.1"
@@ -20472,7 +20550,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 4270,
+          "line": 4298,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20482,7 +20560,7 @@
         },
         {
           "name": "Life",
-          "line": 4278,
+          "line": 4306,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20495,7 +20573,7 @@
         },
         {
           "name": "Speed",
-          "line": 4282,
+          "line": 4310,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20508,7 +20586,7 @@
         },
         {
           "name": "Energy",
-          "line": 4287,
+          "line": 4315,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -20520,7 +20598,7 @@
         },
         {
           "name": "AbilityCost",
-          "line": 4294,
+          "line": 4322,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -20533,7 +20611,7 @@
         },
         {
           "name": "ScaledMana",
-          "line": 4304,
+          "line": 4332,
           "kind": "struct",
           "field_names": [
             "base",
@@ -20550,7 +20628,7 @@
     },
     "PermissionGrantee": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1571,
+      "line": 1582,
       "doc": "CR 611.2a + CR 108.3: Identifies which player a `CastingPermission` is granted to at resolution time. Resolved to a concrete `PlayerId` by `grant_permission::resolve` before the permission is written to the target `GameObject`. Drives both `granted_to` binding and, for durations scoped to that player (e.g., `UntilNextTurnOf`), the prune step in `layers.rs`.  Default is `AbilityController` for all pre-existing parser call sites. Additional variants support compound-exile patterns where multiple objects are granted distinct permissions tied to different players: - `ObjectOwner` — Suspend Aggression: \"its owner may play it\". Each object   in the tracked set is granted to its own owner (CR 108.3). - `ParentTargetController` — Expedited Inheritance: \"its controller may   exile [N] ... They may play those cards\". The grant is tied to the   parent effect's player target rather than the triggered-ability controller.",
       "cr_refs": [
         "CR 108.3",
@@ -20559,7 +20637,7 @@
       "variants": [
         {
           "name": "AbilityController",
-          "line": 1574,
+          "line": 1585,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a default — the controller of the effect that created the grant.",
@@ -20569,7 +20647,7 @@
         },
         {
           "name": "ObjectOwner",
-          "line": 1576,
+          "line": 1587,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 — each iterated object's owner (per-object binding).",
@@ -20579,7 +20657,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 1578,
+          "line": 1589,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 — the player target of the parent effect in the chain.",
@@ -20871,13 +20949,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3368,
+      "line": 3396,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 3372,
+          "line": 3400,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -20887,7 +20965,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3374,
+          "line": 3402,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -20895,7 +20973,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3376,
+          "line": 3404,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -20905,7 +20983,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 3378,
+          "line": 3406,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -20913,7 +20991,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 3380,
+          "line": 3408,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -20921,7 +20999,7 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 3390,
+          "line": 3418,
           "kind": "struct",
           "field_names": [
             "source"
@@ -20936,7 +21014,7 @@
         },
         {
           "name": "OpponentAttackedThisTurn",
-          "line": 3399,
+          "line": 3427,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.6: A player has \"attacked [a player]\" if they declared one or more creatures attacking that player. Each opponent the controller attacked this turn, resolved against `state.attacked_defenders_this_turn[controller]`. Used by \"the number of opponents you attacked this turn\" (Militant Angel). (CR 508.1b: declare-attackers announcement; CR 506.2: active = attacking player.)",
@@ -20948,7 +21026,7 @@
         },
         {
           "name": "OpponentAttackedBySourceThisTurn",
-          "line": 3404,
+          "line": 3432,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.6: Each opponent the ability's source creature attacked this turn. Uses `state.creature_attacked_defenders_this_turn[source_id]` for source-specific text like \"each player this creature attacked this turn\" (Angel of Destiny).",
@@ -20958,7 +21036,7 @@
         },
         {
           "name": "All",
-          "line": 3406,
+          "line": 3434,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -20966,7 +21044,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 3408,
+          "line": 3436,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -20976,7 +21054,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 3411,
+          "line": 3439,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -20984,7 +21062,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 3415,
+          "line": 3443,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -20998,7 +21076,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 3421,
+          "line": 3449,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -21006,7 +21084,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3425,
+          "line": 3453,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -21017,7 +21095,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 3434,
+          "line": 3462,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -21028,7 +21106,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 3445,
+          "line": 3473,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -21041,7 +21119,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3457,
+          "line": 3485,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -21052,7 +21130,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 3478,
+          "line": 3506,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -21068,7 +21146,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 3502,
+          "line": 3530,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -21098,7 +21176,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3356,
+      "line": 3384,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -21108,7 +21186,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 3358,
+          "line": 3386,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -21116,7 +21194,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3360,
+          "line": 3388,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -21124,7 +21202,7 @@
         },
         {
           "name": "All",
-          "line": 3362,
+          "line": 3390,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -21135,7 +21213,7 @@
     },
     "PlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2652,
+      "line": 2675,
       "doc": "CR 102 + CR 119 + CR 402: Player axis for player-scoped quantity references.  Parameterizes the player whose hand size, life total, or other per-player scalar is being read. Replaces sibling enum variants like `LifeTotal` / `TargetLifeTotal` / `OpponentLifeTotal` and `HandSize` / `OpponentHandSize` with a single parameterized form.  Categorical-boundary check (per the \"Parameterize, don't proliferate\" principle): every variant is a player-relativity choice within a single CR section. Aggregate scopes (`Opponent`, `AllPlayers`) compose `AggregateFunction` to express max/min/sum across a population — they do not introduce a new abstraction layer.",
       "cr_refs": [
         "CR 102",
@@ -21145,7 +21223,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 2654,
+          "line": 2677,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 / CR 113.6: The controller of the source ability or effect.",
@@ -21156,7 +21234,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2658,
+          "line": 2681,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This keeps \"their\" quantities separate from \"you\" quantities.",
@@ -21167,7 +21245,7 @@
         },
         {
           "name": "Target",
-          "line": 2661,
+          "line": 2684,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 113.6 + CR 115.1: The first player target of the resolving ability (read from `ability.targets`).",
@@ -21179,7 +21257,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2665,
+          "line": 2688,
           "kind": "struct",
           "field_names": [
             "aggregate"
@@ -21192,7 +21270,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2670,
+          "line": 2693,
           "kind": "struct",
           "field_names": [
             "aggregate",
@@ -21205,7 +21283,7 @@
         },
         {
           "name": "RecipientController",
-          "line": 2684,
+          "line": 2707,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4m + CR 613.4c: The controller of the object currently receiving a layer effect. Used for Aura/Equipment statics such as \"enchanted creature gets +1/+1 for each card in its controller's hand\", where \"its\" refers to the enchanted creature, not the Aura.",
@@ -21216,7 +21294,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2690,
+          "line": 2713,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by attack-trigger intervening-if quantities such as \"no opponent has more life than that player.\"",
@@ -21227,7 +21305,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 2696,
+          "line": 2719,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"that opponent\" anaphoring the controller of a bounced/destroyed creature). The player-scalar-axis analogue of `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -21268,7 +21346,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10822,
+      "line": 10883,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -21277,7 +21355,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 10823,
+          "line": 10884,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21285,7 +21363,7 @@
         },
         {
           "name": "Resolved",
-          "line": 10824,
+          "line": 10885,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -21866,7 +21944,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3686,
+      "line": 3714,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -21874,7 +21952,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 3688,
+          "line": 3716,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -21884,7 +21962,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3690,
+          "line": 3718,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -21894,7 +21972,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 3692,
+          "line": 3720,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -21940,7 +22018,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3701,
+      "line": 3729,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -21949,7 +22027,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 3704,
+          "line": 3732,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -21959,7 +22037,7 @@
         },
         {
           "name": "Base",
-          "line": 3707,
+          "line": 3735,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -21972,13 +22050,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3514,
+      "line": 3542,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 3516,
+          "line": 3544,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -21988,7 +22066,7 @@
         },
         {
           "name": "Fixed",
-          "line": 3518,
+          "line": 3546,
           "kind": "struct",
           "field_names": [
             "value"
@@ -21998,7 +22076,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 3522,
+          "line": 3550,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -22012,7 +22090,7 @@
         },
         {
           "name": "Offset",
-          "line": 3529,
+          "line": 3557,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -22025,7 +22103,7 @@
         },
         {
           "name": "Multiply",
-          "line": 3534,
+          "line": 3562,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -22036,7 +22114,7 @@
         },
         {
           "name": "Sum",
-          "line": 3543,
+          "line": 3571,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -22046,7 +22124,7 @@
         },
         {
           "name": "UpTo",
-          "line": 3568,
+          "line": 3596,
           "kind": "struct",
           "field_names": [
             "max"
@@ -22059,7 +22137,7 @@
         },
         {
           "name": "Power",
-          "line": 3574,
+          "line": 3602,
           "kind": "struct",
           "field_names": [
             "base",
@@ -22072,7 +22150,7 @@
         },
         {
           "name": "Difference",
-          "line": 3589,
+          "line": 3617,
           "kind": "struct",
           "field_names": [
             "left",
@@ -22088,7 +22166,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10670,
+      "line": 10731,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -22096,7 +22174,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 10672,
+          "line": 10733,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -22104,7 +22182,7 @@
         },
         {
           "name": "Plus",
-          "line": 10674,
+          "line": 10735,
           "kind": "struct",
           "field_names": [
             "value"
@@ -22114,7 +22192,7 @@
         },
         {
           "name": "Minus",
-          "line": 10676,
+          "line": 10737,
           "kind": "struct",
           "field_names": [
             "value"
@@ -22124,7 +22202,7 @@
         },
         {
           "name": "Prevent",
-          "line": 10696,
+          "line": 10757,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -22141,13 +22219,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2781,
+      "line": 2804,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 2785,
+          "line": 2808,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22159,7 +22237,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 2788,
+          "line": 2811,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22171,7 +22249,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 2794,
+          "line": 2817,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22183,7 +22261,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 2797,
+          "line": 2820,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -22191,7 +22269,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 2799,
+          "line": 2822,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -22201,7 +22279,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 2802,
+          "line": 2825,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22211,7 +22289,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 2819,
+          "line": 2842,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22225,7 +22303,7 @@
         },
         {
           "name": "ObjectCountBySharedQuality",
-          "line": 2829,
+          "line": 2852,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22240,7 +22318,7 @@
         },
         {
           "name": "PlayerCount",
-          "line": 2836,
+          "line": 2859,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22250,7 +22328,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 2857,
+          "line": 2880,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22263,7 +22341,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 2866,
+          "line": 2889,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -22276,7 +22354,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 2885,
+          "line": 2908,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -22293,7 +22371,7 @@
         },
         {
           "name": "Variable",
-          "line": 2890,
+          "line": 2913,
           "kind": "struct",
           "field_names": [
             "name"
@@ -22303,7 +22381,7 @@
         },
         {
           "name": "Power",
-          "line": 2897,
+          "line": 2920,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22317,7 +22395,7 @@
         },
         {
           "name": "Toughness",
-          "line": 2902,
+          "line": 2925,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22331,7 +22409,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 2908,
+          "line": 2931,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22344,7 +22422,7 @@
         },
         {
           "name": "ObjectColorCount",
-          "line": 2914,
+          "line": 2937,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22357,7 +22435,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 2919,
+          "line": 2942,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -22370,7 +22448,7 @@
         },
         {
           "name": "ManaSymbolsInManaCost",
-          "line": 2926,
+          "line": 2949,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22384,7 +22462,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 2938,
+          "line": 2961,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -22396,7 +22474,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 2940,
+          "line": 2963,
           "kind": "struct",
           "field_names": [
             "function",
@@ -22410,7 +22488,7 @@
         },
         {
           "name": "ControlledByEachPlayer",
-          "line": 2957,
+          "line": 2980,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22424,7 +22502,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 2964,
+          "line": 2987,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22434,7 +22512,7 @@
         },
         {
           "name": "Devotion",
-          "line": 2966,
+          "line": 2989,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -22446,7 +22524,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 2970,
+          "line": 2993,
           "kind": "struct",
           "field_names": [
             "source"
@@ -22458,7 +22536,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 2975,
+          "line": 2998,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -22469,7 +22547,7 @@
         },
         {
           "name": "ZoneCardCount",
-          "line": 2979,
+          "line": 3002,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22483,7 +22561,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 2986,
+          "line": 3009,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -22495,7 +22573,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 2990,
+          "line": 3013,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -22504,8 +22582,21 @@
           ]
         },
         {
+          "name": "FilteredTrackedSetSize",
+          "line": 3018,
+          "kind": "struct",
+          "field_names": [
+            "filter"
+          ],
+          "doc": "CR 608.2c + CR 400.7: Count of members of the most recent tracked set that additionally satisfy the inner filter. Used for \"for each nontoken creature you controlled that was destroyed this way\" patterns where the tracked set holds all affected objects but only a filtered subset is relevant.",
+          "cr_refs": [
+            "CR 400.7",
+            "CR 608.2c"
+          ]
+        },
+        {
           "name": "ExiledFromHandThisResolution",
-          "line": 2996,
+          "line": 3024,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -22516,7 +22607,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 3000,
+          "line": 3028,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -22526,7 +22617,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 3015,
+          "line": 3043,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22539,7 +22630,7 @@
         },
         {
           "name": "PartySize",
-          "line": 3024,
+          "line": 3052,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22552,7 +22643,7 @@
         },
         {
           "name": "Speed",
-          "line": 3031,
+          "line": 3059,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22564,7 +22655,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 3034,
+          "line": 3062,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -22574,7 +22665,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 3042,
+          "line": 3070,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -22588,7 +22679,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 3054,
+          "line": 3082,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -22600,7 +22691,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 3057,
+          "line": 3085,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22613,7 +22704,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 3064,
+          "line": 3092,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22623,7 +22714,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 3070,
+          "line": 3098,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22636,7 +22727,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 3075,
+          "line": 3103,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -22646,7 +22737,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 3081,
+          "line": 3109,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22658,7 +22749,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 3086,
+          "line": 3114,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22670,7 +22761,7 @@
         },
         {
           "name": "LandsPlayedThisTurn",
-          "line": 3090,
+          "line": 3118,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22683,7 +22774,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 3093,
+          "line": 3121,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -22693,7 +22784,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 3097,
+          "line": 3125,
           "kind": "struct",
           "field_names": [
             "from",
@@ -22708,7 +22799,7 @@
         },
         {
           "name": "DamageDealtThisTurn",
-          "line": 3117,
+          "line": 3145,
           "kind": "struct",
           "field_names": [
             "source",
@@ -22725,7 +22816,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 3130,
+          "line": 3158,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -22733,7 +22824,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 3134,
+          "line": 3162,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Number of creatures the controller attacked with this turn. Used for \"if you attacked this turn\" and \"for each creature you attacked with this turn\" patterns.",
@@ -22743,7 +22834,7 @@
         },
         {
           "name": "DescendedThisTurn",
-          "line": 3136,
+          "line": 3164,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -22753,7 +22844,7 @@
         },
         {
           "name": "LoyaltyAbilitiesActivatedThisTurn",
-          "line": 3144,
+          "line": 3172,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22767,7 +22858,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 3147,
+          "line": 3175,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -22777,7 +22868,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 3161,
+          "line": 3189,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22791,7 +22882,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 3172,
+          "line": 3200,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -22806,7 +22897,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 3181,
+          "line": 3209,
           "kind": "struct",
           "field_names": [
             "player"
@@ -22819,7 +22910,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 3186,
+          "line": 3214,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22833,7 +22924,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 3194,
+          "line": 3222,
           "kind": "struct",
           "field_names": [
             "player",
@@ -22847,7 +22938,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 3199,
+          "line": 3227,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -22857,7 +22948,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 3206,
+          "line": 3234,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -22867,7 +22958,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 3209,
+          "line": 3237,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -22878,7 +22969,7 @@
         },
         {
           "name": "AdditionalCostPaymentCount",
-          "line": 3213,
+          "line": 3241,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost payments made for the source spell. Used by Squad so its payment count remains distinct from Kicker's CR 702.33 payment model.",
@@ -22890,7 +22981,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 3217,
+          "line": 3245,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -22900,7 +22991,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 3222,
+          "line": 3250,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -22914,7 +23005,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 3233,
+          "line": 3261,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -22925,7 +23016,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 3238,
+          "line": 3266,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -22935,7 +23026,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 3245,
+          "line": 3273,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22949,7 +23040,7 @@
         },
         {
           "name": "DistinctCounterKindsAmong",
-          "line": 3254,
+          "line": 3282,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22975,20 +23066,12 @@
     },
     "Rarity": {
       "file": "crates/engine/src/types/card.rs",
-      "line": 17,
+      "line": 18,
       "doc": "Card rarity as assigned per-printing in MTGJSON set data.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Common",
-          "line": 18,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Uncommon",
           "line": 19,
           "kind": "unit",
           "field_names": [],
@@ -22996,7 +23079,7 @@
           "cr_refs": []
         },
         {
-          "name": "Rare",
+          "name": "Uncommon",
           "line": 20,
           "kind": "unit",
           "field_names": [],
@@ -23004,7 +23087,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mythic",
+          "name": "Rare",
           "line": 21,
           "kind": "unit",
           "field_names": [],
@@ -23012,7 +23095,7 @@
           "cr_refs": []
         },
         {
-          "name": "Special",
+          "name": "Mythic",
           "line": 22,
           "kind": "unit",
           "field_names": [],
@@ -23020,8 +23103,16 @@
           "cr_refs": []
         },
         {
-          "name": "Bonus",
+          "name": "Special",
           "line": 23,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Bonus",
+          "line": 24,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23032,7 +23123,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8947,
+      "line": 8999,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -23041,7 +23132,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 8951,
+          "line": 9003,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -23054,13 +23145,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9977,
+      "line": 10038,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 9980,
+          "line": 10041,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -23072,7 +23163,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 9986,
+          "line": 10047,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -23082,7 +23173,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 9993,
+          "line": 10054,
           "kind": "struct",
           "field_names": [
             "count",
@@ -23095,7 +23186,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 9998,
+          "line": 10059,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23107,7 +23198,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 10003,
+          "line": 10064,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -23120,7 +23211,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 10006,
+          "line": 10067,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -23132,7 +23223,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 10009,
+          "line": 10070,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -23142,7 +23233,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 10012,
+          "line": 10073,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -23153,7 +23244,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 10020,
+          "line": 10081,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -23166,7 +23257,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 10034,
+          "line": 10095,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -23179,7 +23270,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 10043,
+          "line": 10104,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -23190,7 +23281,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 10046,
+          "line": 10107,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -23200,7 +23291,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 10052,
+          "line": 10113,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -23212,7 +23303,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 10057,
+          "line": 10118,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -23224,7 +23315,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 10062,
+          "line": 10123,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -23235,7 +23326,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 10071,
+          "line": 10132,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -23247,7 +23338,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 10078,
+          "line": 10139,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -23261,7 +23352,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 10086,
+          "line": 10147,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -23271,7 +23362,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 10091,
+          "line": 10152,
           "kind": "struct",
           "field_names": [
             "source"
@@ -23285,7 +23376,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 10095,
+          "line": 10156,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -23298,7 +23389,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 10100,
+          "line": 10161,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -23309,7 +23400,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 10111,
+          "line": 10172,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -23322,7 +23413,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 10122,
+          "line": 10183,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -23334,7 +23425,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 10130,
+          "line": 10191,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -23347,7 +23438,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 10140,
+          "line": 10201,
           "kind": "struct",
           "field_names": [
             "level"
@@ -23359,7 +23450,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 10145,
+          "line": 10206,
           "kind": "struct",
           "field_names": [
             "text"
@@ -23763,13 +23854,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10788,
+      "line": 10849,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 10791,
+          "line": 10852,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -23777,7 +23868,7 @@
         },
         {
           "name": "Optional",
-          "line": 10793,
+          "line": 10854,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -23787,7 +23878,7 @@
         },
         {
           "name": "MayCost",
-          "line": 10800,
+          "line": 10861,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -23804,7 +23895,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10776,
+      "line": 10837,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 614.1a"
@@ -23812,7 +23903,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 10778,
+          "line": 10839,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source's controller.",
@@ -23820,7 +23911,7 @@
         },
         {
           "name": "Opponent",
-          "line": 10780,
+          "line": 10841,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source's controller.",
@@ -23828,11 +23919,42 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 10782,
+          "line": 10843,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
           "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "ResolutionMvRejectAction": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 1632,
+      "doc": "CR 608.2g: Disposition of a Cascade/Discover hit that is not cast.",
+      "cr_refs": [
+        "CR 608.2g"
+      ],
+      "variants": [
+        {
+          "name": "BottomWithMisses",
+          "line": 1634,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.85a: cascade — hit joins misses on the bottom in random order.",
+          "cr_refs": [
+            "CR 702.85a"
+          ]
+        },
+        {
+          "name": "ToHand",
+          "line": 1636,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.57a: discover — hit goes to its owner's hand; misses to bottom.",
+          "cr_refs": [
+            "CR 701.57a"
+          ]
         }
       ],
       "sibling_clusters": []
@@ -23958,7 +24080,7 @@
     },
     "RetargetScope": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3065,
+      "line": 3083,
       "doc": "CR 115.7: Scope of retargeting — single target, all targets, or forced.",
       "cr_refs": [
         "CR 115.7"
@@ -23966,7 +24088,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 3066,
+          "line": 3084,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23974,7 +24096,7 @@
         },
         {
           "name": "All",
-          "line": 3067,
+          "line": 3085,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23982,7 +24104,7 @@
         },
         {
           "name": "ForcedTo",
-          "line": 3068,
+          "line": 3086,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -23993,7 +24115,7 @@
     },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3261,
+      "line": 3289,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -24001,7 +24123,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 3262,
+          "line": 3290,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24009,7 +24131,7 @@
         },
         {
           "name": "Down",
-          "line": 3263,
+          "line": 3291,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24020,7 +24142,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4398,
+      "line": 4426,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -24028,7 +24150,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 4400,
+          "line": 4428,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -24097,7 +24219,7 @@
     },
     "SeatDirection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3343,
+      "line": 3371,
       "doc": "CR 102.1 + CR 103.1: Seating direction relative to a player. The game's default turn order proceeds clockwise (CR 103.1); the next player in turn order is seated to the active player's left (CR 101.4). Thus walking forward through `seat_order` is `Left`, and walking backward is `Right`.",
       "cr_refs": [
         "CR 101.4",
@@ -24107,7 +24229,7 @@
       "variants": [
         {
           "name": "Left",
-          "line": 3346,
+          "line": 3374,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's left — the next player in turn order (CR 101.4). Forward through `seat_order`.",
@@ -24117,7 +24239,7 @@
         },
         {
           "name": "Right",
-          "line": 3349,
+          "line": 3377,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's right — the previous player in turn order. Backward through `seat_order`.",
@@ -24196,13 +24318,13 @@
     },
     "SharedQuality": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1854,
+      "line": 1877,
       "doc": "Qualities that can be shared across multi-target selections. Used by `FilterProp::SharesQuality` for group constraint validation at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Name",
-          "line": 1856,
+          "line": 1879,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: object names compared by shared name.",
@@ -24212,7 +24334,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 1858,
+          "line": 1881,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: mana value.",
@@ -24222,7 +24344,7 @@
         },
         {
           "name": "Power",
-          "line": 1860,
+          "line": 1883,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: power.",
@@ -24232,7 +24354,7 @@
         },
         {
           "name": "Toughness",
-          "line": 1862,
+          "line": 1885,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: toughness.",
@@ -24242,7 +24364,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 1864,
+          "line": 1887,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: sum of power and toughness.",
@@ -24252,7 +24374,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 1865,
+          "line": 1888,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24260,7 +24382,7 @@
         },
         {
           "name": "Color",
-          "line": 1866,
+          "line": 1889,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24268,7 +24390,7 @@
         },
         {
           "name": "CardType",
-          "line": 1867,
+          "line": 1890,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24276,7 +24398,7 @@
         },
         {
           "name": "LandType",
-          "line": 1869,
+          "line": 1892,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.6: land subtypes, including the five basic land types.",
@@ -24290,13 +24412,13 @@
     },
     "SharedQualityRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1874,
+      "line": 1897,
       "doc": "Relationship required by `FilterProp::SharesQuality`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Shares",
-          "line": 1876,
+          "line": 1899,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24304,7 +24426,7 @@
         },
         {
           "name": "DoesNotShare",
-          "line": 1877,
+          "line": 1900,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24413,7 +24535,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3714,
+      "line": 3742,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -24422,7 +24544,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 3716,
+          "line": 3744,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -24434,7 +24556,7 @@
         },
         {
           "name": "Text",
-          "line": 3722,
+          "line": 3750,
           "kind": "struct",
           "field_names": [
             "description"
@@ -24447,7 +24569,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5076,
+      "line": 5104,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -24455,7 +24577,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 5078,
+          "line": 5106,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -24465,7 +24587,7 @@
         },
         {
           "name": "Decrease",
-          "line": 5080,
+          "line": 5108,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -24478,13 +24600,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4885,
+      "line": 4913,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 4886,
+          "line": 4914,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24492,7 +24614,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 4887,
+          "line": 4915,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24500,7 +24622,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 4888,
+          "line": 4916,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24508,7 +24630,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 4890,
+          "line": 4918,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -24521,13 +24643,13 @@
     },
     "StackEntryKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3671,
+      "line": 3707,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 3672,
+          "line": 3708,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -24540,7 +24662,7 @@
         },
         {
           "name": "ActivatedAbility",
-          "line": 3686,
+          "line": 3722,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -24551,7 +24673,7 @@
         },
         {
           "name": "TriggeredAbility",
-          "line": 3690,
+          "line": 3726,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -24567,7 +24689,7 @@
         },
         {
           "name": "KeywordAction",
-          "line": 3726,
+          "line": 3762,
           "kind": "struct",
           "field_names": [
             "action"
@@ -24583,13 +24705,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3788,
+      "line": 3816,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 3789,
+          "line": 3817,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -24600,7 +24722,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 3793,
+          "line": 3821,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24610,7 +24732,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 3799,
+          "line": 3827,
           "kind": "struct",
           "field_names": [
             "color"
@@ -24620,7 +24742,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 3808,
+          "line": 3836,
           "kind": "struct",
           "field_names": [
             "label"
@@ -24633,7 +24755,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 3814,
+          "line": 3842,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -24645,7 +24767,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 3820,
+          "line": 3848,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -24655,7 +24777,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 3822,
+          "line": 3850,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -24668,7 +24790,7 @@
         },
         {
           "name": "And",
-          "line": 3826,
+          "line": 3854,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24678,7 +24800,7 @@
         },
         {
           "name": "Or",
-          "line": 3830,
+          "line": 3858,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24688,7 +24810,7 @@
         },
         {
           "name": "Not",
-          "line": 3836,
+          "line": 3864,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -24698,7 +24820,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 3840,
+          "line": 3868,
           "kind": "struct",
           "field_names": [
             "state"
@@ -24710,7 +24832,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 3849,
+          "line": 3877,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24726,7 +24848,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 3860,
+          "line": 3888,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -24741,7 +24863,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 3868,
+          "line": 3896,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24753,7 +24875,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 3875,
+          "line": 3903,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24765,7 +24887,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 3879,
+          "line": 3907,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -24775,7 +24897,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 3883,
+          "line": 3911,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -24786,7 +24908,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 3887,
+          "line": 3915,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -24797,7 +24919,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 3891,
+          "line": 3919,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -24807,7 +24929,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 3893,
+          "line": 3921,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -24817,7 +24939,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 3896,
+          "line": 3924,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -24827,7 +24949,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 3898,
+          "line": 3926,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -24837,7 +24959,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 3901,
+          "line": 3929,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -24847,7 +24969,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 3907,
+          "line": 3935,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -24859,7 +24981,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 3915,
+          "line": 3943,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -24871,7 +24993,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 3919,
+          "line": 3947,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24883,7 +25005,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 3944,
+          "line": 3972,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -24901,7 +25023,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 3953,
+          "line": 3981,
           "kind": "struct",
           "field_names": [
             "text"
@@ -24911,7 +25033,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 3956,
+          "line": 3984,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24919,7 +25041,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 3959,
+          "line": 3987,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -24929,7 +25051,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 3961,
+          "line": 3989,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -24939,7 +25061,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 3963,
+          "line": 3991,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24951,7 +25073,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 3969,
+          "line": 3997,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -24965,7 +25087,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 3974,
+          "line": 4002,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -24975,7 +25097,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 3981,
+          "line": 4009,
           "kind": "struct",
           "field_names": [
             "player"
@@ -24988,7 +25110,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 3986,
+          "line": 4014,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -24998,7 +25120,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 3990,
+          "line": 4018,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -25008,7 +25130,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 3994,
+          "line": 4022,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -25019,7 +25141,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 3998,
+          "line": 4026,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25031,7 +25153,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 4010,
+          "line": 4038,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25043,7 +25165,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 4014,
+          "line": 4042,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -25053,7 +25175,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 4017,
+          "line": 4045,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -25065,7 +25187,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 4023,
+          "line": 4051,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -25076,7 +25198,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 4028,
+          "line": 4056,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ModifyCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -25087,7 +25209,7 @@
         },
         {
           "name": "None",
-          "line": 4029,
+          "line": 4057,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26100,7 +26222,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5088,
+      "line": 5116,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -26109,7 +26231,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 5089,
+          "line": 5117,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26117,7 +26239,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 5090,
+          "line": 5118,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26128,7 +26250,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8912,
+      "line": 8964,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -26136,7 +26258,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 8920,
+          "line": 8972,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -26144,7 +26266,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 8925,
+          "line": 8977,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -26323,7 +26445,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8582,
+      "line": 8634,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -26333,7 +26455,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 8584,
+          "line": 8636,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26341,7 +26463,7 @@
         },
         {
           "name": "Resolution",
-          "line": 8585,
+          "line": 8637,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26352,13 +26474,13 @@
     },
     "TargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2434,
+      "line": 2457,
       "doc": "Typed target filter replacing all Forge filter strings and TargetSpec.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 2435,
+          "line": 2458,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26366,7 +26488,7 @@
         },
         {
           "name": "Any",
-          "line": 2436,
+          "line": 2459,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26374,7 +26496,7 @@
         },
         {
           "name": "Player",
-          "line": 2437,
+          "line": 2460,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26382,7 +26504,7 @@
         },
         {
           "name": "Controller",
-          "line": 2438,
+          "line": 2461,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26390,7 +26512,7 @@
         },
         {
           "name": "SelfRef",
-          "line": 2439,
+          "line": 2462,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26398,7 +26520,7 @@
         },
         {
           "name": "SourceOrPaired",
-          "line": 2442,
+          "line": 2465,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Resolves to the source object and the creature it is paired with. If the source is not paired, this matches no objects.",
@@ -26408,7 +26530,7 @@
         },
         {
           "name": "Typed",
-          "line": 2443,
+          "line": 2466,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26416,7 +26538,7 @@
         },
         {
           "name": "Not",
-          "line": 2444,
+          "line": 2467,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26426,7 +26548,7 @@
         },
         {
           "name": "Or",
-          "line": 2447,
+          "line": 2470,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -26436,7 +26558,7 @@
         },
         {
           "name": "And",
-          "line": 2450,
+          "line": 2473,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -26446,7 +26568,7 @@
         },
         {
           "name": "StackAbility",
-          "line": 2455,
+          "line": 2478,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26456,7 +26578,7 @@
         },
         {
           "name": "StackSpell",
-          "line": 2461,
+          "line": 2484,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches spells on the stack (not activated/triggered abilities). CR 115.1a: Used by \"becomes the target of a spell\" triggers to filter source type.",
@@ -26466,7 +26588,7 @@
         },
         {
           "name": "SpecificObject",
-          "line": 2465,
+          "line": 2488,
           "kind": "struct",
           "field_names": [
             "id"
@@ -26476,7 +26598,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 2473,
+          "line": 2496,
           "kind": "struct",
           "field_names": [
             "id"
@@ -26489,7 +26611,7 @@
         },
         {
           "name": "Neighbor",
-          "line": 2481,
+          "line": 2504,
           "kind": "struct",
           "field_names": [
             "direction"
@@ -26502,7 +26624,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2487,
+          "line": 2510,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This is not the ability controller; \"you\" and \"your\" still refer to `controller`.",
@@ -26513,7 +26635,7 @@
         },
         {
           "name": "AttachedTo",
-          "line": 2490,
+          "line": 2513,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches the permanent that the trigger source (Equipment/Aura) is attached to. Used for \"equipped creature\" / \"enchanted creature\" trigger subjects.",
@@ -26521,7 +26643,7 @@
         },
         {
           "name": "LastCreated",
-          "line": 2493,
+          "line": 2516,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the most recently created token(s) from Effect::Token. Used for \"create X and [verb] it\" patterns (e.g. \"create a token and suspect it\").",
@@ -26529,7 +26651,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2497,
+          "line": 2520,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the resolving spell or ability. Used by effects such as \"the exiled card\" after an exile-as-cost clause.",
@@ -26540,7 +26662,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 2500,
+          "line": 2523,
           "kind": "struct",
           "field_names": [
             "id"
@@ -26552,7 +26674,7 @@
         },
         {
           "name": "TrackedSetFiltered",
-          "line": 2515,
+          "line": 2538,
           "kind": "struct",
           "field_names": [
             "id",
@@ -26566,7 +26688,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2521,
+          "line": 2544,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 610.3: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
@@ -26576,7 +26698,7 @@
         },
         {
           "name": "TriggeringSpellController",
-          "line": 2523,
+          "line": 2546,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the controller of the spell/ability that triggered this.",
@@ -26586,7 +26708,7 @@
         },
         {
           "name": "TriggeringSpellOwner",
-          "line": 2525,
+          "line": 2548,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the owner of the spell/ability that triggered this.",
@@ -26596,7 +26718,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 2527,
+          "line": 2550,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the player involved in the triggering event.",
@@ -26606,7 +26728,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 2529,
+          "line": 2552,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the source object of the triggering event.",
@@ -26616,7 +26738,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 2534,
+          "line": 2557,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the same target(s) as the parent ability. Used for anaphoric \"it\"/\"that creature\"/\"that player\" in compound effects (e.g., \"tap target creature and put a stun counter on it\"). At resolution time, the sub_ability chain inherits parent targets automatically.",
@@ -26624,7 +26746,7 @@
         },
         {
           "name": "ParentTargetSlot",
-          "line": 2539,
+          "line": 2562,
           "kind": "struct",
           "field_names": [
             "index"
@@ -26636,7 +26758,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2545,
+          "line": 2568,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Resolves to the controller of the parent ability's target object. Used for \"its controller\" in compound effects (e.g., \"counter target spell. Its controller loses 2 life.\"). At resolution time, looks up the controller of the first parent target.",
@@ -26646,7 +26768,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 2556,
+          "line": 2579,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 608.2c: Resolves to the *owner* of the parent ability's target object. Used for \"its owner\" anaphoric references where the acting player is the owner of a previously-mentioned permanent — e.g., Enslave's \"enchanted creature deals 1 damage to its owner\" or Bomb Squad's \"that creature deals 4 damage to its owner\". Resolution mirrors `ParentTargetController` (parent target slot → trigger-event source → AttachedTo host on source for Aura phase triggers), but returns the resolved object's `owner` rather than `controller` per CR 108.3.  Distinct from `Owner` (which always reads the source object's owner) and `ParentTargetController` (which returns the controller per CR 109.4).",
@@ -26658,7 +26780,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 2561,
+          "line": 2584,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 608.2c: Resolves to the player chosen for the source by a linked persisted choice (\"the chosen player\"). This is not a target slot and is distinct from `ControllerRef::ChosenPlayer`, which is resolution-scoped to the current ability chain.",
@@ -26669,7 +26791,7 @@
         },
         {
           "name": "OriginalController",
-          "line": 2582,
+          "line": 2605,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 + CR 608.2c: Resolves to the ability's *original* controller — the player who put the spell or ability on the stack — even when a surrounding `player_scope` iteration has rebound `ResolvedAbility::controller` to a different player for the current per-player iteration.  At resolution time, returns `ability.original_controller.unwrap_or(ability.controller)`. This mirrors the quantity-layer behavior in `resolve_quantity_with_targets`, where \"you\" / \"your\" quantities always read the original controller.  Used by parser-level distribution of compound subjects like \"you and that player each Y\" — the first half (\"you\") MUST resolve to the printed ability controller, not the iterated voter, even when the parent ability has `player_scope: PlayerFilter::VotedFor` (Master of Ceremonies pattern, CR 800.4g).  Distinct from `Controller` (which resolves to `ability.controller` and is rebound per-iteration by the player_scope driver in `resolve_ability_chain`). Distinct from `ParentTargetController` (parent's target's controller) and `PostReplacementSourceController` (replacement-context source's controller).",
@@ -26681,7 +26803,7 @@
         },
         {
           "name": "PostReplacementSourceController",
-          "line": 2601,
+          "line": 2624,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5 + CR 609.7: Resolves to the controller of the *prevented event's* damage source. Used by prevention follow-up sentences such as \"the source's controller draws cards equal to the damage prevented this way\" (Swans of Bryn Argoll) and \"deals damage to that source's controller\" (Deflecting Palm class). At resolution time, looks up `state.post_replacement_event_source` and returns its controller.  Distinct from `ParentTargetController` (which resolves via the parent ability's target slot) and `TriggeringSpellController` (which resolves via `state.current_trigger_event`, which is `None` during post-replacement resolution). Architectural twin of the quantity-side `last_effect_count` fallback at `replacement.rs:317` — both stash event context that lives outside the trigger window. The parser never emits this variant directly; the prevention follow-up call site rewrites `ParentTargetController` → `PostReplacementSourceController` via `each_target_filter_mut` after `parse_effect_chain` returns, so the surface phrase \"the source's controller\" can stay consolidated in `parse_target` for non-prevention callers.",
@@ -26692,7 +26814,7 @@
         },
         {
           "name": "PostReplacementDamageTarget",
-          "line": 2606,
+          "line": 2629,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5: Resolves to the player or permanent that was the target of the prevented damage event. Used by prevention follow-up sentences such as \"that player exiles that many cards\" where the affected player is the damage recipient, not the replacement source or damage source.",
@@ -26702,7 +26824,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2610,
+          "line": 2633,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Resolves to the defending player for the source attacking creature, looked up per attacker through `combat::defending_player_for_attacker`.",
@@ -26713,7 +26835,7 @@
         },
         {
           "name": "HasChosenName",
-          "line": 2613,
+          "line": 2636,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose name equals the source's ChosenAttribute::CardName. Used for \"card with the chosen name\" patterns.",
@@ -26721,7 +26843,7 @@
         },
         {
           "name": "ChosenDamageSource",
-          "line": 2617,
+          "line": 2640,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.7a: Matches the object stored as the source's chosen damage source. Resolution-time prevention effects should resolve this to `SpecificObject` when the shield is created so global shields do not depend on a live source.",
@@ -26731,7 +26853,7 @@
         },
         {
           "name": "Named",
-          "line": 2620,
+          "line": 2643,
           "kind": "struct",
           "field_names": [
             "name"
@@ -26741,7 +26863,7 @@
         },
         {
           "name": "Owner",
-          "line": 2628,
+          "line": 2651,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.3: Resolves to the owner of the object referenced by `source_id`. Used for \"its owner's library/hand/graveyard\" phrasings where the acting player must be the card's owner, not its current controller (e.g., Nexus of Fate's shuffle-back replacement when the card is under opposing control via Mind Control).",
@@ -26751,7 +26873,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2635,
+          "line": 2658,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.12a: Every player in the game (controller + opponents), polled in APNAP order. The unless-payer population for \"[Effect] unless any player pays ...\" clauses (Cleansing, Rhystic cycle, Soul Strings). Resolution is a sequential poll — the first player to pay prevents the effect — so this variant is only valid as an `UnlessPayModifier.payer`; it is never used as a target or affected filter.",
@@ -26782,13 +26904,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11410,
+      "line": 11471,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 11411,
+          "line": 11472,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26796,7 +26918,7 @@
         },
         {
           "name": "Player",
-          "line": 11412,
+          "line": 11473,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -26835,7 +26957,7 @@
     },
     "TargetSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2413,
+      "line": 2436,
       "doc": "CR 115.1 + CR 701.9b: How a target slot's referent is selected.  CR 115.1: Default — the spell/ability's controller chooses each target. CR 701.9b: Some effects override the controller-choice default by requiring the game to make the selection (analogous to \"random discard\" — the affected player does not choose). Magic Oracle text expresses this with the modifier \"random target [predicate]\" appearing immediately before the target word (Mana Clash, Goblin Lyre, Pixie Queen, Vexing Sphinx, Maddening Hex, etc.).  Categorical-boundary check (per CLAUDE.md \"Parameterize, don't proliferate\"): this enum is the *selection-mode* axis — one level above the predicate (`TargetFilter`) and orthogonal to slot count (`MultiTargetSpec`). It does not belong on `TargetFilter` (which captures *what* matches), nor on `MultiTargetSpec` (which captures *how many*). It captures *who selects*.",
       "cr_refs": [
         "CR 115.1",
@@ -26844,7 +26966,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 2416,
+          "line": 2439,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The spell or ability's controller chooses each target.",
@@ -26854,7 +26976,7 @@
         },
         {
           "name": "Random",
-          "line": 2419,
+          "line": 2442,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9b (analogous): The game selects each target uniformly at random from the legal-target set. The controller does not choose.",
@@ -26952,13 +27074,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9672,
+      "line": 9733,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 9675,
+          "line": 9736,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -26968,7 +27090,7 @@
         },
         {
           "name": "LostLife",
-          "line": 9677,
+          "line": 9738,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -26976,7 +27098,7 @@
         },
         {
           "name": "Descended",
-          "line": 9679,
+          "line": 9740,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -26984,7 +27106,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 9681,
+          "line": 9742,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26994,7 +27116,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 9683,
+          "line": 9744,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -27004,7 +27126,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 9685,
+          "line": 9746,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -27014,7 +27136,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 9695,
+          "line": 9756,
           "kind": "struct",
           "field_names": [
             "player"
@@ -27027,7 +27149,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9698,
+          "line": 9759,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -27038,7 +27160,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 9701,
+          "line": 9762,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -27048,7 +27170,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 9705,
+          "line": 9766,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -27060,7 +27182,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 9708,
+          "line": 9769,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -27070,7 +27192,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 9711,
+          "line": 9772,
           "kind": "struct",
           "field_names": [
             "level"
@@ -27082,7 +27204,7 @@
         },
         {
           "name": "WasCast",
-          "line": 9714,
+          "line": 9775,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -27095,7 +27217,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 9721,
+          "line": 9782,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -27106,7 +27228,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 9726,
+          "line": 9787,
           "kind": "struct",
           "field_names": [
             "source",
@@ -27122,7 +27244,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 9742,
+          "line": 9803,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -27132,7 +27254,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9748,
+          "line": 9809,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -27147,7 +27269,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 9752,
+          "line": 9813,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -27158,7 +27280,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 9756,
+          "line": 9817,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -27169,7 +27291,7 @@
         },
         {
           "name": "WasType",
-          "line": 9761,
+          "line": 9822,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -27182,7 +27304,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 9764,
+          "line": 9825,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -27194,7 +27316,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 9768,
+          "line": 9829,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -27207,7 +27329,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 9772,
+          "line": 9833,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27219,7 +27341,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 9776,
+          "line": 9837,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -27229,7 +27351,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9779,
+          "line": 9840,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -27241,7 +27363,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 9783,
+          "line": 9844,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27253,7 +27375,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 9786,
+          "line": 9847,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -27265,7 +27387,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9792,
+          "line": 9853,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -27275,7 +27397,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9795,
+          "line": 9856,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -27285,7 +27407,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 9798,
+          "line": 9859,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -27295,7 +27417,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9805,
+          "line": 9866,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -27307,7 +27429,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9810,
+          "line": 9871,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -27319,7 +27441,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9814,
+          "line": 9875,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -27329,7 +27451,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 9819,
+          "line": 9880,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -27341,7 +27463,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9825,
+          "line": 9886,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -27351,7 +27473,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 9830,
+          "line": 9891,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -27361,7 +27483,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 9833,
+          "line": 9894,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -27371,7 +27493,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 9836,
+          "line": 9897,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -27381,7 +27503,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 9838,
+          "line": 9899,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -27393,7 +27515,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 9841,
+          "line": 9902,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -27403,7 +27525,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 9845,
+          "line": 9906,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -27413,7 +27535,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 9849,
+          "line": 9910,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27426,7 +27548,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 9852,
+          "line": 9913,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -27436,7 +27558,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9856,
+          "line": 9917,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -27449,7 +27571,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9859,
+          "line": 9920,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -27462,7 +27584,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9861,
+          "line": 9922,
           "kind": "struct",
           "field_names": [
             "color",
@@ -27475,7 +27597,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 9863,
+          "line": 9924,
           "kind": "struct",
           "field_names": [
             "text"
@@ -27487,7 +27609,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 9865,
+          "line": 9926,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -27499,7 +27621,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 9869,
+          "line": 9930,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -27513,7 +27635,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 9871,
+          "line": 9932,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -27523,7 +27645,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 9876,
+          "line": 9937,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -27538,7 +27660,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9887,
+          "line": 9948,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -27554,7 +27676,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 9902,
+          "line": 9963,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -27566,7 +27688,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9905,
+          "line": 9966,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27579,7 +27701,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 9915,
+          "line": 9976,
           "kind": "struct",
           "field_names": [
             "label"
@@ -27593,7 +27715,7 @@
         },
         {
           "name": "AttackersDeclaredMin",
-          "line": 9928,
+          "line": 9989,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27609,7 +27731,7 @@
         },
         {
           "name": "NoneOfAttackersTargetedYou",
-          "line": 9933,
+          "line": 9994,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 603.4: Intervening-if \"if none of those creatures attacked you\". Reads the triggering `AttackersDeclared` event's per-attacker `AttackTarget` tuples (CR 508.1b) and returns true iff no attacker in the batch targeted the trigger's controller directly (`AttackTarget::Player(trigger_controller)`).",
@@ -27621,7 +27743,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 9943,
+          "line": 10004,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -27633,7 +27755,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 9954,
+          "line": 10015,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -27645,7 +27767,7 @@
         },
         {
           "name": "And",
-          "line": 9958,
+          "line": 10019,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27655,7 +27777,7 @@
         },
         {
           "name": "Or",
-          "line": 9960,
+          "line": 10021,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27665,7 +27787,7 @@
         },
         {
           "name": "Not",
-          "line": 9970,
+          "line": 10031,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -27681,13 +27803,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10151,
+      "line": 10212,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 10153,
+          "line": 10214,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -27695,7 +27817,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 10155,
+          "line": 10216,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -27703,7 +27825,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 10157,
+          "line": 10218,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -27711,7 +27833,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 10162,
+          "line": 10223,
           "kind": "struct",
           "field_names": [
             "n",
@@ -27722,7 +27844,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 10169,
+          "line": 10230,
           "kind": "struct",
           "field_names": [
             "n"
@@ -27732,7 +27854,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 10171,
+          "line": 10232,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -27740,7 +27862,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 10175,
+          "line": 10236,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -27750,7 +27872,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 10177,
+          "line": 10238,
           "kind": "struct",
           "field_names": [
             "level"
@@ -27762,7 +27884,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 10180,
+          "line": 10241,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29821,13 +29943,13 @@
     },
     "TypeFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1757,
+      "line": 1780,
       "doc": "Type filter for card type matching in filters.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Creature",
-          "line": 1758,
+          "line": 1781,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29835,7 +29957,7 @@
         },
         {
           "name": "Land",
-          "line": 1759,
+          "line": 1782,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29843,7 +29965,7 @@
         },
         {
           "name": "Artifact",
-          "line": 1760,
+          "line": 1783,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29851,7 +29973,7 @@
         },
         {
           "name": "Enchantment",
-          "line": 1761,
+          "line": 1784,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29859,7 +29981,7 @@
         },
         {
           "name": "Instant",
-          "line": 1762,
+          "line": 1785,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29867,7 +29989,7 @@
         },
         {
           "name": "Sorcery",
-          "line": 1763,
+          "line": 1786,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29875,7 +29997,7 @@
         },
         {
           "name": "Planeswalker",
-          "line": 1764,
+          "line": 1787,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29883,7 +30005,7 @@
         },
         {
           "name": "Battle",
-          "line": 1766,
+          "line": 1789,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 310: Battle — a permanent type introduced in March of the Machine.",
@@ -29893,7 +30015,7 @@
         },
         {
           "name": "Permanent",
-          "line": 1767,
+          "line": 1790,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29901,7 +30023,7 @@
         },
         {
           "name": "Card",
-          "line": 1768,
+          "line": 1791,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29909,7 +30031,7 @@
         },
         {
           "name": "Any",
-          "line": 1769,
+          "line": 1792,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29917,7 +30039,7 @@
         },
         {
           "name": "Non",
-          "line": 1772,
+          "line": 1795,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.4b: Negation — matches objects whose type does NOT match the inner filter. \"noncreature\" → `Non(Box::new(Creature))`, \"non-Human\" → `Non(Box::new(Subtype(\"Human\")))`",
@@ -29927,7 +30049,7 @@
         },
         {
           "name": "Subtype",
-          "line": 1775,
+          "line": 1798,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.3: Matches objects with a specific subtype (creature type, land type, etc.). String because MTG has 250+ creature subtypes (CR 205.3m) with new ones each set.",
@@ -29938,7 +30060,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 1778,
+          "line": 1801,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2b: Disjunction — matches if ANY inner filter matches. \"creature or enchantment\" → `AnyOf(vec![Creature, Enchantment])`",
@@ -29988,7 +30110,7 @@
     },
     "UnlessCostBranch": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 90,
+      "line": 91,
       "doc": "CR 118.12a: Player decision at an `UnlessPaymentChooseCost` prompt — the disjunctive (\"unless they X or Y\") unless-cost choice. `Decline` falls through to the effect happening (mirrors `PayUnlessCost { pay: false }`); `Pay { index }` selects the sub-cost by its position in `WaitingFor::UnlessPaymentChooseCost::costs` and routes back into the standard single-cost `handle_unless_payment` path.",
       "cr_refs": [
         "CR 118.12a"
@@ -29996,7 +30118,7 @@
       "variants": [
         {
           "name": "Decline",
-          "line": 91,
+          "line": 92,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30004,7 +30126,7 @@
         },
         {
           "name": "Pay",
-          "line": 92,
+          "line": 93,
           "kind": "struct",
           "field_names": [
             "index"
@@ -30017,7 +30139,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3741,
+      "line": 3769,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -30026,7 +30148,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 3743,
+          "line": 3771,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30034,7 +30156,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 3744,
+          "line": 3772,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30042,7 +30164,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 3745,
+          "line": 3773,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -30052,7 +30174,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 3748,
+          "line": 3776,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -30062,7 +30184,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 3760,
+          "line": 3788,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -30078,7 +30200,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3313,
+      "line": 3341,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -30091,7 +30213,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 3317,
+          "line": 3345,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -30104,7 +30226,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 3321,
+          "line": 3349,
           "kind": "struct",
           "field_names": [
             "property",
@@ -30151,7 +30273,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7294,
+      "line": 7340,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -30160,7 +30282,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 7297,
+          "line": 7343,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -30170,7 +30292,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 7301,
+          "line": 7347,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -30180,7 +30302,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 7309,
+          "line": 7355,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",
@@ -30194,13 +30316,13 @@
     },
     "WaitingFor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1712,
+      "line": 1720,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1713,
+          "line": 1721,
           "kind": "struct",
           "field_names": [
             "player"
@@ -30210,7 +30332,7 @@
         },
         {
           "name": "MulliganDecision",
-          "line": 1729,
+          "line": 1737,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -30225,7 +30347,7 @@
         },
         {
           "name": "MulliganBottomCards",
-          "line": 1742,
+          "line": 1750,
           "kind": "struct",
           "field_names": [
             "pending"
@@ -30237,7 +30359,7 @@
         },
         {
           "name": "OpeningHandBottomCards",
-          "line": 1748,
+          "line": 1756,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -30248,7 +30370,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1752,
+          "line": 1760,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30259,7 +30381,7 @@
         },
         {
           "name": "ChooseXValue",
-          "line": 1770,
+          "line": 1778,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30276,7 +30398,7 @@
         },
         {
           "name": "TargetSelection",
-          "line": 1779,
+          "line": 1787,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30290,7 +30412,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 1795,
+          "line": 1803,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30302,7 +30424,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 1801,
+          "line": 1809,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30315,7 +30437,7 @@
         },
         {
           "name": "UntapChoice",
-          "line": 1817,
+          "line": 1825,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30329,7 +30451,7 @@
         },
         {
           "name": "ExertChoice",
-          "line": 1829,
+          "line": 1837,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30344,7 +30466,7 @@
         },
         {
           "name": "GameOver",
-          "line": 1835,
+          "line": 1843,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -30354,7 +30476,7 @@
         },
         {
           "name": "ReplacementChoice",
-          "line": 1838,
+          "line": 1846,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30366,7 +30488,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 1851,
+          "line": 1859,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30381,7 +30503,7 @@
         },
         {
           "name": "CopyTargetChoice",
-          "line": 1857,
+          "line": 1865,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30396,7 +30518,7 @@
         },
         {
           "name": "ExploreChoice",
-          "line": 1867,
+          "line": 1875,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30412,7 +30534,7 @@
         },
         {
           "name": "ReturnAsAuraTarget",
-          "line": 1889,
+          "line": 1897,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30435,7 +30557,7 @@
         },
         {
           "name": "EquipTarget",
-          "line": 1906,
+          "line": 1914,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30447,7 +30569,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 1912,
+          "line": 1920,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30462,7 +30584,7 @@
         },
         {
           "name": "StationTarget",
-          "line": 1923,
+          "line": 1931,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30476,7 +30598,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 1931,
+          "line": 1939,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30491,7 +30613,7 @@
         },
         {
           "name": "ScryChoice",
-          "line": 1939,
+          "line": 1947,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30502,7 +30624,7 @@
         },
         {
           "name": "DigChoice",
-          "line": 1944,
+          "line": 1952,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30522,7 +30644,7 @@
         },
         {
           "name": "SurveilChoice",
-          "line": 1968,
+          "line": 1976,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30533,7 +30655,7 @@
         },
         {
           "name": "RevealChoice",
-          "line": 1972,
+          "line": 1980,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30547,7 +30669,7 @@
         },
         {
           "name": "SearchChoice",
-          "line": 1991,
+          "line": 1999,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30563,7 +30685,7 @@
         },
         {
           "name": "SearchPartitionChoice",
-          "line": 2025,
+          "line": 2033,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30582,7 +30704,7 @@
         },
         {
           "name": "OutsideGameChoice",
-          "line": 2038,
+          "line": 2046,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30601,7 +30723,7 @@
         },
         {
           "name": "ChooseFromZoneChoice",
-          "line": 2052,
+          "line": 2060,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30618,7 +30740,7 @@
         },
         {
           "name": "ChooseOneOfBranch",
-          "line": 2064,
+          "line": 2072,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30637,7 +30759,7 @@
         },
         {
           "name": "ConniveDiscard",
-          "line": 2082,
+          "line": 2090,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30653,7 +30775,7 @@
         },
         {
           "name": "DiscardChoice",
-          "line": 2091,
+          "line": 2099,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30671,7 +30793,7 @@
         },
         {
           "name": "EffectZoneChoice",
-          "line": 2107,
+          "line": 2115,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30698,7 +30820,7 @@
         },
         {
           "name": "DrawnThisTurnTopdeckChoice",
-          "line": 2160,
+          "line": 2168,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30713,7 +30835,7 @@
         },
         {
           "name": "LearnChoice",
-          "line": 2170,
+          "line": 2178,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30726,7 +30848,7 @@
         },
         {
           "name": "ManifestDreadChoice",
-          "line": 2176,
+          "line": 2184,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30739,7 +30861,7 @@
         },
         {
           "name": "TriggerTargetSelection",
-          "line": 2180,
+          "line": 2188,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30755,7 +30877,7 @@
         },
         {
           "name": "BetweenGamesSideboard",
-          "line": 2200,
+          "line": 2208,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30767,7 +30889,7 @@
         },
         {
           "name": "BetweenGamesChoosePlayDraw",
-          "line": 2205,
+          "line": 2213,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30779,7 +30901,7 @@
         },
         {
           "name": "NamedChoice",
-          "line": 2211,
+          "line": 2219,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30792,7 +30914,7 @@
         },
         {
           "name": "DamageSourceChoice",
-          "line": 2221,
+          "line": 2229,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30806,7 +30928,7 @@
         },
         {
           "name": "ModeChoice",
-          "line": 2227,
+          "line": 2235,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30818,7 +30940,7 @@
         },
         {
           "name": "DiscardToHandSize",
-          "line": 2233,
+          "line": 2241,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30830,7 +30952,7 @@
         },
         {
           "name": "OptionalCostChoice",
-          "line": 2241,
+          "line": 2249,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30843,7 +30965,7 @@
         },
         {
           "name": "DefilerPayment",
-          "line": 2253,
+          "line": 2261,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30858,7 +30980,7 @@
         },
         {
           "name": "CastOffer",
-          "line": 2263,
+          "line": 2271,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30876,7 +30998,7 @@
         },
         {
           "name": "ModalFaceChoice",
-          "line": 2277,
+          "line": 2285,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30892,7 +31014,7 @@
         },
         {
           "name": "AlternativeCastChoice",
-          "line": 2300,
+          "line": 2308,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30918,7 +31040,7 @@
         },
         {
           "name": "CastingVariantChoice",
-          "line": 2332,
+          "line": 2340,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30934,7 +31056,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 2344,
+          "line": 2352,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30951,7 +31073,7 @@
         },
         {
           "name": "MultiTargetSelection",
-          "line": 2355,
+          "line": 2363,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30967,7 +31089,7 @@
         },
         {
           "name": "AbilityModeChoice",
-          "line": 2366,
+          "line": 2374,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30984,7 +31106,7 @@
         },
         {
           "name": "OptionalEffectChoice",
-          "line": 2389,
+          "line": 2397,
           "kind": "struct",
           "field_names": [
             "player",
@@ -30999,7 +31121,7 @@
         },
         {
           "name": "PairChoice",
-          "line": 2400,
+          "line": 2408,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31014,7 +31136,7 @@
         },
         {
           "name": "TributeChoice",
-          "line": 2411,
+          "line": 2419,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31029,7 +31151,7 @@
         },
         {
           "name": "MiracleReveal",
-          "line": 2423,
+          "line": 2431,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31044,7 +31166,7 @@
         },
         {
           "name": "OpponentMayChoice",
-          "line": 2430,
+          "line": 2438,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31060,7 +31182,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 2443,
+          "line": 2451,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31078,7 +31200,7 @@
         },
         {
           "name": "UnlessPaymentChooseCost",
-          "line": 2477,
+          "line": 2485,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31096,7 +31218,7 @@
         },
         {
           "name": "WardDiscardChoice",
-          "line": 2507,
+          "line": 2515,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31110,7 +31232,7 @@
         },
         {
           "name": "WardSacrificeChoice",
-          "line": 2515,
+          "line": 2523,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31125,7 +31247,7 @@
         },
         {
           "name": "UnlessBounceChoice",
-          "line": 2526,
+          "line": 2534,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31140,7 +31262,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 2534,
+          "line": 2542,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31153,7 +31275,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 2539,
+          "line": 2547,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31166,7 +31288,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 2544,
+          "line": 2552,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31181,7 +31303,7 @@
         },
         {
           "name": "PayCost",
-          "line": 2556,
+          "line": 2564,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31200,7 +31322,7 @@
         },
         {
           "name": "ActivationCostOneOfChoice",
-          "line": 2570,
+          "line": 2578,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31214,7 +31336,7 @@
         },
         {
           "name": "BlightChoice",
-          "line": 2576,
+          "line": 2584,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31227,7 +31349,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 2594,
+          "line": 2602,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31243,7 +31365,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 2604,
+          "line": 2612,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31259,7 +31381,7 @@
         },
         {
           "name": "CollectEvidenceChoice",
-          "line": 2611,
+          "line": 2619,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31275,7 +31397,7 @@
         },
         {
           "name": "HarmonizeTapChoice",
-          "line": 2620,
+          "line": 2628,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31292,7 +31414,7 @@
         },
         {
           "name": "RevealUntilKeptChoice",
-          "line": 2632,
+          "line": 2640,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31313,7 +31435,7 @@
         },
         {
           "name": "RepeatDecision",
-          "line": 2653,
+          "line": 2661,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31327,7 +31449,7 @@
         },
         {
           "name": "TopOrBottomChoice",
-          "line": 2660,
+          "line": 2668,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31340,7 +31462,7 @@
         },
         {
           "name": "PopulateChoice",
-          "line": 2665,
+          "line": 2673,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31353,8 +31475,22 @@
           ]
         },
         {
+          "name": "ClashChooseOpponent",
+          "line": 2683,
+          "kind": "struct",
+          "field_names": [
+            "player",
+            "candidates",
+            "ability"
+          ],
+          "doc": "CR 701.30b: \"Clash with an opponent\" lets the clashing player choose which opponent to clash with. Only entered when two or more opponents are available (with one opponent there is no decision). `candidates` is the set of legal opponents; `ability` is the resolving clash ability, carried so the clash can be performed against the chosen opponent.",
+          "cr_refs": [
+            "CR 701.30b"
+          ]
+        },
+        {
           "name": "ClashCardPlacement",
-          "line": 2673,
+          "line": 2691,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31368,7 +31504,7 @@
         },
         {
           "name": "VoteChoice",
-          "line": 2684,
+          "line": 2702,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31390,7 +31526,7 @@
         },
         {
           "name": "SeparatePilesPartition",
-          "line": 2743,
+          "line": 2761,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31411,7 +31547,7 @@
         },
         {
           "name": "SeparatePilesChoice",
-          "line": 2773,
+          "line": 2791,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31428,7 +31564,7 @@
         },
         {
           "name": "CompanionReveal",
-          "line": 2788,
+          "line": 2806,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31441,7 +31577,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 2795,
+          "line": 2813,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31455,7 +31591,7 @@
         },
         {
           "name": "CommanderZoneChoice",
-          "line": 2804,
+          "line": 2822,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31469,7 +31605,7 @@
         },
         {
           "name": "BattleProtectorChoice",
-          "line": 2815,
+          "line": 2833,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31485,7 +31621,7 @@
         },
         {
           "name": "ProliferateChoice",
-          "line": 2822,
+          "line": 2840,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31498,7 +31634,7 @@
         },
         {
           "name": "ChooseObjectsSelection",
-          "line": 2832,
+          "line": 2850,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31512,7 +31648,7 @@
         },
         {
           "name": "CategoryChoice",
-          "line": 2845,
+          "line": 2863,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31536,7 +31672,7 @@
         },
         {
           "name": "CopyRetarget",
-          "line": 2882,
+          "line": 2900,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31551,7 +31687,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 2892,
+          "line": 2910,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31573,7 +31709,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 2916,
+          "line": 2934,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31588,7 +31724,7 @@
         },
         {
           "name": "MoveCountersDistribution",
-          "line": 2924,
+          "line": 2942,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31606,7 +31742,7 @@
         },
         {
           "name": "PayAmountChoice",
-          "line": 2938,
+          "line": 2956,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31624,7 +31760,7 @@
         },
         {
           "name": "RetargetChoice",
-          "line": 2951,
+          "line": 2969,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31640,7 +31776,7 @@
         },
         {
           "name": "CombatTaxPayment",
-          "line": 2973,
+          "line": 2991,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31660,7 +31796,7 @@
         },
         {
           "name": "PhyrexianPayment",
-          "line": 2991,
+          "line": 3009,
           "kind": "struct",
           "field_names": [
             "player",


### PR DESCRIPTION
Replace the boolean "a deck can have any number of cards named X" exemption —
previously a verbatim oracle_text string match duplicated across the engine
validator, the frontend, and a discard-only parser recognizer — with a single
typed authority: enum DeckCopyLimit { Unlimited, UpTo(u32) } (CR 100.2a four-of
override + CR 903.5b Commander singleton override).

A nom combinator (parser/oracle.rs) produces the limit from all five real
phrase variants, reusing parse_number for spelled cardinals:
  - "any number of cards named X"            -> Unlimited (Relentless Rats class)
  - "up to seven cards named X"              -> UpTo(7)   (Seven Dwarves, was a gap)
  - "up to nine cards named X"               -> UpTo(9)   (Nazgul, was a gap)
  - "DCI ruling - ...only one card named X"  -> UpTo(1)   (Once More with Feeling)
  - "Megalegendary (...only one copy...)"    -> UpTo(1)   (Vazal, reminder text)

The value is synthesized onto CardFace.deck_copy_limit, consumed as the single
authority by deck_validation (copy_limit_violations honors the per-card cap;
basic-land Supertype::Basic exemption still short-circuits first), with an
oracle-text recompute fallback for DBs loaded without synthesis (mirrors
is_commander_eligible). Exposed to the deck-builder via a WASM deckCopyLimit()
query so the frontend caps the add-button at the engine value instead of
re-deriving it (hasUnlimitedCopies deleted). The bare "Megalegendary" keyword
line is recognized as a silent no-op so Vazal no longer emits Unimplemented.
