### PR TITLE
fix(engine): auto-order indistinguishable simultaneous triggers (CR 603.3b)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -2147,6 +2147,83 @@ enum TriggerOrderingDisposition {
     NoChoiceNeeded(Vec<PendingTriggerContext>),
 }
 
+/// CR 603.3b: Strip per-instance object identity so two triggers produced by
+/// distinct sources can be compared for genuine indistinguishability. Mirrors
+/// `ResolvedAbility::set_may_trigger_origin_recursive`'s traversal — `sub_ability`
+/// and `else_ability` are the only nested `ResolvedAbility` fields. `controller`
+/// is intentionally left intact (it is the group partition key, already equal
+/// across a group). The recursion is load-bearing: derived `PartialEq` descends
+/// into `sub_ability`/`else_ability`, so their `source_id`s must also be zeroed.
+fn normalize_ability_identity(ability: &mut ResolvedAbility) {
+    ability.source_id = ObjectId(0);
+    if let Some(sub) = ability.sub_ability.as_mut() {
+        normalize_ability_identity(sub);
+    }
+    if let Some(else_branch) = ability.else_ability.as_mut() {
+        normalize_ability_identity(else_branch);
+    }
+}
+
+/// CR 603.3c/603.3d + CR 601.2c/601.2d: A trigger requires ordering-relevant
+/// player input only when it announces a mode, targets, or a division as it goes
+/// on the stack. A trigger with none of those is placed with no observable
+/// choice, so its position relative to an identical sibling cannot matter.
+/// (CR 603.5: optional / "unless pay" choices are made at RESOLUTION, not
+/// placement, so they are NOT gated here — they ride inside the normalized
+/// ability equality instead.)
+fn trigger_has_no_ordering_input(t: &PendingTrigger) -> bool {
+    t.ability.targets.is_empty()
+        && t.target_constraints.is_empty()
+        && t.distribute.is_none()
+        && t.modal.is_none()
+        && t.mode_abilities.is_empty()
+        && t.ability.multi_target.is_none()
+        && t.ability.distribution.is_none()
+}
+
+/// CR 603.3b: Returns true when every trigger in `group` is mutually
+/// INDISTINGUISHABLE, so the controller's CR 603.3b freedom to place them "in
+/// any order they choose" is genuinely immaterial and the engine may auto-order
+/// them with no prompt (matching MTG Arena). Conservative by construction: any
+/// field divergence makes this return false and the group still prompts (a safe
+/// false-negative); it can never auto-order order-sensitive triggers.
+///
+/// Two triggers are indistinguishable when both require no ordering input and
+/// they match on: the normalized ability (CR 603.4 intervening-`if` rides in
+/// `condition`; all outcome fields ride in the derived `ResolvedAbility` `==`),
+/// the trigger-level `condition`, the firing event-context (`trigger_event` and
+/// `subject_match_count` — CR 603.2c: one event with multiple occurrences fires
+/// a batched trigger once per occurrence, each carrying its own subject; these
+/// live on `PendingTrigger`, NOT the ability, and are read at resolution, so
+/// identical abilities with different event context resolve differently and
+/// must NOT be collapsed), and the `may_trigger_origin`.
+fn group_is_order_independent(group: &[PendingTriggerContext]) -> bool {
+    let Some((first, rest)) = group.split_first() else {
+        return false;
+    };
+    if rest.is_empty() {
+        return false;
+    }
+    if !trigger_has_no_ordering_input(&first.pending) {
+        return false;
+    }
+    let mut reference = first.pending.ability.clone();
+    normalize_ability_identity(&mut reference);
+    rest.iter().all(|ctx| {
+        let t = &ctx.pending;
+        trigger_has_no_ordering_input(t)
+            && t.condition == first.pending.condition
+            && t.trigger_event == first.pending.trigger_event
+            && t.subject_match_count == first.pending.subject_match_count
+            && t.may_trigger_origin == first.pending.may_trigger_origin
+            && {
+                let mut candidate = t.ability.clone();
+                normalize_ability_identity(&mut candidate);
+                candidate == reference
+            }
+    })
+}
+
 /// CR 603.3b: Partition `pending` by controller (preserving the APNAP
 /// placement order produced by `collect_pending_triggers`), populate
 /// `state.pending_trigger_order` with one `TriggerOrderGroup` per controller,
@@ -2183,9 +2260,13 @@ fn begin_trigger_ordering(
         });
     }
 
