### PR TITLE
feat(engine): standalone "can't be regenerated this turn" effect (CR 701.19c)

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -769,17 +769,14 @@ fn destroy_applier(
     //      (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort).
     // In both cases the shield is left unconsumed (CR 701.19c: shields are not
     // applied, not destroyed) and destruction proceeds.
-    let target_cant_regenerate = matches!(
-        &event,
+    let target_cant_regenerate = match &event {
         ProposedEvent::Destroy {
-            cant_regenerate: true,
+            object_id,
+            cant_regenerate,
             ..
-        }
-    ) || matches!(
-        &event,
-        ProposedEvent::Destroy { object_id, .. }
-            if object_has_active_cant_be_regenerated(state, *object_id)
-    );
+        } => *cant_regenerate || object_has_active_cant_be_regenerated(state, *object_id),
+        _ => false,
+    };
     if target_cant_regenerate {
         return ApplyResult::Modified(event);
     }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -716,6 +716,24 @@ fn destroy_matcher(event: &ProposedEvent, _source: ObjectId, _state: &GameState)
     matches!(event, ProposedEvent::Destroy { .. })
 }
 
+/// CR 701.19c: Returns true if `object_id` is currently marked with an active
+/// `StaticMode::CantBeRegenerated` static. The standalone "[creature] can't be
+/// regenerated this turn" effect (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort)
+/// grants this mode onto the affected creature's `static_definitions` via a
+/// transient until-end-of-turn continuous effect (CR 514.2 auto-expiry at
+/// cleanup), so the mark is observed directly on the object through the
+/// CR-gated `active_static_definitions` iterator.
+fn object_has_active_cant_be_regenerated(state: &GameState, object_id: ObjectId) -> bool {
+    state.objects.get(&object_id).is_some_and(|obj| {
+        super::functioning_abilities::active_static_definitions(state, obj).any(|def| {
+            matches!(
+                def.mode,
+                crate::types::statics::StaticMode::CantBeRegenerated
+            )
+        })
+    })
+}
+
 /// CR 701.19: Regeneration shield applier for Destroy events.
 /// If the replacement definition is a regeneration shield and the destruction allows
 /// regeneration, removes damage, taps the permanent, removes it from combat,
@@ -742,12 +760,27 @@ fn destroy_applier(
         return ApplyResult::Modified(event);
     }
 
