### PR TITLE
fix: bound DraftAction payloads before draft session dispatch

### DIFF
--- a/crates/lobby-broker/src/inbound_guard.rs
+++ b/crates/lobby-broker/src/inbound_guard.rs
@@ -37,7 +37,7 @@ fn validate_card_name(field: &str, name: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn validate_deck_list(field: &str, cards: &[String], max_entries: usize) -> Result<(), String> {
+pub fn validate_deck_list(field: &str, cards: &[String], max_entries: usize) -> Result<(), String> {
     if cards.len() > max_entries {
         return Err(format!(
             "{field} must contain at most {max_entries} entries"

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -31,6 +31,7 @@ use lobby_broker::{
 };
 use seat_reducer::types::{DeckChoice, DeckResolver, ReducerCtx};
 use server_core::ai_seats_wire_guard::{guard_create_ai_seats, MAX_FULL_GAME_PLAYER_COUNT};
+use server_core::draft_action_payload_guard::guard_draft_action_payload;
 use server_core::draft_session::DraftSessionManager;
 use server_core::draft_wire_guard::{
     guard_create_draft_with_settings, guard_draft_action, guard_join_draft_with_password,
@@ -4190,6 +4191,14 @@ async fn handle_client_message(
 
         ClientMessage::DraftAction { draft_code, action } => {
             if let Err(reason) = guard_draft_action(&draft_code) {
+                let msg = ServerMessage::DraftActionRejected { reason };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
+
+            if let Err(reason) = guard_draft_action_payload(&action) {
                 let msg = ServerMessage::DraftActionRejected { reason };
                 if let Ok(json) = serde_json::to_string(&msg) {
                     let _ = socket.send(Message::text(json)).await;

--- a/crates/server-core/src/draft_action_payload_guard.rs
+++ b/crates/server-core/src/draft_action_payload_guard.rs
@@ -5,41 +5,10 @@
 //! reducers unless bounded here.
 
 use draft_core::types::DraftAction;
-use lobby_broker::inbound_guard::{MAX_DECK_CARD_NAME_LEN, MAX_MAIN_DECK_ENTRIES};
+use lobby_broker::inbound_guard::{validate_deck_list, MAX_MAIN_DECK_ENTRIES};
 use lobby_broker::validation::{
     validate_required_label, validate_token, MAX_DISPLAY_NAME_LEN, MAX_TOKEN_LEN,
 };
-
-fn has_control_char(value: &str) -> bool {
-    value.chars().any(|c| c.is_control())
-}
-
-fn validate_card_name(field: &str, name: &str) -> Result<(), String> {
-    if name.is_empty() {
-        return Err(format!("{field} must not be empty"));
-    }
-    if name.len() > MAX_DECK_CARD_NAME_LEN {
-        return Err(format!(
-            "{field} must be at most {MAX_DECK_CARD_NAME_LEN} bytes"
-        ));
-    }
-    if has_control_char(name) {
-        return Err(format!("{field} must not contain control characters"));
-    }
-    Ok(())
-}
-
-fn validate_main_deck_list(main_deck: &[String]) -> Result<(), String> {
-    if main_deck.len() > MAX_MAIN_DECK_ENTRIES {
-        return Err(format!(
-            "SubmitDeck.main_deck must contain at most {MAX_MAIN_DECK_ENTRIES} entries"
-        ));
-    }
-    for (index, name) in main_deck.iter().enumerate() {
-        validate_card_name(&format!("SubmitDeck.main_deck[{index}]"), name)?;
-    }
-    Ok(())
-}
 
 /// Validate client-supplied `DraftAction` payload fields before session dispatch.
 pub fn guard_draft_action_payload(action: &DraftAction) -> Result<(), String> {
@@ -49,7 +18,9 @@ pub fn guard_draft_action_payload(action: &DraftAction) -> Result<(), String> {
         } => {
             validate_token("Pick.card_instance_id", card_instance_id, MAX_TOKEN_LEN)?;
         }
-        DraftAction::SubmitDeck { main_deck, .. } => validate_main_deck_list(main_deck)?,
+        DraftAction::SubmitDeck { main_deck, .. } => {
+            validate_deck_list("SubmitDeck.main_deck", main_deck, MAX_MAIN_DECK_ENTRIES)?;
+        }
         DraftAction::ReportMatchResult { match_id, .. } => {
             validate_token("ReportMatchResult.match_id", match_id, MAX_TOKEN_LEN)?;
         }
@@ -100,5 +71,25 @@ mod tests {
         };
         let err = guard_draft_action_payload(&action).unwrap_err();
         assert!(err.contains("main_deck"));
+    }
+
+    #[test]
+    fn submit_deck_rejects_invalid_card_name() {
+        let action = DraftAction::SubmitDeck {
+            seat: 0,
+            main_deck: vec!["Forest\nIsland".to_string()],
+        };
+        let err = guard_draft_action_payload(&action).unwrap_err();
+        assert!(err.contains("control characters"));
+    }
+
+    #[test]
+    fn replace_seat_with_bot_rejects_oversized_name() {
+        let action = DraftAction::ReplaceSeatWithBot {
+            seat: 0,
+            name: Some("x".repeat(MAX_DISPLAY_NAME_LEN + 1)),
+        };
+        let err = guard_draft_action_payload(&action).unwrap_err();
+        assert!(err.contains("ReplaceSeatWithBot.name"));
     }
 }

--- a/crates/server-core/src/draft_action_payload_guard.rs
+++ b/crates/server-core/src/draft_action_payload_guard.rs
@@ -7,7 +7,7 @@
 use draft_core::types::DraftAction;
 use lobby_broker::inbound_guard::{MAX_DECK_CARD_NAME_LEN, MAX_MAIN_DECK_ENTRIES};
 use lobby_broker::validation::{
-    validate_optional_label, validate_token, MAX_DISPLAY_NAME_LEN, MAX_TOKEN_LEN,
+    validate_required_label, validate_token, MAX_DISPLAY_NAME_LEN, MAX_TOKEN_LEN,
 };
 
 fn has_control_char(value: &str) -> bool {
@@ -54,7 +54,11 @@ pub fn guard_draft_action_payload(action: &DraftAction) -> Result<(), String> {
             validate_token("ReportMatchResult.match_id", match_id, MAX_TOKEN_LEN)?;
         }
         DraftAction::ReplaceSeatWithBot { name, .. } => {
-            validate_optional_label("ReplaceSeatWithBot.name", name, MAX_DISPLAY_NAME_LEN)?;
+            if let Some(n) = name {
+                if !n.trim().is_empty() {
+                    validate_required_label("ReplaceSeatWithBot.name", n, MAX_DISPLAY_NAME_LEN)?;
+                }
+            }
         }
         DraftAction::StartDraft
         | DraftAction::AdvanceRound

--- a/crates/server-core/src/draft_action_payload_guard.rs
+++ b/crates/server-core/src/draft_action_payload_guard.rs
@@ -1,0 +1,100 @@
+//! Payload bounds for `DraftAction` bodies on the native WebSocket path.
+//!
+//! `draft_wire_guard::guard_draft_action` only validates `draft_code`. Oversized
+//! pick IDs, submit-deck lists, and match IDs still reach clone-heavy draft
+//! reducers unless bounded here.
+
+use draft_core::types::DraftAction;
+use lobby_broker::inbound_guard::{MAX_DECK_CARD_NAME_LEN, MAX_MAIN_DECK_ENTRIES};
+use lobby_broker::validation::{
+    validate_optional_label, validate_token, MAX_DISPLAY_NAME_LEN, MAX_TOKEN_LEN,
+};
+
+fn has_control_char(value: &str) -> bool {
+    value.chars().any(|c| c.is_control())
+}
+
+fn validate_card_name(field: &str, name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    if name.len() > MAX_DECK_CARD_NAME_LEN {
+        return Err(format!(
+            "{field} must be at most {MAX_DECK_CARD_NAME_LEN} bytes"
+        ));
+    }
+    if has_control_char(name) {
+        return Err(format!("{field} must not contain control characters"));
+    }
+    Ok(())
+}
+
+fn validate_main_deck_list(main_deck: &[String]) -> Result<(), String> {
+    if main_deck.len() > MAX_MAIN_DECK_ENTRIES {
+        return Err(format!(
+            "SubmitDeck.main_deck must contain at most {MAX_MAIN_DECK_ENTRIES} entries"
+        ));
+    }
+    for (index, name) in main_deck.iter().enumerate() {
+        validate_card_name(&format!("SubmitDeck.main_deck[{index}]"), name)?;
+    }
+    Ok(())
+}
+
+/// Validate client-supplied `DraftAction` payload fields before session dispatch.
+pub fn guard_draft_action_payload(action: &DraftAction) -> Result<(), String> {
+    match action {
+        DraftAction::Pick {
+            card_instance_id, ..
+        } => {
+            validate_token("Pick.card_instance_id", card_instance_id, MAX_TOKEN_LEN)?;
+        }
+        DraftAction::SubmitDeck { main_deck, .. } => validate_main_deck_list(main_deck)?,
+        DraftAction::ReportMatchResult { match_id, .. } => {
+            validate_token("ReportMatchResult.match_id", match_id, MAX_TOKEN_LEN)?;
+        }
+        DraftAction::ReplaceSeatWithBot { name, .. } => {
+            validate_optional_label("ReplaceSeatWithBot.name", name, MAX_DISPLAY_NAME_LEN)?;
+        }
+        DraftAction::StartDraft
+        | DraftAction::AdvanceRound
+        | DraftAction::GeneratePairings { .. }
+        | DraftAction::SetSeatConnected { .. } => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lobby_broker::inbound_guard::MAX_MAIN_DECK_ENTRIES;
+
+    #[test]
+    fn pick_accepts_valid_instance_id() {
+        let action = DraftAction::Pick {
+            seat: 0,
+            card_instance_id: "card-0".to_string(),
+        };
+        assert!(guard_draft_action_payload(&action).is_ok());
+    }
+
+    #[test]
+    fn pick_rejects_oversized_instance_id() {
+        let action = DraftAction::Pick {
+            seat: 0,
+            card_instance_id: "x".repeat(MAX_TOKEN_LEN + 1),
+        };
+        let err = guard_draft_action_payload(&action).unwrap_err();
+        assert!(err.contains("card_instance_id"));
+    }
+
+    #[test]
+    fn submit_deck_rejects_oversized_main() {
+        let action = DraftAction::SubmitDeck {
+            seat: 0,
+            main_deck: vec!["Forest".to_string(); MAX_MAIN_DECK_ENTRIES + 1],
+        };
+        let err = guard_draft_action_payload(&action).unwrap_err();
+        assert!(err.contains("main_deck"));
+    }
+}

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ai_seats_wire_guard;
 pub mod deck_resolve;
+pub mod draft_action_payload_guard;
 pub mod draft_session;
 pub mod draft_wire_guard;
 pub mod emote_guard;
@@ -19,6 +20,7 @@ pub mod starter_decks;
 
 pub use ai_seats_wire_guard::guard_create_ai_seats;
 pub use deck_resolve::resolve_deck;
+pub use draft_action_payload_guard::guard_draft_action_payload;
 pub use draft_session::{generate_draft_code, DraftSession, DraftSessionManager};
 pub use draft_wire_guard::{
     guard_create_draft_with_settings, guard_draft_action, guard_join_draft_with_password,


### PR DESCRIPTION
Closes #1881.

`DraftAction` now validates pick IDs, submit-deck lists, and match IDs before draft session lookup and reducer work. `draft_code` was already bounded by `guard_draft_action`; this covers the action body.

## Real Behavior Proof

* `SubmitDeck` with 501 main-deck entries is rejected at guard
* `Pick` with 129-byte `card_instance_id` is rejected at guard
* Valid pick/submit payloads pass guard

## Test plan

* `cargo test -p server-core draft_action_payload_guard -- --nocapture`
* `cargo fmt --all -- --check`
* CI Rust lint + tests