### PR TITLE
feat(client): expand sandbox debug menu and enlarge modal cards

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1372,11 +1372,14 @@ export type DebugAction =
         owner: PlayerId;
         zone: Zone;
         attach_to?: AttachTarget;
+        run_etb: boolean;
       };
     }
   | { type: "RemoveObject"; data: { object_id: ObjectId } }
+  | { type: "Sacrifice"; data: { object_id: ObjectId } }
   | { type: "DrawCards"; data: { player_id: PlayerId; count: number } }
   | { type: "Mill"; data: { player_id: PlayerId; count: number } }
+  | { type: "Reveal"; data: { player_id: PlayerId; count: number } }
   | { type: "ShuffleLibrary"; data: { player_id: PlayerId } }
   | { type: "Proliferate"; data: { player_id: PlayerId } }
   | { type: "SetBasePowerToughness"; data: { object_id: ObjectId; power: number | null; toughness: number | null } }
@@ -1400,6 +1403,7 @@ export type DebugAction =
       type: "CreateToken";
       data: {
         request: DebugTokenRequest;
+        run_etb: boolean;
       };
     }
   | { type: "CreateTokenCopy"; data: { source_id: ObjectId; owner: PlayerId } };

--- a/client/src/components/chrome/DebugCardContextMenu.tsx
+++ b/client/src/components/chrome/DebugCardContextMenu.tsx
@@ -275,6 +275,18 @@ function DebugCardContextMenuInner({
         </div>
       )}
 
+      {/* Sacrifice — routes through the engine's CR 701.21 sacrifice pipeline so
+          dies / leaves-the-battlefield triggers fire, unlike "Remove" which
+          deletes the object outright. Offered for any battlefield permanent. */}
+      {onBattlefield && (
+        <div className="border-b border-gray-800 py-0.5">
+          <MenuItem
+            label="Sacrifice"
+            onClick={() => dispatchDebug({ type: "Sacrifice", data: { object_id: objectId } })}
+          />
+        </div>
+      )}
+
       {/* Destructive action */}
       <div className="py-0.5">
         <MenuItem

--- a/client/src/components/chrome/DebugCreateActions.tsx
+++ b/client/src/components/chrome/DebugCreateActions.tsx
@@ -144,6 +144,10 @@ function CreateCardForm({ onDispatch }: Props) {
   const [cardName, setCardName] = useState("");
   const [owner, setOwner] = useState<PlayerId>(0);
   const [zone, setZone] = useState<Zone>("Hand");
+  // Gate the ETB pipeline for battlefield spawns. Checked = run replacements +
+  // ETB triggers + SBAs (engine default); unchecked = raw placement. Only sent
+  // meaningfully for Battlefield — the engine ignores it for other zones.
+  const [runEtb, setRunEtb] = useState(true);
   const [face, setFace] = useState<CardFaceShape | null>(null);
   const [targetKind, setTargetKind] = useState<"Object" | "Player">("Object");
   const [targetObjectId, setTargetObjectId] = useState<ObjectId | null>(null);
@@ -247,11 +251,16 @@ function CreateCardForm({ onDispatch }: Props) {
           )}
         </>
       )}
+      {zone === "Battlefield" && (
+        <FieldRow label="">
+          <CheckboxInput checked={runEtb} onChange={setRunEtb} label="Run ETB effects" />
+        </FieldRow>
+      )}
       <SubmitButton
         onClick={() =>
           onDispatch({
             type: "CreateCard",
-            data: { card_name: cardName, owner, zone, attach_to: buildAttachTo() },
+            data: { card_name: cardName, owner, zone, attach_to: buildAttachTo(), run_etb: runEtb },
           })
         }
         disabled={!cardName.trim() || !hasHost}
@@ -351,6 +360,7 @@ function CatalogTokenForm({ onDispatch }: Props) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [counterType, setCounterType] = useState<CounterType>("P1P1");
   const [counterCount, setCounterCount] = useState(0);
+  const [runEtb, setRunEtb] = useState(true);
 
   useEffect(() => {
     listTokenPresets()
@@ -437,6 +447,7 @@ function CatalogTokenForm({ onDispatch }: Props) {
             enter_with_counters: buildEnterCounters(counterType, counterCount),
           },
         },
+        run_etb: runEtb,
       },
     });
   };
