### PR TITLE
fix(engine): route subtype-grant and self-evasion statics to top-level abilities

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -1267,6 +1267,19 @@ pub fn compute_oathbreaker(mtgjson: &super::mtgjson::AtomicCard, face: &CardFace
 /// Cycling: "[Cost], Discard this card: Draw a card." (activated from hand)
 /// Typecycling: "[Cost], Discard this card: Search library for a [type] card,
 ///   reveal it, put it into your hand. Then shuffle."
+///
+/// DEFERRED RUNTIME GAP (CR 702.29e + CR 113.6b) — Homing Sliver class:
+/// This build-time synthesis reads only the face's INTRINSIC printed keywords.
+/// A Typecycling/Cycling keyword GRANTED at runtime by a continuous effect
+/// (Homing Sliver: "Each Sliver card in each player's hand has slivercycling
+/// {3}.") lands on the recipient's runtime keyword set (CR 113.6b zone-of-
+/// function + `TargetFilter::extract_in_zone` resolves it in the Hand zone), but
+/// is NOT synthesized into a runtime-activatable ability — synthesis never runs
+/// over runtime-granted keywords. Closing this needs a general runtime
+/// granted-keyword -> activatable-ability primitive (not card-specific), which
+/// is deferred. The parser/grant half is correct and covered by
+/// `static_homing_sliver_grants_typecycling_to_slivers_in_hand` in
+/// `parser/oracle_static/tests.rs`.
 pub fn synthesize_cycling(face: &mut CardFace) {
     let cycling_abilities: Vec<AbilityDefinition> = face
         .keywords

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -862,6 +862,35 @@ pub(crate) fn parse_subject_rule_static(text: &str) -> Option<StaticDefinition> 
     let lower = text.to_lowercase();
     let tp = TextPair::new(text, &lower);
     let (affected, predicate_text) = strip_rule_static_subject(tp.original, tp.lower)?;
+
+    // CR 509.1b: Evasion ability — "<self/typed subject> can't be blocked except by
+    // <filter>" is a static ability restricting blockers; must land as a top-level
+    // continuous static (CR 604.1), not a spell-resolution GenericEffect. Reuses
+    // classify_block_exception for the count-vs-quality BlockExceptionKind. Handled
+    // here before the generic predicate parse so it cannot fall through to
+    // dispatch_line_nom. The dispatch.rs CantBeBlockedExceptBy arm is guarded
+    // `!except by`, so the two paths are disjoint.
+    let pred_lower = predicate_text.to_lowercase();
+    if let Some(rest) = nom_tag_lower(predicate_text, &pred_lower, "can't be blocked except by ")
+        .or_else(|| {
+            nom_tag_lower(
+                predicate_text,
+                &pred_lower,
+                "can\u{2019}t be blocked except by ",
+            )
+        })
+    {
+        let def = StaticDefinition::new(StaticMode::CantBeBlockedExceptBy {
+            kind: classify_block_exception(rest),
+        })
+        .affected(affected.clone())
+        .description(text.to_string());
+        // A "can't be blocked except by <filter>" predicate never carries a
+        // trailing granted-keyword companion (the " has "/" gains " needles
+        // can't appear in it), so the evasion static is complete on its own.
+        return Some(def);
+    }
+
     let predicate = parse_rule_static_predicate(predicate_text)?;
     // CR 502.3: Extract trailing condition for CantUntap statics (e.g., "as long as [condition]")
     if matches!(predicate, RuleStaticPredicate::CantUntap) {

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1791,6 +1791,9 @@ pub(crate) fn strip_rule_static_subject<'a>(
         " blocks each turn if able",
         " block each turn if able",
         " can block only creatures with flying",
+        // CR 509.1b: Evasion — "<subject> can't be blocked except by <filter>".
+        " can't be blocked except by ",
+        " can\u{2019}t be blocked except by ",
         " has shroud",
         " have shroud",
         " has hexproof",
@@ -1834,6 +1837,19 @@ pub(crate) fn parse_rule_static_subject_filter(subject: &str) -> Option<TargetFi
 
     if matches!(tp.lower, "players" | "each player") {
         return Some(TargetFilter::Player);
+    }
+
+    // CR 205.3 + CR 604.1: "All/Each <subtype>" universal-quantifier subject for a
+    // rule-static grant (e.g. "All Slivers have shroud"). Strip the quantifier and
+    // delegate to parse_type_phrase (mirroring parse_target), so the subtype filter
+    // is recognized and the line lands as a top-level continuous static (CR 604.1)
+    // instead of a spell-resolution GenericEffect. Runs AFTER the player-scope match
+    // above so it never shadows "all players"/"each player".
+    if let Some(rest_tp) = nom_tag_tp(&tp, "all ").or_else(|| nom_tag_tp(&tp, "each ")) {
+        let (filter, rest) = parse_type_phrase(rest_tp.original);
+        if rest.trim().is_empty() {
+            return Some(filter);
+        }
     }
 
     if tp.lower == "enchanted creature" {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -12516,3 +12516,191 @@ fn static_line_lovisa_coldeyes() {
     assert!(matches!(def.mode, StaticMode::Continuous));
     assert_eq!(def.modifications.len(), 3);
 }
+
+/// CR 205.3 + CR 604.1 + CR 702.18a: "All Slivers have shroud." (Crystalline
+/// Sliver) must land as a TOP-LEVEL continuous static granting Shroud to a
+/// `Typed(Subtype:"Sliver")` subject — NOT a spell-resolution GenericEffect.
+/// The "all " universal quantifier on the rule-static subject must be stripped
+/// and delegated to `parse_type_phrase`.
+#[test]
+fn static_all_slivers_have_shroud_top_level_typed_subtype() {
+    use crate::types::keywords::Keyword;
+    let def =
+        parse_static_line("All Slivers have shroud.").expect("All Slivers have shroud must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(
+                tf.get_subtype(),
+                Some("Sliver"),
+                "expected Subtype(Sliver), got {:?}",
+                tf.type_filters
+            );
+        }
+        other => panic!("expected Typed(Subtype:Sliver), got {other:?}"),
+    }
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddKeyword {
+                keyword: Keyword::Shroud,
+            }),
+        "expected AddKeyword(Shroud), got {:?}",
+        def.modifications
+    );
+}
+
+/// CR 205.3 + CR 604.1 + CR 702.11a: "All Goblins have hexproof." — same
+/// universal-quantifier-strip path, different subtype + keyword, proving the
+/// fix covers the whole "all <type> have <keyword>" class, not one card.
+#[test]
+fn static_all_goblins_have_hexproof_top_level_typed_subtype() {
+    use crate::types::keywords::Keyword;
+    let def = parse_static_line("All Goblins have hexproof.")
+        .expect("All Goblins have hexproof must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.get_subtype(), Some("Goblin"));
+        }
+        other => panic!("expected Typed(Subtype:Goblin), got {other:?}"),
+    }
+    assert!(def
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof,
+        }));
+}
+
+/// CR 205.3 + CR 604.1: "All creatures have shroud." — proves the quantifier
+/// strip is GENERAL (works on the core-type subject "creatures", not just
+/// subtypes).
+#[test]
+fn static_all_creatures_have_shroud_top_level() {
+    use crate::types::keywords::Keyword;
+    let def = parse_static_line("All creatures have shroud.")
+        .expect("All creatures have shroud must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "expected Creature type filter, got {:?}",
+                tf.type_filters
+            );
+        }
+        other => panic!("expected Typed(creatures), got {other:?}"),
+    }
+    assert!(def
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Shroud,
+        }));
+}
+
+/// CR 509.1b + CR 604.1: A self-referential "~ can't be blocked except by
+/// <quality filter>" evasion static must land as a TOP-LEVEL
+/// `CantBeBlockedExceptBy { Quality(..) }` on the source — NOT a GenericEffect.
+#[test]
+fn static_selfref_cant_be_blocked_except_by_quality_top_level() {
+    let def = parse_static_line("~ can't be blocked except by creatures with flying.")
+        .expect("self-ref except-by-quality must parse");
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    match &def.mode {
+        StaticMode::CantBeBlockedExceptBy {
+            kind: BlockExceptionKind::Quality(filter),
+        } => match filter {
+            TargetFilter::Typed(tf) => assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "expected a creature quality filter, got {:?}",
+                tf.type_filters
+            ),
+            other => panic!("expected a Typed creature quality filter, got {other:?}"),
+        },
+        other => panic!("expected CantBeBlockedExceptBy(Quality), got {other:?}"),
+    }
+}
+
+/// CR 509.1b: A self-referential "~ can't be blocked except by two or more
+/// creatures" (menace-style minimum) must land as a TOP-LEVEL
+/// `CantBeBlockedExceptBy { MinBlockers }` static.
+#[test]
+fn static_selfref_cant_be_blocked_except_by_min_blockers_top_level() {
+    let def = parse_static_line("~ can't be blocked except by two or more creatures.")
+        .expect("self-ref except-by-min must parse");
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    assert_eq!(
+        def.mode,
+        StaticMode::CantBeBlockedExceptBy {
+            kind: BlockExceptionKind::MinBlockers { min: 2 }
+        }
+    );
+}
+
+/// CR 509.1b: The Amrou-style disjunction filter ("artifact creatures and/or
+/// white creatures") must land as a TOP-LEVEL `CantBeBlockedExceptBy { Quality }`
+/// evasion static on the self-referential source.
+#[test]
+fn static_selfref_cant_be_blocked_except_by_disjunction_top_level() {
+    let def = parse_static_line(
+        "~ can't be blocked except by artifact creatures and/or white creatures.",
+    )
+    .expect("self-ref except-by-disjunction must parse");
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    assert!(
+        matches!(
+            def.mode,
+            StaticMode::CantBeBlockedExceptBy {
+                kind: BlockExceptionKind::Quality(_)
+            }
+        ),
+        "expected CantBeBlockedExceptBy(Quality(disjunction)), got {:?}",
+        def.mode
+    );
+}
+
+/// CR 702.29e + CR 113.6b: Homing Sliver's top-level static grants Typecycling
+/// to all Sliver cards in their owner's hand. This asserts the PARSE is correct
+/// (affected = Typed(Subtype:Sliver) in the Hand zone; modification =
+/// AddKeyword(Typecycling { cost {3}, subtype "Sliver" })). NOTE: a deferred
+/// RUNTIME gap remains — `synthesize_cycling` reads intrinsic printed keywords
+/// only, so a Typecycling keyword GRANTED at runtime is on the recipient's
+/// keyword set but is not synthesized into an activatable ability. See the
+/// doc comment at `database/synthesis.rs::synthesize_cycling`.
+#[test]
+fn static_homing_sliver_grants_typecycling_to_slivers_in_hand() {
+    use crate::types::keywords::Keyword;
+    use crate::types::mana::ManaCost;
+    // Real Oracle text. The "Each <type> in each player's hand has <keyword>"
+    // shape must land as a TOP-LEVEL continuous grant, not a GenericEffect.
+    let def = parse_static_line("Each Sliver card in each player's hand has slivercycling {3}.")
+        .expect("Homing Sliver slivercycling grant must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    match &def.affected {
+        Some(filter @ TargetFilter::Typed(tf)) => {
+            assert_eq!(
+                tf.get_subtype(),
+                Some("Sliver"),
+                "expected Subtype(Sliver), got {:?}",
+                tf.type_filters
+            );
+            // CR 113.6b: the grant functions on cards in the Hand zone.
+            assert_eq!(
+                filter.extract_in_zone(),
+                Some(Zone::Hand),
+                "expected InZone(Hand) on the affected filter, got {:?}",
+                tf.properties
+            );
+        }
+        other => panic!("expected Typed(Subtype:Sliver in hand), got {other:?}"),
+    }
+    assert!(
+        def.modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Typecycling { cost, subtype }
+            } if *cost == ManaCost::generic(3) && subtype == "Sliver"
+        )),
+        "expected AddKeyword(Typecycling {{ {{3}}, Sliver }}), got {:?}",
+        def.modifications
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -117,6 +117,7 @@ mod scarab_god_regression;
 mod seasoned_dungeoneer_initiative_room_trigger;
 mod serras_emissary_chosen_card_type_protection;
 mod skullwinder_chosen_opponent;
