### PR TITLE
feat(engine): Krark's Thumb — coin-flip replacement seam

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1061,6 +1061,7 @@ export type WaitingFor =
   | { type: "StationTarget"; data: { player: PlayerId; spacecraft_id: ObjectId; eligible_creatures: ObjectId[] } }
   | { type: "SaddleMount"; data: { player: PlayerId; mount_id: ObjectId; saddle_power: number; eligible_creatures: ObjectId[] } }
   | { type: "ScryChoice"; data: { player: PlayerId; cards: ObjectId[] } }
+  | { type: "CoinFlipKeepChoice"; data: { player: PlayerId; results: boolean[]; keep_count: number } }
   | { type: "DigChoice"; data: { player: PlayerId; cards: ObjectId[]; keep_count: number; up_to?: boolean; selectable_cards?: ObjectId[]; kept_destination?: Zone | null; rest_destination?: Zone | null } }
   | { type: "SurveilChoice"; data: { player: PlayerId; cards: ObjectId[] } }
   | { type: "RevealChoice"; data: { player: PlayerId; cards: ObjectId[]; filter: unknown; optional?: boolean } }
@@ -1402,6 +1403,7 @@ export type GameAction =
   | { type: "UntapLandForMana"; data: { object_id: ObjectId } }
   | { type: "TapForConvoke"; data: { object_id: ObjectId; mana_type: ManaType } }
   | { type: "SelectCards"; data: { cards: ObjectId[] } }
+  | { type: "SelectCoinFlips"; data: { keep_indices: number[] } }
   | { type: "ChooseOutsideGameCards"; data: { selections: OutsideGameSelection[] } }
   | { type: "SelectTargets"; data: { targets: TargetRef[] } }
   | { type: "ChooseTarget"; data: { target: TargetRef | null } }

--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -38,6 +38,7 @@ import { ProliferateModal } from "./ProliferateModal.tsx";
 import { CategoryChoiceModal } from "./CategoryChoiceModal.tsx";
 
 type ScryChoice = Extract<WaitingFor, { type: "ScryChoice" }>;
+type CoinFlipKeepChoice = Extract<WaitingFor, { type: "CoinFlipKeepChoice" }>;
 type DigChoice = Extract<WaitingFor, { type: "DigChoice" }>;
 type SurveilChoice = Extract<WaitingFor, { type: "SurveilChoice" }>;
 type RevealChoice = Extract<WaitingFor, { type: "RevealChoice" }>;
@@ -167,6 +168,9 @@ export function CardChoiceModal() {
     case "ScryChoice":
       if (!canActForWaitingState) return null;
       return <ScryModal data={waitingFor.data} />;
+    case "CoinFlipKeepChoice":
+      if (!canActForWaitingState) return null;
+      return <CoinFlipKeepModal data={waitingFor.data} />;
     case "DigChoice":
       if (!canActForWaitingState) return null;
       return <DigModal data={waitingFor.data} />;
@@ -537,6 +541,57 @@ function ScryModal({ data }: { data: ScryChoice["data"] }) {
       reorderHint={t("cardChoice.reorderHint")}
       keepTone="emerald"
     />
+  );
+}
+
+// ── Coin Flip Keep Modal (Krark's Thumb) ────────────────────────────────────
+
+function CoinFlipKeepModal({ data }: { data: CoinFlipKeepChoice["data"] }) {
+  const { t } = useTranslation("game");
+  const dispatch = useGameDispatch();
+
+  const keepFlip = useCallback(
+    (index: number) => {
+      dispatch({
+        type: "SelectCoinFlips",
+        data: { keep_indices: [index] },
+      });
+    },
+    [dispatch],
+  );
+
+  return (
+    <ChoiceOverlay
+      title={t("coinFlip.keep.title")}
+      subtitle={t("coinFlip.keep.subtitle")}
+    >
+      <div className="flex items-center justify-center gap-6 py-4">
+        {data.results.map((won, index) => (
+          <motion.button
+            key={index}
+            className="flex flex-col items-center gap-2 rounded-lg p-3 ring-2 ring-transparent transition hover:ring-emerald-400/80 hover:shadow-[0_0_16px_rgba(200,200,255,0.3)]"
+            initial={{ opacity: 0, y: 40, scale: 0.85 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{ delay: 0.1 + index * 0.08, duration: 0.3 }}
+            whileHover={{ scale: 1.05, y: -4 }}
+            onClick={() => keepFlip(index)}
+          >
+            <span
+              className={`flex h-16 w-16 items-center justify-center rounded-full text-sm font-bold ${
+                won
+                  ? "bg-amber-400/90 text-amber-950"
+                  : "bg-slate-500/80 text-slate-100"
+              }`}
+            >
+              {won ? t("coinFlip.keep.heads") : t("coinFlip.keep.tails")}
+            </span>
+            <span className="rounded-full bg-emerald-500/90 px-3 py-1 text-xs font-bold text-white">
+              {t("coinFlip.buttons.keep")}
+            </span>
+          </motion.button>
+        ))}
+      </div>
+    </ChoiceOverlay>
   );
 }
 

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -81,6 +81,7 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
     "StationTarget",
     "SaddleMount",
     "ScryChoice",
+    "CoinFlipKeepChoice",
     "DigChoice",
     "SurveilChoice",
     "RevealChoice",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1454,5 +1454,16 @@
   "counterMoveDistribution": {
     "title": "Move {{counter}} counters",
     "subtitle": "{{source}} has {{count}} available. Remaining: {{remaining}}"
+  },
+  "coinFlip": {
+    "keep": {
+      "title": "Krark's Thumb",
+      "subtitle": "Flip two coins and ignore one — choose which result to keep.",
+      "heads": "Heads",
+      "tails": "Tails"
+    },
+    "buttons": {
+      "keep": "Keep this"
+    }
   }
 }

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1454,5 +1454,16 @@
   "counterMoveDistribution": {
     "title": "Move {{counter}} counters",
     "subtitle": "{{source}} has {{count}} available. Remaining: {{remaining}}"
+  },
+  "coinFlip": {
+    "keep": {
+      "title": "Krark's Thumb",
+      "subtitle": "Flip two coins and ignore one — choose which result to keep.",
+      "heads": "Heads",
+      "tails": "Tails"
+    },
+    "buttons": {
+      "keep": "Keep this"
+    }
   }
 }

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1454,5 +1454,16 @@
   "counterMoveDistribution": {
     "title": "Move {{counter}} counters",
     "subtitle": "{{source}} has {{count}} available. Remaining: {{remaining}}"
+  },
+  "coinFlip": {
+    "keep": {
+      "title": "Krark's Thumb",
+      "subtitle": "Flip two coins and ignore one — choose which result to keep.",
+      "heads": "Heads",
+      "tails": "Tails"
+    },
+    "buttons": {
+      "keep": "Keep this"
+    }
   }
 }

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1454,5 +1454,16 @@
   "counterMoveDistribution": {
     "title": "Move {{counter}} counters",
     "subtitle": "{{source}} has {{count}} available. Remaining: {{remaining}}"
+  },
+  "coinFlip": {
+    "keep": {
+      "title": "Krark's Thumb",
+      "subtitle": "Flip two coins and ignore one — choose which result to keep.",
+      "heads": "Heads",
+      "tails": "Tails"
+    },
+    "buttons": {
+      "keep": "Keep this"
+    }
   }
 }

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1454,5 +1454,16 @@
   "counterMoveDistribution": {
     "title": "Move {{counter}} counters",
     "subtitle": "{{source}} has {{count}} available. Remaining: {{remaining}}"
+  },
+  "coinFlip": {
+    "keep": {
+      "title": "Krark's Thumb",
+      "subtitle": "Flip two coins and ignore one — choose which result to keep.",
+      "heads": "Heads",
+      "tails": "Tails"
+    },
+    "buttons": {
+      "keep": "Keep this"
+    }
   }
 }

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1454,5 +1454,16 @@
   "counterMoveDistribution": {
     "title": "Move {{counter}} counters",
     "subtitle": "{{source}} has {{count}} available. Remaining: {{remaining}}"
+  },
+  "coinFlip": {
+    "keep": {
+      "title": "Krark's Thumb",
+      "subtitle": "Flip two coins and ignore one — choose which result to keep.",
+      "heads": "Heads",
+      "tails": "Tails"
+    },
+    "buttons": {
+      "keep": "Keep this"
+    }
   }
 }

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1454,5 +1454,16 @@
   "counterMoveDistribution": {
     "title": "Move {{counter}} counters",
     "subtitle": "{{source}} has {{count}} available. Remaining: {{remaining}}"
+  },
+  "coinFlip": {
+    "keep": {
+      "title": "Krark's Thumb",
+      "subtitle": "Flip two coins and ignore one — choose which result to keep.",
+      "heads": "Heads",
+      "tails": "Tails"
+    },
+    "buttons": {
+      "keep": "Keep this"
+    }
   }
 }

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -797,6 +797,31 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             }
         }
         WaitingFor::ScryChoice { player, cards } => select_cards_variants(*player, cards, None),
