### PR TITLE
perf(client): stop card hover from re-rendering the battlefield

### DIFF
--- a/client/src/components/board/GameBoard.tsx
+++ b/client/src/components/board/GameBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { PlayerId } from "../../adapter/types.ts";
@@ -22,7 +22,7 @@ interface GameBoardProps {
   playerHud?: React.ReactNode;
 }
 
-export function GameBoard({ oppHud, playerHud }: GameBoardProps) {
+export const GameBoard = memo(function GameBoard({ oppHud, playerHud }: GameBoardProps) {
   const { t } = useTranslation("game");
   const gameState = useGameStore((s) => s.gameState);
   const waitingFor = useGameStore((s) => s.waitingFor);
@@ -271,4 +271,4 @@ export function GameBoard({ oppHud, playerHud }: GameBoardProps) {
       </div>
     </BoardInteractionContext.Provider>
   );
-}
+});

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -163,7 +163,6 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
 
   const {
     selectedObjectId, selectObject, hoverObject, inspectObject,
-    hoveredObjectId,
     debugHighlightedObjectId,
     combatMode, selectedAttackers, toggleAttacker,
     blockerAssignments, combatClickHandler, selectedCardIds, toggleSelectedCard,
@@ -172,7 +171,6 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
     selectObject: s.selectObject,
     hoverObject: s.hoverObject,
     inspectObject: s.inspectObject,
-    hoveredObjectId: s.hoveredObjectId,
     debugHighlightedObjectId: s.debugHighlightedObjectId,
     combatMode: s.combatMode,
     selectedAttackers: s.selectedAttackers,
@@ -182,6 +180,18 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
     selectedCardIds: s.selectedCardIds,
     toggleSelectedCard: s.toggleSelectedCard,
   })));
+  // Hover is read as derived booleans, NOT the raw hoveredObjectId, so hovering
+  // any permanent re-renders only the card whose hovered/lifted state actually
+  // flips — not every PermanentCard on the board. O(1) per hover, not O(N).
+  const isHovered = useUiStore((s) => s.hoveredObjectId === objectId);
+  // Lifting a host's attachments only applies to cards that HAVE attachments;
+  // for the common (unattached) card this selector is a constant `false`, so it
+  // never re-renders on hover. Attached cards re-render only when their lifted
+  // state changes. Mirrors the `obj.attachments.length > 0` gate below.
+  const hasAttachments = (obj?.attachments.length ?? 0) > 0;
+  const isInHoveredAttachmentTree = useUiStore((s) =>
+    hasAttachments ? attachmentTreeContains(gameObjects, objectId, s.hoveredObjectId) : false,
+  );
   // Debug-panel preview highlight: lights up only when the user is hovering
   // an ObjectSelect option (or otherwise dispatching `setDebugHighlightedObjectId`).
   // Deliberately distinct from the standard hover-lift so the debug signal
@@ -268,10 +278,7 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
   const isSelected = selectedObjectId === objectId;
   const attachmentsLifted =
     obj.attachments.length > 0
-    && (
-      attachmentsLiftedByAncestor
-      || attachmentTreeContains(gameObjects, objectId, hoveredObjectId)
-    );
+    && (attachmentsLiftedByAncestor || isInHoveredAttachmentTree);
 
   // Combat state — check both UI selection and committed combat state
   const isSelectingAttacker =
