### PR TITLE
feat(engine): enforce "can be attached only to" attachment restrictions

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -78,7 +78,7 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             | StaticMode::CantBeBlockedByMoreThan { .. }
             // CR 301.5 + CR 303.4 + CR 701.3a: AttachmentRestriction carries the
             // `TargetFilter` of legal hosts (Strata Scythe, Konda's Banner).
-            // Enforced by direct read in effects/attach.rs::attachment_illegality.
+            // Enforced via active static definitions in effects/attach.rs::attachment_illegality.
             | StaticMode::AttachmentRestriction { .. }
             // CR 602.5 + CR 603.2a: CantBeActivated carries `who` + `source_filter`.
             | StaticMode::CantBeActivated { .. }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -76,6 +76,10 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             // CR 509.1b: CantBeBlockedByMoreThan carries the blocker maximum
             // (Stalking Tiger). Enforced in combat.rs declare-blockers validation.
             | StaticMode::CantBeBlockedByMoreThan { .. }
+            // CR 301.5 + CR 303.4 + CR 701.3a: AttachmentRestriction carries the
+            // `TargetFilter` of legal hosts (Strata Scythe, Konda's Banner).
+            // Enforced by direct read in effects/attach.rs::attachment_illegality.
+            | StaticMode::AttachmentRestriction { .. }
             // CR 602.5 + CR 603.2a: CantBeActivated carries `who` + `source_filter`.
             | StaticMode::CantBeActivated { .. }
             // CR 602.5 + CR 117.1b: CantActivateDuring carries `who`, `when`, and `exemption`.
@@ -6628,6 +6632,12 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                 effective_lower.contains("can't be blocked")
             }
             StaticMode::CantBeBlockedBy { .. } => effective_lower.contains("can't be blocked"),
