### PR TITLE
feat(engine): "Enchanted land is the chosen type" static (CR 305.7 / 305.6)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2590,6 +2590,7 @@ fn fmt_modification(m: &crate::types::ability::ContinuousModification) -> String
         ContinuousModification::SetBasicLandType { land_type } => {
             format!("set land type {}", land_type.as_subtype_str())
         }
+        ContinuousModification::SetChosenBasicLandType => "set chosen land type".into(),
         ContinuousModification::AssignNoCombatDamage => "assign no combat damage".into(),
         ContinuousModification::RetainPrintedTriggerFromSource {
             source_trigger_index,

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -10,9 +10,9 @@ use crate::game::quantity::{filter_uses_recipient, quantity_expr_uses_recipient,
 use crate::game::speed::{effective_speed, has_max_speed};
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, BasicLandType, CastingPermission,
-    CommanderOwnership, ContinuousModification, CopiableValues, Duration, Effect, FilterProp,
-    ManaContribution, ManaProduction, PlayerScope, QuantityExpr, StaticCondition, StaticDefinition,
-    TargetFilter, TypedFilter,
+    ChosenSubtypeKind, CommanderOwnership, ContinuousModification, CopiableValues, Duration,
+    Effect, FilterProp, ManaContribution, ManaProduction, PlayerScope, QuantityExpr,
+    StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
 };
 use crate::types::attribution::EffectRef;
 use crate::types::card_type::{
@@ -2702,6 +2702,7 @@ fn depends_on(a: &ActiveContinuousEffect, b: &ActiveContinuousEffect, _state: &G
             | ContinuousModification::AddAllLandTypes
             | ContinuousModification::AddChosenSubtype { .. }
             | ContinuousModification::SetBasicLandType { .. }
+            | ContinuousModification::SetChosenBasicLandType
     );
 
     if b_changes_types && filter_references_type(&a.affected_filter) {
@@ -3015,6 +3016,7 @@ fn modification_dynamic_quantity(m: &ContinuousModification) -> Option<&Quantity
         | ContinuousModification::AssignNoCombatDamage
         | ContinuousModification::ChangeController
         | ContinuousModification::SetBasicLandType { .. }
+        | ContinuousModification::SetChosenBasicLandType
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. } => None,
@@ -3075,16 +3077,22 @@ fn apply_continuous_effect_filtered(
 
     record_attribution(state, effect, &affected_ids);
 
-    // Pre-read chosen subtype from source (avoids borrow conflict in the loop)
-    let chosen_subtype =
-        if let ContinuousModification::AddChosenSubtype { ref kind } = effect.modification {
-            state
-                .objects
-                .get(&effect.source_id)
-                .and_then(|src| src.chosen_subtype_str(kind))
-        } else {
-            None
-        };
+    // Pre-read chosen subtype from source (avoids borrow conflict in the loop).
+    // Populated for `AddChosenSubtype { kind }` (additive — creature type or
+    // basic land type) AND for `SetChosenBasicLandType` (CR 305.7 replacement
+    // of a land's subtype with the source's chosen basic land type). The latter
+    // is implicitly `ChosenSubtypeKind::BasicLandType`.
+    let chosen_subtype = match effect.modification {
+        ContinuousModification::AddChosenSubtype { ref kind } => state
+            .objects
+            .get(&effect.source_id)
+            .and_then(|src| src.chosen_subtype_str(kind)),
+        ContinuousModification::SetChosenBasicLandType => state
+            .objects
+            .get(&effect.source_id)
+            .and_then(|src| src.chosen_subtype_str(&ChosenSubtypeKind::BasicLandType)),
+        _ => None,
+    };
 
     // Pre-read chosen color from source (avoids borrow conflict in the loop).
     // Used by `AddChosenColor` (CR 105.3) AND by `AddKeyword` when the keyword
@@ -3652,6 +3660,26 @@ fn apply_continuous_effect_filtered(
                 obj.replacement_definitions.clear();
                 obj.static_definitions.clear();
                 obj.keywords.clear();
+            }
+            // CR 305.7 + CR 305.6: Set the land's subtype to the basic land type
+            // chosen by the granting source (Phantasmal Terrain, Convincing
+            // Mirage). Identical replacement semantics to `SetBasicLandType` —
+            // remove old land subtypes (CR 205.3i), clear abilities/triggers/
+            // replacements/statics/keywords generated from rules text — except
+            // the concrete subtype is the source's pre-read `chosen_subtype`
+            // (read above for `BasicLandType`). The intrinsic mana ability is
+            // derived from the subtype in `mana_sources.rs` (CR 305.6). If no
+            // choice was recorded, this is a no-op.
+            ContinuousModification::SetChosenBasicLandType => {
+                if let Some(ref subtype) = chosen_subtype {
+                    obj.card_types.subtypes.retain(|s| !is_land_subtype(s));
+                    obj.card_types.subtypes.push(subtype.clone());
+                    Arc::make_mut(&mut obj.abilities).clear();
+                    obj.trigger_definitions.clear();
+                    obj.replacement_definitions.clear();
+                    obj.static_definitions.clear();
+                    obj.keywords.clear();
+                }
             }
             // CR 707.9a: Retain the source's printed trigger on the copy.
             // After `CopyValues` overwrote `obj.trigger_definitions` with the
@@ -7629,6 +7657,99 @@ mod tests {
         assert!(
             !land.card_types.subtypes.contains(&"Desert".to_string()),
             "CR 305.7: Old land subtypes should be removed"
+        );
+    }
+
+    #[test]
+    fn set_chosen_basic_land_type_reads_source_choice() {
+        // CR 305.7 + CR 305.6: Phantasmal Terrain / Convincing Mirage. The Aura
+        // (source) recorded a chosen basic land type as it entered; its
+        // SetChosenBasicLandType static must set the ENCHANTED land's subtype to
+        // that chosen type with full replacement semantics — old land subtype and
+        // rules-text abilities cleared, intrinsic mana ability for the new type
+        // derived (CR 305.6).
+        use crate::types::ability::{BasicLandType, ChosenAttribute};
+
+        let mut state = setup();
+        let p0 = PlayerId(0);
+
+        // Enchanted land: starts as a Swamp with a rules-text ability.
+        let land_id = make_land(&mut state, "Test Swamp", p0);
+        {
+            let obj = state.objects.get_mut(&land_id).unwrap();
+            obj.card_types.subtypes.push("Swamp".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            Arc::make_mut(&mut obj.base_abilities).push(AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            ));
+            obj.abilities = Arc::new((*obj.base_abilities).clone());
+        }
+
+        // Source Aura: chose Island as it entered, carries the chosen-type static
+        // anchored to its enchanted land.
+        let aura_id = create_object(
+            &mut state,
+            CardId(1),
+            p0,
+            "Convincing Mirage".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let ts = state.next_timestamp();
+            let obj = state.objects.get_mut(&aura_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.card_types.subtypes.push("Aura".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            obj.timestamp = ts;
+            obj.attached_to = Some(land_id.into());
+            obj.chosen_attributes
+                .push(ChosenAttribute::BasicLandType(BasicLandType::Island));
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::land().properties(vec![FilterProp::EnchantedBy]),
+                    ))
+                    .modifications(vec![ContinuousModification::SetChosenBasicLandType]),
+            );
+        }
+        state
+            .objects
+            .get_mut(&land_id)
+            .unwrap()
+            .attachments
+            .push(aura_id);
+
+        evaluate_layers(&mut state);
+
+        let land = state.objects.get(&land_id).unwrap();
+        assert!(
+            land.card_types.subtypes.contains(&"Island".to_string()),
+            "CR 305.7: enchanted land should gain the source's chosen Island subtype"
+        );
+        assert!(
+            !land.card_types.subtypes.contains(&"Swamp".to_string()),
+            "CR 305.7: old land subtype should be removed"
+        );
+        assert!(
+            !land
+                .abilities
+                .iter()
+                .any(|ability| matches!(&*ability.effect, Effect::GainLife { .. })),
+            "CR 305.7: rules-text abilities should be removed"
+        );
+        assert_eq!(
+            count_mana_abilities(land, ManaColor::Blue),
+            1,
+            "CR 305.6: chosen Island should grant the intrinsic blue mana ability"
+        );
+        assert_eq!(
+            count_mana_abilities(land, ManaColor::Black),
+            0,
+            "CR 305.7: old Swamp mana ability should be gone"
         );
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3082,17 +3082,17 @@ fn apply_continuous_effect_filtered(
     // basic land type) AND for `SetChosenBasicLandType` (CR 305.7 replacement
     // of a land's subtype with the source's chosen basic land type). The latter
     // is implicitly `ChosenSubtypeKind::BasicLandType`.
-    let chosen_subtype = match effect.modification {
-        ContinuousModification::AddChosenSubtype { ref kind } => state
-            .objects
-            .get(&effect.source_id)
-            .and_then(|src| src.chosen_subtype_str(kind)),
-        ContinuousModification::SetChosenBasicLandType => state
-            .objects
-            .get(&effect.source_id)
-            .and_then(|src| src.chosen_subtype_str(&ChosenSubtypeKind::BasicLandType)),
+    let chosen_subtype_kind = match effect.modification {
+        ContinuousModification::AddChosenSubtype { ref kind } => Some(kind),
+        ContinuousModification::SetChosenBasicLandType => Some(&ChosenSubtypeKind::BasicLandType),
         _ => None,
     };
+    let chosen_subtype = chosen_subtype_kind.and_then(|kind| {
+        state
+            .objects
+            .get(&effect.source_id)
+            .and_then(|src| src.chosen_subtype_str(kind))
+    });
 
     // Pre-read chosen color from source (avoids borrow conflict in the loop).
     // Used by `AddChosenColor` (CR 105.3) AND by `AddKeyword` when the keyword
@@ -3651,15 +3651,7 @@ fn apply_continuous_effect_filtered(
             // Abilities granted by other effects are re-added in Layer 6.
             // Intrinsic mana abilities are derived from subtypes in mana_sources.rs.
             ContinuousModification::SetBasicLandType { land_type } => {
-                obj.card_types.subtypes.retain(|s| !is_land_subtype(s));
-                obj.card_types
-                    .subtypes
-                    .push(land_type.as_subtype_str().to_string());
-                Arc::make_mut(&mut obj.abilities).clear();
-                obj.trigger_definitions.clear();
-                obj.replacement_definitions.clear();
-                obj.static_definitions.clear();
-                obj.keywords.clear();
+                set_land_subtype_replacing(obj, land_type.as_subtype_str().to_string());
             }
             // CR 305.7 + CR 305.6: Set the land's subtype to the basic land type
             // chosen by the granting source (Phantasmal Terrain, Convincing
@@ -3672,13 +3664,7 @@ fn apply_continuous_effect_filtered(
             // choice was recorded, this is a no-op.
             ContinuousModification::SetChosenBasicLandType => {
                 if let Some(ref subtype) = chosen_subtype {
-                    obj.card_types.subtypes.retain(|s| !is_land_subtype(s));
-                    obj.card_types.subtypes.push(subtype.clone());
-                    Arc::make_mut(&mut obj.abilities).clear();
-                    obj.trigger_definitions.clear();
-                    obj.replacement_definitions.clear();
-                    obj.static_definitions.clear();
-                    obj.keywords.clear();
+                    set_land_subtype_replacing(obj, subtype.clone());
                 }
             }
             // CR 707.9a: Retain the source's printed trigger on the copy.
@@ -3695,6 +3681,18 @@ fn apply_continuous_effect_filtered(
             }
         }
     }
+}
+
+// CR 305.7: Setting a land subtype replaces old land subtypes and removes the
+// land's rules-text abilities; layer 6 reapplies abilities from other effects.
+fn set_land_subtype_replacing(obj: &mut crate::game::game_object::GameObject, subtype: String) {
+    obj.card_types.subtypes.retain(|s| !is_land_subtype(s));
+    obj.card_types.subtypes.push(subtype);
+    Arc::make_mut(&mut obj.abilities).clear();
+    obj.trigger_definitions.clear();
+    obj.replacement_definitions.clear();
+    obj.static_definitions.clear();
+    obj.keywords.clear();
 }
 
 /// CR 305.6: After layer 4 establishes final land types, derive each land's

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -505,6 +505,7 @@ fn walk_continuous_mod(modification: &ContinuousModification, out: &mut Vec<Stri
         | ContinuousModification::AssignNoCombatDamage
         | ContinuousModification::ChangeController
         | ContinuousModification::SetBasicLandType { .. }
+        | ContinuousModification::SetChosenBasicLandType
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -357,6 +357,40 @@ pub(crate) fn parse_static_line_inner(
         }
     }
 
+    // CR 305.7 + CR 305.6: "Enchanted land is the chosen type" — Aura sets the
+    // enchanted land's subtype to the basic land type chosen as the Aura entered
+    // (Phantasmal Terrain, Convincing Mirage). Replacement semantics (clears the
+    // land's old types AND its rules-text abilities) are carried by
+    // `SetChosenBasicLandType`, which reads the source's chosen type at layer
+    // eval time. Must come before the concrete "enchanted land is a <type>" arm;
+    // "is the chosen type" and "is a <type>" are disjoint prefixes so neither
+    // shadows the other. Combinator-pure: a fixed phrase with an optional trailing
+    // "." and an optional "and loses its other [land] types" tail (no semantic
+    // difference — CR 305.7 already removes the old land types).
+    {
+        let parse_chosen_land_type = (
+            tag::<_, _, OracleError<'_>>("enchanted land is the chosen type"),
+            opt(alt((
+                tag(" and loses its other land types"),
+                tag(" and loses its other types"),
+            ))),
+            opt(tag(".")),
+        );
+        if all_consuming(map(parse_chosen_land_type, |_| ()))
+            .parse(tp.lower)
+            .is_ok()
+        {
+            return Some(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::land().properties(vec![FilterProp::EnchantedBy]),
+                    ))
+                    .modifications(vec![ContinuousModification::SetChosenBasicLandType])
+                    .description(text.to_string()),
+            );
+        }
+    }
+
     // CR 305.7: "Enchanted land is a [type]" — must be before general "enchanted land" handler.
     if let Some(rest) = nom_tag_tp(&tp, "enchanted land is a ") {
         let rest = rest.trim_end_matches('.');

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -358,37 +358,9 @@ pub(crate) fn parse_static_line_inner(
     }
 
     // CR 305.7 + CR 305.6: "Enchanted land is the chosen type" — Aura sets the
-    // enchanted land's subtype to the basic land type chosen as the Aura entered
-    // (Phantasmal Terrain, Convincing Mirage). Replacement semantics (clears the
-    // land's old types AND its rules-text abilities) are carried by
-    // `SetChosenBasicLandType`, which reads the source's chosen type at layer
-    // eval time. Must come before the concrete "enchanted land is a <type>" arm;
-    // "is the chosen type" and "is a <type>" are disjoint prefixes so neither
-    // shadows the other. Combinator-pure: a fixed phrase with an optional trailing
-    // "." and an optional "and loses its other [land] types" tail (no semantic
-    // difference — CR 305.7 already removes the old land types).
-    {
-        let parse_chosen_land_type = (
-            tag::<_, _, OracleError<'_>>("enchanted land is the chosen type"),
-            opt(alt((
-                tag(" and loses its other land types"),
-                tag(" and loses its other types"),
-            ))),
-            opt(tag(".")),
-        );
-        if all_consuming(map(parse_chosen_land_type, |_| ()))
-            .parse(tp.lower)
-            .is_ok()
-        {
-            return Some(
-                StaticDefinition::continuous()
-                    .affected(TargetFilter::Typed(
-                        TypedFilter::land().properties(vec![FilterProp::EnchantedBy]),
-                    ))
-                    .modifications(vec![ContinuousModification::SetChosenBasicLandType])
-                    .description(text.to_string()),
-            );
-        }
+    // enchanted land's subtype to the basic land type chosen as the Aura entered.
+    if let Some(def) = parse_enchanted_land_chosen_type_static(&tp, &text) {
+        return Some(def);
     }
 
     // CR 305.7: "Enchanted land is a [type]" — must be before general "enchanted land" handler.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2770,6 +2770,42 @@ fn this_land_is_the_chosen_type() {
 }
 
 #[test]
+fn enchanted_land_is_the_chosen_type() {
+    // CR 305.7 + CR 305.6: Phantasmal Terrain / Convincing Mirage. The Aura's
+    // continuous static must set the enchanted land's subtype to the chosen
+    // basic land type with replacement semantics (SetChosenBasicLandType), not
+    // additive (AddChosenSubtype) — that variant clears the land's old types and
+    // rules-text abilities, which AddChosenSubtype does not.
+    let def = parse_static_line("Enchanted land is the chosen type.").unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(
+        def.affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::land().properties(vec![FilterProp::EnchantedBy])
+        ))
+    );
+    assert_eq!(
+        def.modifications,
+        vec![ContinuousModification::SetChosenBasicLandType]
+    );
+
+    // Tail variants ("and loses its other land types"/"types") parse identically
+    // — CR 305.7 already removes the old land types, so the tail is cosmetic.
+    for line in [
+        "Enchanted land is the chosen type",
+        "Enchanted land is the chosen type and loses its other land types.",
+        "Enchanted land is the chosen type and loses its other types.",
+    ] {
+        let def = parse_static_line(line).unwrap();
+        assert_eq!(
+            def.modifications,
+            vec![ContinuousModification::SetChosenBasicLandType],
+            "line did not parse to SetChosenBasicLandType: {line}"
+        );
+    }
+}
+
+#[test]
 fn this_creature_is_the_chosen_type() {
     let def = parse_static_line("This creature is the chosen type in addition to its other types.")
         .unwrap();

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -25,6 +25,40 @@ pub(crate) fn parse_self_chosen_type_static(input: &str) -> OracleResult<'_, Cho
     Ok((input, kind))
 }
 
+pub(crate) fn parse_enchanted_land_chosen_type_static(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    let ((), _) = nom_on_lower(
+        tp.original,
+        tp.lower,
+        parse_enchanted_land_chosen_type_static_sentence,
+    )?;
+
+    Some(
+        StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::land().properties(vec![FilterProp::EnchantedBy]),
+            ))
+            .modifications(vec![ContinuousModification::SetChosenBasicLandType])
+            .description(description.to_string()),
+    )
+}
+
+pub(crate) fn parse_enchanted_land_chosen_type_static_sentence(
+    input: &str,
+) -> OracleResult<'_, ()> {
+    let (input, _) = tag("enchanted land is the chosen type").parse(input)?;
+    let (input, _) = opt(alt((
+        tag(" and loses its other land types"),
+        tag(" and loses its other types"),
+    )))
+    .parse(input)?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+    eof.parse(input)?;
+    Ok((input, ()))
+}
+
 pub(crate) fn parse_arcane_adaptation_chosen_type_static(
     tp: &TextPair<'_>,
     description: &str,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11636,6 +11636,18 @@ pub enum ContinuousModification {
     SetBasicLandType {
         land_type: BasicLandType,
     },
+    /// CR 305.7 + CR 305.6: Sets a land's subtype to the basic land type CHOSEN
+    /// by the granting source (e.g. Phantasmal Terrain, Convincing Mirage:
+    /// "As this Aura enters, choose a basic land type." + "Enchanted land is the
+    /// chosen type."). Mirrors `SetBasicLandType`'s replacement semantics —
+    /// removes the land's old land subtypes and clears the abilities generated
+    /// from its rules text — but reads the concrete subtype from the source
+    /// object's `chosen_attributes` (`ChosenSubtypeKind::BasicLandType`) at layer
+    /// evaluation time rather than carrying a fixed type. Unit variant: the kind
+    /// is implicitly `BasicLandType`. The intrinsic mana ability for the new type
+    /// is derived from the subtype in `mana_sources.rs` (CR 305.6), so no explicit
+    /// mana grant is needed here.
+    SetChosenBasicLandType,
     /// CR 707.9a: Retain a printed triggered ability from the source object's
     /// printed trigger list at the given index. Used by "becomes a copy of <X>,
     /// except it has this ability" patterns (Irma Part-Time Mutant, Cryptoplasm,

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -112,7 +112,8 @@ impl ContinuousModification {
             | ContinuousModification::AddAllBasicLandTypes
             | ContinuousModification::AddAllLandTypes
             | ContinuousModification::AddChosenSubtype { .. }
-            | ContinuousModification::SetBasicLandType { .. } => Layer::Type, // CR 613.1d + CR 205.4b
+            | ContinuousModification::SetBasicLandType { .. }
+            | ContinuousModification::SetChosenBasicLandType => Layer::Type, // CR 613.1d + CR 205.4b
             // CR 122.1 + CR 614.1c: One-shot counter placement at copy
             // resolution. Consumed by the BecomeCopy / CopyTokenOf resolvers
             // before any continuous-effect machinery is reached. Reaching this


### PR DESCRIPTION
## Summary
**Phantasmal Terrain** and **Convincing Mirage** (*"As this Aura enters, choose a basic land type. Enchanted land is the chosen type."*) were Unimplemented on the *"is the chosen type"* clause. The concrete form (*"Enchanted land is an Island"*, Sea's Claim) already works via `SetBasicLandType`, but the **chosen-type** form had no modification — and composing `RemoveAllSubtypes + AddChosenSubtype` is **incorrect** because CR 305.7 also requires clearing the land's rules-text abilities, which only the `SetBasicLandType` path does. Both cards are single-gap (the "choose a basic land type" ETB already parses + records the choice), so this fully unlocks them.

## What it does
- **`ContinuousModification::SetChosenBasicLandType`** (new) — reads the source's chosen `BasicLandType` at layer-eval; classified layer 4 / Type (with `SetBasicLandType`).
- **`layers.rs`**: the chosen-subtype pre-read now also resolves the chosen land-type string for the new variant; the application arm **mirrors `SetBasicLandType`** (retain non-land subtypes, remove land subtypes, push the chosen subtype, clear abilities/triggers/replacements/statics/keywords). Mana ability is derived from the subtype (CR 305.6), same as `SetBasicLandType`.
- **Parser** (`oracle_static/dispatch.rs`): combinator-pure *"enchanted land is the chosen type"* arm (optional *"and loses its other [land] types"* tail) → the static on the enchanted land (`land() + EnchantedBy`). Disjoint from the *"is a <type>"* and *"this land is the chosen type"* arms (no shadowing).
- Coverage + `printed_cards` + layer-classification matches updated for the new variant.

## Files changed
- `crates/engine/src/types/ability.rs`, `crates/engine/src/types/layers.rs`
- `crates/engine/src/game/layers.rs`, `crates/engine/src/game/coverage.rs`, `crates/engine/src/game/printed_cards.rs`
- `crates/engine/src/parser/oracle_static/dispatch.rs`, `crates/engine/src/parser/oracle_static/tests.rs`

## Anchored on
- `ContinuousModification::SetBasicLandType` — the concrete-type analog; the new variant mirrors its layer body byte-for-byte (substituting the chosen subtype).
- `AddChosenSubtype` — the existing chosen-subtype source-read (`chosen_subtype_str`) this reuses.
- The `"enchanted land is a <type>"` dispatch handler this sits beside.

## CR references
- `CR 305.7` (basic-land-type set: removes old land types + clears rules-text abilities) · `CR 305.6` (intrinsic mana ability) — both verified against `docs/MagicCompRules.txt`.

## Tests
- Parser: *"Enchanted land is the chosen type."* (+ tail variants) → modifications contain `SetChosenBasicLandType`, affected = land + EnchantedBy.
- Layer: an enchanted land takes the source's chosen type (e.g. Island), loses its original land type, and has its abilities cleared.

## Track
Developer (local toolchain)

## LLM
Model: claude-opus-4-8
Thinking: medium

## Verification
Verified locally before push: `./scripts/check-parser-combinators.sh` exit 0; `cargo fmt --all --check` clean; `cargo clippy -p engine --all-targets -- -D warnings` clean (exit 0); `cargo test -p engine` — new tests pass (`chosen_basic_land` 4, `enchanted_land` 11), `basic_land_type` (24) + `chosen`/`layers` suites green, no regressions. CI status checks also apply.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.