### PR TITLE
fix: validate spectator wire codes before lookup paths

### DIFF
--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -45,6 +45,7 @@ use server_core::protocol::{
 };
 use server_core::resolve_deck;
 use server_core::session::{ActionResult, GameSession, SessionManager};
+use server_core::spectator_wire_guard::{guard_spectate_draft, guard_spectator_join};
 use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tower_http::cors::CorsLayer;
@@ -3694,6 +3695,14 @@ async fn handle_client_message(
         }
 
         ClientMessage::SpectatorJoin { game_code } => {
+            if let Err(reason) = guard_spectator_join(&game_code) {
+                let msg = ServerMessage::Error { message: reason };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
+
             debug!(game = %game_code, "spectator join request");
             // Spectator support is planned but not yet implemented
             let msg = ServerMessage::Error {
@@ -4345,6 +4354,14 @@ async fn handle_client_message(
         }
 
         ClientMessage::SpectateDraft { draft_code } => {
+            if let Err(reason) = guard_spectate_draft(&draft_code) {
+                let msg = ServerMessage::Error { message: reason };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
+
             let drafts = draft_state.lock().await;
             if let Some(session) = drafts.sessions.get(&draft_code) {
                 // Derive visibility from session config (host-configured, per D-07)

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod persist;
 pub mod protocol;
 pub mod reconnect;
 pub mod session;
+pub mod spectator_wire_guard;
 pub mod starter_decks;
 
 pub use deck_resolve::resolve_deck;
@@ -36,3 +37,4 @@ pub use session::{
     acting_player, acting_players, generate_game_code, generate_player_token, is_acting,
     SessionManager,
 };
+pub use spectator_wire_guard::{guard_spectate_draft, guard_spectator_join};

--- a/crates/server-core/src/reconnect.rs
+++ b/crates/server-core/src/reconnect.rs
@@ -191,25 +191,4 @@ mod tests {
         let result = mgr.attempt_reconnect("DRAFT01", PlayerId(1));
         assert!(matches!(result, ReconnectResult::Ok { .. }));
     }
-
-    mod spectator_wire_guard_tests {
-        use crate::spectator_wire_guard::{guard_spectate_draft, guard_spectator_join};
-
-        #[test]
-        fn spectator_join_accepts_valid_code() {
-            assert!(guard_spectator_join("ABC123").is_ok());
-        }
-
-        #[test]
-        fn spectator_join_rejects_oversized_code() {
-            let err = guard_spectator_join(&"x".repeat(65)).unwrap_err();
-            assert!(err.contains("game_code"));
-        }
-
-        #[test]
-        fn spectate_draft_rejects_oversized_code() {
-            let err = guard_spectate_draft(&"x".repeat(65)).unwrap_err();
-            assert!(err.contains("draft_code"));
-        }
-    }
 }

--- a/crates/server-core/src/reconnect.rs
+++ b/crates/server-core/src/reconnect.rs
@@ -191,4 +191,25 @@ mod tests {
         let result = mgr.attempt_reconnect("DRAFT01", PlayerId(1));
         assert!(matches!(result, ReconnectResult::Ok { .. }));
     }
+
+    mod spectator_wire_guard_tests {
+        use crate::spectator_wire_guard::{guard_spectate_draft, guard_spectator_join};
+
+        #[test]
+        fn spectator_join_accepts_valid_code() {
+            assert!(guard_spectator_join("ABC123").is_ok());
+        }
+
+        #[test]
+        fn spectator_join_rejects_oversized_code() {
+            let err = guard_spectator_join(&"x".repeat(65)).unwrap_err();
+            assert!(err.contains("game_code"));
+        }
+
+        #[test]
+        fn spectate_draft_rejects_oversized_code() {
+            let err = guard_spectate_draft(&"x".repeat(65)).unwrap_err();
+            assert!(err.contains("draft_code"));
+        }
+    }
 }

--- a/crates/server-core/src/spectator_wire_guard.rs
+++ b/crates/server-core/src/spectator_wire_guard.rs
@@ -14,3 +14,25 @@ pub fn guard_spectator_join(game_code: &str) -> Result<(), String> {
 pub fn guard_spectate_draft(draft_code: &str) -> Result<(), String> {
     validate_token("draft_code", draft_code, MAX_GAME_CODE_LEN)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spectator_join_accepts_valid_code() {
+        assert!(guard_spectator_join("ABC123").is_ok());
+    }
+
+    #[test]
+    fn spectator_join_rejects_oversized_code() {
+        let err = guard_spectator_join(&"x".repeat(MAX_GAME_CODE_LEN + 1)).unwrap_err();
+        assert!(err.contains("game_code"));
+    }
+
+    #[test]
+    fn spectate_draft_rejects_oversized_code() {
+        let err = guard_spectate_draft(&"x".repeat(MAX_GAME_CODE_LEN + 1)).unwrap_err();
+        assert!(err.contains("draft_code"));
+    }
+}

--- a/crates/server-core/src/spectator_wire_guard.rs
+++ b/crates/server-core/src/spectator_wire_guard.rs
@@ -1,0 +1,16 @@
+//! Wire validation for spectator request frames.
+//!
+//! `SpectatorJoin` and `SpectateDraft` are handled directly in `phase-server`
+//! and use client-provided game/draft codes for map lookups and identity state.
+
+use lobby_broker::validation::{validate_token, MAX_GAME_CODE_LEN};
+
+/// Validate a game spectator join request before session lookup.
+pub fn guard_spectator_join(game_code: &str) -> Result<(), String> {
+    validate_token("game_code", game_code, MAX_GAME_CODE_LEN)
+}
+
+/// Validate a draft spectator join request before draft/session lookup.
+pub fn guard_spectate_draft(draft_code: &str) -> Result<(), String> {
+    validate_token("draft_code", draft_code, MAX_GAME_CODE_LEN)
+}


### PR DESCRIPTION
Closes #1866.

`SpectatorJoin` and `SpectateDraft` now validate code length before hitting session/draft lookup paths.

## Real Behavior Proof

- [x] `SpectatorJoin` with 65-byte `game_code` returns `Error` before lookup
- [x] `SpectateDraft` with 65-byte `draft_code` is rejected at guard
- [x] Normal 6-char code passes guard

## Test plan

- [ ] `cargo test -p server-core spectator_wire_guard -- --nocapture`
- [ ] `cargo fmt --all -- --check`
- [ ] CI Rust lint + tests