### PR TITLE
fix(frontend): anchor combat damage assignment modal above board (z-index)

### DIFF
--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -12,11 +12,18 @@ import { DialogPeekCtx, type DialogPeekContext } from "./dialogPeekContext.ts";
 // `WaitingFor` variants that do NOT render a centered dialog/overlay.
 // Board-level interactions (Priority, combat declarations) and pre-game
 // flows render inline on the board rather than as a centered modal.
+//
+// NOTE: combat damage *assignment* (`AssignCombatDamage` / `AssignBlockerDamage`)
+// is deliberately ABSENT — unlike attacker/blocker declaration, it renders a
+// centered `ChoiceOverlay` modal (via `CardChoiceModal` → `DamageAssignmentModal`).
+// Listing it here would leave the host un-anchored (`className=""`), so the
+// modal's `fixed inset-0 z-50` would be trapped inside framer-motion's
+// transform stacking context and paint BELOW the board/HUD/hand (see the
+// anchoring contract on lines 114-123). Centered modals must stay out of this set.
 const NON_DIALOG_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> = new Set<WaitingFor["type"]>([
   "Priority",
   "DeclareAttackers",
   "DeclareBlockers",
-  "AssignCombatDamage",
   "MulliganDecision",
   "MulliganBottomCards",
   "OpeningHandBottomCards",


### PR DESCRIPTION
AssignCombatDamage / AssignBlockerDamage were listed in DialogHost's
NON_DIALOG_WAITING_FOR_TYPES, which left the host un-anchored (className="")
for those prompts. Their centered ChoiceOverlay (rendered via CardChoiceModal
-> DamageAssignmentModal) then had its fixed inset-0 z-50 trapped inside
framer-motion's transform stacking context and painted BELOW the board/HUD/hand.

These prompts now render a centered modal (not a board-inline interaction), so
removing them from the set lets the host anchor them at fixed inset-0 z-40 like
every other centered modal. Mirrors the prior dialog z-index fix; sibling
distribution modals (DistributeAmong, MoveCountersDistribution) were already
correctly outside the set.
