### PR TITLE
fix(parser): Urza Lord High Artificer exiles the blind top card, not a tutor (CR 701.13/701.24)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1,8 +1,8 @@
 use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
-use nom::character::complete::space1;
-use nom::combinator::{all_consuming, eof, map, not, opt, rest, value};
+use nom::character::complete::{one_of, space1};
+use nom::combinator::{all_consuming, eof, map, not, opt, peek, rest, value};
 use nom::error::ParseError;
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
@@ -4376,6 +4376,54 @@ pub(super) fn parse_exile_ast(
                 });
             }
         }
+
+        // CR 701.13: Exile — "exile the top card[s]" with NO "of <player>'s
+        // library" qualifier is an implicit-controller top-of-library exile
+        // (Urza, Lord High Artificer's {5}; Bloodsoaked Insight; the
+        // "shuffle ..., then exile the top card" class). The twelve qualified
+        // suffix patterns above run FIRST so a real "of <player>'s library"
+        // continuation is never shadowed by this fallback.
+        // CR 701.24: Shuffle — after a shuffle the library order is RANDOM, so
+        // the exiled top card is determined by post-shuffle order; the player
+        // makes NO selection. This deterministic top-of-library ExileTop is the
+        // rules-correct shape — NOT a library-wide ChangeZone (which would offer
+        // a tutor prompt). The ABSENCE of a selection prompt is correct.
+        let head = remainder.trim_start();
+        if let Ok((after_noun, _)) = alt((
+            tag::<_, _, OracleError<'_>>("cards"),
+            tag::<_, _, OracleError<'_>>("card"),
+        ))
+        .parse(head)
+        {
+            // Require this is a clause boundary, NOT a qualified continuation
+            // (" of <player>'s library", already handled above). `not(tag(" of "))`
+            // rejects the qualified form on the raw tail; the boundary check
+            // accepts EOF or a sentence/clause terminator (after an optional
+            // single separator space).
+            let not_qualified = not(tag::<_, _, OracleError<'_>>(" of "))
+                .parse(after_noun)
+                .is_ok();
+            let boundary = after_noun.strip_prefix(' ').unwrap_or(after_noun); // allow-noncombinator: trim one optional separator before nom boundary peek
+            let at_boundary = alt((
+                value((), eof::<_, OracleError<'_>>),
+                value((), peek(one_of(".,"))),
+            ))
+            .parse(boundary)
+            .is_ok();
+            if not_qualified && at_boundary {
+                // CR 406.3: honor a trailing "face down" suffix exactly as the
+                // twelve qualified patterns do.
+                let (after_lib, face_down) = strip_exile_top_face_down(after_noun);
+                // CR 107.3c: honor a trailing ", where x is <expr>" binding —
+                // the text defines X, so the controller doesn't choose it.
+                let count = resolve_exile_top_where_x_binding(after_lib, initial_count);
+                return Some(ZoneCounterImperativeAst::ExileTop {
+                    player: TargetFilter::Controller,
+                    count,
+                    face_down,
+                });
+            }
+        }
     }
 
     if let Some((_, rest)) = nom_on_lower(text, lower, |input| {
@@ -4694,8 +4742,7 @@ pub(super) fn parse_counter_ast(text: &str, lower: &str) -> Option<ZoneCounterIm
 /// accidental alpha-suffix matches (e.g., `"x lifelink"`).
 fn parse_pay_life_amount(rest: &str) -> Option<QuantityExpr> {
     use crate::parser::oracle_nom::error::OracleResult;
-    use nom::character::complete::one_of;
-    use nom::combinator::{eof, peek, recognize};
+    use nom::combinator::recognize;
     use nom::sequence::terminated;
 
     // Shared word-boundary guard: the token just consumed must be followed by
@@ -11163,6 +11210,106 @@ mod tests {
         assert_eq!(
             super::try_parse_die_result_line("20 | Win the game."),
             Some((20, 20, "Win the game."))
+        );
+    }
+
+    /// CR 701.13 + CR 701.24: A suffix-less "exile the top card[s]" (no "of
+    /// <player>'s library" qualifier) is an implicit-controller, deterministic
+    /// top-of-library exile — the "shuffle ..., then exile the top card" class
+    /// (Urza, Lord High Artificer's {5}). It must NOT fall through to the
+    /// generic `tag("exile ")` path (which produces a library-wide tutor).
+    /// Covers period-terminated, plural-count, and EOF-terminated forms.
+    #[test]
+    fn exile_the_top_card_no_qualifier_parses_controller_exile_top() {
+        let mut ctx = ParseContext::default();
+
+        let singular = parse_exile_ast("exile the top card.", "exile the top card.", &mut ctx)
+            .expect("'exile the top card.' should parse as ExileTop");
+        assert!(
+            matches!(
+                singular,
+                ZoneCounterImperativeAst::ExileTop {
+                    player: TargetFilter::Controller,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    face_down: false,
+                }
+            ),
+            "expected ExileTop(Controller, 1), got {singular:?}"
+        );
+
+        let plural = parse_exile_ast(
+            "exile the top two cards.",
+            "exile the top two cards.",
+            &mut ctx,
+        )
+        .expect("'exile the top two cards.' should parse as ExileTop");
+        assert!(
+            matches!(
+                plural,
+                ZoneCounterImperativeAst::ExileTop {
+                    player: TargetFilter::Controller,
+                    count: QuantityExpr::Fixed { value: 2 },
+                    face_down: false,
+                }
+            ),
+            "expected ExileTop(Controller, 2), got {plural:?}"
+        );
+
+        let eof = parse_exile_ast("exile the top card", "exile the top card", &mut ctx)
+            .expect("'exile the top card' (no period) should parse as ExileTop");
+        assert!(
+            matches!(
+                eof,
+                ZoneCounterImperativeAst::ExileTop {
+                    player: TargetFilter::Controller,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    face_down: false,
+                }
+            ),
+            "expected ExileTop(Controller, 1) at EOF, got {eof:?}"
+        );
+    }
+
+    /// Regression: the suffix-less branch must NOT shadow the qualified "of
+    /// <player>'s library" patterns, which run first and take precedence.
+    /// "of target opponent's library" → opponent filter; "of each player's
+    /// library" → ScopedPlayer. Both must survive the new fallback.
+    #[test]
+    fn exile_the_top_qualified_library_patterns_take_precedence() {
+        let mut ctx = ParseContext::default();
+
+        let opponent = parse_exile_ast(
+            "exile the top card of target opponent's library.",
+            "exile the top card of target opponent's library.",
+            &mut ctx,
+        )
+        .expect("qualified opponent-library phrase should parse");
+        assert!(
+            matches!(
+                opponent,
+                ZoneCounterImperativeAst::ExileTop {
+                    player: TargetFilter::Typed(_),
+                    ..
+                }
+            ),
+            "expected opponent-typed ExileTop, got {opponent:?}"
+        );
+
+        let each = parse_exile_ast(
+            "exile the top card of each player's library.",
+            "exile the top card of each player's library.",
+            &mut ctx,
+        )
+        .expect("qualified each-player-library phrase should parse");
+        assert!(
+            matches!(
+                each,
+                ZoneCounterImperativeAst::ExileTop {
+                    player: TargetFilter::ScopedPlayer,
+                    ..
+                }
+            ),
+            "expected ScopedPlayer ExileTop, got {each:?}"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12292,7 +12292,27 @@ fn contains_implicit_tracked_set_pronoun(lower: &str) -> bool {
             || tag::<_, _, OracleError<'_>>("play ").parse(lower).is_ok()
             || tag::<_, _, OracleError<'_>>("cast ").parse(lower).is_ok());
 
-    battlefield_recall || hand_recall || copy_token_recall || play_from_exile_grant
+    // CR 603.7 + CR 400.7h + CR 118.9: cross-clause "you may play/cast that card
+    // without paying its mana cost [until end of turn / this turn]" — the "that
+    // card" anaphor refers to the card the preceding exile published into the
+    // tracked set (Urza, Lord High Artificer's {5}; the "shuffle ..., then exile
+    // the top card, you may play it for free until end of turn" class). Distinct
+    // from the `play_from_exile_grant` "remains exiled" impulse grant (which is
+    // PAID and permanent-duration); this is the FREE-cast, turn-scoped
+    // fingerprint. Only consulted after a prior clause publishes a tracked set,
+    // and triply scoped: anaphor (play/cast that card) + free-cast marker
+    // (without paying) + turn duration (until end of turn / this turn).
+    let free_cast_that_card_grant = (scan_contains_phrase(lower, "play that card")
+        || scan_contains_phrase(lower, "cast that card"))
+        && scan_contains_phrase(lower, "without paying")
+        && (scan_contains_phrase(lower, "until end of turn")
+            || scan_contains_phrase(lower, "this turn"));
+
+    battlefield_recall
+        || hand_recall
+        || copy_token_recall
+        || play_from_exile_grant
+        || free_cast_that_card_grant
 }
 
 fn mark_uses_tracked_set(def: &mut AbilityDefinition) {
@@ -24325,6 +24345,92 @@ mod tests {
                 }
             ),
             "Expected PlayFromExile grant bound to the tracked exiled card, got {:?}",
+            grant.effect
+        );
+    }
+
+    /// CR 603.7 + CR 400.7h + CR 118.9: The free-cast cross-clause grant —
+    /// "exile the top card. Until end of turn, you may play that card without
+    /// paying its mana cost." (Urza, Lord High Artificer's {5}) — must rebind
+    /// the cast clause's `ParentTarget` to the tracked set the exile published.
+    /// This proves `contains_implicit_tracked_set_pronoun`'s free-cast
+    /// recognizer fired: without it the `CastFromZone` target stays
+    /// `ParentTarget` (binds to nothing) and the parse is a no-op at runtime.
+    #[test]
+    fn exile_top_then_free_play_that_card_binds_cast_to_tracked_set() {
+        let def = parse_effect_chain(
+            "Exile the top card. Until end of turn, you may play that card without paying its mana cost.",
+            AbilityKind::Activated,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::ExileTop {
+                    player: TargetFilter::Controller,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    face_down: false,
+                }
+            ),
+            "expected a controller ExileTop head, got {:?}",
+            def.effect
+        );
+        let cast = def
+            .sub_ability
+            .as_ref()
+            .expect("the free-cast grant must chain after the exile");
+        assert!(
+            matches!(
+                &*cast.effect,
+                Effect::CastFromZone {
+                    target: TargetFilter::TrackedSet {
+                        id: TrackedSetId(0),
+                    },
+                    without_paying_mana_cost: true,
+                    mode: CardPlayMode::Play,
+                    ..
+                }
+            ),
+            "expected CastFromZone bound to the tracked exiled card (free, Play), got {:?}",
+            cast.effect
+        );
+    }
+
+    /// Regression: Abbot of Keral Keep's "exile the top card of your library"
+    /// with a paid impulse grant ("Until end of turn, you may play that card")
+    /// must be untouched by the free-cast detector. It is a PAID play (no
+    /// "without paying"), so it stays a `GrantCastingPermission(PlayFromExile)`
+    /// — the free-cast `CastFromZone` rebinding must not fire here.
+    #[test]
+    fn abbot_of_keral_keep_paid_impulse_grant_unchanged() {
+        let def = parse_effect_chain(
+            "Exile the top card of your library. Until end of turn, you may play that card.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::ExileTop {
+                    player: TargetFilter::Controller,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    face_down: false,
+                }
+            ),
+            "expected a controller ExileTop head, got {:?}",
+            def.effect
+        );
+        let grant = def
+            .sub_ability
+            .as_ref()
+            .expect("the paid impulse grant must chain after the exile");
+        assert!(
+            matches!(
+                &*grant.effect,
+                Effect::GrantCastingPermission {
+                    permission: CastingPermission::PlayFromExile { .. },
+                    ..
+                }
+            ),
+            "expected a paid PlayFromExile grant (not a free CastFromZone), got {:?}",
             grant.effect
         );
     }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -145,6 +145,7 @@ mod tyvar_activate_as_though_haste;
 mod unstoppable_slasher_half_life;
 mod ureni_attack_trigger;
 mod urge_to_feed_regression;
+mod urza_lord_high_artificer_shuffle_exile_free_cast;
 mod urzas_saga_chapter_two;
 mod urzas_tower_conditional_mana;
 mod vigor_regression;

--- a/crates/engine/tests/integration/urza_lord_high_artificer_shuffle_exile_free_cast.rs
+++ b/crates/engine/tests/integration/urza_lord_high_artificer_shuffle_exile_free_cast.rs
@@ -1,0 +1,237 @@
+//! Regression: Urza, Lord High Artificer's third ability —
+//! "{5}: Shuffle your library, then exile the top card. Until end of turn, you
+//! may play that card without paying its mana cost."
+//!
+//! Before the fix the clause misparsed into a whole-library TUTOR (a generic
+//! `ChangeZone` over the entire library that opened a `WaitingFor::
+//! EffectZoneChoice` selection prompt) plus a `CastFromZone { target:
+//! ParentTarget }` that bound to nothing. The correct parse is a deterministic
+//! top-of-library exile followed by a tracked-set free-cast grant:
+//!
+//!   Shuffle{Controller}
+//!     -> ExileTop { player: Controller, count: Fixed(1) }
+//!     -> CastFromZone { target: TrackedSet(0), without_paying_mana_cost: true,
+//!                       mode: Play, duration: UntilEndOfTurn }
+//!
+//! CR 701.24a: after the shuffle the library order is RANDOM, so the exiled top
+//! card is fixed by post-shuffle order — the player makes NO selection. The
+//! ABSENCE of a tutor prompt is the rules-correct behavior. CR 118.9 + CR 601.2a:
+//! the exiled card is then castable for free until end of turn.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use engine::ai_support::legal_actions;
+use engine::database::card_db::CardDatabase;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::ability::Effect;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+fn load_db() -> Option<&'static CardDatabase> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../client/public/card-data.json");
+    if !path.exists() {
+        return None;
+    }
+    static DB: OnceLock<CardDatabase> = OnceLock::new();
+    Some(DB.get_or_init(|| CardDatabase::from_export(&path).expect("export should load")))
+}
+
+/// Find the index (into `obj.abilities`) of Urza's `{5}` ability — the only one
+/// whose top-level effect is `Effect::Shuffle`. Robust against ability ordering.
+fn shuffle_ability_index(state: &engine::types::game_state::GameState, urza: ObjectId) -> usize {
+    state.objects[&urza]
+        .abilities
+        .iter()
+        .position(|def| matches!(&*def.effect, Effect::Shuffle { .. }))
+        .expect("Urza must have a `{5}` shuffle-then-exile ability")
+}
+
+/// The full end-to-end discriminator: activating Urza's `{5}` exiles the
+/// post-shuffle top card (NOT a tutor) and makes exactly that card castable for
+/// free until end of turn.
+#[test]
+fn urza_five_ability_exiles_top_and_offers_free_cast() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let urza = scenario.add_real_card(P0, "Urza, Lord High Artificer", Zone::Battlefield, db);
+    // A single, known, castable card in P0's library so the post-shuffle top is
+    // deterministic (a one-card library shuffles to itself). Grizzly Bears is a
+    // vanilla {1}{G} creature — no targets, so the free cast completes cleanly to
+    // the stack, and the {1}{G} cost makes "zero mana paid" a real discriminator.
+    let spell = scenario.add_real_card(P0, "Grizzly Bears", Zone::Library, db);
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    // Reduce P0's library to exactly the spell so the shuffled top is known.
+    {
+        let player = runner
+            .state_mut()
+            .players
+            .iter_mut()
+            .find(|p| p.id == P0)
+            .unwrap();
+        player.library.retain(|&id| id == spell);
+        assert_eq!(
+            player.library.len(),
+            1,
+            "library must contain exactly the known top card"
+        );
+    }
+
+    // Fund the {5} activation cost from the pool (source auto-tap is not modeled).
+    {
+        let pool = &mut runner.state_mut().players[0].mana_pool;
+        for _ in 0..5 {
+            pool.add(ManaUnit::new(
+                ManaType::Colorless,
+                ObjectId(0),
+                false,
+                vec![],
+            ));
+        }
+    }
+
+    let idx = shuffle_ability_index(runner.state(), urza);
+
+    // Activate and resolve the {5}. If the buggy library-wide tutor were still
+    // present, resolution would stop at WaitingFor::EffectZoneChoice and the
+    // activation driver would panic on the unhandled prompt — so reaching a
+    // clean Priority window is itself part of the discriminator.
+    let outcome = runner.activate(urza, idx).resolve();
+
+    // NEGATIVE: no tutor selection prompt was raised over the library.
+    assert!(
+        !matches!(
+            outcome.state().waiting_for,
+            WaitingFor::EffectZoneChoice { .. }
+        ),
+        "the {{5}} ability must NOT open a library-wide tutor prompt; got {:?}",
+        outcome.state().waiting_for
+    );
+
+    // Exactly one Library->Exile move: the spell is now in exile and gone from
+    // the library (a deterministic top-of-library exile, not a mass move).
+    assert_eq!(
+        runner.state().objects[&spell].zone,
+        Zone::Exile,
+        "the post-shuffle top card must be exiled"
+    );
+    assert!(
+        !runner.state().players[0].library.contains(&spell),
+        "the exiled top card must have left the library"
+    );
+
+    // POSITIVE discriminator (fails if the cast binding is broken): the exiled
+    // card surfaces as a CastSpell in legal_actions. With the original
+    // `target: ParentTarget` bug this grant bound to nothing and no such action
+    // existed.
+    let legal = legal_actions(runner.state());
+    let has_free_cast = legal.iter().any(|a| {
+        matches!(
+            a,
+            GameAction::CastSpell { object_id, .. } if *object_id == spell
+        )
+    });
+    assert!(
+        has_free_cast,
+        "the exiled top card must be castable from exile; legal_actions={legal:?}"
+    );
+
+    // Cast it for FREE: the spell moves Exile->Stack with zero mana paid. The
+    // pool was emptied by the {5} activation, so a {1}{G} cost would make the
+    // cast illegal here — a vanilla creature has no targets, so the cast lands
+    // directly on the stack.
+    assert_eq!(
+        runner.state().players[0].mana_pool.total(),
+        0,
+        "precondition: the activation drained the pool, so the cast must be free"
+    );
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+        })
+        .expect("the exiled top card must be castable from exile without paying mana");
+    assert_eq!(
+        runner.state().objects[&spell].zone,
+        Zone::Stack,
+        "casting the exiled card for free must move it Exile->Stack"
+    );
+}
+
+/// DURATION discriminator: the free-cast offer is scoped `UntilEndOfTurn`. After
+/// the turn ends the permission is pruned, so the exiled card is no longer a
+/// legal cast (CR 611.2a — the granted `ExileWithAltCost { duration }` expires).
+#[test]
+fn urza_free_cast_offer_expires_at_end_of_turn() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let urza = scenario.add_real_card(P0, "Urza, Lord High Artificer", Zone::Battlefield, db);
+    let spell = scenario.add_real_card(P0, "Grizzly Bears", Zone::Library, db);
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    {
+        let player = runner
+            .state_mut()
+            .players
+            .iter_mut()
+            .find(|p| p.id == P0)
+            .unwrap();
+        player.library.retain(|&id| id == spell);
+    }
+    {
+        let pool = &mut runner.state_mut().players[0].mana_pool;
+        for _ in 0..5 {
+            pool.add(ManaUnit::new(
+                ManaType::Colorless,
+                ObjectId(0),
+                false,
+                vec![],
+            ));
+        }
+    }
+
+    let idx = shuffle_ability_index(runner.state(), urza);
+    runner.activate(urza, idx).resolve();
+
+    // Precondition: the free cast is currently legal.
+    let legal_now = legal_actions(runner.state());
+    assert!(
+        legal_now.iter().any(|a| matches!(
+            a,
+            GameAction::CastSpell { object_id, .. } if *object_id == spell
+        )),
+        "precondition: the exiled card must be castable this turn"
+    );
+
+    // Advance into the next turn's upkeep, crossing the end-of-turn cleanup that
+    // prunes the UntilEndOfTurn casting permission (CR 514 / CR 611.2a).
+    runner.advance_to_phase(Phase::Upkeep);
+
+    let legal_later = legal_actions(runner.state());
+    assert!(
+        !legal_later.iter().any(|a| matches!(
+            a,
+            GameAction::CastSpell { object_id, .. } if *object_id == spell
+        )),
+        "the free-cast offer must NOT survive past end of turn (CR 611.2a); \
+         legal_actions={legal_later:?}"
+    );
+}


