### PR TITLE
fix: bound game Reconnect wire fields before session lookup

### DIFF
--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -34,6 +34,7 @@ use server_core::draft_session::DraftSessionManager;
 use server_core::draft_wire_guard::{
     guard_create_draft_with_settings, guard_join_draft_with_password, guard_reconnect_draft,
 };
+use server_core::game_reconnect_guard::guard_game_reconnect;
 use server_core::legacy_deck_guard::guard_legacy_deck;
 use server_core::lobby::RegisterGameRequest;
 use server_core::lookup_join_guard::guard_lookup_join_target;
@@ -2417,6 +2418,14 @@ async fn handle_client_message(
             player_token,
         } => {
             info!(game = %game_code, "Reconnect attempt");
+
+            if let Err(reason) = guard_game_reconnect(&game_code, &player_token) {
+                let msg = ServerMessage::Error { message: reason };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
 
             // Determine game phase and handle reconnect in a single lock
             // to avoid TOCTOU races (game could fill between check and action).

--- a/crates/server-core/src/game_reconnect_guard.rs
+++ b/crates/server-core/src/game_reconnect_guard.rs
@@ -12,3 +12,25 @@ pub fn guard_game_reconnect(game_code: &str, player_token: &str) -> Result<(), S
     validate_token("player_token", player_token, MAX_TOKEN_LEN)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{guard_game_reconnect, MAX_GAME_CODE_LEN, MAX_TOKEN_LEN};
+
+    #[test]
+    fn game_reconnect_accepts_valid_fields() {
+        assert!(guard_game_reconnect("ABC123", &"t".repeat(32)).is_ok());
+    }
+
+    #[test]
+    fn game_reconnect_rejects_oversized_game_code() {
+        let err = guard_game_reconnect(&"x".repeat(MAX_GAME_CODE_LEN + 1), "token").unwrap_err();
+        assert!(err.contains("game_code"));
+    }
+
+    #[test]
+    fn game_reconnect_rejects_oversized_player_token() {
+        let err = guard_game_reconnect("ABC123", &"t".repeat(MAX_TOKEN_LEN + 1)).unwrap_err();
+        assert!(err.contains("player_token"));
+    }
+}

--- a/crates/server-core/src/game_reconnect_guard.rs
+++ b/crates/server-core/src/game_reconnect_guard.rs
@@ -1,0 +1,14 @@
+//! Wire validation for Full-mode game session `Reconnect` frames.
+//!
+//! Draft reconnect uses `draft_wire_guard::guard_reconnect_draft`. The legacy
+//! game-session reconnect path is handled directly in `phase-server` and
+//! clones `game_code` / `player_token` into session lookup without bounds.
+
+use lobby_broker::validation::{validate_token, MAX_GAME_CODE_LEN, MAX_TOKEN_LEN};
+
+/// Validate `Reconnect` wire fields before session and reconnect-manager work.
+pub fn guard_game_reconnect(game_code: &str, player_token: &str) -> Result<(), String> {
+    validate_token("game_code", game_code, MAX_GAME_CODE_LEN)?;
+    validate_token("player_token", player_token, MAX_TOKEN_LEN)?;
+    Ok(())
+}

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod deck_resolve;
 pub mod draft_session;
 pub mod draft_wire_guard;
 pub mod filter;
+pub mod game_reconnect_guard;
 #[cfg(test)]
 mod harness;
 pub mod legacy_deck_guard;
@@ -19,6 +20,7 @@ pub use draft_wire_guard::{
     guard_create_draft_with_settings, guard_join_draft_with_password, guard_reconnect_draft,
 };
 pub use filter::filter_state_for_player;
+pub use game_reconnect_guard::guard_game_reconnect;
 pub use legacy_deck_guard::guard_legacy_deck;
 pub use lobby::LobbyManager;
 pub use lookup_join_guard::guard_lookup_join_target;

--- a/crates/server-core/src/reconnect.rs
+++ b/crates/server-core/src/reconnect.rs
@@ -191,25 +191,4 @@ mod tests {
         let result = mgr.attempt_reconnect("DRAFT01", PlayerId(1));
         assert!(matches!(result, ReconnectResult::Ok { .. }));
     }
-
-    mod game_reconnect_guard_tests {
-        use crate::game_reconnect_guard::guard_game_reconnect;
-
-        #[test]
-        fn game_reconnect_accepts_valid_fields() {
-            assert!(guard_game_reconnect("ABC123", &"t".repeat(32)).is_ok());
-        }
-
-        #[test]
-        fn game_reconnect_rejects_oversized_game_code() {
-            let err = guard_game_reconnect(&"x".repeat(65), "token").unwrap_err();
-            assert!(err.contains("game_code"));
-        }
-
-        #[test]
-        fn game_reconnect_rejects_oversized_player_token() {
-            let err = guard_game_reconnect("ABC123", &"t".repeat(129)).unwrap_err();
-            assert!(err.contains("player_token"));
-        }
-    }
 }

--- a/crates/server-core/src/reconnect.rs
+++ b/crates/server-core/src/reconnect.rs
@@ -191,4 +191,25 @@ mod tests {
         let result = mgr.attempt_reconnect("DRAFT01", PlayerId(1));
         assert!(matches!(result, ReconnectResult::Ok { .. }));
     }
+
+    mod game_reconnect_guard_tests {
+        use crate::game_reconnect_guard::guard_game_reconnect;
+
+        #[test]
+        fn game_reconnect_accepts_valid_fields() {
+            assert!(guard_game_reconnect("ABC123", &"t".repeat(32)).is_ok());
+        }
+
+        #[test]
+        fn game_reconnect_rejects_oversized_game_code() {
+            let err = guard_game_reconnect(&"x".repeat(65), "token").unwrap_err();
+            assert!(err.contains("game_code"));
+        }
+
+        #[test]
+        fn game_reconnect_rejects_oversized_player_token() {
+            let err = guard_game_reconnect("ABC123", &"t".repeat(129)).unwrap_err();
+            assert!(err.contains("player_token"));
+        }
+    }
 }


### PR DESCRIPTION
Closes #1859.

Draft reconnect already goes through `guard_reconnect_draft`; the game-session `Reconnect` path did not. A client could send oversized `game_code` / `player_token` strings and hit session lookup before anything rejected them.

This adds `guard_game_reconnect` at the handler entry and a couple of unit tests in `reconnect.rs`.

## Real Behavior Proof

- [x] 65-byte `game_code` → `Error`, no session lookup
- [x] 129-byte `player_token` → rejected at guard
- [x] Normal 6-char code + 32-byte token → accepted