@@ -471,7 +478,7 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
       layoutId={`permanent-${objectId}`}
       className="relative inline-flex w-fit cursor-pointer overflow-visible rounded-lg self-end select-none"
       style={{
-        zIndex: attachmentsLifted ? HOVERED_ATTACHMENT_HOST_Z_INDEX : hoveredObjectId === objectId ? HOVERED_CARD_Z_INDEX : isAttacking ? 50 : undefined,
+        zIndex: attachmentsLifted ? HOVERED_ATTACHMENT_HOST_Z_INDEX : isHovered ? HOVERED_CARD_Z_INDEX : isAttacking ? 50 : undefined,
         transformOrigin: "center center",
         // Reserve space below for exile ghost cards
         marginBottom:

--- a/client/src/components/card/GameCardPreview.tsx
+++ b/client/src/components/card/GameCardPreview.tsx
@@ -1,0 +1,64 @@
+import { usePreviewDismiss } from "../../hooks/usePreviewDismiss.ts";
+import { cardImageLookup } from "../../services/cardImageLookup.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+import { usePreferencesStore } from "../../stores/preferencesStore.ts";
+import { useUiStore } from "../../stores/uiStore.ts";
+import { CardPreview } from "./CardPreview.tsx";
+
+/**
+ * In-game wrapper around <CardPreview> that owns the hover-frequency uiStore
+ * subscriptions (inspectedObjectId / inspectedFaceIndex / isDragging / shiftHeld)
+ * and resolves the inspected object's display names from game state.
+ *
+ * Isolating these subscriptions in a leaf keeps GamePageContent from
+ * re-rendering — and cascading into the entire battlefield + Framer Motion
+ * layout machinery — on every card hover. The deck-builder/draft call sites
+ * pass `cardName` to <CardPreview> directly; only the in-game preview derives
+ * it from the inspected game object, which is what this component does.
+ */
+export function GameCardPreview() {
+  // Lives here (not in GamePageContent) so its inspectedObjectId/previewSticky
+  // subscriptions don't re-render the whole page on every hover. This component
+  // is always mounted, so the dismiss listeners run for the game's full life.
+  usePreviewDismiss();
+
+  const inspectedObjectId = useUiStore((s) => s.inspectedObjectId);
+  const inspectedFaceIndex = useUiStore((s) => s.inspectedFaceIndex);
+  const isDragging = useUiStore((s) => s.isDragging);
+  const shiftHeld = useUiStore((s) => s.shiftHeld);
+  // Card-preview behavior preference. In "shift" mode the preview only renders
+  // while Shift is held; in "side" mode it docks to the screen edge.
+  const cardPreviewMode = usePreferencesStore((s) => s.cardPreviewMode);
+  const obj = useGameStore((s) =>
+    inspectedObjectId != null ? s.gameState?.objects[inspectedObjectId] ?? null : null,
+  );
+
+  // Suppress the preview while a card is being dragged — the drag ghost is the
+  // visual feedback, and the inspected object would otherwise flash behind it.
+  const inspectedObj = !isDragging ? obj : null;
+
+  // Scryfall lookups must use the front-face name (scryfall-data.json indexes
+  // only front faces). When a permanent has transformed, the engine swaps
+  // obj.name to the back-face name — cardImageLookup recovers the front name
+  // from obj.back_face. See services/cardImageLookup.ts (issue #90).
+  const inspectedLookup = inspectedObj ? cardImageLookup(inspectedObj) : null;
+  const inspectedCardName = inspectedObj && !inspectedObj.face_down
+    ? inspectedFaceIndex === 1 && inspectedObj.back_face
+      ? inspectedObj.back_face.name
+      : inspectedLookup?.name ?? inspectedObj.name
+    : null;
+  // The "other" face: when viewing front, this is back_face; when viewing back, this is the front.
+  const inspectedOtherFaceName = inspectedObj?.back_face && !inspectedObj.face_down
+    ? inspectedFaceIndex === 1 ? inspectedObj.name : inspectedObj.back_face.name
+    : null;
+
+  const previewSuppressed = cardPreviewMode === "shift" && !shiftHeld;
+
+  return (
+    <CardPreview
+      cardName={previewSuppressed ? null : inspectedCardName}
+      backFaceName={previewSuppressed ? null : inspectedOtherFaceName}
+      dockSide={cardPreviewMode === "side"}
+    />
+  );
+}

--- a/client/src/components/card/__tests__/GameCardPreview.test.tsx
+++ b/client/src/components/card/__tests__/GameCardPreview.test.tsx
@@ -1,0 +1,173 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GameObject, GameState } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { GameCardPreview } from "../GameCardPreview.tsx";
+
+// CardPreview renders <img alt={cardName} …>; mocking the image hook lets us
+// assert the forwarded name without loading Scryfall assets. Mirrors the mocks
+// in CardPreview.test.tsx.
+vi.mock("../../../hooks/useCardImage.ts", () => ({
+  useCardImage: () => ({
+    src: "card.png",
+    isLoading: false,
+    isRotated: false,
+    isFlip: false,
+  }),
+}));
+
+vi.mock("../../../hooks/useEngineCardData.ts", () => ({
+  useEngineCardData: () => null,
+  useCardParseDetails: () => null,
+  useCardRulings: () => [],
+}));
+
+function battlefieldObject(overrides: Partial<GameObject> = {}): GameObject {
+  return {
+    id: 101,
+    card_id: 1,
+    owner: 0,
+    controller: 0,
+    zone: "Battlefield",
+    tapped: false,
+    face_down: false,
+    flipped: false,
+    transformed: false,
+    damage_marked: 0,
+    dealt_deathtouch_damage: false,
+    attached_to: null,
+    attachments: [],
+    counters: {},
+    name: "Pithing Needle",
+    power: null,
+    toughness: null,
+    loyalty: null,
+    card_types: { supertypes: [], core_types: ["Artifact"], subtypes: [] },
+    mana_cost: { type: "Cost", shards: [], generic: 1 },
+    keywords: [],
+    abilities: [],
+    trigger_definitions: [],
+    replacement_definitions: [],
+    static_definitions: [],
+    color: [],
+    base_power: null,
+    base_toughness: null,
+    base_keywords: [],
+    base_color: [],
+    timestamp: 1,
+    entered_battlefield_turn: 1,
+    ...overrides,
+  };
+}
+
+function gameStateWithObject(object: GameObject): GameState {
+  return {
+    turn_number: 1,
+    active_player: 0,
+    phase: "PreCombatMain",
+    players: [],
+    priority_player: 0,
+    objects: { [String(object.id)]: object },
+    next_object_id: 102,
+    battlefield: [object.id],
+    stack: [],
+    exile: [],
+    rng_seed: 1,
+    combat: null,
+    waiting_for: { type: "Priority", data: { player: 0 } },
+    has_pending_cast: false,
+    lands_played_this_turn: 0,
+    max_lands_per_turn: 1,
+    priority_pass_count: 0,
+    pending_replacement: null,
+    layers_dirty: false,
+    next_timestamp: 2,
+  } as GameState;
+}
+
+function inspect(object: GameObject, faceIndex = 0): void {
+  useGameStore.setState({ gameState: gameStateWithObject(object), spellCosts: {} });
+  useUiStore.setState({ inspectedObjectId: object.id, inspectedFaceIndex: faceIndex });
+}
+
+afterEach(() => {
+  cleanup();
+  useGameStore.setState({ gameState: null, spellCosts: {} });
+  useUiStore.setState({
+    inspectedObjectId: null,
+    inspectedFaceIndex: 0,
+    isDragging: false,
+    shiftHeld: false,
+    altHeld: false,
+  });
+  // GameCardPreview adds a third store; reset it so "shift" mode doesn't leak.
+  usePreferencesStore.setState({ cardPreviewMode: "follow" });
+});
+
+describe("GameCardPreview", () => {
+  it("forwards the inspected object's name to the preview", () => {
+    inspect(battlefieldObject());
+
+    render(<GameCardPreview />);
+
+    expect(screen.getAllByAltText("Pithing Needle").length).toBeGreaterThan(0);
+  });
+
+  it("renders no preview while a card is being dragged", () => {
+    inspect(battlefieldObject());
+    useUiStore.setState({ isDragging: true });
+
+    const { container } = render(<GameCardPreview />);
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByAltText("Pithing Needle")).toBeNull();
+  });
+
+  it("suppresses the preview in shift mode when Shift is not held", () => {
+    inspect(battlefieldObject());
+    usePreferencesStore.setState({ cardPreviewMode: "shift" });
+    useUiStore.setState({ shiftHeld: false });
+
+    const { container } = render(<GameCardPreview />);
+
+    expect(container.firstChild).toBeNull();
+
+    // Holding Shift reveals it.
+    cleanup();
+    useUiStore.setState({ shiftHeld: true });
+    render(<GameCardPreview />);
+    expect(screen.getAllByAltText("Pithing Needle").length).toBeGreaterThan(0);
+  });
+
+  it("shows the back-face name when inspecting face index 1", () => {
+    const dfc = battlefieldObject({
+      name: "Delver of Secrets",
+      back_face: {
+        name: "Insectile Aberration",
+        power: 3,
+        toughness: 2,
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: ["Human", "Insect"] },
+        mana_cost: { type: "Cost", shards: [], generic: 0 },
+        keywords: ["Flying"],
+        abilities: [],
+        color: ["Blue"],
+      },
+    });
+    inspect(dfc, 1);
+
+    render(<GameCardPreview />);
+
+    expect(screen.getAllByAltText("Insectile Aberration").length).toBeGreaterThan(0);
+  });
+
+  it("never previews a face-down permanent (hidden information)", () => {
+    inspect(battlefieldObject({ face_down: true }));
+
+    const { container } = render(<GameCardPreview />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -255,8 +255,19 @@ export function PlayerHand() {
         setSelectedCardId(null);
       }}
     >
-      <AnimatePresence>
-        {handObjects.map((obj, i) => {
+      {/* The whole hand lifts as one unit on hover. Keeping this uniform -50px
+          lift on a container — rather than baking `expanded` into each card's
+          animate target — lets the memoized HandCards skip re-rendering when the
+          hand expands/collapses. The lift lives on an inner wrapper so the outer
+          container (which owns onMouseLeave) stays put and its collapse hit-area
+          doesn't move under the cursor. */}
+      <motion.div
+        className="flex items-end justify-center"
+        animate={{ y: expanded ? -50 : 0 }}
+        transition={{ duration: 0.25 }}
+      >
+        <AnimatePresence>
+          {handObjects.map((obj, i) => {
           const rotation = getCardRotation(i, handObjects.length);
           const isPlayable = hasPriority && playableObjectIds.has(Number(obj.id));
 
@@ -270,7 +281,6 @@ export function PlayerHand() {
               index={i}
               handSize={handObjects.length}
               rotation={rotation}
-              expanded={expanded}
               isPlayable={isPlayable}
               isSelected={selectedCardId === obj.id}
               hasPriority={hasPriority}
@@ -287,7 +297,8 @@ export function PlayerHand() {
             />
           );
         })}
-      </AnimatePresence>
+        </AnimatePresence>
+      </motion.div>
     </div>
   );
 }
@@ -300,7 +311,6 @@ interface HandCardProps {
   index: number;
   handSize: number;
   rotation: number;
-  expanded: boolean;
   isPlayable: boolean;
   isSelected: boolean;
   isDragging: boolean;
@@ -324,7 +334,6 @@ const HandCard = memo(function HandCard({
   index,
   handSize,
   rotation,
-  expanded,
   isPlayable,
   isSelected,
   isDragging,
@@ -376,11 +385,11 @@ const HandCard = memo(function HandCard({
       initial={{ opacity: 0, y: 40 }}
       animate={{
         opacity: 1,
-        y: (expanded ? -20 : 30) + arcOffset,
+        y: 30 + arcOffset,
         rotate: rotation,
       }}
       exit={{ opacity: 0, scale: 0.8 }}
-      whileHover={{ y: -30 + arcOffset, scale: 1.08, zIndex: 30 }}
+      whileHover={{ y: 20 + arcOffset, scale: 1.08, zIndex: 30 }}
       whileDrag={{ scale: 1.05, zIndex: 9999 }}
       transition={{
         delay: index * 0.03,

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -33,7 +33,7 @@ import { BlockAssignmentLines } from "../components/board/BlockAssignmentLines.t
 import { BlockRequirementBadges } from "../components/combat/BlockRequirementBadges.tsx";
 import { GameBoard } from "../components/board/GameBoard.tsx";
 import { CardImage } from "../components/card/CardImage.tsx";
-import { CardPreview } from "../components/card/CardPreview.tsx";
+import { GameCardPreview } from "../components/card/GameCardPreview.tsx";
 import { ActionButton } from "../components/board/ActionButton.tsx";
 import { FullControlToggle } from "../components/controls/FullControlToggle.tsx";
 import { CombatPhaseIndicator } from "../components/controls/PhaseStopBar.tsx";
@@ -107,7 +107,6 @@ import { MANA_PAYMENT_WAITING_FOR_TYPES } from "../game/waitingForRegistry.ts";
 import { useGameDispatch } from "../hooks/useGameDispatch.ts";
 import { useInspectHoverProps } from "../hooks/useInspectHoverProps.ts";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts.ts";
-import { usePreviewDismiss } from "../hooks/usePreviewDismiss.ts";
 import { clearGame, loadActiveGame, useGameStore } from "../stores/gameStore.ts";
 import { useUiStore } from "../stores/uiStore.ts";
 import { usePreferencesStore } from "../stores/preferencesStore.ts";
@@ -125,7 +124,6 @@ import { useCanActForWaitingState, usePerspectivePlayerId, usePlayerId } from ".
 import { abilityChoiceLabel, formatAbilityCost } from "../viewmodel/costLabel.ts";
 import { getWaitingForObjectChoiceIds } from "../viewmodel/gameStateView.ts";
 import { gameButtonClass } from "../components/ui/buttonStyles.ts";
-import { cardImageLookup } from "../services/cardImageLookup.ts";
 
 type ZoneRailStyle = CSSProperties & {
   "--card-w": string;
@@ -696,7 +694,6 @@ function GamePageContent({
   const dispatch = useGameDispatch();
   const isMobile = useIsMobile();
   const isCompactHeight = useIsCompactHeight();
-  const inspectedObjectId = useUiStore((s) => s.inspectedObjectId);
   const objects = useGameStore((s) => s.gameState?.objects);
   const seatOrder = useGameStore((s) => s.gameState?.seat_order);
   const players = useGameStore((s) => s.gameState?.players);
@@ -762,6 +759,31 @@ function GamePageContent({
   const activeOpponentId =
     focusedOpponent ?? opponents[0] ?? (perspectivePlayerId === 0 ? 1 : 0);
 
+  // Memoize the HUD elements passed to GameBoard. GameBoard is wrapped in
+  // React.memo, which shallow-compares props; without stable element
+  // references these inline JSX nodes would be new on every GamePageContent
+  // render, defeating the memo. Stable refs let GameBoard skip re-rendering
+  // when GamePageContent re-renders for reasons that don't touch these props.
+  const oppHud = useMemo(
+    () => (
+      <OpponentHud
+        opponentName={isOnlineMode ? opponentDisplayName : undefined}
+        onKickPlayer={
+          isP2PHost
+            ? (pid) => {
+                const adapter = useGameStore.getState().adapter as
+                  | { kickPlayer?: (pid: number) => Promise<void> }
+                  | null;
+                void adapter?.kickPlayer?.(pid);
+              }
+            : undefined
+        }
+      />
+    ),
+    [isOnlineMode, opponentDisplayName, isP2PHost],
+  );
+  const playerHud = useMemo(() => <PlayerHud />, []);
+
   useAudioContext("battlefield");
 
   // Update battlefield music phase based on turn progression
@@ -808,35 +830,7 @@ function GamePageContent({
     navigate("/");
   }, [isOnlineMode, gameId, handleConcede, navigate]);
 
-  const isDragging = useUiStore((s) => s.isDragging);
-  const inspectedFaceIndex = useUiStore((s) => s.inspectedFaceIndex);
-  // Card-preview behavior preference (item: hover preview side/Shift). In
-  // "shift" mode the preview only renders while Shift is held; in "side" mode
-  // it docks to the screen edge instead of following the cursor.
-  const cardPreviewMode = usePreferencesStore((s) => s.cardPreviewMode);
-  const shiftHeld = useUiStore((s) => s.shiftHeld);
-  const previewSuppressed = cardPreviewMode === "shift" && !shiftHeld;
-  const inspectedObj =
-    !isDragging && inspectedObjectId != null && objects
-      ? (objects[inspectedObjectId] ?? null)
-      : null;
-  // Scryfall lookups must use the front-face name (scryfall-data.json indexes
-  // only front faces). When a permanent has transformed, the engine swaps
-  // obj.name to the back-face name — cardImageLookup recovers the front name
-  // from obj.back_face. See services/cardImageLookup.ts (issue #90).
-  const inspectedLookup = inspectedObj ? cardImageLookup(inspectedObj) : null;
-  const inspectedCardName = inspectedObj && !inspectedObj.face_down
-    ? inspectedFaceIndex === 1 && inspectedObj.back_face
-      ? inspectedObj.back_face.name
-      : inspectedLookup?.name ?? inspectedObj.name
-    : null;
-  // The "other" face: when viewing front, this is back_face; when viewing back, this is the front
-  const inspectedOtherFaceName = inspectedObj?.back_face && !inspectedObj.face_down
-    ? inspectedFaceIndex === 1 ? inspectedObj.name : inspectedObj.back_face.name
-    : null;
-
   useKeyboardShortcuts();
-  usePreviewDismiss();
 
   // Toggle debug layout bounds with Ctrl+Shift+D
   useEffect(() => {
@@ -1101,24 +1095,7 @@ function GamePageContent({
 
         {/* Row 2: Battlefield — takes remaining space; HUDs passed inline to PlayerAreas */}
         <div className="relative z-30 flex min-h-0 min-w-0 flex-col">
-          <GameBoard
-            oppHud={
-              <OpponentHud
-                opponentName={isOnlineMode ? opponentDisplayName : undefined}
-                onKickPlayer={
-                  isP2PHost
-                    ? (pid) => {
-                        const adapter = useGameStore.getState().adapter as
-                          | { kickPlayer?: (pid: number) => Promise<void> }
-                          | null;
-                        void adapter?.kickPlayer?.(pid);
-                      }
-                    : undefined
-                }
-              />
-            }
-            playerHud={<PlayerHud />}
-          />
+          <GameBoard oppHud={oppHud} playerHud={playerHud} />
         </div>
 
         {/* Row 3: Player hand + zones */}
@@ -1363,12 +1340,9 @@ function GamePageContent({
           to attackers that carry a minimum-blocker requirement. */}
       <BlockRequirementBadges />
 
-      {/* Card preview overlay */}
-      <CardPreview
-        cardName={previewSuppressed ? null : inspectedCardName}
-        backFaceName={previewSuppressed ? null : inspectedOtherFaceName}
-        dockSide={cardPreviewMode === "side"}
-      />
+      {/* Card preview overlay. Owns its own inspect-state subscriptions so a
+          hover doesn't re-render GamePageContent (and the whole battlefield). */}
+      <GameCardPreview />
 
       {/* WaitingFor-driven prompt overlays (only for human player).
           Wrapped in DialogHost so any active dialog can be peeked away to


### PR DESCRIPTION
Hovering a card re-rendered GamePageContent and cascaded into the entire
board plus all Framer Motion layout machinery (~206 fibers/commit, profiled).
Root cause was the same bug at four altitudes: components subscribing to a
broad, hover-frequency value when they only needed a narrow derived slice.

- GameCardPreview: new leaf that owns the inspectedObjectId/faceIndex/
  isDragging/shiftHeld subscriptions, the preview-name derivation, and
  usePreviewDismiss(). GamePageContent no longer subscribes to any hover
  state, so it (and the board) stop re-rendering on hover.
- GamePage: drop the inspect subscriptions/derivation and page-level
  usePreviewDismiss; useMemo the oppHud/playerHud elements so memo(GameBoard)
  can actually bail out.
- GameBoard: wrap in React.memo (defense-in-depth with the memoized props).
- PlayerHand: move the uniform hand-lift to an inner container motion.div
  and drop the `expanded` prop from HandCard, so the memoized cards skip
  re-rendering when the hand expands/collapses.
- PermanentCard: subscribe to derived booleans (isHovered,
  isInHoveredAttachmentTree) instead of the raw hoveredObjectId, so hovering
  one permanent re-renders only the entering/leaving card (O(1), not O(N)
  across the board).

Profiled before/after: hover commits drop from ~236 fibers (whole board)
to ~18 (preview leaf only); GamePageContent/GameBoard no longer appear in
hover commits at all.