+            // CR 301.5 + CR 303.4: positive "can be attached only to {filter}"
+            // restriction. Anchor on the verb phrase; the filter half is the
+            // reused TargetFilter and is validated by parser tests.
+            StaticMode::AttachmentRestriction { .. } => {
+                effective_lower.contains("can be attached only to")
+            }
             StaticMode::StepEndUnspentMana { action, .. } => match action {
                 crate::types::mana::StepEndManaAction::Retain => {
                     effective_lower.contains("don't lose unspent")

--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -235,6 +235,16 @@ pub(crate) fn attachment_illegality(
         return Some(AttachIllegality::Prohibited);
     }
 
+    // CR 301.5 + CR 303.4 + CR 701.3a: Positive attachment restriction. An
+    // Aura/Equipment that "can be attached only to {filter}" may only attach to a
+    // host matching that filter. Unlike the `CantBe*` host prohibitions above
+    // (read from the HOST's statics), this restriction is carried by the
+    // ATTACHMENT itself, so a candidate host failing the filter makes the attach
+    // illegal (CR 301.5b / CR 303.4j: the attachment doesn't move).
+    if !attachment_satisfies_restrictions(state, attachment_id, host_id) {
+        return Some(AttachIllegality::Prohibited);
+    }
+
     // CR 702.16c: Protection from a quality prevents Auras of that quality from
     // being attached to the protected permanent.
     // CR 702.16d: Protection from a quality prevents Equipment or Fortifications
@@ -249,6 +259,35 @@ pub(crate) fn attachment_illegality(
     }
 
     None
+}
+
+/// CR 301.5 + CR 303.4 + CR 701.3a: True unless `host_id` is forbidden by a
+/// positive "can be attached only to {filter}" restriction on `attachment_id`.
+///
+/// The restriction is a `StaticMode::AttachmentRestriction { filter }` carried by
+/// the attachment's own `static_definitions`. By analogy to CR 702.5c (an Aura
+/// with multiple enchant instances must satisfy ALL of them), every active
+/// restriction must match: the host is legal only if it matches the `filter` of
+/// every `AttachmentRestriction` the attachment has. An attachment with no such
+/// restriction is unconstrained here and returns `true`.
+fn attachment_satisfies_restrictions(
+    state: &GameState,
+    attachment_id: ObjectId,
+    host_id: ObjectId,
+) -> bool {
+    let Some(attachment) = state.objects.get(&attachment_id) else {
+        return true;
+    };
+    let ctx = FilterContext::from_source(state, attachment_id);
+    crate::game::functioning_abilities::active_static_definitions(state, attachment).all(|def| {
+        match &def.mode {
+            crate::types::statics::StaticMode::AttachmentRestriction { filter } => {
+                matches_target_filter(state, host_id, filter, &ctx)
+            }
+            // Any other static imposes no positive attachment constraint.
+            _ => true,
+        }
+    })
 }
 
 /// Returns `Some(reason)` when a player host forbids `attachment` via
@@ -1054,5 +1093,116 @@ mod tests {
         attach_to(&mut state, equipment2, cant_be_attached);
         assert_eq!(state.objects.get(&aura2).unwrap().attached_to, None);
         assert_eq!(state.objects.get(&equipment2).unwrap().attached_to, None);
+    }
+
+    /// Add a positive `AttachmentRestriction` static to an attachment, carrying
+    /// the given legal-host `TargetFilter`.
+    fn apply_attach_restriction(state: &mut GameState, id: ObjectId, filter: TargetFilter) {
+        state.objects.get_mut(&id).unwrap().static_definitions.push(
+            StaticDefinition::new(StaticMode::AttachmentRestriction { filter })
+                .affected(TargetFilter::SelfRef),
+        );
+    }
+
+    /// Build a creature with the given power on the battlefield.
+    fn spawn_creature_with_power(state: &mut GameState, name: &str, power: i32) -> ObjectId {
+        let id = spawn_creature(state, name);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.power = Some(power);
+        obj.toughness = Some(power.max(1));
+        crate::game::layers::mark_layers_full(state);
+        id
+    }
+
+    #[test]
+    fn attachment_restriction_power_ge_blocks_weak_host_allows_strong_host() {
+        // CR 301.5b + CR 701.3a: Strata Scythe class — Equipment that "can be
+        // attached only to a creature with power 3 or greater" may not attach to a
+        // power-2 creature, but may attach to a power-3 creature. The restriction
+        // lives on the ATTACHMENT, not the host (contrast CantBeEquipped).
+        let mut state = setup();
+        let equipment = spawn_with_subtype(&mut state, "Strata Scythe", "Equipment");
+        let power_filter = TargetFilter::Typed(
+            crate::types::ability::TypedFilter::creature().properties(vec![
+                crate::types::ability::FilterProp::PtComparison {
+                    stat: crate::types::ability::PtStat::Power,
+                    scope: crate::types::ability::PtValueScope::Current,
+                    comparator: crate::types::ability::Comparator::GE,
+                    value: crate::types::ability::QuantityExpr::Fixed { value: 3 },
+                },
+            ]),
+        );
+        apply_attach_restriction(&mut state, equipment, power_filter);
+
+        let weak = spawn_creature_with_power(&mut state, "Grizzly Bears", 2);
+        let strong = spawn_creature_with_power(&mut state, "Hill Giant", 3);
+
+        // Non-matching host (power 2) is an illegal attach target — attach is a no-op.
+        assert_eq!(
+            attachment_illegality(&state, equipment, weak),
+            Some(AttachIllegality::Prohibited),
+            "power-2 host must fail the power>=3 attachment restriction"
+        );
+        assert!(!can_attach_to_object(&state, equipment, weak));
+        attach_to(&mut state, equipment, weak);
+        assert_eq!(
+            state.objects.get(&equipment).unwrap().attached_to,
+            None,
+            "Equipment must not move onto a non-matching host (CR 701.3b)"
+        );
+
+        // Matching host (power 3) is a legal attach target.
+        assert_eq!(attachment_illegality(&state, equipment, strong), None);
+        assert!(can_attach_to_object(&state, equipment, strong));
+        attach_to(&mut state, equipment, strong);
+        assert_eq!(
+            state.objects.get(&equipment).unwrap().attached_to,
+            Some(AttachTarget::Object(strong)),
+            "Equipment must attach onto a host matching the restriction filter"
+        );
+        assert!(state
+            .objects
+            .get(&strong)
+            .unwrap()
+            .attachments
+            .contains(&equipment));
+    }
+
+    #[test]
+    fn attachment_restriction_legendary_gates_aura_host() {
+        // CR 303.4j + CR 701.3a: Konda's Banner class — an attachment restricted
+        // to "a legendary creature" may not attach to a nonlegendary host.
+        let mut state = setup();
+        let aura = spawn_with_subtype(&mut state, "Konda's Banner", "Aura");
+        let legendary_filter = TargetFilter::Typed(
+            crate::types::ability::TypedFilter::creature().properties(vec![
+                crate::types::ability::FilterProp::HasSupertype {
+                    value: crate::types::card_type::Supertype::Legendary,
+                },
+            ]),
+        );
+        apply_attach_restriction(&mut state, aura, legendary_filter);
+
+        let nonlegendary = spawn_creature(&mut state, "Bear");
+        let legendary = spawn_creature(&mut state, "Konda, Lord of Eiganjo");
+        state
+            .objects
+            .get_mut(&legendary)
+            .unwrap()
+            .card_types
+            .supertypes
+            .push(crate::types::card_type::Supertype::Legendary);
+        crate::game::layers::mark_layers_full(&mut state);
+
+        assert!(!can_attach_to_object(&state, aura, nonlegendary));
+        attach_to(&mut state, aura, nonlegendary);
+        assert_eq!(state.objects.get(&aura).unwrap().attached_to, None);
+
+        assert!(can_attach_to_object(&state, aura, legendary));
+        attach_to(&mut state, aura, legendary);
+        assert_eq!(
+            state.objects.get(&aura).unwrap().attached_to,
+            Some(AttachTarget::Object(legendary))
+        );
     }
 }

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -178,6 +178,11 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     "have ",
     "has ",
     "can't be blocked",
