### PR TITLE
fix(engine): enforce CR 601.2c distinct targets within a multi-target instance

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -632,10 +632,19 @@ pub enum TargetSelectionAdvance {
     Complete(Vec<Option<TargetRef>>),
 }
 
+/// CR 601.2c + CR 115.3: Identifies one instance of the word "target" on an
+/// ability. Slots sharing a `TargetInstanceId` are the SAME "target" (all slots
+/// of one `multi_target` "up to N target creatures" run) and must be mutually
+/// distinct objects; slots with DIFFERENT ids are separate instances that may
+/// reuse the same object ("Destroy target artifact and target land").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TargetInstanceId(usize);
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TargetSlotSpec {
     filter: TargetFilter,
     optional: bool,
+    instance: TargetInstanceId,
 }
 
 struct AbilityTargetingView<'a> {
@@ -1984,6 +1993,7 @@ fn collect_target_slot_specs(
     state: &GameState,
     ability: &ResolvedAbility,
     specs: &mut Vec<TargetSlotSpec>,
+    next_instance: &mut usize,
 ) {
     if let Some(sub_ability) = ability.sub_ability.as_deref().filter(|sub| {
         matches!(
@@ -1992,7 +2002,7 @@ fn collect_target_slot_specs(
         )
     }) {
         if ability.context.additional_cost_paid {
-            collect_target_slot_specs(state, sub_ability, specs);
+            collect_target_slot_specs(state, sub_ability, specs, next_instance);
             return;
         }
     }
@@ -2005,9 +2015,12 @@ fn collect_target_slot_specs(
             if matches!(filter, TargetFilter::SelfRef) {
                 continue;
             }
+            let id = TargetInstanceId(*next_instance);
+            *next_instance += 1;
             specs.push(TargetSlotSpec {
                 filter: filter.clone(),
                 optional: ability.optional_targeting,
+                instance: id,
             });
         }
         return;
@@ -2022,18 +2035,24 @@ fn collect_target_slot_specs(
     {
         for filter in move_counter_stack_target_filters(source, target, *selection) {
             if !filter.is_context_ref() {
+                let id = TargetInstanceId(*next_instance);
+                *next_instance += 1;
                 specs.push(TargetSlotSpec {
                     filter: filter.clone(),
                     optional: ability.optional_targeting,
+                    instance: id,
                 });
             }
         }
     } else if let Effect::Attach { attachment, target } = &ability.effect {
         for filter in [attachment, target] {
             if attach_filter_needs_target_slot(filter) {
+                let id = TargetInstanceId(*next_instance);
+                *next_instance += 1;
                 specs.push(TargetSlotSpec {
                     filter: filter.clone(),
                     optional: ability.optional_targeting,
+                    instance: id,
                 });
             }
         }
@@ -2050,17 +2069,20 @@ fn collect_target_slot_specs(
             .into_iter()
             .flatten()
         {
+            let id = TargetInstanceId(*next_instance);
+            *next_instance += 1;
             specs.push(TargetSlotSpec {
                 filter: filter.clone(),
                 optional: ability.optional_targeting,
+                instance: id,
             });
         }
     } else {
         if is_per_opponent_target_fanout(ability) {
-            collect_per_opponent_target_fanout_specs(state, ability, specs);
+            collect_per_opponent_target_fanout_specs(state, ability, specs, next_instance);
             if let Some(sub_ability) = ability.sub_ability.as_deref() {
                 if !defers_conditional_target_selection(sub_ability) {
-                    collect_target_slot_specs(state, sub_ability, specs);
+                    collect_target_slot_specs(state, sub_ability, specs, next_instance);
                 }
             }
             return;
@@ -2071,25 +2093,34 @@ fn collect_target_slot_specs(
         if ability.target_choice_timing == TargetChoiceTiming::Stack
             && effect_references_target_player(&ability.effect)
         {
+            let id = TargetInstanceId(*next_instance);
+            *next_instance += 1;
             specs.push(TargetSlotSpec {
                 filter: TargetFilter::Player,
                 optional: ability.optional_targeting,
+                instance: id,
             });
         }
         if ability.target_choice_timing == TargetChoiceTiming::Stack
             && effect_needs_target_creature_quantity_slot(&ability.effect)
         {
+            let id = TargetInstanceId(*next_instance);
+            *next_instance += 1;
             specs.push(TargetSlotSpec {
                 filter: target_creature_quantity_slot_filter(),
                 optional: ability.optional_targeting,
+                instance: id,
             });
         }
         if ability.target_choice_timing == TargetChoiceTiming::Stack
             && effect_needs_parent_target_combat_relation_slot(&ability.effect)
         {
+            let id = TargetInstanceId(*next_instance);
+            *next_instance += 1;
             specs.push(TargetSlotSpec {
                 filter: parent_target_combat_relation_slot_filter(),
                 optional: ability.optional_targeting,
+                instance: id,
             });
         }
         if ability.target_choice_timing == TargetChoiceTiming::Stack {
@@ -2100,17 +2131,28 @@ fn collect_target_slot_specs(
                     if let Ok(bounds) =
                         resolve_multi_target_bounds(state, ability, spec, legal_targets.len())
                     {
+                        // CR 601.2c + CR 115.3: all slots of one "up to N target
+                        // creatures" run are ONE instance of "target" -> one shared
+                        // TargetInstanceId. Allocate it once before the loop and
+                        // stamp every spec in the run so the same object can't be
+                        // chosen into two of these slots.
+                        let id = TargetInstanceId(*next_instance);
+                        *next_instance += 1;
                         for slot_index in 0..bounds.max {
                             specs.push(TargetSlotSpec {
                                 filter: filter.clone(),
                                 optional: slot_index >= bounds.min,
+                                instance: id,
                             });
                         }
                     }
                 } else {
+                    let id = TargetInstanceId(*next_instance);
+                    *next_instance += 1;
                     specs.push(TargetSlotSpec {
                         filter: filter.clone(),
                         optional: ability.optional_targeting,
+                        instance: id,
                     });
                 }
             }
@@ -2121,12 +2163,13 @@ fn collect_target_slot_specs(
             state,
             ability.sub_ability.as_deref(),
             specs,
+            next_instance,
         );
         return;
     }
     if let Some(sub_ability) = ability.sub_ability.as_deref() {
         if !defers_conditional_target_selection(sub_ability) {
-            collect_target_slot_specs(state, sub_ability, specs);
+            collect_target_slot_specs(state, sub_ability, specs, next_instance);
         }
     }
 }
@@ -2324,6 +2367,7 @@ fn collect_per_opponent_target_fanout_specs(
     state: &GameState,
     ability: &ResolvedAbility,
     specs: &mut Vec<TargetSlotSpec>,
+    next_instance: &mut usize,
 ) {
     let Some(object_filter) = per_opponent_fanout_object_filter(ability) else {
         return;
@@ -2339,13 +2383,22 @@ fn collect_per_opponent_target_fanout_specs(
         {
             continue;
         }
+        // CR 601.2c + CR 115.3: per-opponent fanout slots are SEPARATE instances
+        // of "target" — the Player slot and the object slot each get their own
+        // fresh TargetInstanceId so they never cross-constrain each other.
+        let player_id = TargetInstanceId(*next_instance);
+        *next_instance += 1;
+        let object_id = TargetInstanceId(*next_instance);
+        *next_instance += 1;
         specs.push(TargetSlotSpec {
             filter: TargetFilter::SpecificPlayer { id: opponent },
             optional: false,
+            instance: player_id,
         });
         specs.push(TargetSlotSpec {
             filter: object_filter.clone(),
             optional: ability.targeting_is_optional(),
+            instance: object_id,
         });
     }
 }
@@ -2435,7 +2488,10 @@ fn rewrite_relative_controller(
 
 fn target_slot_specs(state: &GameState, ability: &ResolvedAbility) -> Vec<TargetSlotSpec> {
     let mut specs = Vec::new();
-    collect_target_slot_specs(state, ability, &mut specs);
+    // CR 601.2c + CR 115.3: instance ids are allocated densely from 0 as specs
+    // are collected; each fresh-id push site bumps the seed.
+    let mut next_instance = 0usize;
+    collect_target_slot_specs(state, ability, &mut specs, &mut next_instance);
     specs
 }
 
@@ -2453,45 +2509,94 @@ fn relative_filter_controller(
         .unwrap_or(ability.controller)
 }
 
+/// Compute the legal targets for one slot, then drop any object already chosen
+/// in a prior slot of the SAME instance of "target".
+///
+/// `prior_specs` are the specs for the slots before `spec` (i.e. `&specs[..i]`);
+/// `selected_slots` are the corresponding prior selections (same length and
+/// order). The two are zipped so we can tell which prior selections belong to
+/// `spec.instance`. Callers must pass a `prior_specs`/`selected_slots` pair that
+/// lines up one-for-one.
+///
+/// CR 601.2c + CR 115.3 NOTE: the parallel SLOT-ONLY lattice
+/// (`legal_targets_for_slot` / `has_legal_completion` /
+/// `validate_selected_slot_prefix`, and the `choose_target` entry point) is
+/// intentionally NOT given this per-instance distinctness filter. That lattice
+/// is only reached for single-target Aura casts and test fixtures — never a
+/// `multi_target` same-instance group — so there is no same-instance pair for
+/// it to over-share. This is a deliberate scoping choice, not an enforcement
+/// gap: distinctness lives in the spec-aware lattice that the multi_target path
+/// (Mothman et al.) actually flows through.
 fn legal_targets_for_selected_slot(
     state: &GameState,
     ability: &ResolvedAbility,
     spec: &TargetSlotSpec,
+    prior_specs: &[TargetSlotSpec],
     selected_slots: &[Option<TargetRef>],
 ) -> Vec<TargetRef> {
-    if matches!(ability.effect, Effect::PairWith { .. }) {
-        return pair_with_legal_choices(state, ability, &spec.filter);
-    }
-
-    if let Some(targets) = damage_any_target_legal_targets(state, ability, &spec.filter) {
-        return targets;
-    }
-
-    if is_per_opponent_target_fanout(ability) {
+    // Each branch computes the raw legal set into `legal`; the per-instance
+    // distinctness filter (CR 601.2c + CR 115.3) is then applied ONCE at the
+    // single tail return. For single-target / separate-instance / early-return
+    // cases `already_in_instance` is empty, so the tail filter is a no-op.
+    let per_opponent_fanout_targets = if is_per_opponent_target_fanout(ability) {
         if let TargetFilter::SpecificPlayer { id } = spec.filter {
-            return per_opponent_fanout_constraint_targets(state, ability.controller, id);
+            Some(per_opponent_fanout_constraint_targets(
+                state,
+                ability.controller,
+                id,
+            ))
+        } else {
+            None
         }
-    }
-
-    let controller = if uses_relative_controller_you(&spec.filter) {
-        relative_filter_controller(ability, selected_slots)
     } else {
-        ability.controller
+        None
     };
 
-    if target_filter_contains_chosen_x_ref(&spec.filter) {
-        if controller == ability.controller {
-            return targeting::find_legal_targets_for_ability(state, &spec.filter, ability);
-        }
-        return targeting::find_legal_targets_for_ability_with_controller(
-            state,
-            &spec.filter,
-            ability,
-            controller,
-        );
-    }
+    let mut legal: Vec<TargetRef> = if matches!(ability.effect, Effect::PairWith { .. }) {
+        pair_with_legal_choices(state, ability, &spec.filter)
+    } else if let Some(targets) = damage_any_target_legal_targets(state, ability, &spec.filter) {
+        targets
+    } else if let Some(targets) = per_opponent_fanout_targets {
+        targets
+    } else {
+        let controller = if uses_relative_controller_you(&spec.filter) {
+            relative_filter_controller(ability, selected_slots)
+        } else {
+            ability.controller
+        };
 
-    targeting::find_legal_targets(state, &spec.filter, controller, ability.source_id)
+        if target_filter_contains_chosen_x_ref(&spec.filter) {
+            if controller == ability.controller {
+                targeting::find_legal_targets_for_ability(state, &spec.filter, ability)
+            } else {
+                targeting::find_legal_targets_for_ability_with_controller(
+                    state,
+                    &spec.filter,
+                    ability,
+                    controller,
+                )
+            }
+        } else {
+            targeting::find_legal_targets(state, &spec.filter, controller, ability.source_id)
+        }
+    };
+
+    // CR 601.2c + CR 115.3: within one instance of "target", the same object
+    // can't be chosen twice. Remove objects already chosen in prior slots of
+    // THIS instance. Prior slots of a DIFFERENT instance (separate "target") do
+    // not constrain this slot — they may legally reuse the same object
+    // (CR 601.2c "Destroy target artifact and target land" Example).
+    let already_in_instance: std::collections::HashSet<ObjectId> = prior_specs
+        .iter()
+        .zip(selected_slots)
+        .filter(|(prior, _)| prior.instance == spec.instance)
+        .filter_map(|(_, sel)| match sel {
+            Some(TargetRef::Object(id)) => Some(*id),
+            _ => None,
+        })
+        .collect();
+    legal.retain(|t| !matches!(t, TargetRef::Object(id) if already_in_instance.contains(id)));
+    legal
 }
 
 fn damage_any_target_legal_targets(
@@ -2596,6 +2701,7 @@ fn collect_target_slot_specs_after_deferred_effect(
     state: &GameState,
     sub_ability: Option<&ResolvedAbility>,
     specs: &mut Vec<TargetSlotSpec>,
+    next_instance: &mut usize,
 ) {
     let Some(sub_ability) = sub_ability else {
         return;
@@ -2608,10 +2714,11 @@ fn collect_target_slot_specs_after_deferred_effect(
             state,
             sub_ability.sub_ability.as_deref(),
             specs,
+            next_instance,
         );
         return;
     }
-    collect_target_slot_specs(state, sub_ability, specs);
+    collect_target_slot_specs(state, sub_ability, specs, next_instance);
 }
 
 fn build_target_assignments(
@@ -2903,7 +3010,10 @@ fn legal_targets_for_spec_slot(
             .map(|slot| slot.legal_targets.clone())
             .unwrap_or_default();
     };
-    legal_targets_for_selected_slot(state, ability, spec, selected_slots)
+    // CR 601.2c + CR 115.3: pass the prior specs so same-instance distinctness
+    // is enforced. `&specs[..current_slot]` lines up one-for-one with the prior
+    // selections in `selected_slots` (both prefixes of length `current_slot`).
+    legal_targets_for_selected_slot(state, ability, spec, &specs[..current_slot], selected_slots)
 }
 
 fn legal_targets_for_slot_with_specs(
@@ -3132,7 +3242,17 @@ fn validate_selected_slots_with_specs(
         let legal_targets = specs
             .get(index)
             .map(|spec| {
-                legal_targets_for_selected_slot(state, ability, spec, &selected_slots[..index])
+                // CR 601.2c + CR 115.3: `&specs[..index]` (prior specs) lines up
+                // one-for-one with `&selected_slots[..index]` (prior selections),
+                // so the validate path enforces the same per-instance distinctness
+                // as the offered-set path (`legal_targets_for_spec_slot`).
+                legal_targets_for_selected_slot(
+                    state,
+                    ability,
+                    spec,
+                    &specs[..index],
+                    &selected_slots[..index],
+                )
             })
             .unwrap_or_else(|| slot.legal_targets.clone());
 
@@ -7983,6 +8103,205 @@ mod tests {
         assert!(
             labels.iter().all(|l| l.is_none()),
             "no description -> None labels"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // CR 601.2c + CR 115.3: per-instance object-target distinctness
+    // -----------------------------------------------------------------------
+
+    /// Build a multi-target "up to N target creatures" ability (Mothman-shaped)
+    /// whose single multi_target run surfaces up to `max` slots — all ONE
+    /// instance of "target".
+    fn up_to_n_target_creatures(
+        source: ObjectId,
+        controller: PlayerId,
+        max: usize,
+    ) -> ResolvedAbility {
+        let mut ability = ResolvedAbility::new(
+            Effect::Tap {
+                target: TargetFilter::Typed(TypedFilter::creature()),
+            },
+            vec![],
+            source,
+            controller,
+        );
+        ability.multi_target = Some(MultiTargetSpec::fixed(0, max));
+        ability
+    }
+
+    /// CR 601.2c + CR 115.3 (offered set): in a multi_target "up to N target
+    /// creatures" run, once creature A is chosen in slot 0 the spec-aware
+    /// offered set for slot 1 must NOT contain A — it is the same instance of
+    /// "target". The other distinct creatures remain offerable.
+    #[test]
+    fn multi_target_same_instance_offered_set_excludes_prior_choice() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let a = create_creature(&mut state, PlayerId(0), CardId(1), "A");
+        let b = create_creature(&mut state, PlayerId(0), CardId(2), "B");
+        let c = create_creature(&mut state, PlayerId(0), CardId(3), "C");
+
+        let ability = up_to_n_target_creatures(ObjectId(900), PlayerId(0), 3);
+        let specs = target_slot_specs(&state, &ability);
+        let target_slots = build_target_slots(&state, &ability).expect("slots build");
+        assert!(
+            specs.len() >= 2,
+            "multi_target run should surface >= 2 slots"
+        );
+
+        // All slots in the run share ONE instance id.
+        assert!(
+            specs.windows(2).all(|w| w[0].instance == w[1].instance),
+            "every slot of one multi_target run is the same instance of \"target\""
+        );
+
+        // Slot 0 offered set: all three creatures (no prior selection).
+        let slot0 = legal_targets_for_spec_slot(&state, &ability, &specs, &target_slots, 0, &[]);
+        for id in [a, b, c] {
+            assert!(
+                slot0.contains(&TargetRef::Object(id)),
+                "slot 0 should offer every legal creature"
+            );
+        }
+
+        // After choosing A in slot 0, slot 1 must exclude A but still offer B, C.
+        let prior = vec![Some(TargetRef::Object(a))];
+        let slot1 = legal_targets_for_spec_slot(&state, &ability, &specs, &target_slots, 1, &prior);
+        assert!(
+            !slot1.contains(&TargetRef::Object(a)),
+            "CR 601.2c: A already chosen in this instance must not be offered again"
+        );
+        assert!(
+            slot1.contains(&TargetRef::Object(b)) && slot1.contains(&TargetRef::Object(c)),
+            "other distinct creatures remain legal for the next slot"
+        );
+    }
+
+    /// CR 601.2c + CR 115.3 (validate path): selecting the SAME object twice in
+    /// one multi_target instance must be rejected; an all-distinct selection is
+    /// accepted.
+    #[test]
+    fn multi_target_same_instance_validate_rejects_duplicate_object() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let a = create_creature(&mut state, PlayerId(0), CardId(1), "A");
+        let b = create_creature(&mut state, PlayerId(0), CardId(2), "B");
+
+        let ability = up_to_n_target_creatures(ObjectId(900), PlayerId(0), 2);
+        let specs = target_slot_specs(&state, &ability);
+        let target_slots = build_target_slots(&state, &ability).expect("slots build");
+
+        // [A, A] in one instance is illegal.
+        let dup = vec![Some(TargetRef::Object(a)), Some(TargetRef::Object(a))];
+        assert!(
+            validate_selected_slots_with_specs(&state, &ability, &specs, &target_slots, &dup, &[],)
+                .is_err(),
+            "CR 601.2c: the same object can't fill two slots of one instance"
+        );
+
+        // [A, B] (distinct) is legal.
+        let distinct = vec![Some(TargetRef::Object(a)), Some(TargetRef::Object(b))];
+        assert!(
+            validate_selected_slots_with_specs(
+                &state,
+                &ability,
+                &specs,
+                &target_slots,
+                &distinct,
+                &[],
+            )
+            .is_ok(),
+            "two distinct legal creatures must satisfy the multi_target instance"
+        );
+    }
+
+    /// CR 601.2c + CR 115.3 (THE binding cross-instance Example): "Destroy
+    /// target artifact and target land"-shaped abilities use the word "target"
+    /// in two PLACES → two separate instances → the same object may be chosen
+    /// once for each. A two-single-target `ExchangeControl` ability surfaces two
+    /// slots with DISTINCT instance ids; one creature legal for both must be
+    /// offered AND accepted in both slots.
+    #[test]
+    fn cross_instance_object_reuse_is_allowed() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let shared = create_creature(&mut state, PlayerId(0), CardId(1), "Shared");
+
+        let ability = ResolvedAbility::new(
+            Effect::ExchangeControl {
+                target_a: TargetFilter::Typed(TypedFilter::creature()),
+                target_b: TargetFilter::Typed(TypedFilter::creature()),
+            },
+            vec![],
+            ObjectId(900),
+            PlayerId(0),
+        );
+        let specs = target_slot_specs(&state, &ability);
+        let target_slots = build_target_slots(&state, &ability).expect("slots build");
+        assert_eq!(specs.len(), 2, "two target places -> two specs");
+        assert_ne!(
+            specs[0].instance, specs[1].instance,
+            "CR 601.2c: two separate 'target' places are DIFFERENT instances"
+        );
+
+        // Slot 0 offers the shared creature.
+        let slot0 = legal_targets_for_spec_slot(&state, &ability, &specs, &target_slots, 0, &[]);
+        assert!(slot0.contains(&TargetRef::Object(shared)));
+
+        // After choosing it in slot 0, slot 1 (a DIFFERENT instance) STILL offers
+        // it — cross-instance reuse is legal.
+        let prior = vec![Some(TargetRef::Object(shared))];
+        let slot1 = legal_targets_for_spec_slot(&state, &ability, &specs, &target_slots, 1, &prior);
+        assert!(
+            slot1.contains(&TargetRef::Object(shared)),
+            "CR 601.2c: a different instance of 'target' may reuse the same object"
+        );
+
+        // And [shared, shared] validates across the two distinct instances.
+        let reuse = vec![
+            Some(TargetRef::Object(shared)),
+            Some(TargetRef::Object(shared)),
+        ];
+        assert!(
+            validate_selected_slots_with_specs(
+                &state,
+                &ability,
+                &specs,
+                &target_slots,
+                &reuse,
+                &[],
+            )
+            .is_ok(),
+            "CR 601.2c artifact+land Example: same object accepted in both separate instances"
+        );
+    }
+
+    /// CR 115.1 + CR 601.2c: the `DifferentObjectControllers` constraint still
+    /// rejects same-controller object pairs after the per-slot distinctness
+    /// filter is in place (no regression — distinctness and the controller
+    /// constraint are orthogonal gates).
+    #[test]
+    fn different_object_controllers_constraint_still_rejects_same_controller_pair() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        // Two distinct creatures both controlled by P0.
+        let a = create_creature(&mut state, PlayerId(0), CardId(1), "A");
+        let b = create_creature(&mut state, PlayerId(0), CardId(2), "B");
+
+        let ability = up_to_n_target_creatures(ObjectId(900), PlayerId(0), 2);
+        let specs = target_slot_specs(&state, &ability);
+        let target_slots = build_target_slots(&state, &ability).expect("slots build");
+
+        // Distinct objects, but both controlled by P0 -> the constraint rejects.
+        let same_controller = vec![Some(TargetRef::Object(a)), Some(TargetRef::Object(b))];
+        assert!(
+            validate_selected_slots_with_specs(
+                &state,
+                &ability,
+                &specs,
+                &target_slots,
+                &same_controller,
+                &[TargetSelectionConstraint::DifferentObjectControllers],
+            )
+            .is_err(),
+            "DifferentObjectControllers must still reject two P0-controlled objects"
         );
     }
 }

--- a/crates/engine/src/game/engine_stack.rs
+++ b/crates/engine/src/game/engine_stack.rs
@@ -104,33 +104,36 @@ pub(super) fn handle_trigger_target_selection_select_targets(
     let Some(pending) = state.pending_trigger.as_ref() else {
         return Err(EngineError::InvalidAction("No pending trigger".to_string()));
     };
-    validate_selected_targets_for_ability(
-        state,
-        &pending.ability,
-        target_slots,
-        &targets,
-        target_constraints,
-    )?;
     let mut ability = pending.ability.clone();
     // Read the firing batch's subject count out of `pending` before any mutation
     // of `state`, so the shared borrow of `state.pending_trigger` ends here.
     let pending_match_count = pending.subject_match_count;
     // CR 601.2c + CR 603.2c: A variable target count ("up to X target creatures,
     // where X is the number milled this way") is fixed when the ability is put on
-    // the stack and does not change. Re-stamp the firing batch's subject count
-    // into resolution scope so `multi_target.max = EventContextAmount` resolves to
-    // that count on this later `apply()` instead of collapsing to 0. Save/restore
-    // (not a bare stamp) because `current_trigger_match_count` is not cleared at
-    // `apply()` start, so a bare stamp would leak into the next resolution.
-    // Mirrors the auto-target path's push/restore_trigger_event_context in
-    // triggers.rs. Partial re-stamp (only `current_trigger_match_count`, not the
-    // full event-context snapshot) is intentional and sufficient: the demonstrated
-    // bound (`EventContextAmount`) reads only this field.
+    // the stack and does not change. Re-stamp the firing batch's subject count into
+    // resolution scope so `multi_target.max = EventContextAmount` resolves to that
+    // count instead of collapsing to 0. This must wrap BOTH validation and
+    // assignment: each recomputes `target_slot_specs`, and with bounds 0 the
+    // per-slot specs vanish so the CR 601.2c same-instance distinctness check is
+    // bypassed — a duplicate-object selection (`[A, A]`) would then be wrongly
+    // accepted at the validation gate rather than rejected. Save/restore (not a
+    // bare stamp) because `current_trigger_match_count` is not cleared at `apply()`
+    // start. Mirrors the choose-target walk and the auto-target path's
+    // push/restore_trigger_event_context in triggers.rs.
     let prev_match_count = state.current_trigger_match_count;
     state.current_trigger_match_count = pending_match_count;
-    let assign_result = assign_targets_in_chain(state, &mut ability, &targets);
+    let select_result = match validate_selected_targets_for_ability(
+        state,
+        &ability,
+        target_slots,
+        &targets,
+        target_constraints,
+    ) {
+        Ok(()) => assign_targets_in_chain(state, &mut ability, &targets),
+        Err(e) => Err(e),
+    };
     state.current_trigger_match_count = prev_match_count;
-    assign_result?;
+    select_result?;
     // CR 603.3d: Consume the pending trigger only after the fallible assignment
     // succeeds. `apply()` does not roll back on Err and `sync_waiting_for` never
     // runs after an Err, so taking the trigger before assignment would strand
@@ -188,15 +191,36 @@ pub(super) fn handle_trigger_target_selection_choose_target(
     let Some(pending_trigger) = state.pending_trigger.as_ref() else {
         return Err(EngineError::InvalidAction("No pending trigger".to_string()));
     };
+    // Clone the ability and read the firing batch's subject count before mutating
+    // `current_trigger_match_count`, ending the shared borrow of `pending_trigger`.
+    let walk_ability = pending_trigger.ability.clone();
+    let pending_match_count = pending_trigger.subject_match_count;
 
-    match choose_target_for_ability(
+    // CR 601.2c + CR 603.2c: Re-stamp the firing batch's subject count into
+    // resolution scope for the ENTIRE step-by-step walk, not only final assignment.
+    // Each `ChooseTarget` builds the *next* slot's legal-target set via
+    // `build_target_selection_progress_for_ability`, which recomputes
+    // `target_slot_specs` and so re-resolves `multi_target.max = EventContextAmount`.
+    // With `current_trigger_match_count == None` mid-walk the bounds collapse to 0,
+    // the per-slot `TargetSlotSpec`s vanish, and the CR 601.2c same-instance
+    // distinctness filter is silently bypassed via the `slot.legal_targets`
+    // fallback in `legal_targets_for_spec_slot`. Save/restore (not a bare stamp)
+    // because `current_trigger_match_count` is not cleared at `apply()` start.
+    // Mirrors the Complete branch below and the auto-target path's
+    // push/restore_trigger_event_context in triggers.rs.
+    let prev_match_count = state.current_trigger_match_count;
+    state.current_trigger_match_count = pending_match_count;
+    let advance = choose_target_for_ability(
         state,
-        &pending_trigger.ability,
+        &walk_ability,
         &target_slots,
         &target_constraints,
         &selection,
         target,
-    )? {
+    );
+    state.current_trigger_match_count = prev_match_count;
+
+    match advance? {
         // CR 700.2b: preserve the inbound mode labels unchanged across the
         // step-by-step walk — the slot→mode mapping does not change.
         TargetSelectionAdvance::InProgress(selection) => Ok(WaitingFor::TriggerTargetSelection {

--- a/crates/engine/tests/integration/lathiel_end_step_counters_repro.rs
+++ b/crates/engine/tests/integration/lathiel_end_step_counters_repro.rs
@@ -51,7 +51,8 @@ fn lathiel_end_step_distributes_counters_from_lifelink_gain() {
     let lathiel = scenario
         .add_creature_from_oracle(P0, "Lathiel, the Bounteous Dawn", 2, 2, LATHIEL_ORACLE)
         .id();
-    let receiver = scenario.add_creature(P0, "Receiver", 1, 1).id();
+    let receiver = scenario.add_creature(P0, "Receiver A", 1, 1).id();
+    let receiver2 = scenario.add_creature(P0, "Receiver B", 1, 1).id();
     scenario.add_creature(P1, "Blocker", 3, 3);
 
     let mut runner = scenario.build();
@@ -64,7 +65,13 @@ fn lathiel_end_step_distributes_counters_from_lifelink_gain() {
 
     advance_to_end_step_trigger(&mut runner);
 
-    // Choose the receiver as the only distributed target.
+    // CR 601.2c + CR 115.3: "distribute ... among any number of OTHER target
+    // creatures" is a single instance of "target", so each chosen creature must be
+    // a DISTINCT object — the same receiver cannot fill two slots. Choose the two
+    // distinct receivers, one per slot (slot 1's offered set excludes the creature
+    // already chosen in slot 0).
+    let receivers = [receiver, receiver2];
+    let mut next = 0;
     let mut guard = 0;
     while matches!(
         runner.state().waiting_for,
@@ -72,12 +79,18 @@ fn lathiel_end_step_distributes_counters_from_lifelink_gain() {
     ) {
         guard += 1;
         assert!(guard < 10, "target selection did not terminate");
+        let pick = receivers[next];
+        next += 1;
         runner
             .act(GameAction::ChooseTarget {
-                target: Some(TargetRef::Object(receiver)),
+                target: Some(TargetRef::Object(pick)),
             })
             .expect("ChooseTarget should succeed");
     }
+    assert_eq!(
+        next, 2,
+        "two distinct creatures targeted (slots capped to life gained = 2)"
+    );
 
     match &runner.state().waiting_for {
         WaitingFor::DistributeAmong {
@@ -88,9 +101,13 @@ fn lathiel_end_step_distributes_counters_from_lifelink_gain() {
         other => panic!("expected DistributeAmong after targets, got {other:?}"),
     }
 
+    // Split the pool of 2 across the two distinct targets, 1 each.
     runner
         .act(GameAction::DistributeAmong {
-            distribution: vec![(TargetRef::Object(receiver), 2)],
+            distribution: vec![
+                (TargetRef::Object(receiver), 1),
+                (TargetRef::Object(receiver2), 1),
+            ],
         })
         .expect("DistributeAmong should succeed");
 
@@ -98,8 +115,13 @@ fn lathiel_end_step_distributes_counters_from_lifelink_gain() {
 
     assert_eq!(
         p1p1_counters(&runner, receiver),
-        2,
-        "Lathiel must distribute exactly 2 +1/+1 counters (= life gained via lifelink)"
+        1,
+        "first distinct target receives 1 of the 2 +1/+1 counters"
+    );
+    assert_eq!(
+        p1p1_counters(&runner, receiver2),
+        1,
+        "second distinct target receives the other +1/+1 counter (= life gained via lifelink)"
     );
 }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -146,4 +146,5 @@ mod volatile_fault_that_player_search;
 mod wedding_ring_etb_token_copy;
 mod wernog_riders_chaplain_investigate_count;
 mod wise_mothman_milled_trigger;
+mod wise_mothman_target_distinctness;
 mod yuriko_combat_damage;

--- a/crates/engine/tests/integration/wise_mothman_target_distinctness.rs
+++ b/crates/engine/tests/integration/wise_mothman_target_distinctness.rs
@@ -1,0 +1,275 @@
+//! CR 601.2c + CR 115.3 — object-target distinctness WITHIN one instance of the
+//! word "target".
+//!
+//! The Wise Mothman's milled trigger ("…put a +1/+1 counter on each of up to X
+//! target creatures…") is a single `multi_target` instance of "target": its
+//! slots must be mutually distinct objects (CR 601.2c). A controller must not be
+//! able to drop the same creature into two of those slots.
+//!
+//! These tests drive the real trigger through the `apply` pipeline (a genuine
+//! Tome Scour mill fires the trigger), then exercise BOTH enforcement gates:
+//! the offered set surfaced on the live `TriggerTargetSelection` prompt
+//! (`ChooseTarget` path) and the whole-selection validate path
+//! (`SelectTargets`). The cross-instance reuse guard (the binding CR 601.2c
+//! "Destroy target artifact and target land" Example) lives as a spec-layer unit
+//! test inside `game/ability_utils.rs`, where the two-distinct-instance
+//! abilities can be constructed directly.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use engine::database::card_db::CardDatabase;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{ActionResult, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+use engine::types::PlayerId;
+
+fn load_db() -> Option<&'static CardDatabase> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../client/public/card-data.json");
+    if !path.exists() {
+        return None;
+    }
+    static DB: OnceLock<CardDatabase> = OnceLock::new();
+    Some(DB.get_or_init(|| CardDatabase::from_export(&path).expect("export should load")))
+}
+
+/// Give P0 the mana to cast Tome Scour ({U}).
+fn add_blue_mana(runner: &mut engine::game::scenario::GameRunner) {
+    let dummy = ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool;
+    pool.add(ManaUnit::new(ManaType::Blue, dummy, false, vec![]));
+}
+
+/// Cast P0's Tome Scour ("Target player mills five cards") aimed at
+/// `mill_target`'s library and return the post-cast `ActionResult` (spell on the
+/// stack). Mirrors `wise_mothman_milled_trigger::cast_tome_scour`.
+fn cast_tome_scour(
+    runner: &mut engine::game::scenario::GameRunner,
+    tome_scour: ObjectId,
+    mill_target: PlayerId,
+) -> ActionResult {
+    let card_id = runner.state().objects[&tome_scour].card_id;
+    let mut result = runner
+        .act(GameAction::CastSpell {
+            object_id: tome_scour,
+            card_id,
+            targets: vec![],
+        })
+        .expect("Tome Scour cast should be accepted");
+
+    if matches!(result.waiting_for, WaitingFor::TargetSelection { .. }) {
+        result = runner
+            .act(GameAction::ChooseTarget {
+                target: Some(TargetRef::Player(mill_target)),
+            })
+            .expect("Tome Scour should accept the chosen player target");
+    }
+    result
+}
+
+/// Build a Mothman scenario with distinct legal +1/+1-counter targets on P0's
+/// battlefield, mill P0's own library through a real Tome Scour cast, and drive
+/// the stack until the milled trigger surfaces its `TriggerTargetSelection`
+/// prompt. Returns the runner and the ids of the creatures (in creation order).
+fn mothman_until_target_selection(
+    db: &'static CardDatabase,
+    creature_names: &[&str],
+) -> (engine::game::scenario::GameRunner, Vec<ObjectId>) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario.add_real_card(P0, "The Wise Mothman", Zone::Battlefield, db);
+
+    // Distinct legal counter targets.
+    let creatures: Vec<ObjectId> = creature_names
+        .iter()
+        .map(|name| scenario.add_real_card(P0, name, Zone::Battlefield, db))
+        .collect();
+
+    let tome_scour = scenario.add_real_card(P0, "Tome Scour", Zone::Hand, db);
+
+    // Five nonland cards to mill (Lightning Bolt is an instant).
+    for _ in 0..9 {
+        scenario.add_real_card(P0, "Lightning Bolt", Zone::Library, db);
+    }
+
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+    add_blue_mana(&mut runner);
+
+    let result = cast_tome_scour(&mut runner, tome_scour, P0);
+
+    let mut result = result;
+    let mut guard = 0;
+    while !matches!(
+        result.waiting_for,
+        WaitingFor::TriggerTargetSelection { .. }
+    ) {
+        guard += 1;
+        assert!(
+            guard < 64,
+            "The Wise Mothman's milled trigger never surfaced a target prompt; \
+             last waiting_for = {:?}",
+            result.waiting_for
+        );
+        result = runner
+            .act(GameAction::PassPriority)
+            .expect("stack should advance toward the milled trigger");
+    }
+
+    (runner, creatures)
+}
+
+/// Read the live `current_legal_targets` off the trigger target-selection prompt.
+fn current_offered_targets(runner: &engine::game::scenario::GameRunner) -> Vec<TargetRef> {
+    match &runner.state().waiting_for {
+        WaitingFor::TriggerTargetSelection { selection, .. } => {
+            selection.current_legal_targets.clone()
+        }
+        other => panic!("expected TriggerTargetSelection, got {other:?}"),
+    }
+}
+
+/// CR 601.2c + CR 115.3 (offered set): after choosing creature A in an early
+/// slot of the Mothman's "up to X target creatures" instance, the NEXT slot's
+/// offered set must NOT contain A. Choosing all-distinct creatures succeeds.
+#[test]
+fn mothman_offered_set_excludes_already_chosen_creature() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let creature_names = ["Grizzly Bears", "Llanowar Elves", "Centaur Courser"];
+    let (mut runner, creatures) = mothman_until_target_selection(db, &creature_names);
+    let [a, b, c] = [creatures[0], creatures[1], creatures[2]];
+
+    // Slot 0 offers every distinct creature.
+    let slot0 = current_offered_targets(&runner);
+    for id in [a, b, c] {
+        assert!(
+            slot0.contains(&TargetRef::Object(id)),
+            "slot 0 should offer every legal creature; got {slot0:?}"
+        );
+    }
+
+    // Choose A for slot 0.
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(a)),
+        })
+        .expect("choosing A in slot 0 should be legal");
+
+    // Slot 1 must exclude A but still offer B and C.
+    let slot1 = current_offered_targets(&runner);
+    assert!(
+        !slot1.contains(&TargetRef::Object(a)),
+        "CR 601.2c: A is already chosen in this instance — it must not be offered \
+         again for the next slot; got {slot1:?}"
+    );
+    assert!(
+        slot1.contains(&TargetRef::Object(b)) && slot1.contains(&TargetRef::Object(c)),
+        "the other distinct creatures remain legal for slot 1; got {slot1:?}"
+    );
+
+    // Choosing B then C (all distinct) fills three of the up-to-5 slots.
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(b)),
+        })
+        .expect("choosing B in slot 1 should be legal");
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(c)),
+        })
+        .expect("choosing C in slot 2 should be legal");
+
+    // The remaining slots are optional (min was 0) — skip them cleanly so the
+    // selection completes and the trigger resolves.
+    let mut guard = 0;
+    while matches!(
+        runner.state().waiting_for,
+        WaitingFor::TriggerTargetSelection { .. }
+    ) {
+        guard += 1;
+        assert!(guard < 16, "optional Mothman slots failed to skip cleanly");
+        runner
+            .act(GameAction::ChooseTarget { target: None })
+            .expect("skipping a remaining optional Mothman slot should be legal");
+    }
+    runner.advance_until_stack_empty();
+}
+
+/// CR 601.2c + CR 115.3 (validate path): selecting the same creature twice in
+/// one Mothman instance must be REJECTED (illegal target), not silently
+/// accepted.
+#[test]
+fn mothman_validate_rejects_same_creature_twice() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let creature_names = ["Grizzly Bears", "Llanowar Elves"];
+    let (mut runner, creatures) = mothman_until_target_selection(db, &creature_names);
+    let a = creatures[0];
+
+    // [A, A] in one instance is illegal — the apply pipeline must reject it.
+    let rejected = runner.act(GameAction::SelectTargets {
+        targets: vec![TargetRef::Object(a), TargetRef::Object(a)],
+    });
+    assert!(
+        rejected.is_err(),
+        "CR 601.2c: the same creature can't fill two slots of one multi_target \
+         instance; SelectTargets([A, A]) must be rejected"
+    );
+}
+
+/// CR 601.2c + CR 122.1 end-to-end: with K distinct legal creatures and X > K
+/// nonland cards milled, choosing all K distinct creatures lands exactly one
+/// +1/+1 counter on each — no duplicates — and the remaining optional slots skip
+/// cleanly.
+#[test]
+fn mothman_distinct_targets_land_one_counter_each() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    // K = 3 distinct creatures; X = 5 nonland cards milled (X > K).
+    let creature_names = ["Grizzly Bears", "Llanowar Elves", "Centaur Courser"];
+    let (mut runner, creatures) = mothman_until_target_selection(db, &creature_names);
+
+    // Select all three distinct creatures in one instance; the remaining two
+    // optional slots are skipped by the completed selection.
+    runner
+        .act(GameAction::SelectTargets {
+            targets: creatures.iter().map(|id| TargetRef::Object(*id)).collect(),
+        })
+        .expect("choosing three distinct legal creatures must be accepted");
+    runner.advance_until_stack_empty();
+
+    for id in &creatures {
+        let object = &runner.state().objects[id];
+        let plus = object
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(
+            plus, 1,
+            "each distinct chosen creature should receive exactly one +1/+1 \
+             counter (object {id:?})"
+        );
+    }
+}


### PR DESCRIPTION
Within one instance of "target" (a multi_target "up to N target creatures"
run, e.g. The Wise Mothman, Lathiel), the same object cannot be chosen into two
slots (CR 601.2c + CR 115.3). Slots in separate instances may still reuse one
object ("destroy target artifact and target land").

Distinctness core (ability_utils.rs): a private TargetInstanceId on
TargetSlotSpec. The multi_target run shares one id; every other (single-target)
sink and each per-opponent-fanout slot gets a fresh id, so distinctness is
scoped to one instance. legal_targets_for_selected_slot filters out objects
already chosen in prior slots of the same instance, at a single tail return,
enforced on both the offered set (UI/AI) and the validate path
(freeform/multiplayer). Per /add-engine-variant this is a per-slot legal-set
property, deliberately NOT a new whole-set TargetSelectionConstraint variant.

Resolution-scope re-stamp (engine_stack.rs): the distinctness filter only fires
when target_slot_specs resolves the multi_target bounds, which requires
current_trigger_match_count in scope. The manual target-selection walk spans
multiple apply() calls, so this is re-stamped from the firing batch's
subject_match_count across BOTH the step-by-step choose walk (so each next
slot's offered set excludes prior picks instead of falling back to the
unfiltered slot.legal_targets) AND the SelectTargets validate path (so a
duplicate [A, A] submission is rejected at the gate, not after). Save/restore,
because current_trigger_match_count is not cleared at apply() start.

Lathiel test updated to choose two distinct receivers (1 counter each),
preserving DistributeAmong{total:2} coverage now that duplicate targets are
correctly rejected. New wise_mothman_target_distinctness.rs drives the full
pipeline (mill -> trigger -> ChooseTarget walk / SelectTargets) end to end.