-    // Single-trigger groups are trivially in final order.
+    // CR 603.3b: A group needs an ordering choice only when permuting it is
+    // observable. Singleton groups, and groups of genuinely indistinguishable
+    // no-input triggers, commute under any permutation — auto-order them so the
+    // player isn't prompted for an immaterial choice (matching MTG Arena). Any
+    // field divergence is a safe false-negative: the group still prompts.
     for g in groups.iter_mut() {
-        if g.triggers.len() <= 1 {
+        if g.triggers.len() <= 1 || group_is_order_independent(&g.triggers) {
             g.ordered = true;
         }
     }
@@ -13857,31 +13938,16 @@ pub mod tests {
             }
         }
 
-        // CR 603.3b: at P0's upkeep the engine MUST surface the ordering prompt
-        // for the two suspend triggers — not a bare Priority. This is the
-        // assertion that fails without the `auto_advance` fix.
-        match &state.waiting_for {
-            WaitingFor::OrderTriggers { player, triggers } => {
-                assert_eq!(*player, PlayerId(0), "controller orders own triggers");
-                assert_eq!(
-                    triggers.len(),
-                    2,
-                    "both suspend upkeep triggers must be in the ordering prompt"
-                );
-            }
-            other => panic!(
-                "expected OrderTriggers prompt for the two suspend triggers, got {other:?} \
-                 (pending_trigger_order = {:?})",
-                state.pending_trigger_order.is_some()
-            ),
-        }
-
-        // Submit an order, then drain the two triggers off the stack.
-        crate::game::engine::apply_as_current(
-            &mut state,
-            GameAction::OrderTriggers { order: vec![0, 1] },
-        )
-        .expect("submit suspend trigger order");
+        // CR 603.3b + CR 603.4: the two suspend upkeep triggers are identical
+        // no-input triggers (each re-checks its OWN `SelfRef` `HasCounters` and
+        // its `RemoveCounter{SelfRef}` touches only its own card → the result is
+        // independent of placement order), so they now auto-order and reach the
+        // stack via `NoChoiceNeeded` with NO OrderTriggers prompt. (Counters go
+        // 3 → 2, not to 0, so the last-counter cast trigger never fires — no
+        // follow-on interference.) The distinct-source upkeep-prompt path is
+        // covered by `multiple_distinct_upkeep_triggers_still_prompt`.
+        //
+        // Drain whatever the auto-advance path placed on the stack.
         let mut guard = 0;
         while !state.stack.is_empty() {
             guard += 1;
@@ -15793,8 +15859,8 @@ mod dedup_regression_tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter, TargetRef,
-        TriggerDefinition,
+        AbilityDefinition, AbilityKind, Effect, QuantityExpr, ResolvedAbility, TargetFilter,
+        TargetRef, TriggerDefinition,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -17133,6 +17199,144 @@ mod dedup_regression_tests {
             state.stack.len(),
             1,
             "the single trigger reaches the stack directly"
+        );
+    }
+
+    /// CR 603.3b: Two genuinely INDISTINGUISHABLE no-input triggers (same
+    /// controller, same name → identical `format!("{name}: ...")` description →
+    /// byte-identical normalized ability, no targets/modes/division) commute
+    /// under any permutation, so the engine auto-orders them with NO
+    /// `OrderTriggers` prompt (matching MTG Arena). Both still reach the stack.
+    #[test]
+    fn order_triggers_identical_no_input_triggers_auto_order() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.phase = Phase::Upkeep;
+        // SAME name on both → identical descriptions → indistinguishable.
+        let _src_a = make_phase_trigger_source(&mut state, PlayerId(0), "Twin Source", 1);
+        let _src_b = make_phase_trigger_source(&mut state, PlayerId(0), "Twin Source", 1);
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::PhaseChanged {
+                phase: Phase::Upkeep,
+            }],
+        );
+
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }),
+            "indistinguishable no-input triggers must auto-order without a prompt; got {:?}",
+            state.waiting_for
+        );
+        assert!(
+            state.pending_trigger_order.is_none(),
+            "no in-flight ordering state when the group auto-orders"
+        );
+        assert_eq!(
+            state.stack.len(),
+            2,
+            "both auto-ordered triggers reach the stack directly"
+        );
+    }
+
+    /// CR 603.3b + CR 603.7c: Two triggers whose normalized abilities are
+    /// byte-identical but whose firing event context differs
+    /// (`subject_match_count`) resolve differently, so they are NOT
+    /// indistinguishable and MUST still prompt for ordering. Guards the
+    /// `subject_match_count` comparison in `group_is_order_independent` from a
+    /// silent regression that would collapse them.
+    #[test]
+    fn order_triggers_distinct_event_context_still_prompt() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.phase = Phase::Upkeep;
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        // A bare no-input draw ability shared by both pending triggers.
+        let ability = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(0),
+            PlayerId(0),
+        );
+        // Two PendingTriggers identical in every ordering-relevant field EXCEPT
+        // `subject_match_count` (Some(1) vs Some(2)) — the CR 603.2c batched
+        // event-context divergence that makes them distinguishable.
+        let make_ctx = |source: ObjectId, count: u32| {
+            PendingTriggerContext::single(PendingTrigger {
+                source_id: source,
+                controller: PlayerId(0),
+                condition: None,
+                ability: ability.clone(),
+                timestamp: count,
+                target_constraints: Vec::new(),
+                distribute: None,
+                trigger_event: None,
+                modal: None,
+                mode_abilities: Vec::new(),
+                description: Some("Twin: draw a card.".to_string()),
+                may_trigger_origin: None,
+                subject_match_count: Some(count),
+            })
+        };
+        let ctx_a = make_ctx(ObjectId(1), 1);
+        let ctx_b = make_ctx(ObjectId(2), 2);
+
+        let disposition = begin_trigger_ordering(&mut state, vec![ctx_a, ctx_b]);
+        assert!(
+            matches!(disposition, TriggerOrderingDisposition::PromptForChoice(_)),
+            "distinct subject_match_count must still prompt (CR 603.2c event context)"
+        );
+        assert!(
+            state.pending_trigger_order.is_some(),
+            "a live ordering pass must back the prompt"
+        );
+    }
+
+    /// CR 603.3b: A group needs an ordering prompt when its triggers are
+    /// distinguishable. Two `make_phase_trigger_source` permanents with
+    /// DIFFERENT names produce distinct `format!("{name}: ...")` descriptions,
+    /// so the same-controller upkeep group still surfaces `OrderTriggers` even
+    /// though identical suspend-style triggers now auto-order. Guards the
+    /// auto_advance / upkeep prompt path covered formerly by the suspend test.
+    #[test]
+    fn multiple_distinct_upkeep_triggers_still_prompt() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.phase = Phase::Upkeep;
+        let _src_a = make_phase_trigger_source(&mut state, PlayerId(0), "Upkeep Source A", 1);
+        let _src_b = make_phase_trigger_source(&mut state, PlayerId(0), "Upkeep Source B", 1);
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::PhaseChanged {
+                phase: Phase::Upkeep,
+            }],
+        );
+
+        let WaitingFor::OrderTriggers { player, triggers } = state.waiting_for.clone() else {
+            panic!(
+                "distinct same-controller upkeep triggers must still prompt; got {:?}",
+                state.waiting_for
+            );
+        };
+        assert_eq!(player, PlayerId(0), "controller orders own triggers");
+        assert_eq!(
+            triggers.len(),
+            2,
+            "both distinct upkeep triggers await ordering"
+        );
+        assert!(
+            state.pending_trigger_order.is_some(),
+            "the ordering pass must be live while the prompt is up"
         );
     }
 

