### PR TITLE
fix(lobby): reply with Error on rejected broker frames instead of dropping

### DIFF
--- a/lobby-worker/broker-wasm/src/lib.rs
+++ b/lobby-worker/broker-wasm/src/lib.rs
@@ -77,6 +77,17 @@ fn to_dtos(outs: Vec<Outbound>) -> Vec<OutboundDto> {
     outs.into_iter().map(OutboundDto::from).collect()
 }
 
+/// Single `Error` reply for a frame rejected at the parse/validation boundary.
+/// Sent to the originating socket so the client's pending RPC fails fast rather
+/// than waiting out its timeout. Malformed/unknown frames never reach
+/// `Broker::handle`, so this boundary crate is the only place that can answer
+/// them.
+fn reject_reply(message: &str) -> Vec<Outbound> {
+    vec![Outbound::ToSelf(LobbyServerMessage::Error {
+        message: message.to_string(),
+    })]
+}
+
 /// Whether a client frame can mutate the shared `LobbyManager` (and therefore
 /// requires the shell to re-snapshot it to DO storage). Conservative: read-only
 /// frames return `false` so a periodic `Ping`/`SubscribeLobby` never triggers a
@@ -163,8 +174,19 @@ impl WasmBroker {
                 let dirty = mutates_lobby(&msg);
                 (self.inner.handle(&mut conn, *msg, &env), dirty, None)
             }
-            ParsedFrame::UnknownTag(tag) => (Vec::new(), false, Some(format!("unknown tag: {tag}"))),
-            ParsedFrame::Malformed(e) => (Vec::new(), false, Some(format!("malformed frame: {e}"))),
+            // A frame the parser couldn't accept — an unknown tag or a field
+            // that failed validation (e.g. a blank display_name). Reply with an
+            // `Error` so the client's pending RPC resolves immediately instead
+            // of hanging until its timeout, and still flag `reject` so the shell
+            // logs it and skips the state snapshot (nothing mutated).
+            ParsedFrame::UnknownTag(tag) => {
+                let reason = format!("unknown tag: {tag}");
+                (reject_reply(&reason), false, Some(reason))
+            }
+            ParsedFrame::Malformed(e) => {
+                let reason = format!("malformed frame: {e}");
+                (reject_reply(&reason), false, Some(reason))
+            }
         };
 
         result_json(CallResult { conn, outbounds: to_dtos(outbounds), dirty, reject })

--- a/lobby-worker/src/lobby-do.ts
+++ b/lobby-worker/src/lobby-do.ts
@@ -153,10 +153,12 @@ export class LobbyDO {
     const result = JSON.parse(broker.handle(JSON.stringify(conn), text, Date.now())) as CallResult;
 
     if (result.reject) {
-      // Unknown tag / malformed frame — the Rust parser rejected it. Drop it
-      // (no state change, attachment untouched), but log so it surfaces in
-      // Workers Logs.
+      // Unknown tag / malformed frame — the Rust parser rejected it. No state
+      // changed (attachment/snapshot untouched), but the broker attaches an
+      // Error reply so the client's pending RPC fails fast instead of hanging
+      // until its timeout. Deliver it, then log so it surfaces in Workers Logs.
       console.warn({ event: "lobby_frame_rejected", reason: result.reject });
+      this.interpret(ws, result.outbounds);
       return;
     }
 


### PR DESCRIPTION
A frame that failed parse/validation (unknown tag or a bad field, e.g. a
blank display_name) produced ParsedFrame::Malformed, which the worker shell
turned into zero outbounds — no reply at all. The client then waited out its
full RPC timeout ("No response from lobby within 10000ms"). Now the broker-wasm
boundary attaches a single Error reply for rejected frames (the only layer that
sees them, since they never reach Broker::handle), and the DO shell delivers
those outbounds before dropping the frame. Every frame now gets exactly one
reply, so a future validation gap surfaces as an instant toast, not a hang.

Defense-in-depth follow-up to the guest display_name fix (#2063).
