### PR TITLE
fix(ai): penalize re-granting already-active self-buff keywords like Prognostic Sphinx hexproof

### DIFF
--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -781,19 +781,35 @@ fn zero_quantity_redundancy(
 
 /// `GenericEffect` redundancy: the effect's static abilities grant one or
 /// more keywords (via `ContinuousModification::AddKeyword`), and every
-/// candidate target already effectively has each granted keyword.
+/// recipient already effectively has each granted keyword.
+///
+/// Recipients are resolved by layer (CR 611.2 — a continuous effect's
+/// affected set is defined by the ability, which may or may not be a chosen
+/// target):
+/// - A chosen `target` (e.g. "target creature gains flying") drives the set
+///   directly — at decision time the legal-target *filter* stands in for the
+///   not-yet-chosen object.
+/// - A self/affected-scoped grant carries `target: None` (e.g. Prognostic
+///   Sphinx's "~ gains hexproof until end of turn", whose lowered form has
+///   `target: None` and a `StaticDefinition` with `affected: Some(SelfRef)`).
+///   The recipients are then the union of each keyword-granting static's
+///   `affected` filter. Without this fallback the policy is blind to redundant
+///   self-buffs — the AI re-pays the cost (here: discarding a card) to grant a
+///   keyword it already has (issue #1966).
 fn generic_effect_keyword_redundancy(
     state: &GameState,
     source_id: ObjectId,
     static_abilities: &[StaticDefinition],
     target: Option<&TargetFilter>,
 ) -> Option<(f64, i64, i64)> {
-    let target = target?;
     let granted = collect_keyword_grants(static_abilities);
     if granted.is_empty() {
         return None;
     }
-    let candidates = resolved_candidate_targets(state, source_id, target);
+    let candidates = match target {
+        Some(target) => resolved_candidate_targets(state, source_id, target),
+        None => resolve_affected_candidates(state, source_id, static_abilities),
+    };
     if candidates.is_empty() {
         return None;
     }
@@ -808,6 +824,38 @@ fn generic_effect_keyword_redundancy(
     } else {
         None
     }
+}
+
+/// Resolve the recipients of a keyword-granting `GenericEffect` that carries
+/// no chosen `target` — the self/affected-scoped case (Prognostic Sphinx's
+/// "~ gains hexproof until end of turn"). Returns the dedup-preserving union of
+/// objects matched by the `affected` filter of every static ability that
+/// grants at least one keyword. A static whose `affected` is `None` defines no
+/// recipient set and contributes nothing.
+fn resolve_affected_candidates(
+    state: &GameState,
+    source_id: ObjectId,
+    static_abilities: &[StaticDefinition],
+) -> Vec<ObjectId> {
+    let mut out = Vec::new();
+    for stat in static_abilities {
+        let grants_keyword = stat
+            .modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::AddKeyword { .. }));
+        if !grants_keyword {
+            continue;
+        }
+        let Some(affected) = stat.affected.as_ref() else {
+            continue;
+        };
+        for id in resolved_candidate_targets(state, source_id, affected) {
+            if !out.contains(&id) {
+                out.push(id);
+            }
+        }
+    }
+    out
 }
 
 /// Walk `StaticDefinition.modifications` and collect the keywords that
@@ -1205,6 +1253,90 @@ mod tests {
             panic!("expected Score verdict");
         };
         assert_eq!(delta, 0.0, "new keyword grant should not penalise");