-    // CR 701.19: "It can't be regenerated" bypasses regeneration shields.
-    if let ProposedEvent::Destroy {
-        cant_regenerate: true,
-        ..
-    } = &event
-    {
+    // CR 701.19c: Regeneration shields are not applied when the destruction
+    // forbids regeneration. Two sources of this prohibition:
+    //   1. The inline "Destroy X. It can't be regenerated." one-shot rides on the
+    //      event's `cant_regenerate: true` flag (Effect::Destroy { cant_regenerate }).
+    //   2. The standalone "[creature] can't be regenerated this turn" effect marks
+    //      the destroy target with an active `StaticMode::CantBeRegenerated` static
+    //      (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort).
+    // In both cases the shield is left unconsumed (CR 701.19c: shields are not
+    // applied, not destroyed) and destruction proceeds.
+    let target_cant_regenerate = matches!(
+        &event,
+        ProposedEvent::Destroy {
+            cant_regenerate: true,
+            ..
+        }
+    ) || matches!(
+        &event,
+        ProposedEvent::Destroy { object_id, .. }
+            if object_has_active_cant_be_regenerated(state, *object_id)
+    );
+    if target_cant_regenerate {
         return ApplyResult::Modified(event);
     }
 
@@ -7158,6 +7191,69 @@ mod tests {
         // Shield not consumed
         let obj = state.objects.get(&bear_id).unwrap();
         assert!(!obj.replacement_definitions[0].is_consumed);
+    }
+
+    /// CR 701.19c: A creature marked with `StaticMode::CantBeRegenerated`
+    /// (granted by the standalone "[creature] can't be regenerated this turn"
+    /// effect — Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort) has its
+    /// regeneration shield bypassed at destroy time, even though the Destroy
+    /// event itself carries `cant_regenerate: false`. Mirrors
+    /// `cant_regenerate_bypasses_shield` but exercises the static-driven path.
+    #[test]
+    fn cant_be_regenerated_static_bypasses_shield() {
+        let mut state = GameState::new_two_player(42);
+        let bear_id = create_creature_with_regen_shield(&mut state, PlayerId(0), "Bear");
+
+        // Grant the regeneration prohibition onto the creature, mirroring the
+        // transient until-end-of-turn continuous effect's `AddStaticMode`
+        // propagation onto the affected creature's `static_definitions`.
+        state
+            .objects
+            .get_mut(&bear_id)
+            .unwrap()
+            .static_definitions
+            .push(
+                crate::types::ability::StaticDefinition::new(
+                    crate::types::statics::StaticMode::CantBeRegenerated,
+                )
+                .affected(TargetFilter::SelfRef),
+            );
+
+        // Helper observes the active mark.
+        assert!(object_has_active_cant_be_regenerated(&state, bear_id));
+
+        let proposed = ProposedEvent::Destroy {
+            object_id: bear_id,
+            source: Some(ObjectId(100)),
+            // Note: the inline flag is false — the bypass is driven purely by the
+            // static mark, not by the destroy event.
+            cant_regenerate: false,
+            applied: HashSet::new(),
+        };
+        let mut events = Vec::new();
+        let result = replace_event(&mut state, proposed, &mut events);
+
+        // Destruction proceeds; the shield does NOT save the creature.
+        assert!(
+            matches!(
+                result,
+                ReplacementResult::Execute(ProposedEvent::Destroy { .. })
+            ),
+            "CantBeRegenerated static should bypass the shield, got {:?}",
+            result
+        );
+        // CR 701.19c: shields are not applied, not consumed.
+        let obj = state.objects.get(&bear_id).unwrap();
+        assert!(!obj.replacement_definitions[0].is_consumed);
+    }
+
+    /// Negative control for `object_has_active_cant_be_regenerated`: a creature
+    /// with no regeneration prohibition is not reported as marked.
+    #[test]
+    fn object_without_cant_be_regenerated_is_not_marked() {
+        let mut state = GameState::new_two_player(42);
+        let bear_id = create_creature_with_regen_shield(&mut state, PlayerId(0), "Bear");
+        assert!(!object_has_active_cant_be_regenerated(&state, bear_id));
     }
 
     #[test]

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -116,6 +116,12 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     // Runtime enforcement is in effects/copy_spell.rs via active_static_definitions.
     registry.insert(StaticMode::CantBeCopied, handle_cant_be_copied);
     registry.insert(StaticMode::CantBeDestroyed, handle_cant_be_destroyed);
+    // CR 701.19c: CantBeRegenerated — a marked permanent's regeneration shields
+    // are not applied the next time it would be destroyed. Passive rule
+    // modification; runtime enforcement is in replacement.rs::destroy_applier via
+    // object_has_active_cant_be_regenerated(). Registered as a rule-mod so coverage
+    // marks the standalone "can't be regenerated" effect as supported.
+    registry.insert(StaticMode::CantBeRegenerated, handle_rule_mod);
     // CR 702.34: FlashBack — allows casting from graveyard, exiled after resolution.
     registry.insert(StaticMode::FlashBack, handle_flashback);
     // CR 702.18: Shroud — permanent cannot be the target of spells or abilities.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -26641,6 +26641,91 @@ mod tests {
         );
     }
 