--- a/crates/engine/tests/integration/combat_damage_order_triggers_no_hang.rs
+++ b/crates/engine/tests/integration/combat_damage_order_triggers_no_hang.rs
@@ -36,11 +36,20 @@ use engine::types::phase::Phase;
 use super::rules::run_combat;
 
 /// "Whenever this creature deals combat damage to a player, you may draw a
-/// card." — a per-creature combat-damage trigger. Two creatures with the same
-/// controller carrying this trigger fire two simultaneous, same-controller
-/// triggers when both connect, which is the exact CR 603.3b ordering case.
+/// card." — a per-creature combat-damage trigger. Pairing it with a DISTINCT
+/// combat-damage trigger (`GAIN_ON_COMBAT_DAMAGE`) on the second creature keeps
+/// the two simultaneous same-controller triggers distinguishable, so the
+/// CR 603.3b ordering prompt still fires (identical no-input triggers now
+/// auto-order — see `group_is_order_independent`).
 const DRAW_ON_COMBAT_DAMAGE: &str =
     "Whenever this creature deals combat damage to a player, you may draw a card.";
+
+/// Distinct optional companion to `DRAW_ON_COMBAT_DAMAGE`: a different effect
+/// (gain life vs. draw) so the two triggers are NOT indistinguishable and the
+/// CR 603.3b prompt still fires. Gains affect P0's life, leaving the P1
+/// combat-damage life assertions untouched.
+const GAIN_ON_COMBAT_DAMAGE: &str =
+    "Whenever this creature deals combat damage to a player, you may gain 1 life.";
 
 /// Mandatory variant (no "you may") for the first-strike re-entry test. A
 /// per-creature combat-damage trigger with NO optional choice: it resolves with