+    // CR 301.5 + CR 303.4 + CR 701.3a: positive attachment restriction on an
+    // Aura/Equipment ("~ can be attached only to {filter}") — Strata Scythe,
+    // Brass Knuckles, Konda's Banner. Routes to parse_static_line so it lowers
+    // to StaticMode::AttachmentRestriction instead of an effect.
+    "can be attached only to",
     "can't attack",
     "can't block",
     "can't be countered",

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1169,6 +1169,15 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // --- "~ can be attached only to {filter}" ---
+    // CR 301.5 + CR 303.4 + CR 701.3a: Positive attachment restriction on an
+    // Aura/Equipment — the source can only attach to a host matching the parsed
+    // `TargetFilter` (Strata Scythe, Brass Knuckles, Konda's Banner). Enforced in
+    // game/effects/attach.rs::attachment_illegality.
+    if let Some(def) = parse_attach_only_restriction(&tp, &text) {
+        return Some(def);
+    }
+
     // --- "Spells and abilities <scope> can't cause their controller to search their library" ---
     // CR 701.23 + CR 609.3: Ashiok, Dream Render's first static. Subject-scoped
     // prohibition where `cause` identifies whose spells/abilities are muzzled.

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -160,6 +160,57 @@ pub(crate) fn parse_cant_be_countered_subject(tp: &TextPair) -> TargetFilter {
     TargetFilter::SelfRef
 }
 
+/// CR 301.5 + CR 303.4 + CR 701.3a: Parse a positive attachment restriction —
+/// "~ can be attached only to {filter}" — into a `StaticMode::AttachmentRestriction`
+/// carrying the legal-host `TargetFilter`.
+///
+/// The subject is always the source Aura/Equipment itself: by the time the static
+/// parser sees the line, "This Equipment" / the card name has already been
+/// normalized to `~` (see `SELF_REF_TYPE_PHRASES` / `normalize_self_refs_for_static`).
+/// We therefore require the `~` subject and reject any non-self subject so a
+/// hypothetical "other equipment can be attached only to ..." (no such printed
+/// card) is deferred rather than mis-scoped.
+///
+/// Grammar:
+///   "~ can be attached only to " <FILTER> "."?
+///
+/// `<FILTER>` is parsed by the shared `parse_target` building block (the same
+/// combinator used for "a creature with power N or greater", "a legendary
+/// creature", "an {type}", etc.) — no new filter language is invented. The
+/// entire remainder must be consumed; a non-empty tail means the filter phrase
+/// was only partially understood, so we bail to avoid a silently-wrong filter.
+///
+/// Corpus: Strata Scythe ("a creature with power 3 or greater"), Brass Knuckles
+/// ("a creature with toughness 4 or greater"), Konda's Banner ("a legendary
+/// creature").
+pub(crate) fn parse_attach_only_restriction(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<StaticDefinition> {
+    // Require the self-referential subject + verb phrase. `nom_tag_tp` consumes
+    // the prefix on the lowercase view while preserving original casing on the
+    // returned remainder (needed for `parse_target`'s type-name canonicalization).
+    let rest = nom_tag_tp(tp, "~ can be attached only to ")?;
+
+    // Trim the sentence terminator before handing the noun phrase to parse_target.
+    // allow-noncombinator: punctuation cleanup on a pre-tokenized chunk, not dispatch.
+    let host_phrase = rest.original.trim().trim_end_matches('.').trim();
+
+    let (filter, tail) = parse_target(host_phrase);
+    // The whole host phrase must be consumed and must resolve to a real filter —
+    // `parse_target` returns `TargetFilter::Any` / `SelfRef` for input it cannot
+    // interpret, which would silently whitelist everything/nothing.
+    if !tail.trim().is_empty() || matches!(filter, TargetFilter::Any | TargetFilter::SelfRef) {
+        return None;
+    }
+
+    Some(
+        StaticDefinition::new(StaticMode::AttachmentRestriction { filter })
+            .affected(TargetFilter::SelfRef)
+            .description(text.to_string()),
+    )
+}
+
 /// CR 605.1a: Parse the optional "unless they're mana abilities" suffix that
 /// follows a `CantBeActivated` predicate. Returns `ActivationExemption::None`
 /// (and the unconsumed input) when no suffix is present.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -579,6 +579,59 @@ fn static_cant_be_blocked_by_more_than_two_creatures() {
 }
 
 #[test]
