### PR TITLE
Fix Davros villainous choice

### DIFF
--- a/crates/engine/src/game/effects/choose_one_of.rs
+++ b/crates/engine/src/game/effects/choose_one_of.rs
@@ -206,3 +206,59 @@ fn branch_descriptions(branches: &[AbilityDefinition]) -> Vec<String> {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ability::{
+        AbilityKind, Comparator, PlayerFilter, PlayerRelation, PlayerScope, QuantityExpr,
+        QuantityRef, TargetFilter,
+    };
+    use crate::types::format::FormatConfig;
+
+    #[test]
+    fn life_lost_player_attribute_chooser_prompts_only_matching_opponents() {
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+        state.players[1].life_lost_this_turn = 3;
+        state.players[2].life_lost_this_turn = 2;
+
+        let branch = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        let ability = ResolvedAbility::new(
+            Effect::ChooseOneOf {
+                chooser: PlayerFilter::PlayerAttribute {
+                    relation: PlayerRelation::Opponent,
+                    attr: Box::new(QuantityRef::LifeLostThisTurn {
+                        player: PlayerScope::ScopedPlayer,
+                    }),
+                    comparator: Comparator::GE,
+                    value: Box::new(QuantityExpr::Fixed { value: 3 }),
+                },
+                branches: vec![branch],
+            },
+            Vec::new(),
+            ObjectId(1),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::ChooseOneOfBranch {
+                player,
+                remaining_players,
+                ..
+            } => {
+                assert_eq!(*player, PlayerId(1));
+                assert!(remaining_players.is_empty());
+            }
+            other => panic!("expected ChooseOneOfBranch, got {other:?}"),
+        }
+    }
+}

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -320,7 +320,7 @@ pub(crate) fn matches_player_scope(
                                 source_id,
                             )
                     }
-                    // CR 402.1 / 119.1 / 122.1f / 404.1: "each [player class]
+                    // CR 402.1 / 119.1 / 119.3 / 122.1f / 404.1: "each [player class]
                     // whose [scalar attr] [comparator] [value]" — the candidate
                     // satisfies both `relation` and the per-candidate scalar
                     // comparison. `value` is the controller-relative threshold,
@@ -381,11 +381,12 @@ pub(crate) fn player_control_count_compares(
     )
 }
 
-/// CR 402.1 / 119.1 / 122.1f / 404.1: Read scalar `attr` for one candidate
-/// player DIRECTLY off the candidate `Player` (NOT via the controller-scoped
-/// `resolve_quantity`), so `PlayerFilter::PlayerAttribute` reads each player's
-/// own hand size / life / graveyard / player-counter rather than the
-/// controller's. Returns `None` for any non-scalar `QuantityRef`; the parser
+/// CR 402.1 / 119.1 / 119.3 / 122.1f / 404.1: Read scalar `attr` for one
+/// candidate player DIRECTLY off the candidate `Player` (NOT via the
+/// controller-scoped `resolve_quantity`), so `PlayerFilter::PlayerAttribute`
+/// reads each player's own hand size / life total / life lost / graveyard /
+/// player-counter rather than the controller's. Returns `None` for any
+/// non-scalar `QuantityRef`; the parser
 /// invariant guarantees only the scalar subset reaches here, and `None` fails
 /// the candidate predicate closed.
 pub(crate) fn candidate_player_scalar(p: &Player, attr: &QuantityRef) -> Option<i32> {
@@ -395,6 +396,8 @@ pub(crate) fn candidate_player_scalar(p: &Player, attr: &QuantityRef) -> Option<
         QuantityRef::HandSize { .. } => Some(usize_to_i32_saturating(p.hand.len())),
         // CR 119.1: the candidate's current life total.
         QuantityRef::LifeTotal { .. } => Some(p.life),
+        // CR 119.3: life lost this turn is tracked per candidate player.
+        QuantityRef::LifeLostThisTurn { .. } => Some(u32_to_i32_saturating(p.life_lost_this_turn)),
         // CR 404.1: cards in the candidate's graveyard.
         QuantityRef::GraveyardSize { .. } => Some(usize_to_i32_saturating(p.graveyard.len())),
         // CR 122.1f (poison) + CR 122.1: the candidate's named player-counter total.
@@ -13875,8 +13878,8 @@ mod tests {
         );
     }
 
