### PR TITLE
fix(engine): proliferate must ignore zero-count counter map entries

### DIFF
--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -158,6 +158,11 @@ pub(crate) fn apply_counter_addition(
     // sync with the counter map — the field IS the counter count.
     sync_derived_from_counters(obj, &counter_type);
 
+    // CR 122.1: Drop stale zero-count keys left over from prior removals before
+    // recording the object snapshot so counter history never exposes absent
+    // markers as present entries.
+    crate::types::counter::prune_zero_counters(&mut obj.counters);
+
     if counter_type_affects_layers(&counter_type) {
         state.layers_dirty.mark_full();
     }
@@ -190,10 +195,6 @@ pub(crate) fn apply_counter_addition(
         counter_type,
         count,
     });
-
-    // CR 122.1: Drop stale zero-count keys left over from prior removals so
-    // "has a counter" checks stay aligned with rules text.
-    crate::types::counter::prune_zero_counters(&mut obj.counters);
 }
 
 /// CR 122.1: Apply an already-accepted counter removal, clamping to the number
@@ -2662,7 +2663,10 @@ mod tests {
         remove_counter_with_replacement(&mut state, pw_id, CounterType::Loyalty, 5, &mut events);
 
         let obj = &state.objects[&pw_id];
-        assert_eq!(obj.counters.get(&CounterType::Loyalty).copied(), Some(0));
+        assert!(
+            !obj.counters.contains_key(&CounterType::Loyalty),
+            "zero-count loyalty entry should be pruned after removal"
+        );
         assert_eq!(obj.loyalty, Some(0));
     }
 

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -190,6 +190,10 @@ pub(crate) fn apply_counter_addition(
         counter_type,
         count,
     });
+
+    // CR 122.1: Drop stale zero-count keys left over from prior removals so
+    // "has a counter" checks stay aligned with rules text.
+    crate::types::counter::prune_zero_counters(&mut obj.counters);
 }
 
 /// CR 122.1: Apply an already-accepted counter removal, clamping to the number
