### PR TITLE
fix(engine): allow Disturb casts from the graveyard

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -25784,6 +25784,7 @@ mod tests {
         obj_id
     }
 
+    /// Regression for Lunarch Veteran disturb from the graveyard (issue #2007).
     #[test]
     fn disturb_uses_disturb_cost_from_graveyard() {
         let mut state = setup_game_at_main_phase();
@@ -25814,6 +25815,7 @@ mod tests {
         );
     }
 
+    /// Luminous Phantom (back face) enters transformed after a Disturb cast (issue #2007).
     #[test]
     fn disturb_cast_uses_back_face_on_stack_and_battlefield() {
         let mut state = setup_game_at_main_phase();


### PR DESCRIPTION
## Summary

- Link existing Lunarch Veteran / Luminous Phantom **Disturb-from-graveyard** engine regressions to the reported bug ([#2007](https://github.com/phase-rs/phase/issues/2007)).
- **No behavior change** — Disturb graveyard casting, `CastingVariant::Disturb`, and transformed resolve already landed on `main` in [#2089](https://github.com/phase-rs/phase/pull/2089).

Fixes #2007.

## Background

[#2007](https://github.com/phase-rs/phase/issues/2007) reported that Lunarch Veteran could not be cast from the graveyard for its disturb cost (`{1}{W}` → Luminous Phantom).

That runtime behavior was implemented in [#2089](https://github.com/phase-rs/phase/pull/2089) (`Recognize Disturb as graveyard-cast permission (CR 702.140)`). This PR only documents the existing tests so the issue can close with a clear regression anchor.

## Change

| File | Change |
|------|--------|
| `crates/engine/src/game/casting.rs` | Doc comments on `disturb_uses_disturb_cost_from_graveyard` and `disturb_cast_uses_back_face_on_stack_and_battlefield` citing #2007 |

## Test plan

- [x] `cargo test -p engine disturb_uses_disturb_cost_from_graveyard disturb_cast_uses_back_face_on_stack_and_battlefield`
- [x] CI green (single-file, +2 lines vs `main`)