-    /// CR 402.1 / 119.1 / 122.1f / 404.1: `candidate_player_scalar` reads each
-    /// of the four scalar `QuantityRef` attributes directly off the candidate
+    /// CR 402.1 / 119.1 / 119.3 / 122.1f / 404.1: `candidate_player_scalar` reads each
+    /// scalar `QuantityRef` attribute directly off the candidate
     /// `Player`, and returns `None` for any non-scalar `QuantityRef` (failing
     /// the predicate closed). Exercises the building block across its full input
     /// range, not a single card.
@@ -13888,6 +13891,7 @@ mod tests {
         {
             let p = &mut state.players[1];
             p.life = 17;
+            p.life_lost_this_turn = 3;
             p.poison_counters = 4;
             p.hand.push_back(ObjectId(1));
             p.hand.push_back(ObjectId(2));
@@ -13918,6 +13922,16 @@ mod tests {
                 }
             ),
             Some(17)
+        );
+        // CR 119.3: life lost this turn reads p.life_lost_this_turn.
+        assert_eq!(
+            candidate_player_scalar(
+                p,
+                &QuantityRef::LifeLostThisTurn {
+                    player: PlayerScope::ScopedPlayer
+                }
+            ),
+            Some(3)
         );
         // CR 404.1: graveyard size reads p.graveyard.len().
         assert_eq!(

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1729,6 +1729,12 @@ pub(super) fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, St
         // for the dispatcher — ordering invariant, not a defensive escape.
         tag("who doesn't"),
         tag("who does not"),
+        // CR 119.3 + CR 701.55a: "each opponent who lost N or more life this
+        // turn faces a villainous choice" is a restricted chooser phrase, not
+        // a normal per-player imperative. Preserve the full subject so the
+        // `ChooseOneOf` parser can emit a PlayerAttribute chooser instead of
+        // broadening the choice to every opponent.
+        tag("who lost"),
     ))
     .parse(rest_lower.as_str())
     .is_ok()

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -88,11 +88,11 @@ use crate::types::ability::{
     ContinuousModification, ControllerRef, DamageModification, DamageSource,
     DelayedTriggerCondition, DoubleTarget, Duration, Effect, FilterProp, GameRestriction,
     IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty,
-    ObjectScope, PaymentCost, PlayerFilter, PlayerScope, PreventionAmount, PreventionScope,
-    ProhibitedActivity, QuantityExpr, QuantityRef, ReplacementDefinition, RestrictionExpiry,
-    RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition, StepSkipTarget,
-    SubAbilityLink, TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition,
-    TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
+    ObjectScope, PaymentCost, PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount,
+    PreventionScope, ProhibitedActivity, QuantityExpr, QuantityRef, ReplacementDefinition,
+    RestrictionExpiry, RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition,
+    StepSkipTarget, SubAbilityLink, TargetFilter, TargetSelectionMode, TriggerCondition,
+    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterType;
@@ -2645,24 +2645,11 @@ fn try_parse_choose_one_of_inline(
     let mut chooser = PlayerFilter::Controller;
     let mut scoped_choice_player = false;
     let mut tp = tp;
-    if let Some((prefix_chooser, rest_original)) = nom_on_lower(tp.original, tp.lower, |i| {
-        alt((
-            value(
-                PlayerFilter::DefendingPlayer,
-                tag("defending player faces a villainous choice — "),
-            ),
-            value(
-                PlayerFilter::Opponent,
-                tag("target opponent faces a villainous choice — "),
-            ),
-            value(PlayerFilter::Controller, tag("face a villainous choice — ")),
-            value(
-                PlayerFilter::Controller,
-                tag("faces a villainous choice — "),
-            ),
-        ))
-        .parse(i)
-    }) {
+    if let Some((prefix_chooser, rest_original)) = nom_on_lower(
+        tp.original,
+        tp.lower,
+        parse_villainous_choice_chooser_prefix,
+    ) {
         let consumed = tp.original.len() - rest_original.len();
         tp = TextPair::new(rest_original, &tp.lower[consumed..]);
         chooser = prefix_chooser;
@@ -2820,6 +2807,51 @@ fn try_parse_choose_one_of_inline(
         chooser,
         branches: vec![left_def, right_def],
     }))
+}
+
+fn parse_villainous_choice_chooser_prefix(input: &str) -> OracleResult<'_, PlayerFilter> {
+    alt((
+        value(
+            PlayerFilter::DefendingPlayer,
+            tag("defending player faces a villainous choice — "),
+        ),
+        value(
+            PlayerFilter::Opponent,
+            tag("target opponent faces a villainous choice — "),
+        ),
+        parse_life_lost_villainous_choice_chooser,
+        value(PlayerFilter::Controller, tag("face a villainous choice — ")),
+        value(
+            PlayerFilter::Controller,
+            tag("faces a villainous choice — "),
+        ),
+    ))
+    .parse(input)
+}
+
+fn parse_life_lost_villainous_choice_chooser(input: &str) -> OracleResult<'_, PlayerFilter> {
+    let (input, relation) = alt((
+        value(PlayerRelation::Opponent, tag("each other player who lost ")),
+        value(PlayerRelation::Opponent, tag("each opponent who lost ")),
+        value(PlayerRelation::All, tag("each player who lost ")),
+        value(PlayerRelation::Opponent, tag("who lost ")),
+    ))
+    .parse(input)?;
+    let (input, threshold) = nom_primitives::parse_number(input)?;
+    let (input, _) = tag(" or more life this turn faces a villainous choice — ").parse(input)?;
+    let threshold = i32::try_from(threshold).unwrap_or(i32::MAX);
+
+    Ok((
+        input,
+        PlayerFilter::PlayerAttribute {
+            relation,
+            attr: Box::new(QuantityRef::LifeLostThisTurn {
+                player: PlayerScope::ScopedPlayer,
+            }),
+            comparator: Comparator::GE,
+            value: Box::new(QuantityExpr::Fixed { value: threshold }),
+        },
+    ))
 }
 
 fn ability_definition_from_clause(
@@ -37168,6 +37200,112 @@ mod tests {
                 ));
             }
             other => panic!("expected ChooseOneOf, got {other:?}"),
