### PR TITLE
fix: validate SeatMutate payloads before reducer/deck resolution

### DIFF
--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -3774,14 +3774,15 @@ async fn handle_client_message(
                 }
                 return;
             }
+            if require_host(identity, socket).await.is_err() {
+                return;
+            }
+
             if let Err(reason) = guard_seat_mutation(&mutation) {
                 let msg = ServerMessage::Error { message: reason };
                 if let Ok(json) = serde_json::to_string(&msg) {
                     let _ = socket.send(Message::text(json)).await;
                 }
-                return;
-            }
-            if require_host(identity, socket).await.is_err() {
                 return;
             }
 

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -45,6 +45,7 @@ use server_core::protocol::{
     PROTOCOL_VERSION,
 };
 use server_core::resolve_deck;
+use server_core::seat_mutation_wire_guard::guard_seat_mutation;
 use server_core::session::{ActionResult, GameSession, SessionManager};
 use server_core::spectator_wire_guard::{guard_spectate_draft, guard_spectator_join};
 use std::time::Duration;
@@ -3768,6 +3769,13 @@ async fn handle_client_message(
                 let msg = ServerMessage::Error {
                     message: "Seat mutations are not available on lobby-only servers.".to_string(),
                 };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
+            if let Err(reason) = guard_seat_mutation(&mutation) {
+                let msg = ServerMessage::Error { message: reason };
                 if let Ok(json) = serde_json::to_string(&msg) {
                     let _ = socket.send(Message::text(json)).await;
                 }

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod lookup_join_guard;
 pub mod persist;
 pub mod protocol;
 pub mod reconnect;
+pub mod seat_mutation_wire_guard;
 pub mod session;
 pub mod spectator_wire_guard;
 pub mod starter_decks;
@@ -34,6 +35,7 @@ pub use protocol::{
     SeatMutation, SeatView, ServerMessage,
 };
 pub use reconnect::ReconnectManager;
+pub use seat_mutation_wire_guard::guard_seat_mutation;
 pub use session::{
     acting_player, acting_players, generate_game_code, generate_player_token, is_acting,
     SessionManager,

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1098,6 +1098,44 @@ mod tests {
         }
     }
 
+    mod seat_mutation_wire_guard_tests {
+        use crate::seat_mutation_wire_guard::guard_seat_mutation;
+
+        use super::*;
+
+        #[test]
+        fn seat_mutation_guard_accepts_valid_ai_named_deck() {
+            let mutation = SeatMutation::SetKind {
+                seat_index: 1,
+                kind: SeatKind::Ai {
+                    difficulty: AiDifficulty::Medium,
+                    deck: DeckChoice::Named("Mono Green".to_string()),
+                },
+            };
+            assert!(guard_seat_mutation(&mutation).is_ok());
+        }
+
+        #[test]
+        fn seat_mutation_guard_rejects_oversized_named_deck() {
+            let mutation = SeatMutation::SetKind {
+                seat_index: 1,
+                kind: SeatKind::Ai {
+                    difficulty: AiDifficulty::Medium,
+                    deck: DeckChoice::Named("x".repeat(129)),
+                },
+            };
+            let err = guard_seat_mutation(&mutation).unwrap_err();
+            assert!(err.contains("name"));
+        }
+
+        #[test]
+        fn seat_mutation_guard_rejects_oversized_seat_index() {
+            let mutation = SeatMutation::Remove { seat_index: 200 };
+            let err = guard_seat_mutation(&mutation).unwrap_err();
+            assert!(err.contains("seat_index"));
+        }
+    }
+
     #[test]
     fn client_message_ping_roundtrips() {
         let msg = ClientMessage::Ping {

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1098,44 +1098,6 @@ mod tests {
         }
     }
 
-    mod seat_mutation_wire_guard_tests {
-        use crate::seat_mutation_wire_guard::guard_seat_mutation;
-
-        use super::*;
-
-        #[test]
-        fn seat_mutation_guard_accepts_valid_ai_named_deck() {
-            let mutation = SeatMutation::SetKind {
-                seat_index: 1,
-                kind: SeatKind::Ai {
-                    difficulty: AiDifficulty::Medium,
-                    deck: DeckChoice::Named("Mono Green".to_string()),
-                },
-            };
-            assert!(guard_seat_mutation(&mutation).is_ok());
-        }
-
-        #[test]
-        fn seat_mutation_guard_rejects_oversized_named_deck() {
-            let mutation = SeatMutation::SetKind {
-                seat_index: 1,
-                kind: SeatKind::Ai {
-                    difficulty: AiDifficulty::Medium,
-                    deck: DeckChoice::Named("x".repeat(129)),
-                },
-            };
-            let err = guard_seat_mutation(&mutation).unwrap_err();
-            assert!(err.contains("name"));
-        }
-
-        #[test]
-        fn seat_mutation_guard_rejects_oversized_seat_index() {
-            let mutation = SeatMutation::Remove { seat_index: 200 };
-            let err = guard_seat_mutation(&mutation).unwrap_err();
-            assert!(err.contains("seat_index"));
-        }
-    }
-
     #[test]
     fn client_message_ping_roundtrips() {
         let msg = ClientMessage::Ping {

--- a/crates/server-core/src/seat_mutation_wire_guard.rs
+++ b/crates/server-core/src/seat_mutation_wire_guard.rs
@@ -5,7 +5,7 @@
 //! reducer/deck-resolution work to avoid clone-heavy abuse.
 
 use lobby_broker::validate_deck_payload;
-use lobby_broker::validation::{validate_token, MAX_PLAYER_COUNT, MAX_TOKEN_LEN};
+use lobby_broker::validation::{validate_token, MAX_PLAYER_COUNT};
 
 use crate::protocol::{DeckChoice, SeatKind, SeatMutation};
 

--- a/crates/server-core/src/seat_mutation_wire_guard.rs
+++ b/crates/server-core/src/seat_mutation_wire_guard.rs
@@ -1,0 +1,44 @@
+//! Wire validation for `SeatMutate` frames in `phase-server`.
+//!
+//! Seat mutation supports nested AI `DeckChoice` payloads (including
+//! client-supplied full deck lists). These fields must be bounded before
+//! reducer/deck-resolution work to avoid clone-heavy abuse.
+
+use lobby_broker::validate_deck_payload;
+use lobby_broker::validation::{validate_token, MAX_PLAYER_COUNT, MAX_TOKEN_LEN};
+
+use crate::protocol::{DeckChoice, SeatKind, SeatMutation};
+
+/// Max AI starter deck name length in seat mutations.
+pub const MAX_AI_DECK_NAME_LEN: usize = 128;
+
+fn validate_deck_choice(field: &str, deck: &DeckChoice) -> Result<(), String> {
+    match deck {
+        DeckChoice::Random => Ok(()),
+        DeckChoice::Named(name) => {
+            validate_token(&format!("{field}.name"), name, MAX_AI_DECK_NAME_LEN)
+        }
+        DeckChoice::DeckList(deck) => validate_deck_payload(&format!("{field}.deck"), deck),
+    }
+}
+
+/// Validate seat mutation payloads before reducer apply/deck resolution.
+pub fn guard_seat_mutation(mutation: &SeatMutation) -> Result<(), String> {
+    match mutation {
+        SeatMutation::SetKind { seat_index, kind } => {
+            if *seat_index >= MAX_PLAYER_COUNT {
+                return Err(format!("seat_index must be less than {MAX_PLAYER_COUNT}"));
+            }
+            if let SeatKind::Ai { deck, .. } = kind {
+                validate_deck_choice("mutation.kind.ai.deck", deck)?;
+            }
+        }
+        SeatMutation::Remove { seat_index } => {
+            if *seat_index >= MAX_PLAYER_COUNT {
+                return Err(format!("seat_index must be less than {MAX_PLAYER_COUNT}"));
+            }
+        }
+        SeatMutation::Start => {}
+    }
+    Ok(())
+}

--- a/crates/server-core/src/seat_mutation_wire_guard.rs
+++ b/crates/server-core/src/seat_mutation_wire_guard.rs
@@ -42,3 +42,43 @@ pub fn guard_seat_mutation(mutation: &SeatMutation) -> Result<(), String> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use phase_ai::config::AiDifficulty;
+
+    use super::{guard_seat_mutation, MAX_AI_DECK_NAME_LEN};
+    use crate::protocol::{DeckChoice, SeatKind, SeatMutation};
+
+    #[test]
+    fn seat_mutation_guard_accepts_valid_ai_named_deck() {
+        let mutation = SeatMutation::SetKind {
+            seat_index: 1,
+            kind: SeatKind::Ai {
+                difficulty: AiDifficulty::Medium,
+                deck: DeckChoice::Named("Mono Green".to_string()),
+            },
+        };
+        assert!(guard_seat_mutation(&mutation).is_ok());
+    }
+
+    #[test]
+    fn seat_mutation_guard_rejects_oversized_named_deck() {
+        let mutation = SeatMutation::SetKind {
+            seat_index: 1,
+            kind: SeatKind::Ai {
+                difficulty: AiDifficulty::Medium,
+                deck: DeckChoice::Named("x".repeat(MAX_AI_DECK_NAME_LEN + 1)),
+            },
+        };
+        let err = guard_seat_mutation(&mutation).unwrap_err();
+        assert!(err.contains("name"));
+    }
+
+    #[test]
+    fn seat_mutation_guard_rejects_oversized_seat_index() {
+        let mutation = SeatMutation::Remove { seat_index: 200 };
+        let err = guard_seat_mutation(&mutation).unwrap_err();
+        assert!(err.contains("seat_index"));
+    }
+}


### PR DESCRIPTION
Closes #1876.

`SeatMutate` now validates AI deck payloads and seat indices before reducer/deck-resolution work. Host authorization runs first so non-host clients cannot trigger deck validation work.

## Real Behavior Proof

* AI `DeckChoice::Named` with 129-byte name is rejected at guard
* Oversized `seat_index` is rejected at guard
* Valid AI named deck mutation passes guard

## Test plan

* `cargo test -p server-core seat_mutation_wire_guard -- --nocapture`
* `cargo fmt --all -- --check`
* CI Rust lint + tests