### PR TITLE
Fix cascade trigger origin zone lookup

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -716,7 +716,8 @@ fn granted_spell_keywords(
     // through SpellCast event) over pending_cast_origin_zone_for (transient and
     // cleared after finalize_cast). This ensures origin zone is available when
     // triggers are processed for filters like "InZone { zone: Hand }".
-    let origin_zone = spell_obj.cast_from_zone
+    let origin_zone = spell_obj
+        .cast_from_zone
         .or_else(|| pending_cast_origin_zone_for(state, object_id))
         .unwrap_or(spell_obj.zone);
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -712,7 +712,13 @@ fn granted_spell_keywords(
         return Vec::new();
     };
 
-    let origin_zone = pending_cast_origin_zone_for(state, object_id).unwrap_or(spell_obj.zone);
+    // CR 601.2a: Prefer cast_from_zone (stamped during finalize_cast and persists
+    // through SpellCast event) over pending_cast_origin_zone_for (transient and
+    // cleared after finalize_cast). This ensures origin zone is available when
+    // triggers are processed for filters like "InZone { zone: Hand }".
+    let origin_zone = spell_obj.cast_from_zone
+        .or_else(|| pending_cast_origin_zone_for(state, object_id))
+        .unwrap_or(spell_obj.zone);
 
     let mut keywords = Vec::new();
     // CR 702.26b + CR 604.1: Functioning gate owned by

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -12070,9 +12070,7 @@ pub mod tests {
         .affected(TargetFilter::Typed(
             TypedFilter::new(TypeFilter::Sorcery)
                 .controller(ControllerRef::You)
-                .properties(vec![crate::types::ability::FilterProp::InZone {
-                    zone: Zone::Hand,
-                }]),
+                .properties(vec![FilterProp::InZone { zone: Zone::Hand }]),
         ));
         state
             .objects

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -12063,11 +12063,16 @@ pub mod tests {
             "Cascade Grant Source".to_string(),
             Zone::Battlefield,
         );
+        // Use InZone { zone: Hand } to match Quandrix's actual parsed filter
         let grant = StaticDefinition::new(StaticMode::CastWithKeyword {
             keyword: Keyword::Cascade,
         })
         .affected(TargetFilter::Typed(
-            TypedFilter::new(TypeFilter::Sorcery).controller(ControllerRef::You),
+            TypedFilter::new(TypeFilter::Sorcery)
+                .controller(ControllerRef::You)
+                .properties(vec![crate::types::ability::FilterProp::InZone {
+                    zone: Zone::Hand,
+                }]),
         ));
         state
             .objects
@@ -12107,6 +12112,46 @@ pub mod tests {
                 )
             }),
             "cascade granted by a static ability should enqueue a Cascade trigger"
+        );
+    }
+
+    #[test]
+    fn printed_cascade_triggers_for_cast_spell() {
+        let mut state = setup();
+        let caster = PlayerId(0);
+
+        let spell = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "Printed Cascade Spell".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            obj.keywords.push(Keyword::Cascade);
+            obj.cast_from_zone = Some(Zone::Hand);
+        }
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::SpellCast {
+                object_id: spell,
+                controller: caster,
+                card_id: CardId(1),
+            }],
+        );
+
+        assert!(
+            state.stack.iter().any(|entry| {
+                matches!(
+                    &entry.kind,
+                    StackEntryKind::TriggeredAbility { ability, .. }
+                        if matches!(ability.effect, Effect::Cascade)
+                )
+            }),
+            "printed cascade keyword should enqueue a Cascade trigger"
         );
     }
 


### PR DESCRIPTION
Fix Quandrix cascade trigger bug
 
The granted cascade ability was not triggering because the origin zone lookup used the transient `pending_cast` state instead of the persistent `cast_from_zone` field. This caused `InZone { zone: Hand }` filters to fail when comparing against the spell's current zone (Stack) instead of its origin zone (Hand).
 
Changes:
- Modified [granted_spell_keywords](cci:1://file:///d:/Projects/gittensor/phase/crates/engine/src/game/casting.rs:705:0-753:1) to prefer `cast_from_zone` over [pending_cast_origin_zone_for (cci:1://file:///d:/Projects/gittensor/phase/crates/engine/src/game/casting.rs:686:0-703:1)
- Updated test to include `InZone` property matching Quandrix's actual filter
- Added regression test for printed cascade
 
Fixes #1678