### PR TITLE
feat(parser): animate land populations into creatures via continuous static

### DIFF
--- a/crates/engine/src/parser/oracle_effect/animation.rs
+++ b/crates/engine/src/parser/oracle_effect/animation.rs
@@ -414,6 +414,11 @@ fn parse_animation_core_type(input: &str) -> OracleResult<'_, AnimationTypeToken
         value("Planeswalker", tag_no_case("planeswalker")),
     ))
     .parse(input)?;
+    // CR 205.2a: accept an optional plural "s" so a plural-subject animation
+    // ("All lands are 1/1 creatures that are still lands") recognizes the same
+    // core type as the singular "becomes a creature" form. The trailing word
+    // boundary still rejects longer words ("landwalk", "creatured").
+    let (rest, _) = opt(tag_no_case::<_, _, OracleError<'_>>("s")).parse(rest)?;
     let (rest, _) = alpha_word_boundary(rest)?;
     Ok((rest, AnimationTypeToken::CoreType(core)))
 }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -709,6 +709,15 @@ pub(crate) fn parse_static_line_inner(
         }
     }
 
+    // CR 613.1d + CR 613.4b: "[Subject] lands are [P/T] creatures that are still
+    // lands" — continuous land animation (Living Plane, Nature's Revolt). Must
+    // come before parse_land_type_change: both split on "are", but the land
+    // animation form carries a creature descriptor the type-change parser can't
+    // claim. The "creature" guard lets land *type* lines fall through.
+    if let Some(def) = parse_land_animation(&tp, &text) {
+        return Some(def);
+    }
+
     // CR 305.7: "[Subject] lands are [type]" — land type-changing statics.
     // Must come before parse_subject_continuous_static (which splits on "gets/has/gains"
     // verbs and would not match "are" predicates).

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -815,6 +815,13 @@ pub(crate) fn parse_type_retention_clause(input: &str) -> OracleResult<'_, CoreT
     let (input, is_plural) = alt((
         value(false, alt((tag("it's still "), tag("that's still ")))),
         value(true, tag("they're still ")),
+        // CR 205.1b: relative-clause retention attached to a plural/singular
+        // subject — "[plural] that are still lands", "[singular] that is still
+        // a land". Distinct from the standalone-sentence forms above so the
+        // animation building block can keep land/artifact types when the
+        // retention rides on the same clause rather than a new sentence.
+        value(true, tag("that are still ")),
+        value(false, tag("that is still ")),
     ))
     .parse(input)?;
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -7277,6 +7277,81 @@ fn each_land_is_a_swamp_in_addition_urborg() {
 }
 
 #[test]
