### PR TITLE
fix(feed-scraper): infer both colors for Watery Grave, Blood Crypt, Sacred Foundry

### DIFF
--- a/crates/feed-scraper/src/scrape.rs
+++ b/crates/feed-scraper/src/scrape.rs
@@ -253,32 +253,28 @@ fn infer_colors(cards: &[DeckEntry]) -> Vec<String> {
     };
 
     for entry in cards {
-        match entry.name.as_str() {
+        let inferred: &[&str] = match entry.name.as_str() {
             // Basic lands
-            "Plains" | "Snow-Covered Plains" => add("W"),
-            "Island" | "Snow-Covered Island" => add("U"),
-            "Swamp" | "Snow-Covered Swamp" => add("B"),
-            "Mountain" | "Snow-Covered Mountain" => add("R"),
-            "Forest" | "Snow-Covered Forest" => add("G"),
+            "Plains" | "Snow-Covered Plains" => &["W"],
+            "Island" | "Snow-Covered Island" => &["U"],
+            "Swamp" | "Snow-Covered Swamp" => &["B"],
+            "Mountain" | "Snow-Covered Mountain" => &["R"],
+            "Forest" | "Snow-Covered Forest" => &["G"],
             // Shock lands
-            "Hallowed Fountain" | "Temple Garden" | "Godless Shrine" => add("W"),
-            "Watery Grave" | "Steam Vents" | "Breeding Pool" => add("U"),
-            "Blood Crypt" | "Overgrown Tomb" => add("B"),
-            "Sacred Foundry" | "Stomping Ground" => add("R"),
-            _ => {}
-        }
-        // Second color for dual lands. Each shock land's off-color must differ
-        // from the primary color added above; the previous grouping gave Watery
-        // Grave (UB), Blood Crypt (BR), and Sacred Foundry (RW) a second color
-        // equal to their primary, so they only ever inferred one of their two
-        // colors.
-        match entry.name.as_str() {
-            "Sacred Foundry" => add("W"),
-            "Hallowed Fountain" => add("U"),
-            "Watery Grave" | "Godless Shrine" => add("B"),
-            "Steam Vents" | "Blood Crypt" => add("R"),
-            "Breeding Pool" | "Temple Garden" | "Overgrown Tomb" | "Stomping Ground" => add("G"),
-            _ => {}
+            "Hallowed Fountain" => &["W", "U"],
+            "Watery Grave" => &["U", "B"],
+            "Blood Crypt" => &["B", "R"],
+            "Sacred Foundry" => &["R", "W"],
+            "Godless Shrine" => &["W", "B"],
+            "Steam Vents" => &["U", "R"],
+            "Stomping Ground" => &["R", "G"],
+            "Breeding Pool" => &["U", "G"],
+            "Temple Garden" => &["W", "G"],
+            "Overgrown Tomb" => &["B", "G"],
+            _ => &[],
+        };
+        for color in inferred {
+            add(color);
         }
     }
     colors

--- a/crates/feed-scraper/src/scrape.rs
+++ b/crates/feed-scraper/src/scrape.rs
@@ -267,11 +267,16 @@ fn infer_colors(cards: &[DeckEntry]) -> Vec<String> {
             "Sacred Foundry" | "Stomping Ground" => add("R"),
             _ => {}
         }
-        // Second color for dual lands
+        // Second color for dual lands. Each shock land's off-color must differ
+        // from the primary color added above; the previous grouping gave Watery
+        // Grave (UB), Blood Crypt (BR), and Sacred Foundry (RW) a second color
+        // equal to their primary, so they only ever inferred one of their two
+        // colors.
         match entry.name.as_str() {
-            "Hallowed Fountain" | "Watery Grave" => add("U"),
-            "Steam Vents" | "Sacred Foundry" => add("R"),
-            "Blood Crypt" | "Godless Shrine" => add("B"),
+            "Sacred Foundry" => add("W"),
+            "Hallowed Fountain" => add("U"),
+            "Watery Grave" | "Godless Shrine" => add("B"),
+            "Steam Vents" | "Blood Crypt" => add("R"),
             "Breeding Pool" | "Temple Garden" | "Overgrown Tomb" | "Stomping Ground" => add("G"),
             _ => {}
         }
@@ -303,6 +308,43 @@ fn config_format_tag(document: &Html) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shock_lands_infer_both_of_their_colors() {
+        // Each Ravnica shock land is two-colored; inference must yield both.
+        // Watery Grave (UB), Blood Crypt (BR), and Sacred Foundry (RW)
+        // previously inferred only their primary color.
+        let cases: [(&str, [&str; 2]); 10] = [
+            ("Hallowed Fountain", ["W", "U"]),
+            ("Watery Grave", ["U", "B"]),
+            ("Blood Crypt", ["B", "R"]),
+            ("Sacred Foundry", ["R", "W"]),
+            ("Godless Shrine", ["W", "B"]),
+            ("Steam Vents", ["U", "R"]),
+            ("Stomping Ground", ["R", "G"]),
+            ("Breeding Pool", ["U", "G"]),
+            ("Temple Garden", ["W", "G"]),
+            ("Overgrown Tomb", ["B", "G"]),
+        ];
+        for (name, expected) in cases {
+            let cards = [DeckEntry {
+                count: 4,
+                name: name.to_string(),
+            }];
+            let colors = infer_colors(&cards);
+            assert_eq!(
+                colors.len(),
+                2,
+                "{name} should infer two colors, got {colors:?}"
+            );
+            for color in expected {
+                assert!(
+                    colors.iter().any(|c| c.as_str() == color),
+                    "{name} should infer {color}, got {colors:?}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn companion_section_sets_name_and_stays_out_of_main() {


### PR DESCRIPTION
Closes #1898

## Summary

`infer_colors` (feed-scraper) adds a shock land's primary color in a first `match`, then its off-color in a second `match`. Three lands were grouped in the second match under a color **equal to their primary**, and `add` de-dupes, so they only ever inferred one of their two colors:

- **Watery Grave** (U/B) was in the second-match `add("U")` group → only **U**
- **Blood Crypt** (B/R) was in the `add("B")` group → only **B**
- **Sacred Foundry** (R/W) was in the `add("R")` group → only **R**

A deck whose color source is one of these was mis-tagged with a single color.

## Fix

Regroup the second match by each land's actual off-color — Watery Grave → B, Blood Crypt → R, Sacred Foundry → W. The other seven Ravnica shock lands were already correct and are unchanged.

## Tests

Added `shock_lands_infer_both_of_their_colors` (inline test module), asserting all ten Ravnica shock lands infer exactly their two colors — covering the three previously-broken ones and guarding the seven that were correct.

## Verification

`cargo fmt --all --check` clean. `feed-scraper` depends on `reqwest`/`openssl-sys`, which needs system `pkg-config`/OpenSSL that isn't available in my environment (no root to install it), so I could not compile/run the crate locally — the build + the new test run in CI. The change is a pure, deterministic correction to a color-lookup `match` (verified by tracing all ten shock-land color pairs), and the test is self-contained.

Model: claude-opus-4-8
Thinking: high
Tier: Frontier