@@ -212,6 +216,10 @@ pub(crate) fn apply_counter_removal(
     // CR 306.5c / CR 310.4c: Keep obj.loyalty / obj.defense in
     // sync with the counter map — the field IS the counter count.
     sync_derived_from_counters(obj, &counter_type);
+
+    // CR 122.1: Zero-count entries are absent — prune so proliferate and other
+    // "has a counter" checks cannot resurrect removed counter types.
+    crate::types::counter::prune_zero_counters(&mut obj.counters);
 
     if counter_type_affects_layers(&counter_type) {
         state.layers_dirty.mark_full();
@@ -1589,7 +1597,52 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(state.objects[&obj_id].counters[&CounterType::Plus1Plus1], 0);
+        assert!(
+            !state.objects[&obj_id]
+                .counters
+                .contains_key(&CounterType::Plus1Plus1),
+            "zero-count +1/+1 entry should be pruned after removal"
+        );
+    }
+
+    #[test]
+    fn apply_counter_removal_prunes_zero_entry() {
+        let mut state = GameState::new_two_player(42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&obj_id)
+            .unwrap()
+            .counters
+            .insert(CounterType::Generic("charge".to_string()), 1);
+        let mut events = Vec::new();
+
+        apply_counter_removal(
+            &mut state,
+            obj_id,
+            CounterType::Generic("charge".to_string()),
+            1,
+            &mut events,
+        );
+
+        assert!(
+            state.objects[&obj_id].counters.is_empty(),
+            "last charge counter removed should leave an empty map"
+        );
+        assert!(events.iter().any(|e| matches!(
+            e,
+            GameEvent::CounterRemoved {
+                counter_type: CounterType::Generic(_),
+                count: 1,
+                ..
+            }
+        )));
     }
 
     #[test]

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -1999,12 +1999,11 @@ mod tests {
         resolve(&mut state, &ability, &mut events).unwrap();
 
         assert_eq!(state.objects[&battle_id].defense, Some(0));
-        assert_eq!(
-            state.objects[&battle_id]
+        assert!(
+            !state.objects[&battle_id]
                 .counters
-                .get(&CounterType::Defense)
-                .copied(),
-            Some(0)
+                .contains_key(&CounterType::Defense),
+            "zero-count defense entry should be pruned after damage removes the last counter"
         );
     }
 

--- a/crates/engine/src/game/effects/proliferate.rs
+++ b/crates/engine/src/game/effects/proliferate.rs
@@ -1,5 +1,7 @@
 use crate::types::ability::{EffectError, EffectKind, ResolvedAbility, TargetRef};
-use crate::types::counter::CounterType;
+use crate::types::counter::{
+    has_positive_counters, positive_counter_types, prune_zero_counters, CounterType,
+};
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::player::{Player, PlayerCounterKind, PlayerId};
@@ -45,7 +47,7 @@ pub fn resolve(
             state
                 .objects
                 .get(id)
-                .map(|obj| !obj.counters.is_empty())
+                .map(|obj| has_positive_counters(&obj.counters))
                 .unwrap_or(false)
         })
         .map(|id| TargetRef::Object(*id))
@@ -93,10 +95,14 @@ pub fn apply_proliferate(
     for target in selected {
         match target {
             TargetRef::Object(obj_id) => {
+                if let Some(obj) = state.objects.get_mut(obj_id) {
+                    prune_zero_counters(&mut obj.counters);
+                }
+
                 let counter_types: Vec<CounterType> = state
                     .objects
                     .get(obj_id)
-                    .map(|obj| obj.counters.keys().cloned().collect())
+                    .map(|obj| positive_counter_types(&obj.counters))
                     .unwrap_or_default();
 
                 for ct in counter_types {
@@ -418,5 +424,190 @@ mod tests {
                 delta: 1,
             }
         )));
+    }
+
+    #[test]
+    fn resolve_excludes_permanent_with_only_zero_count_entries() {
+        let mut state = GameState::new_two_player(42);
+        let stale = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Stale Counter Map".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&stale)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 0);
+
+        let pumped = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Still Pumped".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&pumped)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+
+        let ability = make_proliferate_ability();
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        if let WaitingFor::ProliferateChoice { eligible, .. } = &state.waiting_for {
+            assert!(
+                !eligible
+                    .iter()
+                    .any(|t| matches!(t, TargetRef::Object(id) if *id == stale)),
+                "zero-count stale entry must not make a permanent proliferate-eligible"
+            );
+            assert!(
+                eligible
+                    .iter()
+                    .any(|t| matches!(t, TargetRef::Object(id) if *id == pumped)),
+                "permanent with a positive counter must remain eligible"
+            );
+        } else {
+            panic!("Expected ProliferateChoice");
+        }
+    }
+
+    #[test]
+    fn apply_proliferate_skips_zero_count_counter_types() {
+        let mut state = GameState::new_two_player(42);
+        let obj = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mixed Counters".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&obj)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 0);
+        state
+            .objects
+            .get_mut(&obj)
+            .unwrap()
+            .counters
+            .insert(CounterType::Generic("charge".to_string()), 2);
+
+        let mut events = Vec::new();
+        apply_proliferate(
+            &mut state,
+            PlayerId(0),
+            &[TargetRef::Object(obj)],
+            &mut events,
+        );
+
+        assert!(
+            !state.objects[&obj]
+                .counters
+                .contains_key(&CounterType::Plus1Plus1),
+            "proliferate must not add a counter type that was at zero"
+        );
+        assert_eq!(
+            state.objects[&obj].counters[&CounterType::Generic("charge".to_string())],
+            3
+        );
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                GameEvent::CounterAdded {
+                    counter_type: CounterType::Plus1Plus1,
+                    ..
+                }
+            )),
+            "no CounterAdded event for the zero-count type"
+        );
+    }
+
+    #[test]
+    fn apply_proliferate_after_counter_removal_does_not_restore_lost_type() {
+        let mut state = GameState::new_two_player(42);
+        let obj = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&obj)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+
+        super::super::counters::apply_counter_removal(
+            &mut state,
+            obj,
+            CounterType::Plus1Plus1,
+            1,
+            &mut Vec::new(),
+        );
+        assert!(
+            state.objects[&obj].counters.is_empty(),
+            "removal should prune the last +1/+1 counter"
+        );
+
+        let mut events = Vec::new();
+        apply_proliferate(
+            &mut state,
+            PlayerId(0),
+            &[TargetRef::Object(obj)],
+            &mut events,
+        );
+
+        assert!(
+            state.objects[&obj].counters.is_empty(),
+            "proliferate must not add +1/+1 back after the permanent lost its last one"
+        );
+        assert!(
+            events
+                .iter()
+                .all(|e| !matches!(e, GameEvent::CounterAdded { .. })),
+            "no counter should be added"
+        );
+    }
+
+    #[test]
+    fn resolve_skips_choice_when_only_zero_count_permanents_exist() {
+        let mut state = GameState::new_two_player(42);
+        let stale = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Stale".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&stale)
+            .unwrap()
+            .counters
+            .insert(CounterType::Minus1Minus1, 0);
+
+        let ability = make_proliferate_ability();
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::ProliferateChoice { .. }),
+            "only stale zero-count entries should not open a proliferate choice"
+        );
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, GameEvent::EffectResolved { .. })));
     }
 }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -18,7 +18,7 @@ use crate::types::attribution::EffectRef;
 use crate::types::card_type::{
     is_land_subtype, noncreature_subtype_set, CoreType, SubtypeSet, Supertype,
 };
