### PR TITLE
fix(parser): Well of Lost Dreams draws 0 cards instead of X

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -15411,4 +15411,48 @@ mod pipeline_snapshot_tests {
             other => panic!("sub-clause must be Destroy, got {:?}", other),
         }
     }
+
+    // ── Well of Lost Dreams: pay {X} ≤ life gained, draw X cards ─────────────
+
+    #[test]
+    fn well_of_lost_dreams_draw_count_is_variable_x() {
+        // CR 107.3i: "where X is less than or equal to <bound>" is a player-
+        // chosen constraint, not a definition of X. The draw count must resolve
+        // to Variable("X") so the PayAmountChoice → chosen_x → draw path
+        // produces X drawn cards (not 0 from a stale QuantityRef string).
+        let r = pipeline_parse(
+            "Whenever you gain life, you may pay {X}, where X is less than or equal to the amount of life you gained. If you do, draw X cards.",
+            "Well of Lost Dreams",
+            &["Artifact"],
+            &[],
+        );
+        assert_eq!(r.triggers.len(), 1, "should have one trigger");
+        let exec = r.triggers[0]
+            .execute
+            .as_ref()
+            .expect("trigger must have execute");
+        assert!(
+            matches!(*exec.effect, Effect::PayCost { .. }),
+            "first effect should be PayCost, got {:?}",
+            exec.effect,
+        );
+        let sub = exec
+            .sub_ability
+            .as_deref()
+            .expect("PayCost must have sub_ability");
+        match sub.effect.as_ref() {
+            Effect::Draw { count, .. } => {
+                assert_eq!(
+                    count.clone(),
+                    crate::types::ability::QuantityExpr::Ref {
+                        qty: crate::types::ability::QuantityRef::Variable {
+                            name: "X".to_string(),
+                        },
+                    },
+                    "draw count must be Variable(\"X\") so chosen_x resolves it, not a stale bound string"
+                );
+            }
+            other => panic!("sub-ability must be Draw, got {:?}", other),
+        }
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -4181,6 +4181,22 @@ pub(crate) fn parse_where_x_quantity_expression(where_x_expression: &str) -> Opt
             },
         });
     }
+    // CR 107.3i + CR 117.1: "where X is less than or equal to <bound>" is a
+    // constraint on the player's chosen X (not a definition of X's exact
+    // value). Well of Lost Dreams pays {X} mana and draws X cards; the bound
+    // only limits what the player may choose — the actual drawn count is the
+    // amount paid (resolved via `chosen_x`). Preserving Variable("X") lets the
+    // existing PayAmountChoice → chosen_x → draw machinery work correctly.
+    if tag::<_, _, OracleError<'_>>("less than or equal to ")
+        .parse(expression_lower.as_str())
+        .is_ok()
+    {
+        return Some(QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        });
+    }
     if let Ok((rest_lower, (n, sign))) = (
         nom_primitives::parse_number,
         alt((

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -17,7 +17,7 @@ use super::super::oracle_quantity::{
 use super::super::oracle_target::{
     parse_target, parse_target_with_ctx, parse_that_clause_suffix, parse_type_phrase_with_ctx,
 };
-use super::super::oracle_util::{parse_count_expr, strip_after, TextPair};
+use super::super::oracle_util::{parse_comparator_prefix, parse_count_expr, strip_after, TextPair};
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
@@ -4160,7 +4160,7 @@ fn apply_where_x_expression(value: PtValue, where_x_expression: Option<&str>) ->
 pub(crate) fn parse_where_x_quantity_expression(where_x_expression: &str) -> Option<QuantityExpr> {
     let expression = where_x_expression.trim().trim_end_matches('.');
     let expression_lower = expression.to_ascii_lowercase();
-    // CR 107.3i + CR 117.1: Within a single resolution, X has one value used
+    // CR 107.3i + CR 608.2g: Within a single resolution, X has one value used
     // everywhere it appears. Join Forces ("Each player draws X cards, where
     // X is the total amount of mana paid this way") binds X to the total
     // payments accumulated by the upstream `PayCost { Mana { X } }` loop:
@@ -4181,15 +4181,14 @@ pub(crate) fn parse_where_x_quantity_expression(where_x_expression: &str) -> Opt
             },
         });
     }
-    // CR 107.3i + CR 117.1: "where X is less than or equal to <bound>" is a
+    // CR 107.3i + CR 608.2g: "where X is less than or equal to <bound>" is a
     // constraint on the player's chosen X (not a definition of X's exact
     // value). Well of Lost Dreams pays {X} mana and draws X cards; the bound
     // only limits what the player may choose — the actual drawn count is the
     // amount paid (resolved via `chosen_x`). Preserving Variable("X") lets the
     // existing PayAmountChoice → chosen_x → draw machinery work correctly.
-    if tag::<_, _, OracleError<'_>>("less than or equal to ")
-        .parse(expression_lower.as_str())
-        .is_ok()
+    if parse_comparator_prefix(expression_lower.as_str())
+        .is_some_and(|(_, bound)| !bound.trim().is_empty())
     {
         return Some(QuantityExpr::Ref {
             qty: QuantityRef::Variable {
@@ -4680,4 +4679,35 @@ pub(crate) fn parse_dynamic_counter_suffix_body(
         nom::Err::Error(OracleError::new(rest, nom::error::ErrorKind::Verify)),
     )?;
     Ok(("", (counter_type, QuantityExpr::Ref { qty })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_where_x_quantity_expression;
+    use crate::types::ability::{QuantityExpr, QuantityRef};
+
+    fn variable_x() -> QuantityExpr {
+        QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn where_x_comparator_bounds_preserve_variable_x() {
+        for expression in [
+            "less than or equal to the amount of life you gained",
+            "less than the amount of life you gained",
+            "greater than the number of creatures you control",
+            "greater than or equal to the number of cards in your hand",
+            "equal to the number of opponents",
+        ] {
+            assert_eq!(
+                parse_where_x_quantity_expression(expression),
+                Some(variable_x()),
+                "{expression}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- `parse_where_x_quantity_expression` returned `None` for "less than or
  equal to <expr>" phrases, causing the fallback in
  `apply_where_x_quantity_expression` to set the draw count to
  `Variable("less than or equal to the amount of life you gained")`
  instead of `Variable("X")`
- That stale variable name resolves via `last_named_choice` → 0 cards
  drawn instead of the amount paid
- Fix adds a branch for comparative-bound phrases ("less than or equal
  to …"), returning `Variable("X")` so `chosen_x` carries the payment
  amount through to the draw

Closes #1551 

## Test plan
- [ ] `cargo test -p engine well_of_lost_dreams` — new parser test passes
- [ ] `cargo test -p engine --lib -- pay_x_mana` — existing engine
  integration test still passes
- [ ] Play Well of Lost Dreams in a game, gain life, pay {X}, confirm X
  cards are drawn
