### PR TITLE
feat(engine): implement Impending keyword end-to-end (CR 702.176a)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -4675,6 +4675,9 @@ pub fn synthesize_all(face: &mut CardFace) {
     // ability that exiles self and grants a Plotted casting permission for
     // free-cast on a later turn. Runs after Suspend; idempotent.
     synthesize_plot(face);
+    // CR 702.176a: Impending — end-step trigger removing one time counter while
+    // the impending cost was paid and a counter remains. Idempotent.
+    synthesize_impending(face);
     synthesize_siege_intrinsics(face);
     synthesize_tribute_intrinsics(face);
     // CR 702.124j: Partner with — ETB trigger letting target player fetch the
@@ -4693,6 +4696,74 @@ pub fn synthesize_all(face: &mut CardFace) {
     // CR 702.165: Backup — ETB trigger placing +1/+1 counters and granting
     // non-Backup abilities printed below Backup until end of turn.
     synthesize_backup(face);
+}
+
+/// CR 702.176a: Synthesize the Impending end-step counter-removal trigger.
+///
+/// "At the beginning of your end step, if this permanent's impending cost was
+/// paid and it has a time counter on it, remove a time counter from it."
+///
+/// The trigger is a battlefield-zone, end-step trigger gated on:
+/// - `TriggerCondition::CastVariantPaid { Impending }` — impending cost was paid
+/// - `TriggerCondition::HasCounters { Time, minimum: 1 }` — still has counters
+///
+/// Combined with `TriggerConstraint::OnlyDuringYourTurn` to enforce "your" end step.
+/// Idempotent: skips if the trigger shape is already present.
+pub fn synthesize_impending(face: &mut CardFace) {
+    if !face
+        .keywords
+        .iter()
+        .any(|k| matches!(k, Keyword::Impending { .. }))
+    {
+        return;
+    }
+    // Idempotency: skip if the end-step counter-removal trigger is already present.
+    let already_has_trigger = face.triggers.iter().any(|t| {
+        matches!(t.mode, TriggerMode::Phase)
+            && t.phase == Some(Phase::End)
+            && matches!(
+                t.execute.as_deref().map(|a| &*a.effect),
+                Some(Effect::RemoveCounter {
+                    counter_type: Some(CounterType::Time),
+                    target: TargetFilter::SelfRef,
+                    ..
+                })
+            )
+    });
+    if already_has_trigger {
+        return;
+    }
+
+    let remove_one = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::RemoveCounter {
+            counter_type: Some(CounterType::Time),
+            count: 1,
+            target: TargetFilter::SelfRef,
+        },
+    );
+    // CR 702.176a: gated on impending cost paid AND has a time counter.
+    let condition = TriggerCondition::And {
+        conditions: vec![
+            TriggerCondition::CastVariantPaid {
+                variant: CastVariantPaid::Impending,
+            },
+            TriggerCondition::HasCounters {
+                counters: CounterMatch::OfType(CounterType::Time),
+                minimum: 1,
+                maximum: None,
+            },
+        ],
+    };
+    let trigger = TriggerDefinition::new(TriggerMode::Phase)
+        .phase(Phase::End)
+        .condition(condition)
+        .constraint(crate::types::ability::TriggerConstraint::OnlyDuringYourTurn)
+        .execute(remove_one)
+        .description(
+            "CR 702.176a: At the beginning of your end step, if this permanent's impending cost was paid and it has a time counter on it, remove a time counter from it.".to_string(),
+        );
+    face.triggers.push(trigger);
 }
 
 /// CR 702.124j: Synthesize the "Partner with [Name]" ETB trigger.

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -15,9 +15,9 @@ use crate::types::ability::{
     KickerVariant, ManaContribution, ManaProduction, ModalSelectionCondition,
     ModalSelectionConstraint, NinjutsuVariant, ObjectScope, ParsedCondition, PlayerFilter,
     PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
-    ReplacementDefinition, RuntimeHandler, SearchSelectionConstraint, StaticDefinition,
-    TargetChoiceTiming, TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
-    UnlessPayModifier,
+    ReplacementDefinition, RuntimeHandler, SearchSelectionConstraint, StaticCondition,
+    StaticDefinition, TargetChoiceTiming, TargetFilter, TriggerCondition, TriggerDefinition,
+    TypeFilter, TypedFilter, UnlessPayModifier,
 };
 use crate::types::card::{CardFace, CardLayout, CleaveVariant};
 use crate::types::card_type::{CardType, CoreType, Supertype};