+    }
+
+    /// Issue #1966 (Prognostic Sphinx): a self-scoped keyword grant lowers to
+    /// `GenericEffect { target: None, static_abilities: [.. affected: SelfRef ..] }`.
+    /// When the source already has the keyword, re-activating (paying the
+    /// discard cost) is redundant and must be penalised. Before the
+    /// `affected`-fallback fix the `target: None` shape returned `None`,
+    /// blinding the policy to the redundant self-buff.
+    #[test]
+    fn generic_effect_self_scoped_already_has_keyword_penalized() {
+        let mut state = GameState::new_two_player(0);
+        let stat = StaticDefinition::new(StaticMode::Continuous)
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Hexproof,
+            }]);
+        let obj_id = make_creature_with_ability(
+            &mut state,
+            "Prognostic Sphinx",
+            Effect::GenericEffect {
+                static_abilities: vec![stat],
+                duration: Some(Duration::UntilEndOfTurn),
+                target: None,
+            },
+        );
+        // Hexproof already active from a prior activation this turn — re-granting
+        // is pure redundancy.
+        state
+            .objects
+            .get_mut(&obj_id)
+            .unwrap()
+            .keywords
+            .push(Keyword::Hexproof);
+
+        let config = AiConfig::default();
+        let ai_ctx = AiContext::empty(&config.weights);
+        let decision = priority_decision();
+        let candidate = activate_candidate(obj_id);
+        let ctx = mk_ctx(&state, &decision, &candidate, &config, &ai_ctx);
+
+        let PolicyVerdict::Score { delta, .. } = RedundancyAvoidancePolicy.verdict(&ctx) else {
+            panic!("expected Score verdict");
+        };
+        assert_eq!(
+            delta, -2.0,
+            "redundant self-scoped keyword grant should emit -2.0 delta"
+        );
+    }
+
+    /// Companion to the issue #1966 case: the first activation, when the source
+    /// does not yet have the keyword, grants real value and must NOT be
+    /// penalised (otherwise the AI never gains hexproof at all).
+    #[test]
+    fn generic_effect_self_scoped_new_keyword_not_penalized() {
+        let mut state = GameState::new_two_player(0);
+        let stat = StaticDefinition::new(StaticMode::Continuous)
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Hexproof,
+            }]);
+        let obj_id = make_creature_with_ability(
+            &mut state,
+            "Prognostic Sphinx",
+            Effect::GenericEffect {
+                static_abilities: vec![stat],
+                duration: Some(Duration::UntilEndOfTurn),
+                target: None,
+            },
+        );
+        // No pre-existing hexproof — the grant is new value.
+
+        let config = AiConfig::default();
+        let ai_ctx = AiContext::empty(&config.weights);
+        let decision = priority_decision();
+        let candidate = activate_candidate(obj_id);
+        let ctx = mk_ctx(&state, &decision, &candidate, &config, &ai_ctx);
+
+        let PolicyVerdict::Score { delta, .. } = RedundancyAvoidancePolicy.verdict(&ctx) else {
+            panic!("expected Score verdict");
+        };
+        assert_eq!(
+            delta, 0.0,
+            "first self-scoped keyword grant should not penalise"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The AI repeatedly activates Prognostic Sphinx's `Discard a card: ~ gains hexproof until end of turn` even when it already has hexproof, discarding its hand for no gain.

The `RedundancyAvoidancePolicy` already penalizes re-granting an active keyword, but `generic_effect_keyword_redundancy` bailed out (`let target = target?;`) whenever an effect had no *chosen target*. Self-scoped grants lower to `GenericEffect { target: None, static_abilities: [{ affected: SelfRef, AddKeyword: Hexproof }] }`, so the policy never saw the redundancy.

Closes: #1966

## Change

- When a keyword-granting `GenericEffect` has `target: None`, resolve the recipients from the static abilities' `affected` filters instead of bailing (`SelfRef` → the source). The policy now correctly emits its `-2.0` redundancy delta for already-active self-buffs.
- New helper `resolve_affected_candidates` unions the `affected` set of every keyword-granting static (dedup-preserving; a static with `affected: None` contributes nothing).
- The `target: Some(..)` path (e.g. *"target creature gains flying"*) is unchanged.

This is a class-level fix, not a card patch: it covers every `target: None` keyword grant — self-buffs (*gains indestructible/flying UEOT*), auras (*enchanted creature has X*), and *creatures you control gain X*. It only ever adds a penalty when **all** recipients **already** have **all** granted keywords, so it cannot produce a false positive. CR 611.2 annotated for the continuous-effect affected-set semantics.

## Behavior

- **First activation** (gain hexproof when threatened) → not penalized; still allowed.
- **Redundant re-activation** (hexproof already active) → `-2.0`, so `PassPriority` wins and the AI stops discarding its hand.

## Testing

- `cargo fmt --all` — clean.
- `cargo test -p phase-ai --lib redundancy` — **22 passed, 0 failed**, including two new tests mirroring the real Prognostic Sphinx parse:
  - `generic_effect_self_scoped_already_has_keyword_penalized` → `-2.0`
  - `generic_effect_self_scoped_new_keyword_not_penalized` → `0.0`
  - All pre-existing redundancy tests remain green (no regression).
- `cargo clippy -p phase-ai --lib --tests` — zero warnings.