@@ -52,6 +61,14 @@ const DRAW_ON_COMBAT_DAMAGE: &str =
 const DRAW_ON_COMBAT_DAMAGE_MANDATORY: &str =
     "Whenever this creature deals combat damage to a player, draw a card.";
 
+/// Distinct mandatory companion to `DRAW_ON_COMBAT_DAMAGE_MANDATORY`: a
+/// different effect (gain life vs. draw) so the two first-strike triggers stay
+/// distinguishable and the CR 603.3b prompt still fires, while remaining
+/// non-optional so the stack-drain helper never stalls on an
+/// `OptionalEffectChoice`.
+const GAIN_ON_COMBAT_DAMAGE_MANDATORY: &str =
+    "Whenever this creature deals combat damage to a player, gain 1 life.";
+
 /// Primary regression — two same-controller creatures with combat-damage
 /// triggers attack unblocked, both deal combat damage to P1, and the resulting
 /// two simultaneous same-controller triggers MUST surface a CR 603.3b
@@ -61,17 +78,19 @@ fn two_same_controller_combat_damage_triggers_surface_order_prompt_then_progress
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
-    // Two attackers, both P0-controlled, each with the draw-on-combat-damage
-    // trigger. Distinct names so the harness can disambiguate.
+    // Two attackers, both P0-controlled, carrying DISTINCT combat-damage
+    // triggers (draw vs. gain life) so they remain distinguishable and the
+    // CR 603.3b ordering prompt still fires (identical no-input triggers now
+    // auto-order). Distinct names so the harness can disambiguate.
     let bear_a = scenario
         .add_creature_from_oracle(P0, "Tide Raider A", 2, 2, DRAW_ON_COMBAT_DAMAGE)
         .id();
     let bear_b = scenario
-        .add_creature_from_oracle(P0, "Tide Raider B", 2, 2, DRAW_ON_COMBAT_DAMAGE)
+        .add_creature_from_oracle(P0, "Tide Raider B", 2, 2, GAIN_ON_COMBAT_DAMAGE)
         .id();
 
-    // Stock P0's library so the optional draws (if taken later) are observable
-    // and never trigger a draw-from-empty loss.
+    // Stock P0's library so the optional draw (if taken later) is observable
+    // and never triggers a draw-from-empty loss.
     for name in ["Lib 1", "Lib 2", "Lib 3", "Lib 4"] {
         scenario.add_card_to_library_top(P0, name);
     }
@@ -157,11 +176,14 @@ fn order_prompt_contents_track_pending_trigger_order_state() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
+    // DISTINCT combat-damage triggers (draw vs. gain life) keep the two
+    // same-controller triggers distinguishable so the CR 603.3b prompt fires
+    // (identical no-input triggers now auto-order).
     let bear_a = scenario
         .add_creature_from_oracle(P0, "Tide Raider A", 2, 2, DRAW_ON_COMBAT_DAMAGE)
         .id();
     let bear_b = scenario