+mod sliver_static_grants;
 mod spellstutter_sprite_counter_with_x;
 mod spikeshell_harrier_speed_superlative;
 mod springheart_nantuko_bestow_landfall;

--- a/crates/engine/tests/integration/sliver_static_grants.rs
+++ b/crates/engine/tests/integration/sliver_static_grants.rs
@@ -1,0 +1,163 @@
+//! Intrinsic permanent statics that previously mis-routed into a kind:"Spell"
+//! GenericEffect (never registered with the layer system) now land as
+//! top-level `static_abilities` and resolve through the real continuous-effect
+//! layer pipeline.
+//!
+//! Gap A — "All <subtype> have <keyword>" universal-quantifier grant
+//! (Crystalline Sliver: "All Slivers have shroud."). CR 205.3 (subtypes),
+//! CR 604.1 (static abilities are continuously true), CR 702.18a (Shroud).
+//!
+//! Gap B — self/typed "can't be blocked except by <filter>" evasion static.
+//! CR 509.1b (the defending player checks each creature for block
+//! restrictions). The restriction must be live in declare-blockers, so it has
+//! to be a top-level continuous static, not a spell-resolution effect.
+//!
+//! These tests drive the REAL pipeline through `apply()` (priority passing /
+//! declare-attackers-blockers) — they never hand-construct expected state. The
+//! assertions read the post-layer keyword set / the engine's own
+//! `find_legal_targets` and block-legality validation.
+
+use engine::game::layers::{flush_layers, mark_layers_full};
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::targeting::find_legal_targets;
+use engine::types::ability::{TargetFilter, TargetRef, TypedFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use super::rules::AttackTarget;
+
+/// Crystalline Sliver's printed static (reminder text stripped by the parser).
+const CRYSTALLINE_SLIVER: &str = "All Slivers have shroud.";
+
+/// CR 205.3 + CR 604.1 + CR 702.18a: Crystalline Sliver's "All Slivers have
+/// shroud" must grant Shroud to OTHER Slivers on the battlefield through the
+/// continuous layer system, and that Shroud must make the affected Sliver
+/// untargetable by an opponent's spell.
+#[test]
+fn crystalline_sliver_grants_shroud_to_other_slivers() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let _crystalline = scenario
+        .add_creature_from_oracle(P0, "Crystalline Sliver", 1, 1, CRYSTALLINE_SLIVER)
+        .with_subtypes(vec!["Sliver"])
+        .id();
+    let other_sliver = scenario
+        .add_creature(P0, "Muscle Sliver", 2, 2)
+        .with_subtypes(vec!["Sliver"])
+        .id();
+    // A non-Sliver control creature proves the grant is subtype-selective.
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    let mut runner = scenario.build();
+    // Run the engine's own continuous-effect layer pipeline (the same
+    // `evaluate_layers` path `apply()` invokes) so the continuous Shroud grant
+    // is written onto the effective keyword set. We mark layers full + flush
+    // rather than hand-construct the result.
+    mark_layers_full(runner.state_mut());
+    flush_layers(runner.state_mut());
+
+    let other = &runner.state().objects[&other_sliver];
+    assert!(
+        other.has_keyword(&Keyword::Shroud),
+        "the other Sliver should have Shroud granted by Crystalline Sliver, \
+         got keywords {:?}",
+        other.keywords
+    );
+    assert!(
+        !runner.state().objects[&bear].has_keyword(&Keyword::Shroud),
+        "a non-Sliver creature must NOT receive the Sliver-only Shroud grant"
+    );
+
+    // Discriminating: an opponent (P1) targeting a creature on the battlefield
+    // must not be able to select the shrouded Sliver. Source id is irrelevant
+    // here (any opponent source is barred by Shroud — CR 702.18a).
+    let creature_filter = TargetFilter::Typed(TypedFilter::creature());
+    let legal_for_opponent =
+        find_legal_targets(runner.state(), &creature_filter, P1, ObjectId(9999));
+    assert!(
+        !legal_for_opponent.contains(&TargetRef::Object(other_sliver)),
+        "the shrouded Sliver must not be a legal target for an opponent's spell"
+    );
+    // Sanity: the non-Sliver bear (no Shroud) IS still targetable by the opponent.
+    assert!(
+        legal_for_opponent.contains(&TargetRef::Object(bear)),
+        "the un-shrouded bear should remain a legal opponent target"
+    );
+}
+
+/// Synthetic self-referential evasion static: "~ can't be blocked except by
+/// creatures with flying." Mirrors the Crystalline-class root cause for Gap B.
+const EXCEPT_BY_FLYING: &str = "~ can't be blocked except by creatures with flying.";
+
+/// CR 509.1b + CR 604.1: An attacker with "can't be blocked except by creatures
+/// with flying" must reject a non-flying blocker in declare-blockers and accept
+/// a flying one — driven through the real combat pipeline via `apply()`.
+#[test]
+fn cant_be_blocked_except_by_flying_rejects_nonflying_blocker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let attacker = scenario
+        .add_creature_from_oracle(P0, "Evasive Striker", 2, 2, EXCEPT_BY_FLYING)
+        .id();
+    let ground_blocker = scenario.add_creature(P1, "Ground Wall", 0, 4).id();
+    let flying_blocker = {
+        let mut b = scenario.add_creature(P1, "Air Wall", 0, 4);
+        b.flying();
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+        })
+        .expect("attacker should be able to attack");
+
+    // Advance to the declare-blockers window (drain any attack-trigger stack).
+    for _ in 0..20 {
+        if matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareBlockers { .. }
+        ) {
+            break;
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareBlockers { .. }
+        ),
+        "expected to reach declare-blockers, got {:?}",
+        runner.state().waiting_for
+    );
+
+    // CR 509.1b: a non-flying blocker is an illegal block — the declaration
+    // must be rejected by the engine's own validation.
+    let illegal = runner.act(GameAction::DeclareBlockers {
+        assignments: vec![(ground_blocker, attacker)],
+    });
+    assert!(
+        illegal.is_err(),
+        "a non-flying creature must NOT be allowed to block a \
+         'can't be blocked except by creatures with flying' attacker"
+    );
+    // The attacker is still attacking (declaration was rejected, not committed).
+    assert_eq!(runner.state().objects[&attacker].zone, Zone::Battlefield);
+
+    // A flying blocker IS a legal block.
+    runner
+        .act(GameAction::DeclareBlockers {
+            assignments: vec![(flying_blocker, attacker)],
+        })
+        .expect("a flying creature should be a legal blocker for the evasion attacker");
+}