-use crate::types::counter::{CounterMatch, CounterType};
+use crate::types::counter::{has_positive_counters, CounterMatch, CounterType};
 use crate::types::game_state::{DayNight, GameState, LayersDirty, StaticGateKey};
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
@@ -1727,7 +1727,7 @@ fn entered_object_blocks_incremental(
     //     genuine new entry are sourced by statics already covered by (1)/(2).
     //     A controller differing from the base controller indicates a Layer-2
     //     override the incremental path does not reset for the rest of the board.
-    if !obj.counters.is_empty() {
+    if has_positive_counters(&obj.counters) {
         return true;
     }
     if obj.attached_to.is_some() || !obj.attachments.is_empty() {
@@ -1928,7 +1928,7 @@ fn apply_prototype_characteristics(state: &mut GameState, ids: impl IntoIterator
 fn apply_pt_counter_modifications(state: &mut GameState, ids: impl IntoIterator<Item = ObjectId>) {
     for id in ids {
         if let Some(obj) = state.objects.get_mut(&id) {
-            if obj.counters.is_empty() {
+            if !has_positive_counters(&obj.counters) {
                 continue;
             }
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -19,7 +19,7 @@ use crate::types::ability::{
     QuantityRef, ResolvedAbility, RoundingMode, TargetFilter, TargetRef, TypeFilter, ZoneRef,
 };
 use crate::types::card_type::CoreType;
-use crate::types::counter::CounterType;
+use crate::types::counter::{positive_counter_types, CounterType};
 use crate::types::game_state::{DamageRecord, GameState};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{ManaColor, ManaCost};
@@ -2537,8 +2537,9 @@ fn object_id_for_scope(
 /// CR 122.1: Distinct counter kinds present on permanents matching `filter`
 /// (controller-relative, CR 109.4). Mirrors `DistinctColorsAmongPermanents`'s
 /// resolver (zone from `filter.extract_in_zone()`, `zone_object_ids`,
-/// `matches_target_filter`), enumerating `obj.counters.keys()` the same way
-/// proliferate does. Returns a `Vec<CounterType>` SORTED by `CounterType::as_str`
+/// `matches_target_filter`), enumerating only positive-count counter kinds the
+/// same way proliferate does. Returns a `Vec<CounterType>` SORTED by
+/// `CounterType::as_str`
 /// for determinism — `CounterType` has no `Ord` (and must not gain one), so the
 /// underlying `HashSet` iteration order is nondeterministic and would cause
 /// replay desync if returned directly. Used both as the `len()` source for
@@ -2558,8 +2559,8 @@ pub(crate) fn distinct_counter_kinds_among(
             continue;
         }
         if let Some(obj) = state.objects.get(&id) {
-            for ct in obj.counters.keys() {
-                seen.insert(ct.clone());
+            for counter_type in positive_counter_types(&obj.counters) {
+                seen.insert(counter_type);
             }
         }
     }
@@ -3719,9 +3720,10 @@ mod tests {
     }
 
     /// CR 122.1 + CR 109.4: count distinct counter kinds among permanents the
-    /// resolving player controls. An opponent's counter kind must be EXCLUDED,
-    /// and the same kind on two controlled permanents counts once. Order is
-    /// deterministic (sorted by `as_str`).
+    /// resolving player controls. An opponent's counter kind and stale
+    /// zero-count map entries must be EXCLUDED, and the same kind on two
+    /// controlled permanents counts once. Order is deterministic (sorted by
+    /// `as_str`).
     #[test]
     fn resolve_distinct_counter_kinds_among_controlled_permanents() {
         let mut state = GameState::new_two_player(42);
@@ -3764,6 +3766,8 @@ mod tests {
             let obj = state.objects.get_mut(&perm_c).unwrap();
             obj.card_types.core_types.push(CoreType::Creature);
             obj.counters.insert(CounterType::Plus1Plus1, 3);
+            obj.counters
+                .insert(CounterType::Generic("charge".to_string()), 0);
         }
         // OPPONENT's permanent: Stun counter — MUST be excluded (CR 109.4).
         let opp_perm = create_object(
@@ -3786,6 +3790,7 @@ mod tests {
         });
 
         // Direct helper: distinct kinds among controlled permanents = {P1P1, Lore},
+        // excluding Perm C's stale zero-count charge entry.
         // sorted by as_str ("P1P1" < "lore" by byte order; uppercase 'P' = 0x50,
         // lowercase 'l' = 0x6C).
         let ctx = FilterContext::from_source_with_controller(perm_a, PlayerId(0));

--- a/crates/engine/src/types/counter.rs
+++ b/crates/engine/src/types/counter.rs
@@ -280,23 +280,31 @@ fn format_counter_delta(value: i32, paired_value: i32) -> String {
     }
 }
 
-/// CR 122.1: A counter with count zero is treated as absent. Stale map keys must
-/// not satisfy "has a counter" checks (e.g. proliferate CR 701.34a).
+/// CR 122.1: A counter is a marker on an object or player; an internal map
+/// entry with count zero is not a marker and must not satisfy "has a counter"
+/// checks (e.g. proliferate CR 701.34a).
 pub fn has_positive_counters(counters: &HashMap<CounterType, u32>) -> bool {
     counters.values().any(|&count| count > 0)
 }
 
-/// Counter types currently present on an object or LKI snapshot (count > 0 only).
-pub fn positive_counter_types(counters: &HashMap<CounterType, u32>) -> Vec<CounterType> {
+/// Counter entries currently present on an object or LKI snapshot (count > 0 only).
+pub fn positive_counter_entries(
+    counters: &HashMap<CounterType, u32>,
+) -> impl Iterator<Item = (&CounterType, u32)> {
     counters
         .iter()
-        .filter(|(_, &count)| count > 0)
-        .map(|(ct, _)| ct.clone())
+        .filter_map(|(counter_type, &count)| (count > 0).then_some((counter_type, count)))
+}
+
+/// Counter types currently present on an object or LKI snapshot (count > 0 only).
+pub fn positive_counter_types(counters: &HashMap<CounterType, u32>) -> Vec<CounterType> {
+    positive_counter_entries(counters)
+        .map(|(counter_type, _)| counter_type.clone())
         .collect()
 }
 
-/// CR 122.1: Drop zero-count entries after removal so counter presence stays
-/// aligned with rules text and downstream eligibility checks.
+/// CR 122.1: Drop zero-count entries so counter presence stays aligned with
+/// actual markers and downstream eligibility checks.
 pub fn prune_zero_counters(counters: &mut HashMap<CounterType, u32>) {
     counters.retain(|_, count| *count > 0);
 }
@@ -304,8 +312,8 @@ pub fn prune_zero_counters(counters: &mut HashMap<CounterType, u32>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        has_positive_counters, parse_counter_type, positive_counter_types, prune_zero_counters,
-        try_parse_counter_type, CounterType,
+        has_positive_counters, parse_counter_type, positive_counter_entries,
+        positive_counter_types, prune_zero_counters, try_parse_counter_type, CounterType,
     };
     use std::collections::HashMap;
 
@@ -408,6 +416,19 @@ mod tests {
         assert_eq!(
             positive_counter_types(&counters),
             vec![CounterType::Generic("charge".to_string())]
+        );
+    }
+
+    #[test]
+    fn positive_counter_entries_skips_zero_entries() {
+        let mut counters = HashMap::new();
+        counters.insert(CounterType::Plus1Plus1, 0);
+        counters.insert(CounterType::Generic("charge".to_string()), 2);
+        assert_eq!(
+            positive_counter_entries(&counters)
+                .map(|(counter_type, count)| (counter_type.clone(), count))
+                .collect::<Vec<_>>(),
+            vec![(CounterType::Generic("charge".to_string()), 2)]
         );
     }
 

--- a/crates/engine/src/types/counter.rs
+++ b/crates/engine/src/types/counter.rs
@@ -1,6 +1,7 @@
 use crate::types::keywords::KeywordKind;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 /// Counter types serialize as flat strings so they can be used as JSON map keys
 /// in `HashMap<CounterType, u32>`. Without this, `Generic("quest")` would serialize
@@ -279,9 +280,34 @@ fn format_counter_delta(value: i32, paired_value: i32) -> String {
     }
 }
 
+/// CR 122.1: A counter with count zero is treated as absent. Stale map keys must
+/// not satisfy "has a counter" checks (e.g. proliferate CR 701.34a).
+pub fn has_positive_counters(counters: &HashMap<CounterType, u32>) -> bool {
+    counters.values().any(|&count| count > 0)
+}
+
+/// Counter types currently present on an object or LKI snapshot (count > 0 only).
+pub fn positive_counter_types(counters: &HashMap<CounterType, u32>) -> Vec<CounterType> {
+    counters
+        .iter()
+        .filter(|(_, &count)| count > 0)
+        .map(|(ct, _)| ct.clone())
+        .collect()
+}
+
+/// CR 122.1: Drop zero-count entries after removal so counter presence stays
+/// aligned with rules text and downstream eligibility checks.
+pub fn prune_zero_counters(counters: &mut HashMap<CounterType, u32>) {
+    counters.retain(|_, count| *count > 0);
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{parse_counter_type, try_parse_counter_type, CounterType};
+    use super::{
+        has_positive_counters, parse_counter_type, positive_counter_types, prune_zero_counters,
+        try_parse_counter_type, CounterType,
+    };
+    use std::collections::HashMap;
 
     #[test]
     fn parses_legacy_power_toughness_counter_deltas() {
@@ -363,5 +389,35 @@ mod tests {
         let back: CounterType = serde_json::from_str(&json).unwrap();
         assert_eq!(back, CounterType::Age);
         assert_eq!(c.power_toughness_delta(), None);
+    }
+
+    #[test]
+    fn has_positive_counters_ignores_zero_entries() {
+        let mut counters = HashMap::new();
+        counters.insert(CounterType::Plus1Plus1, 0);
+        assert!(!has_positive_counters(&counters));
+        counters.insert(CounterType::Lore, 1);
+        assert!(has_positive_counters(&counters));
+    }
+
+    #[test]
+    fn positive_counter_types_skips_zero_entries() {
+        let mut counters = HashMap::new();
+        counters.insert(CounterType::Plus1Plus1, 0);
+        counters.insert(CounterType::Generic("charge".to_string()), 2);
+        assert_eq!(
+            positive_counter_types(&counters),
+            vec![CounterType::Generic("charge".to_string())]
+        );
+    }
+
+    #[test]
+    fn prune_zero_counters_drops_stale_keys() {
+        let mut counters = HashMap::new();
+        counters.insert(CounterType::Plus1Plus1, 0);
+        counters.insert(CounterType::Stun, 1);
+        prune_zero_counters(&mut counters);
+        assert!(!counters.contains_key(&CounterType::Plus1Plus1));
+        assert_eq!(counters.get(&CounterType::Stun), Some(&1));
     }
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -106,6 +106,7 @@ mod plaguecrafter_etb_class;
 mod ponder_decline_shuffle_regression;
 mod power_fist_combat_damage_regression;
 mod primo_unbounded_fractal_counters;
+mod proliferate_zero_counter;
 mod quirion_ranger_activation;
 mod refurbished_familiar;
 mod riot_control_regression;

--- a/crates/engine/tests/integration/proliferate_zero_counter.rs
+++ b/crates/engine/tests/integration/proliferate_zero_counter.rs
@@ -1,0 +1,149 @@
+//! Regression tests for GitHub issue #1995: proliferate must not add counters
+//! of a type a permanent no longer has after losing its last counter of that
+//! kind. CR 701.34a — proliferate only affects permanents/players that already
+//! have counters, and only adds kinds already present at count > 0.
+
+use engine::game::effects::counters::resolve_remove;
+use engine::game::effects::proliferate::{apply_proliferate, resolve};
+use engine::game::zones::create_object;
+use engine::types::ability::{Effect, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::counter::CounterType;
+use engine::types::events::GameEvent;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+fn proliferate_ability(controller: PlayerId) -> ResolvedAbility {
+    ResolvedAbility::new(Effect::Proliferate, vec![], ObjectId(999), controller)
+}
+
+fn remove_all_plus_one(obj: ObjectId, state: &mut GameState) {
+    let ability = ResolvedAbility::new(
+        Effect::RemoveCounter {
+            counter_type: Some(CounterType::Plus1Plus1),
+            count: -1,
+            target: TargetFilter::Any,
+        },
+        vec![TargetRef::Object(obj)],
+        ObjectId(998),
+        PlayerId(0),
+    );
+    resolve_remove(state, &ability, &mut Vec::new()).unwrap();
+}
+
+#[test]
+fn issue_1995_removed_counter_type_not_proliferated() {
+    let mut state = GameState::new_two_player(42);
+    let creature = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Formerly Pumped".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .counters
+        .insert(CounterType::Plus1Plus1, 1);
+
+    remove_all_plus_one(creature, &mut state);
+
+    let mut events = Vec::new();
+    resolve(&mut state, &proliferate_ability(PlayerId(0)), &mut events).unwrap();
+
+    assert!(
+        !matches!(state.waiting_for, WaitingFor::ProliferateChoice { .. }),
+        "creature with no positive counters must not open proliferate choice"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, GameEvent::PlayerPerformedAction { .. })),
+        "empty proliferate still emits PlayerPerformedAction"
+    );
+}
+
+#[test]
+fn issue_1995_stale_zero_map_entry_does_not_reopen_proliferate() {
+    let mut state = GameState::new_two_player(42);
+    let creature = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Stale Entry".to_string(),
+        Zone::Battlefield,
+    );
+    // Simulate the pre-fix bug: counter removed to zero but map key retained.
+    state
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .counters
+        .insert(CounterType::Plus1Plus1, 0);
+
+    let mut events = Vec::new();
+    resolve(&mut state, &proliferate_ability(PlayerId(0)), &mut events).unwrap();
+
+    assert!(
+        !matches!(state.waiting_for, WaitingFor::ProliferateChoice { .. }),
+        "stale zero-count key must not qualify for proliferate"
+    );
+
+    let mut apply_events = Vec::new();
+    apply_proliferate(
+        &mut state,
+        PlayerId(0),
+        &[TargetRef::Object(creature)],
+        &mut apply_events,
+    );
+
+    assert!(
+        !state.objects[&creature]
+            .counters
+            .contains_key(&CounterType::Plus1Plus1),
+        "forcing apply on a stale target must not resurrect +1/+1 counters"
+    );
+}
+
+#[test]
+fn issue_1995_mixed_zero_and_positive_only_proliferates_present_kinds() {
+    let mut state = GameState::new_two_player(42);
+    let artifact = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Battery".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&artifact)
+        .unwrap()
+        .counters
+        .insert(CounterType::Plus1Plus1, 0);
+    state
+        .objects
+        .get_mut(&artifact)
+        .unwrap()
+        .counters
+        .insert(CounterType::Generic("charge".to_string()), 4);
+
+    let mut events = Vec::new();
+    apply_proliferate(
+        &mut state,
+        PlayerId(0),
+        &[TargetRef::Object(artifact)],
+        &mut events,
+    );
+
+    assert_eq!(
+        state.objects[&artifact].counters[&CounterType::Generic("charge".to_string())],
+        5
+    );
+    assert!(!state.objects[&artifact]
+        .counters
+        .contains_key(&CounterType::Plus1Plus1));
+}

--- a/crates/phase-ai/src/planner/mod.rs
+++ b/crates/phase-ai/src/planner/mod.rs
@@ -7,6 +7,7 @@ use engine::ai_support::{
 };
 use engine::game::engine::apply_as_current;
 use engine::game::players;
+use engine::types::counter::{has_positive_counters, positive_counter_entries};
 use engine::types::game_state::{DayNight, GameState, WaitingFor};
 use engine::types::player::PlayerId;
 
@@ -191,17 +192,21 @@ pub fn quick_state_hash(state: &GameState) -> u64 {
             obj.toughness.hash(&mut hasher);
             obj.damage_marked.hash(&mut hasher);
             obj.controller.hash(&mut hasher);
-            // Counters: HashMap iteration order is non-deterministic,
-            // so hash count + sorted entries for stability.
+            // Counters: HashMap iteration order is non-deterministic, so hash
+            // count + sorted positive-count entries for stability. Internal
+            // zero-count map keys are absent markers under the engine's counter
+            // model and must not perturb AI cache keys.
             // Sort by as_str() to break ties between Generic variants.
-            obj.counters.len().hash(&mut hasher);
-            if !obj.counters.is_empty() {
-                let mut counter_entries: Vec<_> = obj.counters.iter().collect();
-                counter_entries.sort_by_key(|(ct, _)| ct.as_str());
-                for (ct, count) in counter_entries {
-                    ct.hash(&mut hasher);
+            if has_positive_counters(&obj.counters) {
+                let mut counter_entries: Vec<_> = positive_counter_entries(&obj.counters).collect();
+                counter_entries.sort_by_key(|(counter_type, _)| counter_type.as_str());
+                counter_entries.len().hash(&mut hasher);
+                for (counter_type, count) in counter_entries {
+                    counter_type.hash(&mut hasher);
                     count.hash(&mut hasher);
                 }
+            } else {
+                0usize.hash(&mut hasher);
             }
         }
     }
@@ -911,6 +916,7 @@ mod tests {
     use engine::game::zones::create_object;
     use engine::types::actions::{GameAction, MulliganChoice};
     use engine::types::card_type::CoreType;
+    use engine::types::counter::CounterType;
     use engine::types::game_state::WaitingFor;
     use engine::types::identifiers::CardId;
     use engine::types::phase::Phase;
@@ -992,6 +998,44 @@ mod tests {
         budget.tick();
         budget.tick();
         assert!(budget.exhausted());
+    }
+
+    #[test]
+    fn quick_state_hash_ignores_stale_zero_count_counter_entries() {
+        let mut absent = make_state();
+        let object_id = create_object(
+            &mut absent,
+            CardId(1),
+            PlayerId(0),
+            "Creature".to_string(),
+            Zone::Battlefield,
+        );
+        absent
+            .objects
+            .get_mut(&object_id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let mut stale = absent.clone();
+        stale
+            .objects
+            .get_mut(&object_id)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 0);
+
+        let mut positive = absent.clone();
+        positive
+            .objects
+            .get_mut(&object_id)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+
+        assert_eq!(quick_state_hash(&absent), quick_state_hash(&stale));
+        assert_ne!(quick_state_hash(&absent), quick_state_hash(&positive));
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/plus_one_counters.rs
+++ b/crates/phase-ai/src/policies/plus_one_counters.rs
@@ -9,7 +9,7 @@
 //! CR 614.1a: doubling replacements modify counter quantities.
 
 use engine::types::actions::GameAction;
-use engine::types::counter::CounterType;
+use engine::types::counter::{has_positive_counters, CounterType};
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
 use engine::types::zones::Zone;
@@ -190,7 +190,7 @@ fn count_permanents_with_counters(state: &GameState, player: PlayerId) -> usize 
                         .players
                         .iter()
                         .any(|p| p.id != player && p.poison_counters > 0))
-                && !obj.counters.is_empty()
+                && has_positive_counters(&obj.counters)
         })
         .count()
 }
@@ -551,6 +551,55 @@ mod tests {
     }
 
     // ─── verdict() — non-counter spell ───────────────────────────────────────
+
+    #[test]
+    fn proliferate_ignores_stale_zero_count_permanents() {
+        let mut state = GameState::new_two_player(42);
+        let gen_id = create_object(
+            &mut state,
+            CardId(1),
+            AI,
+            "Proliferator".to_string(),
+            Zone::Battlefield,
+        );
+        Arc::make_mut(&mut state.objects.get_mut(&gen_id).unwrap().abilities)
+            .push(make_proliferate_ability());
+        let stale = create_object(
+            &mut state,
+            CardId(2),
+            AI,
+            "Stale Map".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&stale)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 0);
+
+        let candidate = activate_candidate(gen_id, 0);
+        let decision = decision();
+        let (context, config) = context_with_commitment(0.9, vec![]);
+        let ctx = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+
+        let verdict = PlusOneCountersPolicy.verdict(&ctx);
+        match verdict {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "proliferate_no_targets");
+                assert!(delta < 0.0, "expected negative delta, got {delta}");
+            }
+            PolicyVerdict::Reject { .. } => panic!("unexpected Reject"),
+        }
+    }
 
     #[test]
     fn any_doubler_on_battlefield_finds_passive_replacement() {


### PR DESCRIPTION
## Summary

- Fixes [#1995](https://github.com/phase-rs/phase/issues/1995): after a permanent lost its last counter of a type, proliferate could incorrectly add one back because zero-count entries remained in the counter map.
- Adds shared counter helpers in `counter.rs` (`has_positive_counters`, `positive_counter_types`, `prune_zero_counters`) and uses them for proliferate eligibility/application, layer P/T checks, and AI proliferate target counting.
- Prunes stale zero-count map entries on counter removal and addition so "has a counter" checks stay aligned with CR 122.1 / CR 701.34a.

## Test plan

- [x] `cargo test -p engine proliferate`
- [x] `cargo test -p engine counter::tests`
- [x] `cargo test -p engine remove_counter`
- [x] `cargo test -p phase-ai plus_one_counters`
- [ ] Manual: put a +1/+1 counter on a creature, remove it, then proliferate — creature should not be eligible and must not regain +1/+1