### PR TITLE
feat(parser): additive "colors and types" type-change clauses (CR 105.2 / 205.1a)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -27255,6 +27255,46 @@ mod tests {
     }
 
     /// CR 701.17a + CR 701.17c + CR 400.7j + CR 608.2c: "Mill a card, then draw
+    /// CR 105.2 + CR 205.1a + CR 613.1d-e: Rise from the Grave reanimation —
+    /// "Put target creature card from a graveyard onto the battlefield under your
+    /// control. It's a black Zombie in addition to its other colors and types."
+    /// The trailing contracted-subject clause must chain (via `sub_ability`) to a
+    /// continuous `GenericEffect` adding the black color (layer 5) and the Zombie
+    /// subtype (layer 4) — not an Unimplemented fallback.
+    #[test]
+    fn reanimate_becomes_black_zombie_in_addition_to_colors_and_types() {
+        use crate::types::mana::ManaColor;
+        let def = parse_effect_chain(
+            "Put target creature card from a graveyard onto the battlefield under your control. It's a black Zombie in addition to its other colors and types.",
+            AbilityKind::Spell,
+        );
+        let mut mods: Vec<ContinuousModification> = Vec::new();
+        let mut node = Some(&def);
+        while let Some(d) = node {
+            if let Effect::GenericEffect {
+                static_abilities, ..
+            } = &*d.effect
+            {
+                for sd in static_abilities {
+                    mods.extend(sd.modifications.iter().cloned());
+                }
+            }
+            node = d.sub_ability.as_deref();
+        }
+        assert!(
+            mods.contains(&ContinuousModification::AddColor {
+                color: ManaColor::Black
+            }),
+            "expected AddColor(Black); chain mods: {mods:?}"
+        );
+        assert!(
+            mods.contains(&ContinuousModification::AddSubtype {
+                subtype: "Zombie".to_string()
+            }),
+            "expected AddSubtype(Zombie); chain mods: {mods:?}"
+        );
+    }
+
     /// cards equal to the milled card's mana value." — Heed the Mists.
     ///
     /// The `Mill` effect must chain (via `sub_ability`) to a `Draw` effect

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -27254,7 +27254,6 @@ mod tests {
         assert!(*tapped);
     }
 
-    /// CR 701.17a + CR 701.17c + CR 400.7j + CR 608.2c: "Mill a card, then draw
     /// CR 105.2 + CR 205.1a + CR 613.1d-e: Rise from the Grave reanimation —
     /// "Put target creature card from a graveyard onto the battlefield under your
     /// control. It's a black Zombie in addition to its other colors and types."
@@ -27263,7 +27262,6 @@ mod tests {
     /// subtype (layer 4) — not an Unimplemented fallback.
     #[test]
     fn reanimate_becomes_black_zombie_in_addition_to_colors_and_types() {
-        use crate::types::mana::ManaColor;
         let def = parse_effect_chain(
             "Put target creature card from a graveyard onto the battlefield under your control. It's a black Zombie in addition to its other colors and types.",
             AbilityKind::Spell,
@@ -27295,6 +27293,7 @@ mod tests {
         );
     }
 
+    /// CR 701.17a + CR 701.17c + CR 400.7j + CR 608.2c: "Mill a card, then draw
     /// cards equal to the milled card's mana value." — Heed the Mists.
     ///
     /// The `Mill` effect must chain (via `sub_ability`) to a `Draw` effect

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -186,10 +186,16 @@ pub(crate) fn parse_additive_type_clause_modifications(
             tag::<_, _, VE>(" in addition to "),
             alt((tag::<_, _, VE>("its"), tag::<_, _, VE>("their"))),
             tag::<_, _, VE>(" other "),
+            // CR 105.2 + CR 205.1a: "colors and types" forms add a color (CR
+            // 613.1e, layer 5) alongside the type/subtype additions. Longer
+            // phrases first so "colors and types" wins over bare "types".
             alt((
+                tag::<_, _, VE>("colors and creature types"),
+                tag::<_, _, VE>("colors and types"),
                 tag::<_, _, VE>("creature types"),
                 tag::<_, _, VE>("land types"),
                 tag::<_, _, VE>("types"),
+                tag::<_, _, VE>("colors"),
             )),
         ),
     )
@@ -233,6 +239,14 @@ pub(crate) fn parse_additive_type_clause_modifications(
             continue;
         }
         let lower_word = word.to_lowercase();
+        // CR 105.2 + CR 613.1e: a color word ("black", "white", …) adds that
+        // color (layer 5), e.g. Rise from the Grave's "black Zombie".
+        if let Ok((rest, color)) = nom_primitives::parse_color(lower_word.as_str()) {
+            if rest.is_empty() {
+                modifications.push(ContinuousModification::AddColor { color });
+                continue;
+            }
+        }
         if let Some(core_type) = core_type_from_additive_word(lower_word.as_str()) {
             modifications.push(ContinuousModification::AddType { core_type });
             continue;


### PR DESCRIPTION
## Summary
Reanimation-style clauses like **Rise from the Grave** / **Grave Betrayal** — *"It's a black Zombie in addition to its other colors and types"* — were falling to the `Effect:its`/Unimplemented fallback. `parse_additive_type_clause_modifications` already handled *"in addition to its other types"*, and the contracted *"It's …"* subject + anaphor were already handled by `try_parse_contracted_subject_additive_type_clause` — the only gaps were the **color suffix** and **color-word extraction**.

This extends the additive type-change building block:
- The *"in addition to its other …"* suffix now accepts **"colors and types"**, **"colors and creature types"**, and bare **"colors"** (longest-first), alongside the existing `types` / `creature types` / `land types`.
- A **color word** in the type list ("black") now emits `ContinuousModification::AddColor` (CR 613.1e, layer 5) in addition to the `AddType`/`AddSubtype` it already produced (layer 4).

## Files changed
- `crates/engine/src/parser/oracle_static/type_change.rs` — suffix alt + color-word → `AddColor` in the modification loop
- `crates/engine/src/parser/oracle_effect/mod.rs` — integration test

## Anchored on
- `parse_additive_type_clause_modifications` — the existing additive type-grant parser this extends (same combinator/suffix structure).
- `try_parse_contracted_subject_additive_type_clause` — already resolves the *"It's …"* contracted/anaphoric subject, so no subject changes were needed.
- `append_color_and_type_modifications` (become_copy_except.rs) — the precedent for parsing a "black zombie" type/color list into `AddColor` + `AddSubtype`.

## CR references
- `CR 105.2` (colors) · `CR 205.1a` (types in addition) · `CR 613.1d-e` (layer 4 type / layer 5 color)

## Tests
- `reanimate_becomes_black_zombie_in_addition_to_colors_and_types` — drives the full Rise from the Grave text through `parse_effect_chain` and asserts the chain carries both `AddColor(Black)` and `AddSubtype(Zombie)`.

## Track
Developer (local toolchain)

## LLM
Model: claude-opus-4-8
Thinking: medium

## Verification
Verified locally before push: `cargo fmt --all --check` clean; `cargo clippy -p engine --all-targets -- -D warnings` clean (exit 0); `cargo test -p engine` — new test passes, and the `additive_type` (3) + `become_copy` (61) suites pass with no regressions. CI status checks also apply.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.