### PR TITLE
fix(engine): mass phase-in applies the effect's filter instead of phasing in every phased-out permanent (CR 702.26b)

### DIFF
--- a/crates/engine/src/game/effects/phase_out.rs
+++ b/crates/engine/src/game/effects/phase_out.rs
@@ -13,7 +13,9 @@
 
 use std::collections::HashSet;
 
-use crate::game::filter::{matches_target_filter, FilterContext};
+use crate::game::filter::{
+    matches_target_filter, matches_target_filter_including_phased_out, FilterContext,
+};
 use crate::game::game_object::PhaseOutCause;
 use crate::game::phasing::{phase_in_object, phase_in_player, phase_out_object, phase_out_player};
 use crate::types::ability::{
@@ -234,18 +236,21 @@ fn collect_phase_in_targets(
         return from_targets;
     }
 
-    // For mass phase-in effects, we must see phased-out permanents — that's
-    // the only sensible target set. Rely on the caller-supplied filter to
-    // narrow (e.g., "all phased-out permanents you control"). The core
-    // filter choke point hides phased-out objects, so we can't use it for
-    // non-trivial mass filters here without extending the filter API. For
-    // now, a mass phase-in with a controller-scoped filter is approximated
-    // by scanning all battlefield objects and checking controller.
-    let _ = (ability, target);
+    // CR 702.26b: phasing-in is one of the rare effects that specifically
+    // mentions phased-out permanents, so the effect's filter must be applied to
+    // the phased-out permanents themselves. `matches_target_filter_including_
+    // phased_out` evaluates the filter (controller scope, type, etc.) while
+    // bypassing the choke point's phased-out exclusion, so a card such as "phase
+    // in each phased-out permanent you control" no longer indiscriminately
+    // phases in every phased-out permanent (including an opponent's).
+    let ctx = FilterContext::from_ability(ability);
     state
         .battlefield
         .iter()
         .copied()
-        .filter(|id| state.objects.get(id).is_some_and(|obj| obj.is_phased_out()))
+        .filter(|id| {
+            let phased_out = state.objects.get(id).is_some_and(|obj| obj.is_phased_out());
+            phased_out && matches_target_filter_including_phased_out(state, *id, target, &ctx)
+        })
         .collect()
 }

--- a/crates/engine/src/game/effects/phase_out.rs
+++ b/crates/engine/src/game/effects/phase_out.rs
@@ -254,3 +254,66 @@ fn collect_phase_in_targets(
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::card_type::CoreType;
+    use crate::types::identifiers::CardId;
+    use crate::types::zones::Zone;
+
+    fn add_creature(state: &mut GameState, owner: PlayerId, name: &str) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(state.next_object_id),
+            owner,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        id
+    }
+
+    /// CR 702.26b: A mass phase-in effect specifically mentioning phased-out
+    /// permanents must still honor the effect's object filter. Reverting
+    /// `collect_phase_in_targets` to return every phased-out battlefield object
+    /// phases in the opponent's creature and fails this regression.
+    #[test]
+    fn phase_in_mass_filter_only_returns_matching_phased_out_objects() {
+        let mut state = GameState::new_two_player(42);
+        let source = add_creature(&mut state, PlayerId(0), "Phase Source");
+        let mine = add_creature(&mut state, PlayerId(0), "Mine");
+        let theirs = add_creature(&mut state, PlayerId(1), "Theirs");
+
+        let mut events = Vec::new();
+        phase_out_object(&mut state, mine, PhaseOutCause::Directly, &mut events);
+        phase_out_object(&mut state, theirs, PhaseOutCause::Directly, &mut events);
+
+        let ability = ResolvedAbility::new(
+            Effect::PhaseIn {
+                target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            },
+            Vec::new(),
+            source,
+            PlayerId(0),
+        );
+
+        resolve_phase_in(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            !state.objects[&mine].is_phased_out(),
+            "controller's matching phased-out creature must phase in"
+        );
+        assert!(
+            state.objects[&theirs].is_phased_out(),
+            "opponent's phased-out creature must remain phased out"
+        );
+    }
+}

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -678,6 +678,34 @@ pub fn matches_target_filter(
     )
 }
 
