### PR TITLE
fix(frontend): make convoke payment modals clickable and collapsible

### DIFF
--- a/client/src/components/mana/ManaPaymentUI.tsx
+++ b/client/src/components/mana/ManaPaymentUI.tsx
@@ -15,6 +15,9 @@ import {
   SHARD_ABBREVIATION,
 } from "../../viewmodel/costLabel.ts";
 import { gameButtonClass } from "../ui/buttonStyles.ts";
+import { useIsNarrowViewport } from "../modal/DialogHost.tsx";
+import { PeekTab } from "../modal/DialogShell.tsx";
+import { useOptionalDialogPeek } from "../modal/dialogPeekContext.ts";
 import { ManaBadge } from "./ManaBadge.tsx";
 import { ManaSymbol } from "./ManaSymbol.tsx";
 
@@ -45,6 +48,13 @@ export function ManaPaymentUI() {
       : null;
   const convokeMode = isManaPayment ? waitingFor.data.convoke_mode : undefined;
   const player = playerId != null ? gameState?.players[playerId] : null;
+
+  // CR 702.51a: the bottom-anchored convoke panel can sit on top of the very
+  // creatures the player must tap to pay. The DialogHost peek affordance lets
+  // them slide it out of the way and back (a no-op for plain mana payment, which
+  // needs no board interaction). `useOptionalDialogPeek` is null outside a host.
+  const peek = useOptionalDialogPeek();
+  const isNarrow = useIsNarrowViewport();
 
   // CR 107.4f + CR 601.2f: Engine-provided per-shard options for Phyrexian payment.
   // The UI maps shard_index → PhyrexianShard so it can disable toggles for trivial
@@ -232,7 +242,17 @@ export function ManaPaymentUI() {
             DialogHost wrapper is `pointer-events: none` so board taps reach the
             artifacts/creatures, but the Pay/Cancel controls must still respond.
             The surrounding full-width strip stays pass-through. */}
-        <div className="pointer-events-auto rounded-xl bg-gray-900/95 p-4 shadow-2xl ring-1 ring-gray-700 min-w-[280px] max-w-[420px]">
+        <div className="pointer-events-auto relative rounded-xl bg-gray-900/95 p-4 shadow-2xl ring-1 ring-gray-700 min-w-[280px] max-w-[420px]">
+          {/* CR 702.51a: collapse cue for convoke/improvise payment — slides this
+              panel off any creature it overlaps so the player can tap it. Only
+              shown while the panel is in place (peeked state surfaces the
+              DialogHost restore tab instead). */}
+          {convokeMode && peek && !peek.peeked && (
+            <PeekTab
+              direction={isNarrow ? "bottom" : "right"}
+              onClick={peek.togglePeek}
+            />
+          )}
           <h3 className="mb-3 text-center text-sm font-semibold text-gray-300">
             {t("mana.payMana")}
             {cardName && (

--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -116,7 +116,15 @@ export function DialogHost({ children }: { children: ReactNode }) {
 
   const dialogVisible =
     (isDialogVisibleFor(waitingFor) && canActForWaitingState) || hasUiDialog;
-  const clickThrough = isClickThroughDialog(waitingFor);
+  // CR 702.51a: convoke/improvise payment marks the host click-through so board
+  // taps reach creatures. But a UI-driven modal opened mid-payment — e.g. the
+  // ability picker fired by tapping a mana creature like Birds of Paradise, which
+  // is convoke-eligible AND has an activatable mana ability — renders INSIDE this
+  // host. Leaving the host click-through makes that modal inherit
+  // `pointer-events: none`, so its buttons are dead and clicks fall through to the
+  // board/hand behind it. While such a modal is up the player interacts with it,
+  // not the board, so suppress click-through to restore pointer events.
+  const clickThrough = isClickThroughDialog(waitingFor) && !hasUiDialog;
   // BASE INVARIANT: every visible prompt is anchored in this viewport-level
   // `fixed inset-0 z-40` stacking context, so no prompt can ever be trapped
   // beneath the board. The board grid is its own `relative z-10` stacking
@@ -128,10 +136,15 @@ export function DialogHost({ children }: { children: ReactNode }) {
   // Click-through is achieved with `pointer-events: none` (below), NOT by
   // un-anchoring, so board taps still reach the battlefield.
   const anchored = dialogVisible;
-  // Only non-click-through dialogs participate in the peek/slide affordance;
-  // click-through overlays (convoke/improvise board taps, target picking) stay
-  // put and pass taps through to the board.
-  const peekable = anchored && !clickThrough;
+  // The convoke/improvise payment panel is bottom-anchored and can overlap the
+  // very creatures the player must tap to pay. Unlike the translucent full-screen
+  // target overlays, it benefits from the peek/slide affordance so the player can
+  // collapse it off an overlapped creature — so it stays peekable even while
+  // click-through. Other click-through overlays (target picking) are translucent
+  // and full-screen, so they stay put and pass taps straight through.
+  const isConvokePayment =
+    waitingFor?.type === "ManaPayment" && waitingFor.data.convoke_mode != null;
+  const peekable = anchored && (!clickThrough || isConvokePayment);
   const showPeekTab = peeked && peekable;
 
   const ctxValue = useMemo<DialogPeekContext>(


### PR DESCRIPTION
During convoke, DialogHost sets pointer-events:none so board taps reach creatures.
A modal opened mid-payment (the ability picker fired by tapping a mana creature
like Birds of Paradise, which is convoke-eligible AND has a mana ability) rendered
inside the host inherited pointer-events:none and was a dead, unclickable panel.
Suppress click-through while a UI modal is open (clickThrough && !hasUiDialog) so
the picker is interactive; the player interacts with it, not the board.

The bottom-anchored convoke payment panel also overlaps the very creatures the
player must tap. Make convoke payment peekable and add a PeekTab collapse cue in
ManaPaymentUI wired to the DialogHost peek context, so the panel can slide off an
overlapped creature and back (CR 702.51a).
