### PR TITLE
fix(engine): resume remaining players in per-opponent fan-out with a conditional rider

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3240,6 +3240,16 @@ fn resolve_chain_body(
                     remaining_scoped.set_original_controller_recursive(controller);
                     remaining_scoped.controller = remaining_pid;
                     remaining_scoped.set_scoped_player_recursive(remaining_pid);
+                    // CR 608.2c: each remaining player's clause is an INDEPENDENT
+                    // following instruction, not a continuation of the prior
+                    // player's. When the scoped template carries a conditional
+                    // rider (e.g. Momentum Breaker's "each opponent who can't
+                    // discards a card"), this clause gets appended after the
+                    // first player's stashed rider; marking it `SequentialSibling`
+                    // ensures it still resolves when that rider's condition is
+                    // false (it ran for a player who DID perform the action), so
+                    // the per-opponent fan-out is not truncated after the first.
+                    remaining_scoped.sub_link = SubAbilityLink::SequentialSibling;
                     if let Some(prev) = tail {
                         super::ability_utils::append_to_sub_chain(&mut remaining_scoped, *prev);
                     }
@@ -3482,13 +3492,32 @@ fn resolve_chain_body(
                 // here: `CopyTokenOf {IfYouDo}` is skipped (no pay → effect not
                 // performed) and the chain descends to `Token(Insect)
                 // {Not(IfYouDo)}`, which evaluates true and creates the Insect.
-                // Restricted to performed-gate sub-conditions so an
-                // unconditional continuation is never run when its parent's
+                // Restricted to performed-gate sub-conditions so a *dependent*
+                // continuation (one whose own gate references the parent's
+                // action, e.g. a `WhenYouDo` reflexive — Ezio's "When you do,
+                // that player loses the game") is never run when its parent's
                 // condition failed (that remains an early return).
+                //
+                // CR 608.2c: An UNCONDITIONAL `SequentialSibling` is the next
+                // INDEPENDENT instruction "in the order written", not a
+                // continuation of this node's action, so it resolves regardless
+                // of this node's condition. The `is_none()` guard is what keeps
+                // Ezio's gated reflexive blocked while letting a truly
+                // independent sibling through. This covers per-opponent
+                // `player_scope` continuations: when a scoped clause carries a
+                // conditional rider (Momentum Breaker's "each opponent who can't
+                // discards a card"), the remaining opponents' unconditional
+                // sacrifice clauses are appended after the first opponent's
+                // stashed rider as `SequentialSibling`s, and must still resolve
+                // when that rider's condition is false. Mirrors the gated-sub
+                // sibling escape hatch (the `next.sub_link == SequentialSibling`
+                // branch below).
                 if sub
                     .condition
                     .as_ref()
                     .is_some_and(condition_depends_on_effect_performed)
+                    || (sub.sub_link == SubAbilityLink::SequentialSibling
+                        && sub.condition.is_none())
                 {
                     let mut sub_resolved = sub.as_ref().clone();
                     if sub_resolved.targets.is_empty() && !ability.targets.is_empty() {

--- a/crates/engine/tests/sheoldred_edict_multi_opponent_sac.rs
+++ b/crates/engine/tests/sheoldred_edict_multi_opponent_sac.rs
@@ -1,0 +1,177 @@
+//! Repro for the multiplayer "each opponent sacrifices a creature" bug
+//! (Sheoldred's Edict / Momentum Breaker). In a 4-player game each opponent
+//! that controls more eligible permanents than the sacrifice count must pause
+//! on its own `EffectZoneChoice`; the `player_scope` driver stashes a
+//! `pending_continuation` for the remaining opponents, which must resume after
+//! each choice resolves.
+//!
+//! CR 701.21a: each affected player sacrifices a permanent THEY control.
+//! CR 608.2e: the scoped instruction is performed once per affected player.
+
+use engine::game::scenario::GameScenario;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaType;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+const P2: PlayerId = PlayerId(2);
+const P3: PlayerId = PlayerId(3);
+
+const SHEOLDRED_EDICT: &str = "Choose one —\n\
+• Each opponent sacrifices a nontoken creature of their choice.\n\
+• Each opponent sacrifices a creature token of their choice.\n\
+• Each opponent sacrifices a planeswalker of their choice.";
+
+#[test]
+fn each_opponent_sacrifices_a_creature_in_four_player() {
+    let mut scenario = GameScenario::new_n_player(4, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Each of the three opponents controls TWO nontoken creatures, so each must
+    // make a choice (the eligible pool exceeds the count of 1) — this is the
+    // path that round-trips through EffectZoneChoice + pending_continuation.
+    for opp in [P1, P2, P3] {
+        scenario.add_vanilla(opp, 2, 2);
+        scenario.add_vanilla(opp, 3, 3);
+    }
+
+    // A Blood Artist-style death observer (the kind a real Tergrid/Muldrotha
+    // sacrifice deck runs). Each opponent's sacrifice fires this trigger; if the
+    // observer-trigger handling clobbers the pending EffectZoneChoice of the
+    // *next* opponent, only the first opponent would end up sacrificing.
+    scenario.add_creature_from_oracle(
+        P0,
+        "Blood Artist",
+        0,
+        1,
+        "Whenever a creature dies, you gain 1 life.",
+    );
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Sheoldred's Edict", true, SHEOLDRED_EDICT)
+        .id();
+
+    let mut runner = scenario.build();
+    // Fund {1}{B}.
+    for _ in 0..2 {
+        let unit = engine::types::mana::ManaUnit::new(
+            ManaType::Black,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        );
+        runner.state_mut().players[0].mana_pool.add(unit);
+    }
+
+    // Mode 0: "Each opponent sacrifices a nontoken creature of their choice."
+    let outcome = runner.cast(spell).modes(&[0]).resolve();
+
+    // First opponent (APNAP after P0) must be prompted to choose.
+    let mut waiting = outcome.final_waiting_for().clone();
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 10, "too many prompts; stuck at {waiting:?}");
+        match waiting {
+            WaitingFor::EffectZoneChoice {
+                player, ref cards, ..
+            } => {
+                let pick = cards[0];
+                let res = runner
+                    .act(GameAction::SelectCards { cards: vec![pick] })
+                    .unwrap_or_else(|e| panic!("opponent {player:?} choice failed: {e:?}"));
+                waiting = res.waiting_for;
+            }
+            _ => break,
+        }
+    }
+
+    // Each opponent must have lost exactly one creature.
+    for opp in [P1, P2, P3] {
+        assert_eq!(
+            runner.battlefield_count(opp),
+            1,
+            "opponent {opp:?} must sacrifice exactly one creature (had 2)"
+        );
+    }
+}
+
+/// Momentum Breaker's ETB effect shape: an `Or` filter ("creature or Vehicle")
+/// PLUS a conditional `Discard` rider ("each opponent who can't discards a
+/// card"). Real-game log showed only the FIRST opponent in turn order
+/// sacrificing — the other three never acted. Reproduce as a cast spell with
+/// the identical Oracle text.
+const MOMENTUM_BREAKER_EFFECT: &str =
+    "Each opponent sacrifices a creature or Vehicle of their choice. \
+Each opponent who can't discards a card.";
+
+#[test]
+fn momentum_breaker_each_opponent_sacrifices_in_four_player() {
+    let mut scenario = GameScenario::new_n_player(4, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Each opponent controls TWO creatures (eligible for "creature or Vehicle")
+    // so each must choose, and a card in hand (so the "who can't discards"
+    // rider has something to act on if the sacrifice path were skipped).
+    for opp in [P1, P2, P3] {
+        scenario.add_vanilla(opp, 2, 2);
+        scenario.add_vanilla(opp, 3, 3);
+        scenario.with_cards_in_hand(opp, &["Filler"]);
+    }
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Momentum Breaker Effect", true, MOMENTUM_BREAKER_EFFECT)
+        .id();
+
+    let mut runner = scenario.build();
+    for _ in 0..4 {
+        let unit = engine::types::mana::ManaUnit::new(
+            ManaType::Black,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        );
+        runner.state_mut().players[0].mana_pool.add(unit);
+    }
+
+    let outcome = runner.cast(spell).resolve();
+
+    let mut waiting = outcome.final_waiting_for().clone();
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 12, "too many prompts; stuck at {waiting:?}");
+        match waiting {
+            WaitingFor::EffectZoneChoice {
+                player, ref cards, ..
+            } => {
+                let pick = cards[0];
+                let res = runner
+                    .act(GameAction::SelectCards { cards: vec![pick] })
+                    .unwrap_or_else(|e| panic!("opponent {player:?} sac choice failed: {e:?}"));
+                waiting = res.waiting_for;
+            }
+            WaitingFor::DiscardChoice {
+                player, ref cards, ..
+            } => {
+                let pick = cards[0];
+                let res = runner
+                    .act(GameAction::SelectCards { cards: vec![pick] })
+                    .unwrap_or_else(|e| panic!("opponent {player:?} discard failed: {e:?}"));
+                waiting = res.waiting_for;
+            }
+            _ => break,
+        }
+    }
+
+    for opp in [P1, P2, P3] {
+        assert_eq!(
+            runner.battlefield_count(opp),
+            1,
+            "opponent {opp:?} must sacrifice exactly one creature (had 2)"
+        );
+    }
+}


### PR DESCRIPTION
When a player_scope clause carries a conditional rider (e.g. Momentum
Breaker's "each opponent who can't discards a card"), the first opponent's
sacrifice pauses on a choice and its rider is stashed as pending_continuation;
the remaining opponents' clauses were appended as that rider's sub-ability
tail. On resume the rider's condition is false (the opponent DID sacrifice),
and the top-level condition-false early return dropped the unconditional
sub-ability — truncating the fan-out after the first opponent (only one of
several opponents sacrificed).

Mark remaining-opponent continuation clauses as SequentialSibling and let the
condition-false path descend into an UNCONDITIONAL SequentialSibling sub
(CR 608.2c — independent following instruction in the order written). The
is_none() guard keeps dependent reflexives (Ezio's WhenYouDo "that player
loses the game") blocked when their gate fails.

Adds a 4-player repro driving the real cast pipeline.
