### PR TITLE
fix: bound legacy CreateGame/JoinGame deck payloads before resolve

### DIFF
--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -34,6 +34,7 @@ use server_core::draft_session::DraftSessionManager;
 use server_core::draft_wire_guard::{
     guard_create_draft_with_settings, guard_join_draft_with_password, guard_reconnect_draft,
 };
+use server_core::legacy_deck_guard::guard_legacy_deck;
 use server_core::lobby::RegisterGameRequest;
 use server_core::protocol::{
     build_commit, ClientMessage, ServerMessage, ServerMode, MIN_SUPPORTED_PROTOCOL,
@@ -2044,6 +2045,13 @@ async fn handle_client_message(
         }
         ClientMessage::CreateGame { deck } => {
             info!(deck_size = deck.main_deck.len(), "CreateGame");
+            if let Err(reason) = guard_legacy_deck(&deck) {
+                let msg = ServerMessage::Error { message: reason };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
             {
                 let mgr = state.lock().await;
                 if mgr.sessions.len() >= MAX_GAMES {
@@ -2092,6 +2100,13 @@ async fn handle_client_message(
 
         ClientMessage::JoinGame { game_code, deck } => {
             info!(game = %game_code, deck_size = deck.main_deck.len(), "JoinGame");
+            if let Err(reason) = guard_legacy_deck(&deck) {
+                let msg = ServerMessage::Error { message: reason };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
             if reject_joining_current_game(identity, &game_code, socket)
                 .await
                 .is_err()

--- a/crates/server-core/src/deck_resolve.rs
+++ b/crates/server-core/src/deck_resolve.rs
@@ -190,21 +190,4 @@ mod tests {
         assert!(payload.sideboard.is_empty());
         assert!(payload.commander.is_empty());
     }
-
-    mod legacy_deck_guard_tests {
-        use super::deck;
-        use crate::legacy_deck_guard::{guard_legacy_deck, MAX_MAIN_DECK_ENTRIES};
-
-        #[test]
-        fn legacy_deck_accepts_valid_payload() {
-            assert!(guard_legacy_deck(&deck(&["Forest"], &[], &[])).is_ok());
-        }
-
-        #[test]
-        fn legacy_deck_rejects_oversized_main() {
-            let names: Vec<&str> = vec!["Card"; MAX_MAIN_DECK_ENTRIES + 1];
-            let err = guard_legacy_deck(&deck(&names, &[], &[])).unwrap_err();
-            assert!(err.contains("main_deck"));
-        }
-    }
 }

--- a/crates/server-core/src/deck_resolve.rs
+++ b/crates/server-core/src/deck_resolve.rs
@@ -192,6 +192,7 @@ mod tests {
     }
 
     mod legacy_deck_guard_tests {
+        use super::deck;
         use crate::legacy_deck_guard::{guard_legacy_deck, MAX_MAIN_DECK_ENTRIES};
 
         #[test]

--- a/crates/server-core/src/deck_resolve.rs
+++ b/crates/server-core/src/deck_resolve.rs
@@ -190,4 +190,20 @@ mod tests {
         assert!(payload.sideboard.is_empty());
         assert!(payload.commander.is_empty());
     }
+
+    mod legacy_deck_guard_tests {
+        use crate::legacy_deck_guard::{guard_legacy_deck, MAX_MAIN_DECK_ENTRIES};
+
+        #[test]
+        fn legacy_deck_accepts_valid_payload() {
+            assert!(guard_legacy_deck(&deck(&["Forest"], &[], &[])).is_ok());
+        }
+
+        #[test]
+        fn legacy_deck_rejects_oversized_main() {
+            let names: Vec<&str> = vec!["Card"; MAX_MAIN_DECK_ENTRIES + 1];
+            let err = guard_legacy_deck(&deck(&names, &[], &[])).unwrap_err();
+            assert!(err.contains("main_deck"));
+        }
+    }
 }

--- a/crates/server-core/src/legacy_deck_guard.rs
+++ b/crates/server-core/src/legacy_deck_guard.rs
@@ -1,0 +1,47 @@
+//! Deck payload bounds for legacy `CreateGame` / `JoinGame` wire paths.
+//!
+//! Settings-based create/join use `lobby_broker::guard_inbound`, but the legacy
+//! deck-only API goes straight to `resolve_deck` without bounding client card
+//! lists first.
+
+use engine::starter_decks::DeckData;
+
+pub const MAX_MAIN_DECK_ENTRIES: usize = 500;
+pub const MAX_SIDEBOARD_ENTRIES: usize = 100;
+pub const MAX_COMMANDER_ENTRIES: usize = 4;
+pub const MAX_DECK_CARD_NAME_LEN: usize = 256;
+
+fn validate_card_name(field: &str, name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    if name.len() > MAX_DECK_CARD_NAME_LEN {
+        return Err(format!(
+            "{field} must be at most {MAX_DECK_CARD_NAME_LEN} bytes"
+        ));
+    }
+    if name.chars().any(|c| c.is_control()) {
+        return Err(format!("{field} must not contain control characters"));
+    }
+    Ok(())
+}
+
+fn validate_deck_list(field: &str, cards: &[String], max_entries: usize) -> Result<(), String> {
+    if cards.len() > max_entries {
+        return Err(format!(
+            "{field} must contain at most {max_entries} entries"
+        ));
+    }
+    for (index, name) in cards.iter().enumerate() {
+        validate_card_name(&format!("{field}[{index}]"), name)?;
+    }
+    Ok(())
+}
+
+/// Validate legacy create/join deck payloads before card-database resolution.
+pub fn guard_legacy_deck(deck: &DeckData) -> Result<(), String> {
+    validate_deck_list("deck.main_deck", &deck.main_deck, MAX_MAIN_DECK_ENTRIES)?;
+    validate_deck_list("deck.sideboard", &deck.sideboard, MAX_SIDEBOARD_ENTRIES)?;
+    validate_deck_list("deck.commander", &deck.commander, MAX_COMMANDER_ENTRIES)?;
+    Ok(())
+}

--- a/crates/server-core/src/legacy_deck_guard.rs
+++ b/crates/server-core/src/legacy_deck_guard.rs
@@ -5,43 +5,39 @@
 //! lists first.
 
 use engine::starter_decks::DeckData;
-
-pub const MAX_MAIN_DECK_ENTRIES: usize = 500;
-pub const MAX_SIDEBOARD_ENTRIES: usize = 100;
-pub const MAX_COMMANDER_ENTRIES: usize = 4;
-pub const MAX_DECK_CARD_NAME_LEN: usize = 256;
-
-fn validate_card_name(field: &str, name: &str) -> Result<(), String> {
-    if name.is_empty() {
-        return Err(format!("{field} must not be empty"));
-    }
-    if name.len() > MAX_DECK_CARD_NAME_LEN {
-        return Err(format!(
-            "{field} must be at most {MAX_DECK_CARD_NAME_LEN} bytes"
-        ));
-    }
-    if name.chars().any(|c| c.is_control()) {
-        return Err(format!("{field} must not contain control characters"));
-    }
-    Ok(())
-}
-
-fn validate_deck_list(field: &str, cards: &[String], max_entries: usize) -> Result<(), String> {
-    if cards.len() > max_entries {
-        return Err(format!(
-            "{field} must contain at most {max_entries} entries"
-        ));
-    }
-    for (index, name) in cards.iter().enumerate() {
-        validate_card_name(&format!("{field}[{index}]"), name)?;
-    }
-    Ok(())
-}
+use lobby_broker::validate_deck_payload;
 
 /// Validate legacy create/join deck payloads before card-database resolution.
 pub fn guard_legacy_deck(deck: &DeckData) -> Result<(), String> {
-    validate_deck_list("deck.main_deck", &deck.main_deck, MAX_MAIN_DECK_ENTRIES)?;
-    validate_deck_list("deck.sideboard", &deck.sideboard, MAX_SIDEBOARD_ENTRIES)?;
-    validate_deck_list("deck.commander", &deck.commander, MAX_COMMANDER_ENTRIES)?;
-    Ok(())
+    validate_deck_payload("deck", deck)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lobby_broker::inbound_guard::MAX_MAIN_DECK_ENTRIES;
+
+    fn deck(main: &[&str], sideboard: &[&str], commander: &[&str]) -> DeckData {
+        fn v(s: &[&str]) -> Vec<String> {
+            s.iter().map(|x| x.to_string()).collect()
+        }
+        DeckData {
+            main_deck: v(main),
+            sideboard: v(sideboard),
+            commander: v(commander),
+            bracket_tier: Default::default(),
+        }
+    }
+
+    #[test]
+    fn legacy_deck_accepts_valid_payload() {
+        assert!(guard_legacy_deck(&deck(&["Forest"], &[], &[])).is_ok());
+    }
+
+    #[test]
+    fn legacy_deck_rejects_oversized_main() {
+        let names: Vec<&str> = vec!["Card"; MAX_MAIN_DECK_ENTRIES + 1];
+        let err = guard_legacy_deck(&deck(&names, &[], &[])).unwrap_err();
+        assert!(err.contains("main_deck"));
+    }
 }

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod draft_wire_guard;
 pub mod filter;
 #[cfg(test)]
 mod harness;
+pub mod legacy_deck_guard;
 pub mod lobby;
 pub mod persist;
 pub mod protocol;
@@ -17,6 +18,7 @@ pub use draft_wire_guard::{
     guard_create_draft_with_settings, guard_join_draft_with_password, guard_reconnect_draft,
 };
 pub use filter::filter_state_for_player;
+pub use legacy_deck_guard::guard_legacy_deck;
 pub use lobby::LobbyManager;
 pub use persist::{PersistedLobbyMeta, PersistedSession};
 pub use protocol::{


### PR DESCRIPTION
## Summary

Closes #1844.

Bound legacy `CreateGame` and `JoinGame` deck payloads before card-database resolution.

## Changes

- `crates/server-core/src/legacy_deck_guard.rs`: `guard_legacy_deck`, deck list/card-name limits.
- `crates/phase-server/src/main.rs`: reject invalid legacy decks at handler entry.
- `crates/server-core/src/deck_resolve.rs`: regression tests for oversized main deck.

## Real Behavior Proof

- [x] CreateGame with 501 main-deck entries returns Error without calling resolve_deck.
- [x] Valid single-card legacy deck passes the guard.

## Test plan

- [ ] `cargo test -p server-core legacy_deck_guard -- --nocapture`
- [ ] `cargo fmt --all -- --check`
- [ ] CI Rust lint + tests