### PR TITLE
fix(engine): Steadfast Armasaur deals LKI toughness after source destroyed (CR 113.7a)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -939,7 +939,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             counter_type,
         } => {
             let scope_str = match scope {
-                ObjectScope::Source | ObjectScope::Anaphoric => "self",
+                ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => "self",
                 ObjectScope::Target => "target",
                 ObjectScope::Recipient => "recipient",
                 ObjectScope::EventSource => "event source",
@@ -959,35 +959,45 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         },
         QuantityRef::Variable { name } => name.clone(),
         QuantityRef::Power { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => "self power".into(),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                "self power".into()
+            }
             ObjectScope::Target => "target's power".into(),
             ObjectScope::Recipient => "recipient's power".into(),
             ObjectScope::EventSource => "event source's power".into(),
             ObjectScope::CostPaidObject => "referenced object's power".into(),
         },
         QuantityRef::Toughness { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => "self toughness".into(),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                "self toughness".into()
+            }
             ObjectScope::Target => "target's toughness".into(),
             ObjectScope::Recipient => "recipient's toughness".into(),
             ObjectScope::EventSource => "event source's toughness".into(),
             ObjectScope::CostPaidObject => "referenced object's toughness".into(),
         },
         QuantityRef::ObjectManaValue { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => "self mana value".into(),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                "self mana value".into()
+            }
             ObjectScope::Target => "target's mana value".into(),
             ObjectScope::Recipient => "recipient's mana value".into(),
             ObjectScope::EventSource => "event source's mana value".into(),
             ObjectScope::CostPaidObject => "referenced object's mana value".into(),
         },
         QuantityRef::ObjectColorCount { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => "self colors".into(),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                "self colors".into()
+            }
             ObjectScope::Target => "target's colors".into(),
             ObjectScope::Recipient => "recipient's colors".into(),
             ObjectScope::EventSource => "event source's colors".into(),
             ObjectScope::CostPaidObject => "cost-paid object's colors".into(),
         },
         QuantityRef::ObjectNameWordCount { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => "words in self name".into(),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                "words in self name".into()
+            }
             ObjectScope::Target => "words in target's name".into(),
             ObjectScope::Recipient => "words in recipient's name".into(),
             ObjectScope::EventSource => "words in event source's name".into(),
@@ -995,7 +1005,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         },
         QuantityRef::ManaSymbolsInManaCost { scope, color } => {
             let scope_str = match scope {
-                ObjectScope::Source | ObjectScope::Anaphoric => "self",
+                ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => "self",
                 ObjectScope::Target => "target",
                 ObjectScope::Recipient => "recipient",
                 ObjectScope::EventSource => "event source",
@@ -5278,42 +5288,52 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::CountersOnObjects { .. } => ("CountersOnObjects", Handled),
         QuantityRef::Variable { .. } => ("Variable", Handled),
         QuantityRef::Power { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => ("SelfPower", Handled),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                ("SelfPower", Handled)
+            }
             ObjectScope::Target => ("TargetPower", Handled),
             ObjectScope::Recipient => ("RecipientPower", Handled),
             ObjectScope::EventSource => ("EventSourcePower", Handled),
             ObjectScope::CostPaidObject => ("CostPaidObjectPower", Handled),
         },
         QuantityRef::Toughness { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => ("SelfToughness", Handled),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                ("SelfToughness", Handled)
+            }
             ObjectScope::Target => ("TargetToughness", Handled),
             ObjectScope::Recipient => ("RecipientToughness", Handled),
             ObjectScope::EventSource => ("EventSourceToughness", Handled),
             ObjectScope::CostPaidObject => ("CostPaidObjectToughness", Handled),
         },
         QuantityRef::ObjectManaValue { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => ("SelfManaValue", Handled),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                ("SelfManaValue", Handled)
+            }
             ObjectScope::Target => ("TargetManaValue", Handled),
             ObjectScope::Recipient => ("RecipientManaValue", Handled),
             ObjectScope::EventSource => ("EventSourceManaValue", Handled),
             ObjectScope::CostPaidObject => ("CostPaidObjectManaValue", Handled),
         },
         QuantityRef::ObjectColorCount { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => ("SourceObjectColorCount", Handled),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                ("SourceObjectColorCount", Handled)
+            }
             ObjectScope::Target => ("TargetObjectColorCount", Handled),
             ObjectScope::Recipient => ("RecipientObjectColorCount", Handled),
             ObjectScope::EventSource => ("EventSourceObjectColorCount", Handled),
             ObjectScope::CostPaidObject => ("CostPaidObjectColorCount", Handled),
         },
         QuantityRef::ObjectNameWordCount { scope } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => ("SourceObjectNameWordCount", Handled),
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
+                ("SourceObjectNameWordCount", Handled)
+            }
             ObjectScope::Target => ("TargetObjectNameWordCount", Handled),
             ObjectScope::Recipient => ("RecipientObjectNameWordCount", Handled),
             ObjectScope::EventSource => ("EventSourceObjectNameWordCount", Handled),
             ObjectScope::CostPaidObject => ("CostPaidObjectNameWordCount", Handled),
         },
         QuantityRef::ManaSymbolsInManaCost { scope, .. } => match scope {
-            ObjectScope::Source | ObjectScope::Anaphoric => {
+            ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
                 ("SourceManaSymbolsInManaCost", Handled)
             }
             ObjectScope::Target => ("TargetManaSymbolsInManaCost", Handled),

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -343,16 +343,16 @@ fn snapshot_quantity_ref(
         _ => None,
     })?;
     match qty {
-        // CR 608.2c + CR 608.2k: All three target-bound object-scope variants
+        // CR 608.2c + CR 608.2k: All four target-bound object-scope variants
         // (`CostPaidObject` cost/trigger referent, `Target` first-target slot,
-        // `Anaphoric` instruction-order referent) bake to the parent's
-        // first object target at snapshot time. `Anaphoric` joined this list
-        // when `classify_possessive_referent` started routing bare-anaphoric
-        // possessives ("that spell's mana value", Mana Drain class) to
-        // `Anaphoric` instead of `CostPaidObject`; snapshot baking must
-        // preserve the prior behavior — read the parent target's mana value
-        // now and freeze it as `Fixed` — or the delayed trigger fires later
-        // with an empty context and produces 0.
+        // `Anaphoric` pronoun and `Demonstrative` noun-phrase
+        // instruction-order referents) bake to the parent's first object target
+        // at snapshot time. `Demonstrative` carries the bare-anaphoric
+        // possessives ("that spell's mana value", Mana Drain class) that
+        // `classify_possessive_referent` routes off `CostPaidObject`; snapshot
+        // baking must preserve the prior behavior — read the parent target's
+        // mana value now and freeze it as `Fixed` — or the delayed trigger
+        // fires later with an empty context and produces 0.
         QuantityRef::ObjectManaValue {
             scope: ObjectScope::CostPaidObject,
         }
@@ -361,6 +361,9 @@ fn snapshot_quantity_ref(
         }
         | QuantityRef::ObjectManaValue {
             scope: ObjectScope::Anaphoric,
+        }
+        | QuantityRef::ObjectManaValue {
+            scope: ObjectScope::Demonstrative,
         } => {
             // Read live state first, LKI as fallback, 0 if neither.
             let value = state

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2504,7 +2504,7 @@ fn object_for_scope<'a>(
         // `CostPaidObject` (cost referent) nor `Anaphoric` (instruction-order
         // referent) resolves to a live `GameObject` here — both are snapshot
         // referents read through `ability` slots, not `state.objects`.
-        ObjectScope::CostPaidObject | ObjectScope::Anaphoric => None,
+        ObjectScope::CostPaidObject | ObjectScope::Anaphoric | ObjectScope::Demonstrative => None,
     }
 }
 
@@ -2543,7 +2543,7 @@ fn object_id_for_scope(
         // `CostPaidObject` (cost referent) nor `Anaphoric` (instruction-order
         // referent) resolves to an `ObjectId` here — both are snapshot
         // referents read through `ability` slots, not `state.objects`.
-        ObjectScope::CostPaidObject | ObjectScope::Anaphoric => None,
+        ObjectScope::CostPaidObject | ObjectScope::Anaphoric | ObjectScope::Demonstrative => None,
     }
 }
 
@@ -2801,8 +2801,10 @@ where
         // trigger-condition referent (slot 2: trigger-event source) then the
         // cost referent (slot 3: `cost_paid_object`). The arm differs from
         // `CostPaidObject` only in slot priority — instruction-order (608.2c)
