### PR TITLE
fix: bound legacy JoinGame game_code before deck resolution

### DIFF
--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -40,6 +40,7 @@ use server_core::draft_wire_guard::{
 use server_core::emote_guard::guard_emote;
 use server_core::game_reconnect_guard::guard_game_reconnect;
 use server_core::legacy_deck_guard::guard_legacy_deck;
+use server_core::legacy_join_guard::guard_legacy_join_game;
 use server_core::lobby::RegisterGameRequest;
 use server_core::lookup_join_guard::guard_lookup_join_target;
 use server_core::protocol::{
@@ -2228,7 +2229,7 @@ async fn handle_client_message(
 
         ClientMessage::JoinGame { game_code, deck } => {
             info!(game = %game_code, deck_size = deck.main_deck.len(), "JoinGame");
-            if let Err(reason) = guard_legacy_deck(&deck) {
+            if let Err(reason) = guard_legacy_join_game(&game_code, &deck) {
                 let msg = ServerMessage::Error { message: reason };
                 if let Ok(json) = serde_json::to_string(&msg) {
                     let _ = socket.send(Message::text(json)).await;

--- a/crates/server-core/src/legacy_join_guard.rs
+++ b/crates/server-core/src/legacy_join_guard.rs
@@ -1,0 +1,51 @@
+//! Wire validation for legacy `JoinGame` frames.
+//!
+//! `guard_legacy_deck` bounds the deck payload, but `JoinGame` also carries a
+//! `game_code` that was cloned through `resolve_deck` and session lookup without
+//! the same bounds enforced on settings-based join paths.
+
+use engine::starter_decks::DeckData;
+use lobby_broker::validation::{validate_token, MAX_GAME_CODE_LEN};
+
+use crate::legacy_deck_guard::guard_legacy_deck;
+
+/// Validate legacy join wire fields before card-database resolution.
+pub fn guard_legacy_join_game(game_code: &str, deck: &DeckData) -> Result<(), String> {
+    validate_token("game_code", game_code, MAX_GAME_CODE_LEN)?;
+    guard_legacy_deck(deck)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lobby_broker::inbound_guard::MAX_MAIN_DECK_ENTRIES;
+    use lobby_broker::validation::MAX_GAME_CODE_LEN;
+
+    fn deck(main: &[&str]) -> DeckData {
+        DeckData {
+            main_deck: main.iter().map(|s| s.to_string()).collect(),
+            sideboard: vec![],
+            commander: vec![],
+            bracket_tier: Default::default(),
+        }
+    }
+
+    #[test]
+    fn legacy_join_accepts_valid_fields() {
+        assert!(guard_legacy_join_game("ABC123", &deck(&["Forest"])).is_ok());
+    }
+
+    #[test]
+    fn legacy_join_rejects_oversized_game_code() {
+        let err = guard_legacy_join_game(&"x".repeat(MAX_GAME_CODE_LEN + 1), &deck(&["Forest"]))
+            .unwrap_err();
+        assert!(err.contains("game_code"));
+    }
+
+    #[test]
+    fn legacy_join_rejects_oversized_deck() {
+        let names: Vec<&str> = vec!["Card"; MAX_MAIN_DECK_ENTRIES + 1];
+        let err = guard_legacy_join_game("ABC123", &deck(&names)).unwrap_err();
+        assert!(err.contains("main_deck"));
+    }
+}

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod game_reconnect_guard;
 #[cfg(test)]
 mod harness;
 pub mod legacy_deck_guard;
+pub mod legacy_join_guard;
 pub mod lobby;
 pub mod lookup_join_guard;
 pub mod persist;
@@ -31,6 +32,7 @@ pub use emote_guard::guard_emote;
 pub use filter::filter_state_for_player;
 pub use game_reconnect_guard::guard_game_reconnect;
 pub use legacy_deck_guard::guard_legacy_deck;
+pub use legacy_join_guard::guard_legacy_join_game;
 pub use lobby::LobbyManager;
 pub use lookup_join_guard::guard_lookup_join_target;
 pub use persist::{PersistedLobbyMeta, PersistedSession};


### PR DESCRIPTION
Closes #1885.

Legacy `JoinGame` now validates `game_code` and deck payloads before `resolve_deck`. Settings-based join already bounded `game_code` via the lobby broker; this closes the legacy API gap.

## Real Behavior Proof

* 65-byte `game_code` is rejected at guard
* 501-entry deck still rejected at guard
* Valid join payload passes guard

## Test plan

* `cargo test -p server-core legacy_join_guard -- --nocapture`
* `cargo fmt --all -- --check`
* CI Rust lint + tests