### PR TITLE
fix(client): wire ReturnAsAuraTarget host pick (CR 303.4 / CR 115.1)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1069,7 +1069,7 @@ export type WaitingFor =
   | { type: "OrderTriggers"; data: { player: PlayerId; triggers: PendingTriggerSummary[] } }
   | { type: "CopyTargetChoice"; data: { player: PlayerId; source_id: ObjectId; valid_targets: ObjectId[]; max_mana_value?: number | null } }
   | { type: "ExploreChoice"; data: { player: PlayerId; source_id: ObjectId; choosable: ObjectId[]; remaining: ObjectId[]; pending_effect: unknown } }
-  | { type: "ReturnAsAuraTarget"; data: { player: PlayerId; source_id: ObjectId; returned_id: ObjectId; legal_targets: ObjectId[]; pending_effect: unknown } }
+  | { type: "ReturnAsAuraTarget"; data: { player: PlayerId; source_id: ObjectId; returned_id: ObjectId; legal_targets: TargetRef[]; pending_effect: unknown } }
   | { type: "EquipTarget"; data: { player: PlayerId; equipment_id: ObjectId; valid_targets: ObjectId[] } }
   | { type: "CrewVehicle"; data: { player: PlayerId; vehicle_id: ObjectId; crew_power: number; eligible_creatures: ObjectId[] } }
   | { type: "StationTarget"; data: { player: PlayerId; spacecraft_id: ObjectId; eligible_creatures: ObjectId[] } }

--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -145,7 +145,12 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
   const isRetargetChoiceForMe = waitingFor?.type === "RetargetChoice"
     && waitingFor.data.player === playerId
     && waitingFor.data.scope.type === "Single";
-  const isTargeting = isHumanTargetSelection || isCopyRetargetForMe || isRetargetChoiceForMe;
+  // CR 303.4g + CR 115.1: a returned / non-spell Aura that enchants a player
+  // (a Curse) is hosted by a board pick — opponents are legal click hosts when
+  // they appear in `legal_targets`.
+  const isReturnAsAuraForMe = waitingFor?.type === "ReturnAsAuraTarget"
+    && waitingFor.data.player === playerId;
+  const isTargeting = isHumanTargetSelection || isCopyRetargetForMe || isRetargetChoiceForMe || isReturnAsAuraForMe;
   const currentLegalTargets = useMemo(() => {
     if (isHumanTargetSelection) {
       return waitingFor.data.selection?.current_legal_targets ?? [];
@@ -157,8 +162,11 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
     if (isRetargetChoiceForMe) {
       return waitingFor.data.legal_new_targets;
     }
+    if (isReturnAsAuraForMe) {
+      return waitingFor.data.legal_targets;
+    }
     return [];
-  }, [isHumanTargetSelection, isCopyRetargetForMe, isRetargetChoiceForMe, waitingFor]);
+  }, [isHumanTargetSelection, isCopyRetargetForMe, isRetargetChoiceForMe, isReturnAsAuraForMe, waitingFor]);
   const validPlayerTargetIds = useMemo(
     () => currentLegalTargets
       .filter((tgt): tgt is { Player: number } => "Player" in tgt)

--- a/client/src/components/hud/PlayerHud.tsx
+++ b/client/src/components/hud/PlayerHud.tsx
@@ -50,9 +50,16 @@ export function PlayerHud() {
     && waitingFor.data.player === playerId
     && waitingFor.data.scope.type === "Single"
     && waitingFor.data.legal_new_targets.some((t) => "Player" in t && t.Player === playerId);
+  // CR 303.4g + CR 115.1: a returned / non-spell Aura that can enchant a player
+  // (a Curse) is hosted by a board pick — the picker's controller may attach it
+  // to this player when they appear in `legal_targets`. Click dispatches the
+  // same `ChooseTarget { Player }` the engine accepts (engine.rs ~2984).
+  const returnAsAuraHasMe = waitingFor?.type === "ReturnAsAuraTarget"
+    && waitingFor.data.player === playerId
+    && waitingFor.data.legal_targets.some((t) => "Player" in t && t.Player === playerId);
   const isValidTarget = (isHumanTargetSelection && (waitingFor.data.selection?.current_legal_targets ?? []).some(
     (target) => "Player" in target && target.Player === playerId,
-  )) || copyRetargetCurrentSlotHasMe || retargetChoiceHasMe;
+  )) || copyRetargetCurrentSlotHasMe || retargetChoiceHasMe || returnAsAuraHasMe;
 
   const handleTargetClick = useCallback(() => {
     if (isValidTarget) {

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -76,6 +76,10 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
     "CopyTargetChoice",
     "CopyRetarget",
     "ExploreChoice",
+    // CR 303.4 + CR 115.1: return-as-Aura / non-spell Aura entry host pick.
+    // Resolved on the board (object hosts) or via player HUD glow (Curse /
+    // enchant-player Auras) — see TargetingOverlay + PlayerHud/OpponentHud.
+    "ReturnAsAuraTarget",
     "EquipTarget",
     "CrewVehicle",
     "StationTarget",

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -81,7 +81,12 @@ export function getWaitingForObjectChoiceIds(
     case "ExploreChoice":
       return waitingFor.data.choosable;
     case "ReturnAsAuraTarget":
-      return waitingFor.data.legal_targets;
+      // CR 303.4 / CR 115.1: `legal_targets` is a TargetRef[] of object hosts
+      // *and* players (Curse / enchant-player Auras). Only object hosts glow on
+      // the board; player hosts are handled by PlayerHud/OpponentHud glow.
+      return waitingFor.data.legal_targets.flatMap((target) =>
+        "Object" in target ? [target.Object] : [],
+      );
     case "PairChoice":
       return waitingFor.data.choices;
     default:


### PR DESCRIPTION
The return-as-Aura / non-spell-Aura host picker reached the fail-loud
UnhandledWaitingForModal instead of its (already-wired) targeting overlay.
Three independent layers each broke the state:

- waitingForRegistry omitted ReturnAsAuraTarget from HANDLED_WAITING_FOR_TYPES,
  so the safety-net modal fired over the working overlay.
- The TS type declared legal_targets: ObjectId[] but the engine emits
  Vec<TargetRef> ({Object}|{Player}); the lie let a buggy consumer type-check.
- getWaitingForObjectChoiceIds returned legal_targets raw, stuffing {Object:N}
  wrappers into a Set<number> that never matched a board id (object hosts
  never glowed). Now flatMaps "Object" like every sibling case.
- Player hosts (Curse / enchant-player Auras, all-Player legal_targets) had no
  clickable UI: PlayerHud/OpponentHud didn't check ReturnAsAuraTarget. Now glow
  + dispatch ChooseTarget{Player}, which engine.rs accepts via attach_to_player.
