### PR TITLE
feat(engine): count creatures of the chosen type on the battlefield (CR 604.3)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -583,6 +583,10 @@ fn parse_number_of_inner(input: &str) -> OracleResult<'_, QuantityRef> {
         // whose " you control" suffix would otherwise not match but whose
         // type-word prefix overlaps.
         parse_controlled_by_extremum_player,
+        // CR 604.3: "<type> of the chosen type on the battlefield" — global CDA
+        // count; must precede `parse_number_of_controlled_type`, whose
+        // " you control" suffix does not match the battlefield-wide form.
+        parse_number_of_chosen_type_on_battlefield,
         parse_number_of_controlled_type,
         parse_cards_exiled_with_source,
         // CR 109.4 + CR 115.7: "cards in their <zone>" / "cards in that player's <zone>"
@@ -763,6 +767,37 @@ fn parse_number_of_controlled_type(input: &str) -> OracleResult<'_, QuantityRef>
                 type_filters,
                 controller: Some(controller),
                 properties: Vec::new(),
+            }),
+        },
+    ))
+}
+
+/// CR 604.3 + CR 613.1: Parse "<type> of the chosen type [on the battlefield]"
+/// after "the number of" → a battlefield-wide (any-controller) population count
+/// of permanents whose subtypes include the source's chosen creature type.
+///
+/// Distinct from `parse_number_of_controlled_type`, whose " you control" suffix
+/// restricts the count to a single controller. This is the global form that
+/// backs characteristic-defining power/toughness abilities such as Caller of
+/// the Hunt ("~'s power and toughness are each equal to the number of creatures
+/// of the chosen type on the battlefield"). The chosen type is read at
+/// evaluation time via `FilterProp::IsChosenCreatureType` (mirrors the existing
+/// "<type> you control of the chosen type" filter), so this covers every CDA in
+/// the class, not a single card.
+fn parse_number_of_chosen_type_on_battlefield(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, head) = parse_type_filter_word(input)?;
+    let (rest, _) = alt((tag(" of the chosen type"), tag(" of that type"))).parse(rest)?;
+    // CR 400.1: the population is battlefield-wide; tolerate an explicit
+    // " on the battlefield" scope phrase without altering the default
+    // battlefield zone of the resulting `ObjectCount`.
+    let (rest, _) = opt(tag(" on the battlefield")).parse(rest)?;
+    Ok((
+        rest,
+        QuantityRef::ObjectCount {
+            filter: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![head],
+                controller: None,
+                properties: vec![FilterProp::IsChosenCreatureType],
             }),
         },
     ))
@@ -2677,6 +2712,32 @@ mod tests {
         let (rest, q) = parse_quantity("3 damage").unwrap();
         assert_eq!(q, QuantityExpr::Fixed { value: 3 });
         assert_eq!(rest, " damage");
+    }
+
+    #[test]
+    fn parse_number_of_chosen_type_on_battlefield_global_count() {
+        // CR 604.3: Caller of the Hunt — "the number of creatures of the chosen
+        // type on the battlefield" is a battlefield-wide CDA count (any
+        // controller), distinct from the " you control" controlled-type form.
+        for text in [
+            "the number of creatures of the chosen type on the battlefield",
+            "the number of creatures of the chosen type",
+        ] {
+            let (rest, q) = parse_quantity_ref(text).unwrap();
+            assert_eq!(rest, "", "{text:?} should fully consume");
+            match q {
+                QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(tf),
+                } => {
+                    assert_eq!(tf.controller, None, "{text:?}: counts every controller");
+                    assert!(
+                        tf.properties.contains(&FilterProp::IsChosenCreatureType),
+                        "{text:?}: must gate on the source's chosen creature type"
+                    );
+                }
+                other => panic!("{text:?}: expected ObjectCount, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -784,6 +784,11 @@ fn parse_number_of_controlled_type(input: &str) -> OracleResult<'_, QuantityRef>
 /// evaluation time via `FilterProp::IsChosenCreatureType` (mirrors the existing
 /// "<type> you control of the chosen type" filter), so this covers every CDA in
 /// the class, not a single card.
+///
+/// Prefix variants such as "other"/"another"/"non-X"/"legendary" are
+/// intentionally out of scope for this global chosen-type CDA class; this mirrors
+/// the controlled chosen-type sibling below and avoids shadowing its controller
+/// suffix.
 fn parse_number_of_chosen_type_on_battlefield(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, head) = parse_type_filter_word(input)?;
     let (rest, _) = alt((tag(" of the chosen type"), tag(" of that type"))).parse(rest)?;


### PR DESCRIPTION
Closes #2118

## Summary

The `the number of …` quantity dispatch in `oracle_nom/quantity.rs` had a parser for the *controlled* form ("[type] you control of the chosen type") but none for the **battlefield-wide** form "[type] of the chosen type on the battlefield". So `Caller of the Hunt` — "…power and toughness are each equal to the number of creatures of the chosen type on the battlefield" — failed the quantity parse and the whole characteristic-defining static line fell through to `Unimplemented { name: "static_structure", … }`.

## Fix

Added `parse_number_of_chosen_type_on_battlefield`, the global (any-controller) sibling of `parse_number_of_controlled_type`. It consumes a type word + "of the chosen type" / "of that type" + an optional " on the battlefield" scope phrase and returns:

```rust
QuantityRef::ObjectCount {
    filter: TargetFilter::Typed(TypedFilter {
        type_filters: vec![head],
        controller: None,                              // battlefield-wide
        properties: vec![FilterProp::IsChosenCreatureType],
    }),
}
```

It is wired into `parse_number_of_inner` immediately before `parse_number_of_controlled_type` (whose " you control" suffix does not match the global form). The chosen type is resolved at evaluation time via the existing `FilterProp::IsChosenCreatureType`, so this covers the whole "P/T equal to the number of [type] of the chosen type" CDA class, not just one card — no new enum variant, reusing `QuantityRef::ObjectCount` and the existing chosen-type filter prop. CR 604.3 (characteristic-defining abilities) / CR 613.1 (layers).

## Tests

Added a building-block test in `oracle_nom::quantity::tests`:

- `parse_number_of_chosen_type_on_battlefield_global_count` — both "the number of creatures of the chosen type on the battlefield" and the bare "the number of creatures of the chosen type" parse to an `ObjectCount` with `controller: None` and `IsChosenCreatureType`.

## Verification

Run locally against the pinned `nightly-2026-04-19` toolchain (Tilt not available in this environment):

- `cargo fmt --all` — clean.
- `scripts/check-parser-combinators.sh` — exit 0 (new parser uses nom `tag`/`alt`/`value`/`opt` only; no string-method dispatch).
- `cargo test -p engine --lib parse_number_of_chosen_type_on_battlefield_global_count` — **1 passed**.
- `cargo clippy -p engine --all-targets -- -D warnings` — clean.

This is a purely additive parser arm reusing existing `QuantityRef::ObjectCount`, so there is no exhaustive-match impact in other workspace crates. I did not regenerate the 89 MB `card-data.json` in this environment; the building-block parser test plus the existing `parse_cda_pt_equality → parse_cda_quantity → parse_quantity_ref` path confirm the CDA quantity now parses.

Model: claude-opus-4-8
Thinking: high
Tier: Frontier