+    /// CR 701.19c: Standalone "target creature can't be regenerated this turn"
+    /// (Hurr Jackal, Furnace Brood) emits a GenericEffect granting
+    /// `StaticMode::CantBeRegenerated` to the chosen creature. The selection rides
+    /// on the outer `target` slot; the per-static `affected` is the runtime-bound
+    /// `ParentTarget` (per `static_affected_for_application`), and the mode is
+    /// propagated onto the granted creature via `AddStaticMode`.
+    #[test]
+    fn cant_be_regenerated_effect_standalone_targets_creature() {
+        use crate::types::statics::StaticMode;
+        let def = parse_effect_chain(
+            "target creature can't be regenerated this turn",
+            AbilityKind::Activated,
+        );
+        let Effect::GenericEffect {
+            static_abilities,
+            target,
+            duration,
+        } = &*def.effect
+        else {
+            panic!("expected GenericEffect, got {:?}", def.effect);
+        };
+        assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+        assert_eq!(static_abilities.len(), 1);
+        let sd = &static_abilities[0];
+        assert!(
+            matches!(&sd.mode, StaticMode::CantBeRegenerated),
+            "expected CantBeRegenerated, got {:?}",
+            sd.mode
+        );
+        assert!(
+            sd.modifications
+                .contains(&ContinuousModification::AddStaticMode {
+                    mode: StaticMode::CantBeRegenerated
+                }),
+            "expected AddStaticMode modification, got {:?}",
+            sd.modifications
+        );
+        assert_eq!(
+            sd.affected,
+            Some(TargetFilter::ParentTarget),
+            "affected must be the runtime-bound ParentTarget"
+        );
+        let outer = target.as_ref().expect("outer target slot must be set");
+        assert!(
+            matches!(
+                outer,
+                TargetFilter::Typed(tf)
+                    if tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Creature))
+            ),
+            "outer target must be the creature selection filter, got {outer:?}"
+        );
+    }
+
+    /// CR 701.19c + CR 608.2c: Lim-Dûl's Cohort prints "Destroy target creature.
+    /// That creature can't be regenerated this turn." The "that creature" anaphor
+    /// binds the regeneration prohibition to the same destroyed creature
+    /// (`ParentTarget`) rather than introducing a fresh target.
+    #[test]
+    fn cant_be_regenerated_anaphor_binds_to_parent_target() {
+        use crate::types::statics::StaticMode;
+        let def = parse_effect_chain(
+            "that creature can't be regenerated this turn",
+            AbilityKind::Activated,
+        );
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = &*def.effect
+        else {
+            panic!("expected GenericEffect, got {:?}", def.effect);
+        };
+        let sd = static_abilities
+            .first()
+            .expect("expected CantBeRegenerated static");
+        assert!(
+            matches!(&sd.mode, StaticMode::CantBeRegenerated),
+            "expected CantBeRegenerated, got {:?}",
+            sd.mode
+        );
+        assert_eq!(
+            sd.affected,
+            Some(TargetFilter::ParentTarget),
+            "the 'that creature' anaphor must resolve to ParentTarget"
+        );
+    }
+
     #[test]
     fn pump_compound_with_extra_blockers() {
         // Give No Ground: the trailing blocking permission is a second

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -407,6 +407,41 @@ fn try_parse_subject_restriction_clause(
         });
     }
 