@@ -4675,8 +4675,9 @@ pub fn synthesize_all(face: &mut CardFace) {
     // ability that exiles self and grants a Plotted casting permission for
     // free-cast on a later turn. Runs after Suspend; idempotent.
     synthesize_plot(face);
-    // CR 702.176a: Impending — end-step trigger removing one time counter while
-    // the impending cost was paid and a counter remains. Idempotent.
+    // CR 702.176a: Impending — static "not a creature" effect plus end-step
+    // trigger removing one time counter while the impending cost was paid and a
+    // counter remains. Idempotent.
     synthesize_impending(face);
     synthesize_siege_intrinsics(face);
     synthesize_tribute_intrinsics(face);
@@ -4698,13 +4699,17 @@ pub fn synthesize_all(face: &mut CardFace) {
     synthesize_backup(face);
 }
 
-/// CR 702.176a: Synthesize the Impending end-step counter-removal trigger.
+/// CR 702.176a: Synthesize Impending's battlefield static and end-step trigger.
 ///
 /// "At the beginning of your end step, if this permanent's impending cost was
 /// paid and it has a time counter on it, remove a time counter from it."
 ///
+/// The static is a Layer 4 `RemoveType(Creature)` continuous effect gated on:
+/// - `StaticCondition::CastVariantPaid { Impending }` — impending cost was paid
+/// - `StaticCondition::HasCounters { Time, minimum: 1 }` — still has counters
+///
 /// The trigger is a battlefield-zone, end-step trigger gated on:
-/// - `TriggerCondition::CastVariantPaid { Impending }` — impending cost was paid
+/// - `TriggerCondition::CastVariantPaidPersistent { Impending }` — impending cost was paid
 /// - `TriggerCondition::HasCounters { Time, minimum: 1 }` — still has counters
 ///
 /// Combined with `TriggerConstraint::OnlyDuringYourTurn` to enforce "your" end step.
@@ -4717,6 +4722,41 @@ pub fn synthesize_impending(face: &mut CardFace) {
     {
         return;
     }
+    let static_condition = StaticCondition::And {
+        conditions: vec![
+            StaticCondition::CastVariantPaid {
+                variant: CastVariantPaid::Impending,
+            },
+            StaticCondition::HasCounters {
+                counters: CounterMatch::OfType(CounterType::Time),
+                minimum: 1,
+                maximum: None,
+            },
+        ],
+    };
+    let already_has_static = face.static_abilities.iter().any(|static_def| {
+        static_def.affected == Some(TargetFilter::SelfRef)
+            && static_def.condition == Some(static_condition.clone())
+            && static_def
+                .modifications
+                .contains(&ContinuousModification::RemoveType {
+                    core_type: CoreType::Creature,
+                })
+    });
+    if !already_has_static {
+        face.static_abilities.push(
+            StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .condition(static_condition)
+                .modifications(vec![ContinuousModification::RemoveType {
+                    core_type: CoreType::Creature,
+                }])
+                .description(
+                    "CR 702.176a: As long as this permanent's impending cost was paid and it has a time counter on it, it's not a creature.".to_string(),
+                ),
+        );
+    }
+
     // Idempotency: skip if the end-step counter-removal trigger is already present.
     let already_has_trigger = face.triggers.iter().any(|t| {
         matches!(t.mode, TriggerMode::Phase)
@@ -4745,7 +4785,7 @@ pub fn synthesize_impending(face: &mut CardFace) {
     // CR 702.176a: gated on impending cost paid AND has a time counter.
     let condition = TriggerCondition::And {
         conditions: vec![
-            TriggerCondition::CastVariantPaid {
+            TriggerCondition::CastVariantPaidPersistent {
                 variant: CastVariantPaid::Impending,
             },
             TriggerCondition::HasCounters {
@@ -5914,6 +5954,115 @@ mod evoke_synthesis_tests {
         face.keywords.push(Keyword::Flying);
         synthesize_evoke(&mut face);
         assert!(face.triggers.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod impending_synthesis_tests {
+    use super::*;
+    use crate::types::mana::{ManaCost, ManaCostShard};
+
+    fn impending_face() -> CardFace {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Impending {
+            counters: 3,
+            cost: ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 1,
+            },
+        });
+        face
+    }
+
+    /// CR 702.176a: Impending synthesizes both battlefield abilities: a static
+    /// Layer 4 type-removal effect while the permanent has a time counter, and
+    /// a recurring end-step trigger that removes those counters.
+    #[test]
+    fn synthesize_impending_adds_static_and_persistent_end_step_trigger() {
+        let mut face = impending_face();
+
+        synthesize_impending(&mut face);
+
+        let static_def = face
+            .static_abilities
+            .iter()
+            .find(|static_def| {
+                static_def.affected == Some(TargetFilter::SelfRef)
+                    && static_def
+                        .modifications
+                        .contains(&ContinuousModification::RemoveType {
+                            core_type: CoreType::Creature,
+                        })
+            })
+            .expect("impending should add a not-creature static");
+        assert!(matches!(
+            static_def.condition,
+            Some(StaticCondition::And { ref conditions })
+                if conditions.contains(&StaticCondition::CastVariantPaid {
+                    variant: CastVariantPaid::Impending,
+                }) && conditions.contains(&StaticCondition::HasCounters {
+                    counters: CounterMatch::OfType(CounterType::Time),
+                    minimum: 1,
+                    maximum: None,
+                })
+        ));
+
+        let trigger = face
+            .triggers
+            .iter()
+            .find(|trigger| {
+                matches!(trigger.mode, TriggerMode::Phase) && trigger.phase == Some(Phase::End)
+            })
+            .expect("impending should add an end-step trigger");
+        assert!(matches!(
+            trigger.condition,
+            Some(TriggerCondition::And { ref conditions })
+                if conditions.contains(&TriggerCondition::CastVariantPaidPersistent {
+                    variant: CastVariantPaid::Impending,
+                }) && conditions.contains(&TriggerCondition::HasCounters {
+                    counters: CounterMatch::OfType(CounterType::Time),
+                    minimum: 1,
+                    maximum: None,
+                })
+        ));
+        assert!(matches!(
+            trigger.execute.as_deref().map(|a| &*a.effect),
+            Some(Effect::RemoveCounter {
+                counter_type: Some(CounterType::Time),
+                target: TargetFilter::SelfRef,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn synthesize_impending_is_idempotent() {
+        let mut face = impending_face();
+
+        synthesize_impending(&mut face);
+        synthesize_impending(&mut face);
+
+        let static_count = face
+            .static_abilities
+            .iter()
+            .filter(|static_def| {
+                static_def
+                    .modifications
+                    .contains(&ContinuousModification::RemoveType {
+                        core_type: CoreType::Creature,
+                    })
+            })
+            .count();
+        let trigger_count = face
+            .triggers
+            .iter()
+            .filter(|trigger| {
+                matches!(trigger.mode, TriggerMode::Phase) && trigger.phase == Some(Phase::End)
+            })
+            .count();
+
+        assert_eq!(static_count, 1);
+        assert_eq!(trigger_count, 1);
     }
 }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2537,6 +2537,18 @@ fn prepare_spell_cast_with_variant_override_inner(
     } else {
         None
     };
+    // CR 702.176a: When the caller explicitly opted into Impending (via
+    // `variant_override = Some(CastingVariant::Impending)`), substitute the
+    // impending mana cost taken from `Keyword::Impending { cost, .. }`.
+    // Mirrors Overload / Bestow / Cleave / Awaken cost substitution.
+    let impending_cost = if casting_variant == CastingVariant::Impending {
+        obj.keywords.iter().find_map(|k| match k {
+            crate::types::keywords::Keyword::Impending { cost, .. } => Some(cost.clone()),
+            _ => None,
+        })
+    } else {
+        None
+    };
     let awaken_cost = awaken_payload.as_ref().map(|(_, cost)| cost.clone());
     // CR 601.2b + CR 118.9a: CastFromHandFree — static permission grants free
     // casting from hand. Auto-application is restricted to `Unlimited` sources
@@ -2658,6 +2670,7 @@ fn prepare_spell_cast_with_variant_override_inner(
             .or(bestow_cost)
             .or(awaken_cost)
             .or(cleave_cost)
+            .or(impending_cost)
             .or(effective_escape_cost_for_path)
             .or(effective_harmonize_cost_for_path)
             .or(effective_flashback_mana_cost_for_path)
@@ -4037,6 +4050,58 @@ pub fn handle_awaken_cost_choice_with_payment_mode(
                 player,
                 object_id,
                 Some(CastingVariant::Awaken),
+            )?;
+            prepared.payment_mode = payment_mode;
+            continue_with_prepared(state, player, prepared, events)
+        }
+        AlternativeCastDecision::Normal => {
+            continue_cast_from_prepared(state, player, object_id, payment_mode, events)
+        }
+    }
+}
+
+/// CR 702.176a: Player chose the normal cast path for an Impending card.
+pub fn handle_impending_cost_choice(
+    state: &mut GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+    card_id: CardId,
+    decision: crate::types::actions::AlternativeCastDecision,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    handle_impending_cost_choice_with_payment_mode(
+        state,
+        player,
+        object_id,
+        card_id,
+        decision,
+        CastPaymentMode::Auto,
+        events,
+    )
+}
+
+/// CR 702.176a: Route an Impending alternative-cost decision into the casting
+/// pipeline. `Alternative` substitutes the impending mana cost (via
+/// `CastingVariant::Impending`); `Normal` proceeds as a standard creature cast.
+/// The ETB time-counter placement and "not a creature" handling occur at stack
+/// resolution in `stack.rs`, not here.
+pub fn handle_impending_cost_choice_with_payment_mode(
+    state: &mut GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+    _card_id: CardId,
+    decision: crate::types::actions::AlternativeCastDecision,
+    payment_mode: CastPaymentMode,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    use crate::types::actions::AlternativeCastDecision;
+    match decision {
+        AlternativeCastDecision::Alternative => {
+            let mut prepared = prepare_spell_cast_with_variant_override(
+                state,
+                player,
+                object_id,
+                Some(CastingVariant::Impending),
             )?;
             prepared.payment_mode = payment_mode;
             continue_with_prepared(state, player, prepared, events)
@@ -5628,6 +5693,55 @@ pub fn handle_cast_spell_with_payment_mode(
                 }
                 // Otherwise (normal-only / no legal land / neither affordable):
                 // fall through to the normal cast path.
+            }
+        }
+    }
+
+    // CR 702.176a: Impending — when a hand card has `Keyword::Impending { cost, .. }`
+    // and both costs are affordable, present a choice. Auto-skip when only one cost
+    // is viable. Impending is opt-in via `variant_override` so a fall-through
+    // proceeds as a normal creature cast with no time counters.
+    if let Some(obj) = state.objects.get(&object_id) {
+        if obj.zone == Zone::Hand {
+            if let Some(impending_cost) = obj.keywords.iter().find_map(|k| match k {
+                crate::types::keywords::Keyword::Impending { cost, .. } => Some(cost.clone()),
+                _ => None,
+            }) {
+                let normal_cost =
+                    apply_cost_modifiers_to_base(state, player, object_id, obj.mana_cost.clone())
+                        .unwrap_or_else(|| obj.mana_cost.clone());
+                let impending_cost_eff =
+                    apply_cost_modifiers_to_base(state, player, object_id, impending_cost.clone())
+                        .unwrap_or_else(|| impending_cost.clone());
+                let normal_affordable =
+                    can_pay_cost_after_auto_tap(state, player, object_id, &normal_cost);
+                let impending_affordable =
+                    can_pay_cost_after_auto_tap(state, player, object_id, &impending_cost_eff);
+                if normal_affordable && impending_affordable {
+                    return Ok(WaitingFor::AlternativeCastChoice {
+                        player,
+                        object_id,
+                        card_id,
+                        payment_mode,
+                        keyword: crate::types::game_state::AlternativeCastKeyword::Impending,
+                        normal_cost,
+                        alternative_cost: Some(impending_cost_eff),
+                        alternative_additional_cost: None,
+                    });
+                }
+                if !normal_affordable && impending_affordable {
+                    // Only impending cost is payable — proceed via the impending path.
+                    return handle_impending_cost_choice_with_payment_mode(
+                        state,
+                        player,
+                        object_id,
+                        card_id,
+                        crate::types::actions::AlternativeCastDecision::Alternative,
+                        payment_mode,
+                        events,
+                    );
+                }
+                // Otherwise (normal-only or neither): fall through to normal cast.
             }
         }
     }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -5,6 +5,7 @@ use crate::types::ability::{
     QuantityExpr, QuantityRef, ResolvedAbility, RestrictionPlayerScope, StaticDefinition,
     TargetFilter, TargetRef,
 };
+use crate::types::actions::AlternativeCastDecision;
 use crate::types::card::LayoutKind;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
@@ -4094,7 +4095,6 @@ pub fn handle_impending_cost_choice_with_payment_mode(
     payment_mode: CastPaymentMode,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    use crate::types::actions::AlternativeCastDecision;
     match decision {
         AlternativeCastDecision::Alternative => {
             let mut prepared = prepare_spell_cast_with_variant_override(

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3329,6 +3329,16 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
             ));
         }
     }
+    // CR 702.176a: Tag the stack object so stack resolution can read the impending
+    // cost-paid marker and place time counters when the permanent enters.
+    if casting_variant == CastingVariant::Impending {
+        if let Some(obj) = state.objects.get_mut(&object_id) {
+            obj.cast_variant_paid = Some((
+                crate::types::ability::CastVariantPaid::Impending,
+                state.turn_number,
+            ));
+        }
+    }
 
     // CR 601.2i: Update the existing stack entry (pushed at announcement) with
     // the finalized ability and the actual mana spent. The entry must still be

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5349,6 +5349,7 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         // `layers::evaluate_condition_with_context` alongside `ChosenColorIs`.
         StaticCondition::ChosenLabelIs { .. } => ("ChosenLabelIs", Handled),
         StaticCondition::HasCounters { .. } => ("HasCounters", Handled),
+        StaticCondition::CastVariantPaid { .. } => ("CastVariantPaid", Handled),
         StaticCondition::RecipientHasCounters { .. } => ("RecipientHasCounters", Handled),
         StaticCondition::RecipientMatchesFilter { .. } => ("RecipientMatchesFilter", Handled),
         StaticCondition::ClassLevelGE { .. } => ("ClassLevelGE", Handled),

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1656,6 +1656,17 @@ fn apply_action(
                         &mut events,
                     )?
                 }
+                AlternativeCastKeyword::Impending => {
+                    casting::handle_impending_cost_choice_with_payment_mode(
+                        state,
+                        *player,
+                        *object_id,
+                        *card_id,
+                        choice,
+                        *payment_mode,
+                        &mut events,
+                    )?
+                }
             }
         }
         (

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1657,6 +1657,7 @@ fn apply_action(
                     )?
                 }
                 AlternativeCastKeyword::Impending => {
+                    // CR 702.176a: Handle the impending alternative cost choice during casting.
                     casting::handle_impending_cost_choice_with_payment_mode(
                         state,
                         *player,

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -574,6 +574,7 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         | StaticCondition::SpeedGE { .. }
         | StaticCondition::DayNightIs { .. }
         | StaticCondition::HasCounters { .. }
+        | StaticCondition::CastVariantPaid { .. }
         | StaticCondition::RecipientHasCounters { .. }
         | StaticCondition::ClassLevelGE { .. }
         | StaticCondition::SourceAttackingAlone
@@ -687,6 +688,7 @@ fn entered_object_perturbs_static_condition(
         | StaticCondition::SpeedGE { .. }
         | StaticCondition::DayNightIs { .. }
         | StaticCondition::HasCounters { .. }
+        | StaticCondition::CastVariantPaid { .. }
         | StaticCondition::RecipientHasCounters { .. }
         | StaticCondition::ClassLevelGE { .. }
         | StaticCondition::SourceAttackingAlone
@@ -840,6 +842,12 @@ fn evaluate_condition_with_context(
             .get(&source_id)
             .map(|obj| counter_condition_matches(obj, counters, *minimum, *maximum))
             .unwrap_or(false),
+        // CR 702.176a + CR 611.3a: Persistent alternative-cost marker on the
+        // source permanent. This is intentionally not turn-scoped.
+        StaticCondition::CastVariantPaid { variant } => state
+            .objects
+            .get(&source_id)
+            .is_some_and(|obj| obj.cast_variant_paid.is_some_and(|(v, _)| v == *variant)),
         StaticCondition::RecipientHasCounters {
             counters,
             minimum,
@@ -1273,11 +1281,6 @@ pub fn evaluate_layers(state: &mut GameState) {
 
         if *layer == Layer::Type {
             apply_intrinsic_basic_land_mana_abilities(state, &bf_ids);
-            // CR 702.176a (Layer 4): Strip Creature type from Impending permanents
-            // that still have time counters. Applied here so every Layer-4 effect
-            // (including AddType / SetType from other sources) is fully resolved
-            // before the strip runs — mirrors the Changeling post-fixup pattern.
-            apply_impending_not_creature(state, &bf_ids);
         }
         if matches!(*layer, Layer::Control | Layer::Type) {
             super::pairing::cleanup_invalid_pairs(state);
@@ -3641,35 +3644,6 @@ fn apply_continuous_effect_filtered(
     }
 }
 
-/// CR 702.176a (Layer 4 post-fixup): "As long as this permanent's impending cost
-/// was paid and it has a time counter on it, it's not a creature."
-///
-/// Runs after all Layer-4 continuous effects have been applied so that
-/// `AddType`/`SetType` grants from other sources are already present before we
-/// strip — the strip is the final word for this layer pass.
-fn apply_impending_not_creature(state: &mut GameState, battlefield_ids: &[ObjectId]) {
-    use crate::types::ability::CastVariantPaid;
-    use crate::types::card_type::CoreType;
-    use crate::types::counter::CounterType;
-    for &id in battlefield_ids {
-        let Some(obj) = state.objects.get_mut(&id) else {
-            continue;
-        };
-        let impending_paid = obj
-            .cast_variant_paid
-            .is_some_and(|(v, _)| v == CastVariantPaid::Impending);
-        if !impending_paid {
-            continue;
-        }
-        let has_time_counter = obj.counters.get(&CounterType::Time).copied().unwrap_or(0) > 0;
-        if has_time_counter {
-            obj.card_types
-                .core_types
-                .retain(|t| !matches!(t, CoreType::Creature));
-        }
-    }
-}
-
 /// CR 305.6: After layer 4 establishes final land types, derive each land's
 /// intrinsic basic-land mana abilities before layer 6 ability effects apply.
 fn apply_intrinsic_basic_land_mana_abilities(state: &mut GameState, battlefield_ids: &[ObjectId]) {
@@ -3838,13 +3812,14 @@ mod tests {
     use crate::game::scenario::GameScenario;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, BasicLandType, ChosenSubtypeKind, CommanderOwnership,
-        Comparator, ContinuousModification, ControllerRef, CountScope, Duration, Effect,
-        FilterProp, ObjectScope, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef,
-        StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TypeFilter, TypedFilter,
-        ZoneRef,
+        AbilityDefinition, AbilityKind, BasicLandType, CastVariantPaid, ChosenSubtypeKind,
+        CommanderOwnership, Comparator, ContinuousModification, ControllerRef, CountScope,
+        Duration, Effect, FilterProp, ObjectScope, PlayerScope, PtStat, PtValueScope, QuantityExpr,
+        QuantityRef, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TypeFilter,
+        TypedFilter, ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
+    use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::game_state::{StaticSourceIndex, TransientContinuousEffect};
     use crate::types::identifiers::CardId;
     use crate::types::keywords::Keyword;
@@ -5827,6 +5802,60 @@ mod tests {
         assert_eq!(obj.trigger_definitions.len(), 1);
         assert_eq!(obj.replacement_definitions.len(), 1);
         assert_eq!(obj.static_definitions.len(), 1);
+    }
+
+    #[test]
+    fn impending_not_creature_participates_in_layer_timestamp_ordering() {
+        let mut state = setup();
+        let impending = make_creature(&mut state, "Impending Permanent", 3, 3, PlayerId(0));
+        {
+            let obj = state.objects.get_mut(&impending).unwrap();
+            obj.timestamp = 5;
+            obj.cast_variant_paid = Some((CastVariantPaid::Impending, 1));
+            obj.counters.insert(CounterType::Time, 1);
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SelfRef)
+                    .condition(StaticCondition::And {
+                        conditions: vec![
+                            StaticCondition::CastVariantPaid {
+                                variant: CastVariantPaid::Impending,
+                            },
+                            StaticCondition::HasCounters {
+                                counters: CounterMatch::OfType(CounterType::Time),
+                                minimum: 1,
+                                maximum: None,
+                            },
+                        ],
+                    })
+                    .modifications(vec![ContinuousModification::RemoveType {
+                        core_type: CoreType::Creature,
+                    }]),
+            );
+        }
+
+        let animator = make_creature(&mut state, "Later Animator", 1, 1, PlayerId(0));
+        {
+            let obj = state.objects.get_mut(&animator).unwrap();
+            obj.timestamp = 10;
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SpecificObject { id: impending })
+                    .modifications(vec![ContinuousModification::AddType {
+                        core_type: CoreType::Creature,
+                    }]),
+            );
+        }
+
+        evaluate_layers(&mut state);
+
+        assert!(
+            state.objects[&impending]
+                .card_types
+                .core_types
+                .contains(&CoreType::Creature),
+            "CR 613.1d + CR 613.7: a later Layer 4 AddType must apply after Impending's RemoveType"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1273,6 +1273,11 @@ pub fn evaluate_layers(state: &mut GameState) {
 
         if *layer == Layer::Type {
             apply_intrinsic_basic_land_mana_abilities(state, &bf_ids);
+            // CR 702.176a (Layer 4): Strip Creature type from Impending permanents
+            // that still have time counters. Applied here so every Layer-4 effect
+            // (including AddType / SetType from other sources) is fully resolved
+            // before the strip runs — mirrors the Changeling post-fixup pattern.
+            apply_impending_not_creature(state, &bf_ids);
         }
         if matches!(*layer, Layer::Control | Layer::Type) {
             super::pairing::cleanup_invalid_pairs(state);
@@ -3632,6 +3637,35 @@ fn apply_continuous_effect_filtered(
                     }
                 }
             }
+        }
+    }
+}
+
+/// CR 702.176a (Layer 4 post-fixup): "As long as this permanent's impending cost
+/// was paid and it has a time counter on it, it's not a creature."
+///
+/// Runs after all Layer-4 continuous effects have been applied so that
+/// `AddType`/`SetType` grants from other sources are already present before we
+/// strip — the strip is the final word for this layer pass.
+fn apply_impending_not_creature(state: &mut GameState, battlefield_ids: &[ObjectId]) {
+    use crate::types::ability::CastVariantPaid;
+    use crate::types::card_type::CoreType;
+    use crate::types::counter::CounterType;
+    for &id in battlefield_ids {
+        let Some(obj) = state.objects.get_mut(&id) else {
+            continue;
+        };
+        let impending_paid = obj
+            .cast_variant_paid
+            .is_some_and(|(v, _)| v == CastVariantPaid::Impending);
+        if !impending_paid {
+            continue;
+        }
+        let has_time_counter = obj.counters.get(&CounterType::Time).copied().unwrap_or(0) > 0;
+        if has_time_counter {
+            obj.card_types
+                .core_types
+                .retain(|t| !matches!(t, CoreType::Creature));
         }
     }
 }

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1329,6 +1329,9 @@ impl GameRunner {
                 crate::types::game_state::AlternativeCastKeyword::MoreThanMeetsTheEye => {
                     "AlternativeCastChoice(MoreThanMeetsTheEye)"
                 }
+                crate::types::game_state::AlternativeCastKeyword::Impending => {
+                    "AlternativeCastChoice(Impending)"
+                }
             },
             WaitingFor::CastingVariantChoice { .. } => "CastingVariantChoice",
             WaitingFor::ChoosePermanentTypeSlot { .. } => "ChoosePermanentTypeSlot",

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -477,6 +477,34 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 }
             }
 
+            // CR 702.176a: Impending — seed the N time counters into the ZoneChange
+            // ProposedEvent BEFORE the replacement pipeline so Doubling Season and
+            // similar counter-doubling replacements (CR 614.1a) can modify them.
+            // N is read from the `Keyword::Impending { counters, .. }` on the still-
+            // stack-resident object; `cast_variant_paid = Impending` is already stamped
+            // by `finalize_cast_to_stack` in `casting_costs.rs`.
+            if casting_variant == CastingVariant::Impending {
+                let impending_counters = state.objects.get(&entry.id).and_then(|obj| {
+                    obj.keywords.iter().find_map(|k| match k {
+                        crate::types::keywords::Keyword::Impending { counters, .. } => {
+                            Some(*counters)
+                        }
+                        _ => None,
+                    })
+                });
+                if let Some(n) = impending_counters {
+                    if n > 0 {
+                        if let crate::types::proposed_event::ProposedEvent::ZoneChange {
+                            enter_with_counters,
+                            ..
+                        } = &mut proposed
+                        {
+                            enter_with_counters.push((CounterType::Time, n));
+                        }
+                    }
+                }
+            }
+
             // CR 702.188a: Web-slinging is a casting alternative cost. Tag the
             // permanent BEFORE the ETB replacement pipeline runs so a
             // `ReplacementCondition::CastVariantPaid` gate (Scarlet Spider's
@@ -929,6 +957,19 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 if let Some(obj) = state.objects.get_mut(&entry.id) {
                     obj.cast_variant_paid = Some((
                         crate::types::ability::CastVariantPaid::Escape,
+                        state.turn_number,
+                    ));
+                }
+            }
+
+            // CR 702.176a: Impending-cast permanent gets the `cast_variant_paid`
+            // tag re-applied after `reset_for_battlefield_entry` cleared it.
+            // The "not a creature" layer fixup and the end-step counter-removal
+            // trigger both gate on this marker being present.
+            if casting_variant == CastingVariant::Impending {
+                if let Some(obj) = state.objects.get_mut(&entry.id) {
+                    obj.cast_variant_paid = Some((
+                        crate::types::ability::CastVariantPaid::Impending,
                         state.turn_number,
                     ));
                 }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3838,6 +3838,11 @@ pub(crate) fn check_trigger_condition(
             .and_then(|id| state.objects.get(&id))
             .map(|obj| obj.cast_variant_paid == Some((*variant, state.turn_number)))
             .unwrap_or(false),
+        // CR 702.176a + CR 603.4: Impending's end-step trigger checks that the
+        // impending cost was paid, not that it was paid this turn.
+        TriggerCondition::CastVariantPaidPersistent { variant } => source_id
+            .and_then(|id| state.objects.get(&id))
+            .is_some_and(|obj| obj.cast_variant_paid.is_some_and(|(v, _)| v == *variant)),
         // CR 605.1a: "that isn't a mana ability" gate on activated-ability
         // trigger events. `KeywordAbilityActivated` carries the explicit flag
         // (Exhaust mana abilities still emit this event). `AbilityActivated`

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2137,6 +2137,10 @@ pub(crate) fn static_condition_to_ability_condition(
             Some(counter_threshold_to_condition(qty, *minimum, *maximum))
         }
         StaticCondition::DevotionGE { .. }
+        // CR 702.176a + CR 611.3a: Persistent alternative-cost markers are
+        // source-bound static predicates with no effect-resolution
+        // `AbilityCondition` equivalent.
+        | StaticCondition::CastVariantPaid { .. }
         | StaticCondition::ChosenColorIs { .. }
         // CR 614.12c + CR 607.2d: Anchor-word linked statics are evaluated
         // by `layers::evaluate_condition_with_context`; no effect-resolution

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1148,7 +1148,7 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::Plot(_) => "plot".to_string(),
         Keyword::Craft(_) => "craft".to_string(),
         Keyword::Offspring(_) => "offspring".to_string(),
-        Keyword::Impending(_) => "impending".to_string(),
+        Keyword::Impending { counters, .. } => format!("impending {counters}"),
         Keyword::LevelUp(_) => "level up".to_string(),
         Keyword::Hideaway(_) => "hideaway".to_string(),
         Keyword::Casualty(n) => format!("casualty {n}"),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2294,6 +2294,14 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
             })
         }
 
+        // CR 702.176a + CR 603.4: Impending's battlefield trigger checks the
+        // persistent alternative-cost marker, not whether it was paid this turn.
+        StaticCondition::CastVariantPaid { variant } => {
+            Some(TriggerCondition::CastVariantPaidPersistent {
+                variant: *variant,
+            })
+        }
+
         // CR 716.2a: Class level condition.
         StaticCondition::ClassLevelGE { level } => {
             Some(TriggerCondition::ClassLevelGE { level: *level })
@@ -2353,6 +2361,11 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
                     }),
                 })
             }
+            StaticCondition::CastVariantPaid { variant } => Some(TriggerCondition::Not {
+                condition: Box::new(TriggerCondition::CastVariantPaidPersistent {
+                    variant: *variant,
+                }),
+            }),
             _ => None,
         },
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3910,6 +3910,13 @@ pub enum StaticCondition {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         maximum: Option<u32>,
     },
+    /// CR 702.176a + CR 611.3a: True while the source permanent carries the
+    /// persistent marker that its named alternative cost was paid. This is not
+    /// turn-scoped; Impending's "not a creature" static must continue across
+    /// turns until its last time counter is removed.
+    CastVariantPaid {
+        variant: CastVariantPaid,
+    },
     /// CR 122.1 + CR 613.4c: True when the object currently receiving an
     /// attached-object static has at least `minimum` (and at most `maximum`, if
     /// specified) counters matching `counters`. Used for Aura/Equipment
@@ -9896,6 +9903,11 @@ pub enum TriggerCondition {
     /// specified cast/activation variant this turn. Negation ("unless it escaped")
     /// is expressed via `Not { Box::new(CastVariantPaid { variant }) }`.
     CastVariantPaid { variant: CastVariantPaid },
+    /// CR 702.176a + CR 603.4: True while the source permanent carries the
+    /// persistent marker that its named alternative cost was paid. Used for
+    /// recurring battlefield triggers such as Impending's end-step time-counter
+    /// removal, which must continue across turns.
+    CastVariantPaidPersistent { variant: CastVariantPaid },
 
     /// CR 605.1a + CR 603.4: Event qualifier for "that isn't a mana ability"
     /// on activated-ability trigger events.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4422,6 +4422,11 @@ pub enum CastVariantPaid {
     /// "if its bestow cost was paid" and by display layers that need to
     /// distinguish a bestow-cast permanent from a hard-cast creature.
     Bestow,
+    /// CR 702.176a: The spell was cast for its impending alternative cost.
+    /// The permanent entered with N time counters and is not a creature
+    /// while any remain. Read by the end-step counter-removal trigger and
+    /// the "not a creature" layer fixup.
+    Impending,
 }
 
 /// CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1647,6 +1647,10 @@ pub enum AlternativeCastKeyword {
     Cleave,
     /// CR 702.162a: Cast converted (back face up, CR 712.14a) for the MTMTE cost.
     MoreThanMeetsTheEye,
+    /// CR 702.176a: Impending alternative cost paid from hand. On resolution the
+    /// permanent enters with N time counters and isn't a creature until the last
+    /// is removed. An end-step trigger removes one counter per turn.
+    Impending,
 }
 
 /// CR 601.2b: Engine-authored cast-variant option for spells with more than
@@ -3696,6 +3700,12 @@ pub enum CastingVariant {
     /// permanent enters the battlefield transformed (back face up) via the
     /// existing `enter_transformed` ZoneChange seed. CR 701.28 (Convert).
     MoreThanMeetsTheEye,
+    /// CR 702.176a: Cast from hand via Impending's alternative cost. The printed
+    /// mana cost is replaced by `Keyword::Impending { cost, .. }` at cast
+    /// preparation (mirrors Overload/Evoke). On resolution the permanent enters
+    /// with N time counters (from the keyword) and is not a creature while any
+    /// remain. At the beginning of your end step one time counter is removed.
+    Impending,
 }
 
 impl CastingVariant {

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -598,10 +598,13 @@ pub enum Keyword {
     Plot(ManaCost),
     Craft(ManaCost),
     Offspring(ManaCost),
-    /// RUNTIME: TODO — converter accepts this keyword but engine has no
-    /// behavioral handler. CR 702.176a: Impending N—{cost} — alt-cast that
-    /// enters with N time counters and is not a creature until they're gone.
-    Impending(ManaCost),
+    /// CR 702.176a: Impending N—{cost} — alternative cast that enters with
+    /// `counters` time counters and is not a creature until the last is removed.
+    /// At the beginning of your end step the permanent loses one time counter.
+    Impending {
+        cost: ManaCost,
+        counters: u32,
+    },
     /// CR 702.87a: Level up is an activated ability that puts a level counter
     /// on this permanent. Activate only as a sorcery.
     LevelUp(ManaCost),
@@ -1055,7 +1058,7 @@ impl Keyword {
             | Keyword::Gravestorm
             | Keyword::Haunt
             | Keyword::Hideaway(_)
-            | Keyword::Impending(_)
+            | Keyword::Impending { .. }
             | Keyword::Improvise
             | Keyword::Ingest
             | Keyword::LevelUp(_)
@@ -1452,6 +1455,18 @@ impl FromStr for Keyword {
                         return Ok(Keyword::Affinity(tf));
                     }
                 }
+                // CR 702.176a: "Impending N—{cost}" — space-separated form from Oracle
+                // text and MTGJSON keyword arrays (no colon). Extract N before the em-dash.
+                if kw == "impending" {
+                    let (counters, cost_str) = rest
+                        .split_once('\u{2014}')
+                        .map(|(n, c)| (n.trim().parse().unwrap_or(0), c.trim()))
+                        .unwrap_or((0, rest));
+                    return Ok(Keyword::Impending {
+                        cost: parse_keyword_mana_cost(cost_str),
+                        counters,
+                    });
+                }
             }
         }
 
@@ -1596,7 +1611,18 @@ impl FromStr for Keyword {
                 "plot" => return Ok(Keyword::Plot(parse_keyword_mana_cost(p))),
                 "craft" => return Ok(Keyword::Craft(parse_keyword_mana_cost(p))),
                 "offspring" => return Ok(Keyword::Offspring(parse_keyword_mana_cost(p))),
-                "impending" => return Ok(Keyword::Impending(parse_keyword_mana_cost(p))),
+                "impending" => {
+                    // CR 702.176a: "Impending N—{cost}" — extract N before the em-dash,
+                    // then parse the mana cost from the remainder.
+                    let (counters, cost_str) = p
+                        .split_once('\u{2014}')
+                        .map(|(n, c)| (n.trim().parse().unwrap_or(0), c.trim()))
+                        .unwrap_or((0, p));
+                    return Ok(Keyword::Impending {
+                        cost: parse_keyword_mana_cost(cost_str),
+                        counters,
+                    });
+                }
                 "levelup" | "level up" => return Ok(Keyword::LevelUp(parse_keyword_mana_cost(p))),
                 "warp" => return Ok(Keyword::Warp(parse_keyword_mana_cost(p))),
                 "sneak" => return Ok(Keyword::Sneak(parse_keyword_mana_cost(p))),
@@ -2256,7 +2282,22 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Plot" => Ok(Keyword::Plot(mana(data)?)),
         "Craft" => Ok(Keyword::Craft(mana(data)?)),
         "Offspring" => Ok(Keyword::Offspring(mana(data)?)),
-        "Impending" => Ok(Keyword::Impending(mana(data)?)),
+        "Impending" => {
+            // New format: {"Impending": {"cost": {...}, "counters": N}}
+            // Legacy format: {"Impending": {mana_cost}} — treat as counters=0 fallback.
+            if let Some(cost_val) = data.get("cost") {
+                let counters = data.get("counters").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+                Ok(Keyword::Impending {
+                    cost: mana(cost_val)?,
+                    counters,
+                })
+            } else {
+                Ok(Keyword::Impending {
+                    cost: mana(data)?,
+                    counters: 0,
+                })
+            }
+        }
         "LevelUp" => Ok(Keyword::LevelUp(mana(data)?)),
         // Parameterized: u32
         "Dredge" => Ok(Keyword::Dredge(uint(data))),
@@ -2904,6 +2945,27 @@ mod tests {
         // CR 702.157: Squad
         let squad = Keyword::from_str("Squad:{2}").unwrap();
         assert!(matches!(squad, Keyword::Squad(ManaCost::Cost { .. })));
+    }
+
+    #[test]
+    /// CR 702.176a: Impending N—{cost} parses N (counter count) and mana cost.
+    fn parse_impending_from_str() {
+        // Oracle keyword line: "Impending 5—{1}{B}"
+        let kw = Keyword::from_str("Impending 5\u{2014}{1}{B}").unwrap();
+        match kw {
+            Keyword::Impending { counters, cost } => {
+                assert_eq!(counters, 5);
+                assert!(matches!(cost, ManaCost::Cost { .. }));
+            }
+            other => panic!("expected Impending, got {other:?}"),
+        }
+
+        // "Impending 3—{2}{U}{U}"
+        let kw2 = Keyword::from_str("Impending 3\u{2014}{2}{U}{U}").unwrap();
+        match kw2 {
+            Keyword::Impending { counters, .. } => assert_eq!(counters, 3),
+            other => panic!("expected Impending, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/mtgish-import/src/convert/keyword.rs
+++ b/crates/mtgish-import/src/convert/keyword.rs
@@ -342,7 +342,7 @@ pub fn try_convert(rule: &Rule, path: &str) -> ConvResult<Option<Keyword>> {
         // a time counter on it, remove a time counter from it."
         Rule::Impending(n, c) => Keyword::Impending {
             cost: pure_mana(c, "Rule::Impending", path)?,
-            counters: *n as u32,
+            counters: int_or_gap(n, "Rule::Impending.counters", path)?,
         },
 
         // CR 702.173a: Freerunning {cost} — alternative cost. Mana-only.

--- a/crates/mtgish-import/src/convert/keyword.rs
+++ b/crates/mtgish-import/src/convert/keyword.rs
@@ -342,7 +342,7 @@ pub fn try_convert(rule: &Rule, path: &str) -> ConvResult<Option<Keyword>> {
         // a time counter on it, remove a time counter from it."
         Rule::Impending(n, c) => Keyword::Impending {
             cost: pure_mana(c, "Rule::Impending", path)?,
-            counters: *n as u32,
+            counters: int_or_gap(n, "Rule::Impending.count", path)?,
         },
 
         // CR 702.173a: Freerunning {cost} — alternative cost. Mana-only.

--- a/crates/mtgish-import/src/convert/keyword.rs
+++ b/crates/mtgish-import/src/convert/keyword.rs
@@ -339,11 +339,11 @@ pub fn try_convert(rule: &Rule, path: &str) -> ConvResult<Option<Keyword>> {
         // permanent's impending cost was paid and it has a time counter
         // on it, it's not a creature" + "At the beginning of your end
         // step, if this permanent's impending cost was paid and it has
-        // a time counter on it, remove a time counter from it." Engine
-        // stores only the mana cost; the N (time-counter count) is
-        // dropped — the engine derives it from a separate metadata
-        // pipeline.
-        Rule::Impending(_n, c) => Keyword::Impending(pure_mana(c, "Rule::Impending", path)?),
+        // a time counter on it, remove a time counter from it."
+        Rule::Impending(n, c) => Keyword::Impending {
+            cost: pure_mana(c, "Rule::Impending", path)?,
+            counters: *n as u32,
+        },
 
         // CR 702.173a: Freerunning {cost} — alternative cost. Mana-only.
         Rule::Freerunning(c) => Keyword::Freerunning(pure_mana(c, "Rule::Freerunning", path)?),


### PR DESCRIPTION
## Summary

Implements the **Impending** keyword (CR 702.176a, *Duskmourn: House of Horror*) across the full engine stack.

- Offers the impending alternative cost at cast time (presents a choice when both costs are affordable, auto-routes when only the impending cost is payable)
- Seeds N time counters into the ETB replacement pipeline so Doubling Season and similar effects see them
- Strips `CoreType::Creature` in Layer 4 while the permanent has time counters and was cast for its impending cost
- Synthesizes a mandatory end-step trigger that removes one time counter per turn (gated on `CastVariantPaid::Impending` + `HasCounters{Time, ≥1}`)
- Re-applies `cast_variant_paid` after `reset_for_battlefield_entry` so the battlefield marker survives the zone change

Closes #1903
## Cards unlocked

All 6 Duskmourn Overlords with Impending:

| Card | Impending cost |
|---|---|
| Lurker in the Deep | Impending 3—{2}{U}{U} |
| Overlord of the Balemurk | Impending 5—{1}{B} |
| Overlord of the Boilerbilges | Impending 4—{2}{R}{R} |
| Overlord of the Floodpits | Impending 4—{1}{U}{U} |
| Overlord of the Hauntwoods | Impending 4—{1}{G}{G} |
| Overlord of the Mistmoors | Impending 4—{2}{W}{W} |

## Files changed

| File | Change |
|---|---|
| `types/keywords.rs` | `Keyword::Impending(ManaCost)` → `{ cost, counters: u32 }`; `from_str` parses "Impending N—{cost}" (space form); `keyword_from_tagged` handles both old and new JSON shapes |
| `types/game_state.rs` | `CastingVariant::Impending`, `AlternativeCastKeyword::Impending` |
| `types/ability.rs` | `CastVariantPaid::Impending` |
| `game/casting.rs` | Alt-cost offer block; `handle_impending_cost_choice[_with_payment_mode]`; mana cost substitution |
| `game/casting_costs.rs` | Tag `cast_variant_paid = Impending` at finalize time (stack phase) |
| `game/stack.rs` | Seed N time counters into ETB pipeline; re-apply `cast_variant_paid` post-zone-change |
| `game/layers.rs` | `apply_impending_not_creature`: post-Type-layer fixup stripping Creature while time counters remain |
| `database/synthesis.rs` | `synthesize_impending`: end-step counter-removal trigger; registered in `synthesize_all` |
| `parser/oracle_keyword.rs` | Display updated to `"impending {N}"` |
| `mtgish-import/convert/keyword.rs` | Threads `n` (counter count) into struct variant |

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check --workspace` clean
- [x] `cargo clippy -p engine` clean (0 warnings)
- [x] New unit test `parse_impending_from_str` verifies N and cost parse correctly from Oracle keyword line format
- [x] Full keyword + synthesis + casting test suites pass (798 + 44 tests, 0 failures)
- [ ] Manual: cast an Overlord for its impending cost, verify it enters with N time counters and is not a creature, verify one counter removed each end step, verify it becomes a creature when the last counter is removed
