### PR TITLE
fix(client): send guest display_name on P2P resolve so join doesn't time out

### DIFF
--- a/client/src/services/brokerClient.ts
+++ b/client/src/services/brokerClient.ts
@@ -249,11 +249,17 @@ export interface ResolveGuestOptions {
    */
   timeoutMs?: number;
   reservationToken?: string | null;
+  /**
+   * Visible name for the joining guest. The broker rejects a blank
+   * `display_name` on `JoinGameWithPassword` (it uses the required-label
+   * validator, unlike the lenient `LookupJoinTarget` path), so this must be
+   * non-blank or the frame is silently dropped and the resolve times out.
+   */
+  displayName?: string | null;
 }
 
 export interface LookupJoinTargetOptions extends ResolveGuestOptions {
   reserve?: boolean;
-  displayName?: string | null;
   releaseReservationToken?: string | null;
 }
 
@@ -372,9 +378,11 @@ export function resolveGuestOver(
           game_code: code,
           // Guest-path resolve is deck-less: the broker does not need a
           // deck to hand back PeerInfo. Deck submission happens over the
-          // P2P channel once the guest has dialed the host.
+          // P2P channel once the guest has dialed the host. The display
+          // name, however, must be non-blank — the broker validates it with
+          // the required-label rule and silently drops the frame otherwise.
           deck: { main_deck: [], sideboard: [], commander: [] },
-          display_name: "",
+          display_name: opts.displayName ?? "",
           password: password ?? null,
           reservation_token: opts.reservationToken ?? null,
         },

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -1211,6 +1211,11 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
           return await resolveGuestOver(socket, code, password, {
             signal: ac.signal,
             reservationToken: opts?.reservationToken,
+            // The broker rejects a blank display_name on the resolve frame
+            // (required-label rule) and the worker shell drops it without a
+            // reply — the guest then times out at deck-select. Always carry
+            // the player's name so the frame validates.
+            displayName: get().displayName || "Player",
           });
         } finally {
           pendingJoinRpcAborts.delete(ac);


### PR DESCRIPTION
The deck-less guest resolve (resolveGuestOver) sent display_name: "" on the
JoinGameWithPassword frame. The broker validates that frame with the
required-label rule (validation.rs validate_join_game_with_password_fields),
rejects the empty name, and the worker shell maps the resulting
ParsedFrame::Malformed to zero outbounds — no Error reply. The guest then
waits the full 10s and surfaces "No response from lobby within 10000ms" right
after picking a deck.

Thread the player's display name (falling back to "Player") through
resolveGuest/resolveGuestOver so the frame validates. Regression dates to
#1768, which wired validate_lobby_message into parse_lobby_client_message
while the LookupJoinTarget path stayed lenient (validate_optional_label).

Affects all P2P lobby joins that reach deck-select, not only password rooms.
