### PR TITLE
refactor(review): idiomatic-at-the-seam follow-up to recent landings

### DIFF
--- a/client/src/components/modal/DialogShell.tsx
+++ b/client/src/components/modal/DialogShell.tsx
@@ -149,19 +149,43 @@ export function DialogHeader({
 }
 
 /**
- * Vertical pill tab attached to the right edge of a dialog. Pulsing
- * right-side glow signals "actionable affordance — click me to peek."
- * Mirrors the stack panel's collapse pattern but with stronger CTA styling
- * since the dialog is blocking content the player likely wants to see.
+ * Pill tab attached to the edge the dialog slides toward when peeked. The
+ * pulsing glow signals "actionable affordance — click me to peek." Mirrors
+ * `PeekRestoreTab`'s `direction` axis so the collapse cue points the same way
+ * the modal exits: the right edge on wide viewports, the bottom edge on narrow
+ * ones (where the dialog slides down rather than sideways).
  */
-export function PeekTab({ onClick }: { onClick: () => void }) {
+export function PeekTab({
+  onClick,
+  direction = "right",
+}: {
+  onClick: () => void;
+  direction?: "right" | "bottom";
+}) {
   const { t } = useTranslation("game");
   const shouldReduceMotion = useReducedMotion();
 
-  // Glow is offset to the right (+x in box-shadow) so it visually radiates
-  // toward the battlefield the player wants to peek at — directional cue.
-  const restingShadow = "0 18px 36px rgba(0,0,0,0.55), 14px 0 0 -8px rgba(34,211,238,0)";
-  const pulseShadow = "0 18px 36px rgba(0,0,0,0.55), 18px 0 36px rgba(34,211,238,0.65)";
+  // Glow is offset toward the edge the modal slides to (+x right / +y bottom)
+  // so it visually radiates toward the battlefield the player wants to peek at.
+  const restingShadow =
+    direction === "right"
+      ? "0 18px 36px rgba(0,0,0,0.55), 14px 0 0 -8px rgba(34,211,238,0)"
+      : "0 18px 36px rgba(0,0,0,0.55), 0 14px 0 -8px rgba(34,211,238,0)";
+  const pulseShadow =
+    direction === "right"
+      ? "0 18px 36px rgba(0,0,0,0.55), 18px 0 36px rgba(34,211,238,0.65)"
+      : "0 18px 36px rgba(0,0,0,0.55), 0 18px 36px rgba(34,211,238,0.65)";
+
+  const positionClass =
+    direction === "right"
+      ? "right-0 top-1/2 h-24 w-9 -translate-y-1/2 translate-x-1/3"
+      : "bottom-0 left-1/2 h-9 w-24 -translate-x-1/2 translate-y-1/3";
+
+  // The chevron points the way the modal exits: right as-is, down when rotated.
+  const iconClass =
+    direction === "right"
+      ? "group-hover:translate-x-0.5"
+      : "rotate-90 group-hover:translate-y-0.5";
 
   return (
     <motion.button
@@ -179,13 +203,13 @@ export function PeekTab({ onClick }: { onClick: () => void }) {
           ? undefined
           : { duration: 2.4, repeat: Infinity, ease: "easeInOut" }
       }
-      className="group absolute right-0 top-1/2 z-20 flex h-24 w-9 -translate-y-1/2 translate-x-1/3 items-center justify-center rounded-2xl border border-cyan-400/50 bg-[#0b1020]/96 text-cyan-200 backdrop-blur-md transition-colors hover:border-cyan-300 hover:bg-cyan-500/20 hover:text-white"
+      className={`group absolute z-20 flex items-center justify-center rounded-2xl border border-cyan-400/50 bg-[#0b1020]/96 text-cyan-200 backdrop-blur-md transition-colors hover:border-cyan-300 hover:bg-cyan-500/20 hover:text-white ${positionClass}`}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="currentColor"
-        className="h-6 w-6 transition-transform group-hover:translate-x-0.5"
+        className={`h-6 w-6 transition-transform ${iconClass}`}
       >
         <path
           fillRule="evenodd"

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1690,7 +1690,10 @@ function MulliganPanel({
               </div>
             )}
           </div>
-          <PeekTab onClick={togglePeek} />
+          <PeekTab
+            direction={isNarrow ? "bottom" : "right"}
+            onClick={togglePeek}
+          />
         </motion.div>
       </div>
     </div>

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1550,7 +1550,7 @@ fn target_filter_contains_chosen_x_ref(filter: &TargetFilter) -> bool {
     match filter {
         TargetFilter::Typed(typed) => typed.properties.iter().any(|prop| match prop {
             FilterProp::Cmc { value, .. } | FilterProp::Counters { count: value, .. } => {
-                quantity_expr_contains_x(value)
+                value.contains_x()
             }
             FilterProp::CanEnchant { target } => target_filter_contains_chosen_x_ref(target),
             _ => false,
@@ -1566,27 +1566,7 @@ fn target_filter_contains_chosen_x_ref(filter: &TargetFilter) -> bool {
 }
 
 fn quantity_expr_has_unresolved_x(ability: &ResolvedAbility, expr: &QuantityExpr) -> bool {
-    ability.chosen_x.is_none() && quantity_expr_contains_x(expr)
-}
-
-fn quantity_expr_contains_x(expr: &QuantityExpr) -> bool {
-    match expr {
-        QuantityExpr::Ref {
-            qty: QuantityRef::Variable { name },
-        } => name == "X",
-        QuantityExpr::Offset { inner, .. }
-        | QuantityExpr::Multiply { inner, .. }
-        | QuantityExpr::DivideRounded { inner, .. }
-        | QuantityExpr::UpTo { max: inner }
-        | QuantityExpr::Power {
-            exponent: inner, ..
-        } => quantity_expr_contains_x(inner),
-        QuantityExpr::Sum { exprs } => exprs.iter().any(quantity_expr_contains_x),
-        QuantityExpr::Difference { left, right } => {
-            quantity_expr_contains_x(left) || quantity_expr_contains_x(right)
-        }
-        QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => false,
-    }
+    ability.chosen_x.is_none() && expr.contains_x()
 }
 
 /// CR 109.4 + CR 115.1: Returns true if `effect` needs a companion

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2756,7 +2756,7 @@ fn additional_cost_x_max(
     cost: &AbilityCost,
 ) -> Option<u32> {
     match cost {
-        AbilityCost::PayLife { amount } if quantity_expr_contains_x(amount) => {
+        AbilityCost::PayLife { amount } if amount.contains_x() => {
             Some(max_pay_life_x(state, player))
         }
         AbilityCost::Sacrifice { target, count } if *count == u32::MAX => {
@@ -2789,26 +2789,6 @@ fn max_pay_life_x(state: &GameState, player: PlayerId) -> u32 {
         .find(|p| p.id == player)
         .map(|p| u32::try_from(p.life.max(0)).unwrap_or(0))
         .unwrap_or(0)
-}
-
-fn quantity_expr_contains_x(expr: &QuantityExpr) -> bool {
-    match expr {
-        QuantityExpr::Ref {
-            qty: QuantityRef::Variable { name },
-        } => name == "X",
-        QuantityExpr::Offset { inner, .. }
-        | QuantityExpr::Multiply { inner, .. }
-        | QuantityExpr::DivideRounded { inner, .. }
-        | QuantityExpr::UpTo { max: inner }
-        | QuantityExpr::Power {
-            exponent: inner, ..
-        } => quantity_expr_contains_x(inner),
-        QuantityExpr::Sum { exprs } => exprs.iter().any(quantity_expr_contains_x),
-        QuantityExpr::Difference { left, right } => {
-            quantity_expr_contains_x(left) || quantity_expr_contains_x(right)
-        }
-        QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => false,
-    }
 }
 
 pub(super) fn effective_casualty_additional_cost(

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -586,28 +586,18 @@ fn evaluate_commander_with_format(
             commander_identity.extend(card_color_identity(face));
         }
     }
-    let mut identity_violations = BTreeSet::new();
-    for name in &request.main_deck {
-        if request
-            .commander
-            .iter()
-            .any(|c| c.eq_ignore_ascii_case(name))
-        {
-            continue;
-        }
-        if unknown_cards.contains(name.as_str()) {
-            continue;
-        }
-        if let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) {
-            let card_colors = card_color_identity(face);
-            for color in &card_colors {
-                if !commander_identity.contains(color) {
-                    identity_violations.insert(name.clone());
-                    break;
-                }
-            }
-        }
-    }
+    let identity_violations = color_identity_violations(
+        db,
+        &request.main_deck,
+        &commander_identity,
+        unknown_cards,
+        |name| {
+            request
+                .commander
+                .iter()
+                .any(|c| c.eq_ignore_ascii_case(name))
+        },
+    );
     if !identity_violations.is_empty() {
         reasons.push(summarize_cards(
             "Cards outside commander's color identity",
@@ -1282,10 +1272,15 @@ fn evaluate_oathbreaker(
         ));
     }
 
-    // Oathbreaker RC: every main-deck card must be within the Oathbreaker's color identity.
+    // Oathbreaker RC: every main-deck card must be within the Oathbreaker's
+    // color identity. CR 903.5c (color identity) is shared with the other
+    // command-zone formats via `color_identity_violations`; CR 903.5d (off-
+    // identity basic land types) is reported in its own bucket alongside it.
     let mut identity_violations = BTreeSet::new();
     let mut basic_type_violations = BTreeSet::new();
     if let Some(identity) = &oathbreaker_identity {
+        identity_violations =
+            color_identity_violations(db, &request.main_deck, identity, unknown_cards, |_| false);
         for name in request.main_deck.iter().map(String::as_str) {
             if unknown_cards.contains(name) {
                 continue;
@@ -1294,12 +1289,6 @@ fn evaluate_oathbreaker(
             let Some(face) = db.get_face_by_name(resolved) else {
                 continue;
             };
-            for color in card_color_identity(face) {
-                if !identity.contains(&color) {
-                    identity_violations.insert(name.to_string());
-                    break;
-                }
-            }
             for color in basic_land_type_colors(face) {
                 if !identity.contains(&color) {
                     basic_type_violations.insert(face.name.clone());
@@ -1869,6 +1858,36 @@ fn collect_unknown_cards(
 }
 
 /// CR 903.4: Compute color identity of a single card from mana cost + color indicator.
+/// CR 903.5c: collect every main-deck card whose color identity is not a
+/// subset of `identity`. Shared by the command-zone formats so the
+/// color-identity-subset loop lives in one place instead of being copied per
+/// format. `is_command_zone_card` skips cards that occupy the command zone
+/// (e.g. a commander also listed in the main deck); unknown cards are skipped
+/// so they are reported only once under "Unknown cards".
+fn color_identity_violations(
+    db: &CardDatabase,
+    main_deck: &[String],
+    identity: &HashSet<ManaColor>,
+    unknown_cards: &BTreeSet<String>,
+    is_command_zone_card: impl Fn(&str) -> bool,
+) -> BTreeSet<String> {
+    let mut violations = BTreeSet::new();
+    for name in main_deck {
+        if is_command_zone_card(name.as_str()) || unknown_cards.contains(name.as_str()) {
+            continue;
+        }
+        if let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) {
+            if card_color_identity(face)
+                .iter()
+                .any(|color| !identity.contains(color))
+            {
+                violations.insert(name.clone());
+            }
+        }
+    }
+    violations
+}
+
 fn card_color_identity(face: &CardFace) -> HashSet<ManaColor> {
     if !face.color_identity.is_empty() {
         return face.color_identity.iter().copied().collect();

--- a/crates/engine/src/game/engine_stack.rs
+++ b/crates/engine/src/game/engine_stack.rs
@@ -86,6 +86,16 @@ pub(super) fn finalize_trigger_target_selection(
     WaitingFor::Priority { player: controller }
 }
 
+/// CR 706.2 + CR 603.12: Re-stamp the pending trigger's carried die-roll
+/// result into resolution scope before computing or validating targets, so a
+/// dynamic `TargetSelectionConstraint::TotalManaValue` cap whose value is
+/// `EventContextAmount` ("where X is the result") resolves against the rolled
+/// number during the legality check or the step-by-step choose walk. The next
+/// `apply()` clears `die_result_this_resolution`, so this cannot leak.
+fn restamp_pending_die_result(state: &mut GameState) {
+    state.die_result_this_resolution = state.pending_trigger.as_ref().and_then(|t| t.die_result);
+}
+
 pub(super) fn handle_trigger_target_selection_select_targets(
     state: &mut GameState,
     _player: PlayerId,
@@ -94,13 +104,7 @@ pub(super) fn handle_trigger_target_selection_select_targets(
     targets: Vec<TargetRef>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    // CR 706.2 + CR 603.12: Re-stamp the carried die-roll result into
-    // resolution scope before validating targets, so a dynamic
-    // `TargetSelectionConstraint::TotalManaValue` whose cap is the
-    // `where X is the result` value (`EventContextAmount`) resolves against the
-    // rolled number during the legality check. The next `apply()` clears
-    // `die_result_this_resolution`, so this cannot leak.
-    state.die_result_this_resolution = state.pending_trigger.as_ref().and_then(|t| t.die_result);
+    restamp_pending_die_result(state);
     let Some(pending) = state.pending_trigger.as_ref() else {
         return Err(EngineError::InvalidAction("No pending trigger".to_string()));
     };
@@ -178,12 +182,7 @@ pub(super) fn handle_trigger_target_selection_choose_target(
             }
         };
 
-    // CR 706.2 + CR 603.12: Re-stamp the carried die-roll result into resolution
-    // scope before computing/validating legal targets, so a dynamic
-    // `TotalManaValue` cap (`EventContextAmount` = "where X is the result")
-    // resolves against the rolled number during the step-by-step choose walk.
-    // Cleared by the next `apply()`, so it cannot leak.
-    state.die_result_this_resolution = state.pending_trigger.as_ref().and_then(|t| t.die_result);
+    restamp_pending_die_result(state);
 
     let Some(pending_trigger) = state.pending_trigger.as_ref() else {
         return Err(EngineError::InvalidAction("No pending trigger".to_string()));

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -127,6 +127,22 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         }
     }
 
+    // CR 717.2: A player's Attraction deck is a hidden-order supplementary
+    // deck, like a library — even its owner doesn't know the order. Redact
+    // every unrevealed Attraction card's identity for all viewers, mirroring
+    // the library treatment above, so the serialized state can't leak the
+    // contents or order of any player's Attraction deck.
+    let all_attraction_ids: Vec<ObjectId> = filtered
+        .players
+        .iter()
+        .flat_map(|p| p.attraction_deck.iter().copied())
+        .collect();
+    for obj_id in all_attraction_ids {
+        if !state.revealed_cards.contains(&obj_id) {
+            hide_card(&mut filtered, obj_id);
+        }
+    }
+
     // CR 406.3: A card exiled face down can't be examined by any player
     // except when an instruction allows it. Foretell is the only modeled
     // face-down-exile look permission today; other face-down exile classes

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5674,8 +5674,9 @@ pub(super) fn parse_imperative_family_ast(
             } else if let Some(effect) =
                 try_parse_gain_keyword(text).or_else(|| try_parse_gain_quoted_ability(text))
             {
-                // CR 702.1b: keyword-ability grant (CR 113.3 + CR 604.1: or
-                // quoted-ability grant). Checked BEFORE the life-gain branch because the bare
+                // CR 113.3 + CR 604.1: grant a keyword ability (or, via
+                // try_parse_gain_quoted_ability, a quoted ability) to an object.
+                // Checked BEFORE the life-gain branch because the bare
                 // `scan_contains(lower, "life")` guard below also matches
                 // keywords whose name contains "life" — e.g. "gain lifelink",
                 // which otherwise misrouted to the numeric life-gain parser and

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -241,11 +241,13 @@ pub(crate) fn parse_additive_type_clause_modifications(
         let lower_word = word.to_lowercase();
         // CR 105.2 + CR 613.1e: a color word ("black", "white", …) adds that
         // color (layer 5), e.g. Rise from the Grave's "black Zombie".
-        if let Ok((rest, color)) = nom_primitives::parse_color(lower_word.as_str()) {
-            if rest.is_empty() {
-                modifications.push(ContinuousModification::AddColor { color });
-                continue;
-            }
+        // `all_consuming` asserts the whole token is the color word, matching
+        // the sibling guard idiom rather than a manual `rest.is_empty()` check.
+        if let Ok((_, color)) =
+            all_consuming(nom_primitives::parse_color).parse(lower_word.as_str())
+        {
+            modifications.push(ContinuousModification::AddColor { color });
+            continue;
         }
         if let Some(core_type) = core_type_from_additive_word(lower_word.as_str()) {
             modifications.push(ContinuousModification::AddType { core_type });

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3674,6 +3674,31 @@ impl QuantityExpr {
         }
     }
 
+    /// Returns true if this expression resolves through a
+    /// `QuantityRef::Variable { name: "X" }` anywhere in its tree — i.e. its
+    /// value depends on the spell or ability's chosen X. Single authority for
+    /// "does this quantity use X": the engine cost machinery (X-affordability,
+    /// pay-life-X) and the AI X-value policy all rely on it. The match is
+    /// exhaustive so a new `QuantityExpr` variant forces every consumer to
+    /// reconsider X-dependence rather than silently defaulting to false.
+    pub fn contains_x(&self) -> bool {
+        match self {
+            QuantityExpr::Ref {
+                qty: QuantityRef::Variable { name },
+            } => name == "X",
+            QuantityExpr::Offset { inner, .. }
+            | QuantityExpr::Multiply { inner, .. }
+            | QuantityExpr::DivideRounded { inner, .. }
+            | QuantityExpr::UpTo { max: inner }
+            | QuantityExpr::Power {
+                exponent: inner, ..
+            } => inner.contains_x(),
+            QuantityExpr::Sum { exprs } => exprs.iter().any(QuantityExpr::contains_x),
+            QuantityExpr::Difference { left, right } => left.contains_x() || right.contains_x(),
+            QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => false,
+        }
+    }
+
     /// Construct an `UpTo { max }` expression, debug-asserting the
     /// non-nesting invariant. Always use this rather than the raw struct
     /// literal.

--- a/crates/phase-ai/src/policies/x_value.rs
+++ b/crates/phase-ai/src/policies/x_value.rs
@@ -20,9 +20,7 @@
 //! Krasis), and counters-X (Reinforce X) all share this shape and all want a
 //! non-zero X.
 
-use engine::types::ability::{
-    AbilityDefinition, Effect, QuantityExpr, QuantityRef, ResolvedAbility,
-};
+use engine::types::ability::{AbilityDefinition, Effect, ResolvedAbility};
 use engine::types::actions::GameAction;
 use engine::types::game_state::{GameState, WaitingFor};
 use engine::types::identifiers::ObjectId;
@@ -100,7 +98,7 @@ fn ability_references_x(ability: &ResolvedAbility) -> bool {
         return true;
     }
     if let Some(expr) = &ability.repeat_for {
-        if quantity_expr_contains_x(expr) {
+        if expr.contains_x() {
             return true;
         }
     }
@@ -162,7 +160,7 @@ fn ability_definition_references_x(ability: &AbilityDefinition) -> bool {
         return true;
     }
     if let Some(expr) = &ability.repeat_for {
-        if quantity_expr_contains_x(expr) {
+        if expr.contains_x() {
             return true;
         }
     }
@@ -180,16 +178,16 @@ fn ability_definition_references_x(ability: &AbilityDefinition) -> bool {
 }
 
 /// Walk every `QuantityExpr` reachable from `effect` and return true if any
-/// resolves through `QuantityRef::Variable { name: "X" }`. Mirrors
-/// `engine::game::casting_costs::quantity_expr_contains_x` (kept private
-/// there) so the AI layer can run the same predicate without an engine edit.
+/// resolves through `QuantityRef::Variable { name: "X" }`. Delegates the
+/// per-expression test to `QuantityExpr::contains_x`, the engine's single
+/// authority, so the AI scores X exactly as the engine evaluates it.
 fn effect_references_x(effect: &Effect) -> bool {
     match effect {
         Effect::DealDamage { amount, .. }
         | Effect::DamageAll { amount, .. }
         | Effect::DamageEachPlayer { amount, .. }
         | Effect::GainLife { amount, .. }
-        | Effect::LoseLife { amount, .. } => quantity_expr_contains_x(amount),
+        | Effect::LoseLife { amount, .. } => amount.contains_x(),
         Effect::Draw { count, .. }
         | Effect::Mill { count, .. }
         | Effect::Discard { count, .. }
@@ -203,38 +201,13 @@ fn effect_references_x(effect: &Effect) -> bool {
         | Effect::PutCounter { count, .. }
         | Effect::PutCounterAll { count, .. }
         | Effect::CopyTokenOf { count, .. }
-        | Effect::SearchLibrary { count, .. } => quantity_expr_contains_x(count),
+        | Effect::SearchLibrary { count, .. } => count.contains_x(),
         Effect::Token {
             count,
             enter_with_counters,
             ..
-        } => {
-            quantity_expr_contains_x(count)
-                || enter_with_counters
-                    .iter()
-                    .any(|(_, qty)| quantity_expr_contains_x(qty))
-        }
+        } => count.contains_x() || enter_with_counters.iter().any(|(_, qty)| qty.contains_x()),
         _ => false,
-    }
-}
-
-fn quantity_expr_contains_x(expr: &QuantityExpr) -> bool {
-    match expr {
-        QuantityExpr::Ref {
-            qty: QuantityRef::Variable { name },
-        } => name == "X",
-        QuantityExpr::Offset { inner, .. }
-        | QuantityExpr::Multiply { inner, .. }
-        | QuantityExpr::DivideRounded { inner, .. }
-        | QuantityExpr::UpTo { max: inner }
-        | QuantityExpr::Power {
-            exponent: inner, ..
-        } => quantity_expr_contains_x(inner),
-        QuantityExpr::Sum { exprs } => exprs.iter().any(quantity_expr_contains_x),
-        QuantityExpr::Difference { left, right } => {
-            quantity_expr_contains_x(left) || quantity_expr_contains_x(right)
-        }
-        QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => false,
     }
 }
 

--- a/crates/server-core/src/seat_mutation_wire_guard.rs
+++ b/crates/server-core/src/seat_mutation_wire_guard.rs
@@ -12,6 +12,13 @@ use crate::protocol::{DeckChoice, SeatKind, SeatMutation};
 /// Max AI starter deck name length in seat mutations.
 pub const MAX_AI_DECK_NAME_LEN: usize = 128;
 
+fn bound_seat_index(seat_index: u8) -> Result<(), String> {
+    if seat_index >= MAX_PLAYER_COUNT {
+        return Err(format!("seat_index must be less than {MAX_PLAYER_COUNT}"));
+    }
+    Ok(())
+}
+
 fn validate_deck_choice(field: &str, deck: &DeckChoice) -> Result<(), String> {
     match deck {
         DeckChoice::Random => Ok(()),
@@ -26,17 +33,13 @@ fn validate_deck_choice(field: &str, deck: &DeckChoice) -> Result<(), String> {
 pub fn guard_seat_mutation(mutation: &SeatMutation) -> Result<(), String> {
     match mutation {
         SeatMutation::SetKind { seat_index, kind } => {
-            if *seat_index >= MAX_PLAYER_COUNT {
-                return Err(format!("seat_index must be less than {MAX_PLAYER_COUNT}"));
-            }
+            bound_seat_index(*seat_index)?;
             if let SeatKind::Ai { deck, .. } = kind {
                 validate_deck_choice("mutation.kind.ai.deck", deck)?;
             }
         }
         SeatMutation::Remove { seat_index } => {
-            if *seat_index >= MAX_PLAYER_COUNT {
-                return Err(format!("seat_index must be less than {MAX_PLAYER_COUNT}"));
-            }
+            bound_seat_index(*seat_index)?;
         }
         SeatMutation::Start => {}
     }


### PR DESCRIPTION
Implementation-quality pass over the last 36h of commits. The seams were
already validated correct; this tightens the implementation at each seam.

- fix(engine): redact unrevealed Attraction-deck cards in the multiplayer
  hidden-info filter (CR 717.2) — opponents could otherwise read attraction
  identities/order off the wire
- refactor(engine): single QuantityExpr::contains_x method replacing three
  byte-identical copies (ability_utils, casting_costs, phase-ai x_value)
- refactor(engine): extract shared color_identity_violations (CR 903.5c)
  used by both Commander and Oathbreaker deck validation
- refactor(engine): extract restamp_pending_die_result, de-duplicating the
  CR 706.2/603.12 re-stamp across both trigger-target handlers
- refactor(server-core): extract bound_seat_index in the SeatMutate guard
- refactor(parser): all_consuming(parse_color) for the additive-color
  type-change guard, matching the sibling combinator idiom
- docs(engine): correct the "gain lifelink" annotation to CR 113.3/604.1
  (CR 702.1b is for variable-defining keywords, not general grants)
- fix(client): parameterize PeekTab direction so the collapse cue points the
  way the modal exits (bottom on narrow viewports), mirroring PeekRestoreTab