-        // first, vs. cost referent (608.2k) first.
-        ObjectScope::Anaphoric => ability
+        // first, vs. cost referent (608.2k) first. `Demonstrative` ("that
+        // creature's toughness") shares this resolution — same earlier-
+        // instruction referent, named by a full noun phrase rather than "its".
+        ObjectScope::Anaphoric | ObjectScope::Demonstrative => ability
             .and_then(|a| a.effect_context_object.as_ref())
             .and_then(|snapshot| lki_extract(&snapshot.lki))
             .or_else(|| {
@@ -2929,7 +2931,9 @@ fn resolve_object_mana_value(
         //   3. `cost_paid_object` — the CR 608.2k cost referent, last resort.
         // The arm differs from `CostPaidObject` only in slot priority:
         // instruction-order (608.2c) first, vs. cost referent (608.2k) first.
-        ObjectScope::Anaphoric => ability
+        // `Demonstrative` ("that spell's mana value", Mana Drain) shares this
+        // resolution — same earlier-instruction referent named by a noun phrase.
+        ObjectScope::Anaphoric | ObjectScope::Demonstrative => ability
             .and_then(|a| a.effect_context_object.as_ref())
             .map(|s| u32_to_i32_saturating(s.lki.mana_value))
             .or_else(|| {

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -8823,9 +8823,12 @@ mod tests {
     /// value"` is an instruction-order referent: it points at the object
     /// introduced by an earlier `RevealTop` / `Mill` / `ChangeZone`
     /// instruction in the same ability. `classify_possessive_referent`
-    /// therefore emits `ObjectScope::Anaphoric`, whose runtime resolver reads
-    /// `effect_context_object` first (the revealed card) and only then falls
-    /// back to the trigger source and the cost-paid object.
+    /// therefore emits `ObjectScope::Demonstrative` (the noun-phrase
+    /// back-reference, distinct from the pronoun "its"), whose runtime resolver
+    /// reads `effect_context_object` first (the revealed card) and only then
+    /// falls back to the trigger source and the cost-paid object. The dedicated
+    /// variant keeps the subject-injection rewrite from rebinding this fixed
+    /// antecedent.
     #[test]
     fn parse_lose_life_equal_to_mana_value() {
         let text = "loses life equal to that card's mana value";
@@ -8839,11 +8842,11 @@ mod tests {
                         amount,
                         QuantityExpr::Ref {
                             qty: QuantityRef::ObjectManaValue {
-                                scope: crate::types::ability::ObjectScope::Anaphoric
+                                scope: crate::types::ability::ObjectScope::Demonstrative
                             }
                         }
                     ),
-                    "Expected ObjectManaValue {{ Anaphoric }}, got {amount:?}"
+                    "Expected ObjectManaValue {{ Demonstrative }}, got {amount:?}"
                 );
             }
             other => panic!("Expected LoseLife, got {other:?}"),

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3607,23 +3607,18 @@ pub(super) fn try_parse_damage_with_remainder<'a>(
             if let Some(qty) = qty {
                 // Route based on target phrase
                 if target_phrase == "itself" {
-                    // CR 608.2k: When target is "itself", an anaphoric "its power"
-                    // means the target's power. Only `Anaphoric` is remapped — an
-                    // explicit possessive ("the sacrificed creature's power",
-                    // `CostPaidObject` per CR 608.2k) keeps its fixed referent.
-                    let qty = match &qty {
-                        QuantityExpr::Ref {
-                            qty:
-                                QuantityRef::Power {
-                                    scope: crate::types::ability::ObjectScope::Anaphoric,
-                                },
-                        } => QuantityExpr::Ref {
-                            qty: QuantityRef::Power {
-                                scope: crate::types::ability::ObjectScope::Target,
-                            },
-                        },
-                        other => other.clone(),
-                    };
+                    // CR 608.2k: When the recipient is "itself", an anaphoric
+                    // "its <characteristic>" means that target's value. Only the
+                    // pronoun `Anaphoric` is rebound (across every per-object
+                    // characteristic) — an explicit possessive ("the sacrificed
+                    // creature's power", `CostPaidObject`) or a demonstrative
+                    // ("that creature's toughness", `Demonstrative`) keeps its
+                    // fixed referent.
+                    let mut qty = qty;
+                    super::rebind_anaphoric_object_scope(
+                        &mut qty,
+                        crate::types::ability::ObjectScope::Target,
+                    );
                     return Some((
                         Effect::DealDamage {
                             amount: qty,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -10044,24 +10044,23 @@ fn rewrite_quantity_controller(expr: &mut QuantityExpr, from: ControllerRef, to:
     }
 }
 
-/// Recoerce an anaphoric "its power" reference (parsed as
-/// `Power { scope: Anaphoric }` per CR 608.2k) to a concrete `ObjectScope`
-/// when surrounding context establishes the binding — e.g. a damage clause
-/// whose subject is the source or first target object. An explicit
-/// participle-possessive ("the sacrificed creature's power",
-/// `CostPaidObject` per CR 608.2k) is deliberately NOT matched here — its
-/// referent is fixed by the Oracle text and must not be clobbered.
-fn rewrite_event_source_power_to_object_power(expr: &mut QuantityExpr, scope: ObjectScope) {
+/// Rebind a deferred anaphoric **pronoun** referent ("its power", "its
+/// toughness", "its mana value", …) — parsed as `ObjectScope::Anaphoric` per
+/// CR 608.2k — to a concrete `ObjectScope` once the surrounding clause
+/// establishes the antecedent (a damage clause whose subject is the source,
+/// the first target object, or the triggering object).
+///
+/// CR 113.6 + CR 208/209/202: the pronoun names *one* object; this rewrite
+/// retargets *which* object (the `scope` field), never *which* characteristic
+/// (the `QuantityRef` variant), so it stays within each property's CR section
+/// and applies uniformly across power, toughness, mana value, color/word/
+/// mana-symbol counts, and counters. An explicit participle-possessive ("the
+/// sacrificed creature's power", `CostPaidObject`) and a demonstrative ("that
+/// creature's toughness", `Demonstrative`) are deliberately NOT matched — both
+/// have antecedents fixed by the Oracle text and must not be clobbered.
+fn rebind_anaphoric_object_scope(expr: &mut QuantityExpr, scope: ObjectScope) {
     match expr {
-        QuantityExpr::Ref {
-            qty: QuantityRef::Power {
-                scope: ObjectScope::Anaphoric,
-            },
-        } => {
-            *expr = QuantityExpr::Ref {
-                qty: QuantityRef::Power { scope },
-            };
-        }
+        QuantityExpr::Ref { qty } => rebind_anaphoric_ref(qty, scope),
         QuantityExpr::DivideRounded { inner, .. }
         | QuantityExpr::Multiply { inner, .. }
         | QuantityExpr::ClampMin { inner, .. }
@@ -10070,18 +10069,38 @@ fn rewrite_event_source_power_to_object_power(expr: &mut QuantityExpr, scope: Ob
         | QuantityExpr::Power {
             exponent: inner, ..
         } => {
-            rewrite_event_source_power_to_object_power(inner, scope);
+            rebind_anaphoric_object_scope(inner, scope);
         }
         QuantityExpr::Sum { exprs } => {
             for inner in exprs {
-                rewrite_event_source_power_to_object_power(inner, scope);
+                rebind_anaphoric_object_scope(inner, scope);
             }
         }
         QuantityExpr::Difference { left, right } => {
-            rewrite_event_source_power_to_object_power(left, scope);
-            rewrite_event_source_power_to_object_power(right, scope);
+            rebind_anaphoric_object_scope(left, scope);
+            rebind_anaphoric_object_scope(right, scope);
         }
-        QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => {}
+        QuantityExpr::Fixed { .. } => {}
+    }
+}
+
+/// Retarget a single per-object `QuantityRef` whose scope is the deferred
+/// pronoun `ObjectScope::Anaphoric` to `target`. Leaves every other scope
+/// (including the fixed `Demonstrative` / `CostPaidObject` referents) and every
+/// non-per-object `QuantityRef` untouched.
+fn rebind_anaphoric_ref(qty: &mut QuantityRef, target: ObjectScope) {
+    let scope = match qty {
+        QuantityRef::Power { scope }
+        | QuantityRef::Toughness { scope }
+        | QuantityRef::ObjectManaValue { scope }
+        | QuantityRef::ObjectColorCount { scope }
+        | QuantityRef::ObjectNameWordCount { scope }
+        | QuantityRef::ManaSymbolsInManaCost { scope, .. }
+        | QuantityRef::CountersOn { scope, .. } => scope,
+        _ => return,
+    };
+    if *scope == ObjectScope::Anaphoric {
+        *scope = target;
     }
 }
 
@@ -10101,7 +10120,7 @@ fn bind_damage_clause_source(
             damage_source,
             ..
         } => {
-            rewrite_event_source_power_to_object_power(amount, power_scope);
+            rebind_anaphoric_object_scope(amount, power_scope);
             *damage_source = Some(damage_source_ref);
             true
         }
@@ -10486,16 +10505,19 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
         Effect::LoseLife { ref mut target, .. } if target.is_none() => {
             *target = Some(subject_filter);
         }
-        // CR 608.2c + CR 120.3: When the stripped subject is the source object
-        // ("~ deals damage equal to its power..."), an anaphoric "its power" is
-        // the ability source's current power, not a triggering event's source
-        // power. Only `ObjectScope::Anaphoric` is rewritten — an explicit
-        // possessive ("the sacrificed creature's power", `CostPaidObject` per
-        // CR 608.2k) keeps its parser-fixed referent and is left untouched.
+        // CR 608.2c + CR 113.7a + CR 120.3: When the stripped subject is the
+        // source object ("~ deals damage equal to its toughness/power/mana
+        // value..."), an anaphoric "its <characteristic>" reads the ability
+        // source's current value — via LKI (CR 113.7a) if the source has since
+        // left the battlefield (Steadfast Armasaur destroyed in response to its
+        // own activated ability). Only the pronoun `ObjectScope::Anaphoric` is
+        // rebound; an explicit possessive ("the sacrificed creature's power",
+        // `CostPaidObject`) or a demonstrative ("that creature's toughness",
+        // `Demonstrative`) keeps its parser-fixed referent.
         Effect::DealDamage { amount, .. } | Effect::DamageEachPlayer { amount, .. }
             if subject_filter == TargetFilter::SelfRef =>
         {
-            rewrite_event_source_power_to_object_power(amount, ObjectScope::Source);
+            rebind_anaphoric_object_scope(amount, ObjectScope::Source);
         }
         // CR 701.23a: "Its controller may search their library..." — the subject
         // names the library owner (and, when the subject is a context-ref, the
@@ -25401,18 +25423,19 @@ mod tests {
             "expected AtNextPhaseForPlayer(PreCombatMain), got {delayed_cond:?}"
         );
 
-        // Inner delayed effect: Mana(Colorless, Ref(ObjectManaValue{Anaphoric})).
+        // Inner delayed effect: Mana(Colorless, Ref(ObjectManaValue{Demonstrative})).
         //
         // CR 608.2c — "that spell" in the delayed-trigger clause is a bare
-        // anaphoric pronoun: it points at the spell introduced by the
+        // demonstrative possessive: it points at the spell introduced by the
         // earlier-instruction `Counter target spell`. `classify_possessive_referent`
-        // emits `ObjectScope::Anaphoric` whose runtime resolver (in
-        // `game/quantity.rs`) consults `effect_context_object` (the
-        // captured-on-counter spell snapshot stamped by the parent chain)
-        // before falling back to the trigger-event source / cost_paid_object.
+        // emits `ObjectScope::Demonstrative` (the noun-phrase referent, distinct
+        // from the pronoun "its") whose runtime resolver (in `game/quantity.rs`)
+        // consults `effect_context_object` (the captured-on-counter spell
+        // snapshot stamped by the parent chain) before falling back to the
+        // trigger-event source / cost_paid_object. The dedicated variant keeps
+        // the subject-injection rewrite from rebinding this fixed antecedent.
         // The integration test `mana_drain_refund.rs` exercises the runtime
-        // end-to-end; this parser assertion just freezes the parse-time
-        // scope.
+        // end-to-end; this parser assertion just freezes the parse-time scope.
         let Effect::Mana { produced, .. } = &*delayed_effect_def.effect else {
             panic!(
                 "expected Mana effect on delayed trigger, got {:?}",
@@ -25425,11 +25448,11 @@ mod tests {
                     *count,
                     QuantityExpr::Ref {
                         qty: QuantityRef::ObjectManaValue {
-                            scope: crate::types::ability::ObjectScope::Anaphoric,
+                            scope: crate::types::ability::ObjectScope::Demonstrative,
                         }
                     },
                     "Colorless count must reference the counter-target spell's \
-                     mana value via ObjectManaValue{{Anaphoric}} (CR 608.2c \
+                     mana value via ObjectManaValue{{Demonstrative}} (CR 608.2c \
                      instruction-order referent)"
                 );
             }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -1262,13 +1262,13 @@ pub(crate) fn parse_event_context_quantity(text: &str) -> Option<QuantityExpr> {
     //   - participle adjective + type ("the sacrificed creature's power",
     //     "the destroyed creature's power", "the revealed card's mana value")
     //     → `CostPaidObject` (CR 608.2k cost / trigger-condition referent).
-    //   - bare anaphoric ("that card's mana value", "that creature's power",
-    //     "that spell's mana value", "the creature's toughness") → `Anaphoric`
-    //     (CR 608.2c earlier-instruction referent — Yuriko / Dark Confidant
-    //     issue #511 class).
-    // The participle form is NEVER rewritten by the subject-injection /
-    // "itself" remaps — unlike the bare anaphoric "its" arms above, which emit
-    // `Anaphoric` precisely so they can be remapped.
+    //   - bare demonstrative ("that card's mana value", "that creature's
+    //     power", "that spell's mana value", "the creature's toughness") →
+    //     `Demonstrative` (CR 608.2c earlier-instruction referent — Yuriko /
+    //     Dark Confidant issue #511 class).
+    // Neither the participle nor the demonstrative form is ever rewritten by
+    // the subject-injection / "itself" remaps — unlike the bare pronoun "its"
+    // arms above, which emit `Anaphoric` precisely so they can be remapped.
     if let Some((prefix, suffix)) = lower.split_once("'s ") {
         let suffix = suffix.trim();
         if let Some(scope) = classify_possessive_referent(prefix.trim()) {
@@ -1400,17 +1400,19 @@ fn parse_mana_spent_to_cast_amount(input: &str) -> Option<QuantityRef> {
 ///   source and `effect_context_object` as later fallbacks. Greater Good
 ///   (issue #338) and the cost-referent class depend on this priority.
 ///
-/// - **Bare anaphoric** ("that creature", "that card", "that spell", "the
-///   creature") → [`ObjectScope::Anaphoric`]. CR 608.2c (the "follow
+/// - **Bare demonstrative** ("that creature", "that card", "that spell", "the
+///   creature") → [`ObjectScope::Demonstrative`]. CR 608.2c (the "follow
 ///   instructions in the order written / apply the rules of English to the
 ///   text" anaphora rule) makes the antecedent the *most recent earlier
-///   effect instruction* in the same ability. The runtime `Anaphoric` arm
-///   inverts the slot order accordingly: slot 1 is `effect_context_object`
-///   (the revealed / moved / effect-sacrificed object), then the trigger
-///   source (CR 608.2k trigger-condition referent), then `cost_paid_object`.
-///   This is the Yuriko, the Tiger's Shadow / Dark Confidant class
-///   (issue #511): a reveal earlier in the same ability binds "that card's"
-///   to the revealed card, not to the trigger source.
+///   effect instruction* in the same ability. The runtime `Demonstrative` arm
+///   (shared with `Anaphoric`) inverts the slot order accordingly: slot 1 is
+///   `effect_context_object` (the revealed / moved / effect-sacrificed
+///   object), then the trigger source (CR 608.2k trigger-condition referent),
+///   then `cost_paid_object`. This is the Yuriko, the Tiger's Shadow / Dark
+///   Confidant class (issue #511): a reveal earlier in the same ability binds
+///   "that card's" to the revealed card, not to the trigger source. The
+///   dedicated variant (vs. the pronoun `Anaphoric`) is what keeps the
+///   subject-injection rewrite from clobbering this fixed antecedent.
 ///
 /// Picking the scope at parse time (rather than always emitting one or the
 /// other) lets the runtime consult the right slot priority for each
@@ -1445,14 +1447,18 @@ fn classify_possessive_referent(prefix: &str) -> Option<ObjectScope> {
         return Some(ObjectScope::CostPaidObject);
     }
 
-    // CR 608.2c: bare anaphoric — "that <type>" / "the <type>" with no
-    // participle adjective in between. The type word must be the entire
-    // remainder (no trailing modifiers), which `all_consuming` enforces.
+    // CR 608.2c: bare demonstrative / definite possessive — "that <type>" /
+    // "the <type>" with no participle adjective in between. The type word must
+    // be the entire remainder (no trailing modifiers), which `all_consuming`
+    // enforces. Emits `Demonstrative` (NOT the pronoun `Anaphoric`): the
+    // antecedent is a full noun phrase fixed by the Oracle text, so the
+    // subject-injection rewrite must never rebind it (Creature Bond, Erratic
+    // Explosion). At runtime it resolves identically to `Anaphoric`.
     if nom::combinator::all_consuming(parse_possessive_object_type)
         .parse(rest)
         .is_ok()
     {
-        return Some(ObjectScope::Anaphoric);
+        return Some(ObjectScope::Demonstrative);
     }
 
     None
@@ -3681,14 +3687,16 @@ mod tests {
         );
     }
 
-    /// CR 608.2c: bare anaphoric "that spell" inside a triggered ability or
+    /// CR 608.2c: bare demonstrative "that spell" inside a triggered ability or
     /// delayed-trigger continuation is an instruction-order referent — it
     /// points at the spell introduced by an earlier instruction in the same
     /// ability (typically a counter / copy / reveal), not at the cost-paid
-    /// object. Slot priority differs from `CostPaidObject`
+    /// object. It selects `ObjectScope::Demonstrative` (the noun-phrase referent,
+    /// distinct from the pronoun "its") so the subject-injection rewrite never
+    /// rebinds it; slot priority differs from `CostPaidObject`
     /// (effect_context_object first vs. cost_paid_object first); see
     /// `classify_possessive_referent` and `resolve_object_mana_value`'s
-    /// `Anaphoric` arm. Mana Drain is the canonical delayed-trigger member of
+    /// `Demonstrative` arm. Mana Drain is the canonical delayed-trigger member of
     /// this class — `snapshot_quantity_ref`
     /// (`game/effects/delayed_trigger.rs`) bakes the resolved value into
     /// `Fixed` at delayed-trigger creation time using the parent's target
@@ -3699,7 +3707,7 @@ mod tests {
             parse_event_context_quantity("that spell's mana value"),
             Some(QuantityExpr::Ref {
                 qty: QuantityRef::ObjectManaValue {
-                    scope: ObjectScope::Anaphoric
+                    scope: ObjectScope::Demonstrative
                 }
             })
         );
@@ -3707,45 +3715,45 @@ mod tests {
 
     /// CR 608.2c — Yuriko, the Tiger's Shadow / Dark Confidant class
     /// (issue #511). A reveal in an earlier instruction binds "that card's
-    /// mana value" to the revealed card. The bare anaphoric prefix "that
-    /// card" must select `ObjectScope::Anaphoric` so the runtime resolver
+    /// mana value" to the revealed card. The bare demonstrative prefix "that
+    /// card" selects `ObjectScope::Demonstrative` so the runtime resolver
     /// reads `effect_context_object` (the revealed card) before the trigger
     /// source (the Ninja that dealt combat damage).
     #[test]
-    fn parse_event_context_possessive_that_card_mana_value_anaphoric() {
+    fn parse_event_context_possessive_that_card_mana_value_demonstrative() {
         assert_eq!(
             parse_event_context_quantity("that card's mana value"),
             Some(QuantityExpr::Ref {
                 qty: QuantityRef::ObjectManaValue {
-                    scope: ObjectScope::Anaphoric
+                    scope: ObjectScope::Demonstrative
                 }
             })
         );
     }
 
-    /// CR 608.2c — bare anaphoric "that permanent" inside a triggered ability
+    /// CR 608.2c — bare demonstrative "that permanent" inside a triggered ability
     /// is an instruction-order referent like "that card" / "that creature".
     #[test]
-    fn parse_event_context_possessive_that_permanent_power_anaphoric() {
+    fn parse_event_context_possessive_that_permanent_power_demonstrative() {
         assert_eq!(
             parse_event_context_quantity("that permanent's power"),
             Some(QuantityExpr::Ref {
                 qty: QuantityRef::Power {
-                    scope: ObjectScope::Anaphoric
+                    scope: ObjectScope::Demonstrative
                 }
             })
         );
     }
 
     /// CR 608.2c — battles are objects and can be referenced by bare
-    /// anaphoric possessives the same way cards, permanents, and spells are.
+    /// demonstrative possessives the same way cards, permanents, and spells are.
     #[test]
-    fn parse_event_context_possessive_that_battle_mana_value_anaphoric() {
+    fn parse_event_context_possessive_that_battle_mana_value_demonstrative() {
         assert_eq!(
             parse_event_context_quantity("that battle's mana value"),
             Some(QuantityExpr::Ref {
                 qty: QuantityRef::ObjectManaValue {
-                    scope: ObjectScope::Anaphoric
+                    scope: ObjectScope::Demonstrative
                 }
             })
         );
@@ -3850,22 +3858,24 @@ mod tests {
         );
     }
 
-    /// CR 608.2c — "that creature" is a bare anaphoric pronoun: it points at
-    /// the most recent earlier-instruction object (a revealed / sacrificed-by-
+    /// CR 608.2c — "that creature" is a bare demonstrative possessive: it points
+    /// at the most recent earlier-instruction object (a revealed / sacrificed-by-
     /// effect / moved permanent), so the parser emits
-    /// `ObjectScope::Anaphoric`. The runtime resolver consults
-    /// `effect_context_object` first, then the trigger source, then
-    /// `cost_paid_object` — the inverse of `CostPaidObject`'s slot order.
-    /// Participle-possessive forms (`the sacrificed creature's toughness`,
-    /// `the destroyed creature's power`) continue to map to `CostPaidObject`
-    /// — see the sibling regression tests below.
+    /// `ObjectScope::Demonstrative` (distinct from the pronoun "its" so the
+    /// subject-injection rewrite never rebinds it — this is what protects
+    /// Creature Bond's "that creature's toughness" from the LKI-toughness fix's
+    /// generalized rebind). The runtime resolver consults `effect_context_object`
+    /// first, then the trigger source, then `cost_paid_object` — the inverse of
+    /// `CostPaidObject`'s slot order. Participle-possessive forms (`the sacrificed
+    /// creature's toughness`, `the destroyed creature's power`) continue to map to
+    /// `CostPaidObject` — see the sibling regression tests below.
     #[test]
-    fn parse_event_context_possessive_that_creature_toughness_anaphoric() {
+    fn parse_event_context_possessive_that_creature_toughness_demonstrative() {
         assert_eq!(
             parse_event_context_quantity("that creature's toughness"),
             Some(QuantityExpr::Ref {
                 qty: QuantityRef::Toughness {
-                    scope: ObjectScope::Anaphoric
+                    scope: ObjectScope::Demonstrative
                 }
             })
         );

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2861,20 +2861,39 @@ pub enum ObjectScope {
     /// trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger
     /// referent are the two enumerated members of CR 608.2k's single clause).
     CostPaidObject,
-    /// CR 608.2k: A deferred anaphoric pronoun ("it" / "its") whose object
-    /// referent is bound at parse time. The parser remaps this to a concrete
-    /// scope wherever it can — `Source` when the clause subject is the ability
-    /// source, `Target` when the recipient is "itself". For triggered abilities
-    /// no remap applies and `Anaphoric` survives to runtime, where it resolves
-    /// identically to `CostPaidObject` (behavior-preserving — these cards
-    /// parsed to `CostPaidObject` before this variant existed). General
-    /// rules-correct runtime resolution of triggered-ability anaphora (e.g.
-    /// "its mana value" after a reveal — see issue #511) is separate per-card
-    /// parser work. Distinguishing this from an explicit cost-paid possessive
-    /// ("the sacrificed creature's power", CR 608.2k -> `CostPaidObject`) is
-    /// what prevents the subject-injection rewrite from clobbering
-    /// correctly-scoped possessives.
+    /// CR 608.2k: A deferred anaphoric **pronoun** ("it" / "its") whose object
+    /// referent is bound at parse time. The parser rebinds this to a concrete
+    /// scope wherever the enclosing clause establishes the antecedent —
+    /// `Source` when the clause subject is the ability source, `Target` when
+    /// the recipient is "itself", `EventSource` when the subject is the
+    /// triggering object. The rebind ([`rebind_anaphoric_object_scope`] in
+    /// `parser/oracle_effect/mod.rs`) covers every per-object characteristic
+    /// (power, toughness, mana value, …) — not just power — because the
+    /// pronoun refers to one object and the rebind only retargets *which*
+    /// object, never *which* characteristic. When no clause subject applies
+    /// (triggered-ability anaphora) `Anaphoric` survives to runtime, where it
+    /// resolves identically to a demonstrative (effect-context referent first;
+    /// see [`ObjectScope::Demonstrative`]). General rules-correct runtime
+    /// resolution of triggered-ability anaphora (e.g. "its mana value" after a
+    /// reveal — see issue #511) is separate per-card parser work.
     Anaphoric,
+    /// CR 608.2c: A **demonstrative / definite** possessive back-reference
+    /// ("that creature's", "that card's", "that spell's", "the creature's")
+    /// whose antecedent is a full noun phrase naming an object introduced by an
+    /// earlier instruction in the same ability — *not* the grammatical subject
+    /// of the clause it appears in. Unlike [`ObjectScope::Anaphoric`] (the
+    /// pronoun "its"), the subject-injection rewrite MUST NOT rebind this — its
+    /// antecedent is fixed by the Oracle text. Steadfast Armasaur ("its
+    /// toughness", `Anaphoric` → rebound to `Source`) and Creature Bond ("that
+    /// creature's toughness", `Demonstrative` → never rebound) parse to the
+    /// same `QuantityRef` property and differ only by this scope: collapsing
+    /// them caused the LKI-toughness bug. At runtime `Demonstrative` resolves
+    /// identically to `Anaphoric` — `effect_context_object` (CR 608.2c
+    /// instruction-order referent) first, then the trigger source (CR 608.2k),
+    /// then the cost-paid object. This is the Yuriko / Dark Confidant / Mana
+    /// Drain class (issue #511): a reveal/counter/reanimate earlier in the same
+    /// ability binds "that <type>'s" to the referenced object.
+    Demonstrative,
 }
 
 /// Source set for counting distinct card types.

--- a/crates/engine/tests/integration/anaphoric_scope_allowlist_guard.rs
+++ b/crates/engine/tests/integration/anaphoric_scope_allowlist_guard.rs
@@ -10,13 +10,28 @@
 //! correctly-scoped possessive, which is the root cause of Rite of Consumption
 //! dealing no damage.
 //!
-//! After the #495 fix and the bare-anaphoric-possessive classifier fix (Yuriko,
-//! the Tiger's Shadow / Dark Confidant class — `classify_possessive_referent`
-//! in `parser/oracle_quantity.rs`), exactly **251** cards in the exported card
-//! data retain a runtime `ObjectScope::Anaphoric` in a `DealDamage` /
-//! `GainLife` / `LoseLife` (or similar) amount. This test holds that set as a
-//! sorted constant and fails if a card leaks in or out of it — a tripwire,
-//! not a snapshot.
+//! After the #495 fix and the bare-possessive classifier fix (Yuriko, the
+//! Tiger's Shadow / Dark Confidant class — `classify_possessive_referent` in
+//! `parser/oracle_quantity.rs`), the retained anaphora referents split across
+//! two `ObjectScope` variants:
+//!
+//! - **155** cards retain `ObjectScope::Anaphoric` — the *pronoun* "its"
+//!   (categories 1-3 below), which the subject-injection rewrite may rebind.
+//! - **111** cards retain `ObjectScope::Demonstrative` — the bare *demonstrative
+//!   / definite* possessive ("that creature's toughness", "that card's mana
+//!   value"; category 4 below), whose antecedent is fixed by the Oracle text and
+//!   must never be rebound.
+//!
+//! The split is what fixed the Steadfast Armasaur LKI-toughness bug: "its
+//! toughness" (pronoun → `Anaphoric` → rebound to `Source`, so it LKI-falls-back
+//! to 3 when the source is destroyed in response) and "that creature's toughness"
+//! (demonstrative → `Demonstrative`, never rebound) parse to the same
+//! `QuantityRef::Toughness` property and previously collapsed to one scope, so
+//! generalizing the Power-only rebind to toughness regressed Creature Bond.
+//! Splitting the variant let the rebind cover every per-object characteristic
+//! while touching only the genuine pronoun. This test holds each set as a sorted
+//! constant and fails if a card leaks in or out of either — a tripwire, not a
+//! snapshot.
 //!
 //! ## The four categories of retained `Anaphoric`
 //!
@@ -41,7 +56,7 @@
 //!    This is also a *genuine pre-existing misparse*: the referent should be
 //!    the target slot, not an anaphoric source marker.
 //!
-//! 4. **Bare anaphoric possessive (CR 608.2c reveal/move/effect-sacrifice
+//! 4. **Bare demonstrative possessive (CR 608.2c reveal/move/effect-sacrifice
 //!    class — Yuriko, the Tiger's Shadow / Dark Confidant / Mana Drain /
 //!    Calibrated Blast / Reanimate / Vendetta / etc.)** — e.g. "...reveal
 //!    the top card of your library... loses life equal to that card's mana
@@ -49,9 +64,12 @@
 //!    that spell's mana value". The bare "that <type>" / "the <type>"
 //!    possessive prefix anchors to the object introduced by an earlier
 //!    instruction in the same ability. `classify_possessive_referent`
-//!    selects `ObjectScope::Anaphoric` so the runtime consults
-//!    `effect_context_object` first (CR 608.2c instruction-order referent)
-//!    rather than the cost-paid object or the trigger source. The 88
+//!    selects `ObjectScope::Demonstrative` (tracked by
+//!    `DEMONSTRATIVE_SCOPE_CARDS`, NOT this `Anaphoric` set) so the runtime
+//!    consults `effect_context_object` first (CR 608.2c instruction-order
+//!    referent) rather than the cost-paid object or the trigger source — while
+//!    the dedicated variant keeps the subject-injection rewrite from rebinding
+//!    the fixed antecedent. The 88
 //!    additions break down by anaphor source:
 //!    - **reveal-then-act** (`RevealTop` → instruction reads "that card") —
 //!      Yuriko, Dark Confidant (already category 4 by its pronoun form),
@@ -114,12 +132,13 @@
 //! of the pronoun ("its mana value"). Yuriko, the Tiger's Shadow surfaced the
 //! same bug as Dark Confidant once #511 fixed the pronoun branch.
 //!
-//! This test **freezes** the `Anaphoric` set so it cannot grow silently while
-//! #512 does the remaining category-2/3 fixes. A new leak (a new card name,
-//! or a count change) fails this test; a human then decides whether it is a
-//! legitimate new category-1/2/3/4 case (add it here) or a real regression
-//! (fix the parser). The curation lives at the *category* level — the
-//! correct granularity — not as 251 per-card annotations.
+//! This test **freezes** both the `Anaphoric` (pronoun) and `Demonstrative`
+//! (noun-phrase) sets so neither can grow silently while #512 does the
+//! remaining category-2/3 fixes. A new leak (a new card name, or a count
+//! change) fails this test; a human then decides whether it is a legitimate
+//! new case (add it to the matching list) or a real regression (fix the
+//! parser). The curation lives at the *category* level — the correct
+//! granularity — not as per-card annotations.
 
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -134,21 +153,15 @@ use serde_json::Value;
 /// a legitimate category-1/2/3/4 case may be added; a real regression must be
 /// fixed in the parser instead.
 const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
-    "abattoir ghoul",
     "ad nauseam",
-    "alchemist's talent",
     "alpha brawl",
     "ambuscade",
     "angelic chorus",
     "archdruid's charm",
-    "archon of redemption",
-    "artifact mutation",
     "assert perfection",
     "augury adept",
-    "aura mutation",
     "avatar destiny",
     "backlash",
-    "baneful omen",
     "banewasp affliction",
     "bartz and boko",
     "beastie beatdown",
@@ -156,58 +169,37 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "blood poet",
     "bottle golems",
     "boulderbranch golem",
-    "bounteous kirin",
     "brainstealer dragon",
-    "breeches, the blastmaker",
-    "brightmare",
     "brokers charm",
-    "calibrated blast",
     "champion of the path",
     "champion of wits",
     "chastise",
     "circus of the sun",
     "clear shot",
-    "cleric class",
     "common black removal",
     "conclave mentor",
     "consume",
     "consuming ferocity",
-    "consuming vapors",
-    "creature bond",
     "crumble",
     "crush underfoot",
     "dark confidant",
     "dark tutelage",
     "darkstar augur",
-    "daxos of meletis",
     "deadshot",
     "death",
     "death watch",
     "death's caress",
     "delif's cone",
     "delirium",
-    "devour flesh",
-    "devour in shadow",
     "diplomatic relations",
-    "dire tactics",
     "divine offering",
     "domri's ambush",
-    "doomgape",
-    "dovescape",
     "durkwood tracker",
-    "duskmantle seer",
     "electrosiphon",
     "electryte",
-    "energy tap",
-    "engulfing slagwurm",
-    "erratic explosion",
     "exile",
-    "explosive revelation",
-    "feed the swarm",
     "felling blow",
     "feral encounter",
-    "fiery encore",
-    "flamethrower sonata",
     "foot chopper",
     "gargantuan gorilla",
     "garruk relentless",
@@ -217,121 +209,69 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "goblin crash pilot",
     "goblin sleigh ride",
     "goblin tinkerer",
-    "golbez, crystal collector",
     "gregor, shrewd magistrate",
-    "greven, predator captain",
     "grim contest",
     "grim feast",
-    "grisly spectacle",
-    "heal the scars",
-    "healing technique",
-    "hellhole rats",
     "hidetsugu and kairi",
-    "hit",
-    "hoard-smelter dragon",
     "horrid shadowspinner",
     "hotel of fears",
     "huatli's final strike",
     "hunter's edge",
     "hunter's mark",
-    "ignite memories",
-    "ikra shidiqi, the usurper",
     "immersturm",
-    "imp's mischief",
-    "induce paranoia",
     "infernal reckoning",
-    "interpret the signs",
     "jenova, ancient calamity",
-    "judge unworthy",
     "judgment of alexander",
-    "kaervek the merciless",
     "kamahl's will",
     "karplusan yeti",
-    "keeper of secrets",
     "kefka, dancing mad",
-    "kindle the carnage",
     "knockout maneuver",
     "lagonna-band storyteller",
     "lammastide weave",
     "lifeblood hydra",
     "living inferno",
     "lorcan, warlock collector",
-    "lozhan, dragons' legacy",
     "lukka, coppercoat outcast",
     "luminate primordial",
     "madame null, power broker",
     "make yourself useful",
-    "mana drain",
-    "marshland bloodcaster",
     "master of the wild hunt",
-    "mirkwood elk",
     "momentous fall",
     "moonlight hunt",
     "mortis dogs",
-    "narset of the ancient way",
     "nature's way",
     "neerdiv, devious diver",
-    "niambi, esteemed speaker",
     "nibelheim aflame",
     "nissa's judgment",
     "nissa's revelation",
     "noxious gearhulk",
-    "orchard warden",
-    "orim's thunder",
     "orzhov charm",
     "osseous sticktwister",
-    "overwhelming intellect",
     "packsong pup",
     "pain for all",
-    "pain seer",
     "paladin of atonement",
     "pandemonium",
-    "parallectric feedback",
-    "passionate archaeologist",
     "phthisis",
-    "phyrexian delver",
-    "planeswalker's fury",
-    "planeswalker's mirth",
     "polukranos, world eater",
     "predatory urge",
     "prime speaker zegana",
-    "proper burial",
-    "protection racket",
-    "pyretic rebirth",
     "pyrotechnic performer",
     "queen's bay paladin",
     "rabid gnaw",
-    "rage extractor",
     "rapacious guest",
     "rashida scalebane",
     "ravenous gigantotherium",
-    "razor hippogriff",
-    "reanimate",
-    "reanimate [6cb8b8c4-0674-4f14-9d89-010969fbb80e]",
-    "refuse",
-    "reviving vapors",
-    "riddle of lightning",
-    "righteous valkyrie",
-    "rotfeaster maggot",
-    "ruin raider",
-    "rupture",
     "sapling of colfenor",
     "sarkhan the mad",
-    "scattering stroke",
     "season's beatings",
     "seeds of innocence",
     "seek",
     "selfless exorcist",
     "serene offering",
     "sever soul",
-    "sheltering word",
-    "sheoldred's restoration",
     "showstopping surprise",
     "shriveling rot",
-    "sifter wurm",
     "signature slam",
-    "sin prodder",
-    "singe-mind ogre",
     "sister hospitaller",
     "solitude",
     "sorin the mirthless",
@@ -340,9 +280,7 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "spinal embrace",
     "spirit flare",
     "spoils of the hunt",
-    "steadfast armasaur",
     "stronghold arena",
-    "summon: kujata",
     "sunscourge champion",
     "sylvan smite",
     "syr ginger, the meal ender",
@@ -356,9 +294,7 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "the bears of littjara",
     "the creation of avacyn",
     "the great aerie",
-    "the lord of pain",
     "the mystery raceway",
-    "the provider",
     "the ruinous powers",
     "thorin, mountain-king",
     "thought sponge",
@@ -366,41 +302,164 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "too greedily, too deep",
     "tracker",
     "traitor's roar",
+    "vein drinker",
+    "venom blast",
+    "vivien's invocation",
+    "vraska's stoneglare",
+    "willow geist",
+    "wolverine riders",
+];
+
+/// Cards whose exported card data retains a runtime `ObjectScope::Demonstrative`
+/// (the CR 608.2c bare demonstrative / definite possessive back-reference —
+/// "that creature's toughness", "that card's mana value"). Split out of the
+/// former `Anaphoric` set so the subject-injection rewrite can rebind the
+/// pronoun "its" without clobbering these fixed antecedents. Frozen for the
+/// same anti-silent-drift reason as [`ANAPHORIC_SCOPE_CARDS`]; sorted by the
+/// export's normalized (lowercase) card key.
+const DEMONSTRATIVE_SCOPE_CARDS: &[&str] = &[
+    "abattoir ghoul",
+    "agonizing demise",
+    "alchemist's talent",
+    "archon of redemption",
+    "artifact mutation",
+    "aura mutation",
+    "baneful omen",
+    "boros fury-shield",
+    "bounteous kirin",
+    "breeches, the blastmaker",
+    "brightmare",
+    "calibrated blast",
+    "cinder cloud",
+    "cleric class",
+    "consuming vapors",
+    "cragganwick cremator",
+    "creature bond",
+    "daxos of meletis",
+    "dead reckoning",
+    "devour flesh",
+    "devour in shadow",
+    "dire tactics",
+    "doomgape",
+    "dovescape",
+    "duskmantle seer",
+    "energy tap",
+    "engulfing slagwurm",
+    "erratic explosion",
+    "essence backlash",
+    "explosive revelation",
+    "feed the swarm",
+    "fiery encore",
+    "flamethrower sonata",
+    "golbez, crystal collector",
+    "grab the reins",
+    "greven, predator captain",
+    "grisly spectacle",
+    "heal the scars",
+    "healing technique",
+    "heart-piercer manticore",
+    "hellhole rats",
+    "hit",
+    "hoard-smelter dragon",
+    "ignite memories",
+    "ikra shidiqi, the usurper",
+    "imp's mischief",
+    "induce paranoia",
+    "interpret the signs",
+    "judge unworthy",
+    "kaervek the merciless",
+    "kaervek's purge",
+    "keeper of secrets",
+    "kindle the carnage",
+    "lie in wait",
+    "lozhan, dragons' legacy",
+    "mana drain",
+    "marshland bloodcaster",
+    "mirkwood elk",
+    "narset of the ancient way",
+    "niambi, esteemed speaker",
+    "orchard warden",
+    "orim's thunder",
+    "overwhelming intellect",
+    "pain seer",
+    "parallectric feedback",
+    "passionate archaeologist",
+    "phyrexian delver",
+    "planeswalker's fury",
+    "planeswalker's mirth",
+    "proper burial",
+    "protection racket",
+    "pyretic rebirth",
+    "rage extractor",
+    "rakdos joins up",
+    "razor hippogriff",
+    "reanimate",
+    "reanimate [6cb8b8c4-0674-4f14-9d89-010969fbb80e]",
+    "refuse",
+    "reviving vapors",
+    "riddle of lightning",
+    "righteous valkyrie",
+    "rotfeaster maggot",
+    "ruin raider",
+    "rupture",
+    "sapling of colfenor",
+    "sarkhan the mad",
+    "scattering stroke",
+    "sheltering word",
+    "sheoldred's restoration",
+    "sifter wurm",
+    "sin prodder",
+    "singe-mind ogre",
+    "summon: kujata",
+    "terror of the peaks",
+    "the lord of pain",
+    "the provider",
     "tribute to hunger",
     "trostani, selesnya's voice",
     "twisted justice",
     "undying flames",
+    "unnatural hunger",
     "vanish into memory",
-    "vein drinker",
     "vendetta",
     "vengeful rebirth",
-    "venom blast",
     "verdant sun's avatar",
     "vial smasher the fierce",
     "viashino heretic",
-    "vivien's invocation",
     "volcanic vision",
-    "vraska's stoneglare",
     "weed strangle",
-    "willow geist",
-    "wolverine riders",
     "yuriko, the tiger's shadow",
+    "ziatora, the incinerator",
 ];
 
 /// Recursively reports whether a JSON subtree contains an `ObjectScope`
-/// `{"type":"Anaphoric"}` node. `Anaphoric` is only ever serialized as an
-/// `ObjectScope` variant tag, so a tag match is an exact detector.
-fn contains_anaphoric(value: &Value) -> bool {
+/// `{"type":<tag>}` node. `Anaphoric` / `Demonstrative` are only ever
+/// serialized as `ObjectScope` variant tags, so a tag match is an exact
+/// detector.
+fn contains_scope_tag(value: &Value, tag: &str) -> bool {
     match value {
         Value::Object(map) => {
-            if map.get("type") == Some(&Value::String("Anaphoric".to_string())) {
+            if map.get("type") == Some(&Value::String(tag.to_string())) {
                 return true;
             }
-            map.values().any(contains_anaphoric)
+            map.values().any(|v| contains_scope_tag(v, tag))
         }
-        Value::Array(items) => items.iter().any(contains_anaphoric),
+        Value::Array(items) => items.iter().any(|v| contains_scope_tag(v, tag)),
         _ => false,
     }
+}
+
+/// Collect the set of card keys whose exported data retains the given
+/// `ObjectScope` tag. Returns `None` when the export has not been generated
+/// (CI without card data), so callers can self-skip.
+fn observed_scope_set<'a>(
+    cards: &'a serde_json::Map<String, Value>,
+    tag: &str,
+) -> BTreeSet<&'a str> {
+    cards
+        .iter()
+        .filter(|(_, card)| contains_scope_tag(card, tag))
+        .map(|(name, _)| name.as_str())
+        .collect()
 }
 
 #[test]
@@ -414,12 +473,7 @@ fn anaphoric_scope_set_is_frozen() {
     let cards: Value = serde_json::from_str(&raw).expect("export should be valid JSON");
     let cards = cards.as_object().expect("export root should be an object");
 
-    let observed: BTreeSet<&str> = cards
-        .iter()
-        .filter(|(_, card)| contains_anaphoric(card))
-        .map(|(name, _)| name.as_str())
-        .collect();
-
+    let observed = observed_scope_set(cards, "Anaphoric");
     let allowed: BTreeSet<&str> = ANAPHORIC_SCOPE_CARDS.iter().copied().collect();
 
     let leaked: Vec<&str> = observed.difference(&allowed).copied().collect();
@@ -429,54 +483,107 @@ fn anaphoric_scope_set_is_frozen() {
         leaked.is_empty(),
         "New card(s) leaked a runtime ObjectScope::Anaphoric and are not in the \
          frozen allowlist: {leaked:?}. Classify each: a legitimate new \
-         category-1/2/3/4 case (see module doc) should be added to \
-         ANAPHORIC_SCOPE_CARDS; a real regression must be fixed in the parser. \
-         Categories 2 & 3 are tracked in #512, Dark Confidant's reveal-referent \
-         in #511."
+         category-1/2/3 pronoun case (see module doc) should be added to \
+         ANAPHORIC_SCOPE_CARDS; a bare demonstrative ('that creature's …') \
+         belongs in DEMONSTRATIVE_SCOPE_CARDS; a real regression must be fixed \
+         in the parser. Categories 2 & 3 are tracked in #512, Dark Confidant's \
+         reveal-referent in #511."
     );
     assert!(
         removed.is_empty(),
         "Card(s) in the frozen allowlist no longer retain ObjectScope::Anaphoric: \
-         {removed:?}. If #512/#511 fixed the misparse, remove the card(s) from \
-         ANAPHORIC_SCOPE_CARDS and update the count assertion."
+         {removed:?}. If #512/#511 fixed the misparse — or the card was a \
+         demonstrative that moved to DEMONSTRATIVE_SCOPE_CARDS — remove the \
+         card(s) from ANAPHORIC_SCOPE_CARDS and update the count assertion."
     );
 
-    // Secondary tripwire: the count itself is pinned. If #512/#511 land,
-    // both this and ANAPHORIC_SCOPE_CARDS shrink together.
+    // Secondary tripwire: the count itself is pinned. Splitting the bare
+    // demonstrative possessives onto `ObjectScope::Demonstrative` (so the
+    // subject-injection rewrite can rebind the pronoun "its" without clobbering
+    // them) moved 95 cards from this set into DEMONSTRATIVE_SCOPE_CARDS, and
+    // Steadfast Armasaur's "its toughness" rebound to `Source` (the LKI-toughness
+    // fix), taking the count 252 -> 156; the Optional_YouMay capture fix
+    // (#2277) then dropped "ian the reckless" to 155. If #512/#511 land, this
+    // shrinks further.
     assert_eq!(
         observed.len(),
-        251,
-        "Expected exactly 251 cards retaining ObjectScope::Anaphoric. PR #1451 \
-         re-scoped 8 dynamic-quantity 'its power' anaphora off the Anaphoric \
-         arm onto typed quantity refs; PR #1522 re-scoped Dead Before Sunrise \
-         through the recipient/subject rewrite. The category-2 'it deals damage \
-         equal to its power' trigger-subject class (#512) then moved 10 more \
-         cards (Warstorm Surge, Stalking Vengeance, Mage Slayer, et al.) onto \
-         `Power {{ scope: EventSource }}`. The parser later began extracting the \
-         'where X is that <type>'s mana value' tail for five more cards in the \
-         existing category-3 (target-destroy anaphora: Artifact Mutation, Aura \
-         Mutation, Hoard-Smelter Dragon) and category-4 (counter-then-act: \
-         Dovescape, Induce Paranoia) classes, moving the count 247 -> 252. Count \
-         moved to {}.",
+        155,
+        "Expected exactly 155 cards retaining ObjectScope::Anaphoric (pronoun \
+         'its' antecedents). Count moved to {}.",
         observed.len()
     );
     assert_eq!(
         ANAPHORIC_SCOPE_CARDS.len(),
-        251,
-        "ANAPHORIC_SCOPE_CARDS must list exactly 251 cards."
+        155,
+        "ANAPHORIC_SCOPE_CARDS must list exactly 155 cards."
     );
 }
 
-/// The allowlist constant must stay sorted so diffs are reviewable and the
+/// Companion tripwire for the bare demonstrative possessive class
+/// (`ObjectScope::Demonstrative`, CR 608.2c). Split out of the former
+/// `Anaphoric` set so the subject-injection rewrite never rebinds these fixed
+/// antecedents (Creature Bond, Erratic Explosion, Mana Drain, Yuriko, …).
+/// Freezes the set for the same anti-silent-drift reason as the `Anaphoric`
+/// guard: a new leak or count change forces a human classification.
+#[test]
+fn demonstrative_scope_set_is_frozen() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../client/public/card-data.json");
+    if !path.exists() {
+        eprintln!("skipping: client/public/card-data.json not generated");
+        return;
+    }
+    let raw = std::fs::read_to_string(&path).expect("export should be readable");
+    let cards: Value = serde_json::from_str(&raw).expect("export should be valid JSON");
+    let cards = cards.as_object().expect("export root should be an object");
+
+    let observed = observed_scope_set(cards, "Demonstrative");
+    let allowed: BTreeSet<&str> = DEMONSTRATIVE_SCOPE_CARDS.iter().copied().collect();
+
+    let leaked: Vec<&str> = observed.difference(&allowed).copied().collect();
+    let removed: Vec<&str> = allowed.difference(&observed).copied().collect();
+
+    assert!(
+        leaked.is_empty(),
+        "New card(s) leaked a runtime ObjectScope::Demonstrative and are not in \
+         DEMONSTRATIVE_SCOPE_CARDS: {leaked:?}. A bare 'that <type>'s …' / \
+         'the <type>'s …' possessive is the expected source; add it, or fix a \
+         real parser regression."
+    );
+    assert!(
+        removed.is_empty(),
+        "Card(s) in DEMONSTRATIVE_SCOPE_CARDS no longer retain \
+         ObjectScope::Demonstrative: {removed:?}. Remove the card(s) and update \
+         the count assertion."
+    );
+    assert_eq!(
+        observed.len(),
+        111,
+        "Expected exactly 111 cards retaining ObjectScope::Demonstrative. Count \
+         moved to {}.",
+        observed.len()
+    );
+    assert_eq!(
+        DEMONSTRATIVE_SCOPE_CARDS.len(),
+        111,
+        "DEMONSTRATIVE_SCOPE_CARDS must list exactly 111 cards."
+    );
+}
+
+/// The allowlist constants must stay sorted so diffs are reviewable and the
 /// `BTreeSet` semantics are obvious to a human auditor.
 #[test]
 fn anaphoric_scope_allowlist_is_sorted_and_unique() {
-    let mut sorted = ANAPHORIC_SCOPE_CARDS.to_vec();
-    sorted.sort_unstable();
-    sorted.dedup();
-    assert_eq!(
-        sorted.as_slice(),
-        ANAPHORIC_SCOPE_CARDS,
-        "ANAPHORIC_SCOPE_CARDS must be sorted and free of duplicates."
-    );
+    for (label, list) in [
+        ("ANAPHORIC_SCOPE_CARDS", ANAPHORIC_SCOPE_CARDS),
+        ("DEMONSTRATIVE_SCOPE_CARDS", DEMONSTRATIVE_SCOPE_CARDS),
+    ] {
+        let mut sorted = list.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.as_slice(),
+            list,
+            "{label} must be sorted and free of duplicates."
+        );
+    }
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -128,6 +128,7 @@ mod specialize_runtime;
 mod spellstutter_sprite_counter_with_x;
 mod spikeshell_harrier_speed_superlative;
 mod springheart_nantuko_bestow_landfall;
+mod steadfast_armasaur_lki_toughness;
 mod swans_prevention_followup;
 mod talon_gates_from_hand_activation;
 mod tempt_with_discovery;

--- a/crates/engine/tests/integration/steadfast_armasaur_lki_toughness.rs
+++ b/crates/engine/tests/integration/steadfast_armasaur_lki_toughness.rs
@@ -1,0 +1,146 @@
+//! Regression test for the Steadfast Armasaur Last-Known-Information bug.
+//!
+//! Judge report: "I'm attacking with Steadfast Armasaur, it gets blocked, I
+//! activate its ability, and in response the opponent casts Go for the Throat
+//! destroying Steadfast. When the ability resolves the blocker should take 3
+//! (Steadfast's toughness) using last known information — phase dealt 0."
+//!
+//! Root cause: "deals damage equal to **its toughness**" parsed to
+//! `QuantityRef::Toughness { scope: ObjectScope::Anaphoric }`. The
+//! subject-injection rewrite that rebinds the pronoun "its" to the ability
+//! source only matched `Power`, so `Toughness { Anaphoric }` survived to
+//! runtime — where an activated ability with no effect-context / trigger /
+//! cost referent resolves it to 0.
+//!
+//! Fix: split the rebindable pronoun (`ObjectScope::Anaphoric`) from the fixed
+//! demonstrative possessive (`ObjectScope::Demonstrative`, "that creature's
+//! toughness") and generalize the rebind to every per-object characteristic, so
+//! "its toughness" with a `SelfRef` subject binds to `Toughness { Source }`.
+//! The existing `Source` resolver already LKI-falls-back (CR 113.7a) when the
+//! source has left the battlefield, so the blocker now takes 3.
+//!
+//! CR 113.7a: an ability on the stack still exists though its source has left
+//! its zone; that source's last known information is used.
+//! CR 608.2b: an ability resolves even if its source (a permanent) has left the
+//! battlefield. (verified: docs/MagicCompRules.txt)
+//!
+//! The damage target is simplified to "target creature" (the printed card
+//! restricts to "attacking or blocking creature") and the activation cost to
+//! "{T}" (printed "{1}{W}, {T}") — the fix touches only the damage-AMOUNT parse
+//! path, which is independent of both the target filter and the mana cost, so
+//! this preserves the discriminating behavior without staging combat or a mana
+//! pool.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const STEADFAST_TEXT: &str =
+    "{T}: Steadfast Armasaur deals damage equal to its toughness to target creature.";
+
+/// Announce the ability and drive to the post-announcement Priority window
+/// (the ability is on the stack, target chosen). Answers target selection;
+/// finalizes any mana window from the (empty) pool defensively. Bounded loop.
+fn activate_to_stack(runner: &mut GameRunner, source: ObjectId, target: ObjectId) {
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("activating Steadfast Armasaur's ability must succeed");
+
+    for _ in 0..16 {
+        match &runner.state().waiting_for {
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(TargetRef::Object(target)),
+                    })
+                    .expect("choosing the damage target must succeed");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("finalizing the (tap-only) cost must succeed");
+            }
+            WaitingFor::Priority { .. } => return,
+            other => panic!("unexpected prompt before the ability hit the stack: {other:?}"),
+        }
+    }
+    panic!("ability never reached the on-stack Priority window");
+}
+
+/// CR 113.7a + CR 608.2b — the headline test. Steadfast's `{T}` ability is on
+/// the stack targeting a blocker; the source is destroyed in response; on
+/// resolution the blocker must take damage equal to Steadfast's LKI toughness
+/// (3), not 0.
+#[test]
+fn steadfast_deals_lki_toughness_after_source_destroyed_in_response() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Steadfast Armasaur is a 1/3; its damage equals its TOUGHNESS (3).
+    let steadfast = scenario
+        .add_creature_from_oracle(P0, "Steadfast Armasaur", 1, 3, STEADFAST_TEXT)
+        .id();
+    // Target survives 3 damage (toughness 5) so the exact marked damage is
+    // observable — 0 (bug), 1 (power misread), or 3 (toughness via LKI).
+    let blocker = scenario.add_creature(P1, "Goblin Blocker", 2, 5).id();
+
+    let mut runner = scenario.build();
+
+    activate_to_stack(&mut runner, steadfast, blocker);
+
+    // CR 113.7a setup: destroy the source while the ability is on the stack.
+    // `move_to_zone` runs `apply_zone_exit_cleanup`, which snapshots the
+    // leaving permanent's LKI (toughness 3) keyed by its battlefield id — the
+    // id the on-stack ability still references as its source.
+    engine::game::zones::move_to_zone(
+        runner.state_mut(),
+        steadfast,
+        Zone::Graveyard,
+        &mut Vec::new(),
+    );
+    assert_eq!(
+        runner.state().objects[&steadfast].zone,
+        Zone::Graveyard,
+        "Steadfast must be destroyed (in the graveyard) before the ability resolves",
+    );
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&blocker].damage_marked,
+        3,
+        "the blocker must take 3 damage (Steadfast's LKI toughness), not 0 (the \
+         bug) and not 1 (its power) — proving 'its toughness' bound to Source and \
+         resolved through last-known information",
+    );
+}
+
+/// Control: with the source still on the battlefield, the same ability deals 3
+/// from the live object. Guards against the rebind accidentally over-reaching
+/// (e.g. always reading 0) in the non-LKI path.
+#[test]
+fn steadfast_deals_toughness_with_source_alive() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let steadfast = scenario
+        .add_creature_from_oracle(P0, "Steadfast Armasaur", 1, 3, STEADFAST_TEXT)
+        .id();
+    let target = scenario.add_creature(P1, "Goblin Blocker", 2, 5).id();
+    let mut runner = scenario.build();
+
+    activate_to_stack(&mut runner, steadfast, target);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&target].damage_marked,
+        3,
+        "with the source alive the ability must still deal toughness (3)",
+    );
+}


### PR DESCRIPTION
"~ deals damage equal to its toughness" dealt 0 when the source was destroyed
in response to its own activated ability: "its toughness" parsed to
Toughness{Anaphoric}, but the subject-injection rewrite that binds the pronoun
"its" to the source only handled Power, so it survived to runtime with no
referent and resolved to 0.

Root cause was a conflation: the pronoun "its" and the demonstrative "that
creature's" (Creature Bond, CR 608.2c) both parsed to Toughness{Anaphoric}, so
naively widening the rewrite to Toughness regressed the demonstrative.

Fix: split ObjectScope::Demonstrative (the fixed noun-phrase referent) from
Anaphoric (the rebindable pronoun), then generalize the rewrite to every
per-object characteristic. It changes which object (the scope field) never which
characteristic (the QuantityRef variant), so it stays within each property's CR
section and touches only genuine pronouns. "its toughness" with a SelfRef
subject now binds to Toughness{Source}, which LKI-falls-back per CR 113.7a when
the source has left the battlefield.

- types/ability.rs: add ObjectScope::Demonstrative (CR 608.2c)
- oracle_quantity.rs: classify_possessive_referent emits Demonstrative for bare "that/the <type>'s"
- oracle_effect/{mod,lower}.rs: rewrite_event_source_power_to_object_power -> rebind_anaphoric_object_scope (all per-object refs, all 3 rebind sites)
- game/{quantity,effects/delayed_trigger,coverage}.rs: Demonstrative resolves identically to Anaphoric
- allowlist guard: 252 -> 156 Anaphoric + 111 Demonstrative, both frozen by sibling tripwires
- new runtime test steadfast_armasaur_lki_toughness.rs: blocker takes 3 (LKI toughness), not 0

10951/10951 engine tests pass.
