### PR TITLE
fix(parser): don't normalize sentence-initial instruction verbs to self-ref ~

### DIFF
--- a/crates/engine/src/parser/oracle_nom/primitives.rs
+++ b/crates/engine/src/parser/oracle_nom/primitives.rs
@@ -670,7 +670,7 @@ pub fn parse_alt_cost_keyword_name_to_kind(input: &str) -> OracleResult<'_, Keyw
 /// Matches common Oracle text action verbs: "destroy", "exile", "draw",
 /// "create", "sacrifice", "discard", "return", "put", "counter", "gain",
 /// "lose", "deal", "tap", "untap", "search", "shuffle", "reveal", "mill",
-/// "scry", "surveil", "fight".
+/// "scry", "surveil", "fight", "seek", "choose", "double".
 /// Returns the matched verb as a string slice.
 pub fn parse_verb(input: &str) -> OracleResult<'_, &str> {
     static VERBS: &[&str] = &[
@@ -727,6 +727,12 @@ pub fn parse_verb(input: &str) -> OracleResult<'_, &str> {
         "bolster",
         "explore",
         "adapt",
+        "seeks",
+        "seek",
+        "chooses",
+        "choose",
+        "doubles",
+        "double",
     ];
 
     for &verb in VERBS {
@@ -745,6 +751,20 @@ pub fn parse_verb(input: &str) -> OracleResult<'_, &str> {
         input,
         nom::error::ErrorKind::Fail,
     )))
+}
+
+/// Test whether a lowercased candidate word is a complete Oracle-text imperative
+/// verb (e.g. `search`, `destroy`, `return`). Used by `normalize_card_name_refs`
+/// strategy-5 guard to reject single-word card-name first-word replacements that
+/// would corrupt a sentence-initial instruction verb (e.g. `Search for Tomorrow`
+/// must not rewrite `Search your library...` to `~ your library...`).
+///
+/// Uses `all_consuming(parse_verb)` so only a candidate that *is* a verb in its
+/// entirety returns true; a card-name prefix that merely starts with a verb does
+/// not. CR 201.5: self-references are by name, never by an instruction verb, so
+/// no genuine self-reference is ever an imperative verb.
+pub(crate) fn is_verb_word(candidate_lower: &str) -> bool {
+    all_consuming(parse_verb).parse(candidate_lower).is_ok()
 }
 
 /// Parse common Oracle phrase fragments.

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1697,6 +1697,11 @@ pub fn normalize_card_name_refs(text: &str, card_name: &str) -> String {
                         || is_non_subtype_subject_name(&lower_candidate)
                         || is_supertype_word(&lower_candidate)
                         || super::oracle_nom::primitives::is_keyword_word(&lower_candidate)
+                        // CR 201.5: a sentence-initial imperative verb ("Search
+                        // your library...") is never a self-reference, even when
+                        // it is the first word of a verb-named card ("Search for
+                        // Tomorrow"). Reject it so the verb survives unmangled.
+                        || super::oracle_nom::primitives::is_verb_word(&lower_candidate)
                         || is_subtype_word(&lower_candidate)
                     {
                         continue;
@@ -1847,6 +1852,64 @@ mod tests {
         assert_eq!(
             normalize_card_name_refs("When Sharuum enters", "Sharuum the Hegemon"),
             "When ~ enters"
+        );
+    }
+
+    #[test]
+    fn normalize_verb_first_word_name_preserves_instruction_verb() {
+        // CR 201.5: "Search for Tomorrow" begins its Oracle text with the
+        // imperative verb "Search", not a self-reference. The strategy-5
+        // first-word fallback must not rewrite the verb to `~`.
+        assert_eq!(
+            normalize_card_name_refs(
+                "Search your library for a basic land card, put it onto the battlefield, then shuffle.",
+                "Search for Tomorrow"
+            ),
+            "Search your library for a basic land card, put it onto the battlefield, then shuffle."
+        );
+        // Same class: "Destroy the Evidence" / "Return to Battle".
+        assert_eq!(
+            normalize_card_name_refs("Destroy target land.", "Destroy the Evidence"),
+            "Destroy target land."
+        );
+        assert_eq!(
+            normalize_card_name_refs(
+                "Return target creature card from your graveyard to your hand.",
+                "Return to Battle"
+            ),
+            "Return target creature card from your graveyard to your hand."
+        );
+        // Sibling instruction verbs also in the lexicon: "Seek New Knowledge",
+        // "Choose Your Weapon", "Double Trouble" must not mangle their leading
+        // verb either.
+        assert_eq!(
+            normalize_card_name_refs(
+                "Seek two nonland cards, then put a card from your hand on the bottom of your library.",
+                "Seek New Knowledge"
+            ),
+            "Seek two nonland cards, then put a card from your hand on the bottom of your library."
+        );
+        assert_eq!(
+            normalize_card_name_refs("Choose one —", "Choose Your Weapon"),
+            "Choose one —"
+        );
+        assert_eq!(
+            normalize_card_name_refs(
+                "Double the power of each creature you control until end of turn.",
+                "Double Trouble"
+            ),
+            "Double the power of each creature you control until end of turn."
+        );
+    }
+
+    #[test]
+    fn normalize_verb_guard_preserves_split_half_self_ref() {
+        // The verb guard must not over-reach: a split-card half-name that is a
+        // noun ("Fire", "Cut", "Assault") is still a genuine self-reference and
+        // must normalize to `~`.
+        assert_eq!(
+            normalize_card_name_refs("Fire deals 2 damage divided as you choose.", "Fire // Ice"),
+            "~ deals 2 damage divided as you choose."
         );
     }
 


### PR DESCRIPTION
normalize_card_name_refs' strategy-5 first-word fallback fires when a card's
full name is absent from its Oracle text, rewriting a matching single-word
name prefix to the self-reference token ~. For verb-named spells this mangled
the leading imperative verb: 'Search for Tomorrow' turned 'Search your
library...' into '~ your library...', breaking the library-search parser.

Add an is_verb_word guard (all_consuming over the existing canonical parse_verb
VERBS lexicon) to the len==1 fallback, alongside the existing type/subtype/
keyword/article guards. CR 201.5: self-references are by name, never by an
instruction verb, so no genuine self-reference is ever an imperative verb
(verified across all of MTGJSON: zero cards use a VERBS-word as a noun
self-reference). Split-card halves (Fire, Cut, Assault) and legendary
short-names (Crovax, Zurgo, Tuvasa) are not verbs and stay untouched.

Extend VERBS with seek/choose/double so the same fallback no longer mangles
'Seek New Knowledge', 'Choose Your Weapon', or 'Double Trouble' (parse_verb has
no production dispatch consumer, so widening the lexicon only widens this guard).
