### PR TITLE
fix: affinity for daleks applies no cost reduction

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -18288,6 +18288,70 @@ mod tests {
         );
     }
 
+    #[test]
+    fn affinity_for_daleks_reduces_dalek_emperor_generic_cost() {
+        let mut state = setup_game_at_main_phase();
+        let emperor_id = create_object(
+            &mut state,
+            CardId(2184),
+            PlayerId(0),
+            "The Dalek Emperor".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&emperor_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.supertypes.push(Supertype::Legendary);
+            obj.card_types.subtypes.push("Dalek".to_string());
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Black, ManaCostShard::Red],
+                generic: 5,
+            };
+            obj.keywords
+                .push("Affinity for Daleks".parse::<Keyword>().unwrap());
+        }
+
+        for i in 0u64..4 {
+            let id = create_object(
+                &mut state,
+                CardId(2200 + i),
+                PlayerId(0),
+                format!("Dalek Token {i}"),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Dalek".to_string());
+        }
+        let opponent_dalek = create_object(
+            &mut state,
+            CardId(2300),
+            PlayerId(1),
+            "Opponent Dalek".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&opponent_dalek).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Dalek".to_string());
+        }
+
+        let cost = effective_spell_cost(&state, PlayerId(0), emperor_id)
+            .expect("Dalek Emperor cost should compute");
+        let ManaCost::Cost { generic, shards } = cost else {
+            panic!("expected mana cost");
+        };
+        assert_eq!(generic, 1, "four controlled Daleks reduce {{5}} to {{1}}");
+        assert_eq!(
+            shards,
+            vec![ManaCostShard::Black, ManaCostShard::Red],
+            "Affinity only reduces generic mana"
+        );
+    }
+
     // Witherbloom, the Balancer's second clause: "Instant and sorcery spells you cast
     // have affinity for creatures." This is a static ability that functions while
     // Witherbloom is on the battlefield. When the player casts an instant or sorcery,

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1257,8 +1257,8 @@ fn parse_keyword_mana_cost(s: &str) -> ManaCost {
     ManaCost::Cost { shards, generic }
 }
 
-/// CR 702.41a: Parse the type text from "Affinity for [type]" into a TypedFilter.
-/// Handles common affinity patterns: "artifacts", "Plains", "creatures", etc.
+/// CR 702.41a: Parse the text from "Affinity for [text]" into the permanents
+/// counted for the cost reduction.
 fn parse_affinity_type(s: &str) -> Option<TypedFilter> {
     use super::ability::TypeFilter;
     // MTGJSON provides "Affinity for artifacts" — FromStr splits on first ':' giving
@@ -1275,16 +1275,20 @@ fn parse_affinity_type(s: &str) -> Option<TypedFilter> {
             Some(TypedFilter::new(TypeFilter::Artifact).subtype("Equipment".to_string()))
         }
         _ => {
-            // Try as a land subtype (Plains, Islands, etc.)
+            // CR 702.41a + CR 205.3: "Affinity for [text]" counts permanents
+            // matching the text. Unknown names are subtypes, but not always
+            // land subtypes ("Daleks", "Cats", "Birds"). Keep this as a bare
+            // subtype constraint so it covers land, artifact, enchantment, and
+            // creature subtype affinity without adding a false type conjunct.
             let capitalized = format!("{}{}", &s[..1].to_uppercase(), &s[1..]);
-            // Strip trailing 's' for plural land subtypes (e.g., "Plains" stays "Plains",
-            // but "Islands" → "Island", "Swamps" → "Swamp")
+            // Strip trailing 's' for plural subtype words (e.g., "Daleks" →
+            // "Dalek", "Islands" → "Island"; "Plains" stays "Plains").
             let subtype = if capitalized.ends_with('s') && capitalized != "Plains" {
                 capitalized[..capitalized.len() - 1].to_string()
             } else {
                 capitalized
             };
-            Some(TypedFilter::land().subtype(subtype))
+            Some(TypedFilter::default().subtype(subtype))
         }
     }
 }