+    // CR 701.19c: "[subject] can't be regenerated [this turn]" — the standalone,
+    // until-end-of-turn form (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort).
+    // Marks the subject so regeneration shields are not applied the next time it
+    // would be destroyed. Splits the same way as the `must be blocked` /
+    // `activated abilities can't be activated` arms: `before` is the subject
+    // ("target creature", "that creature", "it", "~"). Bare pronoun/anaphor
+    // subjects bind to `ParentTarget` via `subject_application_for_cant_be_activated`
+    // (Lim-Dûl's Cohort: "Destroy target creature ... That creature can't be
+    // regenerated this turn." → "that creature" → ParentTarget), while
+    // "target creature" routes through the full subject grammar. The trailing
+    // " this turn" is absorbed by `split_around` (everything after the match is
+    // discarded); the duration is encoded directly as `UntilEndOfTurn`.
+    if let Some((before, _)) = tp.split_around(" can't be regenerated") {
+        let subject = before.original.trim();
+        let application = subject_application_for_cant_be_activated(subject, ctx)?;
+        let affected = static_affected_for_application(&application);
+        let mode = StaticMode::CantBeRegenerated;
+        return Some(ParsedEffectClause {
+            effect: Effect::GenericEffect {
+                static_abilities: vec![StaticDefinition::new(mode.clone())
+                    .affected(affected)
+                    .modifications(vec![ContinuousModification::AddStaticMode { mode }])],
+                duration: Some(Duration::UntilEndOfTurn),
+                target: application.target,
+            },
+            distribute: None,
+            multi_target: None,
+            duration: Some(Duration::UntilEndOfTurn),
+            sub_ability: None,
+            condition: None,
+            optional: false,
+            unless_pay: None,
+        });
+    }
+
     // CR 119.7 + CR 119.8: "[possessor] life total can't change" — bidirectional
     // life-lock for the named player (Teferi's Protection: "your life total can't
     // change"). Distinct from the generic " can't " split below because the
@@ -2422,6 +2457,11 @@ pub(crate) fn static_mode_needs_grant_propagation(mode: &StaticMode) -> bool {
             | StaticMode::CantLoseLife
             | StaticMode::CantLoseTheGame
             | StaticMode::CantWinTheGame
+            // CR 701.19c: CantBeRegenerated is granted to a target/anaphor creature
+            // and must propagate onto its `static_definitions` so the regen-shield
+            // bypass in replacement.rs::destroy_applier observes it via
+            // active_static_definitions.
+            | StaticMode::CantBeRegenerated
     )
 }
 
