### PR TITLE
Fix multi-core-type disjunction dropping conjoined types

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -5239,6 +5239,95 @@ mod tests {
         }
     }
 
+    /// CR 205.2a + CR 701.17c + CR 608.2c: Szarekh, the Silent King (#1537).
+    /// "Mill three cards. You may put an artifact creature card or Vehicle card
+    /// from among the cards milled this way into your hand." The disjunction
+    /// "artifact creature card or Vehicle card" must parse into a
+    /// `TrackedSetFiltered` whose inner filter ANDs `Artifact` with `Creature`
+    /// on the left branch — dropping the trailing `Creature` would let any
+    /// milled artifact (e.g. an Equipment, an artifact land) be moved to hand.
+    ///
+    /// End-to-end guard: the building-block fix lives in
+    /// `parse_type_phrase_with_ctx` (`oracle_target.rs`); this test pins the
+    /// full Oracle-text → typed-AST contract for the milled-card retrieval
+    /// path so future refactors to the dig-from-among lowering can't silently
+    /// regress the AND-of-types semantics.
+    #[test]
+    fn szarekh_mill_artifact_creature_or_vehicle_filter() {
+        use super::super::parse_effect_chain;
+        use crate::types::ability::{TypeFilter, TypedFilter};
+
+        let def = parse_effect_chain(
+            "Mill three cards. You may put an artifact creature card or Vehicle card from among the cards milled this way into your hand.",
+            AbilityKind::Spell,
+        );
+
+        let mut effects: Vec<&AbilityDefinition> = Vec::new();
+        let mut node = Some(&def);
+        while let Some(d) = node {
+            effects.push(d);
+            node = d.sub_ability.as_deref();
+        }
+        assert!(
+            matches!(&*effects[0].effect, Effect::Mill { .. }),
+            "first effect should be Mill, got {:?}",
+            effects[0].effect
+        );
+        let Effect::ChangeZone {
+            destination,
+            target,
+            up_to,
+            ..
+        } = &*effects[1].effect
+        else {
+            panic!("expected ChangeZone retrieval, got {:?}", effects[1].effect);
+        };
+        assert_eq!(*destination, Zone::Hand);
+        assert!(*up_to, "\"you may put\" → up_to (optional)");
+        let TargetFilter::TrackedSetFiltered { id, filter } = target else {
+            panic!("expected TrackedSetFiltered target, got {target:?}");
+        };
+        assert_eq!(id.0, 0, "sentinel TrackedSetId(0)");
+        let TargetFilter::Or { filters } = filter.as_ref() else {
+            panic!("expected Or filter for milled set, got {filter:?}");
+        };
+        assert_eq!(filters.len(), 2, "expected two disjuncts, got {filters:?}");
+
+        // Left: artifact creature card → Typed must contain BOTH Artifact and Creature.
+        let TargetFilter::Typed(left) = &filters[0] else {
+            panic!("expected left Typed, got {:?}", filters[0]);
+        };
+        assert!(
+            left.type_filters.contains(&TypeFilter::Artifact),
+            "left branch missing Artifact: {left:?}",
+        );
+        assert!(
+            left.type_filters.contains(&TypeFilter::Creature),
+            "left branch missing Creature — Szarekh regression (#1537): {left:?}",
+        );
+
+        // Right: Vehicle card → subtype Vehicle (inferred core type may also
+        // be added by normalization; only the subtype is load-bearing).
+        let TargetFilter::Typed(right) = &filters[1] else {
+            panic!("expected right Typed, got {:?}", filters[1]);
+        };
+        assert!(
+            right
+                .type_filters
+                .contains(&TypeFilter::Subtype("Vehicle".into())),
+            "right branch missing Vehicle subtype: {right:?}",
+        );
+
+        // Sanity: the left branch is strictly stricter than `Typed{Artifact}`.
+        // Construct the buggy filter and confirm we don't match it.
+        let buggy_left = TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact));
+        assert_ne!(
+            &filters[0], &buggy_left,
+            "left branch parsed to the buggy filter shape (just Artifact) — \
+             this is the exact #1537 regression",
+        );
+    }
+
     /// CR 708.2a + CR 205.1a: `parse_theyre_face_down_profile` building-block
     /// tests — Cyberman and a non-Cyberman sibling form must parse from parts.
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1717,11 +1717,32 @@ pub fn parse_type_phrase_with_ctx<'a>(
             if starts_with_type_word(after_trimmed) {
                 let sep_text = &text[pos + rest_offset + separator.len()..];
                 let (other_filter, final_rest) = parse_type_phrase_with_ctx(sep_text, ctx);
+                // CR 205.2a: The left branch of a type disjunction must retain
+                // every type word that bound to it before the connector — the
+                // primary core type (`card_type`), the trailing core types from
+                // adjective-conjunction ("artifact creature" → `Creature` in
+                // `extra_core_type_filters`), any adjective subtype unions
+                // ("outlaw" → `AnyOf(...)` in `adjective_type_filters`), and the
+                // negated types collected via the `non-` scan. Dropping any of
+                // these on the floor would collapse a multi-type conjunction
+                // (AND of `type_filters`, per `game/filter.rs`) into a strictly
+                // looser filter, e.g. parsing "artifact creature card or
+                // Vehicle card" to `Or[Typed{Artifact}, Typed{Vehicle}]` —
+                // which would match any artifact, not only artifact creatures
+                // (#1537, Szarekh, the Silent King).
+                let mut left_extras = Vec::with_capacity(
+                    adjective_type_filters.len()
+                        + extra_core_type_filters.len()
+                        + neg_type_filters.len(),
+                );
+                left_extras.extend(adjective_type_filters.iter().cloned());
+                left_extras.extend(extra_core_type_filters.iter().cloned());
+                left_extras.extend(neg_type_filters.iter().cloned());
                 let left = typed(
                     card_type.unwrap_or(TypeFilter::Any),
                     subtype,
                     properties.clone(),
-                    neg_type_filters.clone(),
+                    left_extras,
                 );
                 let combined = merge_or_filters(left, other_filter);
                 let combined = distribute_shared_properties(combined, &properties);
@@ -5584,6 +5605,87 @@ mod tests {
             }
             _ => panic!("Expected Or filter, got {:?}", f),
         }
