### PR TITLE
fix(client): convoke creature taps work during mana payment (#1532)

### DIFF
--- a/client/src/components/modal/__tests__/DialogHost.test.tsx
+++ b/client/src/components/modal/__tests__/DialogHost.test.tsx
@@ -133,6 +133,8 @@ describe("DialogHost", () => {
       </DialogHost>,
     );
     const wrapper = container.firstElementChild as HTMLElement | null;
+    expect(wrapper?.className ?? "").toMatch(/fixed/);
+    expect(wrapper?.className ?? "").toMatch(/z-40/);
     expect(wrapper?.style.pointerEvents).not.toBe("none");
   });
 

--- a/client/src/components/modal/__tests__/DialogHost.test.tsx
+++ b/client/src/components/modal/__tests__/DialogHost.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DialogHost } from "../DialogHost.tsx";
 import { DialogShell } from "../DialogShell.tsx";
 import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
 import type { WaitingFor } from "../../../adapter/types.ts";
 
 function setWaitingFor(waitingFor: WaitingFor | null) {
@@ -28,6 +29,7 @@ describe("DialogHost", () => {
     cleanup();
     setWaitingFor(null);
     useGameStore.setState({ gameState: null });
+    useUiStore.setState({ pendingAbilityChoice: null, enchantmentsDialogPlayer: null });
   });
 
   it("hides the peek-restore tab while the dialog is visible (un-peeked)", () => {
@@ -109,6 +111,29 @@ describe("DialogHost", () => {
     expect(wrapper?.className ?? "").toMatch(/fixed/);
     expect(wrapper?.className ?? "").toMatch(/z-40/);
     expect(wrapper?.style.pointerEvents).toBe("none");
+  });
+
+  it("restores host pointer events during convoke when a UI modal is open (#1532)", () => {
+    // Issue #1532: convoke payment is click-through so board taps reach creatures,
+    // but an ability picker opened mid-payment (mana dork + convoke-eligible) must
+    // stay interactive — not inherit pointer-events:none from the host.
+    setWaitingFor({
+      type: "ManaPayment",
+      data: { player: 0, convoke_mode: "Convoke" },
+    } as never);
+    useUiStore.setState({
+      pendingAbilityChoice: {
+        objectId: 41,
+        actions: [{ type: "TapForConvoke", data: { object_id: 41, mana_type: "Green" } }],
+      },
+    });
+    const { container } = render(
+      <DialogHost>
+        <div data-testid="child" />
+      </DialogHost>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    expect(wrapper?.style.pointerEvents).not.toBe("none");
   });
 
   it("keeps the viewport wrapper for plain mana payment without convoke", () => {


### PR DESCRIPTION
## Summary

Fixes [#1532](https://github.com/phase-rs/phase/issues/1532): when casting with convoke, the game prompted to tap creatures but clicks on the battlefield did nothing.

**Root cause:** After [#1935](https://github.com/phase-rs/phase/pull/1935) anchored `DialogHost` at `fixed inset-0 z-40`, convoke payment needed click-through (`pointer-events: none`) so taps reach permanents. A mid-payment ability picker (e.g. Birds of Paradise — convoke-eligible and has a mana ability) also rendered inside the host and inherited that click-through, so its buttons were dead and creature taps appeared to do nothing.

**Fix (already on `main` via [#2307](https://github.com/phase-rs/phase/pull/2307)):**
- Convoke/improvise/waterbend `ManaPayment` keeps the host anchored but click-through so board taps reach creatures.
- Suppress click-through while `pendingAbilityChoice` / enchantments UI is open so the picker stays interactive.
- Convoke payment panel is peekable (slide off overlapped creatures) with a collapse cue in `ManaPaymentUI`.

This PR adds a `DialogHost` regression test for the convoke + ability-picker case.

## Test plan

- [x] `pnpm test --run src/components/modal/__tests__/DialogHost.test.tsx` (new `#1532` case)
- [ ] Cast a convoke spell; tap creatures on the board and confirm they tap / mana is applied
- [ ] Tap a convoke-eligible mana creature with multiple `TapForConvoke` options; confirm the ability picker is clickable
- [ ] Use peek/slide on the convoke payment panel when it covers a creature you need to tap

Fixes #1532