### PR TITLE
fix(parser): exempt ExileCastPermission from Duration_ThisTurn swallow warning (#594)

### DIFF
--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -1988,6 +1988,14 @@ fn detect_duration_this_turn(
         // in unrelated positions (e.g. a description string).
         "\"PerTurnCastLimit\":{",
         "\"PerTurnDrawLimit\":{",
+        // CR 604.1 + CR 601.2a + CR 113.6b: `ExileCastPermission` is a static
+        // ability (CR 604.1) that is itself the per-turn permission window
+        // (`frequency: OncePerTurn` slot reset at turn cleanup, plus the per-turn
+        // rolling `cards_exiled_with_source_this_turn` pool keyed by source). The
+        // "this turn" / "once each turn" wording is intrinsic to the variant — not
+        // a separate `duration` slot. Mirrors PerTurnCastLimit / PerTurnDrawLimit
+        // above.
+        "\"ExileCastPermission\":{",
     ];
     if json_has_any(ast_json, markers) {
         return;
@@ -2351,6 +2359,34 @@ mod tests {
             &["Land"],
         );
 
+        assert!(!has_swallowed_detector(&parsed, "Duration_ThisTurn"));
+    }
+
+    #[test]
+    fn duration_this_turn_accepts_exile_cast_permission_scope() {
+        // CR 601.2a + CR 113.6b: Maralen, Fae Ascendant — the "this turn"
+        // wording on the cast-permission line is intrinsic to
+        // `ExileCastPermission { frequency: OncePerTurn, ... }` (the per-turn
+        // rolling pool keyed by source), not a separate duration slot.
+        let parsed = parse_named(
+            "Flying\n\
+             Whenever ~ or another Elf or Faerie you control enters, exile the top two cards of target opponent's library.\n\
+             Once each turn, you may cast a spell with mana value less than or equal to the number of Elves and Faeries you control from among cards exiled with ~ this turn without paying its mana cost.",
+            "Maralen, Fae Ascendant",
+            &["Creature"],
+        );
+
+        // Guard against the silent-regression case: the negative assertion below
+        // would also pass if the `ExileCastPermission` static simply stopped
+        // parsing (no marker emitted, no other "this turn" AST). Pin that the
+        // structural variant the exemption keys on is actually present.
+        assert!(
+            parsed.statics.iter().any(|s| matches!(
+                s.mode,
+                crate::types::statics::StaticMode::ExileCastPermission { .. }
+            )),
+            "expected an ExileCastPermission static to parse for Maralen"
+        );
         assert!(!has_swallowed_detector(&parsed, "Duration_ThisTurn"));
     }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -2268,6 +2268,7 @@ fn effect_name(effect: &Effect) -> &str {
 mod tests {
     use crate::parser::oracle::parse_oracle_text;
     use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
+    use crate::types::statics::StaticMode;
 
     fn parse(text: &str, types: &[&str]) -> crate::parser::oracle::ParsedAbilities {
         parse_named(text, "Test Card", types)
@@ -2381,10 +2382,10 @@ mod tests {
         // parsing (no marker emitted, no other "this turn" AST). Pin that the
         // structural variant the exemption keys on is actually present.
         assert!(
-            parsed.statics.iter().any(|s| matches!(
-                s.mode,
-                crate::types::statics::StaticMode::ExileCastPermission { .. }
-            )),
+            parsed
+                .statics
+                .iter()
+                .any(|s| matches!(s.mode, StaticMode::ExileCastPermission { .. })),
             "expected an ExileCastPermission static to parse for Maralen"
         );
         assert!(!has_swallowed_detector(&parsed, "Duration_ThisTurn"));


### PR DESCRIPTION
## Summary
Fixes a false-positive parser diagnostic where `StaticMode::ExileCastPermission` (for example, Maralen, Fae Ascendant-style "exile it / you may cast it this turn" text) triggered the `Duration_ThisTurn` swallow warning.

The "this turn" / "once each turn" wording is intrinsic to the exile-cast permission static and its per-turn tracked exile pool. It should not be lifted as a separate `Duration::ThisTurn` modifier, so suppressing this warning is the correct parser-diagnostic behavior.

## Files changed
- `crates/engine/src/parser/swallow_check.rs`

## CR references
- CR 604.1 — static abilities
- CR 601.2a — casting a spell from a zone
- CR 113.6b — abilities that state which zones they function in

## Track
Developer

## LLM
Model: claude-opus-4-7
Thinking: high

## Verification
- cargo fmt --all -- --check: clean
- cargo test -p engine: pass
- Tilt clippy: clean
- Tilt test-engine: pass
- Parser combinator gate: clean
- Targeted: confirmed Maralen, Fae Ascendant no longer emits the Duration_ThisTurn swallow warning; no regressions in adjacent ExileCastPermission cards

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

Closes #594
Closes #611
