### PR TITLE
fix(mtgish-import): convert AllCreaturesMustBlockIt for issue #2075

### DIFF
--- a/crates/mtgish-import/src/convert/mod.rs
+++ b/crates/mtgish-import/src/convert/mod.rs
@@ -2852,6 +2852,27 @@ mod tests {
     }
 
     #[test]
+    fn breaker_of_armies_rule_effect_imports_must_be_blocked_by_all() {
+        use crate::schema::types::PermanentRule;
+        use engine::types::statics::StaticMode;
+
+        let rule = Rule::PermanentRuleEffect(
+            Box::new(Permanent::ThisPermanent),
+            vec![PermanentRule::AllCreaturesMustBlockIt(Box::new(
+                Permanents::IsCardtype(CardType::Creature),
+            ))],
+        );
+        let mut report = crate::report::ImportReport::default();
+        let mut ctx = Ctx::new("breaker of armies".to_string(), &mut report);
+
+        let converted = recurse_rules(&[rule], "main", 0, &mut ctx).unwrap();
+
+        assert_eq!(converted.statics.len(), 1);
+        assert_eq!(converted.statics[0].mode, StaticMode::MustBeBlockedByAll);
+        assert_eq!(converted.statics[0].affected, Some(TargetFilter::SelfRef));
+    }
+
+    #[test]
     fn host_conditioned_static_uses_attached_host_for_condition_and_affected() {
         let rule = Rule::If(
             Condition::PermanentPassesFilter(

--- a/crates/mtgish-import/src/convert/static_effect.rs
+++ b/crates/mtgish-import/src/convert/static_effect.rs
@@ -298,6 +298,10 @@ pub fn convert_permanent_rule(
         P::MustAttack => StaticMode::MustAttack,
         P::MustBlock => StaticMode::MustBlock,
         P::MustBeBlocked => StaticMode::MustBeBlocked,
+        // CR 509.1c: "All creatures able to block [this] do so" (Lure, Breaker of Armies).
+        // Blocker-eligibility payload (`Permanents`) is not yet modeled on
+        // `StaticMode::MustBeBlockedByAll`; combat treats every able blocker.
+        P::AllCreaturesMustBlockIt(_permanents) => StaticMode::MustBeBlockedByAll,
         P::CanBlockOnly(filter) if is_creature_with_flying_filter(filter) => {
             StaticMode::BlockRestriction
         }
@@ -989,6 +993,20 @@ mod tests {
     use super::*;
     use crate::schema::types::{LandType, PermanentRule, Permanents, Player};
     use engine::types::ability::{TargetFilter, TypeFilter, TypedFilter};
+
+    #[test]
+    fn all_creatures_must_block_it_lowers_to_must_be_blocked_by_all() {
+        let converted = convert_permanent_rule(
+            &PermanentRule::AllCreaturesMustBlockIt(Box::new(Permanents::IsCardtype(
+                CardType::Creature,
+            ))),
+            TargetFilter::SelfRef,
+        )
+        .unwrap();
+
+        assert_eq!(converted.mode, StaticMode::MustBeBlockedByAll);
+        assert_eq!(converted.affected, Some(TargetFilter::SelfRef));
+    }
 
     #[test]
     fn can_block_only_creatures_with_flying_lowers_to_block_restriction() {


### PR DESCRIPTION
## Summary

Fixes [#2075](https://github.com/phase-rs/phase/issues/2075): `PermanentRule::AllCreaturesMustBlockIt` (Lure, Breaker of Armies, etc.) now converts to `StaticMode::MustBeBlockedByAll` instead of `ConversionGap::UnknownVariant`.

- Add `P::AllCreaturesMustBlockIt` arm in `convert_permanent_rule` (matches oracle `MustBeBlockedByAll` lowering).
- Unit test: `all_creatures_must_block_it_lowers_to_must_be_blocked_by_all`.
- Integration test: `breaker_of_armies_rule_effect_imports_must_be_blocked_by_all`.

Note: the mtgish `Permanents` blocker-eligibility payload is not yet stored on `StaticMode::MustBeBlockedByAll`; combat already enforces “every creature able to block must block” for the standard `Creature` case. Parameterized cases (e.g. Marble Priest Walls-only, Talruum Piper flying-only) need a follow-up engine field.

## Test plan

- [x] `cargo test -p mtgish-import must_be_blocked_by_all --lib`
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/check-parser-combinators.sh origin/main`

Closes #2075