### PR TITLE
Map mtgish `AbilitiesOfTypeCantBeActivated` to `CantBeActivated` (CR 602.5 / 605.1a)

### DIFF
--- a/crates/mtgish-import/src/convert/mod.rs
+++ b/crates/mtgish-import/src/convert/mod.rs
@@ -1975,6 +1975,26 @@ fn activated_ability_effect_to_static(
     Ok(StaticDefinition::new(mode))
 }
 
+/// CR 602.5 + CR 605.1a: Exemption axis for `AbilitiesOfTypeCantBeActivated`
+/// on a host permanent (`Bound in Gold`, `Faith's Fetters`). The affected
+/// permanent is supplied separately as `CantBeActivated::source_filter`.
+pub(crate) fn activated_abilities_exemption(
+    abilities: &crate::schema::types::ActivatedAbilities,
+) -> ConvResult<engine::types::statics::ActivationExemption> {
+    use crate::schema::types::ActivatedAbilities as A;
+    use engine::types::statics::ActivationExemption;
+    Ok(match abilities {
+        A::NonManaAbility => ActivationExemption::ManaAbilities,
+        A::AnyAbility => ActivationExemption::None,
+        other => {
+            return Err(ConversionGap::EnginePrerequisiteMissing {
+                engine_type: "StaticMode::CantBeActivated",
+                needed_variant: format!("AbilitiesOfTypeCantBeActivated({other:?})"),
+            });
+        }
+    })
+}
+
 /// CR 602.5: Decompose an `ActivatedAbilities` filter into the
 /// `(source_filter, exemption)` pair that engine `CantBeActivated`
 /// expects. `AbilityOfAPermanent`/`AbilityOfPermanent` carry the source

--- a/crates/mtgish-import/src/convert/static_effect.rs
+++ b/crates/mtgish-import/src/convert/static_effect.rs
@@ -354,6 +354,14 @@ pub fn convert_permanent_rule(
             source_filter: affected.clone(),
             exemption: engine::types::statics::ActivationExemption::None,
         },
+        // CR 602.5 + CR 605.1a: Filtered prohibition ("non-mana abilities",
+        // etc.) on the host permanent. `source_filter` is the affected object;
+        // the `ActivatedAbilities` payload selects the exemption only.
+        P::AbilitiesOfTypeCantBeActivated(abilities) => StaticMode::CantBeActivated {
+            who: engine::types::statics::ProhibitionScope::AllPlayers,
+            source_filter: affected.clone(),
+            exemption: super::activated_abilities_exemption(abilities)?,
+        },
 
         _ => {
             return Err(ConversionGap::UnknownVariant {
@@ -986,8 +994,34 @@ fn check_hasable_to_keyword(c: &CheckHasable) -> ConvResult<engine::types::keywo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schema::types::{LandType, PermanentRule, Permanents, Player};
+    use crate::schema::types::{ActivatedAbilities, LandType, PermanentRule, Permanents, Player};
     use engine::types::ability::{TargetFilter, TypeFilter, TypedFilter};
+    use engine::types::statics::{ActivationExemption, ProhibitionScope};
+
+    #[test]
+    fn abilities_of_type_cant_be_activated_non_mana_lowers_to_cant_be_activated() {
+        let converted = convert_permanent_rule(
+            &PermanentRule::AbilitiesOfTypeCantBeActivated(Box::new(
+                ActivatedAbilities::NonManaAbility,
+            )),
+            TargetFilter::SelfRef,
+        )
+        .unwrap();
+
+        match converted.mode {
+            StaticMode::CantBeActivated {
+                who,
+                source_filter,
+                exemption,
+            } => {
+                assert_eq!(who, ProhibitionScope::AllPlayers);
+                assert_eq!(source_filter, TargetFilter::SelfRef);
+                assert_eq!(exemption, ActivationExemption::ManaAbilities);
+            }
+            other => panic!("expected CantBeActivated, got {other:?}"),
+        }
+        assert_eq!(converted.affected, Some(TargetFilter::SelfRef));
+    }
 
     #[test]
     fn can_block_only_creatures_with_flying_lowers_to_block_restriction() {


### PR DESCRIPTION
Fixes #2065

## Summary

Auras such as **Bound in Gold** encode “activated abilities can't be activated” with a **non-mana** exemption as `PermanentRule::AbilitiesOfTypeCantBeActivated` in mtgish data. `convert_permanent_rule` handled `AbilitiesCantBeActivated` but not the typed variant, so import strict-failed.

This PR maps `NonManaAbility` to `StaticMode::CantBeActivated` on the host permanent with `ActivationExemption::ManaAbilities`. Runtime enforcement already exists in `casting.rs`.

## Type of change

- [x] Bug fix (rules correctness / card data import)
- [ ] New feature
- [ ] Refactor

## Test plan

- [x] `cargo test -p mtgish-import abilities_of_type_cant_be_activated_non_mana`
- [ ] `cargo test -p mtgish-import`
- [ ] `cargo clippy -p mtgish-import -- -D warnings`
- [ ] `cargo fmt --all`

## Note

`HasTapSelfInCost` (Katabatic Winds, Serra Bestiary) still strict-fails with `EnginePrerequisiteMissing` — needs ability-cost-shape filtering beyond `ActivationExemption`.