### PR TITLE
feat(client): wire PopulateChoice to board targeting UI

### DIFF
--- a/client/src/adapter/__tests__/boundary-guardrails.test.ts
+++ b/client/src/adapter/__tests__/boundary-guardrails.test.ts
@@ -104,6 +104,15 @@ describe("adapter boundary guardrails", () => {
     expect(isWaitingForHandled(waitingFor)).toBe(true);
   });
 
+  it("handles the populate creature-token choice waiting payload", () => {
+    const waitingFor: WaitingFor = {
+      type: "PopulateChoice",
+      data: { player: 0, source_id: 1, valid_tokens: [10, 11] },
+    };
+
+    expect(isWaitingForHandled(waitingFor)).toBe(true);
+  });
+
   it("handles the copy-retarget waiting payload", () => {
     const waitingFor: WaitingFor = {
       type: "CopyRetarget",

--- a/client/src/components/board/GroupedPermanent.tsx
+++ b/client/src/components/board/GroupedPermanent.tsx
@@ -39,6 +39,7 @@ function waitingForPlayer(waitingFor: WaitingFor | null | undefined): number | n
     case "EquipTarget":
     case "CopyTargetChoice":
     case "ExploreChoice":
+    case "PopulateChoice":
     case "ReturnAsAuraTarget":
     case "TriggerTargetSelection":
     case "RetargetChoice":

--- a/client/src/components/help/HelpSheet.tsx
+++ b/client/src/components/help/HelpSheet.tsx
@@ -115,6 +115,8 @@ function currentPromptSummary({
     case "CopyTargetChoice":
     case "CopyRetarget":
     case "ReturnAsAuraTarget":
+    case "ExploreChoice":
+    case "PopulateChoice":
       return t("help.prompt.targetSelection");
     case "DeclareAttackers":
       return t("help.prompt.declareAttackers");

--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -42,6 +42,7 @@ export const CLICK_THROUGH_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> = 
   "CopyRetarget",
   "RetargetChoice",
   "ExploreChoice",
+  "PopulateChoice",
   "ReturnAsAuraTarget",
 ]);
 

--- a/client/src/components/modal/__tests__/UnhandledWaitingForModal.roundtrip.integration.test.tsx
+++ b/client/src/components/modal/__tests__/UnhandledWaitingForModal.roundtrip.integration.test.tsx
@@ -5,7 +5,7 @@
 // Tests 1–4 mock `isWaitingForHandled` to inject an "unhandled" verdict for an
 // otherwise-handled variant (`Priority`); they exercise the modal + store
 // round-trip, NOT the registry. Test 5 uses the real registry (no override)
-// with a genuinely-unhandled variant (`PopulateChoice`) — it is the only case
+// with a genuinely-unhandled variant (`OrphanEngineChoice`) — exercises real
 // that proves `HANDLED_WAITING_FOR_TYPES` membership end-to-end.
 
 import { readFileSync } from "node:fs";
@@ -153,8 +153,8 @@ describe("UnhandledWaitingForModal round-trip (issue #337)", () => {
     // HANDLED_WAITING_FOR_TYPES membership end-to-end.
     vi.mocked(isWaitingForHandled).mockImplementation((wf) => realIsHandled(wf));
     const orphan = {
-      type: "PopulateChoice",
-      data: { player: 0, source_id: 0, valid_tokens: [] },
+      type: "OrphanEngineChoice",
+      data: { player: 0 },
     } as unknown as WaitingFor;
     seedStoreFromState(orphan, { gameMode: "ai", activePlayerId: 0 });
 
@@ -164,7 +164,7 @@ describe("UnhandledWaitingForModal round-trip (issue #337)", () => {
 
     expect(screen.getByText("Action required, but UI is missing")).toBeInTheDocument();
     expect(
-      container.querySelector('[data-unhandled-waiting-for="PopulateChoice"]'),
+      container.querySelector('[data-unhandled-waiting-for="OrphanEngineChoice"]'),
     ).not.toBeNull();
   });
 });

--- a/client/src/components/modal/__tests__/UnhandledWaitingForModal.roundtrip.integration.test.tsx
+++ b/client/src/components/modal/__tests__/UnhandledWaitingForModal.roundtrip.integration.test.tsx
@@ -5,8 +5,8 @@
 // Tests 1–4 mock `isWaitingForHandled` to inject an "unhandled" verdict for an
 // otherwise-handled variant (`Priority`); they exercise the modal + store
 // round-trip, NOT the registry. Test 5 uses the real registry (no override)
-// with a genuinely-unhandled variant (`OrphanEngineChoice`) — exercises real
-// that proves `HANDLED_WAITING_FOR_TYPES` membership end-to-end.
+// with a genuinely-unhandled variant (`OrphanEngineChoice`) — the only case
+// that exercises real `HANDLED_WAITING_FOR_TYPES` membership end-to-end.
 
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";

--- a/client/src/components/modal/__tests__/UnhandledWaitingForModal.test.tsx
+++ b/client/src/components/modal/__tests__/UnhandledWaitingForModal.test.tsx
@@ -58,7 +58,7 @@ describe("UnhandledWaitingForModal (issue #311 safety net)", () => {
   it("renders nothing when the local player is not the actor", () => {
     // Opponent is acting — local player has nothing to do, no fallback needed.
     const orphan = {
-      type: "PopulateChoice",
+      type: "OrphanEngineChoice",
       data: { player: 1 },
     } as unknown as WaitingFor;
     const state = makeState(orphan);
@@ -73,8 +73,8 @@ describe("UnhandledWaitingForModal (issue #311 safety net)", () => {
   it("surfaces fail-loud diagnostic when local player is the actor on an unhandled type", () => {
     // Engine-only WaitingFor variant that the FE has no modal for.
     const orphan = {
-      type: "PopulateChoice",
-      data: { player: 0, source_id: 0, valid_tokens: [] },
+      type: "OrphanEngineChoice",
+      data: { player: 0 },
     } as unknown as WaitingFor;
     const state = makeState(orphan);
     useGameStore.setState({ gameMode: "ai", gameState: state, waitingFor: state.waiting_for });
@@ -84,14 +84,14 @@ describe("UnhandledWaitingForModal (issue #311 safety net)", () => {
     );
     expect(screen.getByText("Action required, but UI is missing")).toBeInTheDocument();
     // The missing type is named so the user can report it.
-    expect(screen.getByText("PopulateChoice")).toBeInTheDocument();
+    expect(screen.getByText("OrphanEngineChoice")).toBeInTheDocument();
     // Exit button is present and labeled per caller.
     expect(screen.getByRole("button", { name: "Return to menu" })).toBeInTheDocument();
   });
 
   it("invokes onExit when the exit button is clicked", () => {
     const orphan = {
-      type: "PopulateChoice",
+      type: "OrphanEngineChoice",
       data: { player: 0 },
     } as unknown as WaitingFor;
     const state = makeState(orphan);

--- a/client/src/components/targeting/TargetingOverlay.tsx
+++ b/client/src/components/targeting/TargetingOverlay.tsx
@@ -25,6 +25,8 @@ export function TargetingOverlay() {
   const isCopyRetarget = waitingFor?.type === "CopyRetarget";
   const canKeepCurrentTargets = isCopyRetarget && waitingFor.data.target_slots.every((slot) => slot.current != null);
   const isExploreChoice = waitingFor?.type === "ExploreChoice";
+  // CR 701.36a: Populate — choose a creature token you control to copy.
+  const isPopulateChoice = waitingFor?.type === "PopulateChoice";
   // CR 303.4 + CR 303.4g + CR 115.1: Return-as-Aura attach pick. Picker is a
   // CHOICE (not a target), but the action shape mirrors ExploreChoice
   // (`GameAction::ChooseTarget` with the chosen ObjectId).
@@ -51,6 +53,8 @@ export function TargetingOverlay() {
     : waitingFor?.type === "TargetSelection"
       ? waitingFor.data.pending_cast?.object_id
       : waitingFor?.type === "ExploreChoice"
+        ? waitingFor.data.source_id
+      : waitingFor?.type === "PopulateChoice"
         ? waitingFor.data.source_id
       : waitingFor?.type === "ReturnAsAuraTarget"
         ? waitingFor.data.source_id
@@ -99,7 +103,7 @@ export function TargetingOverlay() {
     return () => clearSelectedCards();
   }, [clearSelectedCards, isTapCreatureChoice]);
 
-  if (!isTargetSelection && !isCopyTargetChoice && !isCopyRetarget && !isExploreChoice && !isReturnAsAuraTarget && !isRetargetChoice && !isTapCreatureChoice) return null;
+  if (!isTargetSelection && !isCopyTargetChoice && !isCopyRetarget && !isExploreChoice && !isPopulateChoice && !isReturnAsAuraTarget && !isRetargetChoice && !isTapCreatureChoice) return null;
 
   // Only show targeting UI for the human player
   if (!canActForWaitingState) return null;
@@ -138,6 +142,8 @@ export function TargetingOverlay() {
                   })()
               : isExploreChoice
                 ? t("targeting.chooseCreatureToExplore")
+              : isPopulateChoice
+                ? t("targeting.chooseCreatureTokenToPopulate")
               : isReturnAsAuraTarget
                 ? t("targeting.chooseReturnAsAuraTarget")
               : isRetargetChoice

--- a/client/src/components/targeting/__tests__/TargetingOverlay.test.tsx
+++ b/client/src/components/targeting/__tests__/TargetingOverlay.test.tsx
@@ -408,6 +408,30 @@ describe("TargetingOverlay", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the populate creature-token prompt", () => {
+    const dispatch = vi.fn().mockResolvedValue([]);
+    const gameState = createGameState({
+      waiting_for: {
+        type: "PopulateChoice",
+        data: { player: 0, source_id: 1, valid_tokens: [10, 11] },
+      },
+    });
+
+    act(() => {
+      useGameStore.setState({
+        gameState,
+        waitingFor: gameState.waiting_for,
+        dispatch,
+      });
+    });
+
+    render(<TargetingOverlay />);
+
+    expect(
+      screen.getByText("Choose a creature token to populate"),
+    ).toBeInTheDocument();
+  });
+
   it("renders the plain prompt when no mode label is present", () => {
     const dispatch = vi.fn().mockResolvedValue([]);
     const gameState = createGameState({

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -60,8 +60,8 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
     // unified special-cast offer (Adventure / Miracle / Madness / Cascade /
     // Discover / Paradigm); dispatches on `data.kind.type`.
     "CastOffer",
-    // Note: `PopulateChoice` is intentionally NOT registered — it has no
-    // renderer anywhere in client/src/, so the safety-net modal must fire for it.
+    // CR 701.36a: choose a creature token to copy (board click via TargetingOverlay).
+    "PopulateChoice",
     // Mana abilities (cost-selection prompts now route through PayCost above).
     "PayManaAbilityMana",
     "ChooseManaColor",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -409,6 +409,7 @@
     "chooseNewTargetForCopy": "Wähle ein neues Ziel für die Kopie",
     "chooseTargetForCopy": "Wähle ein Ziel für die Kopie",
     "chooseCreatureToExplore": "Wähle, welche Kreatur als Nächstes erkundet",
+    "chooseCreatureTokenToPopulate": "Wähle einen Kreaturspielstein zum Populieren",
     "chooseReturnAsAuraTarget": "Wähle eine bleibende Karte zum Verzaubern",
     "tapUntappedCreatures_one": "Tappe {{count}} ungetappte Kreatur",
     "tapUntappedCreatures_other": "Tappe {{count}} ungetappte Kreaturen",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -411,6 +411,7 @@
     "chooseNewTarget": "Choose the spell's new target",
     "chooseNewTargetForSpell": "Choose a new target for {{spell}}",
     "chooseCreatureToExplore": "Choose which creature explores next",
+    "chooseCreatureTokenToPopulate": "Choose a creature token to populate",
     "chooseReturnAsAuraTarget": "Choose a permanent to enchant",
     "tapUntappedCreatures_one": "Tap {{count}} untapped creature",
     "tapUntappedCreatures_other": "Tap {{count}} untapped creatures",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -409,6 +409,7 @@
     "chooseNewTargetForCopy": "Elige un nuevo objetivo para la copia",
     "chooseTargetForCopy": "Elige objetivo para la copia",
     "chooseCreatureToExplore": "Elige qué criatura explora a continuación",
+    "chooseCreatureTokenToPopulate": "Elige una ficha de criatura para poblar",
     "chooseReturnAsAuraTarget": "Elige un permanente para encantar",
     "tapUntappedCreatures_one": "Gira {{count}} criatura sin girar",
     "tapUntappedCreatures_other": "Gira {{count}} criaturas sin girar",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -409,6 +409,7 @@
     "chooseNewTargetForCopy": "Choisissez une nouvelle cible pour la copie",
     "chooseTargetForCopy": "Choisissez la cible de la copie",
     "chooseCreatureToExplore": "Choisissez quelle créature explore ensuite",
+    "chooseCreatureTokenToPopulate": "Choisissez un jeton de créature à peupler",
     "chooseReturnAsAuraTarget": "Choisissez un permanent à enchanter",
     "tapUntappedCreatures_one": "Engagez {{count}} créature dégagée",
     "tapUntappedCreatures_other": "Engagez {{count}} créatures dégagées",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -409,6 +409,7 @@
     "chooseNewTargetForCopy": "Scegli un nuovo bersaglio per la copia",
     "chooseTargetForCopy": "Scegli il bersaglio per la copia",
     "chooseCreatureToExplore": "Scegli quale creatura esplora dopo",
+    "chooseCreatureTokenToPopulate": "Scegli una pedina creatura da popolare",
     "chooseReturnAsAuraTarget": "Scegli un permanente da incantare",
     "tapUntappedCreatures_one": "TAPpa {{count}} creatura STAPpata",
     "tapUntappedCreatures_other": "TAPpa {{count}} creature STAPpate",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -411,6 +411,7 @@
     "chooseNewTarget": "Wybierz nowy cel czaru",
     "chooseNewTargetForSpell": "Wybierz nowy cel dla {{spell}}",
     "chooseCreatureToExplore": "Wybierz, który stwór eksploruje jako następny",
+    "chooseCreatureTokenToPopulate": "Wybierz żeton stwora do populacji",
     "chooseReturnAsAuraTarget": "Wybierz permanent do zaczarowania",
     "tapUntappedCreatures_one": "Obróć {{count}} nieobróconego stwora",
     "tapUntappedCreatures_other": "Obróć {{count}} nieobróconych stworów",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -409,6 +409,7 @@
     "chooseNewTargetForCopy": "Escolha um novo alvo para a cópia",
     "chooseTargetForCopy": "Escolha o alvo da cópia",
     "chooseCreatureToExplore": "Escolha qual criatura explora em seguida",
+    "chooseCreatureTokenToPopulate": "Escolha uma ficha de criatura para popular",
     "chooseReturnAsAuraTarget": "Escolha um permanente para encantar",
     "tapUntappedCreatures_one": "Vire {{count}} criatura desvirada",
     "tapUntappedCreatures_other": "Vire {{count}} criaturas desviradas",

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -4,6 +4,7 @@ import type { GameState, PlayerId } from "../../adapter/types";
 import {
   getOpponentIds,
   getSeatCount,
+  getWaitingForObjectChoiceIds,
   isOneOnOne,
 } from "../gameStateView";
 
@@ -73,6 +74,17 @@ describe("isOneOnOne", () => {
 
   it("returns false for a null state", () => {
     expect(isOneOnOne(null)).toBe(false);
+  });
+});
+
+describe("getWaitingForObjectChoiceIds", () => {
+  it("returns valid_tokens for PopulateChoice", () => {
+    expect(
+      getWaitingForObjectChoiceIds({
+        type: "PopulateChoice",
+        data: { player: 0, source_id: 1, valid_tokens: [10, 11] },
+      }),
+    ).toEqual([10, 11]);
   });
 });
 

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -80,6 +80,8 @@ export function getWaitingForObjectChoiceIds(
       );
     case "ExploreChoice":
       return waitingFor.data.choosable;
+    case "PopulateChoice":
+      return waitingFor.data.valid_tokens;
     case "ReturnAsAuraTarget":
       // CR 303.4 / CR 115.1: `legal_targets` is a TargetRef[] of object hosts
       // *and* players (Curse / enchant-player Auras). Only object hosts glow on


### PR DESCRIPTION
## Summary

- Registers `PopulateChoice` in `HANDLED_WAITING_FOR_TYPES` so Populate no longer hits the unhandled-state modal.
- Uses the same board-click pattern as Explore: `TargetingOverlay` prompt, `getWaitingForObjectChoiceIds` highlights `valid_tokens`, and `ChooseTarget` dispatches to the engine.
- Adds i18n for `targeting.chooseCreatureTokenToPopulate` across all game locales.

## Test plan

- [x] `pnpm exec vitest run` on:
  - `TargetingOverlay.test.tsx`
  - `gameStateView.test.ts`
  - `boundary-guardrails.test.ts`
  - `UnhandledWaitingForModal.test.tsx`
  - `UnhandledWaitingForModal.roundtrip.integration.test.tsx`
- [ ] Manual: cast a spell with Populate while controlling **two or more** creature tokens; confirm tokens highlight, overlay text appears, click copies the chosen token, and the game continues (no “UI is missing” modal).
- [ ] Manual: Populate with **one** token still auto-resolves with no prompt (engine path unchanged).