### PR TITLE
fix(engine): route controlled-turn legal actions to controller

### DIFF
--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -733,10 +733,21 @@ pub fn legal_actions_full(state: &GameState) -> LegalActionsFull {
 /// per guest; only the acting guest needs a populated legal-actions map.
 pub fn legal_actions_for_viewer(state: &GameState, viewer: PlayerId) -> LegalActionsFull {
     // CR 103.5: For simultaneous-decision states (MulliganDecision,
-    // MulliganBottomCards, OpeningHandBottomCards), every pending player has a legal action set. Use
-    // `acting_players()` so guests in a multiplayer mulligan can see and
-    // submit their own decisions concurrently.
-    if state.waiting_for.acting_players().contains(&viewer) {
+    // MulliganBottomCards, OpeningHandBottomCards), every pending player has a
+    // legal action set, so guests in a multiplayer mulligan can see and submit
+    // their own decisions concurrently.
+    //
+    // CR 723.5 + CR 723.8: Under a turn-control effect (Mindslaver, Emrakul,
+    // Word of Command, Opposition Agent) the *controller* makes the controlled
+    // player's choices while still making their own — but the controlled
+    // player remains the active player (CR 723.3), so `acting_players()`
+    // reports the controlled seat, not the authorized submitter. Authorize the
+    // viewer through `is_authorized_submitter`, which maps every acting seat to
+    // its authorized submitter, so the controller receives the controlled
+    // turn's legal actions instead of an empty set (which would freeze the
+    // controlled turn for them). Coincides with `acting_players().contains`
+    // whenever no turn-control effect is active.
+    if crate::game::turn_control::is_authorized_submitter(state, viewer) {
         legal_actions_full(state)
     } else {
         (Vec::new(), HashMap::new(), HashMap::new())
@@ -992,6 +1003,44 @@ mod tests {
         assert!(
             grouped.is_empty(),
             "non-acting viewer must receive no grouped actions"
+        );
+    }
+
+    /// CR 723.3 + CR 723.5 (issue #2012): under a turn-control effect the
+    /// controlled player is still the active/acting seat, but the *controller*
+    /// makes their choices. `legal_actions_for_viewer` must authorize the
+    /// controller (the authorized submitter), returning the controlled turn's
+    /// actions to them — not an empty set, which would freeze the turn.
+    #[test]
+    fn legal_actions_for_viewer_routes_to_turn_controller() {
+        use crate::types::player::PlayerId;
+
+        let mut state = GameState::new_two_player(42);
+        let controlled = PlayerId(1);
+        let controller = PlayerId(0);
+
+        // CR 723.3: P1 is still the active player while controlled by P0.
+        state.active_player = controlled;
+        state.turn_decision_controller = Some(controller);
+        state.waiting_for = WaitingFor::Priority { player: controlled };
+        // The authorized submitter is the controller, not the acting seat.
+        state.priority_player = crate::game::turn_control::turn_decision_maker(&state);
+
+        // The acting seat (P1) is NOT the authorized submitter, so it gets none.
+        let (controlled_actions, _, _) = legal_actions_for_viewer(&state, controlled);
+        assert!(
+            controlled_actions.is_empty(),
+            "the controlled seat is not the authorized submitter"
+        );
+
+        // CR 723.5: the controller receives the controlled turn's full set,
+        // matching the unfiltered engine view.
+        let (controller_actions, _, _) = legal_actions_for_viewer(&state, controller);
+        let full = legal_actions_full(&state);
+        assert_eq!(
+            controller_actions.len(),
+            full.0.len(),
+            "CR 723.5: the controller must receive the controlled player's legal actions"
         );
     }
 

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -1038,8 +1038,7 @@ mod tests {
         let (controller_actions, _, _) = legal_actions_for_viewer(&state, controller);
         let full = legal_actions_full(&state);
         assert_eq!(
-            controller_actions.len(),
-            full.0.len(),
+            controller_actions, full.0,
             "CR 723.5: the controller must receive the controlled player's legal actions"
         );
     }

--- a/crates/engine/tests/integration/emrakul_control_turn_crash.rs
+++ b/crates/engine/tests/integration/emrakul_control_turn_crash.rs
@@ -1,0 +1,105 @@
+//! Regression (issue #2012): under a turn-control effect, the controller must
+//! receive the controlled player's legal actions — not an empty set.
+//!
+//! CR 723 ("Controlling Another Player"): Emrakul, the Promised End grants its
+//! caster control of a target opponent during that player's next turn. Per
+//! CR 723.3 the controlled player is still the active player, so the engine's
+//! `WaitingFor` reports the controlled seat as the acting player. Per CR 723.5
+//! the controller makes all of the controlled player's choices.
+//!
+//! `legal_actions_for_viewer` is the per-viewer authority the P2P/WASM transport
+//! broadcasts to each seat. It previously gated on
+//! `acting_players().contains(&viewer)`, which is the controlled seat — so the
+//! controller (the player who must actually act) received an empty action set
+//! and the controlled turn froze for them ("crashes my game when I go to the
+//! controlled player's turn"). The fix authorizes the viewer through
+//! `is_authorized_submitter`, which maps each acting seat to its authorized
+//! submitter.
+
+use engine::ai_support::{legal_actions_for_viewer, legal_actions_full};
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+/// During P1's controlled turn (P0 is the controller), the controller P0 — the
+/// authorized submitter — must receive the controlled turn's full legal-action
+/// set, and the controlled seat P1 (not the submitter) must receive none.
+#[test]
+fn controller_receives_controlled_turns_legal_actions() {
+    let mut runner = {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        // Give the controlled player (P1) a land to play so the action set is
+        // non-trivially populated.
+        scenario.add_land_to_hand(P1, "Forest");
+        scenario.build()
+    };
+    {
+        let state = runner.state_mut();
+        // CR 723.3: the controlled player (P1) is still the active player.
+        state.active_player = P1;
+        // CR 723: P0 controls P1's turn.
+        state.turn_decision_controller = Some(P0);
+        // P1 holds priority; sync re-derives the authorized submitter (P0).
+        engine::game::public_state::sync_waiting_for(state, &WaitingFor::Priority { player: P1 });
+    }
+
+    // Baseline: the unfiltered engine view has actions to offer this turn.
+    let full = legal_actions_full(runner.state());
+    assert!(
+        !full.0.is_empty(),
+        "precondition: the controlled turn should have legal actions to offer"
+    );
+
+    // CR 723.5: the controller (authorized submitter) sees the controlled
+    // turn's full action set.
+    let (controller_actions, controller_costs, controller_by_object) =
+        legal_actions_for_viewer(runner.state(), P0);
+    assert_eq!(
+        controller_actions.len(),
+        full.0.len(),
+        "CR 723.5: the controller must receive the controlled player's legal actions"
+    );
+    assert_eq!(controller_costs.len(), full.1.len());
+    assert_eq!(controller_by_object.len(), full.2.len());
+
+    // The controlled seat (P1) is not the authorized submitter under turn
+    // control, so it receives no actions of its own.
+    let (controlled_actions, controlled_costs, controlled_by_object) =
+        legal_actions_for_viewer(runner.state(), P1);
+    assert!(
+        controlled_actions.is_empty(),
+        "the controlled seat is not the authorized submitter and must receive no actions"
+    );
+    assert!(controlled_costs.is_empty());
+    assert!(controlled_by_object.is_empty());
+}
+
+/// Without any turn-control effect, `legal_actions_for_viewer` is unchanged: the
+/// acting player sees the full set and the other player sees none.
+#[test]
+fn no_turn_control_preserves_viewer_gating() {
+    let mut runner = {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.add_land_to_hand(P0, "Forest");
+        scenario.build()
+    };
+    {
+        let state = runner.state_mut();
+        state.active_player = P0;
+        state.turn_decision_controller = None;
+        engine::game::public_state::sync_waiting_for(state, &WaitingFor::Priority { player: P0 });
+    }
+
+    let full = legal_actions_full(runner.state());
+    let (acting, _, _) = legal_actions_for_viewer(runner.state(), P0);
+    assert_eq!(
+        acting.len(),
+        full.0.len(),
+        "acting player sees the full set"
+    );
+
+    let (other, _, _) = legal_actions_for_viewer(runner.state(), P1);
+    assert!(other.is_empty(), "non-acting player sees no actions");
+}

--- a/crates/engine/tests/integration/emrakul_control_turn_crash.rs
+++ b/crates/engine/tests/integration/emrakul_control_turn_crash.rs
@@ -56,12 +56,11 @@ fn controller_receives_controlled_turns_legal_actions() {
     let (controller_actions, controller_costs, controller_by_object) =
         legal_actions_for_viewer(runner.state(), P0);
     assert_eq!(
-        controller_actions.len(),
-        full.0.len(),
+        controller_actions, full.0,
         "CR 723.5: the controller must receive the controlled player's legal actions"
     );
-    assert_eq!(controller_costs.len(), full.1.len());
-    assert_eq!(controller_by_object.len(), full.2.len());
+    assert_eq!(controller_costs, full.1);
+    assert_eq!(controller_by_object, full.2);
 
     // The controlled seat (P1) is not the authorized submitter under turn
     // control, so it receives no actions of its own.
@@ -94,11 +93,7 @@ fn no_turn_control_preserves_viewer_gating() {
 
     let full = legal_actions_full(runner.state());
     let (acting, _, _) = legal_actions_for_viewer(runner.state(), P0);
-    assert_eq!(
-        acting.len(),
-        full.0.len(),
-        "acting player sees the full set"
-    );
+    assert_eq!(acting, full.0, "acting player sees the full set");
 
     let (other, _, _) = legal_actions_for_viewer(runner.state(), P1);
     assert!(other.is_empty(), "non-acting player sees no actions");

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -46,6 +46,7 @@ mod dredgers_insight_mill_from_among;
 mod elemental_spectacle_regression;
 mod elusive_otter_repro;
 mod emissary_green;
+mod emrakul_control_turn_crash;
 #[cfg(feature = "proptest")]
 mod engine_invariants;
 mod enlightened_tutor_regression;


### PR DESCRIPTION
Closes #2012

## Problem

Under a turn-control effect (Emrakul, the Promised End; Mindslaver; Word of Command; Opposition Agent) the controlled player remains the active/acting seat (CR 723.3) while the **controller** makes their choices (CR 723.5) and still makes their own (CR 723.8). The user experiences entering the controlled player's turn as a freeze/"crash."

## Root cause

`legal_actions_for_viewer` — the per-viewer authority the P2P/WASM transport broadcasts to each seat — gated on `acting_players().contains(viewer)`, which is the **controlled** seat, never the controller. So when the game entered the controlled player's turn, the controller (the player who must actually act) received an empty action set and the controlled turn froze for them.

## Fix

Authorize the viewer through `turn_control::is_authorized_submitter`, which maps each acting seat to its authorized submitter, so the controller receives the controlled turn's legal actions. This coincides with the old check whenever no turn-control effect is active, so non-control play is unchanged. Builds for the whole CR 723 class, not just Emrakul.

## Tests

- Building-block unit test `legal_actions_for_viewer_routes_to_turn_controller`.
- Integration regression `controller_receives_controlled_turns_legal_actions` (+ a `no_turn_control_preserves_viewer_gating` guard). Confirmed discriminating: with the fix reverted the controller receives 0 actions instead of the controlled turn's full set.
- `cargo test -p engine --lib` (9865) and `--test integration` (635) green; clippy clean; prior `turn_control_priority_softlock` test still passes.