### PR TITLE
fix: bound CreateGameWithSettings ai_seats before AI deck setup

### DIFF
--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -30,7 +30,7 @@ use lobby_broker::{
     Outbound, NOT_OWNED_RESERVATION,
 };
 use seat_reducer::types::{DeckChoice, DeckResolver, ReducerCtx};
-use server_core::ai_seats_wire_guard::guard_create_ai_seats;
+use server_core::ai_seats_wire_guard::{guard_create_ai_seats, MAX_FULL_GAME_PLAYER_COUNT};
 use server_core::draft_session::DraftSessionManager;
 use server_core::draft_wire_guard::{
     guard_create_draft_with_settings, guard_join_draft_with_password, guard_reconnect_draft,
@@ -2680,7 +2680,8 @@ async fn handle_client_message(
                 return;
             }
 
-            if let Err(reason) = guard_create_ai_seats(&ai_seats, requested_player_count) {
+            let pc = requested_player_count.clamp(2, MAX_FULL_GAME_PLAYER_COUNT);
+            if let Err(reason) = guard_create_ai_seats(&ai_seats, pc) {
                 let msg = ServerMessage::Error { message: reason };
                 if let Ok(json) = serde_json::to_string(&msg) {
                     let _ = socket.send(Message::text(json)).await;
@@ -2740,7 +2741,6 @@ async fn handle_client_message(
                 }
             }
 
-            let pc = requested_player_count.clamp(2, 6);
             let mut ai_requests = Vec::new();
             for seat in &ai_seats {
                 if seat.seat_index == 0 || seat.seat_index >= pc {

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -30,6 +30,7 @@ use lobby_broker::{
     Outbound, NOT_OWNED_RESERVATION,
 };
 use seat_reducer::types::{DeckChoice, DeckResolver, ReducerCtx};
+use server_core::ai_seats_wire_guard::guard_create_ai_seats;
 use server_core::draft_session::DraftSessionManager;
 use server_core::draft_wire_guard::{
     guard_create_draft_with_settings, guard_join_draft_with_password, guard_reconnect_draft,
@@ -2672,6 +2673,14 @@ async fn handle_client_message(
                     start_when_full,
                 },
             ) {
+                let msg = ServerMessage::Error { message: reason };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
+
+            if let Err(reason) = guard_create_ai_seats(&ai_seats, requested_player_count) {
                 let msg = ServerMessage::Error { message: reason };
                 if let Ok(json) = serde_json::to_string(&msg) {
                     let _ = socket.send(Message::text(json)).await;

--- a/crates/server-core/src/ai_seats_wire_guard.rs
+++ b/crates/server-core/src/ai_seats_wire_guard.rs
@@ -1,0 +1,59 @@
+//! Wire validation for `CreateGameWithSettings::ai_seats` on Full-mode hosts.
+//!
+//! The lobby projection drops `ai_seats` when mapping to `LobbyClientMessage`, so
+//! `lobby_broker::guard_inbound` never bounds AI seat payloads. Full-mode create
+//! then clones deck names and nested deck lists for every AI seat entry.
+
+use lobby_broker::validate_deck_payload;
+use lobby_broker::validation::{validate_token, MAX_PLAYER_COUNT, MAX_TOKEN_LEN};
+
+use crate::protocol::{AiSeatRequest, DeckChoice};
+
+/// Max AI seat entries per create request (host occupies seat 0).
+pub const MAX_AI_SEATS: usize = 5;
+/// Max starter-deck name length accepted on the wire for AI seats.
+pub const MAX_AI_DECK_NAME_LEN: usize = 128;
+
+fn validate_optional_deck_name(field: &str, value: &Option<String>) -> Result<(), String> {
+    match value {
+        Some(name) => validate_token(field, name, MAX_AI_DECK_NAME_LEN),
+        None => Ok(()),
+    }
+}
+
+fn validate_deck_choice(field: &str, choice: &DeckChoice) -> Result<(), String> {
+    match choice {
+        DeckChoice::Random => Ok(()),
+        DeckChoice::Named(name) => {
+            validate_token(&format!("{field}.name"), name, MAX_AI_DECK_NAME_LEN)
+        }
+        DeckChoice::DeckList(deck) => validate_deck_payload(&format!("{field}.deck"), deck),
+    }
+}
+
+/// Validate AI seat wire payloads before deck resolve and session setup.
+pub fn guard_create_ai_seats(ai_seats: &[AiSeatRequest], player_count: u8) -> Result<(), String> {
+    if ai_seats.len() > MAX_AI_SEATS {
+        return Err(format!(
+            "ai_seats must contain at most {MAX_AI_SEATS} entries"
+        ));
+    }
+
+    let max_seat = player_count.clamp(2, MAX_PLAYER_COUNT);
+    for (index, seat) in ai_seats.iter().enumerate() {
+        let field = format!("ai_seats[{index}]");
+        if seat.seat_index == 0 {
+            return Err(format!("{field}.seat_index must not be 0 (host seat)"));
+        }
+        if seat.seat_index >= max_seat {
+            return Err(format!(
+                "{field}.seat_index must be less than player_count ({max_seat})"
+            ));
+        }
+        validate_optional_deck_name(&format!("{field}.deck_name"), &seat.deck_name)?;
+        if let Some(choice) = &seat.deck {
+            validate_deck_choice(&format!("{field}.deck"), choice)?;
+        }
+    }
+    Ok(())
+}

--- a/crates/server-core/src/ai_seats_wire_guard.rs
+++ b/crates/server-core/src/ai_seats_wire_guard.rs
@@ -5,12 +5,14 @@
 //! then clones deck names and nested deck lists for every AI seat entry.
 
 use lobby_broker::validate_deck_payload;
-use lobby_broker::validation::{validate_token, MAX_PLAYER_COUNT, MAX_TOKEN_LEN};
+use lobby_broker::validation::validate_token;
 
 use crate::protocol::{AiSeatRequest, DeckChoice};
 
+/// Full-mode game sessions support at most six seats.
+pub const MAX_FULL_GAME_PLAYER_COUNT: u8 = 6;
 /// Max AI seat entries per create request (host occupies seat 0).
-pub const MAX_AI_SEATS: usize = 5;
+pub const MAX_AI_SEATS: usize = (MAX_FULL_GAME_PLAYER_COUNT - 1) as usize;
 /// Max starter-deck name length accepted on the wire for AI seats.
 pub const MAX_AI_DECK_NAME_LEN: usize = 128;
 
@@ -39,7 +41,8 @@ pub fn guard_create_ai_seats(ai_seats: &[AiSeatRequest], player_count: u8) -> Re
         ));
     }
 
-    let max_seat = player_count.clamp(2, MAX_PLAYER_COUNT);
+    let max_seat = player_count.clamp(2, MAX_FULL_GAME_PLAYER_COUNT);
+    let mut seen_seats = 0u8;
     for (index, seat) in ai_seats.iter().enumerate() {
         let field = format!("ai_seats[{index}]");
         if seat.seat_index == 0 {
@@ -50,10 +53,72 @@ pub fn guard_create_ai_seats(ai_seats: &[AiSeatRequest], player_count: u8) -> Re
                 "{field}.seat_index must be less than player_count ({max_seat})"
             ));
         }
+        let seat_mask = 1u8 << seat.seat_index;
+        if (seen_seats & seat_mask) != 0 {
+            return Err(format!(
+                "{field}.seat_index ({}) is duplicated",
+                seat.seat_index
+            ));
+        }
+        seen_seats |= seat_mask;
         validate_optional_deck_name(&format!("{field}.deck_name"), &seat.deck_name)?;
         if let Some(choice) = &seat.deck {
             validate_deck_choice(&format!("{field}.deck"), choice)?;
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use phase_ai::config::AiDifficulty;
+
+    use super::{guard_create_ai_seats, MAX_AI_DECK_NAME_LEN, MAX_AI_SEATS};
+    use crate::protocol::{AiSeatRequest, DeckChoice};
+
+    fn ai_seat(seat_index: u8) -> AiSeatRequest {
+        AiSeatRequest {
+            seat_index,
+            difficulty: AiDifficulty::Medium,
+            deck_name: None,
+            deck: None,
+        }
+    }
+
+    #[test]
+    fn ai_seats_accepts_valid_entry() {
+        assert!(guard_create_ai_seats(&[ai_seat(1)], 4).is_ok());
+    }
+
+    #[test]
+    fn ai_seats_rejects_too_many_entries() {
+        let seats: Vec<AiSeatRequest> = (0..=MAX_AI_SEATS).map(|_| ai_seat(1)).collect();
+        let err = guard_create_ai_seats(&seats, 6).unwrap_err();
+        assert!(err.contains("ai_seats"));
+    }
+
+    #[test]
+    fn ai_seats_rejects_duplicate_seats() {
+        let seats = vec![ai_seat(1), ai_seat(1)];
+        let err = guard_create_ai_seats(&seats, 4).unwrap_err();
+        assert!(err.contains("duplicated"));
+    }
+
+    #[test]
+    fn ai_seats_rejects_seat_outside_effective_player_count() {
+        let err = guard_create_ai_seats(&[ai_seat(6)], 8).unwrap_err();
+        assert!(err.contains("less than player_count (6)"));
+    }
+
+    #[test]
+    fn ai_seats_rejects_oversized_named_deck() {
+        let seats = vec![AiSeatRequest {
+            seat_index: 1,
+            difficulty: AiDifficulty::Medium,
+            deck_name: None,
+            deck: Some(DeckChoice::Named("x".repeat(MAX_AI_DECK_NAME_LEN + 1))),
+        }];
+        let err = guard_create_ai_seats(&seats, 4).unwrap_err();
+        assert!(err.contains("name"));
+    }
 }

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ai_seats_wire_guard;
 pub mod deck_resolve;
 pub mod draft_session;
 pub mod draft_wire_guard;
@@ -16,6 +17,7 @@ pub mod session;
 pub mod spectator_wire_guard;
 pub mod starter_decks;
 
+pub use ai_seats_wire_guard::guard_create_ai_seats;
 pub use deck_resolve::resolve_deck;
 pub use draft_session::{generate_draft_code, DraftSession, DraftSessionManager};
 pub use draft_wire_guard::{

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1060,50 +1060,6 @@ mod tests {
         }
     }
 
-    mod ai_seats_wire_guard_tests {
-        use crate::ai_seats_wire_guard::guard_create_ai_seats;
-        use crate::protocol::AiSeatRequest;
-        use phase_ai::config::AiDifficulty;
-        use seat_reducer::types::DeckChoice;
-
-        #[test]
-        fn ai_seats_accepts_valid_entry() {
-            let seats = vec![AiSeatRequest {
-                seat_index: 1,
-                difficulty: AiDifficulty::Medium,
-                deck_name: None,
-                deck: None,
-            }];
-            assert!(guard_create_ai_seats(&seats, 4).is_ok());
-        }
-
-        #[test]
-        fn ai_seats_rejects_too_many_entries() {
-            let seats: Vec<AiSeatRequest> = (0..6)
-                .map(|_| AiSeatRequest {
-                    seat_index: 1,
-                    difficulty: AiDifficulty::Medium,
-                    deck_name: None,
-                    deck: None,
-                })
-                .collect();
-            let err = guard_create_ai_seats(&seats, 6).unwrap_err();
-            assert!(err.contains("ai_seats"));
-        }
-
-        #[test]
-        fn ai_seats_rejects_oversized_named_deck() {
-            let seats = vec![AiSeatRequest {
-                seat_index: 1,
-                difficulty: AiDifficulty::Medium,
-                deck_name: None,
-                deck: Some(DeckChoice::Named("x".repeat(129))),
-            }];
-            let err = guard_create_ai_seats(&seats, 4).unwrap_err();
-            assert!(err.contains("name"));
-        }
-    }
-
     #[test]
     fn seat_mutation_deck_list_choice_roundtrips() {
         let msg = ClientMessage::SeatMutate {

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1060,6 +1060,50 @@ mod tests {
         }
     }
 
+    mod ai_seats_wire_guard_tests {
+        use crate::ai_seats_wire_guard::guard_create_ai_seats;
+        use crate::protocol::AiSeatRequest;
+        use phase_ai::config::AiDifficulty;
+        use seat_reducer::types::DeckChoice;
+
+        #[test]
+        fn ai_seats_accepts_valid_entry() {
+            let seats = vec![AiSeatRequest {
+                seat_index: 1,
+                difficulty: AiDifficulty::Medium,
+                deck_name: None,
+                deck: None,
+            }];
+            assert!(guard_create_ai_seats(&seats, 4).is_ok());
+        }
+
+        #[test]
+        fn ai_seats_rejects_too_many_entries() {
+            let seats: Vec<AiSeatRequest> = (0..6)
+                .map(|_| AiSeatRequest {
+                    seat_index: 1,
+                    difficulty: AiDifficulty::Medium,
+                    deck_name: None,
+                    deck: None,
+                })
+                .collect();
+            let err = guard_create_ai_seats(&seats, 6).unwrap_err();
+            assert!(err.contains("ai_seats"));
+        }
+
+        #[test]
+        fn ai_seats_rejects_oversized_named_deck() {
+            let seats = vec![AiSeatRequest {
+                seat_index: 1,
+                difficulty: AiDifficulty::Medium,
+                deck_name: None,
+                deck: Some(DeckChoice::Named("x".repeat(129))),
+            }];
+            let err = guard_create_ai_seats(&seats, 4).unwrap_err();
+            assert!(err.contains("name"));
+        }
+    }
+
     #[test]
     fn seat_mutation_deck_list_choice_roundtrips() {
         let msg = ClientMessage::SeatMutate {


### PR DESCRIPTION
Closes #1871.

`CreateGameWithSettings` now validates `ai_seats` before AI deck setup. The lobby projection drops this field, so `guard_inbound` never saw it.

## Real Behavior Proof

- [x] 6 AI seat entries are rejected before deck resolve
- [x] AI seat with 129-byte named deck is rejected at guard
- [x] Valid single AI seat entry passes guard

## Test plan

- [ ] `cargo test -p server-core ai_seats_wire_guard -- --nocapture`
- [ ] `cargo fmt --all -- --check`
- [ ] CI Rust lint + tests