### PR TITLE
fix(mtgish-import): convert AssignsNoCombatDamage for issue #2074

### DIFF
--- a/crates/mtgish-import/src/convert/static_effect.rs
+++ b/crates/mtgish-import/src/convert/static_effect.rs
@@ -356,6 +356,14 @@ pub fn convert_permanent_rule(
             exemption: engine::types::statics::ActivationExemption::None,
         },
 
+        // CR 510.1a: Assigns no combat damage (Master of Cruelties until end of combat).
+        // Mirrors `oracle_effect/subject.rs` — `AssignNoCombatDamage` + modification.
+        P::AssignsNoCombatDamage => {
+            return Ok(StaticDefinition::new(StaticMode::AssignNoCombatDamage)
+                .affected(affected)
+                .modifications(vec![ContinuousModification::AssignNoCombatDamage]));
+        }
+
         _ => {
             return Err(ConversionGap::UnknownVariant {
                 path: String::new(),
@@ -1003,6 +1011,22 @@ mod tests {
 
         assert_eq!(converted.mode, StaticMode::BlockRestriction);
         assert_eq!(converted.affected, Some(TargetFilter::SelfRef));
+    }
+
+    #[test]
+    fn assigns_no_combat_damage_lowers_to_assign_no_combat_damage_static() {
+        let converted = convert_permanent_rule(
+            &PermanentRule::AssignsNoCombatDamage,
+            TargetFilter::SelfRef,
+        )
+        .unwrap();
+
+        assert_eq!(converted.mode, StaticMode::AssignNoCombatDamage);
+        assert_eq!(converted.affected, Some(TargetFilter::SelfRef));
+        assert_eq!(
+            converted.modifications,
+            vec![ContinuousModification::AssignNoCombatDamage]
+        );
     }
 
     #[test]

--- a/crates/mtgish-import/src/convert/static_effect.rs
+++ b/crates/mtgish-import/src/convert/static_effect.rs
@@ -1015,11 +1015,9 @@ mod tests {
 
     #[test]
     fn assigns_no_combat_damage_lowers_to_assign_no_combat_damage_static() {
-        let converted = convert_permanent_rule(
-            &PermanentRule::AssignsNoCombatDamage,
-            TargetFilter::SelfRef,
-        )
-        .unwrap();
+        let converted =
+            convert_permanent_rule(&PermanentRule::AssignsNoCombatDamage, TargetFilter::SelfRef)
+                .unwrap();
 
         assert_eq!(converted.mode, StaticMode::AssignNoCombatDamage);
         assert_eq!(converted.affected, Some(TargetFilter::SelfRef));


### PR DESCRIPTION
## Summary

Fixes [#2074](https://github.com/phase-rs/phase/issues/2074): `PermanentRule::AssignsNoCombatDamage` (26 mtgish entries, e.g. Master of Cruelties until end of combat) now converts instead of `ConversionGap::UnknownVariant`.

- Add `P::AssignsNoCombatDamage` arm in `convert_permanent_rule` → `StaticMode::AssignNoCombatDamage` with `ContinuousModification::AssignNoCombatDamage` (matches `oracle_effect/subject.rs`).
- Unit test: `assigns_no_combat_damage_lowers_to_assign_no_combat_damage_static`.

## Test plan

- [x] `cargo test -p mtgish-import assigns_no_combat_damage --lib`
- [x] `./scripts/check-parser-combinators.sh origin/main` (no new parser diff)
- [ ] Strict mtgish import for Master of Cruelties face (manual / CI card-data if applicable)

Closes #2074