### PR TITLE
fix(client): anchor DialogHost prompts above the board so modals can't hide behind the hand

### DIFF
--- a/client/src/components/mana/ManaPaymentUI.tsx
+++ b/client/src/components/mana/ManaPaymentUI.tsx
@@ -227,7 +227,12 @@ export function ManaPaymentUI() {
         exit={{ y: 80, opacity: 0 }}
         transition={{ duration: 0.25 }}
       >
-        <div className="rounded-xl bg-gray-900/95 p-4 shadow-2xl ring-1 ring-gray-700 min-w-[280px] max-w-[420px]">
+        {/* `pointer-events-auto` re-enables clicks on the panel itself: under a
+            click-through convoke/improvise host (CR 702.51a / 702.126a) the
+            DialogHost wrapper is `pointer-events: none` so board taps reach the
+            artifacts/creatures, but the Pay/Cancel controls must still respond.
+            The surrounding full-width strip stays pass-through. */}
+        <div className="pointer-events-auto rounded-xl bg-gray-900/95 p-4 shadow-2xl ring-1 ring-gray-700 min-w-[280px] max-w-[420px]">
           <h3 className="mb-3 text-center text-sm font-semibold text-gray-300">
             {t("mana.payMana")}
             {cardName && (

--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -67,13 +67,13 @@ function isClickThroughDialog(waitingFor: WaitingFor | null | undefined): boolea
   // CR 702.51a (Convoke) / CR 701.67a (Waterbend) / CR 702.126a (Improvise):
   // these tap-payment modes let the caster tap creatures/artifacts on the
   // battlefield to pay generic/colored mana while the `ManaPaymentUI` panel
-  // (a self-anchored `fixed inset-x-0 bottom-0` strip) is open. The host must
-  // stay click-through for them so those board taps reach the cards —
-  // otherwise the `fixed inset-0 z-40` wrapper swallows the clicks and the
-  // player cannot tap creatures to pay (the creatures still get the mana-tap
-  // ring, but clicking them does nothing). Plain/hybrid/Phyrexian payment needs
-  // no board interaction (the panel's Pay button passes priority), so it stays
-  // wrapped — `convoke_mode` is the engine's signal that board taps are live.
+  // is open. The host still anchors the panel at `fixed inset-0 z-40` (so it
+  // can't be trapped beneath the board), but click-through marks it
+  // `pointer-events: none` so those board taps reach the cards — the panel's
+  // own controls re-enable events. Plain/hybrid/Phyrexian payment needs no
+  // board interaction (the panel's Pay button passes priority), so it keeps
+  // pointer events — `convoke_mode` is the engine's signal that board taps are
+  // live.
   return waitingFor.type === "ManaPayment" && waitingFor.data.convoke_mode != null;
 }
 
@@ -109,12 +109,22 @@ export function DialogHost({ children }: { children: ReactNode }) {
   const dialogVisible =
     (isDialogVisibleFor(waitingFor) && canActForWaitingState) || hasUiDialog;
   const clickThrough = isClickThroughDialog(waitingFor);
-  // Only wrap when there's a centered dialog that benefits from being
-  // anchored to the viewport. Click-through overlays (TargetingOverlay)
-  // must NOT be wrapped — the host would intercept board clicks at z-40
-  // and break target picking.
-  const wrapped = dialogVisible && !clickThrough;
-  const showPeekTab = peeked && wrapped;
+  // BASE INVARIANT: every visible prompt is anchored in this viewport-level
+  // `fixed inset-0 z-40` stacking context, so no prompt can ever be trapped
+  // beneath the board. The board grid is its own `relative z-10` stacking
+  // context; framer-motion leaves a `transform`/`will-change: transform` on
+  // this node, which would demote an un-anchored (className="") host to a
+  // `z-auto` context that paints BELOW the board — burying the dialog behind
+  // the HUD and hand. Anchoring at an explicit `z-40` keeps the context at
+  // level 40 (above the board) regardless of any transform framer applies.
+  // Click-through is achieved with `pointer-events: none` (below), NOT by
+  // un-anchoring, so board taps still reach the battlefield.
+  const anchored = dialogVisible;
+  // Only non-click-through dialogs participate in the peek/slide affordance;
+  // click-through overlays (convoke/improvise board taps, target picking) stay
+  // put and pass taps through to the board.
+  const peekable = anchored && !clickThrough;
+  const showPeekTab = peeked && peekable;
 
   const ctxValue = useMemo<DialogPeekContext>(
     () => ({
@@ -137,22 +147,22 @@ export function DialogHost({ children }: { children: ReactNode }) {
 
   return (
     <DialogPeekCtx.Provider value={ctxValue}>
-      {/* The host's motion.div must (a) NOT establish a transform-CB that
-          mis-anchors `fixed inset:0` dialog descendants when at rest, and
-          (b) NOT block board clicks/hovers when no dialog is up.
-          Both are achieved by gating `fixed inset-0` on `dialogVisible`:
-          when a dialog is visible the host fills the viewport (so the
-          transform CB IS the viewport, dialogs render correctly, slide
-          works); when none is up the host collapses to an in-flow 0-size
-          box that intercepts nothing. Pointer-events:none kicks in only
-          while peeked so clicks/hovers pass through to the battlefield —
-          otherwise the dialog itself handles events normally. */}
+      {/* When a dialog is visible the host fills the viewport as a `z-40`
+          stacking context so descendants render above the board; when none is
+          up it collapses to an in-flow 0-size box that intercepts nothing.
+          `pointer-events: none` lets taps/hovers pass through to the
+          battlefield while peeked OR for click-through prompts (convoke /
+          improvise / target picking); interactive children re-enable events
+          with `pointer-events-auto`. Otherwise the dialog handles events
+          normally. */}
       <motion.div
-        className={wrapped ? "fixed inset-0 z-40" : ""}
+        className={anchored ? "fixed inset-0 z-40" : ""}
         style={
-          wrapped ? { pointerEvents: peeked ? "none" : undefined } : undefined
+          anchored
+            ? { pointerEvents: clickThrough || peeked ? "none" : undefined }
+            : undefined
         }
-        animate={wrapped ? slideTransform : undefined}
+        animate={peekable ? slideTransform : undefined}
         transition={
           shouldReduceMotion
             ? { duration: 0 }

--- a/client/src/components/modal/__tests__/DialogHost.test.tsx
+++ b/client/src/components/modal/__tests__/DialogHost.test.tsx
@@ -87,12 +87,15 @@ describe("DialogHost", () => {
     expect(wrapper?.className ?? "").not.toMatch(/fixed/);
   });
 
-  it("stays click-through (no viewport-blocking wrapper) during convoke mana payment (regression)", () => {
-    // CR 702.51a: a convoke spell enters `ManaPayment` with `convoke_mode` set,
-    // and the caster taps creatures on the battlefield to pay. If the host
-    // wrapped children in `fixed inset-0 z-40`, that overlay would swallow the
-    // board clicks and the player could not tap convoke creatures — the
-    // reported bug was "creatures are highlighted but clicking does nothing".
+  it("anchors convoke mana payment at z-40 but stays click-through via pointer-events (regression)", () => {
+    // CR 702.51a / CR 702.126a: a convoke/improvise spell enters `ManaPayment`
+    // with `convoke_mode` set, and the caster taps creatures/artifacts on the
+    // battlefield to pay. The host MUST anchor the panel in its `fixed inset-0
+    // z-40` stacking context (otherwise framer-motion's transform demotes an
+    // un-anchored host to a z-auto context that paints BELOW the board's z-10
+    // grid, burying the pay panel behind the HUD/hand). Click-through is
+    // achieved with `pointer-events: none` so board taps still reach the
+    // creatures/artifacts; the panel's own controls re-enable events.
     setWaitingFor({
       type: "ManaPayment",
       data: { player: 0, convoke_mode: "Convoke" },
@@ -103,7 +106,9 @@ describe("DialogHost", () => {
       </DialogHost>,
     );
     const wrapper = container.firstElementChild as HTMLElement | null;
-    expect(wrapper?.className ?? "").not.toMatch(/fixed/);
+    expect(wrapper?.className ?? "").toMatch(/fixed/);
+    expect(wrapper?.className ?? "").toMatch(/z-40/);
+    expect(wrapper?.style.pointerEvents).toBe("none");
   });
 
   it("keeps the viewport wrapper for plain mana payment without convoke", () => {


### PR DESCRIPTION
Click-through prompts (Improvise/Convoke mana payment, target selection)
rendered their DialogHost wrapper un-anchored (className=""), relying on
each panel's own `fixed z-40` floating at the root. framer-motion leaves a
residual transform/will-change on that motion.div, which promotes it to a
z-auto stacking context that paints BELOW the board grid's own z-10 context
— trapping the pay panel behind the HUD and hand (reported: "the Improvise
pay screen is hidden by my hand").

Make DialogHost ALWAYS anchor a visible prompt in its `fixed inset-0 z-40`
stacking context; achieve click-through via pointer-events:none instead of
by un-anchoring. An explicit positive z-index keeps the context at level 40
regardless of any transform framer applies, so no prompt routed through
DialogHost can be trapped beneath the board. ManaPaymentUI's panel box opts
back into pointer events so its controls respond under the click-through host
while the full-width strip stays pass-through for tapping artifacts.

Verified live via elementsFromPoint against the real board: un-anchored+
transform -> panel behind hand-card img; anchored z-40 -> panel on top.