@@ -2456,6 +2496,13 @@ pub(crate) fn parse_restriction_modes(lower: &str) -> Option<Vec<StaticMode>> {
     // CR 701.27: "~ can't transform" — prohibition on transform (e.g., Immerwolf).
     if lower == "can't transform" || lower == "cannot transform" {
         return Some(vec![StaticMode::Other("CantTransform".to_string())]);
+    }
+    // CR 701.19c: "~ can't be regenerated" — marks the subject so regeneration
+    // shields are not applied. Backstop for the "cannot" phrasing and any caller
+    // that routes through the generic " can't " / " cannot " split before
+    // reaching the dedicated arm in `try_parse_subject_restriction_clause`.
+    if lower == "can't be regenerated" || lower == "cannot be regenerated" {
+        return Some(vec![StaticMode::CantBeRegenerated]);
     }
     // CR 101.2: Spell/ability restriction predicate; the subject path owns
     // the "spells you control" / "green spells you control" grammar.

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -416,11 +416,13 @@ fn try_parse_subject_restriction_clause(
     // subjects bind to `ParentTarget` via `subject_application_for_cant_be_activated`
     // (Lim-Dûl's Cohort: "Destroy target creature ... That creature can't be
     // regenerated this turn." → "that creature" → ParentTarget), while
-    // "target creature" routes through the full subject grammar. The trailing
-    // " this turn" is absorbed by `split_around` (everything after the match is
-    // discarded); the duration is encoded directly as `UntilEndOfTurn`.
-    if let Some((before, _)) = tp.split_around(" can't be regenerated") {
-        let subject = before.original.trim();
+    // "target creature" routes through the full subject grammar. The predicate
+    // itself is an anchored nom production that absorbs the optional "this turn"
+    // suffix; the duration is encoded directly as `UntilEndOfTurn`.
+    if let Some((before_lower, (), _)) =
+        nom_primitives::scan_preceded(&lower, parse_cant_be_regenerated_predicate)
+    {
+        let subject = text[..before_lower.len()].trim();
         let application = subject_application_for_cant_be_activated(subject, ctx)?;
         let affected = static_affected_for_application(&application);
         let mode = StaticMode::CantBeRegenerated;
@@ -2501,7 +2503,7 @@ pub(crate) fn parse_restriction_modes(lower: &str) -> Option<Vec<StaticMode>> {
     // shields are not applied. Backstop for the "cannot" phrasing and any caller
     // that routes through the generic " can't " / " cannot " split before
     // reaching the dedicated arm in `try_parse_subject_restriction_clause`.
-    if lower == "can't be regenerated" || lower == "cannot be regenerated" {
+    if parse_cant_be_regenerated_predicate(lower.trim()).is_ok() {
         return Some(vec![StaticMode::CantBeRegenerated]);
     }
     // CR 101.2: Spell/ability restriction predicate; the subject path owns
@@ -2685,6 +2687,22 @@ pub(crate) fn parse_restriction_modes(lower: &str) -> Option<Vec<StaticMode>> {
     }
 
     None
+}
+
+fn parse_cant_be_regenerated_predicate(input: &str) -> OracleResult<'_, ()> {
+    all_consuming(value(
+        (),
+        (
+            alt((
+                tag::<_, _, OracleError<'_>>("can't"),
+                tag::<_, _, OracleError<'_>>("cannot"),
+            )),
+            tag(" be regenerated"),
+            opt(tag(" this turn")),
+            opt(tag(".")),
+        ),
+    ))
+    .parse(input)
 }
 
 fn extract_pump_modifiers(
@@ -3816,6 +3834,21 @@ mod tests {
         assert_eq!(
             parse_restriction_modes("can't transform"),
             Some(vec![StaticMode::Other("CantTransform".to_string())])
+        );
+    }
+
+    #[test]
+    fn parse_restriction_modes_cant_be_regenerated_variants() {
+        let expected = Some(vec![StaticMode::CantBeRegenerated]);
+        assert_eq!(parse_restriction_modes("can't be regenerated"), expected);
+        assert_eq!(parse_restriction_modes("cannot be regenerated"), expected);
+        assert_eq!(
+            parse_restriction_modes("can't be regenerated this turn"),
+            expected
+        );
+        assert_eq!(
+            parse_restriction_modes("cannot be regenerated this turn."),
+            expected
         );
     }
 

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -833,6 +833,18 @@ pub enum StaticMode {
     Indestructible,
     /// Permanent cannot be destroyed (distinct from Indestructible).
     CantBeDestroyed,
+    /// CR 701.19c: "[Permanent] can't be regenerated [this turn]." This does not
+    /// stop regeneration abilities from being activated or shields from being
+    /// created; rather, it causes regeneration shields to not be applied the
+    /// next time the affected permanent would be destroyed. The per-target
+    /// `StaticDefinition::affected` filter carries which permanent is marked;
+    /// runtime enforcement bypasses the regen shield in
+    /// `replacement.rs::destroy_applier` (CR 701.19). Distinct from
+    /// `CantBeDestroyed` (which prevents destruction outright) and the inline
+    /// `Effect::Destroy { cant_regenerate }` (the "Destroy X. It can't be
+    /// regenerated." one-shot) — this is the standalone, until-end-of-turn form
+    /// (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort).
+    CantBeRegenerated,
     /// CR 702.34: Flashback — allows casting from graveyard, exiled after resolution.
     FlashBack,
     /// CR 702.18: Shroud — permanent cannot be the target of spells or abilities.
@@ -1261,6 +1273,7 @@ impl fmt::Display for StaticMode {
             StaticMode::Protection => write!(f, "Protection"),
             StaticMode::Indestructible => write!(f, "Indestructible"),
             StaticMode::CantBeDestroyed => write!(f, "CantBeDestroyed"),
+            StaticMode::CantBeRegenerated => write!(f, "CantBeRegenerated"),
             StaticMode::FlashBack => write!(f, "FlashBack"),
             StaticMode::Shroud => write!(f, "Shroud"),
             StaticMode::Hexproof => write!(f, "Hexproof"),
@@ -1562,6 +1575,8 @@ impl FromStr for StaticMode {
             "Protection" => StaticMode::Protection,
             "Indestructible" => StaticMode::Indestructible,
             "CantBeDestroyed" => StaticMode::CantBeDestroyed,
+            // CR 701.19c: "[Permanent] can't be regenerated."
+            "CantBeRegenerated" => StaticMode::CantBeRegenerated,
             "FlashBack" => StaticMode::FlashBack,
             "Shroud" => StaticMode::Shroud,
             "Hexproof" => StaticMode::Hexproof,


### PR DESCRIPTION
## Summary
Adds the **standalone, until-end-of-turn** "can't be regenerated" effect — *"Target creature can't be regenerated this turn"* (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort, …), which previously fell to Unimplemented. The **inline** *"Destroy X. It can't be regenerated."* form already worked via `Effect::Destroy { cant_regenerate }`; this covers the standalone form that marks a creature so regeneration shields can't save it (CR 701.19c).

Modeled exactly like the merged `CantBeActivated` effect-form: a `GenericEffect` granting a new `StaticMode` to the target, with runtime enforcement querying that static.

## What it does
- **`StaticMode::CantBeRegenerated`** (unit variant) — with `Display`/`FromStr` arms and rule-mod registration in `static_abilities.rs` (so coverage reports it Handled).
- **Parser** (`try_parse_subject_restriction_clause`): splits *"[subject] can't be regenerated [this turn]"* and emits a `GenericEffect { CantBeRegenerated, AddStaticMode }` on the subject until end of turn. Anaphor subjects ("that creature"/"it" → `ParentTarget`; "target creature" → its target). A `parse_restriction_modes` backstop also covers the "cannot" phrasing.
- **Enforcement** (`replacement.rs`, CR 701.19c): the regeneration-shield replacement now bypasses the shield when the destroy target has an **active `CantBeRegenerated` static**, in addition to the existing event-level `cant_regenerate` flag. The grant is a transient until-EOT continuous effect, so it auto-expires at cleanup (CR 514.2).

## Files changed
- `crates/engine/src/types/statics.rs` — new variant + Display/FromStr
- `crates/engine/src/game/static_abilities.rs` — rule-mod registration
- `crates/engine/src/parser/oracle_effect/subject.rs` — restriction-clause arm + `parse_restriction_modes` backstop
- `crates/engine/src/game/replacement.rs` — `object_has_active_cant_be_regenerated` + shield-bypass
- `crates/engine/src/parser/oracle_effect/mod.rs` — tests

## Anchored on
- The merged `StaticMode::CantBeActivated` effect-form (PR #1868) — same GenericEffect→AddStaticMode pattern, same `try_parse_subject_restriction_clause` arm shape, same anaphor binding.
- `cant_regenerate_bypasses_shield` in replacement.rs — the existing shield-bypass test this extends.

## CR references
- `CR 701.19c` — "Effects that say a permanent can't be regenerated … cause regeneration shields to not be applied." (verified against `docs/MagicCompRules.txt`)

## Tests
- Parser: `cant_be_regenerated_effect_standalone_targets_creature`, `cant_be_regenerated_anaphor_binds_to_parent_target`.
- Engine: `cant_be_regenerated_static_bypasses_shield`, `object_without_cant_be_regenerated_is_not_marked`.

## Track
Developer (local toolchain)

## LLM
Model: claude-opus-4-8
Thinking: medium

## Verification
Verified locally before push: `cargo fmt --all --check` clean; `cargo clippy -p engine --all-targets -- -D warnings` clean (exit 0); `cargo test -p engine` — 4 new tests pass, `regenerat` suite (25) + `static_mode` (7) + `restriction_modes` (10) pass, no regressions; `./scripts/check-parser-combinators.sh` exit 0. No exhaustive-match breakage. CI status checks also apply.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.