@@ -508,6 +519,9 @@ function CatalogTokenForm({ onDispatch }: Props) {
         setCount={setCounterCount}
         hint={survivalHint}
       />
+      <FieldRow label="">
+        <CheckboxInput checked={runEtb} onChange={setRunEtb} label="Run ETB effects" />
+      </FieldRow>
       <SubmitButton onClick={handleSubmit} disabled={!selectedId}>
         Create Selected Token
       </SubmitButton>
@@ -526,6 +540,7 @@ function CustomTokenForm({ onDispatch }: Props) {
   const [keywordsText, setKeywordsText] = useState("");
   const [counterType, setCounterType] = useState<CounterType>("P1P1");
   const [counterCount, setCounterCount] = useState(0);
+  const [runEtb, setRunEtb] = useState(true);
 
   const toggleCoreType = (ct: CoreType) => {
     setCoreTypes((prev) =>
@@ -569,6 +584,7 @@ function CustomTokenForm({ onDispatch }: Props) {
             enter_with_counters: buildEnterCounters(counterType, counterCount),
           },
         },
+        run_etb: runEtb,
       },
     });
   };
@@ -639,6 +655,9 @@ function CustomTokenForm({ onDispatch }: Props) {
         setCount={setCounterCount}
         hint={survivalHint}
       />
+      <FieldRow label="">
+        <CheckboxInput checked={runEtb} onChange={setRunEtb} label="Run ETB effects" />
+      </FieldRow>
       <SubmitButton onClick={handleSubmit}>Create Custom Token</SubmitButton>
     </>
   );