+fn all_lands_are_creatures_living_plane() {
+    use crate::types::card_type::CoreType;
+
+    // CR 613.1d + CR 613.4b + CR 205.1b: Living Plane / Nature's Revolt —
+    // a continuous static animating every land into a creature while it stays
+    // a land. P/T is set (Layer 7b), the creature type is added (Layer 4), and
+    // the land type is retained (additive types, confirmed by "that are still
+    // lands").
+    let def = parse_static_line("All lands are 1/1 creatures that are still lands.").unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    let mods = &def.modifications;
+    assert!(
+        mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddType { core_type } if *core_type == CoreType::Creature
+        )),
+        "must add the Creature type (Layer 4): {mods:?}"
+    );
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::SetPower { value } if *value == 1)),
+        "must set power to 1 (Layer 7b): {mods:?}"
+    );
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::SetToughness { value } if *value == 1)),
+        "must set toughness to 1 (Layer 7b): {mods:?}"
+    );
+    // No SetBasicLandType / type replacement — the land keeps its land type.
+    assert!(
+        !mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::SetBasicLandType { .. }
+                | ContinuousModification::SetCardTypes { .. }
+        )),
+        "must not replace types (CR 205.1b retention): {mods:?}"
+    );
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(tf.type_filters.contains(&TypeFilter::Land));
+            assert!(tf.controller.is_none(), "all lands — no controller scope");
+        }
+        _ => panic!("Expected Typed land filter (all lands)"),
+    }
+}
+
+#[test]
+fn lands_you_control_are_creatures_scope_and_pt() {
+    use crate::types::card_type::CoreType;
+
+    // Same building block, controller-scoped subject + a different P/T proves
+    // the animation spec (not a hardcoded 1/1) drives the result.
+    let def =
+        parse_static_line("Lands you control are 2/2 creatures that are still lands.").unwrap();
+    let mods = &def.modifications;
+    assert!(mods.iter().any(|m| matches!(
+        m,
+        ContinuousModification::AddType { core_type } if *core_type == CoreType::Creature
+    )));
+    assert!(mods
+        .iter()
+        .any(|m| matches!(m, ContinuousModification::SetPower { value } if *value == 2)));
+    assert!(mods
+        .iter()
+        .any(|m| matches!(m, ContinuousModification::SetToughness { value } if *value == 2)));
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(tf.type_filters.contains(&TypeFilter::Land));
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+        }
+        _ => panic!("Expected Typed land filter scoped to you"),
+    }
+}
+
+#[test]
 fn all_lands_are_islands_in_addition_stormtide() {
     let def = parse_static_line("All lands are Islands in addition to their other types.").unwrap();
     assert_eq!(

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1206,6 +1206,63 @@ pub(crate) fn parse_land_type_change(tp: &TextPair<'_>, text: &str) -> Option<St
     None
 }
 
+/// CR 613.1d (Layer 4) + CR 613.4b (Layer 7b) + CR 205.1b: Parse a continuous
+/// static that animates a population of lands into creatures while they remain
+/// lands — "All lands are 1/1 creatures that are still lands" (Living Plane,
+/// Nature's Revolt), "Lands you control are X/X creatures that are still lands".
+///
+/// The land subject is shared with [`parse_land_type_change`]; the
+/// "[P/T] creature[s] ..." remainder is delegated to the animation building
+/// block (`parse_animation_spec` + `animation_modifications`), so power/
+/// toughness (Layer 7b), color, keyword, and creature-subtype grants all
+/// compose for free. `animation_modifications` adds the creature type
+/// additively (CR 613.1d), and card types stay additive, so the land keeps its
+/// land type — the "that are still lands" tail (CR 205.1b) merely confirms that
+/// reading and is consumed by `split_type_retention_clause`.
+///
+/// Dispatched before `parse_land_type_change`; the `"creature"` guard makes
+/// land *type* lines ("Lands you control are Plains") fall through unclaimed.
+pub(crate) fn parse_land_animation(tp: &TextPair<'_>, text: &str) -> Option<StaticDefinition> {
+    let (subject_tp, rest_tp) = tp
+        .split_around(" are ")
+        .or_else(|| tp.split_around(" is a "))
+        .or_else(|| tp.split_around(" is an "))?;
+    let affected = parse_land_type_change_subject(subject_tp.original)?;
+
+    let rest = rest_tp.original.trim().trim_end_matches('.');
+    let lower_rest = rest.to_lowercase();
+    // Only claim creature-animation remainders so land type-change lines
+    // ("Lands you control are Plains") fall through to parse_land_type_change.
+    if !nom_primitives::scan_contains(&lower_rest, "creature") {
+        return None;
+    }
+
+    // CR 205.1b: strip the "that are still land(s)" / "that's still a land"
+    // retention tail. The creature type is added additively, so retention is
+    // the default behavior; the clause is confirmatory. Split on the lowercased
+    // text and reuse the byte offset on the original to preserve subtype casing.
+    let animation_text = match super::grammar::split_type_retention_clause(&lower_rest) {
+        Some((descriptor_lower, _retained)) => &rest[..descriptor_lower.len()],
+        None => rest,
+    }
+    .trim();
+
+    let spec = super::oracle_effect::animation::parse_animation_spec(
+        animation_text,
+        &mut ParseContext::default(),
+    )?;
+    let modifications = super::oracle_effect::animation::animation_modifications(&spec);
+    if modifications.is_empty() {
+        return None;
+    }
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(modifications)
+            .description(text.to_string()),
+    )
+}
+
 /// Parse the subject of a land type-change line into a TargetFilter.
 pub(crate) fn parse_land_type_change_subject(subject: &str) -> Option<TargetFilter> {
     match subject.to_lowercase().as_str() {


### PR DESCRIPTION
## Problem

Continuous statics that animate a *population* of lands into creatures parsed to an `Unimplemented` effect:

- **Living Plane** / **Nature's Revolt** — `All lands are 1/1 creatures that are still lands.`
- controller-scoped form — `Lands you control are X/X creatures that are still lands.`

The engine already animates individual lands ("becomes a creature" — Nissa, etc.) and already type-changes land populations (`Lands you control are Plains`), but the **continuous land→creature animation** had no parser route.

## Fix

`parse_land_animation` is a parser-routing addition that composes three existing building blocks — no new resolver/effect machinery:

- `parse_land_type_change_subject` → the land population filter (`All lands`, `Lands you control`)
- the animation spec (`parse_animation_spec` + `animation_modifications`) → P/T, color, keyword, and creature-subtype grants
- `split_type_retention_clause` → consumes the `that are still lands` tail

The resulting `StaticDefinition::continuous()` carries `SetPower`/`SetToughness` (Layer 7b) + `AddType{Creature}` (Layer 4) over the land filter, so the existing layer resolver applies it. Dispatched before `parse_land_type_change` with a `"creature"` guard, so land *type* lines (`Lands you control are Plains`) fall through unchanged.

### Two shared combinators extended (so the whole class composes)

1. **`parse_animation_core_type`** now accepts an optional plural `s`. Animation descriptors are singular for "becomes a creature" but **plural** for "[plural subject] are creatures"; the word-boundary guard previously rejected the trailing `s`, dropping the creature type. The boundary still rejects longer words (`landwalk`, `creatured`).
2. **`parse_type_retention_clause`** now recognizes the relative-clause forms `that are still` / `that is still`, in addition to the standalone-sentence `it's/that's/they're still`. Retention riding on the same clause is now consumed everywhere.

## Rules

- **CR 613.1d** — Layer 4 type-changing (adds the creature type).
- **CR 613.4b** — Layer 7b, effects that set power/toughness to a specific value.
- **CR 205.1b** — an object that "becomes a creature … still a land" retains its land type (card types stay additive).

All three verified against `docs/MagicCompRules.txt`.

## Tests

- `all_lands_are_creatures_living_plane` — `SetPower{1}` + `SetToughness{1}` (7b) + `AddType{Creature}` (4), all-lands filter, **no** type replacement (205.1b retention).
- `lands_you_control_are_creatures_scope_and_pt` — controller-scoped subject + a 2/2 proves the animation spec (not a hardcoded 1/1) drives the result.

## Verification

- `scripts/check-parser-combinators.sh` — pass
- `cargo fmt --all --check` — clean
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- Regression: `animation` (22), `land_type` (30), `still_a`, `type_retention`, `all_lands`, `lands_you`, `becomes` (89) — all pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)