+        WaitingFor::CoinFlipKeepChoice {
+            player,
+            results,
+            keep_count,
+        } => {
+            // CR 705.1 + CR 614.1a: Krark's Thumb keep choice. `keep_count` is
+            // always 1 for the only consumer today, so each candidate keeps a
+            // single index. (Generalization: enumerate C(results.len(),
+            // keep_count) combos if a multi-keep effect is ever added.)
+            if *keep_count == 1 {
+                (0..results.len())
+                    .map(|index| {
+                        candidate(
+                            GameAction::SelectCoinFlips {
+                                keep_indices: vec![index],
+                            },
+                            TacticalClass::Selection,
+                            Some(*player),
+                        )
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        }
         WaitingFor::DigChoice {
             player,
             keep_count,

--- a/crates/engine/src/game/effects/flip_coin.rs
+++ b/crates/engine/src/game/effects/flip_coin.rs
@@ -1,11 +1,119 @@
+use std::collections::HashSet;
+
 use rand::Rng;
 
 use crate::game::quantity::resolve_quantity;
-use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
+use crate::game::replacement::{self, ReplacementResult};
+use crate::types::ability::{
+    AbilityDefinition, Effect, EffectError, EffectKind, ResolvedAbility, TargetRef,
+};
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingCoinFlip, PendingCoinFlipKind, WaitingFor};
+use crate::types::identifiers::ObjectId;
+use crate::types::player::PlayerId;
+use crate::types::proposed_event::ProposedEvent;
 
 use super::resolve_ability_chain;
+
+/// CR 705.1 + CR 614.1a: Outcome of routing a single logical coin flip through
+/// the replacement pipeline.
+enum CoinFlipOutcome {
+    /// Exactly one coin was flipped (no Krark-style doubling). `CoinFlipped` has
+    /// already been pushed; the bool is the won/heads result (CR 705.2).
+    Resolved(bool),
+    /// The flip was doubled (Krark's Thumb). The controller must keep one of the
+    /// `results` via `WaitingFor::CoinFlipKeepChoice`, which is already set. No
+    /// `CoinFlipped` was pushed yet — that happens in `resume_after_keep` once the
+    /// player keeps a flip (CR 614.1a: the ignored flips never "happen").
+    Suspended,
+    /// CR 614.6: a replacement prevented the flip entirely (the event never
+    /// happens). No `CoinFlipped` pushed; the caller skips this flip's branch.
+    Prevented,
+}
+
+/// CR 705.1 + CR 614.1a: Route one logical coin flip through the CR 614
+/// replacement pipeline before touching the RNG, mirroring `draw`/`scry`/`mill`.
+///
+/// Krark's Thumb replaces each individual flip with "flip two and ignore one",
+/// so the pipeline may return a doubled `count`. When `count == 1` the flip is
+/// performed and `CoinFlipped` emitted inline (`Resolved`). When `count > 1` the
+/// coins are flipped but the controller must keep one — the resolver suspends on
+/// `WaitingFor::CoinFlipKeepChoice` (`Suspended`) and `resume_after_keep` emits
+/// the single surviving `CoinFlipped`.
+fn flip_through_replacement(
+    state: &mut GameState,
+    player: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> CoinFlipOutcome {
+    let proposed = ProposedEvent::CoinFlip {
+        player_id: player,
+        count: 1,
+        applied: HashSet::new(),
+    };
+
+    let count = match replacement::replace_event(state, proposed, events) {
+        ReplacementResult::Execute(ProposedEvent::CoinFlip { count, .. }) => count,
+        // A different event was substituted, or nothing matched cleanly — treat
+        // as a normal single flip rather than guessing at a foreign event.
+        ReplacementResult::Execute(_) => 1,
+        ReplacementResult::Prevented => return CoinFlipOutcome::Prevented,
+        ReplacementResult::NeedsChoice(choice_player) => {
+            // CR 614 interactive replacement (none ship for CoinFlip today, but
+            // stay correct if one is added): defer to the replacement-choice UI.
+            state.waiting_for =
+                crate::game::replacement::replacement_choice_waiting_for(choice_player, state);
+            return CoinFlipOutcome::Suspended;
+        }
+    };
+
+    if count == 0 {
+        return CoinFlipOutcome::Prevented;
+    }
+
+    // CR 705.1: flip each coin with the game's seeded RNG.
+    let results: Vec<bool> = (0..count).map(|_| state.rng.random_bool(0.5)).collect();
+
+    if count == 1 {
+        let won = results[0];
+        events.push(GameEvent::CoinFlipped {
+            player_id: player,
+            won,
+        });
+        CoinFlipOutcome::Resolved(won)
+    } else {
+        // CR 614.1a + CR 705.1: Krark's Thumb — keep one, ignore the rest. The
+        // kept flip's `CoinFlipped` is emitted in `resume_after_keep` so the
+        // ignored flips never "happen".
+        state.waiting_for = WaitingFor::CoinFlipKeepChoice {
+            player,
+            results,
+            keep_count: 1,
+        };
+        CoinFlipOutcome::Suspended
+    }
+}
+
+/// CR 705.2: Execute a flip's win/lose branch, preserving its
+/// `optional`/`sub_ability`/`condition`/`duration` via the canonical converter.
+fn run_flip_branch(
+    state: &mut GameState,
+    branch: Option<&AbilityDefinition>,
+    source_id: ObjectId,
+    controller: PlayerId,
+    targets: &[TargetRef],
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    if let Some(def) = branch {
+        let sub = crate::game::ability_utils::build_resolved_from_def_with_targets(
+            def,
+            source_id,
+            controller,
+            targets.to_vec(),
+        );
+        resolve_ability_chain(state, &sub, events, 0)?;
+    }
+    Ok(())
+}
 
 /// CR 705: Flip a coin and optionally execute win/lose effects.
 pub fn resolve(
@@ -21,13 +129,34 @@ pub fn resolve(
         _ => return Err(EffectError::MissingParam("FlipCoin".to_string())),
     };
 
-    // CR 705.1: Flip a coin using the game's seeded RNG.
-    let won = state.rng.random_bool(0.5);
-
-    events.push(GameEvent::CoinFlipped {
-        player_id: ability.controller,
-        won,
-    });
+    // CR 705.1 + CR 614.1a: route the flip through the replacement pipeline so
+    // Krark's Thumb can double it.
+    let prior_waiting_for = state.waiting_for.clone();
+    let won = match flip_through_replacement(state, ability.controller, events) {
+        CoinFlipOutcome::Resolved(won) => won,
+        CoinFlipOutcome::Prevented => {
+            // CR 614.6: the flip never happened — no branch, report resolved.
+            events.push(GameEvent::EffectResolved {
+                kind: EffectKind::FlipCoin,
+                source_id: ability.source_id,
+            });
+            return Ok(());
+        }
+        CoinFlipOutcome::Suspended => {
+            // CR 614.1a + CR 705.1: doubled flip — stash the resolution context so
+            // `resume_after_keep` can run the kept flip's branch. `EffectResolved`
+            // is deferred until the keep choice resolves.
+            state.pending_coin_flip = Some(PendingCoinFlip {
+                source_id: ability.source_id,
+                controller: ability.controller,
+                targets: ability.targets.clone(),
+                win_effect: win_effect.map(|d| Box::new(d.clone())),
+                lose_effect: lose_effect.map(|d| Box::new(d.clone())),
+                kind: PendingCoinFlipKind::Single,
+            });
+            return Ok(());
+        }
+    };
 
     // CR 705.2: Execute the appropriate branch. Use the canonical converter so
     // the branch's `optional`, `sub_ability`, `condition`, and `duration` survive
@@ -36,16 +165,14 @@ pub fn resolve(
     // (CR 712.8e: a nonmodal double-faced permanent put onto the battlefield
     // transformed has its back face up).
     let branch = if won { win_effect } else { lose_effect };
-    let prior_waiting_for = state.waiting_for.clone();
-    if let Some(def) = branch {
-        let sub = crate::game::ability_utils::build_resolved_from_def_with_targets(
-            def,
-            ability.source_id,
-            ability.controller,
-            ability.targets.clone(),
-        );
-        resolve_ability_chain(state, &sub, events, 0)?;
-    }
+    run_flip_branch(
+        state,
+        branch,
+        ability.source_id,
+        ability.controller,
+        &ability.targets,
+        events,
+    )?;
 
     // CR 608.2c: if an optional branch suspended for `WaitingFor::OptionalEffectChoice`,
     // the controller has not yet finished following the instructions in order — defer
@@ -84,29 +211,40 @@ pub fn resolve_flip_coins(
     let n =
         resolve_quantity(state, count_expr, ability.controller, ability.source_id).max(0) as u32;
 
-    // CR 705.1: Flip each coin with the game's seeded RNG, routing each
-    // outcome through the appropriate branch exactly as the single-flip
-    // resolver does — so downstream `win_effect`/`lose_effect` see the same
-    // stacking/target semantics whether they ran once or N times.
+    // CR 705.1 + CR 614.1a: Flip each coin through the replacement pipeline (so
+    // Krark's Thumb can double it), routing each outcome through the appropriate
+    // branch exactly as the single-flip resolver does.
     let prior_waiting_for = state.waiting_for.clone();
-    for _ in 0..n {
-        let won = state.rng.random_bool(0.5);
-        events.push(GameEvent::CoinFlipped {
-            player_id: ability.controller,
-            won,
-        });
+    for i in 0..n {
+        let won = match flip_through_replacement(state, ability.controller, events) {
+            CoinFlipOutcome::Resolved(won) => won,
+            // CR 614.6: this flip was prevented entirely — skip its branch.
+            CoinFlipOutcome::Prevented => continue,
+            CoinFlipOutcome::Suspended => {
+                // CR 614.1a: doubled flip — stash loop position and resume after
+                // the keep choice. `remaining` excludes the paused flip itself.
+                state.pending_coin_flip = Some(PendingCoinFlip {
+                    source_id: ability.source_id,
+                    controller: ability.controller,
+                    targets: ability.targets.clone(),
+                    win_effect: win_effect.map(|d| Box::new(d.clone())),
+                    lose_effect: lose_effect.map(|d| Box::new(d.clone())),
+                    kind: PendingCoinFlipKind::FlipN {
+                        remaining: n - i - 1,
+                    },
+                });
+                return Ok(());
+            }
+        };
         let branch = if won { win_effect } else { lose_effect };
-        if let Some(def) = branch {
-            // CR 705.2: preserve the branch's `optional`/`sub_ability`/`condition`
-            // via the canonical converter rather than the lossy `ResolvedAbility::new`.
-            let sub = crate::game::ability_utils::build_resolved_from_def_with_targets(
-                def,
-                ability.source_id,
-                ability.controller,
-                ability.targets.clone(),
-            );
-            resolve_ability_chain(state, &sub, events, 0)?;
-        }
+        run_flip_branch(
+            state,
+            branch,
+            ability.source_id,
+            ability.controller,
+            &ability.targets,
+            events,
+        )?;
         // CR 608.2c: a branch may suspend for an optional choice; stop flipping
         // until the player resolves it.
         if state.waiting_for != prior_waiting_for {
@@ -136,39 +274,99 @@ pub fn resolve_until_lose(
         _ => return Err(EffectError::MissingParam("FlipCoinUntilLose".to_string())),
     };
 
-    // CR 705: Flip coins until a flip is lost. Count the wins.
+    // CR 705 + CR 614.1a: Flip coins until a flip is lost, routing each flip
+    // through the replacement pipeline (Krark's Thumb doubles each flip). Count
+    // the wins, then run the win effect once per win.
+    let win_count = match flip_until_lose_loop(
+        state,
+        ability.controller,
+        win_effect,
+        &ability.targets,
+        ability.source_id,
+        0,
+        events,
+    )? {
+        Some(count) => count,
+        // CR 614.1a: a flip suspended for a Krark's Thumb keep choice — the
+        // pending state is stashed; `resume_after_keep` will continue.
+        None => return Ok(()),
+    };
+
+    finish_until_lose(
+        state,
+        win_count,
+        win_effect,
+        &ability.targets,
+        ability.source_id,
+        ability.controller,
+        events,
+    )
+}
+
+/// CR 705 + CR 614.1a: Flip-until-lose loop body, returning `Some(win_count)`
+/// when the losing flip was reached, or `None` if a flip suspended for a keep
+/// choice (in which case `pending_coin_flip` is stashed). `wins_so_far` seeds
+/// the win count when re-entered from `resume_after_keep`.
+fn flip_until_lose_loop(
+    state: &mut GameState,
+    controller: PlayerId,
+    win_effect: &AbilityDefinition,
+    targets: &[TargetRef],
+    source_id: ObjectId,
+    wins_so_far: u32,
+    events: &mut Vec<GameEvent>,
+) -> Result<Option<u32>, EffectError> {
     // Safety cap prevents infinite loops with pathological RNG seeds.
     const MAX_FLIPS: u32 = 1000;
-    let mut win_count = 0u32;
-    for _ in 0..MAX_FLIPS {
-        let won = state.rng.random_bool(0.5);
-        events.push(GameEvent::CoinFlipped {
-            player_id: ability.controller,
-            won,
-        });
-        if !won {
-            break;
-        }
-        win_count += 1;
-    }
-
-    // Execute the win effect once for each win (via repeat_for-like iteration).
-    let prior_waiting_for = state.waiting_for.clone();
-    if win_count > 0 {
-        for _ in 0..win_count {
-            // CR 705.2: preserve the win effect's `optional`/`sub_ability`/`condition`
-            // via the canonical converter rather than the lossy `ResolvedAbility::new`.
-            let sub = crate::game::ability_utils::build_resolved_from_def_with_targets(
-                win_effect,
-                ability.source_id,
-                ability.controller,
-                ability.targets.clone(),
-            );
-            resolve_ability_chain(state, &sub, events, 0)?;
-            // CR 608.2c: a win effect may suspend for an optional choice.
-            if state.waiting_for != prior_waiting_for {
-                break;
+    let mut win_count = wins_so_far;
+    while win_count < MAX_FLIPS {
+        match flip_through_replacement(state, controller, events) {
+            CoinFlipOutcome::Resolved(true) => win_count += 1,
+            CoinFlipOutcome::Resolved(false) => return Ok(Some(win_count)),
+            // CR 614.6: a prevented flip is neither a win nor the losing flip.
+            CoinFlipOutcome::Prevented => continue,
+            CoinFlipOutcome::Suspended => {
+                state.pending_coin_flip = Some(PendingCoinFlip {
+                    source_id,
+                    controller,
+                    targets: targets.to_vec(),
+                    win_effect: Some(Box::new(win_effect.clone())),
+                    lose_effect: None,
+                    kind: PendingCoinFlipKind::UntilLose {
+                        wins_so_far: win_count,
+                    },
+                });
+                return Ok(None);
             }
+        }
+    }
+    Ok(Some(win_count))
+}
+
+/// CR 705.2: Run the win effect once per win, then emit `EffectResolved` unless a
+/// win effect suspended for a player choice.
+fn finish_until_lose(
+    state: &mut GameState,
+    win_count: u32,
+    win_effect: &AbilityDefinition,
+    targets: &[TargetRef],
+    source_id: ObjectId,
+    controller: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let prior_waiting_for = state.waiting_for.clone();
+    for _ in 0..win_count {
+        run_flip_branch(
+            state,
+            Some(win_effect),
+            source_id,
+            controller,
+            targets,
+            events,
+        )?;
+        // CR 608.2c: a win effect may suspend for an optional choice.
+        if state.waiting_for != prior_waiting_for {
+            break;
         }
     }
 
@@ -176,11 +374,182 @@ pub fn resolve_until_lose(
     if state.waiting_for == prior_waiting_for {
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::FlipCoinUntilLose,
-            source_id: ability.source_id,
+            source_id,
         });
     }
 
     Ok(())
+}
+
+/// CR 705.1 + CR 614.1a: Resume a multi-flip resolver after the controller keeps
+/// one of the doubled (Krark's Thumb) coins.
+///
+/// Emits EXACTLY ONE `CoinFlipped` for the kept flip (the ignored flips never
+/// "happen", CR 614.6), runs that flip's branch, then continues the resolver's
+/// loop from the stashed position. Each re-entered flip may itself re-suspend and
+/// re-stash `pending_coin_flip`.
+///
+/// Returns `Ok(Some(wf))` when the resolver re-suspended for another interactive
+/// choice (`wf` is the new `WaitingFor` — a fresh `CoinFlipKeepChoice` or an
+/// optional-effect prompt). Returns `Ok(None)` when the whole flip effect
+/// completed; the caller then drains the continuation back to Priority.
+///
+/// On entry the resolving `CoinFlipKeepChoice` is cleared to a neutral
+/// `Priority { controller }` so any new resolution-choice `WaitingFor` is an
+/// unambiguous re-suspension (`super::waits_for_resolution_choice`), even when a
+/// re-suspended flip's results coincide with the one just resolved.
+pub fn resume_after_keep(
+    state: &mut GameState,
+    pending: PendingCoinFlip,
+    kept: Vec<bool>,
+    events: &mut Vec<GameEvent>,
+) -> Result<Option<WaitingFor>, EffectError> {
+    let PendingCoinFlip {
+        source_id,
+        controller,
+        targets,
+        win_effect,
+        lose_effect,
+        kind,
+    } = pending;
+
+    // CR 705.1 + CR 614.1a: the single surviving flip. The keep validation
+    // upstream guarantees exactly one kept result.
+    let won = kept[0];
+    events.push(GameEvent::CoinFlipped {
+        player_id: controller,
+        won,
+    });
+
+    let effect_kind = match kind {
+        PendingCoinFlipKind::Single => EffectKind::FlipCoin,
+        PendingCoinFlipKind::FlipN { .. } => EffectKind::FlipCoins,
+        PendingCoinFlipKind::UntilLose { .. } => EffectKind::FlipCoinUntilLose,
+    };
+
+    // Clear the resolving keep choice so a re-suspension is unambiguous.
+    state.waiting_for = WaitingFor::Priority { player: controller };
+    let suspended = |state: &GameState| super::waits_for_resolution_choice(&state.waiting_for);
+
+    match kind {
+        PendingCoinFlipKind::Single => {
+            // CR 705.2: run the kept flip's won/lost branch.
+            let branch = if won {
+                win_effect.as_deref()
+            } else {
+                lose_effect.as_deref()
+            };
+            run_flip_branch(state, branch, source_id, controller, &targets, events)?;
+            if suspended(state) {
+                return Ok(Some(state.waiting_for.clone()));
+            }
+            events.push(GameEvent::EffectResolved {
+                kind: effect_kind,
+                source_id,
+            });
+            Ok(None)
+        }
+        PendingCoinFlipKind::FlipN { remaining } => {
+            // CR 705.2: run the kept flip's branch, then continue the loop.
+            let branch = if won {
+                win_effect.as_deref()
+            } else {
+                lose_effect.as_deref()
+            };
+            run_flip_branch(state, branch, source_id, controller, &targets, events)?;
+            if suspended(state) {
+                return Ok(Some(state.waiting_for.clone()));
+            }
+
+            for i in 0..remaining {
+                match flip_through_replacement(state, controller, events) {
+                    CoinFlipOutcome::Resolved(flip_won) => {
+                        let branch = if flip_won {
+                            win_effect.as_deref()
+                        } else {
+                            lose_effect.as_deref()
+                        };
+                        run_flip_branch(state, branch, source_id, controller, &targets, events)?;
+                        if suspended(state) {
+                            return Ok(Some(state.waiting_for.clone()));
+                        }
+                    }
+                    CoinFlipOutcome::Prevented => continue,
+                    CoinFlipOutcome::Suspended => {
+                        state.pending_coin_flip = Some(PendingCoinFlip {
+                            source_id,
+                            controller,
+                            targets: targets.clone(),
+                            win_effect: win_effect.clone(),
+                            lose_effect: lose_effect.clone(),
+                            kind: PendingCoinFlipKind::FlipN {
+                                remaining: remaining - i - 1,
+                            },
+                        });
+                        return Ok(Some(state.waiting_for.clone()));
+                    }
+                }
+            }
+            events.push(GameEvent::EffectResolved {
+                kind: effect_kind,
+                source_id,
+            });
+            Ok(None)
+        }
+        PendingCoinFlipKind::UntilLose { wins_so_far } => {
+            let win_effect_def = win_effect
+                .as_deref()
+                .ok_or_else(|| EffectError::MissingParam("FlipCoinUntilLose".to_string()))?;
+            // CR 705: the kept flip counts toward the win streak (won) or ends it.
+            if won {
+                let seed = wins_so_far + 1;
+                match flip_until_lose_loop(
+                    state,
+                    controller,
+                    win_effect_def,
+                    &targets,
+                    source_id,
+                    seed,
+                    events,
+                )? {
+                    Some(win_count) => {
+                        finish_until_lose(
+                            state,
+                            win_count,
+                            win_effect_def,
+                            &targets,
+                            source_id,
+                            controller,
+                            events,
+                        )?;
+                        if suspended(state) {
+                            Ok(Some(state.waiting_for.clone()))
+                        } else {
+                            Ok(None)
+                        }
+                    }
+                    // A subsequent flip re-suspended for a keep choice.
+                    None => Ok(Some(state.waiting_for.clone())),
+                }
+            } else {
+                // CR 705: the kept flip is a loss — the streak ends here.
+                finish_until_lose(
+                    state,
+                    wins_so_far,
+                    win_effect_def,
+                    &targets,
+                    source_id,
+                    controller,
+                    events,
+                )?;
+                if suspended(state) {
+                    Ok(Some(state.waiting_for.clone()))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -915,6 +915,7 @@ fn waits_for_resolution_choice(waiting_for: &WaitingFor) -> bool {
     matches!(
         waiting_for,
         WaitingFor::ScryChoice { .. }
+            | WaitingFor::CoinFlipKeepChoice { .. }
             | WaitingFor::DigChoice { .. }
             | WaitingFor::SurveilChoice { .. }
             | WaitingFor::RevealChoice { .. }

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -315,6 +315,17 @@ pub(super) fn handle_replacement_choice(
                     );
                     state.pending_step_end_mana_handlers.clear();
                 }
+                // CR 705.1 + CR 614.1a: Coin-flip replacements (Krark's Thumb)
+                // are always Mandatory and applied inline by
+                // `flip_coin::flip_through_replacement`; they never reach the
+                // optional replacement-choice resume path. Unreachable in
+                // practice — present only for match exhaustiveness.
+                ProposedEvent::CoinFlip { .. } => {
+                    debug_assert!(
+                        false,
+                        "CoinFlip replacement reached the optional-choice resume path"
+                    );
+                }
             }
 
             let mut waiting_for = WaitingFor::Priority {

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -63,6 +63,7 @@ pub(super) fn handles(waiting_for: &WaitingFor) -> bool {
     matches!(
         waiting_for,
         WaitingFor::ScryChoice { .. }
+            | WaitingFor::CoinFlipKeepChoice { .. }
             | WaitingFor::ManifestDreadChoice { .. }
             | WaitingFor::CastOffer {
                 kind: CastOfferKind::Discover { .. },
@@ -285,6 +286,50 @@ pub(super) fn handle_resolution_choice(
                 player_state.library.push_back(card_id);
             }
             ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+        }
+        (
+            WaitingFor::CoinFlipKeepChoice {
+                player,
+                results,
+                keep_count,
+            },
+            GameAction::SelectCoinFlips { keep_indices },
+        ) => {
+            // CR 614.1a + CR 705.1: the player must keep exactly `keep_count`
+            // distinct, in-range flips and ignore the rest.
+            if keep_indices.len() != keep_count {
+                return Err(EngineError::InvalidAction(format!(
+                    "Must keep exactly {keep_count} coin flip(s), got {}",
+                    keep_indices.len()
+                )));
+            }
+            let mut seen = std::collections::HashSet::new();
+            for &index in &keep_indices {
+                if index >= results.len() {
+                    return Err(EngineError::InvalidAction(format!(
+                        "Coin flip index {index} out of range"
+                    )));
+                }
+                if !seen.insert(index) {
+                    return Err(EngineError::InvalidAction(format!(
+                        "Duplicate coin flip index {index}"
+                    )));
+                }
+            }
+            let kept: Vec<bool> = keep_indices.iter().map(|&index| results[index]).collect();
+            let pending = state.pending_coin_flip.take().ok_or_else(|| {
+                EngineError::InvalidAction("No pending coin flip to resume".to_string())
+            })?;
+            let next =
+                crate::game::effects::flip_coin::resume_after_keep(state, pending, kept, events)
+                    .map_err(|error| EngineError::InvalidAction(format!("{error}")))?;
+            // CR 608.2c: re-suspended for another interactive choice, else the
+            // whole flip effect completed — drain back to Priority.
+            let wf = match next {
+                Some(wf) => wf,
+                None => finish_with_continuation(state, player, events),
+            };
+            ResolutionChoiceOutcome::WaitingFor(wf)
         }
         (
             WaitingFor::ManifestDreadChoice { player, cards },

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -903,6 +903,55 @@ fn scry_applier(
     }
 }
 
+// --- 4c. CoinFlip (Krark's Thumb) ---
+
+// CR 705.1 + CR 614.1a: A coin flip is about to happen. Krark's Thumb replaces
+// each individual flip ("instead flip two coins and ignore one"), so the
+// matcher fires per flip while `count > 0`.
+fn coin_flip_matcher(event: &ProposedEvent, _source: ObjectId, _state: &GameState) -> bool {
+    matches!(event, ProposedEvent::CoinFlip { count, .. } if *count > 0)
+}
+
+fn coin_flip_applier(
+    event: ProposedEvent,
+    rid: ReplacementId,
+    state: &mut GameState,
+    _events: &mut Vec<GameEvent>,
+) -> ApplyResult {
+    let ProposedEvent::CoinFlip {
+        player_id,
+        count,
+        applied,
+    } = event
+    else {
+        return ApplyResult::Modified(event);
+    };
+
+    // CR 614.1a: "instead flip two coins" — double the flip count via the
+    // replacement definition's `FlipCoins { count: Multiply { factor: 2, .. } }`.
+    let execute = state
+        .objects
+        .get(&rid.source)
+        .and_then(|source| source.replacement_definitions.get(rid.index))
+        .and_then(|def| def.execute.as_deref());
+
+    let new_count = match execute {
+        Some(ability) if ability.sub_ability.is_none() => match &*ability.effect {
+            Effect::FlipCoins { count: qty, .. } => resolve_event_replacement_quantity(qty, count)
+                .map(|resolved| resolved.max(0) as u32)
+                .unwrap_or(count),
+            _ => count,
+        },
+        _ => count,
+    };
+
+    ApplyResult::Modified(ProposedEvent::CoinFlip {
+        player_id,
+        count: new_count,
+        applied,
+    })
+}
+
 fn resolve_event_replacement_quantity(expr: &QuantityExpr, event_count: u32) -> Option<i32> {
     match expr {
         QuantityExpr::Ref {
@@ -1935,6 +1984,13 @@ pub fn build_replacement_registry() -> IndexMap<ReplacementEvent, ReplacementHan
             applier: scry_applier,
         },
     );
+    registry.insert(
+        ReplacementEvent::CoinFlip,
+        ReplacementHandlerEntry {
+            matcher: coin_flip_matcher,
+            applier: coin_flip_applier,
+        },
+    );
     registry.insert(ReplacementEvent::DrawCards, stub()); // stays stub (alias for Draw)
     registry.insert(
         ReplacementEvent::GainLife,
@@ -2806,7 +2862,8 @@ pub fn find_applicable_replacements(
                     if let ProposedEvent::LifeGain { player_id, .. }
                     | ProposedEvent::Draw { player_id, .. }
                     | ProposedEvent::Scry { player_id, .. }
-                    | ProposedEvent::Mill { player_id, .. } = event
+                    | ProposedEvent::Mill { player_id, .. }
+                    | ProposedEvent::CoinFlip { player_id, .. } = event
                     {
                         let player_ok = match &repl_def.valid_player {
                             // CR 614.1a: opponent-scoped replacement (Tainted Remedy).

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1279,6 +1279,7 @@ impl GameRunner {
             WaitingFor::ReturnAsAuraTarget { .. } => "ReturnAsAuraTarget",
             WaitingFor::EquipTarget { .. } => "EquipTarget",
             WaitingFor::ScryChoice { .. } => "ScryChoice",
+            WaitingFor::CoinFlipKeepChoice { .. } => "CoinFlipKeepChoice",
             WaitingFor::DigChoice { .. } => "DigChoice",
             WaitingFor::SurveilChoice { .. } => "SurveilChoice",
             WaitingFor::RevealChoice { .. } => "RevealChoice",

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -79,6 +79,14 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
     let normalized = replace_self_refs(&text, card_name);
     let norm_lower = normalized.to_lowercase();
 
+    // --- Krark's Thumb: "If you would flip a coin, instead flip two coins and
+    //     ignore one." (CR 705.1 + CR 614.1a) ---
+    // Checked early so the generic "instead" / event-substitution handlers below
+    // don't mis-claim the line.
+    if let Some(def) = parse_krark_coin_flip_replacement(&text, &lower) {
+        return Some(def);
+    }
+
     // --- "As ~ enters, choose a [type]" → Moved replacement with persisted Choose ---
     // Must be checked BEFORE shock lands, which may contain this as a sub-pattern.
     if let Some(def) = parse_as_enters_choose(&norm_lower, &text) {
@@ -634,6 +642,50 @@ fn parse_self_enters_pay_cost_replacement(
 /// Case-insensitive replacement of card name and self-referencing phrases with "~".
 fn replace_self_refs(text: &str, card_name: &str) -> String {
     normalize_card_name_refs(text, card_name)
+}
+
+/// CR 705.1 + CR 614.1a: Krark's Thumb — "If you would flip a coin, instead flip
+/// two coins and ignore one."
+///
+/// Emits a controller-scoped `CoinFlip` replacement whose `execute` doubles the
+/// flip count (`Multiply { factor: 2, EventContextAmount }`). The runtime applier
+/// reads this to set the doubled count; the resolver then performs the keep-1
+/// choice. No `valid_card` filter — the replacement is objectless (it watches the
+/// controller's flips, not a permanent moving), so it must not be skipped by an
+/// object-filter mismatch.
+fn parse_krark_coin_flip_replacement(text: &str, lower: &str) -> Option<ReplacementDefinition> {
+    let ((), rest) = nom_on_lower(text, lower, |i| {
+        let (i, _) = tag("if you would flip a coin, instead flip ").parse(i)?;
+        let (i, _) = alt((tag("two coins"), tag("2 coins"))).parse(i)?;
+        let (i, _) = tag(" and ignore ").parse(i)?;
+        let (i, _) = alt((tag("one"), tag("1"))).parse(i)?;
+        let (i, _) = opt(char('.')).parse(i)?;
+        Ok((i, ()))
+    })?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    let mut def = ReplacementDefinition::new(ReplacementEvent::CoinFlip)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            // CR 614.1a: "instead flip two coins" — double the count the
+            // replacement applier sees, then ignore all but one (CR 705.1).
+            Effect::FlipCoins {
+                count: QuantityExpr::Multiply {
+                    factor: 2,
+                    inner: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount,
+                    }),
+                },
+                win_effect: None,
+                lose_effect: None,
+            },
+        ))
+        .description(text.to_string());
+    // CR 614.1a: "If you would flip a coin" — controller-scoped.
+    def.valid_player = Some(ReplacementPlayerScope::You);
+    Some(def)
 }
 
 fn parse_enters_prepared(norm_lower: &str, text: &str) -> Option<ReplacementDefinition> {

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -188,6 +188,11 @@ pub enum GameAction {
     SelectCards {
         cards: Vec<ObjectId>,
     },
+    /// CR 705.1: Krark's Thumb keep-choice — indices into `results` the player
+    /// keeps (ignoring the rest, CR 614.1a). Length must equal `keep_count`.
+    SelectCoinFlips {
+        keep_indices: Vec<usize>,
+    },
     /// CR 400.11 + CR 406.3: Player commits one or more selections from the
     /// offered outside-game pool. Each selection is a discriminated source —
     /// a sideboard slot (wishboard) or a face-up exile object (Karn / Coax).
@@ -1141,6 +1146,7 @@ impl GameAction {
             | GameAction::MulliganDecision { .. }
             | GameAction::ReorderHand { .. }
             | GameAction::SelectCards { .. }
+            | GameAction::SelectCoinFlips { .. }
             | GameAction::ChooseOutsideGameCards { .. }
             | GameAction::SelectTargets { .. }
             | GameAction::ChooseTarget { .. }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -773,6 +773,34 @@ pub struct PendingRepeatIteration {
     pub total_iterations: usize,
 }
 
+/// CR 705.1 + CR 614.1a: Discriminates which multi-flip resolver paused for a
+/// Krark's Thumb keep-1 choice, carrying the loop position needed to re-enter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PendingCoinFlipKind {
+    /// `Effect::FlipCoin` — a single logical flip.
+    Single,
+    /// `Effect::FlipCoins { count }` — `remaining` flips still to perform after
+    /// the one currently paused for a keep choice.
+    FlipN { remaining: u32 },
+    /// `Effect::FlipCoinUntilLose` — `wins_so_far` flips won before the one
+    /// currently paused for a keep choice.
+    UntilLose { wins_so_far: u32 },
+}
+
+/// CR 705.1 + CR 614.1a: Full resolution context + loop position for a
+/// multi-flip resolver paused mid-loop for a Krark's Thumb keep-1 choice.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingCoinFlip {
+    pub source_id: ObjectId,
+    pub controller: PlayerId,
+    pub targets: Vec<TargetRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub win_effect: Option<Box<AbilityDefinition>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lose_effect: Option<Box<AbilityDefinition>>,
+    pub kind: PendingCoinFlipKind,
+}
+
 /// CR 614.12b + CR 614.1c + CR 614.13: Resume state for a multi-target
 /// `ChangeZone` resolution loop paused when one of the moving objects
 /// triggered a per-permanent replacement choice (shock-land "pay 2 life?",
@@ -1947,6 +1975,14 @@ pub enum WaitingFor {
     ScryChoice {
         player: PlayerId,
         cards: Vec<ObjectId>,
+    },
+    /// CR 705.1 + CR 614.1a: Krark's Thumb — the controller flipped `results.len()`
+    /// coins for one logical flip and must ignore all but `keep_count`. `results[i]`
+    /// is true for heads/won (CR 705.2).
+    CoinFlipKeepChoice {
+        player: PlayerId,
+        results: Vec<bool>,
+        keep_count: usize,
     },
     /// CR 701.20e: Waiting for the player to choose which looked-at cards to keep.
     DigChoice {
@@ -3134,6 +3170,7 @@ impl WaitingFor {
             | WaitingFor::StationTarget { player, .. }
             | WaitingFor::SaddleMount { player, .. }
             | WaitingFor::ScryChoice { player, .. }
+            | WaitingFor::CoinFlipKeepChoice { player, .. }
             | WaitingFor::DigChoice { player, .. }
             | WaitingFor::SurveilChoice { player, .. }
             | WaitingFor::RevealChoice { player, .. }
@@ -4618,6 +4655,13 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_change_zone_iteration: Option<PendingChangeZoneIteration>,
 
+    /// CR 705.1 + CR 614.1a: Pending multi-flip coin resolver paused mid-loop
+    /// for a Krark's Thumb keep-1 choice. Stashes the full resolution context +
+    /// loop position so `resume_after_keep` can re-enter the flip loop after the
+    /// player's `CoinFlipKeepChoice`. See [`PendingCoinFlip`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_coin_flip: Option<PendingCoinFlip>,
+
     /// CR 608.2c + CR 107.1c: Pending "repeat this process" loop paused because
     /// an iteration's process entered an interactive `WaitingFor` state.
     /// Drained by `drain_pending_continuation` after `pending_continuation`,
@@ -5246,6 +5290,7 @@ impl GameState {
             pending_continuation: None,
             pending_repeat_iteration: None,
             pending_change_zone_iteration: None,
+            pending_coin_flip: None,
             pending_repeat_until: None,
             pending_choose_one_of: None,
             pending_counter_moves: None,
@@ -5542,6 +5587,7 @@ impl PartialEq for GameState {
             && self.pending_continuation == other.pending_continuation
             && self.pending_repeat_iteration == other.pending_repeat_iteration
             && self.pending_change_zone_iteration == other.pending_change_zone_iteration
+            && self.pending_coin_flip == other.pending_coin_flip
             && self.pending_repeat_until == other.pending_repeat_until
             && self.pending_choose_one_of == other.pending_choose_one_of
             && self.pending_counter_moves == other.pending_counter_moves

--- a/crates/engine/src/types/proposed_event.rs
+++ b/crates/engine/src/types/proposed_event.rs
@@ -187,6 +187,15 @@ pub enum ProposedEvent {
         destination: Zone,
         applied: HashSet<ReplacementId>,
     },
+    /// CR 705.1 + CR 614.1a: A player is about to flip a single coin. Carried
+    /// through the replacement pipeline so per-flip "instead flip two and ignore
+    /// one" effects (Krark's Thumb) double the count before the RNG runs. Per the
+    /// card's 2019-01-25 ruling, each individual flip is replaced separately.
+    CoinFlip {
+        player_id: PlayerId,
+        count: u32,
+        applied: HashSet<ReplacementId>,
+    },
     LifeGain {
         player_id: PlayerId,
         amount: u32,
@@ -421,6 +430,7 @@ impl ProposedEvent {
             | ProposedEvent::Draw { applied, .. }
             | ProposedEvent::Scry { applied, .. }
             | ProposedEvent::Mill { applied, .. }
+            | ProposedEvent::CoinFlip { applied, .. }
             | ProposedEvent::LifeGain { applied, .. }
             | ProposedEvent::LifeLoss { applied, .. }
             | ProposedEvent::AddCounter { applied, .. }
@@ -446,6 +456,7 @@ impl ProposedEvent {
             | ProposedEvent::Draw { applied, .. }
             | ProposedEvent::Scry { applied, .. }
             | ProposedEvent::Mill { applied, .. }
+            | ProposedEvent::CoinFlip { applied, .. }
             | ProposedEvent::LifeGain { applied, .. }
             | ProposedEvent::LifeLoss { applied, .. }
             | ProposedEvent::AddCounter { applied, .. }
@@ -511,6 +522,7 @@ impl ProposedEvent {
             ProposedEvent::Draw { player_id, .. }
             | ProposedEvent::Scry { player_id, .. }
             | ProposedEvent::Mill { player_id, .. }
+            | ProposedEvent::CoinFlip { player_id, .. }
             | ProposedEvent::LifeGain { player_id, .. }
             | ProposedEvent::LifeLoss { player_id, .. }
             | ProposedEvent::Discard { player_id, .. }
@@ -553,6 +565,7 @@ impl ProposedEvent {
             ProposedEvent::Draw { .. }
             | ProposedEvent::Scry { .. }
             | ProposedEvent::Mill { .. }
+            | ProposedEvent::CoinFlip { .. }
             | ProposedEvent::LifeGain { .. }
             | ProposedEvent::LifeLoss { .. }
             | ProposedEvent::CreateToken { .. }
@@ -568,8 +581,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn proposed_event_has_19_variants() {
-        // Verify all 19 variants compile
+    fn proposed_event_has_21_variants() {
+        // Verify all 21 variants compile
         let events: Vec<ProposedEvent> = vec![
             ProposedEvent::zone_change(ObjectId(1), Zone::Battlefield, Zone::Graveyard, None),
             ProposedEvent::Damage {
@@ -593,6 +606,11 @@ mod tests {
                 player_id: PlayerId(0),
                 count: 1,
                 destination: Zone::Graveyard,
+                applied: HashSet::new(),
+            },
+            ProposedEvent::CoinFlip {
+                player_id: PlayerId(0),
+                count: 1,
                 applied: HashSet::new(),
             },
             ProposedEvent::LifeGain {
@@ -689,7 +707,7 @@ mod tests {
                 applied: HashSet::new(),
             },
         ];
-        assert_eq!(events.len(), 20);
+        assert_eq!(events.len(), 21);
     }
 
     #[test]

--- a/crates/engine/src/types/replacements.rs
+++ b/crates/engine/src/types/replacements.rs
@@ -63,6 +63,8 @@ pub enum ReplacementEvent {
     ProduceMana,
     /// CR 614.1a: Replaces a scry event.
     Scry,
+    /// CR 614.1a + CR 705.1: Replaces an individual coin flip.
+    CoinFlip,
     /// CR 614.1a: Replaces a transform event.
     Transform,
     /// CR 614.1a: Replaces an explore event.
@@ -123,6 +125,7 @@ impl fmt::Display for ReplacementEvent {
             ReplacementEvent::DrawCards => write!(f, "DrawCards"),
             ReplacementEvent::ProduceMana => write!(f, "ProduceMana"),
             ReplacementEvent::Scry => write!(f, "Scry"),
+            ReplacementEvent::CoinFlip => write!(f, "CoinFlip"),
             ReplacementEvent::Transform => write!(f, "Transform"),
             ReplacementEvent::Explore => write!(f, "Explore"),
             ReplacementEvent::AssembleContraption => write!(f, "AssembleContraption"),
@@ -171,6 +174,7 @@ impl FromStr for ReplacementEvent {
             "DrawCards" => ReplacementEvent::DrawCards,
             "ProduceMana" => ReplacementEvent::ProduceMana,
             "Scry" => ReplacementEvent::Scry,
+            "CoinFlip" => ReplacementEvent::CoinFlip,
             "Transform" => ReplacementEvent::Transform,
             "Explore" => ReplacementEvent::Explore,
             "AssembleContraption" => ReplacementEvent::AssembleContraption,
@@ -248,6 +252,7 @@ mod tests {
             ReplacementEvent::AddCounter,
             ReplacementEvent::CreateToken,
             ReplacementEvent::DealtDamage,
+            ReplacementEvent::CoinFlip,
             ReplacementEvent::Other("Custom".to_string()),
         ];
         for event in events {

--- a/crates/engine/tests/integration/krark_thumb_coin_flip.rs
+++ b/crates/engine/tests/integration/krark_thumb_coin_flip.rs
@@ -1,0 +1,405 @@
+//! Krark's Thumb — "If you would flip a coin, instead flip two coins and ignore
+//! one." (CR 705.1 + CR 614.1a)
+//!
+//! Validates the reusable coin-flip replacement seam:
+//! `ProposedEvent::CoinFlip` -> CR 614 replacement pipeline -> RNG, mirroring
+//! Draw/Scry/Mill. Per the card's 2019-01-25 ruling, each individual flip is
+//! replaced separately (an N-coin effect = N independent flip-2-keep-1 choices).
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 614.1a: "instead" is a replacement effect.
+//!   - CR 614.6: a replaced event never happens (the ignored flips don't occur).
+//!   - CR 705.1: to flip a coin, the player calls heads or tails, then flips it.
+//!   - CR 705.2: only the flipping player wins or loses the flip.
+//!
+//! These are apply()-driven runtime tests: the interactive keep choice is
+//! exercised through the real `apply()` pipeline, not a direct `resolve()`.
+
+use engine::game::replacement::{replace_event, ReplacementResult};
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{Effect, QuantityExpr, ReplacementPlayerScope};
+use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::proposed_event::ProposedEvent;
+use engine::types::replacements::ReplacementEvent;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use std::collections::HashSet;
+
+/// Krark's Thumb printed Oracle text — byte-identical to card-data.json.
+const KRARK: &str = "If you would flip a coin, instead flip two coins and ignore one.";
+
+// --- Parser ----------------------------------------------------------------
+
+/// CR 614.1a + CR 705.1: Krark's text parses into a controller-scoped `CoinFlip`
+/// replacement that doubles the flip count, with no `valid_card` filter (the
+/// replacement is objectless — it watches the controller's flips).
+#[test]
+fn parses_krark_coin_flip_replacement() {
+    let parsed = parse_oracle_text(KRARK, "Krark's Thumb", &[], &[], &[]);
+    let repl = parsed
+        .replacements
+        .iter()
+        .find(|r| matches!(r.event, ReplacementEvent::CoinFlip))
+        .expect("Krark must parse a CoinFlip replacement");
+
+    assert_eq!(
+        repl.valid_player,
+        Some(ReplacementPlayerScope::You),
+        "Krark is controller-scoped (\"If YOU would flip\")"
+    );
+    assert!(
+        repl.valid_card.is_none(),
+        "Krark's replacement is objectless — no valid_card filter"
+    );
+
+    let execute = repl
+        .execute
+        .as_ref()
+        .expect("the replacement must carry an execute Template");
+    match execute.effect.as_ref() {
+        Effect::FlipCoins {
+            count: QuantityExpr::Multiply { factor, .. },
+            ..
+        } => assert_eq!(*factor, 2, "Krark doubles the flip count"),
+        other => panic!("expected FlipCoins {{ Multiply {{ factor: 2 }} }}, got {other:?}"),
+    }
+}
+
+// --- Replacement applier / scoping -----------------------------------------
+
+/// Put Krark's Thumb on the given player's battlefield (parsed from Oracle so
+/// the test exercises the live replacement shape). Krark is an artifact, but the
+/// replacement's controller scope is card-type-independent, so a creature body
+/// is a harmless test scaffold.
+fn add_krark(scenario: &mut GameScenario, player: PlayerId) -> ObjectId {
+    scenario
+        .add_creature_from_oracle(player, "Krark's Thumb", 0, 1, KRARK)
+        .id()
+}
+
+/// CR 614.1a: with Krark on P0's battlefield, P0's `CoinFlip { count: 1 }` event
+/// is doubled to `count: 2` by the replacement applier.
+#[test]
+fn applier_doubles_controllers_flip() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    add_krark(&mut scenario, P0);
+    let mut runner = scenario.build();
+
+    let mut events = Vec::new();
+    let proposed = ProposedEvent::CoinFlip {
+        player_id: P0,
+        count: 1,
+        applied: HashSet::new(),
+    };
+    match replace_event(runner.state_mut(), proposed, &mut events) {
+        ReplacementResult::Execute(ProposedEvent::CoinFlip { count, .. }) => {
+            assert_eq!(count, 2, "Krark doubles P0's flip");
+        }
+        other => panic!("expected Execute(CoinFlip {{ count: 2 }}), got {other:?}"),
+    }
+}
+
+/// CR 614.1a: Krark is controller-scoped (B2). With Krark under P0, a flip by P1
+/// is NOT doubled; a flip by P0 IS doubled.
+#[test]
+fn applier_scopes_to_controller_only() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    add_krark(&mut scenario, P0);
+    let mut runner = scenario.build();
+
+    // P1's flip — not doubled.
+    let mut events = Vec::new();
+    let p1_flip = ProposedEvent::CoinFlip {
+        player_id: P1,
+        count: 1,
+        applied: HashSet::new(),
+    };
+    match replace_event(runner.state_mut(), p1_flip, &mut events) {
+        ReplacementResult::Execute(ProposedEvent::CoinFlip { count, .. }) => {
+            assert_eq!(count, 1, "P1's flip is not doubled by P0's Krark");
+        }
+        other => panic!("expected Execute(CoinFlip {{ count: 1 }}), got {other:?}"),
+    }
+
+    // P0's flip — doubled.
+    let mut events = Vec::new();
+    let p0_flip = ProposedEvent::CoinFlip {
+        player_id: P0,
+        count: 1,
+        applied: HashSet::new(),
+    };
+    match replace_event(runner.state_mut(), p0_flip, &mut events) {
+        ReplacementResult::Execute(ProposedEvent::CoinFlip { count, .. }) => {
+            assert_eq!(count, 2, "P0's own flip is doubled");
+        }
+        other => panic!("expected Execute(CoinFlip {{ count: 2 }}), got {other:?}"),
+    }
+}
+
+// --- Runtime suspend / resume (apply-driven) -------------------------------
+
+/// Add a no-cost instant to P0's hand whose only effect is `effect`, returning
+/// its object id. Cast it via `act` and resolve via PassPriority.
+fn add_flip_spell(scenario: &mut GameScenario, effect: Effect) -> ObjectId {
+    let mut builder = scenario.add_spell_to_hand(P0, "Flip Spell", true);
+    builder.with_ability(effect);
+    builder.id()
+}
+
+/// Cast the flip spell and pass priority until either the stack starts resolving
+/// (reaching a CoinFlipKeepChoice) or it fully resolves. Returns the
+/// `ActionResult` of the action that produced the current `waiting_for`.
+fn cast_and_resolve(
+    runner: &mut engine::game::scenario::GameRunner,
+    spell_id: ObjectId,
+) -> engine::types::game_state::ActionResult {
+    let card_id = runner.state().objects[&spell_id].card_id;
+    let mut result = runner
+        .act(GameAction::CastSpell {
+            object_id: spell_id,
+            card_id,
+            targets: vec![],
+        })
+        .expect("P0 casts the flip spell");
+
+    for _ in 0..20 {
+        match &result.waiting_for {
+            WaitingFor::CoinFlipKeepChoice { .. } => return result,
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => return result,
+            WaitingFor::Priority { .. } => {
+                result = runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority to resolve the flip spell");
+            }
+            other => panic!("unexpected waiting state resolving flip: {other:?}"),
+        }
+    }
+    panic!("flip spell did not resolve within 20 steps");
+}
+
+fn setup_single_flip(seed: u64) -> (engine::game::scenario::GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    add_krark(&mut scenario, P0);
+    let spell = add_flip_spell(
+        &mut scenario,
+        Effect::FlipCoin {
+            win_effect: None,
+            lose_effect: None,
+        },
+    );
+    let mut runner = scenario.build();
+    runner.state_mut().rng = ChaCha20Rng::seed_from_u64(seed);
+    (runner, spell)
+}
+
+/// B1 (objectless replacement not skipped) + G-NEW-1 (zero CoinFlipped while
+/// suspended): with Krark on the battlefield, P0's FlipCoin suspends on a
+/// `CoinFlipKeepChoice` carrying two results, keep_count 1, and emits NO
+/// `CoinFlipped` event yet (CR 614.6: the ignored flips never happen).
+#[test]
+fn single_flip_suspends_for_keep_choice_with_no_coin_flipped() {
+    let (mut runner, spell) = setup_single_flip(0);
+    let result = cast_and_resolve(&mut runner, spell);
+
+    match &result.waiting_for {
+        WaitingFor::CoinFlipKeepChoice {
+            player,
+            results,
+            keep_count,
+        } => {
+            assert_eq!(*player, P0);
+            assert_eq!(results.len(), 2, "Krark doubled the single flip");
+            assert_eq!(*keep_count, 1, "keep exactly one (ignore one)");
+        }
+        other => panic!("expected CoinFlipKeepChoice, got {other:?}"),
+    }
+
+    // CR 614.6: no flip has "happened" yet — the suspend step emits no
+    // CoinFlipped event (the ignored flips never occur).
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|e| matches!(e, GameEvent::CoinFlipped { .. })),
+        "no CoinFlipped may be emitted while suspended for the keep choice"
+    );
+}
+
+/// G-NEW-1 + keep round-trip: after `SelectCoinFlips { [i] }`, EXACTLY ONE
+/// `CoinFlipped` fires with `won == results[i]`, and the engine returns to a
+/// normal Priority state with the flip spell resolved.
+#[test]
+fn keeping_a_flip_emits_exactly_one_coin_flipped_and_returns_to_priority() {
+    let (mut runner, spell) = setup_single_flip(0);
+    let result = cast_and_resolve(&mut runner, spell);
+
+    let (player, results) = match result.waiting_for {
+        WaitingFor::CoinFlipKeepChoice {
+            player, results, ..
+        } => (player, results),
+        other => panic!("expected CoinFlipKeepChoice, got {other:?}"),
+    };
+
+    // Keep the first flip. (`act` dispatches as the current acting player, P0.)
+    let _ = player;
+    let keep_index = 0usize;
+    let expected_won = results[keep_index];
+    let keep_result = runner
+        .act(GameAction::SelectCoinFlips {
+            keep_indices: vec![keep_index],
+        })
+        .expect("SelectCoinFlips must succeed");
+
+    let coin_flips: Vec<bool> = keep_result
+        .events
+        .iter()
+        .filter_map(|e| match e {
+            GameEvent::CoinFlipped { won, .. } => Some(*won),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        coin_flips,
+        vec![expected_won],
+        "exactly one CoinFlipped with won == kept result"
+    );
+
+    // The flip effect completed and we are back at Priority.
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+        "engine returns to Priority after the keep choice; got {:?}",
+        runner.state().waiting_for
+    );
+    assert!(
+        runner.state().pending_coin_flip.is_none(),
+        "no pending coin flip remains after completion"
+    );
+}
+
+/// B3: `FlipCoins { count: 3 }` with Krark produces THREE sequential
+/// `CoinFlipKeepChoice` prompts (each individual flip is replaced separately per
+/// the 2019-01-25 ruling), and exactly three `CoinFlipped` events total.
+#[test]
+fn flip_coins_three_with_krark_prompts_three_times() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    add_krark(&mut scenario, P0);
+    let spell = add_flip_spell(
+        &mut scenario,
+        Effect::FlipCoins {
+            count: QuantityExpr::Fixed { value: 3 },
+            win_effect: None,
+            lose_effect: None,
+        },
+    );
+    let mut runner = scenario.build();
+    runner.state_mut().rng = ChaCha20Rng::seed_from_u64(7);
+
+    let mut result = cast_and_resolve(&mut runner, spell);
+
+    let mut prompts = 0;
+    let mut total_coin_flips = 0;
+    for _ in 0..30 {
+        match result.waiting_for.clone() {
+            WaitingFor::CoinFlipKeepChoice { results, .. } => {
+                prompts += 1;
+                assert_eq!(results.len(), 2, "each individual flip is doubled");
+                result = runner
+                    .act(GameAction::SelectCoinFlips {
+                        keep_indices: vec![0],
+                    })
+                    .expect("SelectCoinFlips must succeed");
+                total_coin_flips += result
+                    .events
+                    .iter()
+                    .filter(|e| matches!(e, GameEvent::CoinFlipped { .. }))
+                    .count();
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            WaitingFor::Priority { .. } => {
+                result = runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            other => panic!("unexpected waiting state: {other:?}"),
+        }
+    }
+
+    assert_eq!(prompts, 3, "three independent flips => three keep prompts");
+    assert_eq!(
+        total_coin_flips, 3,
+        "exactly one CoinFlipped per kept flip (three total)"
+    );
+}
+
+/// until-lose + Krark: `FlipCoinUntilLose` with Krark prompts a keep choice per
+/// flip and terminates once a kept loss occurs, emitting one CoinFlipped per
+/// kept flip and returning to Priority.
+#[test]
+fn flip_until_lose_with_krark_resolves_via_per_flip_keep_choices() {
+    use engine::types::ability::{AbilityDefinition, AbilityKind, TargetFilter};
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    add_krark(&mut scenario, P0);
+    let spell = add_flip_spell(
+        &mut scenario,
+        Effect::FlipCoinUntilLose {
+            win_effect: Box::new(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )),
+        },
+    );
+    let mut runner = scenario.build();
+    runner.state_mut().rng = ChaCha20Rng::seed_from_u64(3);
+
+    let mut result = cast_and_resolve(&mut runner, spell);
+
+    let mut kept_losses = 0;
+    let mut prompts = 0;
+    for _ in 0..60 {
+        match result.waiting_for.clone() {
+            WaitingFor::CoinFlipKeepChoice { results, .. } => {
+                prompts += 1;
+                assert_eq!(results.len(), 2);
+                // Keep the first flip; track whether it was a loss.
+                if !results[0] {
+                    kept_losses += 1;
+                }
+                result = runner
+                    .act(GameAction::SelectCoinFlips {
+                        keep_indices: vec![0],
+                    })
+                    .expect("SelectCoinFlips must succeed");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            WaitingFor::Priority { .. } => {
+                result = runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            other => panic!("unexpected waiting state: {other:?}"),
+        }
+    }
+
+    assert!(prompts >= 1, "until-lose must prompt at least once");
+    assert_eq!(
+        kept_losses, 1,
+        "the loop ends exactly when a kept flip is a loss"
+    );
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+        "engine returns to Priority after until-lose completes; got {:?}",
+        runner.state().waiting_for
+    );
+    assert!(runner.state().pending_coin_flip.is_none());
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -74,6 +74,7 @@ mod json_smoke_test;
 mod kaito_integration;
 mod kodama_anti_recursion_intervening_if;
 mod krark_clan_ironworks_castability;
+mod krark_thumb_coin_flip;
 mod lathiel_end_step_counters_repro;
 mod leyline_taps_for_mana_repro;
 mod liliana_waker_cross_scope_decline;

--- a/crates/phase-ai/src/decision_kind.rs
+++ b/crates/phase-ai/src/decision_kind.rs
@@ -143,6 +143,9 @@ pub fn classify(waiting_for: &WaitingFor, action: &GameAction) -> DecisionKind {
         | WaitingFor::MiracleReveal { .. }
         | WaitingFor::ChooseOneOfBranch { .. }
         | WaitingFor::PayManaAbilityMana { .. }
+        // CR 705.1 + CR 614.1a: Krark's Thumb keep choice is a forced
+        // mid-resolution selection; route to the ability catch-all.
+        | WaitingFor::CoinFlipKeepChoice { .. }
         | WaitingFor::ActivationCostOneOfChoice { .. } => DecisionKind::ActivateAbility,
     }
 }

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -344,6 +344,11 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
         | WaitingFor::UnlessBounceChoice { .. } => {
             Some(GameAction::SelectCards { cards: Vec::new() })
         }
+        // CR 705.1 + CR 614.1a: Krark's Thumb keep choice — keep the first
+        // `keep_count` flips (always in range, since keep_count <= results.len()).
+        WaitingFor::CoinFlipKeepChoice { keep_count, .. } => Some(GameAction::SelectCoinFlips {
+            keep_indices: (0..*keep_count).collect(),
+        }),
         // CR 608.2d: SearchPartitionChoice requires EXACTLY primary_count cards —
         // an empty selection is illegal. Deterministically take the first
         // primary_count of the found set for the battlefield (rest auto-route).


### PR DESCRIPTION
## What

Implements **Krark's Thumb** — *"If you would flip a coin, instead flip two coins and ignore one."* — at full fidelity, including a real player keep-choice.

The card was a dead no-op: it parsed to `Unimplemented{replacement_structure}` with empty `replacements[]` because coin flips bypassed the replacement pipeline entirely (direct RNG in `flip_coin.rs`).

## The seam (load-bearing)

Routes every coin flip through a new `ProposedEvent::CoinFlip` → CR 614 replacement pipeline → RNG, mirroring the existing Draw/Scry/Mill seam. Krark's Thumb is the validating consumer; any future coin-flip replacement (and the die analog) reuses the seam.

## Rules fidelity

- **CR 614.1a** ("instead" = replacement) layered over **CR 705.1/705.2** flips. (There is no CR 705.4 — 705 ends at 705.3.)
- Per the card's 2019 ruling, Krark replaces **each individual flip**: an N-coin effect becomes N independent flip-2-keep-1 events (not flip-2N-keep-N).
- Exactly **one** `CoinFlipped` event is emitted (the kept, non-ignored coin), so "whenever you win/flip a coin" triggers fire on the kept result only.
- Controller-scoped (`valid_player = You`, CR 705.2): an opponent's flips are not replaced.

## Changes (26 files)

- **types**: `ProposedEvent::CoinFlip`, `ReplacementEvent::CoinFlip`, `WaitingFor::CoinFlipKeepChoice` + `PendingCoinFlip`, `GameAction::SelectCoinFlips`
- **replacement.rs**: coin-flip matcher/applier (count doubling) + controller scoping
- **flip_coin.rs**: all three resolvers reroute via `flip_through_replacement`; `resume_after_keep` continues FlipN/UntilLose loops after the keep choice
- **parser**: nom-combinator coin-flip replacement branch
- **AI**: candidates + phase-ai fallback/classify arms
- **frontend**: `CoinFlipKeepModal` + i18n keys (all 7 locales)
- **tests**: apply()-driven integration coverage

## Verification

Verified green via Tilt on `main`:
- compile + clippy clean
- engine lib suite: **9714 passed, 0 failed** (the three Ral, Monsoon Mage coin-flip tests unchanged & green)
- all 7 Krark integration tests pass (parser, applier doubling, controller scoping, per-flip B3, single-emit, zero-emit-on-suspend, until-lose)
- frontend type-check + i18n parity gate green