+    }
+
+    /// CR 205.2a + CR 205.3a + CR 301.7: A multi-core-type adjective
+    /// conjunction ("artifact creature card") on the left side of an `or` /
+    /// `and/or` disjunction must keep every core type word that bound to that
+    /// branch — the primary `card_type` AND the trailing core types in
+    /// `extra_core_type_filters`. Dropping the trailing types collapses the
+    /// left branch's AND-constraint into a strictly looser filter (any
+    /// artifact, not only artifact creatures).
+    ///
+    /// Issue #1537 (Szarekh, the Silent King): Oracle text
+    /// "artifact creature card or Vehicle card" was parsing to
+    /// `Or[Typed{Artifact}, Typed{Subtype(Vehicle)}]`, letting `Mill 3`
+    /// retrieval pull any milled artifact (e.g. an Equipment) into hand
+    /// instead of restricting to artifact creatures or Vehicles.
+    ///
+    /// This is a building-block test: any `<typeword1> <typeword2> card or
+    /// <typeword> card` shape must preserve the full type conjunction on the
+    /// left branch.
+    #[test]
+    fn multi_core_type_disjunction_preserves_conjoined_types() {
+        let (f, rest) = parse_target("artifact creature card or Vehicle card");
+        assert_eq!(rest, "");
+        let TargetFilter::Or { filters } = &f else {
+            panic!("expected Or disjunction, got {f:?}");
+        };
+        assert_eq!(filters.len(), 2, "expected two disjuncts, got {filters:?}");
+
+        // Left branch: "artifact creature card" must AND Artifact with
+        // Creature — both type filters must be present so the runtime
+        // `type_filters.iter().all(...)` check rejects artifacts that
+        // aren't also creatures (e.g. Equipment, artifact lands).
+        let TargetFilter::Typed(left) = &filters[0] else {
+            panic!("expected left Typed, got {:?}", filters[0]);
+        };
+        assert!(
+            has_type(left, TypeFilter::Artifact),
+            "left branch missing Artifact: {left:?}",
+        );
+        assert!(
+            has_type(left, TypeFilter::Creature),
+            "left branch dropped the trailing Creature core type — \
+             this is the #1537 regression: {left:?}",
+        );
+
+        // Right branch: "Vehicle card" — Vehicle is a creature subtype, so
+        // `normalize_search_typed_filter` (and the bare subtype path in
+        // `parse_specialized_type_word`) lift it onto Creature. We only
+        // assert that the Vehicle subtype is present; the inferred core
+        // type may or may not be Creature depending on the parse path.
+        let TargetFilter::Typed(right) = &filters[1] else {
+            panic!("expected right Typed, got {:?}", filters[1]);
+        };
+        assert!(
+            has_type(right, TypeFilter::Subtype("Vehicle".into())),
+            "right branch missing Vehicle subtype: {right:?}",
+        );
+    }
+
+    /// Companion case to `multi_core_type_disjunction_preserves_conjoined_types`:
+    /// the right branch can also carry a multi-type adjective conjunction.
+    /// Both branches must independently retain their full type set.
+    #[test]
+    fn multi_core_type_disjunction_preserves_both_branches() {
+        let (f, _) = parse_target("creature card or artifact creature card");
+        let TargetFilter::Or { filters } = &f else {
+            panic!("expected Or disjunction, got {f:?}");
+        };
+        assert_eq!(filters.len(), 2);
+        let TargetFilter::Typed(left) = &filters[0] else {
+            panic!("expected left Typed");
+        };
+        assert!(has_type(left, TypeFilter::Creature));
+        let TargetFilter::Typed(right) = &filters[1] else {
+            panic!("expected right Typed");
+        };
+        assert!(has_type(right, TypeFilter::Artifact));
+        assert!(
+            has_type(right, TypeFilter::Creature),
+            "right branch dropped the trailing Creature core type: {right:?}",
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1730,14 +1730,15 @@ pub fn parse_type_phrase_with_ctx<'a>(
                 // Vehicle card" to `Or[Typed{Artifact}, Typed{Vehicle}]` —
                 // which would match any artifact, not only artifact creatures
                 // (#1537, Szarekh, the Silent King).
-                let mut left_extras = Vec::with_capacity(
-                    adjective_type_filters.len()
-                        + extra_core_type_filters.len()
-                        + neg_type_filters.len(),
-                );
-                left_extras.extend(adjective_type_filters.iter().cloned());
-                left_extras.extend(extra_core_type_filters.iter().cloned());
-                left_extras.extend(neg_type_filters.iter().cloned());
+                // This branch `return`s immediately below, so the three
+                // accumulators are never read again — drain them into
+                // `left_extras` instead of cloning. `std::mem::take` (rather
+                // than a plain move) keeps the borrow checker happy inside the
+                // `for separator` loop, and `append` reuses each backing
+                // allocation rather than heap-cloning every `TypeFilter`.
+                let mut left_extras = std::mem::take(&mut adjective_type_filters);
+                left_extras.append(&mut extra_core_type_filters);
+                left_extras.append(&mut neg_type_filters);
                 let left = typed(
                     card_type.unwrap_or(TypeFilter::Any),
                     subtype,


### PR DESCRIPTION
## Summary
Fixes Szarekh, the Silent King (#1537). The card's milled-card retrieval ("artifact creature card or Vehicle card") parsed to `Or[Typed{[Artifact]}, Typed{[Subtype(Vehicle)]}]`, dropping the trailing `Creature` core type from the left disjunct. Because `game/filter.rs` ANDs `type_filters` via `.all(...)`, the left branch matched any milled artifact (Equipment, artifact lands), not just artifact creatures. Class-level fix in `parse_type_phrase_with_ctx`: build `left_extras = adjective_type_filters ++ extra_core_type_filters ++ neg_type_filters`, mirroring the non-disjunction terminal path. Result is now `Or[Typed{[Artifact, Creature]}, Typed{[Subtype(Vehicle)]}]`, repairing the whole grammar class `<core1> <core2> [card] or <coreX> [card]`.

## Files changed
- crates/engine/src/parser/oracle_target.rs
- crates/engine/src/parser/oracle_effect/sequence.rs

## CR references
- CR 205.2a — card types
- CR 205.3a — subtypes
- CR 301.7 — Vehicle artifact subtype
- CR 701.17c — Mill
- CR 608.2c — effect resolution

## Track
Developer

## Tier
Frontier

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all -- --check` — clean
- Parser combinator gate — clean
- `cargo clippy -D warnings` — clean
- Full `parser::` suite — 4938/4938 passing, including 3 new tests:
  - `multi_core_type_disjunction_preserves_conjoined_types`
  - `multi_core_type_disjunction_preserves_both_branches`
  - `szarekh_mill_artifact_creature_or_vehicle_filter`
- Pipeline review: doc-guardian CLEAN; code-reviewer APPROVE WITH SUGGESTIONS (RULES BUG CR 305.7→301.7 fixed in-PR); qa-tester READY FOR PR.

Non-blocking follow-ups (not in this PR): optional `adjective_type_filters`-axis test; optional `typed(...)` Vec-ordering unification.

Closes #1537.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.