+fn static_attach_only_restriction_power_ge_lowers_to_filter() {
+    // CR 301.5 + CR 303.4 + CR 701.3a: Strata Scythe class — a positive
+    // attachment restriction lowers to `AttachmentRestriction` whose `filter` is
+    // the reused `TargetFilter` for "a creature with power 3 or greater".
+    let def =
+        parse_static_line("~ can be attached only to a creature with power 3 or greater.").unwrap();
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    assert!(
+        matches!(
+            &def.mode,
+            StaticMode::AttachmentRestriction { filter }
+            if matches!(
+                filter,
+                TargetFilter::Typed(tf)
+                    if tf.type_filters.contains(&TypeFilter::Creature)
+                        && tf.properties.contains(&FilterProp::PtComparison {
+                            stat: PtStat::Power,
+                            scope: PtValueScope::Current,
+                            comparator: Comparator::GE,
+                            value: QuantityExpr::Fixed { value: 3 },
+                        })
+            )
+        ),
+        "Expected AttachmentRestriction with PtComparison(Power, GE, 3), got {:?}",
+        def.mode
+    );
+}
+
+#[test]
+fn static_attach_only_restriction_legendary_lowers_to_filter() {
+    // CR 301.5 + CR 303.4 + CR 701.3a: Konda's Banner class — "a legendary
+    // creature" host whitelist via the reused `TargetFilter` legendary property.
+    let def = parse_static_line("~ can be attached only to a legendary creature.").unwrap();
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    assert!(
+        matches!(
+            &def.mode,
+            StaticMode::AttachmentRestriction { filter }
+            if matches!(
+                filter,
+                TargetFilter::Typed(tf)
+                    if tf.type_filters.contains(&TypeFilter::Creature)
+                        && tf.properties.contains(&FilterProp::HasSupertype {
+                            value: crate::types::card_type::Supertype::Legendary,
+                        })
+            )
+        ),
+        "Expected AttachmentRestriction with Legendary creature filter, got {:?}",
+        def.mode
+    );
+}
+
+#[test]
 fn static_source_power_cant_block_creatures_you_control() {
     let def = parse_static_line(
         "Creatures with power less than ~'s power can't block creatures you control.",

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -827,6 +827,26 @@ pub enum StaticMode {
     CantBeBlockedByMoreThan {
         max: u32,
     },
+    /// CR 301.5 + CR 303.4 + CR 701.3a: Positive attachment restriction — this
+    /// Aura/Equipment "can be attached only to" a permanent matching `filter`.
+    /// The complement of the negative `Other("CantBeEquipped" | "CantBeEnchanted"
+    /// | "CantBeAttached")` host-prohibition family: those live on the *host* and
+    /// refuse any attachment, whereas this lives on the *attachment* and whitelists
+    /// the legal hosts it may attach to. CR 701.3a folds equip/enchant legality
+    /// into one attach gate, so a single typed variant covers both Equipment
+    /// (CR 301.5) and Aura (CR 303.4) — the `filter` (a reused `TargetFilter`)
+    /// expresses "a creature with power N or greater", "a legendary creature",
+    /// "an {type}", etc. Corpus: Strata Scythe, Brass Knuckles ("a creature with
+    /// power/toughness N or greater"), Konda's Banner ("a legendary creature").
+    ///
+    /// Data-carrying variant (holds `TargetFilter`) — not registry-registered
+    /// (see `coverage::is_data_carrying_static`); enforced by direct read of the
+    /// attachment's own statics in `game/effects/attach.rs::attachment_illegality`.
+    /// A candidate host that does not match `filter` is an illegal attach/equip
+    /// target (CR 301.5b / CR 303.4j: the attachment doesn't move).
+    AttachmentRestriction {
+        filter: TargetFilter,
+    },
     /// CR 702.16: Protection prevents targeting, blocking, damage, and attachment.
     Protection,
     /// CR 702.12: Indestructible — prevents destruction by lethal damage and destroy effects.
@@ -1058,6 +1078,7 @@ impl Hash for StaticMode {
                 BlockExceptionKind::MinBlockers { min } => min.hash(state),
             },
             StaticMode::CantBeBlockedBy { .. } => {} // TargetFilter does not implement Hash; discriminant only
+            StaticMode::AttachmentRestriction { .. } => {} // TargetFilter does not implement Hash; discriminant only
             StaticMode::CantBeBlockedByMoreThan { max } => max.hash(state),
             StaticMode::AdditionalLandDrop { count } => count.hash(state),
             StaticMode::StepEndUnspentMana { filter, action } => {
@@ -1266,6 +1287,12 @@ impl fmt::Display for StaticMode {
             },
             StaticMode::CantBeBlockedBy { filter } => {
                 write!(f, "CantBeBlockedBy({filter:?})")
+            }
+            // CR 301.5 + CR 303.4: TargetFilter has no parseable string form —
+            // Debug format, one-way (mirrors CantBeBlockedBy). No from_str
+            // reconstruction; the variant is data-carrying.
+            StaticMode::AttachmentRestriction { filter } => {
+                write!(f, "AttachmentRestriction({filter:?})")
             }
             StaticMode::CantBeBlockedByMoreThan { max } => {
                 write!(f, "CantBeBlockedByMoreThan({max})")

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -840,8 +840,8 @@ pub enum StaticMode {
     /// power/toughness N or greater"), Konda's Banner ("a legendary creature").
     ///
     /// Data-carrying variant (holds `TargetFilter`) — not registry-registered
-    /// (see `coverage::is_data_carrying_static`); enforced by direct read of the
-    /// attachment's own statics in `game/effects/attach.rs::attachment_illegality`.
+    /// (see `coverage::is_data_carrying_static`); enforced via the attachment's
+    /// active static definitions in `game/effects/attach.rs::attachment_illegality`.
     /// A candidate host that does not match `filter` is an illegal attach/equip
     /// target (CR 301.5b / CR 303.4j: the attachment doesn't move).
     AttachmentRestriction {


### PR DESCRIPTION
Closes #2120

## Summary
Implements and enforces Equipment/Aura **"can be attached only to {filter}"** restrictions, which were previously dropped at parse time (so the attachment could be equipped/moved onto any permanent — illegal per CR 301.5b/303.4j).

Adds `StaticMode::AttachmentRestriction { filter: TargetFilter }`, parsed from `~ can be attached only to {filter}` and enforced in the attach legality gate. Builds for the **class** (power/toughness comparators, legendary, creature types) by reusing the existing `TargetFilter` — not a new filter language.

## Behavior
- A prospective host that does not match the filter is an illegal attach/equip target — the Equipment/Aura doesn't move (CR 301.5b / 303.4j).
- Enforced for the Attach effect, Aura ETB/zone-entry, equip-action resolution, and the continuous SBA re-check (an attachment that becomes illegal falls off).

## Files changed
- crates/engine/src/types/statics.rs — `AttachmentRestriction { filter }` variant (+ Hash/Display arms)
- crates/engine/src/parser/oracle_static/restriction.rs — `parse_attach_only_restriction` (nom, reuses `parse_target`; full-consume guard)
- crates/engine/src/parser/oracle_static/dispatch.rs, oracle_classifier.rs — wiring
- crates/engine/src/game/effects/attach.rs — legality enforcement (reads the restriction off the attachment, evaluates filter against the host)
- crates/engine/src/game/coverage.rs — data-carrying static registration
- crates/engine/src/parser/oracle_static/tests.rs — parser lowering tests

## CR references
- CR 301.5b, 303.4j, 701.3a/b, 702.5c, 702.16c/d — verified against docs/MagicCompRules.txt

## Track
Developer

## LLM
Model: claude-opus-4-8

## Verification
- `cargo fmt --all` — clean
- `cargo test -p engine --lib attach` — 167 passed / 0 failed (incl. 2 new: power-GE blocks weak host/allows strong host; legendary gates Aura host)
- parser lowering tests pass (oracle_static)
- Independent review pass: correct enforcement direction (only-to whitelist), nom-compliant parser, CR numbers verified, all StaticMode match sites updated.
- clippy deferred to CI (clippy-driver crashes locally on this Windows nightly host).

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.