### PR TITLE
test(engine): opinionated cast-pipeline driver (GameRunner::cast) + card-test skill

### DIFF
--- a/.claude/skills/card-test/SKILL.md
+++ b/.claude/skills/card-test/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: card-test
+description: Canonical recipe for writing engine cast-pipeline tests. Use GameScenario + GameRunner::cast(...).resolve() and assert via CastOutcome deltas. Covers the five test-harness foot-guns (hand-written TargetRef vectors, incomplete modal target submission, wrong-point hand baseline, inline-keyword cards, AST-internal flag assertions) and the right-way fix for each. Use whenever writing or porting a runtime test that casts a spell and checks its effect.
+---
+
+# card-test — the canonical cast-pipeline test recipe
+
+This skill gives ONE rigid recipe for runtime engine tests that cast a spell and
+assert its effect. It exists because five test-harness foot-guns recur; the
+[`SpellCast`] driver and [`CastOutcome`] (in `crates/engine/src/game/scenario.rs`)
+make them structurally impossible when you follow this recipe.
+
+Reference ports that demonstrate the pattern:
+
+- `crates/engine/tests/chord_of_calling.rs` — X-spell, convoke, `final_waiting_for()` boundary.
+- `crates/engine/src/game/casting.rs` — `exsanguinate_*` (life deltas, 2- and 3-player), `vicious_rivalry_*` (X-cost filter + zones), `kozileks_command_modes_*` (modal + X + multi-target).
+
+## The recipe
+
+```rust
+use engine::game::scenario::{GameScenario, GameRunner};
+// ... typed imports for the effect under test ...
+
+#[test]
+fn my_card_does_the_thing() {
+    // 1. BUILD STATE via GameScenario (or wrap a raw GameState with
+    //    GameRunner::from_state(state) when the test builds state imperatively).
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "My Card", /* is_instant */ true, ORACLE)
+        .id();
+    // ... stage targets / mana / library as needed ...
+    let mut runner = scenario.build();
+
+    // 2. CAST through the pipeline. Declare INTENT, never targets-by-hand.
+    let outcome = runner
+        .cast(spell)
+        .modes(&[0, 2])              // modal "choose N" — omit if non-modal
+        .x(3)                        // announce X — omit if non-X
+        .target_player(P1)           // declare a player intent (reusable across slots)
+        .target_objects(&[victim])   // declare object intents (one per slot, in order)
+        .convoke_with(&[creature])   // tap creatures to pay via Convoke — omit otherwise
+        .resolve();
+
+    // 3. ASSERT via CastOutcome deltas — behavior/semantics, never AST internals.
+    outcome.assert_life_delta(P1, -3);
+    outcome.assert_zone(&[victim], Zone::Exile);
+    outcome.assert_hand_drawn(P0, 1);
+    // For "no further prompt" boundaries (e.g. fail-to-find), inspect the halt state:
+    assert!(matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }));
+}
+```
+
+### What the driver does for you
+
+`resolve()` runs a bounded state-machine over `state.waiting_for` (CR 601.2a–h):
+
+- `ModeChoice` → submits `.modes(..)` (panics if modal but no modes declared).
+- `ChooseXValue` → submits `.x(..)` (panics if X needed but not declared).
+- `ManaPayment { convoke_mode }` → taps each `.convoke_with(..)` creature with
+  mana of its color, then finalizes (CR 702.51b). Pool-funded casts auto-pay and
+  never surface this window.
+- `TargetSelection` → answers **one slot at a time, in written order**
+  (CR 601.2c). Object intent is consumed (one declared object per slot); player
+  intent is reusable (one player may be targeted by several modes).
+- `Priority` (post-cast) → captures the per-player hand baseline at stack commit
+  (CR 601.2a) and proceeds to resolution.
+- Resolution auto-answers `OrderTriggers` (CR 603.3b) and `ScryChoice` (keeps
+  looked-at cards on top, CR 701.22a); it stops at stack-empty or at any prompt
+  it is not taught to answer (e.g. `SearchChoice`) so you can assert on it via
+  `final_waiting_for()`.
+- Any unhandled prompt → a clear `extend the driver or drive this case manually`
+  panic. Extending the driver is the correct response; never assert around a
+  silent skip.
+
+### CastOutcome accessors
+
+| Accessor | Returns |
+|---|---|
+| `hand_drawn(p)` / `assert_hand_drawn(p, n)` | net cards drawn since stack commit (the clean resolution delta) |
+| `zone_of(o)` / `assert_zone(&[o], zone)` | an object's current zone |
+| `life_delta(p)` / `assert_life_delta(p, n)` | net life change since before the cast |
+| `final_waiting_for()` | the state the pipeline halted in |
+| `state()` | read-only `&GameState` for assertions the typed accessors don't cover |
+
+## Anti-patterns — the five foot-guns and the right-way fix
+
+1. **Hand-written `TargetRef` vectors.** Building a flat `Vec<TargetRef>` and
+   submitting `SelectTargets { targets }` is fragile (`TargetRef` is non-`Copy`;
+   `.copied()` won't compile, and the order must match the slots exactly).
+   *Fix:* declare intent with `.target_object(..)` / `.target_player(..)`; the
+   driver matches each intent to its slot.
+
+2. **Incomplete modal target submission.** Omitting one mode's slot yields
+   `InvalidAction("Illegal target selected")` because targets are validated one
+   per slot, in written order (`ability_utils::choose_target`).
+   *Fix:* the driver answers every slot via `ChooseTarget` in order — you cannot
+   forget a slot.
+
+3. **Hand/zone baseline captured at the wrong point.** `handle_cast_spell` does
+   NOT remove the spell from hand; CR 601.2a removes it only when the cast
+   commits to the stack (the `Priority` window). A baseline taken before that is
+   off by one.
+   *Fix:* `CastOutcome::hand_drawn` is measured against the stack-commit
+   baseline the driver captures for you. Use `assert_hand_drawn`, never a
+   hand-picked `let hand_before = ...`.
+
+4. **Keywords fed as inline Oracle reminder text.** Writing `"Convoke (Your
+   creatures ...)"` as plain text parses to `Effect::Unimplemented`.
+   *Fix:* build keyworded cards via
+   `from_oracle_text_with_keywords(&["Convoke"], text)`, and pay convoke via
+   `.convoke_with(&[..])` (which the driver routes through `TapForConvoke`).
+
+5. **Asserting representation-internal dual-encoded flags.** Asserting an
+   AST field such as `ChangeZone.up_to` couples the test to one encoding of the
+   spec rather than the behavior.
+   *Fix:* assert behavior via `CastOutcome` deltas (`zone_of`, `life_delta`,
+   `hand_drawn`). When a SHAPE assertion is genuinely needed (parser structure),
+   label the test SHAPE and assert via semantic accessors (e.g. a
+   `MultiTargetSpec`), not internal bools.
+
+## Hard rules
+
+- **Never call the raw `resolve()` stack function directly.** Drive through the
+  `apply()` pipeline (via `runner.cast(..).resolve()` or `runner.act(..)`).
+  Calling `stack::resolve_top` / `effect::resolve` directly bypasses the
+  intervening-if recheck and the `cast_from_zone` carry-through, so cast-trigger
+  bugs (cascade/storm/casualty) go invisible. See the memory landmine
+  `project_cast_from_zone_stack_wipe`.
+- **Prefer runtime-behavior tests.** Reserve AST-SHAPE tests for parser
+  structure; label them SHAPE and assert via semantic accessors, not internal
+  flags. The two Kozilek/Chord SHAPE tests
+  (`kozileks_command_full_four_mode_parse`,
+  `chord_of_calling_parses_x_mana_value_search_shape`) are the correct pattern
+  for that and are intentionally NOT driven through `cast()`.
+- **CR-annotate any assertion that encodes a rule** (verify the number against
+  `docs/MagicCompRules.txt` before writing it).

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -12644,7 +12644,6 @@ mod tests {
     ///   reads it via `QuantityRef::PreviousEffectAmount`.
     #[test]
     fn exsanguinate_oracle_text_drains_each_opponent_and_gains_controller() {
-        use super::super::engine::apply_as_current;
         use crate::types::ability::{AbilityKind, PlayerFilter, QuantityRef};
         use crate::types::zones::Zone;
 
@@ -12700,6 +12699,9 @@ mod tests {
         }
 
         // --- Runtime contract (2-player) ------------------------------------
+        // Driven through the canonical `GameRunner::cast` pipeline so the
+        // drain/gain life deltas are read from `CastOutcome` rather than
+        // hand-picked snapshots.
         let mut state = setup_game_at_main_phase();
         let obj_id = create_object(
             &mut state,
@@ -12723,47 +12725,14 @@ mod tests {
         add_mana(&mut state, PlayerId(0), ManaType::Black, 2);
         add_mana(&mut state, PlayerId(0), ManaType::Colorless, 3);
 
-        let controller_life_before = state.players[0].life;
-        let opponent_life_before = state.players[1].life;
+        let mut runner = crate::game::scenario::GameRunner::from_state(state);
+        let outcome = runner.cast(obj_id).x(3).resolve();
 
-        let result = apply_as_current(
-            &mut state,
-            GameAction::CastSpell {
-                object_id: obj_id,
-                card_id: CardId(910),
-                targets: vec![],
-            },
-        )
-        .unwrap();
-        let max = match result.waiting_for {
-            WaitingFor::ChooseXValue { max, .. } => max,
-            other => panic!("expected ChooseXValue, got {other:?}"),
-        };
-        assert_eq!(
-            max, 3,
-            "3 colorless mana bounds the generic {{X}} portion at 3"
-        );
-
-        apply_as_current(&mut state, GameAction::ChooseX { value: 3 }).unwrap();
-
-        for _ in 0..5 {
-            if state.stack.is_empty() && matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                break;
-            }
-            let _ = apply_as_current(&mut state, GameAction::PassPriority).unwrap();
-        }
-
-        assert_eq!(
-            opponent_life_before - state.players[1].life,
-            3,
-            "the single opponent loses exactly X = 3 life"
-        );
-        // 2-player: only one opponent lost life, so the sum is 3.
-        assert_eq!(
-            state.players[0].life - controller_life_before,
-            3,
-            "controller gains exactly the 3 life lost this way (sum across opponents)"
-        );
+        // CR 119.3: the single opponent loses exactly X = 3 life.
+        outcome.assert_life_delta(PlayerId(1), -3);
+        // 2-player: only one opponent lost life, so the controller's gain (the
+        // sum across opponents) is exactly 3 (CR 608.2c PreviousEffectAmount).
+        outcome.assert_life_delta(PlayerId(0), 3);
     }
 
     /// Exsanguinate in a 3-player game locks the SUM-across-opponents semantic
@@ -12777,7 +12746,6 @@ mod tests {
     ///   `QuantityRef::PreviousEffectAmount`.
     #[test]
     fn exsanguinate_three_player_controller_gains_sum_across_opponents() {
-        use super::super::engine::apply_as_current;
         use crate::types::ability::AbilityKind;
         use crate::types::format::FormatConfig;
         use crate::types::zones::Zone;
@@ -12818,49 +12786,17 @@ mod tests {
         add_mana(&mut state, PlayerId(0), ManaType::Black, 2);
         add_mana(&mut state, PlayerId(0), ManaType::Colorless, 3);
 
-        let controller_life_before = state.players[0].life;
-        let opp1_life_before = state.players[1].life;
-        let opp2_life_before = state.players[2].life;
+        // Drive the cast through the canonical pipeline; assert the SUM-vs-
+        // per-opponent discriminator via `CastOutcome` life deltas.
+        let mut runner = crate::game::scenario::GameRunner::from_state(state);
+        let outcome = runner.cast(obj_id).x(3).resolve();
 
-        let result = apply_as_current(
-            &mut state,
-            GameAction::CastSpell {
-                object_id: obj_id,
-                card_id: CardId(911),
-                targets: vec![],
-            },
-        )
-        .unwrap();
-        assert!(matches!(
-            result.waiting_for,
-            WaitingFor::ChooseXValue { max: 3, .. }
-        ));
-
-        apply_as_current(&mut state, GameAction::ChooseX { value: 3 }).unwrap();
-
-        for _ in 0..5 {
-            if state.stack.is_empty() && matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                break;
-            }
-            let _ = apply_as_current(&mut state, GameAction::PassPriority).unwrap();
-        }
-
-        assert_eq!(
-            opp1_life_before - state.players[1].life,
-            3,
-            "opponent 1 loses exactly X = 3 life"
-        );
-        assert_eq!(
-            opp2_life_before - state.players[2].life,
-            3,
-            "opponent 2 loses exactly X = 3 life"
-        );
+        // CR 119.3: each opponent loses exactly X = 3 life.
+        outcome.assert_life_delta(PlayerId(1), -3);
+        outcome.assert_life_delta(PlayerId(2), -3);
         // SUM-across-opponents: 3 + 3 = 6, NOT 3 (max/single opponent).
-        assert_eq!(
-            state.players[0].life - controller_life_before,
-            6,
-            "controller gains the SUM of life lost across both opponents (3+3=6)"
-        );
+        // CR 608.2c: the GainLife sub-ability reads the accumulated life lost.
+        outcome.assert_life_delta(PlayerId(0), 6);
     }
 
     /// Passing priority during `ChooseXValue` is illegal — caster must commit
@@ -16476,51 +16412,22 @@ mod tests {
         add_mana(&mut state, PlayerId(0), ManaType::Green, 1);
         add_mana(&mut state, PlayerId(0), ManaType::Colorless, 2);
 
-        // CR 601.2b: X for the additional cost is announced as the spell is cast.
-        let waiting = handle_cast_spell(
-            &mut state,
-            PlayerId(0),
-            spell,
-            CardId(15404),
-            &mut Vec::new(),
-        )
-        .expect("pay-X-life additional cost should prompt for X");
-        state.waiting_for = waiting;
-        match state.waiting_for {
-            // CR 119.4: the maximum payable life equals the full life total (20).
-            WaitingFor::ChooseXValue { max, .. } => assert_eq!(max, 20),
-            ref other => panic!("expected ChooseXValue, got {other:?}"),
-        }
+        // CR 601.2b: X for the additional pay-life cost is announced as the spell
+        // is cast; the fluent driver announces X=3 and resolves the DestroyAll.
+        let mut runner = crate::game::scenario::GameRunner::from_state(state);
+        let outcome = runner.cast(spell).x(3).resolve();
 
-        apply_as_current(&mut state, GameAction::ChooseX { value: 3 }).unwrap();
-        // CR 119.4: 3 life actually paid; CR 601.2f: the mana cost is also paid.
-        assert_eq!(state.players[0].life, 17);
-        assert_eq!(state.players[0].mana_pool.total(), 0);
-        assert_eq!(state.stack.len(), 1);
-        // CR 107.3: the announced X is locked onto the spell on the stack.
-        match &state.stack[0].kind {
-            StackEntryKind::Spell {
-                ability: Some(ability),
-                ..
-            } => assert_eq!(ability.chosen_x, Some(3)),
-            other => panic!("expected spell on stack, got {other:?}"),
-        }
-
-        for _ in 0..5 {
-            if state.stack.is_empty() && matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                break;
-            }
-            apply_as_current(&mut state, GameAction::PassPriority).unwrap();
-        }
+        // CR 119.4: exactly 3 life paid for the additional cost (shared X = 3).
+        outcome.assert_life_delta(PlayerId(0), -3);
+        // CR 601.2f: the mana cost is fully paid (pool drained).
+        assert_eq!(outcome.state().players[0].mana_pool.total(), 0);
 
         // CR 701.8a + CR 202.3: at X=3, artifact MV2 and creature MV3 (LE bound)
-        // are destroyed to the owner's graveyard.
-        assert_eq!(state.objects[&artifact_mv2].zone, Zone::Graveyard);
-        assert_eq!(state.objects[&creature_mv3].zone, Zone::Graveyard);
-        // Creature MV4 exceeds X=3 and survives on the battlefield.
-        assert_eq!(state.objects[&creature_mv4].zone, Zone::Battlefield);
-        // The land matches neither Or branch (not artifact/creature) and survives.
-        assert_eq!(state.objects[&land].zone, Zone::Battlefield);
+        // are destroyed to the owner's graveyard; creature MV4 exceeds X=3 and
+        // the land matches neither Or branch — both survive on the battlefield.
+        // This proves the single shared X (CR 107.3) drives the DestroyAll filter.
+        outcome.assert_zone(&[artifact_mv2, creature_mv3], Zone::Graveyard);
+        outcome.assert_zone(&[creature_mv4, land], Zone::Battlefield);
     }
 
     #[test]
@@ -22241,67 +22148,24 @@ mod tests {
         let big = add_creature_with_mv(&mut state, CardId(63), PlayerId(1), "Three Drop", 3);
         add_mana(&mut state, PlayerId(0), ManaType::Colorless, 4);
 
-        let mut events = Vec::new();
-        state.waiting_for =
-            handle_cast_spell(&mut state, PlayerId(0), spell_id, CardId(61), &mut events).unwrap();
-        // Modes 0 (tokens) and 2 (exile target creature with MV X or less).
-        state.waiting_for =
-            handle_select_modes(&mut state, PlayerId(0), vec![0, 2], &mut events).unwrap();
-        assert!(
-            matches!(state.waiting_for, WaitingFor::ChooseXValue { .. }),
-            "X must be announced before mode-2 target legality (CR 601.2b), got {:?}",
-            state.waiting_for
-        );
-
-        state.waiting_for = apply_as_current(&mut state, GameAction::ChooseX { value: 2 })
-            .unwrap()
-            .waiting_for;
-        // Mode 0 (tokens) targets a player; mode 2 targets a creature. After X is
-        // chosen, the deferred target slots are built with the resolved X.
-        let WaitingFor::TargetSelection { target_slots, .. } = &state.waiting_for else {
-            panic!(
-                "expected target selection after choosing X, got {:?}",
-                state.waiting_for
-            );
-        };
-        // The creature slot must include the MV<=2 creature and exclude the MV-3
-        // creature (CR 202.3 + X = 2). Locate the slot whose legal set contains
-        // the small creature (the other slot is the player-owner slot for tokens).
-        let creature_slot = target_slots
-            .iter()
-            .find(|slot| slot.legal_targets.contains(&TargetRef::Object(small)))
-            .expect("a target slot must offer the MV<=2 creature as a legal exile target");
-        assert!(
-            !creature_slot
-                .legal_targets
-                .contains(&TargetRef::Object(big)),
-            "with X = 2, the MV-3 creature must NOT be a legal exile target"
-        );
-
-        // Select the targeted player (controller) for the token owner and the
-        // small creature for the exile. Walk slots in order, matching each to the
-        // legal target it offers.
-        let mut chosen = Vec::new();
-        for slot in target_slots.iter() {
-            if slot.legal_targets.contains(&TargetRef::Object(small)) {
-                chosen.push(TargetRef::Object(small));
-            } else if slot.legal_targets.contains(&TargetRef::Player(PlayerId(0))) {
-                chosen.push(TargetRef::Player(PlayerId(0)));
-            } else {
-                chosen.push(
-                    slot.legal_targets
-                        .first()
-                        .cloned()
-                        .expect("each slot must offer at least one legal target"),
-                );
-            }
-        }
-        state.waiting_for =
-            apply_as_current(&mut state, GameAction::SelectTargets { targets: chosen })
-                .unwrap()
-                .waiting_for;
-
-        stack::resolve_top(&mut state, &mut events);
+        // Drive the modal cast through the canonical pipeline: choose modes
+        // 0 (tokens) and 2 (exile target creature with MV X or less), announce
+        // X = 2, then declare the exile target (small) and the token owner (P0).
+        // The driver matches each declared intent to its slot, so no flat
+        // target vector is hand-built (CR 601.2c). NOTE: this test declares only
+        // `small` as the exile target, so `big` surviving below proves the cast
+        // resolved correctly — NOT that the MV<=X slot filter excluded it. That
+        // slot-legality exclusion is covered separately by
+        // `activated_modal_x_target_selection_carries_labels_and_pays_mana`.
+        let mut runner = crate::game::scenario::GameRunner::from_state(state);
+        let outcome = runner
+            .cast(spell_id)
+            .modes(&[0, 2])
+            .x(2)
+            .target_object(small)
+            .target_player(PlayerId(0))
+            .resolve();
+        let state = outcome.state();
 
         // CR 701.13 + CR 406: the targeted creature is exiled.
         assert_eq!(
@@ -22312,7 +22176,7 @@ mod tests {
         assert_eq!(
             state.objects[&big].zone,
             Zone::Battlefield,
-            "the untargeted MV-3 creature must remain on the battlefield"
+            "the untargeted MV-3 creature must remain on the battlefield (it was never declared as a target)"
         );
         // Mode 0: the targeted player (P0) receives exactly X = 2 Eldrazi Spawn
         // tokens, each a 0/1 with a Sacrifice: Add {C} ability.
@@ -22402,113 +22266,31 @@ mod tests {
         }
         add_mana(&mut state, PlayerId(0), ManaType::Colorless, 4);
 
-        let mut events = Vec::new();
-        state.waiting_for =
-            handle_cast_spell(&mut state, PlayerId(0), spell_id, CardId(71), &mut events).unwrap();
-        // Modes 1 (scry X, draw) and 3 (exile up to X target cards from graveyards).
-        state.waiting_for =
-            handle_select_modes(&mut state, PlayerId(0), vec![1, 3], &mut events).unwrap();
-        // CR 601.2b: the mode-3 "up to X" multi-target maximum references X, so
-        // target selection must be deferred until X is announced — proving the
-        // multi_target branch of `ability_target_legality_needs_chosen_x`.
-        assert!(
-            matches!(state.waiting_for, WaitingFor::ChooseXValue { .. }),
-            "mode-3 'up to X' must defer target selection until X is chosen \
-             (CR 601.2b), got {:?}",
-            state.waiting_for
-        );
+        // Drive the modal cast through the canonical pipeline: choose modes
+        // 1 (scry X, draw) and 3 (exile up to X target cards from graveyards),
+        // announce X = 2, then declare the scry player (P0) and both graveyard
+        // cards as the mode-3 "up to X = 2" targets. That both graveyard cards
+        // are accepted proves the "up to X" maximum resolved to 2
+        // (resolve_multi_target_bounds); the driver matches each declared
+        // intent to its slot in written order (CR 601.2c). The driver auto-
+        // answers the mid-resolution scry ordering prompt (CR 701.22a), keeping
+        // the looked-at cards on top.
+        let mut runner = crate::game::scenario::GameRunner::from_state(state);
+        let outcome = runner
+            .cast(spell_id)
+            .modes(&[1, 3])
+            .x(2)
+            .target_player(PlayerId(0))
+            .target_objects(&[gy_a, gy_b])
+            .resolve();
 
-        state.waiting_for = apply_as_current(&mut state, GameAction::ChooseX { value: 2 })
-            .unwrap()
-            .waiting_for;
-        // The deferred target slot for mode 3 must offer the graveyard cards and
-        // resolve the "up to X" maximum to 2 (resolve_multi_target_bounds).
-        let WaitingFor::TargetSelection { target_slots, .. } = &state.waiting_for else {
-            panic!(
-                "expected mode-3 graveyard target selection after choosing X, got {:?}",
-                state.waiting_for
-            );
-        };
-        let gy_slot = target_slots
-            .iter()
-            .find(|slot| slot.legal_targets.contains(&TargetRef::Object(gy_a)))
-            .expect("mode-3 slot must offer graveyard card A");
-        assert!(
-            gy_slot.legal_targets.contains(&TargetRef::Object(gy_b)),
-            "mode-3 slot must offer both graveyard cards as legal targets"
-        );
-
-        // CR 601.2c: targets are declared slot-by-slot in written order. Mode 1
-        // ("Target player scries X") contributes a player slot that precedes the
-        // mode-3 graveyard slots, so the flat target vector must cover every slot:
-        // the caster for the player slot (so the scry+draw below is observed on
-        // P0) and the two graveyard cards for the mode-3 "up to X = 2" slots.
-        let mut remaining_gy = vec![gy_a, gy_b];
-        let mut chosen: Vec<TargetRef> = Vec::new();
-        for slot in target_slots {
-            if let Some(pos) = remaining_gy
-                .iter()
-                .position(|&g| slot.legal_targets.contains(&TargetRef::Object(g)))
-            {
-                chosen.push(TargetRef::Object(remaining_gy.remove(pos)));
-            } else if slot.legal_targets.contains(&TargetRef::Player(PlayerId(0))) {
-                chosen.push(TargetRef::Player(PlayerId(0)));
-            } else {
-                chosen.push(
-                    slot.legal_targets
-                        .first()
-                        .cloned()
-                        .expect("each target slot must offer at least one legal target"),
-                );
-            }
-        }
-        // Both graveyard cards must be assignable, proving the mode-3 "up to X"
-        // maximum resolved to 2 (resolve_multi_target_bounds).
-        assert!(
-            remaining_gy.is_empty(),
-            "mode-3 'up to X = 2' must accept both graveyard cards"
-        );
-
-        state.waiting_for =
-            apply_as_current(&mut state, GameAction::SelectTargets { targets: chosen })
-                .unwrap()
-                .waiting_for;
-
-        // Baseline captured immediately before resolution: the only hand change
-        // during the resolve loop is mode 1's draw (+1) — scry does not change
-        // hand size and the mode-3 exile moves graveyard->exile, never the hand.
-        let hand_before = state.players[0].hand.len();
-
-        // Resolve the spell, submitting any scry ordering prompt that surfaces
-        // mid-resolution (CR 701.22a). Keep the looked-at cards on top.
-        for _ in 0..8 {
-            stack::resolve_top(&mut state, &mut events);
-            if let WaitingFor::ScryChoice { cards, .. } = state.waiting_for.clone() {
-                state.waiting_for = apply_as_current(&mut state, GameAction::SelectCards { cards })
-                    .unwrap()
-                    .waiting_for;
-                continue;
-            }
-            break;
-        }
-
-        // CR 701.22a + draw: the player scried then drew exactly one card.
-        assert_eq!(
-            state.players[0].hand.len(),
-            hand_before + 1,
-            "mode 1 must scry then draw exactly one card"
-        );
+        // CR 701.22a + draw + CR 601.2a: the hand baseline is captured at stack
+        // commit, so the only hand change during resolution is mode 1's single
+        // draw (scry never changes hand size; the mode-3 exile moves
+        // graveyard->exile, never the hand).
+        outcome.assert_hand_drawn(PlayerId(0), 1);
         // CR 701.13 + CR 406: both selected graveyard cards are exiled.
-        assert_eq!(
-            state.objects[&gy_a].zone,
-            Zone::Exile,
-            "mode-3 exile must move graveyard card A to exile"
-        );
-        assert_eq!(
-            state.objects[&gy_b].zone,
-            Zone::Exile,
-            "mode-3 exile must move graveyard card B to exile"
-        );
+        outcome.assert_zone(&[gy_a, gy_b], Zone::Exile);
     }
 
     /// CR 700.2 + CR 700.2d: Kozilek's Command is a "Choose two —" spell, so

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -16,7 +16,8 @@ use crate::game::printed_cards::apply_card_face_to_object;
 use crate::game::zones::create_object;
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, AdditionalCost, Effect, PtValue, QuantityExpr,
-    ReplacementDefinition, ResolvedAbility, StaticDefinition, TargetFilter, TriggerDefinition,
+    ReplacementDefinition, ResolvedAbility, StaticDefinition, TargetFilter, TargetRef,
+    TriggerDefinition,
 };
 use crate::types::actions::GameAction;
 use crate::types::card::CardFace;
@@ -28,7 +29,7 @@ use crate::types::game_state::{
 };
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::Keyword;
-use crate::types::mana::{ManaColor, ManaUnit};
+use crate::types::mana::{ManaColor, ManaType, ManaUnit};
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
 use crate::types::statics::StaticMode;
@@ -1037,6 +1038,21 @@ pub struct GameRunner {
 }
 
 impl GameRunner {
+    /// Wrap a raw `GameState` so tests that build state imperatively (rather
+    /// than via `GameScenario`) can still drive casts through the fluent
+    /// [`GameRunner::cast`] pipeline. Pure additive escape hatch — the caller
+    /// owns construction of `state` (phase, mana, objects).
+    pub fn from_state(state: GameState) -> GameRunner {
+        GameRunner { state }
+    }
+
+    /// Begin a fluent cast of `spell` through the full casting pipeline
+    /// (CR 601.2a–h). See [`SpellCast`] for the builder methods and the
+    /// driving-loop contract.
+    pub fn cast(&mut self, spell: ObjectId) -> SpellCast<'_> {
+        SpellCast::new(self, spell)
+    }
+
     /// Execute a single action. Returns the `ActionResult` from the engine.
     pub fn act(&mut self, action: GameAction) -> Result<ActionResult, EngineError> {
         apply_as_current(&mut self.state, action)
@@ -1429,6 +1445,475 @@ impl GameRunner {
             state: self.state.clone(),
             events: all_events,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SpellCast (fluent cast-pipeline driver)
+// ---------------------------------------------------------------------------
+
+/// Fluent builder that drives a spell through the full casting pipeline
+/// (CR 601.2a–h): announcement, mode choice, X announcement, target selection,
+/// mana payment (including convoke), and resolution. Constructed via
+/// [`GameRunner::cast`].
+///
+/// The driver exists to make five test-harness foot-guns structurally
+/// impossible:
+///
+/// 1. **Hand-written `TargetRef` vectors.** Callers declare *intent*
+///    (`.target_object`, `.target_player`); the driver matches that intent to
+///    each slot's `legal_targets` itself. No flat `SelectTargets` vector is
+///    ever built by hand.
+/// 2. **Incomplete modal target submission.** The driver answers exactly one
+///    slot per `ChooseTarget`, walking `target_slots` in written order
+///    (CR 601.2c) so every mode's slot is covered.
+/// 3. **Hand baseline captured at the wrong point.** CR 601.2a: the spell
+///    leaves hand only when it is put on the stack. The driver captures the
+///    per-player hand-size baseline at stack commit (the `Priority` window),
+///    so [`CastOutcome::hand_drawn`] reports a clean resolution delta.
+/// 4. **Keywords fed as inline Oracle text.** Convoke (and other keywords) must
+///    be built via [`CardBuilder::from_oracle_text_with_keywords`]; the driver
+///    pays convoke via `TapForConvoke` rather than reparsing reminder text.
+/// 5. **Asserting representation-internal flags.** [`CastOutcome`] exposes
+///    behavior/semantic deltas (`hand_drawn`, `zone_of`, `life_delta`,
+///    `final_waiting_for`) instead of dual-encoded AST fields.
+pub struct SpellCast<'a> {
+    runner: &'a mut GameRunner,
+    spell: ObjectId,
+    modes: Option<Vec<usize>>,
+    x: Option<u32>,
+    target_players: Vec<PlayerId>,
+    target_objects: Vec<ObjectId>,
+    convoke_with: Vec<ObjectId>,
+}
+
+impl<'a> SpellCast<'a> {
+    fn new(runner: &'a mut GameRunner, spell: ObjectId) -> Self {
+        SpellCast {
+            runner,
+            spell,
+            modes: None,
+            x: None,
+            target_players: Vec::new(),
+            target_objects: Vec::new(),
+            convoke_with: Vec::new(),
+        }
+    }
+
+    /// Declare the modal "choose N" mode indices for a modal spell (CR 700.2).
+    /// Omit for non-modal spells.
+    pub fn modes(mut self, modes: &[usize]) -> Self {
+        self.modes = Some(modes.to_vec());
+        self
+    }
+
+    /// Announce the value of X (CR 107.3a / CR 601.2b). Omit for non-X spells.
+    pub fn x(mut self, value: u32) -> Self {
+        self.x = Some(value);
+        self
+    }
+
+    /// Declare a player as an intended target (CR 601.2c). Matched to the first
+    /// slot whose `legal_targets` contains it.
+    pub fn target_player(mut self, player: PlayerId) -> Self {
+        self.target_players.push(player);
+        self
+    }
+
+    /// Declare several players as intended targets, in order.
+    pub fn target_players(mut self, players: &[PlayerId]) -> Self {
+        self.target_players.extend_from_slice(players);
+        self
+    }
+
+    /// Declare an object as an intended target (CR 601.2c). Matched to the first
+    /// unused slot whose `legal_targets` contains it.
+    pub fn target_object(mut self, object: ObjectId) -> Self {
+        self.target_objects.push(object);
+        self
+    }
+
+    /// Declare several objects as intended targets, in order.
+    pub fn target_objects(mut self, objects: &[ObjectId]) -> Self {
+        self.target_objects.extend_from_slice(objects);
+        self
+    }
+
+    /// Tap these creatures to pay the cost via Convoke (CR 702.51a). Each is
+    /// tapped during the `ManaPayment { convoke_mode }` window with mana of the
+    /// creature's first declared color (falling back to colorless for the
+    /// generic portion of the cost — CR 702.51b).
+    pub fn convoke_with(mut self, creatures: &[ObjectId]) -> Self {
+        self.convoke_with.extend_from_slice(creatures);
+        self
+    }
+
+    /// Drive the full cast pipeline to its conclusion and return the outcome.
+    ///
+    /// Panics with a clear, extend-me message on any pipeline state the driver
+    /// is not yet taught to handle, or when a declared intent cannot be matched
+    /// to a required slot. A panic here is a *test-harness* signal: extend the
+    /// driver or drive the case manually — never assert around a silent skip.
+    pub fn resolve(self) -> CastOutcome {
+        let SpellCast {
+            runner,
+            spell,
+            modes,
+            x,
+            target_players,
+            target_objects,
+            convoke_with,
+        } = self;
+
+        // CR 119.3: snapshot life totals before the cast so `life_delta` reads a
+        // clean pre-cast → final difference.
+        let life_before: Vec<(PlayerId, i32)> = runner
+            .state
+            .players
+            .iter()
+            .map(|p| (p.id, p.life))
+            .collect();
+
+        let card_id = runner.state.objects[&spell].card_id;
+        runner
+            .act(GameAction::CastSpell {
+                object_id: spell,
+                card_id,
+                targets: vec![],
+            })
+            .expect("CastSpell must be accepted by the engine");
+
+        // Intent the driver matches as it walks slots: object targets are
+        // consumed one per slot (most slots are object slots), while player
+        // targets are reusable across slots (one player may be targeted by
+        // several modes — see `pick_slot_target`).
+        let mut remaining_objects: Vec<ObjectId> = target_objects;
+        let declared_players: Vec<PlayerId> = target_players;
+
+        // CR 601.2a: the spell leaves hand only at stack commit. Captured when
+        // the driver reaches the post-cast `Priority` window.
+        let mut hand_at_commit: Option<Vec<(PlayerId, usize)>> = None;
+
+        for _ in 0..64 {
+            match &runner.state.waiting_for {
+                // CR 601.2b: modal spell announces its mode choice.
+                WaitingFor::ModeChoice { .. } => {
+                    let indices = modes.clone().unwrap_or_else(|| {
+                        panic!(
+                            "SpellCast reached WaitingFor::ModeChoice but no .modes(..) were \
+                             declared — this is a modal spell; declare its chosen mode indices"
+                        )
+                    });
+                    runner
+                        .act(GameAction::SelectModes { indices })
+                        .expect("SelectModes must be accepted");
+                }
+                // CR 107.3a / CR 601.2b: announce X.
+                WaitingFor::ChooseXValue { .. } => {
+                    let value = x.unwrap_or_else(|| {
+                        panic!(
+                            "SpellCast reached WaitingFor::ChooseXValue but no .x(..) was \
+                             declared — this spell needs X announced"
+                        )
+                    });
+                    runner
+                        .act(GameAction::ChooseX { value })
+                        .expect("ChooseX must be accepted");
+                }
+                // CR 702.51a / CR 601.2g–h: mana payment, possibly via convoke.
+                WaitingFor::ManaPayment { .. } => {
+                    if convoke_with.is_empty() {
+                        // Pool-funded casts usually auto-pay and never surface a
+                        // ManaPayment window. If one surfaces with no convoke
+                        // declared, the driver has no payment policy — fail loud.
+                        panic!(
+                            "SpellCast reached WaitingFor::ManaPayment with no .convoke_with(..) \
+                             declared — pool-funded casts should auto-pay; drive this payment \
+                             manually or declare convoke creatures"
+                        );
+                    }
+                    for &creature in &convoke_with {
+                        // CR 702.51b: pay one mana of the creature's color, or
+                        // colorless toward the generic portion of the cost.
+                        let mana_type = runner
+                            .state
+                            .objects
+                            .get(&creature)
+                            .and_then(|obj| obj.color.first().copied())
+                            .map(ManaType::from)
+                            .unwrap_or(ManaType::Colorless);
+                        runner
+                            .act(GameAction::TapForConvoke {
+                                object_id: creature,
+                                mana_type,
+                            })
+                            .expect("TapForConvoke must be accepted");
+                    }
+                    // CR 601.2h: finalize the (now fully convoke-paid) cost.
+                    runner
+                        .act(GameAction::PassPriority)
+                        .expect("finalizing the convoke payment must be accepted");
+                }
+                // CR 601.2c: declare one target per slot, in written order.
+                WaitingFor::TargetSelection {
+                    target_slots,
+                    selection,
+                    ..
+                } => {
+                    let slot = &target_slots[selection.current_slot];
+                    let choice = pick_slot_target(
+                        slot,
+                        &mut remaining_objects,
+                        &declared_players,
+                        selection.current_slot,
+                    );
+                    runner
+                        .act(GameAction::ChooseTarget { target: choice })
+                        .expect("ChooseTarget must be accepted");
+                }
+                // CR 601.2a: spell is on the stack — capture the hand baseline.
+                WaitingFor::Priority { .. } => {
+                    hand_at_commit = Some(
+                        runner
+                            .state
+                            .players
+                            .iter()
+                            .map(|p| (p.id, p.hand.len()))
+                            .collect(),
+                    );
+                    break;
+                }
+                other => panic!(
+                    "SpellCast driver does not handle WaitingFor::{} yet — extend the driver \
+                     or drive this case manually",
+                    waiting_for_variant_name(other)
+                ),
+            }
+        }
+
+        let hand_baseline = hand_at_commit.unwrap_or_else(|| {
+            panic!(
+                "SpellCast never reached a Priority window after committing the cast \
+                 (loop cap exceeded) — the spell did not commit to the stack"
+            )
+        });
+
+        // Resolution. Auto-answer ordering/scry prompts; stop at any prompt the
+        // driver is not taught to answer so the caller can assert on it via
+        // `final_waiting_for()` (e.g. a `SearchChoice` fail-to-find boundary).
+        for _ in 0..64 {
+            match &runner.state.waiting_for {
+                WaitingFor::OrderTriggers { .. } => {
+                    // CR 603.3b: drain the per-controller ordering prompt.
+                    super::triggers::drain_order_triggers_with_identity(&mut runner.state);
+                }
+                WaitingFor::ScryChoice { cards, .. } => {
+                    // CR 701.22a: default policy keeps the looked-at cards on top.
+                    let cards = cards.clone();
+                    runner
+                        .act(GameAction::SelectCards { cards })
+                        .expect("SelectCards (scry) must be accepted");
+                }
+                WaitingFor::Priority { .. } => {
+                    if runner.state.stack.is_empty() {
+                        break;
+                    }
+                    if runner.act(GameAction::PassPriority).is_err() {
+                        break;
+                    }
+                }
+                // Any other prompt (e.g. SearchChoice) is left for the caller to
+                // inspect via `final_waiting_for()`; the driver stops here.
+                _ => break,
+            }
+        }
+
+        CastOutcome {
+            state: runner.state.clone(),
+            hand_baseline,
+            life_before,
+        }
+    }
+}
+
+/// Pick the `ChooseTarget` payload for a single slot from declared intent,
+/// matching CR 601.2c (targets declared one per slot, in written order).
+///
+/// Object intent is *consumed* (each declared object satisfies at most one
+/// slot, so distinct exile/destroy targets never alias). Player intent is
+/// *reusable* — the same player is routinely targeted by several modes of one
+/// modal spell (e.g. Kozilek's Command mode 1 scries *and* draws for the same
+/// target player), so a declared player may satisfy multiple player slots.
+/// Falls back to `None` for optional slots; panics for an unsatisfiable
+/// required slot.
+fn pick_slot_target(
+    slot: &crate::types::game_state::TargetSelectionSlot,
+    remaining_objects: &mut Vec<ObjectId>,
+    declared_players: &[PlayerId],
+    slot_index: usize,
+) -> Option<TargetRef> {
+    if let Some(pos) = remaining_objects
+        .iter()
+        .position(|&o| slot.legal_targets.contains(&TargetRef::Object(o)))
+    {
+        return Some(TargetRef::Object(remaining_objects.remove(pos)));
+    }
+    if let Some(&player) = declared_players
+        .iter()
+        .find(|&&p| slot.legal_targets.contains(&TargetRef::Player(p)))
+    {
+        return Some(TargetRef::Player(player));
+    }
+    if slot.optional {
+        return None;
+    }
+    panic!(
+        "SpellCast could not satisfy required target slot {slot_index}: no declared target \
+         matches its legal set.\n  legal_targets: {:?}\n  remaining declared objects: {:?}\n  \
+         declared players: {:?}",
+        slot.legal_targets, remaining_objects, declared_players
+    );
+}
+
+/// Stable variant name for the extend-me panic messages (mirrors the engine's
+/// own discriminant naming so failures point at the exact unhandled prompt).
+fn waiting_for_variant_name(waiting: &WaitingFor) -> &'static str {
+    // Reuse the runner's authoritative mapping by wrapping in a throwaway
+    // borrow-free match. Kept in sync with `GameRunner::waiting_for_kind`.
+    match waiting {
+        WaitingFor::ManaPayment { .. } => "ManaPayment",
+        WaitingFor::ChooseXValue { .. } => "ChooseXValue",
+        WaitingFor::TargetSelection { .. } => "TargetSelection",
+        WaitingFor::MultiTargetSelection { .. } => "MultiTargetSelection",
+        WaitingFor::TriggerTargetSelection { .. } => "TriggerTargetSelection",
+        WaitingFor::ModeChoice { .. } => "ModeChoice",
+        WaitingFor::AbilityModeChoice { .. } => "AbilityModeChoice",
+        WaitingFor::Priority { .. } => "Priority",
+        WaitingFor::OrderTriggers { .. } => "OrderTriggers",
+        WaitingFor::ScryChoice { .. } => "ScryChoice",
+        WaitingFor::SearchChoice { .. } => "SearchChoice",
+        WaitingFor::OptionalCostChoice { .. } => "OptionalCostChoice",
+        WaitingFor::GameOver { .. } => "GameOver",
+        _ => "<other>",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CastOutcome (behavior/semantic delta accessors)
+// ---------------------------------------------------------------------------
+
+/// Post-cast snapshot exposing behavior/semantic deltas — never AST-internal
+/// flags. Produced by [`SpellCast::resolve`].
+pub struct CastOutcome {
+    state: GameState,
+    /// Per-player hand sizes captured at stack commit (CR 601.2a) — the clean
+    /// baseline for resolution-draw deltas (foot-gun 3 fix).
+    hand_baseline: Vec<(PlayerId, usize)>,
+    /// Per-player life totals captured before the cast (CR 119.3).
+    life_before: Vec<(PlayerId, i32)>,
+}
+
+impl CastOutcome {
+    fn hand_baseline_for(&self, player: PlayerId) -> usize {
+        self.hand_baseline
+            .iter()
+            .find(|(p, _)| *p == player)
+            .map(|(_, n)| *n)
+            .expect("player must have a hand baseline")
+    }
+
+    fn life_before_for(&self, player: PlayerId) -> i32 {
+        self.life_before
+            .iter()
+            .find(|(p, _)| *p == player)
+            .map(|(_, l)| *l)
+            .expect("player must have a pre-cast life snapshot")
+    }
+
+    fn current_hand(&self, player: PlayerId) -> usize {
+        self.state
+            .players
+            .iter()
+            .find(|p| p.id == player)
+            .map(|p| p.hand.len())
+            .expect("player must exist")
+    }
+
+    fn current_life(&self, player: PlayerId) -> i32 {
+        self.state
+            .players
+            .iter()
+            .find(|p| p.id == player)
+            .map(|p| p.life)
+            .expect("player must exist")
+    }
+
+    /// Net cards drawn during resolution: final hand minus the stack-commit
+    /// baseline (CR 601.2a). Positive = net draw, negative = net discard.
+    pub fn hand_drawn(&self, player: PlayerId) -> i64 {
+        self.current_hand(player) as i64 - self.hand_baseline_for(player) as i64
+    }
+
+    /// The zone an object currently occupies (CR 400.1).
+    pub fn zone_of(&self, object: ObjectId) -> Zone {
+        self.state.objects[&object].zone
+    }
+
+    /// Net life change for a player: final minus pre-cast (CR 119.3).
+    pub fn life_delta(&self, player: PlayerId) -> i32 {
+        self.current_life(player) - self.life_before_for(player)
+    }
+
+    /// The waiting state the pipeline halted in (e.g. `Priority` for a clean
+    /// resolve, or a `SearchChoice` the driver left for the caller to inspect).
+    pub fn final_waiting_for(&self) -> &WaitingFor {
+        &self.state.waiting_for
+    }
+
+    /// Read-only view of the final game state for assertions the typed
+    /// accessors don't yet cover.
+    pub fn state(&self) -> &GameState {
+        &self.state
+    }
+
+    /// Assert net cards drawn since stack commit (foot-gun 3 fix).
+    pub fn assert_hand_drawn(&self, player: PlayerId, expected: i64) {
+        let actual = self.hand_drawn(player);
+        assert_eq!(
+            actual,
+            expected,
+            "P{} hand delta since stack commit: expected {expected}, got {actual} \
+             (baseline {}, final {})",
+            player.0,
+            self.hand_baseline_for(player),
+            self.current_hand(player)
+        );
+    }
+
+    /// Assert every listed object now occupies `zone`.
+    pub fn assert_zone(&self, objects: &[ObjectId], zone: Zone) {
+        for &object in objects {
+            let actual = self.zone_of(object);
+            assert_eq!(
+                actual, zone,
+                "object {} expected in {zone:?}, found in {actual:?}",
+                object.0
+            );
+        }
+    }
+
+    /// Assert a player's net life change since before the cast (CR 119.3).
+    pub fn assert_life_delta(&self, player: PlayerId, expected: i32) {
+        let actual = self.life_delta(player);
+        assert_eq!(
+            actual,
+            expected,
+            "P{} life delta: expected {expected}, got {actual} \
+             (before {}, final {})",
+            player.0,
+            self.life_before_for(player),
+            self.current_life(player)
+        );
     }
 }
 

--- a/crates/engine/tests/chord_of_calling.rs
+++ b/crates/engine/tests/chord_of_calling.rs
@@ -29,7 +29,7 @@ use engine::types::ability::{
 };
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
-use engine::types::game_state::{ConvokeMode, WaitingFor};
+use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::keywords::Keyword;
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
@@ -224,29 +224,13 @@ fn chord_x_four_offers_only_mv_le_four_then_battlefield() {
     // X=4 → total cost {4}{G}{G}{G} = 7 green sources from pool.
     add_mana(&mut runner, ManaType::Green, 7);
 
-    let card_id = runner.state().objects[&spell_id].card_id;
-    runner
-        .act(GameAction::CastSpell {
-            object_id: spell_id,
-            card_id,
-            targets: vec![],
-        })
-        .expect("casting Chord of Calling must be accepted");
-
-    // CR 107.3a + CR 601.2b: X is announced before mana is paid.
-    assert!(
-        matches!(runner.state().waiting_for, WaitingFor::ChooseXValue { .. }),
-        "expected ChooseXValue, got {:?}",
-        runner.state().waiting_for
-    );
-    runner
-        .act(GameAction::ChooseX { value: 4 })
-        .expect("announcing X=4 must be accepted");
-
-    runner.advance_until_stack_empty();
+    // CR 107.3a + CR 601.2b: announce X=4 through the fluent driver; the pool
+    // auto-pays the {4}{G}{G}{G} cost and the driver halts at the mid-resolution
+    // SearchChoice (the discriminating prompt for this test).
+    let outcome = runner.cast(spell_id).x(4).resolve();
 
     // CR 701.23a: the offer must be exactly the MV-≤-4 creatures.
-    match &runner.state().waiting_for {
+    match outcome.final_waiting_for() {
         WaitingFor::SearchChoice { cards, .. } => {
             assert_eq!(
                 cards.len(),
@@ -335,58 +319,21 @@ fn chord_convoke_paid_x_does_not_corrupt_announced_x() {
         "Chord must carry the Convoke keyword"
     );
 
-    let card_id = runner.state().objects[&spell_id].card_id;
-    runner
-        .act(GameAction::CastSpell {
-            object_id: spell_id,
-            card_id,
-            targets: vec![],
-        })
-        .expect("casting Chord with Convoke must be accepted");
-
-    // CR 601.2f + CR 702.51b: X is announced first; convoke applies afterward.
-    let convoke_mode = match runner.state().waiting_for.clone() {
-        WaitingFor::ChooseXValue { convoke_mode, .. } => convoke_mode,
-        other => panic!("expected ChooseXValue, got {other:?}"),
-    };
-    assert_eq!(
-        convoke_mode,
-        Some(ConvokeMode::Convoke),
-        "Convoke keyword must thread through ChooseXValue (CR 702.51b)"
-    );
-
-    runner
-        .act(GameAction::ChooseX { value: 4 })
-        .expect("announcing X=4 must be accepted");
-
-    // Pay {G}{G}{G} via convoke (green) and the {4} X-generic via convoke
-    // (colorless). Every shard of the {X}{G}{G}{G} cost is convoke-paid.
-    for &c in convokers.iter().take(3) {
-        runner
-            .act(GameAction::TapForConvoke {
-                object_id: c,
-                mana_type: ManaType::Green,
-            })
-            .expect("convoke-tapping a green creature for {G} must be accepted");
-    }
-    for &c in convokers.iter().skip(3) {
-        runner
-            .act(GameAction::TapForConvoke {
-                object_id: c,
-                mana_type: ManaType::Colorless,
-            })
-            .expect("convoke-tapping a creature for the {4} X-generic must be accepted");
-    }
-
-    runner
-        .act(GameAction::PassPriority)
-        .expect("finalizing the convoke payment must be accepted");
-
-    runner.advance_until_stack_empty();
+    // CR 601.2f + CR 702.51b: X is announced first, then the ENTIRE
+    // {X}{G}{G}{G} cost is convoke-paid. The fluent driver announces X=4 and
+    // taps every convoke creature for mana of its color (green) — 3 cover the
+    // {G}{G}{G} colored shards and the remaining 4 green pay the {4} X-generic
+    // (CR 702.51b: a tapped creature pays {1} or one mana of its color, and a
+    // colored payment is a legal payment for a generic shard).
+    let outcome = runner
+        .cast(spell_id)
+        .x(4)
+        .convoke_with(&convokers)
+        .resolve();
 
     // THE DISCRIMINATOR: convoke-toward-X must not have shifted the announced X.
     // The offer must still be exactly MV-≤-4.
-    match &runner.state().waiting_for {
+    match outcome.final_waiting_for() {
         WaitingFor::SearchChoice { cards, .. } => {
             assert_eq!(
                 cards.len(),
@@ -456,35 +403,20 @@ fn chord_x_zero_offers_only_mv_zero_and_fails_to_find_cleanly() {
     // X=0 → total cost {G}{G}{G} = 3 green sources.
     add_mana(&mut runner, ManaType::Green, 3);
 
-    let card_id = runner.state().objects[&spell_id].card_id;
-    runner
-        .act(GameAction::CastSpell {
-            object_id: spell_id,
-            card_id,
-            targets: vec![],
-        })
-        .expect("casting Chord must be accepted");
-
-    assert!(
-        matches!(runner.state().waiting_for, WaitingFor::ChooseXValue { .. }),
-        "expected ChooseXValue, got {:?}",
-        runner.state().waiting_for
-    );
-    runner
-        .act(GameAction::ChooseX { value: 0 })
-        .expect("announcing X=0 must be accepted");
-
-    runner.advance_until_stack_empty();
+    // CR 107.3a (X=0): announce X=0 via the fluent driver; the pool auto-pays
+    // {G}{G}{G} and the spell resolves to completion (no SearchChoice surfaces).
+    let outcome = runner.cast(spell_id).x(0).resolve();
 
     // CR 701.23a: with no MV-0 creature, the search finds nothing — it must
-    // resolve cleanly rather than pause on a non-empty SearchChoice.
+    // resolve cleanly rather than pause on a non-empty SearchChoice. The driver
+    // halts at the post-resolution Priority window, never a SearchChoice.
     assert!(
-        !matches!(runner.state().waiting_for, WaitingFor::SearchChoice { .. }),
+        !matches!(outcome.final_waiting_for(), WaitingFor::SearchChoice { .. }),
         "X=0 with no MV-0 creatures must fail to find (no SearchChoice prompt), got {:?}",
-        runner.state().waiting_for
+        outcome.final_waiting_for()
     );
     assert!(
-        runner.state().stack.is_empty(),
+        outcome.state().stack.is_empty(),
         "the stack must drain after the fail-to-find resolution"
     );
 }


### PR DESCRIPTION
Adds a fluent SpellCast driver and CastOutcome to scenario.rs that drives the
full cast pipeline (modes -> X -> targets-by-intent -> mana/convoke -> resolve)
and exposes behavior deltas (hand_drawn, zone_of, life_delta, final_waiting_for).
Makes the five recurring test-harness foot-guns structurally impossible:
hand-built target vectors, incomplete modal target submission, wrong-point hand
baselines, inline-keyword cards, and AST-internal flag assertions.

Ports the four Witherbloom runtime tests (Exsanguinate, Kozilek's Command,
Chord of Calling, Vicious Rivalry) to the driver as reference examples, and adds
a card-test skill documenting the canonical recipe + anti-patterns.

CR 601.2a/c/h, 702.51a/b (grep-verified).