### PR DESCRIPTION
Intrinsic permanent statics of the form "All <type> have <keyword>" (e.g.
Crystalline Sliver — "All Slivers have shroud") and self-scoped "~ can't be
blocked except by <filter>" (Signal Pest, Amrou Seekers, et al.) were
mis-routed into a kind:Spell GenericEffect and never registered with the
continuous-effects engine, so the grant/restriction silently no-opped at
runtime. AST content was correct; only placement was wrong.

Two parser dispatch gaps fixed (no layers.rs change needed — the layer system
already reads only top-level static_definitions, CR 604.1):

- Gap A: strip the universal quantifier ("all "/"each ") in
  parse_rule_static_subject_filter before delegating to parse_type_phrase
  (mirrors parse_target), so "All Slivers" resolves to Typed(Subtype:Sliver)
  and the line lands as a top-level continuous static. CR 205.3 + CR 604.1.
- Gap B: recognize the self/typed "can't be blocked except by" evasion
  predicate in parse_subject_rule_static (new strip markers + classify_block_
  exception), emitting a top-level CantBeBlockedExceptBy static. CR 509.1b.

Covers a ~42-card class (subtype/type keyword grants + self-evasion). Adds
building-block parser tests (top-level static shape, not GenericEffect) and
two apply()-driven integration tests proving another Sliver gains shroud and a
non-flier can't block a "can't be blocked except by flying" creature.

Deferred (documented, out of scope): Homing Sliver's runtime granted-keyword->
activatable-ability synthesis (parser is correct; needs a cross-cutting
keyword->ability primitive), and conditional self-grants ("If <past event>,
~ has <keyword>" — Soulflayer, Animus of Predation), a separate dispatch class.
