### PR TITLE
fix(parser): enters-with counter count parses "N minus/plus X" (Slumbering Trudge #1988)

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -1926,7 +1926,12 @@ fn parse_enters_with_counters(
     // sibling shorthand "counters on it equal to [quantity]", parse the
     // dynamic expression.
     if let Ok((_, (_, qty_text))) = nom_primitives::split_once_on(work_text, "equal to ") {
-        let trimmed = qty_text.trim().trim_end_matches('.');
+        // The quantity phrase never spans a sentence boundary, so isolate the
+        // first sentence before parsing — Slumbering Trudge trails a separate
+        // "If X is 2 or less, it enters tapped." clause after "equal to three
+        // minus X.", which would otherwise leave the quantity parsers a dangling
+        // tail and force the `Fixed { 1 }` fallback (only 1 stun counter).
+        let trimmed = qty_text.split('.').next().unwrap_or(qty_text).trim();
         if let Some(qty_ref) = crate::parser::oracle_quantity::parse_quantity_ref(trimmed) {
             count_expr = QuantityExpr::Ref { qty: qty_ref };
         } else if let Some(qty) = crate::parser::oracle_quantity::parse_cda_quantity(trimmed) {
@@ -1935,11 +1940,24 @@ fn parse_enters_with_counters(
             crate::parser::oracle_quantity::parse_event_context_quantity(trimmed)
         {
             count_expr = qty;
+        } else if let Some((qty, rest_q)) = crate::parser::oracle_util::parse_count_expr(trimmed) {
+            // CR 107.3a: arithmetic over the cost variable ("three minus X").
+            // `parse_count_expr` emits `Variable("X")`; the rewrite below maps it
+            // to the entering object's `CostXPaid`. Require full consumption so a
+            // partial parse never silently truncates the quantity.
+            if rest_q.trim().is_empty() {
+                count_expr = qty;
+            }
         }
     }
     if let Some(qty) = parse_enters_with_where_x_suffix(work_text) {
         count_expr = qty;
     }
+    // CR 614.12: Any `Variable("X")` that survived the dynamic-quantity
+    // overrides above refers to the X paid on the *entering* object's cost, not
+    // a trigger-event source, so rewrite it to `CostXPaid` (idempotent —
+    // already-rewritten `CostXPaid` leaves are untouched).
+    rewrite_variable_x_to_cost_x_paid(&mut count_expr);
 
     let put_counter = build_enters_counter_ability(
         counter_entries.unwrap_or_else(|| vec![(counter_type, count_expr)]),
@@ -7116,6 +7134,63 @@ mod tests {
                 target: TargetFilter::SelfRef,
             } if *counter_type == CounterType::Stun
         ));
+    }
+
+    /// Issue #1988 — Slumbering Trudge. "This creature enters with a number of
+    /// stun counters on it equal to three minus X. If X is 2 or less, it enters
+    /// tapped." The "three minus X" arithmetic plus the trailing tapped sentence
+    /// previously defeated every quantity parser, so `count` fell back to
+    /// `Fixed { 1 }` (1 stun counter regardless of X). The count must be the
+    /// `Offset { Multiply { -1, CostXPaid }, 3 }` expression so X=0 resolves to
+    /// 3 stun counters (and X>3 clamps to 0 in the resolver).
+    #[test]
+    fn slumbering_trudge_enters_with_three_minus_x_stun_counters() {
+        let def = parse_replacement_line(
+            "This creature enters with a number of stun counters on it equal to \
+             three minus X. If X is 2 or less, it enters tapped.",
+            "Slumbering Trudge",
+        )
+        .unwrap();
+        assert_eq!(def.event, ReplacementEvent::Moved);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        let execute = def.execute.as_ref().expect("execute ability");
+        // "it enters tapped" → Tap wrapper with the counter as its sub_ability.
+        assert!(matches!(
+            *execute.effect,
+            Effect::Tap {
+                target: TargetFilter::SelfRef
+            }
+        ));
+        let sub = execute.sub_ability.as_ref().expect("counter sub_ability");
+        match &*sub.effect {
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target,
+            } => {
+                assert_eq!(*counter_type, CounterType::Stun);
+                assert_eq!(*target, TargetFilter::SelfRef);
+                match count {
+                    QuantityExpr::Offset { inner, offset } => {
+                        assert_eq!(*offset, 3);
+                        match inner.as_ref() {
+                            QuantityExpr::Multiply { factor, inner } => {
+                                assert_eq!(*factor, -1);
+                                assert!(matches!(
+                                    inner.as_ref(),
+                                    QuantityExpr::Ref {
+                                        qty: QuantityRef::CostXPaid
+                                    }
+                                ));
+                            }
+                            other => panic!("expected Multiply{{-1, CostXPaid}}, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected Offset{{.., 3}}, got {other:?}"),
+                }
+            }
+            other => panic!("expected PutCounter, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -532,6 +532,47 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
             after_sup.trim_start(),
         ));
     }
+    // CR 107.1b + CR 107.3a: "N plus/minus <inner>" — a leading integer offset
+    // over a nested count expression ("three minus X" → Slumbering Trudge,
+    // "two plus X", etc.). CR 107.1b governs the arithmetic (a negative result
+    // is clamped to zero by the counter resolver); CR 107.3a covers the `X`
+    // operand. The operand recurses through the full count grammar
+    // (bare X, "twice X", fractions, "equal to <ref>"), so this composes over
+    // the existing `Offset`/`Multiply` variants rather than enumerating forms.
+    // The negative branch is modeled as `Multiply { factor: -1, inner }` inside
+    // the `Offset`, mirroring `parse_cda_quantity`'s offset arm. The "plus"/
+    // "minus" connectives are always lowercase in Oracle text and `parse_number`
+    // returns a leading-whitespace-trimmed remainder, so the tags carry no
+    // leading space (the trailing space enforces a word boundary). If the
+    // operand does not parse, fall through to the bare `Fixed` below — no
+    // regression for "N plus the number of …" (which `parse_count_expr` rejects).
+    if let Ok((after_op, sign)) = nom::branch::alt((
+        nom::combinator::value(
+            1i32,
+            nom::bytes::complete::tag::<_, _, OracleError<'_>>("plus "),
+        ),
+        nom::combinator::value(-1i32, nom::bytes::complete::tag("minus ")),
+    ))
+    .parse(rest)
+    {
+        if let Some((inner, after_inner)) = parse_count_expr(after_op) {
+            let inner_expr = if sign < 0 {
+                QuantityExpr::Multiply {
+                    factor: -1,
+                    inner: Box::new(inner),
+                }
+            } else {
+                inner
+            };
+            return Some((
+                QuantityExpr::Offset {
+                    inner: Box::new(inner_expr),
+                    offset: base,
+                },
+                after_inner,
+            ));
+        }
+    }
     Some((QuantityExpr::Fixed { value: base }, rest))
 }
 
@@ -2325,6 +2366,50 @@ mod tests {
     #[test]
     fn parse_count_expr_none_for_text() {
         assert!(parse_count_expr("target creature").is_none());
+    }
+
+    #[test]
+    fn parse_count_expr_three_minus_x() {
+        // CR 107.1b: "three minus X" → Offset { Multiply { -1, X }, offset: 3 }
+        // (Slumbering Trudge's stun-counter count). At X=0 this resolves to 3.
+        let (qty, rest) = parse_count_expr("three minus X").unwrap();
+        match qty {
+            QuantityExpr::Offset { inner, offset } => {
+                assert_eq!(offset, 3);
+                match *inner {
+                    QuantityExpr::Multiply { factor, inner } => {
+                        assert_eq!(factor, -1);
+                        assert!(matches!(
+                            *inner,
+                            QuantityExpr::Ref {
+                                qty: QuantityRef::Variable { .. }
+                            }
+                        ));
+                    }
+                    other => panic!("Expected Multiply{{-1, X}}, got {other:?}"),
+                }
+            }
+            other => panic!("Expected Offset, got {other:?}"),
+        }
+        assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn parse_count_expr_two_plus_x() {
+        // CR 107.1b: "two plus X" → Offset { X, offset: 2 } (no negation wrapper).
+        let (qty, _rest) = parse_count_expr("two plus X").unwrap();
+        match qty {
+            QuantityExpr::Offset { inner, offset } => {
+                assert_eq!(offset, 2);
+                assert!(matches!(
+                    *inner,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Variable { .. }
+                    }
+                ));
+            }
+            other => panic!("Expected Offset, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1988. **Slumbering Trudge** reads "This creature enters with a number of stun counters on it equal to **three minus X**. If X is 2 or less, it enters tapped." It was always entering with a single stun counter regardless of X.

Two parser gaps caused the `Fixed { 1 }` fallback:

1. **`parse_count_expr` had no arithmetic-offset arm.** "three minus X" (and "two plus X", etc.) was unparseable. Added an `N plus/minus <inner>` arm that composes over the existing `Offset`/`Multiply` `QuantityExpr` variants and recurses through the full count grammar (bare X, "twice X", fractions). This is the count-position building block, so **every** count-taking verb gains the arithmetic — not just enters-with.

2. **The enters-with "equal to ⟨quantity⟩" override** only tried the board/CDA/event quantity parsers and trimmed trailing dots, so the trailing second sentence ("If X is 2 or less…") left a dangling tail. Now it isolates the first sentence, adds `parse_count_expr` as the arithmetic fallback, and rewrites the surviving `Variable("X")` → `CostXPaid` so it reads the *entering* object's announced X (CR 614.12).

At X=0 the count resolves to **3** stun counters; the counter resolver already clamps negative results to 0 (CR 107.1b) for X>3.

## CR references
- **CR 107.1b** — calculation arithmetic; a negative result is clamped to zero.
- **CR 107.3a** — the value of X is the value announced when the spell was cast.
- **CR 614.12** — ETB-modifying replacement effects; the entering permanent's own X.

## Tests
- `parse_count_expr_three_minus_x` / `parse_count_expr_two_plus_x` — building-block arithmetic arm.
- `slumbering_trudge_enters_with_three_minus_x_stun_counters` — end-to-end via `parse_replacement_line`, asserting `Offset { Multiply { -1, CostXPaid }, 3 }` Stun counter on SelfRef.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
