### PR TITLE
test: unblock anaphoric guard (+5 cat-3/4 cards) and recalibrate Gifts beam ceiling

### DIFF
--- a/crates/engine/tests/integration/anaphoric_scope_allowlist_guard.rs
+++ b/crates/engine/tests/integration/anaphoric_scope_allowlist_guard.rs
@@ -142,8 +142,10 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "angelic chorus",
     "archdruid's charm",
     "archon of redemption",
+    "artifact mutation",
     "assert perfection",
     "augury adept",
+    "aura mutation",
     "avatar destiny",
     "backlash",
     "baneful omen",
@@ -191,6 +193,7 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "divine offering",
     "domri's ambush",
     "doomgape",
+    "dovescape",
     "durkwood tracker",
     "duskmantle seer",
     "electrosiphon",
@@ -225,6 +228,7 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "hellhole rats",
     "hidetsugu and kairi",
     "hit",
+    "hoard-smelter dragon",
     "horrid shadowspinner",
     "hotel of fears",
     "huatli's final strike",
@@ -235,6 +239,7 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "ikra shidiqi, the usurper",
     "immersturm",
     "imp's mischief",
+    "induce paranoia",
     "infernal reckoning",
     "interpret the signs",
     "jenova, ancient calamity",
@@ -441,22 +446,26 @@ fn anaphoric_scope_set_is_frozen() {
     // both this and ANAPHORIC_SCOPE_CARDS shrink together.
     assert_eq!(
         observed.len(),
-        247,
-        "Expected exactly 247 cards retaining ObjectScope::Anaphoric. PR #1451 \
+        252,
+        "Expected exactly 252 cards retaining ObjectScope::Anaphoric. PR #1451 \
          re-scoped 8 dynamic-quantity 'its power' anaphora off the Anaphoric \
          arm onto typed quantity refs; PR #1522 re-scoped Dead Before Sunrise \
          through the recipient/subject rewrite. The category-2 'it deals damage \
          equal to its power' trigger-subject class (#512) then moved 10 more \
          cards (Warstorm Surge, Stalking Vengeance, Mage Slayer, et al.) onto \
          `Power {{ scope: EventSource }}`; Sly Spy remains a legitimate \
-         reveal-referent case. Count moved to \
-         {}.",
+         reveal-referent case. The parser later began extracting the \
+         'where X is that <type>'s mana value' tail for five more cards in the \
+         existing category-3 (target-destroy anaphora: Artifact Mutation, Aura \
+         Mutation, Hoard-Smelter Dragon) and category-4 (counter-then-act: \
+         Dovescape, Induce Paranoia) classes, moving the count 247 -> 252. \
+         Count moved to {}.",
         observed.len()
     );
     assert_eq!(
         ANAPHORIC_SCOPE_CARDS.len(),
-        247,
-        "ANAPHORIC_SCOPE_CARDS must list exactly 247 cards."
+        252,
+        "ANAPHORIC_SCOPE_CARDS must list exactly 252 cards."
     );
 }
 

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -2539,13 +2539,21 @@ mod tests {
     }
 
     /// CR 608.2c + CR 701.23: Gifts Ungiven scaling regression — with a
-    /// large library (80 cards), a count-4 search must complete in well
-    /// under 100 ms via the BEAM_K-bounded path. The pre-fix Cartesian
-    /// enumerator (~C(80, 4) ≈ 1.5M combos × per-combo scoring) stalled
-    /// the AI; the beam reduces to C(BEAM_K, 4) candidates. The DistinctNames
-    /// constraint is honored by the engine candidate filter and re-checked
-    /// inside the AI beam, so the returned selection must contain only
-    /// uniquely-named cards.
+    /// large library (80 cards), a count-4 search must complete via the
+    /// BEAM_K-bounded path rather than the pre-fix Cartesian enumerator
+    /// (~C(80, 4) ≈ 1.5M combos × per-combo scoring) that stalled the AI.
+    /// The beam reduces this to C(BEAM_K, 4) ≈ 794 scored selections.
+    ///
+    /// The ceiling is a *blowup* guard, not a tight micro-benchmark: the
+    /// healthy beam path runs in ~60–130 ms (machine- and load-dependent —
+    /// this runs in CI and alongside concurrent Tilt rebuilds), while a
+    /// reversion to Cartesian enumeration costs *tens of seconds*. A 1 s
+    /// ceiling cleanly separates the two — ~8× headroom over the loaded
+    /// healthy path, ~1000× below a Cartesian regression — so it catches the
+    /// regression it exists to catch without flaking on contention. The
+    /// DistinctNames constraint is honored by the engine candidate filter and
+    /// re-checked inside the AI beam, so the returned selection must contain
+    /// only uniquely-named cards.
     #[test]
     fn gifts_ungiven_search_choice_returns_quickly_with_distinct_names() {
         use engine::types::ability::{SearchSelectionConstraint, SharedQuality};
@@ -2594,8 +2602,10 @@ mod tests {
         let action = choose_action(&state, PlayerId(0), &config, &mut rng);
         let elapsed = started.elapsed();
         assert!(
-            elapsed.as_millis() < 100,
-            "AI search-choice took {elapsed:?}; beam path must keep it under 100ms"
+            elapsed.as_millis() < 1000,
+            "AI search-choice took {elapsed:?}; a Cartesian-enumeration regression \
+             (C(80,4) ≈ 1.5M combos) costs tens of seconds — the BEAM_K path must \
+             stay well under the 1s blowup ceiling"
         );
 
         match action {


### PR DESCRIPTION
Two independent local-test failures, neither a real regression:

- anaphoric_scope_set_is_frozen: the committed parser now extracts the
  'where X is that <type>'s mana value' anaphor for 5 more cards in the
  existing tracked classes — Artifact Mutation, Aura Mutation,
  Hoard-Smelter Dragon (category 3, target-destroy anaphora) and
  Dovescape, Induce Paranoia (category 4, counter-then-act). All parse to
  ObjectManaValue { scope: Anaphoric }, the documented-correct scope. The
  guard self-skips in CI (no card-data.json) so the parser change landed
  green and only failed locally. Add the 5 cards in sorted position and
  bump the frozen count 247 -> 252.

- gifts_ungiven_search_choice_returns_quickly: the beam path is intact
  (80 > BEAM_K=12 -> 794 scored selections); 132ms was machine contention,
  not the C(80,4)~=1.5M Cartesian reversion this test guards against (which
  costs tens of seconds). The 100ms ceiling sat inside the load noise band.
  Recalibrate to a 1s blowup ceiling (~8x over the loaded healthy path,
  ~1000x below a Cartesian regression) and document the intent.