+        }
+    }
+
+    fn assert_life_lost_villainous_chooser(
+        chooser: &PlayerFilter,
+        expected_relation: PlayerRelation,
+    ) {
+        match chooser {
+            PlayerFilter::PlayerAttribute {
+                relation,
+                attr,
+                comparator,
+                value,
+            } => {
+                assert_eq!(*relation, expected_relation);
+                assert_eq!(*comparator, Comparator::GE);
+                assert!(matches!(
+                    attr.as_ref(),
+                    QuantityRef::LifeLostThisTurn {
+                        player: PlayerScope::ScopedPlayer
+                    }
+                ));
+                assert_eq!(value.as_ref(), &QuantityExpr::Fixed { value: 3 });
+            }
+            other => panic!("expected life-lost PlayerAttribute chooser, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn villainous_choice_supports_life_lost_restricted_chooser() {
+        let ability = parse_effect_chain(
+            "Each opponent who lost 3 or more life this turn faces a villainous choice — You draw a card, or that player discards a card.",
+            AbilityKind::Spell,
+        );
+
+        match &*ability.effect {
+            Effect::ChooseOneOf { chooser, branches } => {
+                assert_eq!(
+                    ability.player_scope, None,
+                    "restricted villainous choice must use chooser, not player_scope fan-out"
+                );
+                assert_life_lost_villainous_chooser(chooser, PlayerRelation::Opponent);
+                assert_eq!(branches.len(), 2);
+                assert!(matches!(&*branches[0].effect, Effect::Draw { .. }));
+                assert!(matches!(
+                    &*branches[1].effect,
+                    Effect::Discard {
+                        target: TargetFilter::ScopedPlayer,
+                        ..
+                    }
+                ));
+            }
+            other => panic!("expected ChooseOneOf, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn villainous_choice_supports_life_lost_continuation_remainder() {
+        let ability = parse_effect_chain(
+            "Who lost 3 or more life this turn faces a villainous choice — You draw a card, or that player discards a card.",
+            AbilityKind::Spell,
+        );
+
+        match &*ability.effect {
+            Effect::ChooseOneOf { chooser, branches } => {
+                assert_life_lost_villainous_chooser(chooser, PlayerRelation::Opponent);
+                assert_eq!(branches.len(), 2);
+            }
+            other => panic!("expected ChooseOneOf, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn villainous_choice_supports_life_lost_restricted_all_players() {
+        let ability = parse_effect_chain(
+            "Each player who lost 3 or more life this turn faces a villainous choice — You draw a card, or that player discards a card.",
+            AbilityKind::Spell,
+        );
+
+        match &*ability.effect {
+            Effect::ChooseOneOf { chooser, branches } => {
+                assert_life_lost_villainous_chooser(chooser, PlayerRelation::All);
+                assert_eq!(branches.len(), 2);
+            }
+            other => panic!("expected ChooseOneOf, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn davros_token_then_restricted_villainous_choice_chain() {
+        let ability = parse_effect_chain(
+            "Create a 3/3 black Dalek artifact creature token with menace. Then each opponent who lost 3 or more life this turn faces a villainous choice — You draw a card, or that player discards a card.",
+            AbilityKind::Spell,
+        );
+
+        assert!(matches!(&*ability.effect, Effect::Token { .. }));
+        let choice = ability
+            .sub_ability
+            .as_ref()
+            .expect("expected Davros villainous choice as sub-ability");
+        match &*choice.effect {
+            Effect::ChooseOneOf { chooser, branches } => {
+                assert_life_lost_villainous_chooser(chooser, PlayerRelation::Opponent);
+                assert_eq!(branches.len(), 2);
+            }
+            other => panic!("expected ChooseOneOf sub-ability, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes Davros, Dalek Creator's end-step villainous choice clause.

Davros now parses the token creation followed by a restricted `ChooseOneOf` sub-ability for players who lost 3 or more life this turn, instead of leaving the continuation as `Unimplemented { name: "who" }`.

Fixes #2166

## Files changed
- `crates/engine/src/parser/oracle_effect/mod.rs`
- `crates/engine/src/parser/oracle_effect/lower.rs`
- `crates/engine/src/game/effects/mod.rs`
- `crates/engine/src/game/effects/choose_one_of.rs`

## CR references
- `CR 119.3`
- `CR 701.55a`
- `CR 701.55a-b`
- `CR 608.2d`
- `CR 402.1`
- `CR 119.1`
- `CR 122.1f`
- `CR 404.1`

## Track
Developer

## LLM
Model: codex-5
Thinking: medium
Tier: Standard

## Gate A
`./scripts/check-parser-combinators.sh` exited 0 with no stdout.

## Anchored on
- `crates/engine/src/parser/oracle_effect/mod.rs:2641` — existing inline `ChooseOneOf` parser uses `nom_on_lower`, `alt()`, `tag()`, and branch reparsing for villainous-choice forms.
- `crates/engine/src/game/effects/choose_one_of.rs:152` — existing `ChooseOneOf` resolver routes chooser populations through `matches_player_scope`.
- `crates/engine/src/game/effects/mod.rs:328` — existing `PlayerFilter::PlayerAttribute` runtime branch evaluates relation + scalar comparator per candidate player.

## Verification
- `cargo fmt --all -- --check` — clean
- `git diff --check` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo test -p engine life_lost` — 19 passed / 0 failed
- `cargo test -p engine davros_token_then_restricted_villainous_choice_chain` — 1 passed / 0 failed
- `cargo test -p engine candidate_player_scalar_reads_each_attribute` — 1 passed / 0 failed
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- `./scripts/gen-card-data.sh` — clean; `Davros, Dalek Creator`: no `Unimplemented "who"` sub-ability
- `cargo coverage` — clean; `Davros, Dalek Creator`: `supported: true`, `gap_count: 0`
- `cargo semantic-audit` — completed; `Davros, Dalek Creator`: 0 findings

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