+/// CR 702.26b exception: evaluate `filter` against `object_id` **without** the
+/// phased-out exclusion that [`matches_target_filter`] applies at its choke
+/// point. Phasing-in is one of the rare "rules and effects that specifically
+/// mention phased-out permanents," so a mass phase-in must be able to match the
+/// very permanents the choke point normally hides. Every other aspect of the
+/// filter (controller scope, type, etc.) is evaluated exactly as usual.
+pub fn matches_target_filter_including_phased_out(
+    state: &GameState,
+    object_id: ObjectId,
+    filter: &TargetFilter,
+    ctx: &FilterContext<'_>,
+) -> bool {
+    let Some(obj) = state.objects.get(&object_id) else {
+        return false;
+    };
+    filter_inner_for_object(
+        state,
+        obj,
+        object_id,
+        filter,
+        ctx.source_id,
+        ctx.source_controller,
+        ctx.ability,
+        ctx.recipient_id,
+        ControllerLookup::LiveOnly,
+    )
+}
+
 /// CR 109.5 + CR 400.3: In owner-scoped zones (hand, library, graveyard),
 /// Oracle text still says "your card" even though cards are owned rather than
 /// controlled there. Evaluate the same typed filter with ownership standing in
@@ -3873,6 +3901,39 @@ mod tests {
         let mut state = setup();
         let id = add_creature(&mut state, PlayerId(0), "Bear");
         assert!(!matches_target_filter(&state, id, &TargetFilter::None, id));
+    }
+
+    /// CR 702.26b: `matches_target_filter_including_phased_out` evaluates the
+    /// filter against phased-out permanents (which the normal choke point hides)
+    /// while still honoring controller scope — the basis for filtered mass
+    /// phase-in.
+    #[test]
+    fn including_phased_out_matches_controller_scoped_phased_out_object() {
+        use crate::types::ability::TypedFilter;
+
+        let mut state = setup();
+        let mine = add_creature(&mut state, PlayerId(0), "Mine");
+        let theirs = add_creature(&mut state, PlayerId(1), "Theirs");
+        for id in [mine, theirs] {
+            state.objects.get_mut(&id).unwrap().phase_status =
+                crate::game::game_object::PhaseStatus::PhasedOut {
+                    cause: crate::game::game_object::PhaseOutCause::Directly,
+                };
+        }
+
+        let you = TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::You));
+        let ctx = FilterContext::from_source_with_controller(mine, PlayerId(0));
+
+        // The regular choke point excludes phased-out objects entirely.
+        assert!(!super::matches_target_filter(&state, mine, &you, &ctx));
+        // The phased-out-aware matcher matches the controller's phased-out
+        // object, but still respects controller scope (opponent's is excluded).
+        assert!(super::matches_target_filter_including_phased_out(
+            &state, mine, &you, &ctx
+        ));
+        assert!(!super::matches_target_filter_including_phased_out(
+            &state, theirs, &you, &ctx
+        ));
     }
 
     /// Issue #1747 (perf): `matches_target_filter_in_owner_zone` skips the


### PR DESCRIPTION
Closes #1864

## Summary

A mass (non-targeted) `Effect::PhaseIn` ignored the effect's filter and phased in **every** phased-out permanent on the battlefield. `collect_phase_in_targets` discarded both `ability` and `target` (`let _ = (ability, target)`) and returned all phased-out battlefield objects — so a card like "phase in each phased-out permanent **you control**" also phased in an opponent's phased-out permanents (returning them outside their controller's untap step). The existing comment even claimed the controller scope was "approximated by ... checking controller," but no such check was implemented.

The phased-out objects are exactly the ones the standard filter choke point (`matches_target_filter`) hides (CR 702.26b), so the filter could not previously be applied here.

## Fix

- **`filter.rs`** — add `matches_target_filter_including_phased_out`, which evaluates a filter against an object **without** the phased-out exclusion (CR 702.26b carves out "effects that specifically mention phased-out permanents"). It reuses the same lower-level `filter_inner_for_object` path that `matches_target_filter_in_owner_zone` already uses, so controller scope, type, and every other filter aspect are evaluated normally.
- **`phase_out.rs`** — `collect_phase_in_targets` now applies the effect's filter to the phased-out permanents via that helper, instead of returning all of them. Explicit `TargetRef::Object` targets still take precedence (unchanged).

A mass phase-in now phases in only the permanents the effect actually names (e.g. just the controller's), matching CR 702.26b + the card's scope.

## Tests

- `filter.rs`: `including_phased_out_matches_controller_scoped_phased_out_object` — the new helper matches a controller's phased-out permanent (which the regular `matches_target_filter` excludes) while still rejecting an opponent's, confirming controller scope is honored.

## Verification

Run locally against the pinned toolchain:

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --all-targets -- -D warnings` — clean.
- `cargo test -p engine --lib phas` — 187 passed, 0 failed (phasing/filter suites, incl. the new test).

Model: claude-opus-4-8
Thinking: high
Tier: Frontier