--- a/client/src/components/chrome/DebugLibraryViewer.tsx
+++ b/client/src/components/chrome/DebugLibraryViewer.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useMemo, useState, type CSSProperties } from "react";
+
+import type { DebugAction, GameObject } from "../../adapter/types";
+import { CardImage } from "../card/CardImage";
+import { ModalPanelShell } from "../ui/ModalPanelShell";
+import { useInspectHoverProps } from "../../hooks/useInspectHoverProps";
+import { useGameDispatch } from "../../hooks/useGameDispatch";
+import { useGameStore } from "../../stores/gameStore";
+import { useUiStore } from "../../stores/uiStore";
+
+/**
+ * Debug-only library browser. Lists the given player's full library so a
+ * specific card can be moved to any zone (battlefield, hand, …) without
+ * scrubbing through a dropdown.
+ *
+ * The cards are shown in a STABLE RANDOMIZED order rather than their true
+ * library order. The engine deliberately leaves the on-wire `library` Vec order
+ * untouched (sandbox debug exposes card *names* but must not leak *draw order*,
+ * per `visibility.rs`), so this view shuffles the display once per open. Moving
+ * a card out simply removes it from its slot — the rest keep their positions.
+ */
+export function DebugLibraryViewer() {
+  const viewer = useUiStore((s) => s.debugLibraryViewer);
+  const close = useUiStore((s) => s.closeDebugLibraryViewer);
+
+  if (!viewer) return null;
+
+  return <DebugLibraryViewerInner playerId={viewer.playerId} onClose={close} />;
+}
+
+function DebugLibraryViewerInner({
+  playerId,
+  onClose,
+}: {
+  playerId: number;
+  onClose: () => void;
+}) {
+  const objects = useGameStore((s) => s.gameState?.objects);
+  const libraryIds = useGameStore((s) => s.gameState?.players[playerId]?.library);
+  const openDebugContextMenu = useUiStore((s) => s.openDebugContextMenu);
+  const dispatch = useGameDispatch();
+
+  // One shuffle seed per open: keeps the order stable across re-renders (and
+  // across card moves) so the grid doesn't reshuffle every time a card leaves.
+  const [seed] = useState(() => Math.floor(Math.random() * 2 ** 31));
+
+  const cards = useMemo(() => {
+    if (!objects || !libraryIds) return [];
+    const rank = (id: number) => {
+      // Deterministic per (seed, id) pseudo-random key — a stable shuffle.
+      const x = Math.sin((id + 1) * (seed + 1)) * 43758.5453;
+      return x - Math.floor(x);
+    };
+    return libraryIds
+      .map((id) => objects[id])
+      .filter((obj): obj is GameObject => Boolean(obj))
+      .sort((a, b) => rank(a.id) - rank(b.id));
+  }, [objects, libraryIds, seed]);
+
+  const move = useCallback(
+    (objectId: number, toZone: "Battlefield" | "Hand") => {
+      const action: DebugAction = {
+        type: "MoveToZone",
+        data: { object_id: objectId, to_zone: toZone },
+      };
+      void dispatch({ type: "Debug", data: action });
+    },
+    [dispatch],
+  );
+
+  return (
+    <ModalPanelShell
+      title={`Library — Player ${playerId} (${cards.length})`}
+      subtitle="Debug: shown in randomized order. Click a card for all zones; use the buttons for quick moves."
+      onClose={onClose}
+      maxWidthClassName="max-w-6xl"
+      bodyClassName="flex min-h-0 flex-col"
+    >
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-4 lg:px-6">
+        {cards.length === 0 ? (
+          <p className="py-8 text-center text-sm italic text-gray-600">
+            Library is empty.
+          </p>
+        ) : (
+          <div
+            className="flex flex-wrap justify-center gap-3"
+            style={
+              {
+                "--card-w": "clamp(100px, 9vw, 150px)",
+                "--card-h": "clamp(140px, 12.6vw, 210px)",
+              } as CSSProperties
+            }
+          >
+            {cards.map((obj) => (
+              <LibraryCard
+                key={obj.id}
+                obj={obj}
+                onOpenMenu={(x, y) => openDebugContextMenu({ objectId: obj.id, x, y })}
+                onMove={(zone) => move(obj.id, zone)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </ModalPanelShell>
+  );
+}
+
+function LibraryCard({
+  obj,
+  onOpenMenu,
+  onMove,
+}: {
+  obj: GameObject;
+  onOpenMenu: (x: number, y: number) => void;
+  onMove: (zone: "Battlefield" | "Hand") => void;
+}) {
+  const hoverProps = useInspectHoverProps();
+
+  return (
+    <div
+      className="group relative shrink-0 cursor-pointer rounded-lg transition-transform hover:scale-[1.03] hover:ring-1 hover:ring-white/20"
+      data-card-hover
+      {...hoverProps(obj.id)}
+      onClick={(e) => {
+        e.stopPropagation();
+        onOpenMenu(e.clientX, e.clientY);
+      }}
+    >
+      <CardImage cardName={obj.name} size="normal" />
+      {/* Quick-move buttons for the two most common debug destinations; the
+          full zone list is one click away via the card's debug context menu. */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center gap-1 rounded-b-lg bg-black/60 p-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
+        <QuickMoveButton label="BF" title="Move to battlefield" onClick={() => onMove("Battlefield")} />
+        <QuickMoveButton label="Hand" title="Move to hand" onClick={() => onMove("Hand")} />
+      </div>
+    </div>
+  );
+}
+
+function QuickMoveButton({
+  label,
+  title,
+  onClick,
+}: {
+  label: string;
+  title: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      className="rounded bg-blue-600/80 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-white transition-colors hover:bg-blue-500"
+    >
+      {label}
+    </button>
+  );
+}

--- a/client/src/components/chrome/DebugPlayerActions.tsx
+++ b/client/src/components/chrome/DebugPlayerActions.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 
 import type { DebugAction, ManaType, PlayerCounterKind, PlayerId } from "../../adapter/types";
+import { usePerspectivePlayerId } from "../../hooks/usePlayerId";
+import { useUiStore } from "../../stores/uiStore";
 import {
   AccordionItem,
   FieldRow,
@@ -75,6 +77,25 @@ function MillForm({ onDispatch }: Props) {
       </FieldRow>
       <SubmitButton onClick={() => onDispatch({ type: "Mill", data: { player_id: playerId, count } })}>
         Mill
+      </SubmitButton>
+    </>
+  );
+}
+
+function RevealForm({ onDispatch }: Props) {
+  const [playerId, setPlayerId] = useState<PlayerId>(0);
+  const [count, setCount] = useState(1);
+
+  return (
+    <>
+      <FieldRow label="Player">
+        <PlayerSelect value={playerId} onChange={setPlayerId} />
+      </FieldRow>
+      <FieldRow label="Count">
+        <NumberInput value={count} onChange={setCount} min={1} />
+      </FieldRow>
+      <SubmitButton onClick={() => onDispatch({ type: "Reveal", data: { player_id: playerId, count } })}>
+        Reveal Top
       </SubmitButton>
     </>
   );
@@ -183,6 +204,27 @@ function ModifyEnergyForm({ onDispatch }: Props) {
   );
 }
 
+// Opens the debug library browser for the local (perspective) player. The
+// engine only exposes the viewer's OWN library names in sandbox debug
+// (`visibility.rs`), so this is intentionally scoped to the perspective seat
+// rather than offering a player picker that would render opponent backs.
+function BrowseLibraryForm() {
+  const openDebugLibraryViewer = useUiStore((s) => s.openDebugLibraryViewer);
+  const perspectivePlayerId = usePerspectivePlayerId();
+
+  return (
+    <>
+      <p className="mb-2 px-2 text-[10px] text-gray-500">
+        Opens a modal of your library in randomized order. Click a card to move
+        it to any zone, or use the quick Battlefield / Hand buttons.
+      </p>
+      <SubmitButton onClick={() => openDebugLibraryViewer(perspectivePlayerId)}>
+        Browse Library
+      </SubmitButton>
+    </>
+  );
+}
+
 export function DebugPlayerActions({ onDispatch }: Props) {
   const { expanded, toggle } = useAccordion();
 
@@ -197,8 +239,14 @@ export function DebugPlayerActions({ onDispatch }: Props) {
       <AccordionItem label="Mill" expanded={expanded === "mill"} onToggle={() => toggle("mill")}>
         <MillForm onDispatch={onDispatch} />
       </AccordionItem>
+      <AccordionItem label="Reveal Top" expanded={expanded === "reveal"} onToggle={() => toggle("reveal")}>
+        <RevealForm onDispatch={onDispatch} />
+      </AccordionItem>
       <AccordionItem label="Shuffle Library" expanded={expanded === "shuffle"} onToggle={() => toggle("shuffle")}>
         <ShuffleLibraryForm onDispatch={onDispatch} />
+      </AccordionItem>
+      <AccordionItem label="Browse Library" expanded={expanded === "browse"} onToggle={() => toggle("browse")}>
+        <BrowseLibraryForm />
       </AccordionItem>
       <AccordionItem label="Proliferate" expanded={expanded === "proliferate"} onToggle={() => toggle("proliferate")}>
         <ProliferateForm onDispatch={onDispatch} />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -475,7 +475,7 @@ body {
 .zone-viewer-strip .animate-pulse,
 .card-choice-strip [role="img"],
 .card-choice-strip .animate-pulse {
-  --strip-card-h: clamp(180px, 52vh, 420px);
+  --strip-card-h: clamp(240px, 64vh, 560px);
   width: auto !important;
   height: var(--strip-card-h) !important;
   aspect-ratio: 5 / 7;

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -27,6 +27,7 @@ import { flashStartingPlayerContest } from "../game/diceContest.ts";
 import { BattlefieldBackground } from "../components/board/BattlefieldBackground.tsx";
 import { BoardContextMenu } from "../components/board/BoardContextMenu.tsx";
 import { DebugCardContextMenu } from "../components/chrome/DebugCardContextMenu.tsx";
+import { DebugLibraryViewer } from "../components/chrome/DebugLibraryViewer.tsx";
 import { AttackTargetLines } from "../components/board/AttackTargetLines.tsx";
 import { BlockAssignmentLines } from "../components/board/BlockAssignmentLines.tsx";
 import { BlockRequirementBadges } from "../components/combat/BlockRequirementBadges.tsx";
@@ -1347,6 +1348,7 @@ function GamePageContent({
       )}
 
       <DebugCardContextMenu />
+      <DebugLibraryViewer />
 
       {/* Animation overlay (above board, below modals) */}
       <AnimationOverlay containerRef={containerRef} />
@@ -1852,8 +1854,8 @@ function MulliganDecisionPrompt({
         className="modal-card-area flex min-h-0 flex-1 items-center justify-center"
         style={
           {
-            "--card-w": "clamp(100px, 14vw, 180px)",
-            "--card-h": "clamp(140px, 19.6vw, 252px)",
+            "--card-w": "clamp(140px, 18vw, 257px)",
+            "--card-h": "clamp(196px, 25.2vw, 360px)",
           } as React.CSSProperties
         }
       >
@@ -1882,7 +1884,7 @@ function MulliganDecisionPrompt({
                 <CardImage
                   cardName={obj.name}
                   size="normal"
-                  className="h-[clamp(160px,28vh,252px)] w-[clamp(114px,20vh,180px)]"
+                  className="h-[clamp(200px,40vh,360px)] w-[clamp(143px,28.6vh,257px)]"
                 />
               </motion.div>
             ))}
@@ -1945,8 +1947,8 @@ function CompanionRevealPrompt({
         className="modal-card-area flex min-h-0 flex-1 items-center justify-center"
         style={
           {
-            "--card-w": "clamp(100px, 14vw, 180px)",
-            "--card-h": "clamp(140px, 19.6vw, 252px)",
+            "--card-w": "clamp(140px, 18vw, 257px)",
+            "--card-h": "clamp(196px, 25.2vw, 360px)",
           } as React.CSSProperties
         }
       >
@@ -1975,7 +1977,7 @@ function CompanionRevealPrompt({
                 <CardImage
                   cardName={name}
                   size="normal"
-                  className="h-[clamp(160px,28vh,252px)] w-[clamp(114px,20vh,180px)]"
+                  className="h-[clamp(200px,40vh,360px)] w-[clamp(143px,28.6vh,257px)]"
                 />
               </motion.div>
             ))}
@@ -2064,8 +2066,8 @@ function MulliganBottomCardsPrompt({
         className="modal-card-area flex min-h-0 flex-1 items-center justify-center"
         style={
           {
-            "--card-w": "clamp(100px, 14vw, 180px)",
-            "--card-h": "clamp(140px, 19.6vw, 252px)",
+            "--card-w": "clamp(140px, 18vw, 257px)",
+            "--card-h": "clamp(196px, 25.2vw, 360px)",
           } as React.CSSProperties
         }
       >
@@ -2098,7 +2100,7 @@ function MulliganBottomCardsPrompt({
                   <CardImage
                     cardName={obj.name}
                     size="normal"
-                    className="h-[clamp(160px,28vh,252px)] w-[clamp(114px,20vh,180px)]"
+                    className="h-[clamp(200px,40vh,360px)] w-[clamp(143px,28.6vh,257px)]"
                   />
                 </motion.button>
               );

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -146,6 +146,10 @@ interface UiStoreState {
   debugPanelTab: "console" | "actions";
   debugInteractionMode: boolean;
   debugContextMenu: { objectId: ObjectId; x: number; y: number } | null;
+  /** Debug-only library browser: when set, a modal lists the player's full
+   *  library (in a stable randomized order) so individual cards can be moved to
+   *  any zone via the standard debug context menu. `null` when closed. */
+  debugLibraryViewer: { playerId: number } | null;
   helpSheetOpen: boolean;
   /** Object currently being "previewed" by a debug-panel control (e.g. an
    *  ObjectSelect dropdown option under the cursor). Drives a distinct,
@@ -205,6 +209,8 @@ interface UiStoreActions {
   toggleDebugInteractionMode: () => void;
   openDebugContextMenu: (menu: { objectId: ObjectId; x: number; y: number }) => void;
   closeDebugContextMenu: () => void;
+  openDebugLibraryViewer: (playerId: number) => void;
+  closeDebugLibraryViewer: () => void;
   setHelpSheetOpen: (open: boolean) => void;
   toggleHelpSheet: () => void;
   /** Set or clear the debug-panel preview highlight for an object. */
@@ -246,6 +252,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   debugPanelTab: "console",
   debugInteractionMode: false,
   debugContextMenu: null,
+  debugLibraryViewer: null,
   helpSheetOpen: false,
   debugHighlightedObjectId: null,
   debugHighlightedPlayerId: null,
@@ -493,6 +500,8 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   })),
   openDebugContextMenu: (menu) => set({ debugContextMenu: menu, selectedObjectId: menu.objectId }),
   closeDebugContextMenu: () => set({ debugContextMenu: null }),
+  openDebugLibraryViewer: (playerId) => set({ debugLibraryViewer: { playerId } }),
+  closeDebugLibraryViewer: () => set({ debugLibraryViewer: null }),
   setHelpSheetOpen: (open) => set({ helpSheetOpen: open }),
   toggleHelpSheet: () => set((state) => ({ helpSheetOpen: !state.helpSheetOpen })),
   setLogPanelOpen: (open) => set({ logPanelOpen: open }),

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -761,9 +761,10 @@ pub fn submit_action(actor: u8, action: JsValue) -> JsValue {
         owner,
         zone,
         attach_to,
+        run_etb,
     }) = action
     {
-        return handle_debug_create_card(card_name, owner, zone, attach_to);
+        return handle_debug_create_card(card_name, owner, zone, attach_to, run_etb);
     }
 
     match with_state_mut(|state| match apply(state, actor, action) {
@@ -783,6 +784,7 @@ fn handle_debug_create_card(
     owner: PlayerId,
     zone: engine::types::zones::Zone,
     attach_to: Option<engine::game::game_object::AttachTarget>,
+    run_etb: bool,
 ) -> JsValue {
     let face = CARD_DB.with(|cell| {
         let db = cell.borrow();
@@ -880,7 +882,7 @@ fn handle_debug_create_card(
         }
 
         let result = if zone == engine::types::zones::Zone::Battlefield {
-            engine::game::route_debug_create_to_battlefield(state, obj_id)
+            engine::game::route_debug_create_to_battlefield(state, obj_id, run_etb)
         } else {
             engine::types::game_state::ActionResult {
                 events: vec![],

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -91,6 +91,28 @@ pub fn apply_debug_action(
             crate::game::layers::mark_layers_full(state);
         }
 
+        DebugAction::Sacrifice { object_id } => {
+            validate_object(state, object_id)?;
+            // CR 701.21: A player sacrifices a permanent they control. Route
+            // through the single sacrifice authority so the replacement pipeline
+            // (e.g. Rest in Peace → exile) and dies/leaves-the-battlefield
+            // triggers fire — unlike `RemoveObject`, which deletes the object
+            // outright with no triggers.
+            let controller = state.objects[&object_id].controller;
+            match super::sacrifice::sacrifice_permanent(state, object_id, controller, events)
+                .map_err(|err| EngineError::InvalidAction(format!("{err:?}")))?
+            {
+                super::sacrifice::SacrificeOutcome::Complete => {
+                    super::triggers::process_triggers(state, events); // CR 603: dies/LTB triggers
+                    super::sba::check_state_based_actions(state, events); // CR 704
+                }
+                super::sacrifice::SacrificeOutcome::NeedsReplacementChoice(player) => {
+                    state.waiting_for =
+                        super::replacement::replacement_choice_waiting_for(player, state);
+                }
+            }
+        }
+
         DebugAction::DrawCards { player_id, count } => {
             validate_player(state, player_id)?;
             // CR 614.6 + CR 614.11 + CR 704.3: route through the single-authority
@@ -117,6 +139,26 @@ pub fn apply_debug_action(
             for id in top_ids {
                 zones::move_to_zone(state, id, Zone::Graveyard, events);
             }
+        }
+
+        DebugAction::Reveal { player_id, count } => {
+            validate_player(state, player_id)?;
+            // CR 701.20a/b: Reveal the top `count` cards of the player's library
+            // via the real `Effect::RevealTop` resolver — marks them revealed and
+            // emits `CardsRevealed` without moving the cards. `TargetFilter::Any`
+            // + an explicit `TargetRef::Player` makes the resolver reveal exactly
+            // the requested library (see `reveal_top::resolve`).
+            let ability = ResolvedAbility::new(
+                Effect::RevealTop {
+                    player: TargetFilter::Any,
+                    count,
+                },
+                vec![TargetRef::Player(player_id)],
+                ObjectId(0),
+                player_id,
+            );
+            super::effects::reveal_top::resolve(state, &ability, events)
+                .map_err(|err| EngineError::InvalidAction(format!("{err:?}")))?;
         }
 
         DebugAction::ShuffleLibrary { player_id } => {
@@ -349,7 +391,7 @@ pub fn apply_debug_action(
             super::triggers::process_triggers(state, events);
         }
 
-        DebugAction::CreateToken { request } => {
+        DebugAction::CreateToken { request, run_etb } => {
             let (owner, characteristics, enter_with_counters, preset_image_ref) = match request {
                 DebugTokenRequest::Preset {
                     preset_id,
@@ -415,8 +457,14 @@ pub fn apply_debug_action(
                             }
                         }
                     }
-                    super::triggers::process_triggers(state, events); // CR 603: Process triggers
-                    super::sba::check_state_based_actions(state, events); // CR 704: Check SBAs
+                    // "Run ETB effects" unchecked: the token is still created
+                    // (with its replacement-window counters) but its ETB triggers
+                    // and the SBA pass are skipped — mirrors the raw placement of
+                    // `MoveToZone { simulate: false }`.
+                    if run_etb {
+                        super::triggers::process_triggers(state, events); // CR 603: Process triggers
+                        super::sba::check_state_based_actions(state, events); // CR 704: Check SBAs
+                    }
                 }
                 super::replacement::ReplacementResult::Prevented => {}
                 super::replacement::ReplacementResult::NeedsChoice(player) => {
@@ -533,10 +581,27 @@ fn apply_energy_delta(
 pub fn route_debug_create_to_battlefield(
     state: &mut GameState,
     object_id: ObjectId,
+    run_etb: bool,
 ) -> ActionResult {
     use super::replacement::{self, ReplacementResult};
 
     let mut events: Vec<GameEvent> = vec![];
+
+    // "Run ETB effects" unchecked: place the staged object on the battlefield
+    // raw — no replacement window, no ETB triggers, no SBA pass. This mirrors
+    // `MoveToZone { simulate: false }`, letting a board position be staged
+    // without the entering permanent's "when ~ enters" abilities going on the
+    // stack.
+    if !run_etb {
+        zones::move_to_zone(state, object_id, Zone::Battlefield, &mut events);
+        crate::game::layers::mark_layers_full(state);
+        return ActionResult {
+            events,
+            waiting_for: state.waiting_for.clone(),
+            log_entries: vec![],
+        };
+    }
+
     let from = state
         .objects
         .get(&object_id)
@@ -693,6 +758,7 @@ mod tests {
                 characteristics: zero_zero_creature(),
                 enter_with_counters: vec![(CounterType::Plus1Plus1, 2)],
             },
+            run_etb: true,
         });
         let result = crate::game::engine::apply(&mut state, PlayerId(0), action)
             .expect("debug CreateToken should succeed");
@@ -1222,6 +1288,7 @@ mod tests {
                 characteristics: zero_zero_creature(),
                 enter_with_counters: Vec::new(),
             },
+            run_etb: true,
         });
         let result = crate::game::engine::apply(&mut state, PlayerId(0), action)
             .expect("debug CreateToken should succeed");

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -662,6 +662,13 @@ pub enum LearnOption {
     Skip,
 }
 
+/// Serde default for debug spawn `run_etb` flags: omitting the field means
+/// "run the ETB pipeline", preserving the historical always-ETB behavior for
+/// any payload that predates the toggle.
+fn default_true() -> bool {
+    true
+}
+
 /// Direct game-state manipulation actions for debugging, testing, and remediation.
 /// Bypasses `WaitingFor` validation — fires from any game state without disrupting
 /// the current prompt. Gated on `GameState::debug_mode`.
@@ -693,14 +700,30 @@ pub enum DebugAction {
         zone: Zone,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         attach_to: Option<AttachTarget>,
+        /// When `true`, route a `Battlefield` spawn through the real ETB pipeline
+        /// (replacements → ETB triggers → SBAs). When `false`, place the card raw
+        /// with no entry effects — mirrors `MoveToZone { simulate: false }`. Only
+        /// consulted for `zone == Battlefield`; ignored for other destinations.
+        #[serde(default = "default_true")]
+        run_etb: bool,
     },
     /// Remove an object from the game entirely.
     RemoveObject { object_id: ObjectId },
+    /// CR 701.21: Sacrifice a permanent — route through the single sacrifice
+    /// authority so the replacement pipeline and dies/leaves-the-battlefield
+    /// triggers fire. Distinct from `RemoveObject`, which deletes the object
+    /// outright with no triggers. The sacrificing player is the permanent's
+    /// controller.
+    Sacrifice { object_id: ObjectId },
     /// Draw N cards using the real draw pipeline (CR 121.1).
     /// Routes through replacement effects and emits CardDrawn events.
     DrawCards { player_id: PlayerId, count: u32 },
     /// Mill N cards from library to graveyard.
     Mill { player_id: PlayerId, count: u32 },
+    /// CR 701.20a: Reveal the top N card(s) of a player's library using the real
+    /// `Effect::RevealTop` resolver — marks them revealed and emits
+    /// `CardsRevealed` without moving the cards (CR 701.20b).
+    Reveal { player_id: PlayerId, count: u32 },
     /// Shuffle a player's library.
     ShuffleLibrary { player_id: PlayerId },
     /// Start a proliferate choice for a player using the real proliferate
@@ -801,7 +824,16 @@ pub enum DebugAction {
     /// `TokenSpec::enter_with_counters` — same semantics, real pipeline.
     /// CR 122.6a (counters placed at ETB), CR 614.1 (replacement window),
     /// CR 704.5f (0-toughness SBA — why this field exists).
-    CreateToken { request: DebugTokenRequest },
+    ///
+    /// When `run_etb` is `true`, the created token's ETB triggers are placed on
+    /// the stack and SBAs run; when `false`, the token is still created (with its
+    /// replacement-window counters) but its "when ~ enters" triggers and the SBA
+    /// pass are skipped — mirrors `MoveToZone { simulate: false }`.
+    CreateToken {
+        request: DebugTokenRequest,
+        #[serde(default = "default_true")]
+        run_etb: bool,
+    },
     /// Create a token copy of an existing object using the real copy-token
     /// resolver (CR 707.2).
     CreateTokenCopy {
@@ -896,6 +928,7 @@ impl DebugAction {
                 owner,
                 zone,
                 attach_to,
+                run_etb,
             } => {
                 let attach_suffix = match attach_to {
                     Some(AttachTarget::Object(id)) => format!(" attached to {}", obj(*id)),
@@ -904,16 +937,24 @@ impl DebugAction {
                     }
                     None => String::new(),
                 };
+                let etb_suffix = if *run_etb { "" } else { " (no ETB)" };
                 format!(
-                    "CreateCard ({} for {} in {:?}{})",
+                    "CreateCard ({} for {} in {:?}{}{})",
                     card_name,
                     player_label(*owner),
                     zone,
                     attach_suffix,
+                    etb_suffix,
                 )
             }
             DebugAction::RemoveObject { object_id } => {
                 format!("RemoveObject ({})", obj(*object_id))
+            }
+            DebugAction::Sacrifice { object_id } => {
+                format!("Sacrifice ({})", obj(*object_id))
+            }
+            DebugAction::Reveal { player_id, count } => {
+                format!("Reveal (top {} of {})", count, player_label(*player_id))
             }
             DebugAction::DrawCards { player_id, count } => {
                 format!("DrawCards ({} draws {})", player_label(*player_id), count)
@@ -1029,7 +1070,7 @@ impl DebugAction {
                 player_label(*active_player)
             ),
             DebugAction::RunStateBasedActions => "RunStateBasedActions".to_string(),
-            DebugAction::CreateToken { request } => {
+            DebugAction::CreateToken { request, run_etb } => {
                 let counters = if request.enter_with_counters().is_empty() {
                     String::new()
                 } else {
@@ -1046,11 +1087,13 @@ impl DebugAction {
                         characteristics, ..
                     } => characteristics.display_name.as_str(),
                 };
+                let etb_suffix = if *run_etb { "" } else { " (no ETB)" };
                 format!(
-                    "CreateToken ({} for {}{})",
+                    "CreateToken ({} for {}{}{})",
                     token_label,
                     player_label(request.owner()),
-                    counters
+                    counters,
+                    etb_suffix
                 )
             }
             DebugAction::CreateTokenCopy { source_id, owner } => format!(

--- a/crates/server-core/src/game_action_payload_guard.rs
+++ b/crates/server-core/src/game_action_payload_guard.rs
@@ -122,11 +122,13 @@ fn guard_debug_action_payload(action: &DebugAction) -> Result<(), String> {
         DebugAction::AddMana { mana, .. } => {
             bound_list("Debug.AddMana.mana", mana.len())?;
         }
-        DebugAction::CreateToken { request } => {
+        DebugAction::CreateToken { request, .. } => {
             guard_debug_token_request_payload(request)?;
         }
         DebugAction::MoveToZone { .. }
         | DebugAction::RemoveObject { .. }
+        | DebugAction::Sacrifice { .. }
+        | DebugAction::Reveal { .. }
         | DebugAction::DrawCards { .. }
         | DebugAction::Mill { .. }
         | DebugAction::ShuffleLibrary { .. }


### PR DESCRIPTION
Debug menu additions (engine + wasm + server + adapter + UI):
- "Run ETB effects" toggle on the Create Card / Create Token (Catalog +
  Custom) spawn forms. Checked routes battlefield entry through the real
  ETB pipeline (replacements + triggers + SBAs); unchecked places the
  permanent raw, mirroring MoveToZone { simulate: false }. Plumbed via a
  new run_etb field on DebugAction::CreateCard / CreateToken (serde
  default true) and threaded through route_debug_create_to_battlefield.
- "Sacrifice" entry in the card right-click menu for any battlefield
  permanent. Routes through the CR 701.21 sacrifice authority so dies /
  leaves-the-battlefield triggers fire, unlike "Remove" which deletes the
  object outright.
- "Reveal Top N" player action, dispatching the real Effect::RevealTop
  resolver (CR 701.20a/b) — marks cards revealed and emits CardsRevealed
  without moving them.
- "Browse Library" modal: lists the player's library in a stable
  randomized order (the engine already exposes own-library names in
  sandbox debug per visibility.rs; randomizing the display avoids leaking
  draw order). Each card opens the standard debug context menu plus quick
  Battlefield / Hand move buttons.

Modal card sizing:
- Enlarge cards in the mulligan / companion-reveal / London-bottom prompts
  and in the shared zone-viewer + choice-overlay strip (exile, graveyard,
  scry, surveil, search), which were rendering too small.
