### PR TITLE
Fix wishboard optional warning detection

### DIFF
--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -367,6 +367,10 @@ fn trigger_tree_has_optional(trigger: &TriggerDefinition) -> bool {
 /// handling the "if you don't" alternative.
 fn effect_has_internal_optionality(effect: &Effect) -> bool {
     match effect {
+        // CR 701.23j: Outside-game searches are optional at the selection
+        // level; the parser lowers "you may reveal a ... card you own from
+        // outside the game" as `count: UpTo(1)` instead of `def.optional`.
+        Effect::SearchOutsideGame { count, .. } if count.is_up_to() => true,
         Effect::Dig { up_to: true, .. }
         | Effect::GrantCastingPermission { .. }
         | Effect::CastFromZone { .. }
@@ -2268,6 +2272,7 @@ fn effect_name(effect: &Effect) -> &str {
 mod tests {
     use crate::parser::oracle::parse_oracle_text;
     use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
+    use crate::types::ability::{AbilityDefinition, Effect, OutsideGameSourcePool};
     use crate::types::statics::StaticMode;
 
     fn parse(text: &str, types: &[&str]) -> crate::parser::oracle::ParsedAbilities {
@@ -2301,6 +2306,15 @@ mod tests {
                 } if warning_detector == detector
             )
         })
+    }
+
+    fn find_search_outside_game(def: &AbilityDefinition) -> Option<&Effect> {
+        if matches!(&*def.effect, Effect::SearchOutsideGame { .. }) {
+            return Some(&def.effect);
+        }
+        def.sub_ability
+            .as_deref()
+            .and_then(find_search_outside_game)
     }
 
     #[test]
@@ -2339,6 +2353,64 @@ mod tests {
             &["Instant"],
         );
 
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_accepts_outside_game_wish_search() {
+        let parsed = parse_named(
+            "You may reveal a sorcery card you own from outside the game and put it into your hand. \
+             Exile Burning Wish.",
+            "Burning Wish",
+            &["Sorcery"],
+        );
+
+        let effect = parsed
+            .abilities
+            .iter()
+            .find_map(find_search_outside_game)
+            .expect("expected outside-game wish search to parse");
+        match effect {
+            Effect::SearchOutsideGame {
+                count, source_pool, ..
+            } => {
+                assert!(
+                    count.is_up_to(),
+                    "wish search must encode the optional reveal as an up-to count"
+                );
+                assert_eq!(*source_pool, OutsideGameSourcePool::Sideboard);
+            }
+            other => panic!("expected SearchOutsideGame, got {other:?}"),
+        }
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_accepts_outside_game_face_up_exile_disjunction() {
+        let parsed = parse_named(
+            "You may reveal an Eldrazi card you own from outside the game or choose a \
+             face-up Eldrazi card you own in exile. Put that card into your hand.",
+            "Coax from the Blind Eternities",
+            &["Sorcery"],
+        );
+
+        let effect = parsed
+            .abilities
+            .iter()
+            .find_map(find_search_outside_game)
+            .expect("expected outside-game Coax search to parse");
+        match effect {
+            Effect::SearchOutsideGame {
+                count, source_pool, ..
+            } => {
+                assert!(
+                    count.is_up_to(),
+                    "Coax search must encode the optional reveal as an up-to count"
+                );
+                assert_eq!(*source_pool, OutsideGameSourcePool::SideboardAndFaceUpExile);
+            }
+            other => panic!("expected SearchOutsideGame, got {other:?}"),
+        }
         assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
     }
 


### PR DESCRIPTION
## Summary
Fixes `Optional_YouMay` false positives for outside-the-game wishboard searches by treating `SearchOutsideGame { count: UpTo(..) }` as represented internal optionality.

Addresses the wishboard portion of #2276. `Retriever Phoenix` remains reported because its warning covers a separate unmodeled Learn replacement line, not the existing wishboard search effect.

## Files changed
- crates/engine/src/parser/swallow_check.rs

## CR references
- CR 701.23j

## Track
Developer

## LLM
Model: codex-5
Thinking: medium
Tier: Standard

## Anchored on
- crates/engine/src/parser/swallow_check.rs:373 - existing `effect_has_internal_optionality` entries for effect-internal optionality such as `Dig { up_to: true }`
- crates/engine/src/parser/swallow_check.rs:2350 - existing `Optional_YouMay` regression for `UpTo`-encoded optional zone movement

## Gate A
```text
./scripts/check-parser-combinators.sh
<no stdout; exited 0>
```

## Verification
- `cargo fmt --all -- --check` - clean
- `./scripts/check-parser-combinators.sh` - clean
- `cargo test -p engine optional_you_may_accepts_outside_game --lib` - 2 passed
- `cargo clippy -p engine --lib -- -D warnings` - clean
- `./scripts/gen-card-data.sh` - clean
- `./target/tool/coverage-report data --all --warning-detector Optional_YouMay --warning-limit 500` - wishboard issue cards removed except `Retriever Phoenix`, which remains a separate Learn replacement gap

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
