### PR TITLE
fix: bound ClientHello version fields before handshake store

### DIFF
--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -32,6 +32,7 @@ use lobby_broker::{
 };
 use seat_reducer::types::{DeckChoice, DeckResolver, ReducerCtx};
 use server_core::ai_seats_wire_guard::{guard_create_ai_seats, MAX_FULL_GAME_PLAYER_COUNT};
+use server_core::client_hello_guard::guard_client_hello;
 use server_core::draft_action_payload_guard::guard_draft_action_payload;
 use server_core::draft_session::DraftSessionManager;
 use server_core::draft_wire_guard::{
@@ -394,6 +395,8 @@ enum HelloGateOutcome {
     /// ClientHello arrived but declares an incompatible protocol version.
     /// Send Error with this (client, server) pair and drop the frame.
     RejectProtocol { client: u32, server: u32 },
+    /// ClientHello fields failed wire validation. Send Error with this reason.
+    RejectInvalidHello(String),
     /// A non-hello frame arrived before the handshake completed. Send Error
     /// ("ClientHello required before any other message") and drop.
     RejectHandshakeRequired,
@@ -427,6 +430,8 @@ fn classify_hello_gate(
                     client: *protocol_version,
                     server: *server_protocol_range.end(),
                 }
+            } else if let Err(reason) = guard_client_hello(client_version, build_commit) {
+                HelloGateOutcome::RejectInvalidHello(reason)
             } else {
                 HelloGateOutcome::Accept(ClientHelloInfo {
                     client_version: client_version.clone(),
@@ -2199,6 +2204,14 @@ async fn handle_client_message(
                 "ClientHello accepted"
             );
             identity.client_hello = Some(info);
+            return;
+        }
+        HelloGateOutcome::RejectInvalidHello(reason) => {
+            warn!(%reason, "ClientHello rejected at wire guard");
+            let msg = ServerMessage::Error { message: reason };
+            if let Ok(json) = serde_json::to_string(&msg) {
+                let _ = socket.send(Message::text(json)).await;
+            }
             return;
         }
         HelloGateOutcome::RejectProtocol { client, server } => {
@@ -5127,6 +5140,22 @@ mod handshake_tests {
             MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
         );
         assert!(matches!(outcome, HelloGateOutcome::RejectProtocol { .. }));
+    }
+
+    #[test]
+    fn rejects_oversized_client_hello_fields() {
+        use lobby_broker::validation::MAX_TOKEN_LEN;
+
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::ClientHello {
+                client_version: "v".repeat(MAX_TOKEN_LEN + 1),
+                build_commit: "abc1234".into(),
+                protocol_version: PROTOCOL_VERSION,
+            },
+            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+        );
+        assert!(matches!(outcome, HelloGateOutcome::RejectInvalidHello(_)));
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -5014,6 +5014,7 @@ mod mode_gate_tests {
 mod handshake_tests {
     use super::*;
     use engine::types::actions::GameAction;
+    use lobby_broker::validation::MAX_TOKEN_LEN;
     use server_core::protocol::DeckData;
 
     fn empty_identity() -> SocketIdentity {
@@ -5144,8 +5145,6 @@ mod handshake_tests {
 
     #[test]
     fn rejects_oversized_client_hello_fields() {
-        use lobby_broker::validation::MAX_TOKEN_LEN;
-
         let outcome = classify_hello_gate(
             false,
             &ClientMessage::ClientHello {

--- a/crates/server-core/src/client_hello_guard.rs
+++ b/crates/server-core/src/client_hello_guard.rs
@@ -1,0 +1,37 @@
+//! Wire validation for the WebSocket `ClientHello` handshake.
+//!
+//! Lobby broker frames validate `client_version` and `build_commit` via
+//! `validate_lobby_message`, but native `phase-server` accepted and cloned
+//! unbounded strings in `classify_hello_gate` before any size check.
+
+use lobby_broker::validation::{validate_token, MAX_TOKEN_LEN};
+
+/// Validate `ClientHello` identity fields before they are stored on the socket.
+pub fn guard_client_hello(client_version: &str, build_commit: &str) -> Result<(), String> {
+    validate_token("client_version", client_version, MAX_TOKEN_LEN)?;
+    validate_token("build_commit", build_commit, MAX_TOKEN_LEN)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lobby_broker::validation::MAX_TOKEN_LEN;
+
+    #[test]
+    fn client_hello_accepts_valid_fields() {
+        assert!(guard_client_hello("1.0.0", "abc123").is_ok());
+    }
+
+    #[test]
+    fn client_hello_rejects_oversized_version() {
+        let err = guard_client_hello(&"v".repeat(MAX_TOKEN_LEN + 1), "abc").unwrap_err();
+        assert!(err.contains("client_version"));
+    }
+
+    #[test]
+    fn client_hello_rejects_oversized_build_commit() {
+        let err = guard_client_hello("1.0.0", &"c".repeat(MAX_TOKEN_LEN + 1)).unwrap_err();
+        assert!(err.contains("build_commit"));
+    }
+}

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod ai_seats_wire_guard;
+pub mod client_hello_guard;
 pub mod deck_resolve;
 pub mod draft_action_payload_guard;
 pub mod draft_session;
@@ -21,6 +22,7 @@ pub mod spectator_wire_guard;
 pub mod starter_decks;
 
 pub use ai_seats_wire_guard::guard_create_ai_seats;
+pub use client_hello_guard::guard_client_hello;
 pub use deck_resolve::resolve_deck;
 pub use draft_action_payload_guard::guard_draft_action_payload;
 pub use draft_session::{generate_draft_code, DraftSession, DraftSessionManager};


### PR DESCRIPTION
Closes #1890.

`ClientHello` now validates `client_version` and `build_commit` in `classify_hello_gate` before cloning them onto the socket. Lobby broker frames already used `validate_lobby_message`; this closes the native handshake gap.

## Real Behavior Proof

* 129-byte `client_version` returns `RejectInvalidHello` at guard
* Valid handshake fields still accept
* Oversized `build_commit` rejected at guard

## Test plan

* `cargo test -p server-core client_hello_guard -- --nocapture`
* `cargo test -p phase-server rejects_oversized_client_hello_fields -- --nocapture`
* `cargo fmt --all -- --check`
* CI Rust lint + tests