@@ -2705,6 +2709,29 @@ mod tests {
 
         let equip = Keyword::from_str("Equip:3").unwrap();
         assert!(matches!(equip, Keyword::Equip(ManaCost::Cost { .. })));
+    }
+
+    #[test]
+    fn parse_affinity_for_arbitrary_subtype_without_land_constraint() {
+        let daleks = Keyword::from_str("Affinity for Daleks").unwrap();
+        let Keyword::Affinity(dalek_filter) = daleks else {
+            panic!("expected Affinity keyword");
+        };
+        assert_eq!(
+            dalek_filter.type_filters,
+            vec![TypeFilter::Subtype("Dalek".to_string())],
+            "CR 702.41a: arbitrary subtype affinity must not add a false Land constraint"
+        );
+
+        let islands = Keyword::from_str("Affinity for Islands").unwrap();
+        let Keyword::Affinity(island_filter) = islands else {
+            panic!("expected Affinity keyword");
+        };
+        assert_eq!(
+            island_filter.type_filters,
+            vec![TypeFilter::Subtype("Island".to_string())],
+            "land subtype affinity still matches by subtype without requiring an explicit Land conjunct"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixed `Affinity for Daleks` so The Dalek Emperor correctly reduces its generic mana cost for each Dalek controlled by the caster.

Previously, the Affinity parser treated unknown affinity subtype text as a land subtype. This caused `Affinity for Daleks` to parse as `Land + Subtype(Dalek)`, which never matched Dalek artifact creatures. The parser now emits a bare subtype filter for arbitrary affinity subtype text.
## Related Issue
Closes: #2184
## Change Type

- [x] Bug fix
- [x] Engine/rules behavior
- [x] Parser fix
- [x] Test coverage
- [ ] UI change
- [ ] Documentation-only change
- [ ] Refactor-only change

## Real Behavior Proof

Focused regression tests passed:
```bash
CARGO_TARGET_DIR=/tmp/phase-affinity-target cargo test -p engine affinity_for_daleks_reduces_dalek_emperor_generic_cost --lib -- --nocapture
CARGO_TARGET_DIR=/tmp/phase-affinity-target cargo test -p engine parse_affinity_for_arbitrary_subtype_without_land_constraint --lib -- --nocapture
```

Broader Affinity test coverage passed:

```bash
CARGO_TARGET_DIR=/tmp/phase-affinity-target cargo test -p engine affinity --lib -- --nocapture
```

Result:

```text
running 9 tests
test game::casting::tests::affinity_for_daleks_reduces_dalek_emperor_generic_cost ... ok
test types::keywords::tests::parse_affinity_for_arbitrary_subtype_without_land_constraint ... ok
test game::casting::tests::affinity_for_creatures_on_commander_in_command_zone_reduces_generic ... ok
test game::casting::tests::witherbloom_grants_affinity_to_instant_and_sorcery_spells ... ok
test ai_support::tests::spell_costs_apply_granted_affinity_from_battlefield_static ... ok
test ai_support::tests::spell_costs_include_commander_affinity_reduction_without_castability ... ok
test parser::oracle_static::tests::static_instant_and_sorcery_spells_have_affinity_for_creatures ... ok
test parser::oracle_effect::tests::parse_next_spell_has_affinity ... ok
test game::casting::tests::x_cost_max_accounts_for_granted_affinity_exceeding_fixed_generic ... ok

test result: ok. 9 passed; 0 failed
```

Additional validation:

```bash
cargo fmt --all
CARGO_TARGET_DIR=/tmp/phase-affinity-target cargo check -p engine --lib
git diff --check
```

All passed.

## Checklist

- [x] Reviewed issue `#2184`.
- [x] Verified CR reference for Affinity: `CR 702.41a`.
- [x] Identified parser root cause.
- [x] Fixed arbitrary subtype Affinity parsing.
- [x] Preserved existing explicit Affinity forms such as artifacts, creatures, lands, tokens, and equipment.
- [x] Added parser regression test.
- [x] Added runtime cost-reduction regression test.
- [x] Ran focused tests.
- [x] Ran broader Affinity tests.
- [x] Ran engine compile check.
- [x] Ran formatter.
- [x] Ran whitespace diff check.