### PR TITLE
chore(tilt): isolate clippy/wasm target roots and split native test compile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -23,10 +23,16 @@ WASM_SRC = ['crates/engine-wasm/src/']
 DRAFT_CORE_SRC = ['crates/draft-core/src/']
 DRAFT_WASM_SRC = ['crates/draft-wasm/src/']
 
+# The wasm32 build gets its own target root too. Although it writes to a
+# distinct target/wasm32-unknown-unknown/ subdir, the cargo build lock is per
+# target ROOT, so without this it would still serialize behind native builds.
+# Its own root lets it compile in parallel — hence no resource_deps on clippy.
+# build-wasm.sh honors CARGO_TARGET_DIR (defaulting to target/ for CI/deploy
+# callers that don't set it), so only this dev-loop invocation is relocated.
 local_resource('wasm',
-    cmd = './scripts/build-wasm.sh',
+    cmd = 'CARGO_TARGET_DIR=target/wasm ./scripts/build-wasm.sh',
     deps = ENGINE_SRC + AI_SRC + WASM_SRC + DRAFT_CORE_SRC + DRAFT_WASM_SRC,
-    resource_deps = ['clippy'],
+    allow_parallel = True,
     labels = ['build'],
 )
 
@@ -94,9 +100,25 @@ local_resource('server',
 # Test
 # ---------------------------------------------------------------------------
 
+# Compile the native test harnesses once, then let the test runners fan out to
+# parallel execution. Without this, test-engine and test-ai each serialize on
+# the cargo build lock during their compile phase. `--no-run` builds the test
+# binaries without executing them; the downstream `cargo test -p ...` then finds
+# everything fingerprint-fresh and just runs (no recompile). Default features —
+# matching the test resources, which (unlike `cargo test-all`) do not enable
+# engine/proptest; a feature mismatch here would force a rebuild.
+local_resource('build-native',
+    cmd = 'cargo test -p engine -p phase-ai --no-run',
+    deps = ENGINE_SRC + AI_SRC,
+    allow_parallel = True,
+    auto_init = 'test' in enabled,
+    labels = ['test'],
+)
+
 local_resource('test-engine',
     cmd = 'cargo test -p engine',
     deps = ENGINE_SRC,
+    resource_deps = ['build-native'],
     allow_parallel = True,
     auto_init = 'test' in enabled,
     labels = ['test'],
@@ -105,6 +127,8 @@ local_resource('test-engine',
 local_resource('test-ai',
     cmd = 'cargo test -p phase-ai',
     deps = ENGINE_SRC + AI_SRC,
+    resource_deps = ['build-native'],
+    allow_parallel = True,
     auto_init = 'test' in enabled,
     labels = ['test'],
 )
@@ -123,8 +147,13 @@ local_resource('test-frontend',
 # Lint
 # ---------------------------------------------------------------------------
 
+# clippy builds into its own target root. The clippy driver writes different
+# fingerprints than `cargo build`/`cargo test` into the shared target/debug,
+# mutually invalidating artifacts (rebuild thrash). A separate CARGO_TARGET_DIR
+# also gives it its own build lock, so it never queues behind the native test
+# builds. Cost: a second debug tree on disk (reclaimed by cargo-sweep).
 local_resource('clippy',
-    cmd = 'cargo clippy --all-targets -- -D warnings',
+    cmd = 'CARGO_TARGET_DIR=target/clippy cargo clippy --all-targets -- -D warnings',
     deps = ['crates/'],
     auto_init = 'lint' in enabled,
     allow_parallel = True,

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 WASM_OUT="client/src/wasm"
 PROFILE="${1:-wasm-dev}"
+# Honor CARGO_TARGET_DIR so callers (e.g. Tilt's dev loop) can relocate the
+# build tree off the shared target/ root. cargo build already respects the env
+# var; this mirrors it for the wasm-bindgen input path below. Defaults to
+# target/ for CI/deploy/setup callers that don't set it.
+TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 
 # Build a single WASM crate: compile, bind, optimize.
 build_wasm_crate() {
@@ -21,7 +26,7 @@ build_wasm_crate() {
     --target web \
     --out-dir "$WASM_OUT" \
     --out-name "$OUT_NAME" \
-    "target/wasm32-unknown-unknown/$PROFILE/${PACKAGE//-/_}.wasm"
+    "$TARGET_DIR/wasm32-unknown-unknown/$PROFILE/${PACKAGE//-/_}.wasm"
 
   if [ "$PROFILE" = "release" ] && command -v wasm-opt &> /dev/null; then
     echo "Optimizing $OUT_NAME..."

--- a/scripts/clean-target.sh
+++ b/scripts/clean-target.sh
@@ -24,11 +24,16 @@ echo "target/ before: $before"
 sweep_args=(--time 3 --recursive "$TARGET")
 if [[ $DRY_RUN -eq 1 ]]; then
   cargo sweep --dry-run "${sweep_args[@]}"
-  echo "(dry run — skipping rm of target/tool and target/wasm-dev)"
+  echo "(dry run — skipping rm of target/tool, target/wasm-dev, target/wasm)"
 else
   cargo sweep "${sweep_args[@]}"
+  # target/wasm/ is Tilt's relocated wasm-dev tree (CARGO_TARGET_DIR=target/wasm);
+  # the default target/wasm32-unknown-unknown/wasm-dev is still produced by the
+  # no-Tilt setup.sh path. target/clippy is intentionally left to cargo-sweep's
+  # recursive prune above — a blanket rm would force a cold clippy rebuild.
   rm -rf "$TARGET/tool" \
          "$TARGET/wasm32-unknown-unknown/wasm-dev" \
+         "$TARGET/wasm/wasm32-unknown-unknown/wasm-dev" \
          "$TARGET/codex-copy" \
          "$TARGET/x86_64-unknown-linux-gnu"
 fi


### PR DESCRIPTION
Editing crates/engine/src/ fired clippy, test-engine, test-ai, card-data, and
wasm simultaneously; they serialized on the cargo build lock (which is per
target-dir ROOT, shared across all profile/triple subdirs) and clippy thrashed
fingerprints against the shared target/debug.

- clippy builds into CARGO_TARGET_DIR=target/clippy: its own lock + no
  fingerprint thrash against the native test/build artifacts.
- wasm builds into CARGO_TARGET_DIR=target/wasm and drops its resource_deps on
  clippy, so it compiles in parallel. build-wasm.sh now honors CARGO_TARGET_DIR
  (defaulting to target/ for CI/deploy/setup callers that don't set it).
- New build-native resource compiles the native test harnesses once
  (cargo test -p engine -p phase-ai --no-run, default features); test-engine
  and test-ai depend on it and fan out to parallel execution instead of each
  serializing their compile on the lock.
- wasm and build-native gain allow_parallel=True so Tilt's own scheduler
  actually runs them concurrently (target-root isolation alone is not enough).
- clean-target.sh reclaims the relocated target/wasm dev-wasm tree; target/clippy
  is left to cargo-sweep's recursive prune.

card-data, server, and tauri are intentionally untouched: card-data mutates an
engine source input (known-tokens.toml) so it must stay unparallelizable, and
server/tauri are rarely run locally (auto_init=False).