-        .add_creature_from_oracle(P0, "Tide Raider B", 2, 2, DRAW_ON_COMBAT_DAMAGE)
+        .add_creature_from_oracle(P0, "Tide Raider B", 2, 2, GAIN_ON_COMBAT_DAMAGE)
         .id();
     for name in ["Lib 1", "Lib 2", "Lib 3", "Lib 4"] {
         scenario.add_card_to_library_top(P0, name);
@@ -228,11 +250,12 @@ fn first_strike_order_prompt_does_not_skip_regular_combat_damage_substep() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
-    // Two P0 first-strike 2/2s, each with the combat-damage trigger → the
-    // first-strike sub-step produces a CR 603.3b ordering prompt. The builder
-    // borrows `&mut state`, so each creature must be built in its own scope
-    // (a fluent `.first_strike().id()` chain or multiple live builders won't
-    // compile).
+    // Two P0 first-strike 2/2s carrying DISTINCT mandatory combat-damage
+    // triggers (draw vs. gain life) → the first-strike sub-step produces a
+    // CR 603.3b ordering prompt (identical no-input triggers now auto-order, so
+    // the two triggers must differ to still prompt). The builder borrows
+    // `&mut state`, so each creature must be built in its own scope (a fluent
+    // `.first_strike().id()` chain or multiple live builders won't compile).
     let fs_a = {
         let mut b = scenario.add_creature_from_oracle(
             P0,
@@ -250,7 +273,7 @@ fn first_strike_order_prompt_does_not_skip_regular_combat_damage_substep() {
             "FS Raider B",
             2,
             2,
-            DRAW_ON_COMBAT_DAMAGE_MANDATORY,
+            GAIN_ON_COMBAT_DAMAGE_MANDATORY,
         );
         b.first_strike();
         b.id()

--- a/crates/engine/tests/scry_choice_not_clobbered_by_triggers.rs
+++ b/crates/engine/tests/scry_choice_not_clobbered_by_triggers.rs
@@ -31,9 +31,11 @@ fn scry_with_two_watchers_still_prompts_and_fires_triggers() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
-    // Two distinct "whenever you scry, draw a card" watchers (the user's board
-    // had Matoya draw + Elrond counters; two draw-watchers make the after-effect
-    // observable as +2 cards without a target-selection step).
+    // Two DISTINCT "whenever you scry" watchers (draw vs. gain life). They must
+    // differ so the two same-controller scry-watcher triggers still surface the
+    // CR 603.3b OrderTriggers prompt — the exact path that clobbered ScryChoice
+    // (identical no-input triggers now auto-order, which would bypass the
+    // clobber path this test guards).
     scenario.add_creature_from_oracle(
         P0,
         "Scry Watcher A",
@@ -46,7 +48,7 @@ fn scry_with_two_watchers_still_prompts_and_fires_triggers() {
         "Scry Watcher B",
         2,
         2,
-        "Whenever you scry, draw a card.",
+        "Whenever you scry, you gain 1 life.",
     );
 
     let spell = scenario
@@ -80,6 +82,7 @@ fn scry_with_two_watchers_still_prompts_and_fires_triggers() {
     assert_eq!(cards.len(), 2, "Scry 2 looks at the top two cards");
 
     let hand_after_cast = runner.state().players[0].hand.len();
+    let life_after_cast = runner.state().players[0].life;
 
     // Submit the scry (keep both on top), then let the now-unparked triggers
     // resolve through any ordering prompt.
@@ -103,7 +106,12 @@ fn scry_with_two_watchers_still_prompts_and_fires_triggers() {
     );
     assert_eq!(
         runner.state().players[0].hand.len(),
-        hand_after_cast + 2,
-        "both 'whenever you scry, draw' triggers must fire after the scry choice"
+        hand_after_cast + 1,
+        "the 'whenever you scry, draw' trigger must fire after the scry choice"
+    );
+    assert_eq!(
+        runner.state().players[0].life,
+        life_after_cast + 1,
+        "the 'whenever you scry, gain 1 life' trigger must fire after the scry choice"
     );
 }


### PR DESCRIPTION
The engine surfaced a WaitingFor::OrderTriggers prompt whenever one player
controlled 2+ simultaneously-firing triggers, without checking whether the
order was observable. Two copies of the same no-input trigger (e.g. two
Hinterland Sanctifiers' "Whenever another creature you control enters, you
gain 1 life") forced a pointless ordering prompt.

CR 603.3b lets a player place their own simultaneous triggers "in any order
they choose"; when the triggers are indistinguishable, every order yields the
same result, so the engine may auto-order them (matching MTG Arena). begin_
trigger_ordering now marks a multi-trigger group ordered (-> NoChoiceNeeded,
no prompt) when group_is_order_independent holds: every trigger requires no
stack-placement input (no targets/target_constraints/distribute/modal/mode_
abilities/multi_target/distribution) and is identical after zeroing per-
instance source_id, matching on condition, trigger_event, subject_match_count
(CR 603.2c batched event-context lives on PendingTrigger, not the ability, and
affects resolution), and may_trigger_origin. Conservative by construction: any
divergence falls back to prompting; it can never auto-order order-sensitive
triggers.

Hardened combat-damage / scry regression tests to distinct-described triggers
so their prompt-path coverage (turn-18 hang, CR 510.4 sub-step, ScryChoice
clobber) survives, migrated the suspend test to the auto-order path, and added
positive + event-context-discriminator coverage.
