### PR TITLE
fix: render CR 103.1 starting-player roll-off round by round

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1604,6 +1604,16 @@ export type GameEvent =
   // CR 706: a die was rolled. Animated by DiceRollOverlay. `sides`/`result` are
   // the engine's authoritative roll (1..=sides after modifiers).
   | { type: "DieRolled"; data: { player_id: PlayerId; sides: number; result: number } }
+  // CR 103.1: the starting-player d20 roll-off as one structured event. `rounds`
+  // preserves the round boundaries (round 1 = every seat; each later round = the
+  // previous round's tied-max group that rerolled); `winner` is the engine's
+  // authoritative starting player. Each round's `rolls` are [playerId, result]
+  // pairs in seat order. Replaces the flat per-roll DieRolled batch for the
+  // contest; in-game die rolls still emit DieRolled.
+  | {
+      type: "StartingPlayerContest";
+      data: { rounds: { rolls: [PlayerId, number][] }[]; winner: PlayerId };
+    }
   // CR 705: a coin was flipped. `won` is whether the flipping player won the flip
   // (relative to that player) — there is no engine-named face; the heads/tails
   // depiction is a presentation choice.

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -110,9 +110,9 @@ export class WebSocketAdapter implements EngineAdapter {
   private pendingReject: ((error: Error) => void) | null = null;
   private initResolve: (() => void) | null = null;
   private initReject: ((error: Error) => void) | null = null;
-  /** Starting-player contest DieRolled batch captured from the initial
-   *  GameStarted message, handed back by `initializeGame()` so the dice overlay
-   *  animates it. Empty on reconnects (the server drains it after first send). */
+  /** Starting-player contest event captured from the initial GameStarted
+   *  message, handed back by `initializeGame()` so the dice overlay animates it.
+   *  Empty on reconnects (the server drains it after first send). */
   private initStartEvents: GameEvent[] = [];
   private listeners: WsAdapterEventListener[] = [];
   private reconnectAttempt = 0;
@@ -613,11 +613,10 @@ export class WebSocketAdapter implements EngineAdapter {
           ...(playerNames === undefined ? {} : { playerNames }),
         });
         if (this.initResolve) {
-          // CR 103.1: the server sends the starting-player contest DieRolled
-          // batch only on the initial GameStarted (drained server-side, so
-          // reconnects carry none). Stash it for initializeGame() to return,
-          // routing it through the same gameStore.initGame contest path as
-          // local games.
+          // CR 103.1: the server sends the StartingPlayerContest event only on
+          // the initial GameStarted (drained server-side, so reconnects carry
+          // none). Stash it for initializeGame() to return, routing it through
+          // the same gameStore.initGame contest path as local games.
           this.initStartEvents = data.events ?? [];
           this.initResolve();
           this.initResolve = null;

--- a/client/src/animation/eventNormalizer.ts
+++ b/client/src/animation/eventNormalizer.ts
@@ -32,6 +32,7 @@ const NON_VISUAL_EVENTS = new Set([
   // Dice/coin are presented out-of-band by DiceRollOverlay (via flashDiceRoll),
   // not as queued animation steps — same pattern as TurnStarted → the turn banner.
   "DieRolled",
+  "StartingPlayerContest",
   "CoinFlipped",
 ]);
 

--- a/client/src/components/animation/DiceRollOverlay.tsx
+++ b/client/src/components/animation/DiceRollOverlay.tsx
@@ -190,10 +190,14 @@ function DiceRollContent({ payload, animate }: { payload: DiceRollPayload; anima
 }
 
 /**
- * Starting-player contest (CR 103.1): one die per seat, a VS framing for the
- * two-player case, then a winner reveal once every die has settled — the
- * winner's panel lifts and glows gold, the others dim, and the caption resolves.
- * `winner` is the engine's authoritative pick, never recomputed here.
+ * Starting-player contest (CR 103.1): the d20 roll-off, rendered one round at a
+ * time. Round 0 rolls every seat; on a tie the tied-max group rerolls in the
+ * next round (the others drop out), until one seat is the unique high roller —
+ * the engine's authoritative `winner`. Rendering round-by-round (rather than
+ * collapsing to last-roll-per-player) keeps the winner the visible high roller
+ * of the round shown; the prior collapse could surface an eliminated seat's
+ * higher earlier die as if it beat the winner's lower reroll. `rounds` and
+ * `winner` come straight from the engine event — never recomputed here.
  */
 function ContestDice({
   payload,
@@ -207,13 +211,34 @@ function ContestDice({
   playerLabel: (playerId: number) => string;
 }) {
   const { t } = useTranslation();
+  // `rounds` is always present for the contest; fall back to a single round from
+  // `rolls` for safety (e.g. an older event mid-deploy).
+  const rounds = payload.rounds ?? [payload.rolls];
+  // Reduced motion / no-WebGL: there's no per-round throw to watch, so jump to
+  // the decisive final round (its high roller is the winner) instead of flashing
+  // through rounds on timers.
+  const [roundIndex, setRoundIndex] = useState(animate ? 0 : rounds.length - 1);
   const [settledCount, setSettledCount] = useState(0);
   const onDieSettle = useCallback(() => setSettledCount((c) => c + 1), []);
-  // Without animation the result is shown immediately, so treat it as settled.
-  const allSettled = !animate || settledCount >= payload.rolls.length;
+
+  const currentRolls = rounds[roundIndex] ?? [];
+  const isFinalRound = roundIndex >= rounds.length - 1;
+  const roundSettled = !animate || settledCount >= currentRolls.length;
+
+  // Walk the reroll rounds: once a non-final round's dice settle, hold a beat so
+  // the tie reads, then advance — the tied group rerolls (remounted by key).
+  useEffect(() => {
+    if (!animate || isFinalRound || !roundSettled) return;
+    const id = setTimeout(() => {
+      setRoundIndex((r) => r + 1);
+      setSettledCount(0);
+    }, 1100 / speedMultiplier);
+    return () => clearTimeout(id);
+  }, [animate, isFinalRound, roundSettled, speedMultiplier]);
 
   const winner = payload.winner;
   const winnerIsYou = winner === getPlayerId();
+  const revealed = isFinalRound && roundSettled && winner != null;
   const caption =
     winner != null
       ? winnerIsYou
@@ -224,77 +249,69 @@ function ContestDice({
   return (
     <div className="relative flex flex-col items-center gap-8 select-none">
       <motion.span
+        key={roundIndex}
         className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400"
         initial={{ opacity: 0, y: -8 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4 }}
       >
-        {t("diceRoll.rollingForFirst")}
+        {roundIndex === 0 ? t("diceRoll.rollingForFirst") : t("diceRoll.tieReroll")}
       </motion.span>
 
       <div className="flex items-center justify-center gap-8">
-        {payload.rolls.map((roll, i) => {
+        {currentRolls.map((roll) => {
           const isWinner = roll.playerId === winner;
-          const revealed = allSettled && winner != null;
           return (
-            <div key={roll.playerId} className="contents">
-              {/* `VS` separator between two contestants. */}
-              {i > 0 && (
-                <motion.span
-                  className="text-xl font-black italic tracking-tight text-slate-500"
-                  initial={{ opacity: 0, scale: 0.6 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: 0.2, duration: 0.3 }}
-                >
-                  {t("diceRoll.versus")}
-                </motion.span>
-              )}
-              <motion.div
-                className="flex flex-col items-center gap-3"
-                animate={{
-                  scale: revealed ? (isWinner ? 1.06 : 0.94) : 1,
-                  opacity: revealed && !isWinner ? 0.45 : 1,
-                }}
-                transition={{ type: "spring", stiffness: 260, damping: 22 }}
+            // Keyed by round+seat so advancing a round remounts the die → it
+            // physically rerolls (new 3D throw) for the tied group.
+            <motion.div
+              key={`${roundIndex}-${roll.playerId}`}
+              className="flex flex-col items-center gap-3"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{
+                opacity: revealed && !isWinner ? 0.45 : 1,
+                y: 0,
+                scale: revealed ? (isWinner ? 1.06 : 0.94) : 1,
+              }}
+              transition={{ type: "spring", stiffness: 260, damping: 22 }}
+            >
+              <span
+                className="text-base font-bold uppercase tracking-wide transition-colors"
+                style={{ color: revealed && isWinner ? `rgb(${GOLD})` : "#cbd5e1" }}
               >
-                <span
-                  className="text-base font-bold uppercase tracking-wide transition-colors"
-                  style={{ color: revealed && isWinner ? `rgb(${GOLD})` : "#cbd5e1" }}
-                >
-                  {playerLabel(roll.playerId)}
-                </span>
-                <DieFace
-                  animate={animate}
-                  accent={isWinner ? GOLD : NEUTRAL}
-                  emphasize={revealed && isWinner}
-                  value={roll.value}
-                  onSettle={onDieSettle}
-                >
-                  {(handleSettle) =>
-                    animate ? (
-                      <Suspense fallback={<DiePlaceholder label={String(roll.value)} />}>
-                        <Dice3D
-                          sides={payload.sides}
-                          result={roll.value}
-                          speedMultiplier={speedMultiplier}
-                          size={DIE_SIZE}
-                          onSettle={handleSettle}
-                        />
-                      </Suspense>
-                    ) : (
-                      <DiePlaceholder label={String(roll.value)} />
-                    )
-                  }
-                </DieFace>
-              </motion.div>
-            </div>
+                {playerLabel(roll.playerId)}
+              </span>
+              <DieFace
+                animate={animate}
+                accent={revealed && isWinner ? GOLD : NEUTRAL}
+                emphasize={revealed && isWinner}
+                value={roll.value}
+                onSettle={onDieSettle}
+              >
+                {(handleSettle) =>
+                  animate ? (
+                    <Suspense fallback={<DiePlaceholder label={String(roll.value)} />}>
+                      <Dice3D
+                        sides={payload.sides}
+                        result={roll.value}
+                        speedMultiplier={speedMultiplier}
+                        size={DIE_SIZE}
+                        onSettle={handleSettle}
+                      />
+                    </Suspense>
+                  ) : (
+                    <DiePlaceholder label={String(roll.value)} />
+                  )
+                }
+              </DieFace>
+            </motion.div>
           );
         })}
       </div>
 
       <div className="flex h-10 items-center">
         <AnimatePresence>
-          {allSettled && caption && (
+          {revealed && caption && (
             <motion.span
               className="text-4xl font-extrabold uppercase tracking-wider"
               style={{

--- a/client/src/game/__tests__/diceContest.test.ts
+++ b/client/src/game/__tests__/diceContest.test.ts
@@ -14,6 +14,12 @@ const coin = (player_id: number, won: boolean): GameEvent => ({
   data: { player_id, won },
 });
 const gameStarted: GameEvent = { type: "GameStarted" };
+// CR 103.1 starting-player contest: each round is a list of [playerId, value]
+// rolls; round 0 is every seat, later rounds are the tied-max reroll group.
+const contest = (rounds: [number, number][][], winner: number): GameEvent => ({
+  type: "StartingPlayerContest",
+  data: { rounds: rounds.map((rolls) => ({ rolls })), winner },
+});
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -27,45 +33,78 @@ afterEach(() => {
 });
 
 describe("flashStartingPlayerContest", () => {
-  it("builds a startingPlayer die payload using the engine's winner", () => {
-    flashStartingPlayerContest([die(0, 20, 17), die(1, 20, 9), gameStarted], 0);
+  it("builds a startingPlayer die payload from the engine contest event", () => {
+    flashStartingPlayerContest([contest([[[0, 17], [1, 9]]], 0), gameStarted], 0);
     const d = useUiStore.getState().diceRoll;
     expect(d).toMatchObject({ kind: "die", sides: 20, context: "startingPlayer", winner: 0 });
+    expect(d?.kind === "die" && d.rounds).toEqual([
+      [
+        { playerId: 0, value: 17 },
+        { playerId: 1, value: 9 },
+      ],
+    ]);
+    // `rolls` mirrors the decisive (final) round.
     expect(d?.kind === "die" && d.rolls).toEqual([
       { playerId: 0, value: 17 },
       { playerId: 1, value: 9 },
     ]);
   });
 
-  it("shows each player's FINAL roll after tie rerolls", () => {
-    // Round 1 ties at 11; round 2 decides. The overlay should show the decisive
-    // values (18 vs 4), not the tied first round.
+  it("preserves the per-round structure across a tie reroll", () => {
+    // Round 1 ties at 11; round 2 decides (18 vs 4). Each round is kept separate
+    // so within the decisive round the winner (18) is the visible high roller —
+    // no cross-round mixing (the bug this fixes).
     flashStartingPlayerContest(
-      [die(0, 20, 11), die(1, 20, 11), die(0, 20, 18), die(1, 20, 4), gameStarted],
+      [
+        contest(
+          [
+            [
+              [0, 11],
+              [1, 11],
+            ],
+            [
+              [0, 18],
+              [1, 4],
+            ],
+          ],
+          0,
+        ),
+        gameStarted,
+      ],
       0,
     );
     const d = useUiStore.getState().diceRoll;
+    expect(d?.kind === "die" && d.rounds).toEqual([
+      [
+        { playerId: 0, value: 11 },
+        { playerId: 1, value: 11 },
+      ],
+      [
+        { playerId: 0, value: 18 },
+        { playerId: 1, value: 4 },
+      ],
+    ]);
     expect(d?.kind === "die" && d.rolls).toEqual([
       { playerId: 0, value: 18 },
       { playerId: 1, value: 4 },
     ]);
   });
 
-  it("honors the engine winner even when it isn't the highest shown roll (lowest-seat fallback)", () => {
-    // Engine's all-tied-at-cap fallback picks the lowest seat; the winner is
-    // passed in, never recomputed from the rolls.
-    flashStartingPlayerContest([die(0, 20, 7), die(1, 20, 7), gameStarted], 0);
+  it("uses the engine winner, never recomputed from the rolls (lowest-seat fallback)", () => {
+    // The engine's all-tied-at-cap fallback picks the lowest seat; the winner is
+    // passed in, not derived from the shown dice.
+    flashStartingPlayerContest([contest([[[0, 7], [1, 7]]], 0), gameStarted], 0);
     expect(useUiStore.getState().diceRoll).toMatchObject({ winner: 0 });
   });
 
-  it("no-ops when the starter was chosen explicitly (no leading DieRolled)", () => {
+  it("no-ops when the starter was chosen explicitly (no contest event)", () => {
     flashStartingPlayerContest([gameStarted], 1);
     expect(useUiStore.getState().diceRoll).toBeNull();
   });
 
-  it("respects instant animation speed (0): no overlay", () => {
+  it("skips the overlay entirely at instant animation speed (0)", () => {
     usePreferencesStore.setState({ animationSpeedMultiplier: 0 });
-    flashStartingPlayerContest([die(0, 20, 5)], 0);
+    flashStartingPlayerContest([contest([[[0, 5], [1, 3]]], 0), gameStarted], 0);
     expect(useUiStore.getState().diceRoll).toBeNull();
   });
 });

--- a/client/src/game/diceContest.ts
+++ b/client/src/game/diceContest.ts
@@ -3,48 +3,36 @@ import { useUiStore } from "../stores/uiStore";
 
 type DieRolledEvent = Extract<GameEvent, { type: "DieRolled" }>;
 type CoinFlippedEvent = Extract<GameEvent, { type: "CoinFlipped" }>;
-
-/**
- * The leading run of consecutive `DieRolled` events — the starting-player
- * contest the engine emits before `GameStarted` (CR 103.1). Empty when the
- * starter was chosen explicitly (play/draw in setup), so callers no-op.
- */
-function leadingDieRolls(events: GameEvent[]): DieRolledEvent[] {
-  const out: DieRolledEvent[] = [];
-  for (const e of events) {
-    if (e.type !== "DieRolled") break;
-    out.push(e);
-  }
-  return out;
-}
-
-/**
- * The last roll per player — the decisive round after any tie rerolls — in
- * first-seen seat order. The engine emits every reroll round; for display we
- * show each player's final value.
- */
-function finalRollPerPlayer(rolls: DieRolledEvent[]): { playerId: PlayerId; value: number }[] {
-  const byPlayer = new Map<PlayerId, number>();
-  for (const r of rolls) byPlayer.set(r.data.player_id, r.data.result);
-  return [...byPlayer.entries()].map(([playerId, value]) => ({ playerId, value }));
-}
+type StartingPlayerContestEvent = Extract<GameEvent, { type: "StartingPlayerContest" }>;
 
 /**
  * Fire the starting-player contest overlay from a game-start event batch.
  *
- * `startingPlayer` is the engine's authoritative choice (the player taking turn
- * 1) — never recomputed on the frontend, so the highlighted winner always
- * matches engine state even in the all-tied-at-cap → lowest-seat fallback. The
- * `context` is supplied here (this code path IS the contest), not inferred from
- * event ordering. No-ops on an empty contest (explicit play/draw choice).
+ * The engine emits one `StartingPlayerContest` event carrying the full roll-off
+ * by round (round 0 = every seat; each later round = the previous round's
+ * tied-max group that rerolled) plus the authoritative winner (CR 103.1). The
+ * overlay renders it round-by-round so the winner is always the high roller of
+ * the round shown — fixing the prior last-roll-per-player collapse, which could
+ * surface an eliminated seat's higher earlier die as beating the winner's lower
+ * reroll. `startingPlayer` is the engine's pick (never recomputed here); it
+ * equals the event's `winner` by construction. No-ops when no contest ran
+ * (explicit play/draw choice).
  */
 export function flashStartingPlayerContest(events: GameEvent[], startingPlayer: PlayerId): void {
-  const rolls = leadingDieRolls(events);
-  if (rolls.length === 0) return;
+  const contest = events.find(
+    (e): e is StartingPlayerContestEvent => e.type === "StartingPlayerContest",
+  );
+  if (!contest) return;
+  const rounds = contest.data.rounds.map((round) =>
+    round.rolls.map(([playerId, value]) => ({ playerId, value })),
+  );
   useUiStore.getState().flashDiceRoll({
     kind: "die",
-    sides: rolls[0].data.sides,
-    rolls: finalRollPerPlayer(rolls),
+    // CR 103.1: the first-player roll-off is always a d20.
+    sides: 20,
+    // The decisive (final) round, kept for the no-rounds fallback and keying.
+    rolls: rounds[rounds.length - 1] ?? [],
+    rounds,
     context: "startingPlayer",
     winner: startingPlayer,
   });

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -201,6 +201,7 @@
   },
   "diceRoll": {
     "rollingForFirst": "Auswürfeln, wer beginnt",
+    "tieReroll": "Gleichstand — neu würfeln!",
     "versus": "VS",
     "skip": "Zum Überspringen tippen",
     "continue": "Zum Fortfahren tippen",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -201,6 +201,7 @@
   },
   "diceRoll": {
     "rollingForFirst": "Rolling for first player",
+    "tieReroll": "Tie — reroll!",
     "versus": "VS",
     "skip": "Tap to skip",
     "continue": "Tap to continue",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -201,6 +201,7 @@
   },
   "diceRoll": {
     "rollingForFirst": "Tirada para ver quién empieza",
+    "tieReroll": "Empate: ¡a tirar de nuevo!",
     "versus": "VS",
     "skip": "Toca para omitir",
     "continue": "Toca para continuar",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -201,6 +201,7 @@
   },
   "diceRoll": {
     "rollingForFirst": "Tirage pour savoir qui commence",
+    "tieReroll": "Égalité — on relance !",
     "versus": "VS",
     "skip": "Toucher pour passer",
     "continue": "Toucher pour continuer",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -201,6 +201,7 @@
   },
   "diceRoll": {
     "rollingForFirst": "Tiro per stabilire chi inizia",
+    "tieReroll": "Pareggio — si ritira!",
     "versus": "VS",
     "skip": "Tocca per saltare",
     "continue": "Tocca per continuare",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -201,6 +201,7 @@
   },
   "diceRoll": {
     "rollingForFirst": "Rzut o pierwszego gracza",
+    "tieReroll": "Remis — rzut ponownie!",
     "versus": "VS",
     "skip": "Dotknij, aby pominąć",
     "continue": "Dotknij, aby kontynuować",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -201,6 +201,7 @@
   },
   "diceRoll": {
     "rollingForFirst": "Rolagem para ver quem começa",
+    "tieReroll": "Empate — rolar de novo!",
     "versus": "VS",
     "skip": "Toque para pular",
     "continue": "Toque para continuar",

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -176,7 +176,10 @@ export const useGameStore = create<GameStore>()(
       // play/draw choice. `current_starting_player` is the engine's pick — never
       // recomputed from the rolls on the frontend.
       const initEvents = initResult.events ?? [];
-      const rolledStart = initEvents[0]?.type === "DieRolled";
+      // The engine emits a single StartingPlayerContest event (round structure +
+      // winner) at the head of the game-start batch when it ran a roll-off
+      // (random starter); absent for an explicit play/draw choice.
+      const rolledStart = initEvents[0]?.type === "StartingPlayerContest";
       const startingContest = rolledStart
         ? {
             events: initEvents,

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -18,11 +18,19 @@ export type DiceRollPayload =
       kind: "die";
       /** d-sides (e.g. 20 for the first-player contest, dN for card rolls). */
       sides: number;
-      /** One entry per physical die shown — one per player for the contest. */
+      /** One entry per physical die shown. For the contest this is the FINAL
+       *  (decisive) round — kept for the no-rounds fallback and overlay keying. */
       rolls: { playerId: PlayerId; value: number }[];
       context: "startingPlayer" | "ability";
       /** Starting-player contest: the high roller who takes the first turn. */
       winner?: PlayerId;
+      /** Starting-player contest only (CR 103.1): the roll-off by round. Round 0
+       *  is every seat; each later round is the previous round's tied-max group
+       *  that rerolled. Rendered round-by-round so the winner is always the high
+       *  roller of the round shown — never conflated across rounds (the bug that
+       *  made an eliminated seat's higher earlier die look like it beat the
+       *  winner's lower reroll). Absent for in-game `ability` rolls. */
+      rounds?: { playerId: PlayerId; value: number }[][];
     }
   | {
       kind: "coin";

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::types::ability::{EffectKind, KeywordAction, TargetRef};
 use crate::types::actions::GameAction;
-use crate::types::events::{BendingType, GameEvent, ManaTapState, PlayerActionKind};
+use crate::types::events::{BendingType, ContestRound, GameEvent, ManaTapState, PlayerActionKind};
 use crate::types::game_state::{
     ActionResult, AutoPassMode, AutoPassRequest, CastOfferKind, ConvokeMode, CostResume, GameState,
     PayCostKind, RetargetScope, StackEntry, StackEntryKind, WaitingFor,
@@ -5590,56 +5590,28 @@ pub fn new_game(seed: u64) -> GameState {
 /// broken deterministically by lowest seat index (see `start_game`).
 const FIRST_PLAYER_CONTEST_MAX_ROUNDS: usize = 16;
 
-/// Start game with mulligan flow. If no cards in libraries, skips mulligan.
+/// CR 103.1: run the starting-player roll-off and capture its round structure.
 ///
-/// CR 103.1: At the start of game 1 of a match the players determine who takes
-/// the first turn "using any mutually agreeable method (flipping a coin,
-/// rolling dice, etc.)". This engine models that determination as an
-/// authoritative d20 high-roll contest — one d20 per seat using the game's
-/// seeded RNG (CR 706, rolling a die) — with ties rerolled among the tied top
-/// group. NOTE ON FIDELITY: the literal CR 103.1 sequence is "contest winner
-/// *chooses* who takes the first turn"; this engine collapses that to "contest
-/// winner *becomes* the starting player" (it does not present a play/draw
-/// choice here), an existing, accepted simplification — the annotation does not
-/// claim the choose-step is implemented. Subsequent games in a multi-game match
-/// route through `match_flow::start_next_game`, which uses `next_game_chooser`
-/// instead, so this function is always the game-1 path.
+/// `roll_round` is called once per round with the current contender set (in
+/// seat order) and returns each contender's d20 result. Round 1 = all seats;
+/// each later round = the prior round's tied-max group (CR 103.1 reroll).
+/// Returns the per-round structure and the winner: the unique max of the final
+/// round, or the lowest seat index when still tied at
+/// `FIRST_PLAYER_CONTEST_MAX_ROUNDS`.
 ///
-/// DETERMINISM: the contest draws only from `state.rng` (the seeded
-/// `ChaCha20Rng`), never thread/global RNG, so replays and AI search stay
-/// deterministic. This consumes a different number of RNG draws than the
-/// previous single `random_range(0..len)` pick, so a given seed now produces a
-/// different downstream sequence — an intentional, accepted determinism shift
-/// (verified: no in-repo test or replay fixture pins exact post-start RNG
-/// state).
-///
-/// Callers that need a deterministic starter (tests, fixed scenarios) must use
-/// `start_game_with_starting_player` directly — that path runs no contest and
-/// emits no `DieRolled` events.
-pub fn start_game(state: &mut GameState) -> ActionResult {
-    if state.seat_order.is_empty() {
-        return start_game_with_starting_player(state, PlayerId(0));
-    }
-
-    // CR 103.1 / CR 706: roll one d20 per seat; the high roller becomes the
-    // starting player. Emit a DieRolled event for every roll (including reroll
-    // rounds) so the contest can be surfaced/animated downstream.
-    let mut dice_events: Vec<GameEvent> = Vec::new();
-
-    let roll_for =
-        |state: &mut GameState, dice_events: &mut Vec<GameEvent>, seat: PlayerId| -> u8 {
-            let result = state.rng.random_range(1..=20u8);
-            dice_events.push(GameEvent::DieRolled {
-                player_id: seat,
-                sides: 20,
-                result,
-            });
-            result
-        };
+/// The selection logic (contenders narrowing, max/top filtering, bounded cap,
+/// lowest-seat fallback) is identical to the prior inline loop; the only change
+/// is that each round's rolls are captured into a `ContestRound` instead of
+/// pushed as flat `DieRolled` events.
+fn build_contest_rounds(
+    seat_order: &[PlayerId],
+    mut roll_round: impl FnMut(&[PlayerId]) -> Vec<(PlayerId, u8)>,
+) -> (Vec<ContestRound>, PlayerId) {
+    let mut rounds: Vec<ContestRound> = Vec::new();
 
     // `contenders` is the set of seats still in the running. It starts as every
     // seat and, after each tie, narrows to the tied top group only.
-    let mut contenders: Vec<PlayerId> = state.seat_order.clone();
+    let mut contenders: Vec<PlayerId> = seat_order.to_vec();
     let mut starting_player: Option<PlayerId> = None;
 
     // BOUNDED tie loop. Each iteration rolls every contender; a unique high
@@ -5650,16 +5622,14 @@ pub fn start_game(state: &mut GameState) -> ActionResult {
     // shrinking. If the cap is reached while still tied, the tie is broken
     // deterministically by lowest seat index below — the engine can never hang.
     for _round in 0..FIRST_PLAYER_CONTEST_MAX_ROUNDS {
-        let rolls: Vec<(PlayerId, u8)> = contenders
-            .iter()
-            .map(|&seat| (seat, roll_for(state, &mut dice_events, seat)))
-            .collect();
+        let rolls: Vec<(PlayerId, u8)> = roll_round(&contenders);
         let max_roll = rolls.iter().map(|&(_, r)| r).max().expect("non-empty");
         let top: Vec<PlayerId> = rolls
             .iter()
             .filter(|&&(_, r)| r == max_roll)
             .map(|&(seat, _)| seat)
             .collect();
+        rounds.push(ContestRound { rolls });
         if top.len() == 1 {
             starting_player = Some(top[0]);
             break;
@@ -5677,10 +5647,70 @@ pub fn start_game(state: &mut GameState) -> ActionResult {
             .expect("contenders is always non-empty")
     });
 
+    (rounds, starting_player)
+}
+
+/// Start game with mulligan flow. If no cards in libraries, skips mulligan.
+///
+/// CR 103.1: At the start of game 1 of a match the players determine who takes
+/// the first turn "using any mutually agreeable method (flipping a coin,
+/// rolling dice, etc.)". This engine models that determination as an
+/// authoritative d20 high-roll contest — one d20 per seat using the game's
+/// seeded RNG (CR 706, rolling a die) — with ties rerolled among the tied top
+/// group. NOTE ON FIDELITY: the literal CR 103.1 sequence is "contest winner
+/// *chooses* who takes the first turn"; this engine collapses that to "contest
+/// winner *becomes* the starting player" (it does not present a play/draw
+/// choice here), an existing, accepted simplification — the annotation does not
+/// claim the choose-step is implemented. Subsequent games in a multi-game match
+/// route through `match_flow::start_next_game`, which uses `next_game_chooser`
+/// instead, so this function is always the game-1 path.
+///
+/// The contest is surfaced as a single authoritative
+/// `GameEvent::StartingPlayerContest` carrying the full round structure (round
+/// 1 = all seats, each later round = the prior round's tied-max reroll group)
+/// plus the engine's authoritative `winner`, so downstream consumers render the
+/// contest round by round without re-deriving anything. It is inserted at the
+/// front of the result, ahead of `GameStarted` → `TurnStarted`. This replaces
+/// the prior flat per-roll `DieRolled` batch; in-game die rolls still emit
+/// `DieRolled`.
+///
+/// DETERMINISM: the contest draws only from `state.rng` (the seeded
+/// `ChaCha20Rng`), never thread/global RNG, so replays and AI search stay
+/// deterministic. The RNG draw count and order are EXACTLY as before — one
+/// `random_range(1..=20)` per contender per round, in seat order — so this
+/// representation change introduces ZERO determinism shift relative to the
+/// prior `DieRolled`-batch implementation. (It still differs from the original
+/// single `random_range(0..len)` pick that predated the contest, an earlier,
+/// accepted shift.)
+///
+/// Callers that need a deterministic starter (tests, fixed scenarios) must use
+/// `start_game_with_starting_player` directly — that path runs no contest and
+/// emits no `StartingPlayerContest` event.
+pub fn start_game(state: &mut GameState) -> ActionResult {
+    if state.seat_order.is_empty() {
+        return start_game_with_starting_player(state, PlayerId(0));
+    }
+
+    // CR 103.1 / CR 706: roll one d20 per seat; the high roller becomes the
+    // starting player. Draw order/count is identical to the prior
+    // implementation — one `random_range(1..=20)` per contender, in seat order.
+    let seat_order = state.seat_order.clone();
+    let (rounds, starting_player) = build_contest_rounds(&seat_order, |contenders| {
+        contenders
+            .iter()
+            .map(|&seat| (seat, state.rng.random_range(1..=20u8)))
+            .collect()
+    });
+
     let mut result = start_game_with_starting_player(state, starting_player);
-    // Sequence: all DieRolled (every round) → GameStarted → TurnStarted.
-    dice_events.append(&mut result.events);
-    result.events = dice_events;
+    // CR 103.1: StartingPlayerContest → GameStarted → TurnStarted.
+    result.events.insert(
+        0,
+        GameEvent::StartingPlayerContest {
+            rounds,
+            winner: starting_player,
+        },
+    );
     result
 }
 
@@ -21288,37 +21318,39 @@ mod mdfc_land_tests {
 
     // --- First-player d20 contest (start_game) -------------------------------
 
-    /// Collect the d20 contest rolls (seat → result) from an ActionResult's
-    /// leading `DieRolled` batch, preserving emission order.
-    fn contest_rolls(result: &ActionResult) -> Vec<(PlayerId, u8)> {
-        result
-            .events
-            .iter()
-            .filter_map(|e| match e {
-                GameEvent::DieRolled {
-                    player_id,
-                    sides: 20,
-                    result,
-                } => Some((*player_id, *result)),
-                _ => None,
-            })
-            .collect()
+    /// Extract the single `StartingPlayerContest` event's (rounds, winner) from
+    /// an ActionResult. Panics if absent or duplicated — the contest path emits
+    /// exactly one such event.
+    fn contest_event(result: &ActionResult) -> (Vec<ContestRound>, PlayerId) {
+        let mut found = result.events.iter().filter_map(|e| match e {
+            GameEvent::StartingPlayerContest { rounds, winner } => Some((rounds.clone(), *winner)),
+            _ => None,
+        });
+        let event = found.next().expect("a StartingPlayerContest event");
+        assert!(
+            found.next().is_none(),
+            "exactly one StartingPlayerContest event"
+        );
+        event
     }
 
-    /// CR 103.1 / CR 706: a seeded contest emits one d20 `DieRolled` per seat
-    /// (when there is no tie) and the high roller becomes the starting player.
+    /// CR 103.1 / CR 706: a seeded contest with no tie emits a single round
+    /// with one d20 per seat and the high roller becomes the starting player.
     #[test]
     fn start_game_contest_emits_d20_per_seat_and_picks_high_roller() {
         let mut state = GameState::new(FormatConfig::standard(), 2, 7);
         let result = start_game(&mut state);
-        let rolls = contest_rolls(&result);
+        let (rounds, winner) = contest_event(&result);
 
-        // No tie at this seed → exactly one roll per seat.
-        assert_eq!(rolls.len(), 2, "no tie → one roll per seat");
+        // No tie at this seed → exactly one round, one roll per seat.
+        assert_eq!(rounds.len(), 1, "no tie → single round");
+        let rolls = &rounds[0].rolls;
+        assert_eq!(rolls.len(), 2, "one roll per seat");
         assert_ne!(rolls[0].1, rolls[1].1, "seed 7 should not tie");
         let max_roll = rolls.iter().map(|&(_, r)| r).max().unwrap();
         // The winner is the seat that rolled the max.
-        let winner = rolls.iter().find(|&&(_, r)| r == max_roll).unwrap().0;
+        let argmax = rolls.iter().find(|&&(_, r)| r == max_roll).unwrap().0;
+        assert_eq!(winner, argmax, "winner == argmax of the round");
         assert_eq!(
             state.current_starting_player, winner,
             "high roller becomes the starting player"
@@ -21327,12 +21359,17 @@ mod mdfc_land_tests {
         assert!(rolls.iter().all(|&(_, r)| (1..=20).contains(&r)));
     }
 
-    /// Event sequencing: all `DieRolled` precede `GameStarted`, which precedes
-    /// `TurnStarted`.
+    /// Event sequencing: the single `StartingPlayerContest` precedes
+    /// `GameStarted`, which precedes `TurnStarted`.
     #[test]
     fn start_game_contest_sequences_dice_before_game_started() {
         let mut state = GameState::new(FormatConfig::standard(), 2, 7);
         let result = start_game(&mut state);
+        let contest = result
+            .events
+            .iter()
+            .position(|e| matches!(e, GameEvent::StartingPlayerContest { .. }))
+            .expect("StartingPlayerContest present");
         let first_game_started = result
             .events
             .iter()
@@ -21343,14 +21380,9 @@ mod mdfc_land_tests {
             .iter()
             .position(|e| matches!(e, GameEvent::TurnStarted { .. }))
             .expect("TurnStarted present");
-        let last_die = result
-            .events
-            .iter()
-            .rposition(|e| matches!(e, GameEvent::DieRolled { .. }))
-            .expect("DieRolled present");
         assert!(
-            last_die < first_game_started,
-            "all DieRolled must precede GameStarted"
+            contest < first_game_started,
+            "StartingPlayerContest must precede GameStarted"
         );
         assert!(
             first_game_started < first_turn_started,
@@ -21358,20 +21390,18 @@ mod mdfc_land_tests {
         );
     }
 
-    /// Tie path: when the first round ties, a reroll occurs (more rolls than
-    /// seats) and the contest still resolves to a unique starting player.
+    /// Tie path: when the first round ties, a reroll round occurs and each
+    /// later round's seat set is a subset of the prior round's tied-max group.
     #[test]
     fn start_game_contest_tie_triggers_reroll_and_resolves() {
-        // Scan seeds for one whose first round of two d20s ties, forcing a
-        // reroll. This proves the reroll branch is exercised end-to-end.
+        // Scan seeds for one whose contest needs more than one round (a tie at
+        // the round's max forces a reroll). Proves the reroll branch end-to-end.
         let mut tie_seed = None;
         for seed in 0..2000u64 {
             let mut probe = GameState::new(FormatConfig::standard(), 2, seed);
             let result = start_game(&mut probe);
-            let rolls = contest_rolls(&result);
-            // A tie on the first round means seat 0 and seat 1 rolled equal,
-            // producing a third (reroll) DieRolled event.
-            if rolls.len() > 2 {
+            let (rounds, _) = contest_event(&result);
+            if rounds.len() > 1 {
                 tie_seed = Some(seed);
                 break;
             }
@@ -21379,80 +21409,196 @@ mod mdfc_land_tests {
         let seed = tie_seed.expect("a tie within 2000 seeds (P(tie) = 1/20)");
         let mut state = GameState::new(FormatConfig::standard(), 2, seed);
         let result = start_game(&mut state);
-        let rolls = contest_rolls(&result);
-        assert!(
-            rolls.len() > 2,
-            "tie seed must produce reroll events beyond the two initial rolls"
-        );
+        let (rounds, winner) = contest_event(&result);
+        assert!(rounds.len() > 1, "tie seed must produce a reroll round");
+        // CR 103.1: each later round rerolls exactly the prior round's tied-max
+        // group, so its seat set ⊆ that group.
+        for window in rounds.windows(2) {
+            let (prev, next) = (&window[0], &window[1]);
+            let prev_max = prev.rolls.iter().map(|&(_, r)| r).max().unwrap();
+            let prev_top: Vec<PlayerId> = prev
+                .rolls
+                .iter()
+                .filter(|&&(_, r)| r == prev_max)
+                .map(|&(s, _)| s)
+                .collect();
+            for &(seat, _) in &next.rolls {
+                assert!(
+                    prev_top.contains(&seat),
+                    "reroll round seats must be a subset of the prior tied-max group"
+                );
+            }
+        }
         // Resolves to exactly one starting player that is a valid seat.
+        assert_eq!(state.current_starting_player, winner);
         assert!(
-            state.seat_order.contains(&state.current_starting_player),
+            state.seat_order.contains(&winner),
             "starting player is a valid seat after a reroll"
         );
         exactly_one_game_started(&result);
     }
 
-    /// N-seat (3–4 player) contest picks the global max roller.
+    /// CR 103.1: high roller wins — for 3- and 4-player contests across many
+    /// seeds, the winner is the unique-max roller of the FINAL round's rolls.
     #[test]
-    fn start_game_contest_three_and_four_seats_pick_global_max() {
+    fn start_game_contest_high_roller_wins_three_and_four_seats() {
         for player_count in [3u8, 4] {
-            let mut state = GameState::new(FormatConfig::commander(), player_count, 11);
-            let result = start_game(&mut state);
-            let rolls = contest_rolls(&result);
-            assert!(
-                rolls.len() >= player_count as usize,
-                "at least one roll per seat"
-            );
-            // The first `player_count` rolls are the opening round (one per seat).
-            let opening = &rolls[..player_count as usize];
-            let max_roll = opening.iter().map(|&(_, r)| r).max().unwrap();
-            // Count how many seats tied at the opening max.
-            let top: Vec<PlayerId> = opening
-                .iter()
-                .filter(|&&(_, r)| r == max_roll)
-                .map(|&(s, _)| s)
-                .collect();
-            if top.len() == 1 {
-                // Clean win: starting player is the unique opening max roller.
+            for seed in 0..500u64 {
+                let mut state = GameState::new(FormatConfig::commander(), player_count, seed);
+                let result = start_game(&mut state);
+                let (rounds, winner) = contest_event(&result);
+                let final_round = rounds.last().expect("at least one round");
+                let max_roll = final_round.rolls.iter().map(|&(_, r)| r).max().unwrap();
+                let top: Vec<PlayerId> = final_round
+                    .rolls
+                    .iter()
+                    .filter(|&&(_, r)| r == max_roll)
+                    .map(|&(s, _)| s)
+                    .collect();
+                // ChaCha20 never reaches the all-tie cap within these seeds, so
+                // the final round always has a unique max == winner.
                 assert_eq!(
-                    state.current_starting_player, top[0],
-                    "global max roller wins when there is no opening tie"
+                    top.len(),
+                    1,
+                    "final round has a unique max (no cap fallback) at seed {seed}"
                 );
-            } else {
-                // Opening tie → reroll happened; winner is still a valid seat.
-                assert!(rolls.len() > player_count as usize, "tie forced a reroll");
-                assert!(state.seat_order.contains(&state.current_starting_player));
+                assert_eq!(
+                    winner, top[0],
+                    "winner is the unique-max roller of the final round"
+                );
+                assert_eq!(state.current_starting_player, winner);
             }
         }
     }
 
-    /// The tie loop is BOUNDED: it can roll at most one initial round plus
-    /// FIRST_PLAYER_CONTEST_MAX_ROUNDS reroll rounds before falling back to the
-    /// lowest seat index. With at most `seats` rolls per round, the total
-    /// `DieRolled` count can never exceed `seats * (MAX_ROUNDS + 1)` — so the
-    /// engine can never hang at game start. (Forcing a *true* all-tie out of
-    /// ChaCha20 is impractical, so this asserts the structural bound that makes
-    /// the lowest-seat fallback reachable rather than the fallback firing.)
+    /// CR 103.1: round-structure invariants across player counts and seeds —
+    /// round 1 covers exactly the seat order, each later round's seat set equals
+    /// the prior round's tied-max group, and the winner is the final round's
+    /// unique max.
+    #[test]
+    fn start_game_contest_round_structure_invariants() {
+        for player_count in [2u8, 3, 4] {
+            for seed in 0..300u64 {
+                let format = if player_count == 2 {
+                    FormatConfig::standard()
+                } else {
+                    FormatConfig::commander()
+                };
+                let mut state = GameState::new(format, player_count, seed);
+                let seat_order = state.seat_order.clone();
+                let result = start_game(&mut state);
+                let (rounds, winner) = contest_event(&result);
+                assert!(!rounds.is_empty(), "at least one round");
+
+                // Round 1 covers exactly the seat order, in seat order.
+                let round1_seats: Vec<PlayerId> = rounds[0].rolls.iter().map(|&(s, _)| s).collect();
+                assert_eq!(
+                    round1_seats, seat_order,
+                    "round 1 rolls cover exactly the seat order"
+                );
+
+                // Each later round == set of seats tied at max of the prior round.
+                for window in rounds.windows(2) {
+                    let (prev, next) = (&window[0], &window[1]);
+                    let prev_max = prev.rolls.iter().map(|&(_, r)| r).max().unwrap();
+                    let mut prev_top: Vec<PlayerId> = prev
+                        .rolls
+                        .iter()
+                        .filter(|&&(_, r)| r == prev_max)
+                        .map(|&(s, _)| s)
+                        .collect();
+                    let mut next_seats: Vec<PlayerId> =
+                        next.rolls.iter().map(|&(s, _)| s).collect();
+                    prev_top.sort();
+                    next_seats.sort();
+                    assert_eq!(
+                        next_seats, prev_top,
+                        "reroll round seat set == prior round's tied-max group"
+                    );
+                }
+
+                // Winner == unique max of the final round (no all-tie cap hit
+                // within these seeds).
+                let final_round = rounds.last().unwrap();
+                let max_roll = final_round.rolls.iter().map(|&(_, r)| r).max().unwrap();
+                let top: Vec<PlayerId> = final_round
+                    .rolls
+                    .iter()
+                    .filter(|&&(_, r)| r == max_roll)
+                    .map(|&(s, _)| s)
+                    .collect();
+                assert_eq!(top.len(), 1, "final round has a unique max");
+                assert_eq!(winner, top[0]);
+                assert_eq!(state.current_starting_player, winner);
+            }
+        }
+    }
+
+    /// The tie loop is BOUNDED: at most FIRST_PLAYER_CONTEST_MAX_ROUNDS rounds
+    /// before the lowest-seat fallback. (Forcing a *true* all-tie out of
+    /// ChaCha20 is impractical, so this asserts the structural round bound that
+    /// makes the fallback reachable rather than the fallback firing.)
     #[test]
     fn start_game_contest_is_bounded_no_hang() {
         for seed in 0..200u64 {
             for player_count in [2u8, 3, 4] {
                 let mut state = GameState::new(FormatConfig::commander(), player_count, seed);
                 let result = start_game(&mut state);
-                let rolls = contest_rolls(&result);
-                let upper = player_count as usize * (FIRST_PLAYER_CONTEST_MAX_ROUNDS + 1);
+                let (rounds, winner) = contest_event(&result);
                 assert!(
-                    rolls.len() <= upper,
-                    "contest must terminate within the bounded reroll cap (got {} rolls, cap {upper})",
-                    rolls.len()
+                    rounds.len() <= FIRST_PLAYER_CONTEST_MAX_ROUNDS,
+                    "contest must terminate within the bounded reroll cap (got {} rounds, cap {FIRST_PLAYER_CONTEST_MAX_ROUNDS})",
+                    rounds.len()
                 );
-                assert!(state.seat_order.contains(&state.current_starting_player));
+                assert!(state.seat_order.contains(&winner));
+                assert_eq!(state.current_starting_player, winner);
             }
         }
     }
 
+    /// `build_contest_rounds` with SCRIPTED rolls (no RNG): a unique max in a
+    /// later round breaks an earlier tie, and an all-tie path falls back to the
+    /// lowest seat index. The one allowed hand-constructed contest test.
+    #[test]
+    fn build_contest_rounds_scripted_paths() {
+        let seats = [PlayerId(0), PlayerId(1), PlayerId(2)];
+
+        // Round 1: seats 0,1,2 roll 20,20,5 → tie among 0,1.
+        // Round 2: seats 0,1 roll 20,3 → seat 0 wins.
+        let scripted = [
+            vec![(PlayerId(0), 20u8), (PlayerId(1), 20), (PlayerId(2), 5)],
+            vec![(PlayerId(0), 20u8), (PlayerId(1), 3)],
+        ];
+        let mut idx = 0;
+        let (rounds, winner) = build_contest_rounds(&seats, |contenders| {
+            let round = scripted[idx].clone();
+            // The closure receives exactly the contenders we scripted for.
+            let seats_in: Vec<PlayerId> = round.iter().map(|&(s, _)| s).collect();
+            assert_eq!(contenders.to_vec(), seats_in);
+            idx += 1;
+            round
+        });
+        assert_eq!(rounds.len(), 2, "tie forces exactly one reroll round");
+        assert_eq!(rounds[0].rolls.len(), 3);
+        assert_eq!(rounds[1].rolls.len(), 2, "reroll only the tied group");
+        assert_eq!(winner, PlayerId(0));
+
+        // All-tie path: every round ties the full group → cap reached → lowest
+        // seat index (seat 1 here) wins.
+        let tie_seats = [PlayerId(2), PlayerId(1)];
+        let (rounds, winner) = build_contest_rounds(&tie_seats, |contenders| {
+            contenders.iter().map(|&s| (s, 7u8)).collect()
+        });
+        assert_eq!(
+            rounds.len(),
+            FIRST_PLAYER_CONTEST_MAX_ROUNDS,
+            "all-tie runs to the cap"
+        );
+        assert_eq!(winner, PlayerId(1), "lowest seat index wins on cap");
+    }
+
     /// Explicit `start_game_with_starting_player` runs no contest and emits NO
-    /// `DieRolled` events.
+    /// `StartingPlayerContest` event.
     #[test]
     fn start_game_with_explicit_player_emits_no_dice() {
         let mut state = GameState::new(FormatConfig::standard(), 2, 7);
@@ -21461,13 +21607,13 @@ mod mdfc_land_tests {
             !result
                 .events
                 .iter()
-                .any(|e| matches!(e, GameEvent::DieRolled { .. })),
-            "explicit starting player path must emit no contest dice"
+                .any(|e| matches!(e, GameEvent::StartingPlayerContest { .. })),
+            "explicit starting player path must emit no contest event"
         );
         assert_eq!(state.current_starting_player, PlayerId(1));
     }
 
-    /// Empty seat order keeps the PlayerId(0) fast path and emits no dice.
+    /// Empty seat order keeps the PlayerId(0) fast path and emits no contest.
     #[test]
     fn start_game_empty_seat_order_no_contest() {
         let mut state = GameState::new(FormatConfig::standard(), 2, 7);
@@ -21477,8 +21623,8 @@ mod mdfc_land_tests {
             !result
                 .events
                 .iter()
-                .any(|e| matches!(e, GameEvent::DieRolled { .. })),
-            "empty seat order must not roll any dice"
+                .any(|e| matches!(e, GameEvent::StartingPlayerContest { .. })),
+            "empty seat order must emit no contest event"
         );
         assert_eq!(state.current_starting_player, PlayerId(0));
     }

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -89,6 +89,10 @@ fn categorize(event: &GameEvent) -> LogCategory {
         | GameEvent::GameOver { .. }
         | GameEvent::PlayerLost { .. }
         | GameEvent::PlayerEliminated { .. }
+        // CR 103.1: grouped with the setup event MulliganStarted under `Game`
+        // (not `Special` like in-game DieRolled) — it is game setup, not a
+        // CR 706 die-roll log entry.
+        | GameEvent::StartingPlayerContest { .. }
         | GameEvent::MulliganStarted => LogCategory::Game,
 
         GameEvent::TurnStarted { .. }
@@ -750,6 +754,13 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
 
         GameEvent::MulliganStarted => vec![text("Mulligan phase begins")],
 
+        // CR 103.1: concise one-line summary of the starting-player roll-off;
+        // round-by-round detail lives in the structured event for the UI.
+        GameEvent::StartingPlayerContest { winner, .. } => vec![
+            player_seg(state, *winner),
+            text(" wins the roll to take the first turn"),
+        ],
+
         GameEvent::GameOver { winner } => match winner {
             Some(pid) => vec![
                 text("Game over — "),
@@ -1239,6 +1250,12 @@ mod tests {
                 player_id: PlayerId(0),
                 sides: 20,
                 result: 17,
+            },
+            GameEvent::StartingPlayerContest {
+                rounds: vec![crate::types::events::ContestRound {
+                    rolls: vec![(PlayerId(0), 17), (PlayerId(1), 5)],
+                }],
+                winner: PlayerId(0),
             },
             GameEvent::CoinFlipped {
                 player_id: PlayerId(0),

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -346,6 +346,9 @@ pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]
             | GameEvent::ClassLevelGained { .. }
             | GameEvent::DieRolled { .. }
             | GameEvent::CoinFlipped { .. }
+            // CR 103.1: starting-player contest carries no public-state delta;
+            // it is rendered from the structured event log, not derived state.
+            | GameEvent::StartingPlayerContest { .. }
             | GameEvent::RoomEntered { .. }
             | GameEvent::RoomDoorUnlocked { .. }
             | GameEvent::BecomesPlotted { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -564,6 +564,8 @@ fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
         }
         GameEvent::MonarchChanged { .. } => push(TriggerEventKey::MonarchOrInitiative),
         GameEvent::CityBlessingGained { .. } => {}
+        // CR 103.1: setup determination, not a CR 706 die-roll trigger source.
+        GameEvent::StartingPlayerContest { .. } => {}
         GameEvent::DieRolled { .. } | GameEvent::CoinFlipped { .. } => {
             push(TriggerEventKey::DieOrCoin);
         }

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -829,7 +829,8 @@ fn count_matching_trigger_event_subjects(
         | GameEvent::CascadeMissed { .. }
         | GameEvent::DebugActionUsed { .. }
         | GameEvent::DebugPermissionGranted { .. }
-        | GameEvent::DebugPermissionRevoked { .. } => 0,
+        | GameEvent::DebugPermissionRevoked { .. }
+        | GameEvent::StartingPlayerContest { .. } => 0,
     }
 }
 

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -99,6 +99,15 @@ pub enum ClashResult {
     Tied,
 }
 
+/// CR 103.1 / CR 706: one round of the starting-player d20 roll-off.
+/// `rolls` are in seat order; round 1 contains every seat, and each later
+/// round contains exactly the previous round's tied-max group (CR 103.1
+/// reroll). The high roller of the final round becomes the starting player.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContestRound {
+    pub rolls: Vec<(PlayerId, u8)>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum GameEvent {
@@ -530,6 +539,18 @@ pub enum GameEvent {
         player_id: PlayerId,
         sides: u8,
         result: u8,
+    },
+    /// CR 103.1 / CR 706: The game-1 starting-player roll-off, emitted as one
+    /// authoritative structured event so the contest can be rendered round by
+    /// round (including tie rerolls) with no downstream re-derivation. `rounds`
+    /// preserves the round boundaries the engine computes; `winner` is the
+    /// engine's authoritative starting player (unique max of the final round, or
+    /// the lowest-seat fallback when tied at the reroll cap). Replaces the prior
+    /// flat per-roll `DieRolled` batch on the starting-player contest path; in-game
+    /// die rolls still emit `DieRolled`.
+    StartingPlayerContest {
+        rounds: Vec<ContestRound>,
+        winner: PlayerId,
     },
     /// CR 705: A coin was flipped.
     CoinFlipped {

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -141,10 +141,10 @@ async fn switch_game_spectator_slot(
 /// Build the `GameStarted` message for a single seat.
 ///
 /// `events` carries the engine's start-of-game events (the d20 first-player
-/// contest's `DieRolled` batch). Only the INITIAL post-start fan-out
-/// (`build_game_started_messages`) passes a non-empty batch; late joiners and
-/// reconnects pass an empty `Vec` so they never re-see the contest dice. The
-/// full batch goes to every seat unchanged — rolls are public (no
+/// contest's `StartingPlayerContest` event). Only the INITIAL post-start
+/// fan-out (`build_game_started_messages`) passes a non-empty batch; late
+/// joiners and reconnects pass an empty `Vec` so they never re-see the contest.
+/// The events go to every seat unchanged — the contest is public (no
 /// `visibility.rs` redaction), so this deliberately does NOT apply the
 /// `is_actor` gating used for `legal_actions`.
 fn build_game_started_message(
@@ -193,9 +193,9 @@ fn build_game_started_message(
 }
 
 /// Initial post-start fan-out. DRAINS `session.start_events` so the first-player
-/// contest dice are sent exactly once — every subsequent `GameStarted` build
-/// (late joiners, reconnects) sees an empty batch and never re-shows the dice.
-/// Every seat receives the full contest batch (public; not actor-gated).
+/// contest is sent exactly once — every subsequent `GameStarted` build
+/// (late joiners, reconnects) sees an empty batch and never re-shows the
+/// contest. Every seat receives the contest event (public; not actor-gated).
 fn build_game_started_messages(session: &mut GameSession) -> Vec<(PlayerId, ServerMessage)> {
     let start_events = std::mem::take(&mut session.start_events);
     (0..session.player_count)

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -298,11 +298,11 @@ pub enum ServerMessage {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         player_token: Option<String>,
         /// Engine events produced by `start_game` — currently the d20
-        /// first-player contest (`DieRolled`) batch. Populated ONLY on the
-        /// initial post-start broadcast; empty for late joiners and reconnects
-        /// (a reconnecting player must not re-see the contest dice). Rolls are
-        /// public (no `visibility.rs` redaction), so the full batch goes to
-        /// every seat. `serde(default)` keeps this back-compat for older clients.
+        /// first-player contest (`StartingPlayerContest`) event. Populated ONLY
+        /// on the initial post-start broadcast; empty for late joiners and
+        /// reconnects (a reconnecting player must not re-see the contest). The
+        /// contest is public (no `visibility.rs` redaction), so it goes to every
+        /// seat. `serde(default)` keeps this back-compat for older clients.
         #[serde(default)]
         events: Vec<GameEvent>,
     },

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -116,10 +116,10 @@ pub struct GameSession {
     /// Ranked rooms apply rating updates when a match completes.
     pub ranked: bool,
     /// Engine events produced by `start_game` (the d20 first-player contest's
-    /// `DieRolled` batch). Captured here so the INITIAL post-start broadcast can
-    /// surface them to clients; cleared after that broadcast so late joiners and
-    /// reconnects do not re-receive the contest dice. Empty when the game has
-    /// not started or the events have already been broadcast.
+    /// `StartingPlayerContest` event). Captured here so the INITIAL post-start
+    /// broadcast can surface them to clients; cleared after that broadcast so
+    /// late joiners and reconnects do not re-receive the contest. Empty when the
+    /// game has not started or the events have already been broadcast.
     pub start_events: Vec<GameEvent>,
 }
 


### PR DESCRIPTION
## What

The starting-player dice roll-off (CR 103.1) could **look** like the wrong player won after a tie. The engine's winner selection was always correct (argmax over all seats, narrow-on-tie, reroll); the bug was display-only and intermittent — it only surfaced when a tie forced a reroll.

## Root cause

`start_game` ran a correct multi-round contest but emitted a **flat** `DieRolled` batch with no round boundaries. The frontend collapsed that to last-roll-per-player, so an eliminated seat's higher round-1 die displayed next to the winner's lower final-round die — making the winner look like they didn't roll highest.

## Fix (engine owns the structure)

- **Engine** emits one authoritative `StartingPlayerContest { rounds, winner }` event — the round structure it already computes (round 1 = all seats; each later round = the tied-max group that rerolled). Winner selection is byte-for-byte unchanged (same RNG draws). In-game d20/coin rolls still emit `DieRolled`.
- **Frontend** renders the roll-off **round by round** (the tied group rerolls while others drop out), with the winner revealed only on the final round — so the winner is always the visible high roller. Removes the buggy last-roll-per-player collapse and the 2-player-only 'VS' framing.

## Tests / verification

- Engine: new tests assert the high roller wins for 3 **and** 4 players across seeds, and that the emitted round structure is correct (round membership + final-round winner). `cargo clippy -p engine --tests` clean; full engine suite green (9840 passed).
- Frontend: `diceContest` suite migrated to the new event (10 passed); type-check + lint clean; i18n parity green (`tieReroll` added to all 7 locales).
- Both halves ship together so `main` never has the engine-without-frontend intermediate (which would briefly hide the overlay).

CR 103.1 (starting player determination), CR 706 (rolling a die).