### PR TITLE
Fix LobbyOnly deck clone before guard validation

### DIFF
--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -2919,6 +2919,14 @@ async fn handle_client_message(
             // LobbyGameAdded fan-out (in order). Deck data, AI seats, and
             // format-legality are host-authoritative and irrelevant here.
             if matches!(mode, ServerMode::LobbyOnly) {
+                // Validate deck bounds before cloning to reject oversized decks early
+                if let Err(reason) = lobby_broker::validate_deck_payload("deck", &deck) {
+                    let msg = ServerMessage::Error { message: reason };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                    return;
+                }
                 dispatch_broker_msg(
                     lobby_broker::LobbyClientMessage::CreateGameWithSettings {
                         deck: deck.clone(),
@@ -3624,6 +3632,14 @@ async fn handle_client_message(
             // is created server-side. The deck is ignored — the host validates
             // guest decks over P2P once the connection is up.
             if matches!(mode, ServerMode::LobbyOnly) {
+                // Validate deck bounds before cloning to reject oversized decks early
+                if let Err(reason) = lobby_broker::validate_deck_payload("deck", &deck) {
+                    let msg = ServerMessage::Error { message: reason };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                    return;
+                }
                 dispatch_broker_msg(
                     lobby_broker::LobbyClientMessage::JoinGameWithPassword {
                         game_code: game_code.clone(),

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -2929,17 +2929,17 @@ async fn handle_client_message(
                 }
                 dispatch_broker_msg(
                     lobby_broker::LobbyClientMessage::CreateGameWithSettings {
-                        deck: deck.clone(),
-                        display_name: display_name.clone(),
+                        deck,
+                        display_name,
                         public,
-                        password: password.clone(),
+                        password,
                         timer_seconds,
                         player_count: requested_player_count,
                         match_config,
-                        format_config: format_config.clone(),
-                        room_name: room_name.clone(),
-                        host_peer_id: host_peer_id.clone(),
-                        draft_metadata: draft_metadata.clone(),
+                        format_config,
+                        room_name,
+                        host_peer_id,
+                        draft_metadata,
                         start_when_full,
                         ranked,
                     },
@@ -3642,11 +3642,11 @@ async fn handle_client_message(
                 }
                 dispatch_broker_msg(
                     lobby_broker::LobbyClientMessage::JoinGameWithPassword {
-                        game_code: game_code.clone(),
-                        deck: deck.clone(),
-                        display_name: display_name.clone(),
-                        password: password.clone(),
-                        reservation_token: reservation_token.clone(),
+                        game_code,
+                        deck,
+                        display_name,
+                        password,
+                        reservation_token,
                     },
                     lobby,
                     lobby_subscribers,


### PR DESCRIPTION
Fixes #1893
 
## Problem
In LobbyOnly mode, `phase-server` clones deck data into `LobbyClientMessage` before passing to the broker. The broker's [guard_inbound](cci:1://file:///d:/Projects/gittensor/phase/crates/lobby-broker/src/inbound_guard.rs:73:0-88:1) would reject oversized decks, but the clone happens first, allowing attackers to send megabyte-scale decks that get cloned before rejection.
 
Full mode already calls [guard_inbound](cci:1://file:///d:/Projects/gittensor/phase/crates/lobby-broker/src/inbound_guard.rs:73:0-88:1) before further processing, but LobbyOnly skips this guard and pays an extra eager clone into the broker dispatch struct.
 
## Solution
Add [lobby_broker::validate_deck_payload("deck", &deck)](cci:1://file:///d:/Projects/gittensor/phase/crates/lobby-broker/src/inbound_guard.rs:51:0-71:1) check in LobbyOnly mode BEFORE the `deck.clone()` call in both handlers:
- `CreateGameWithSettings` (line ~2923)
- `JoinGameWithPassword` (line ~3636)
 
This validates deck bounds on the original borrowed reference, rejecting oversized decks (501+ cards) without the expensive clone operation.
 
## Testing
- Oversized deck (501+ cards) in LobbyOnly mode now rejects before clone
- Normal deck sizes still work in LobbyOnly mode
- Full mode behavior unchanged