### PR DESCRIPTION
"{5}: Shuffle your library, then exile the top card. Until end of turn,
you may play that card without paying its mana cost." misparsed two ways:

1. The suffix-less "exile the top card" (no "of your library") fell through
   parse_exile_ast's twelve qualified patterns into a generic library
   ChangeZone, which at runtime resolved to a whole-library EffectZoneChoice
   — i.e. a tutor letting the player pick any card.
2. The free-cast clause emitted CastFromZone{ target: ParentTarget }, which
   binds to nothing once the exile step is an ExileTop, so the card was
   unplayable.

Fixes (parser only; no game/ resolver change — the resolvers already handle
ExileTop and CastFromZone{TrackedSet}):

- parse_exile_ast: add a precedence-guarded suffix-less "exile the top
  card[s]" branch -> ExileTop{ player: Controller }. The twelve qualified
  "of <player>'s library" patterns run first; a not(" of ") + clause-boundary
  guard prevents shadowing "exile the top card of target opponent's library"
  and friends. CR 701.24a: after the shuffle the order is random, so the top
  card is exiled with no selection prompt — the absence of a choice is correct.
- contains_implicit_tracked_set_pronoun: recognize the free-cast
  "you may play/cast that card without paying ... until end of turn"
  fingerprint (triply scoped, only consulted after a clause publishes a
  tracked set) so the existing rewrite_parent_targets_to_tracked_set
  machinery rebinds ParentTarget -> TrackedSet{0} for the whole class.

Final parse: Shuffle -> ExileTop{Controller, 1} -> CastFromZone{ TrackedSet,
without_paying_mana_cost, Play, UntilEndOfTurn }.

Tests: discriminating runtime test (no tutor prompt; blind post-shuffle top
card exiled; castable for free until end of turn and gone afterward),
building-block parser tests for the suffix-less ExileTop class, a lowering
test proving the ParentTarget->TrackedSet rebind, and Abbot of Keral Keep /
opponent-library / each-player-library regression guards.
