### PR TITLE
fix: convoke payment modal — dedup picker, color-gate taps, show staged taps

### DIFF
--- a/client/src/components/mana/ManaPaymentUI.tsx
+++ b/client/src/components/mana/ManaPaymentUI.tsx
@@ -159,6 +159,25 @@ export function ManaPaymentUI() {
     return MANA_ORDER.filter((c) => counts[c] > 0).map((c) => ({ color: c, amount: counts[c] }));
   }, [player]);
 
+  // CR 702.51a / CR 702.126a: each creature/artifact tapped for convoke/improvise
+  // adds a `ConvokePayment`-restricted marker to the pool (engine
+  // `ManaUnit::convoke_payment`). These are deliberately excluded from
+  // `manaPoolSummary` above because they are not spendable mana — only a record
+  // that the permanent has been tapped toward this cost. Surface them in their
+  // own row so each tap gives the player visible feedback (otherwise the panel
+  // looks frozen as creatures are tapped).
+  const convokeStaged = useMemo(() => {
+    if (!player) return [];
+    const counts: Record<ManaType, number> = {
+      White: 0, Blue: 0, Black: 0, Red: 0, Green: 0, Colorless: 0,
+    };
+    for (const unit of player.mana_pool.mana) {
+      if (!unit.restrictions.includes("ConvokePayment")) continue;
+      counts[unit.color]++;
+    }
+    return MANA_ORDER.filter((c) => counts[c] > 0).map((c) => ({ color: c, amount: counts[c] }));
+  }, [player]);
+
   // CR 107.4f + CR 601.2f: Only shards with `ManaOrLife` can be toggled; ManaOnly
   // / LifeOnly shards are locked to their single legal payment.
   const shardByIndex = useMemo(() => {
@@ -279,6 +298,20 @@ export function ManaPaymentUI() {
                       ? t("mana.improviseHint")
                       : t("mana.convokeOrImproviseHint")}
                 </p>
+              )}
+
+              {/* CR 702.51a: live feedback for staged convoke/improvise taps —
+                  each tapped permanent shows here as a cyan-tinted badge so the
+                  player can see the payment progressing as the cost is covered. */}
+              {convokeMode && convokeStaged.length > 0 && (
+                <div className="mb-3 flex items-center justify-center gap-2">
+                  <span className="text-xs text-cyan-400">
+                    {t("mana.convokeStaged")}
+                  </span>
+                  {convokeStaged.map(({ color, amount }) => (
+                    <ManaBadge key={color} color={color} amount={amount} />
+                  ))}
+                </div>
               )}
 
               {/* Phyrexian toggles — during PhyrexianPayment we iterate the

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -308,6 +308,7 @@
     "convokeHint": "Tappe Kreaturen, um die Bezahlung zu unterstützen.",
     "improviseHint": "Tappe Artefakte, um die Bezahlung zu unterstützen.",
     "convokeOrImproviseHint": "Tappe Kreaturen oder Artefakte, um die Bezahlung zu unterstützen.",
+    "convokeStaged": "Getappt:",
     "lifeAmount": "2 Leben",
     "lifeCostSummary": "({{count}} Leben)",
     "paymentPending": "Die Bezahlung steht noch aus. Tappe bleibende Karten oder brich diese Aktion ab.",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -308,6 +308,7 @@
     "convokeHint": "Tap creatures to help pay.",
     "improviseHint": "Tap artifacts to help pay.",
     "convokeOrImproviseHint": "Tap creatures or artifacts to help pay.",
+    "convokeStaged": "Tapped:",
     "lifeAmount": "2 life",
     "lifeCostSummary": "({{count}} life)",
     "paymentPending": "Payment is still pending. Tap permanents or cancel this action.",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -308,6 +308,7 @@
     "convokeHint": "Gira criaturas para ayudar a pagar.",
     "improviseHint": "Gira artefactos para ayudar a pagar.",
     "convokeOrImproviseHint": "Gira criaturas o artefactos para ayudar a pagar.",
+    "convokeStaged": "Giradas:",
     "lifeAmount": "2 vidas",
     "lifeCostSummary": "({{count}} vidas)",
     "paymentPending": "El pago sigue pendiente. Gira permanentes o cancela esta acción.",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -308,6 +308,7 @@
     "convokeHint": "Engagez des créatures pour aider à payer.",
     "improviseHint": "Engagez des artefacts pour aider à payer.",
     "convokeOrImproviseHint": "Engagez des créatures ou des artefacts pour aider à payer.",
+    "convokeStaged": "Engagés :",
     "lifeAmount": "2 points de vie",
     "lifeCostSummary": "({{count}} points de vie)",
     "paymentPending": "Le paiement est toujours en attente. Engagez des permanents ou annulez cette action.",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -308,6 +308,7 @@
     "convokeHint": "TAPpa le creature per aiutare a pagare.",
     "improviseHint": "TAPpa gli artefatti per aiutare a pagare.",
     "convokeOrImproviseHint": "TAPpa creature o artefatti per aiutare a pagare.",
+    "convokeStaged": "TAPpate:",
     "lifeAmount": "2 punti vita",
     "lifeCostSummary": "({{count}} punti vita)",
     "paymentPending": "Il pagamento è ancora in sospeso. TAPpa i permanenti o annulla questa azione.",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -308,6 +308,7 @@
     "convokeHint": "Obróć stwory, aby pomóc zapłacić.",
     "improviseHint": "Obróć artefakty, aby pomóc zapłacić.",
     "convokeOrImproviseHint": "Obróć stwory lub artefakty, aby pomóc zapłacić.",
+    "convokeStaged": "Obrócone:",
     "lifeAmount": "2 życia",
     "lifeCostSummary": "({{count}} życia)",
     "paymentPending": "Płatność wciąż oczekuje. Obróć trwałe lub anuluj tę akcję.",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -308,6 +308,7 @@
     "convokeHint": "Vire criaturas para ajudar a pagar.",
     "improviseHint": "Vire artefatos para ajudar a pagar.",
     "convokeOrImproviseHint": "Vire criaturas ou artefatos para ajudar a pagar.",
+    "convokeStaged": "Viradas:",
     "lifeAmount": "2 de vida",
     "lifeCostSummary": "({{count}} de vida)",
     "paymentPending": "O pagamento ainda está pendente. Vire permanentes ou cancele esta ação.",

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -3436,6 +3436,17 @@ fn mana_payment_actions(
     ));
     if let Some(mode) = convoke_mode {
         // CR 702.51a + CR 302.6: Summoning sickness does not restrict tapping for convoke.
+        // CR 702.51a: a Convoke tap reduces the cost by {1} (a Colorless marker) or by one
+        // mana of the creature's color (a colored marker, which pays ONLY a matching colored
+        // pip — see `mana_payment`). Capture the locked spell cost's shards so a colored tap
+        // is offered only when the cost actually contains a pip of that color; tapping for a
+        // color the cost can't use spends the creature for nothing. Unavailable cost ⇒ offer
+        // every color (never prune a possibly-useful option on missing information).
+        let convoke_cost_shards: Option<&[crate::types::mana::ManaCostShard]> =
+            state.pending_cast.as_ref().and_then(|pc| match &pc.cost {
+                crate::types::mana::ManaCost::Cost { shards, .. } => Some(shards.as_slice()),
+                _ => None,
+            });
         for (obj_id, obj) in &state.objects {
             match mode {
                 ConvokeMode::Waterbend if obj.is_waterbend_eligible(player) => {
@@ -3470,8 +3481,17 @@ fn mana_payment_actions(
                         TacticalClass::Mana,
                         Some(player),
                     ));
-                    // Plus one per color the creature has
+                    // CR 702.51a: one colored tap per color the creature has — but only
+                    // colors the cost can actually use. A colored convoke marker pays only a
+                    // matching colored pip, so a color absent from the cost is a wasted tap.
+                    // `contributes_to` covers hybrid/Phyrexian/two-brid pips. When the cost is
+                    // unavailable, offer every color rather than risk pruning a useful option.
                     for color in &obj.color {
+                        if let Some(shards) = convoke_cost_shards {
+                            if !shards.iter().any(|shard| shard.contributes_to(*color)) {
+                                continue;
+                            }
+                        }
                         actions.push(candidate(
                             GameAction::TapForConvoke {
                                 object_id: *obj_id,
@@ -4532,6 +4552,101 @@ mod tests {
                 GameAction::TapLandForMana { object_id } if object_id == blank_land
             )
         }));
+    }
+
+    #[test]
+    fn convoke_offers_only_cost_relevant_colored_taps() {
+        // CR 702.51a: a Convoke tap reduces the cost by {1} (Colorless marker) or by one
+        // mana of the creature's color (a colored marker that pays ONLY a matching colored
+        // pip). For a {4}{W} cost, a green creature can only help via the generic {1} — a
+        // green colored tap pays nothing and wastes the creature. The generator must offer
+        // the Colorless tap for every eligible creature, suppress the green colored tap, and
+        // still offer the white creature's white tap (the cost contains a {W} pip).
+        let mut state = GameState::new_two_player(42);
+
+        // Lock in a {4}{W} pending cast — the convoke spell being paid.
+        let spell = create_object(
+            &mut state,
+            CardId(400),
+            PlayerId(0),
+            "Venerated Loxodon".to_string(),
+            Zone::Stack,
+        );
+        state.pending_cast = Some(Box::new(crate::types::game_state::PendingCast::new(
+            spell,
+            CardId(400),
+            crate::types::ability::ResolvedAbility::new(
+                Effect::Unimplemented {
+                    name: "test".to_string(),
+                    description: None,
+                },
+                Vec::new(),
+                spell,
+                PlayerId(0),
+            ),
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::White],
+                generic: 4,
+            },
+        )));
+
+        // Mono-green creature: its color is absent from the cost.
+        let green = create_object(
+            &mut state,
+            CardId(401),
+            PlayerId(0),
+            "Llanowar Elves".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&green).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.color = vec![ManaColor::Green];
+        }
+        // Mono-white creature: its color is present in the cost.
+        let white = create_object(
+            &mut state,
+            CardId(402),
+            PlayerId(0),
+            "Soldier".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&white).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.color = vec![ManaColor::White];
+        }
+
+        let actions = mana_payment_actions(&state, PlayerId(0), Some(ConvokeMode::Convoke));
+        let has = |object_id, mana_type| {
+            actions.iter().any(|candidate| {
+                matches!(
+                    candidate.action,
+                    GameAction::TapForConvoke { object_id: o, mana_type: m }
+                        if o == object_id && m == mana_type
+                )
+            })
+        };
+
+        // Generic tap: always available for any convoke-eligible creature.
+        assert!(
+            has(green, ManaType::Colorless),
+            "green creature must offer the generic convoke tap"
+        );
+        assert!(
+            has(white, ManaType::Colorless),
+            "white creature must offer the generic convoke tap"
+        );
+        // Green is absent from {4}{W} → no green colored tap (the wasted-tap bug).
+        assert!(
+            !has(green, ManaType::Green),
+            "green convoke must NOT be offered for a cost with no green pip"
+        );
+        // White is present in {4}{W} → the white creature's colored tap is offered.
+        assert!(
+            has(white, ManaType::White),
+            "white convoke must be offered when the cost contains a white pip"
+        );
     }
 
     #[test]

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -711,7 +711,19 @@ pub fn legal_actions_full(state: &GameState) -> LegalActionsFull {
     let mut grouped: HashMap<ObjectId, Vec<GameAction>> = HashMap::new();
     for action in &grouped_actions {
         if let Some(id) = action.source_object() {
-            grouped.entry(id).or_default().push(action.clone());
+            // Dedup per object. During WaitingFor::ManaPayment the flat
+            // candidate list already contains non-land mana abilities (e.g.
+            // Birds of Paradise's ActivateAbility, emitted by
+            // `mana_payment_actions` so the AI/server can pay), and the
+            // `activatable_object_mana_actions` extension above re-derives the
+            // same ones. `is_mana_ability()` only strips land taps, so the flat
+            // copy is not filtered out — without this guard the per-object map
+            // (the frontend ability picker) lists an identical mana ability
+            // twice (the convoke "Add one mana of any color" duplicate).
+            let bucket = grouped.entry(id).or_default();
+            if !bucket.contains(action) {
+                bucket.push(action.clone());
+            }
         }
     }
 
@@ -1431,6 +1443,53 @@ mod tests {
         assert!(!flat.iter().any(
             |action| matches!(action, GameAction::ActivateAbility { source_id, .. } if *source_id == rock)
         ));
+    }
+
+    #[test]
+    fn legal_actions_by_object_dedups_mana_ability_during_payment() {
+        // Regression: during WaitingFor::ManaPayment the flat candidate list
+        // (from `mana_payment_actions`) carries the non-land mana ability so the
+        // AI/server can pay, and the `activatable_object_mana_actions` extension
+        // re-derives it. `is_mana_ability()` only strips land taps, so without a
+        // per-object dedup the grouped map (the frontend ability picker) listed
+        // the same ActivateAbility twice — surfacing as Birds of Paradise's "Add
+        // one mana of any color" appearing twice in the convoke picker.
+        let mut state = setup_priority();
+        let rock = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Mana Rock".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&rock)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Artifact);
+        let ability_index = add_fixed_mana_ability(&mut state, rock, ManaColor::Green);
+        set_dummy_pending_cast(&mut state);
+        state.waiting_for = WaitingFor::ManaPayment {
+            player: PlayerId(0),
+            convoke_mode: None,
+        };
+
+        let (_, _, grouped) = legal_actions_full(&state);
+
+        let mana_action = GameAction::ActivateAbility {
+            source_id: rock,
+            ability_index,
+        };
+        let count = grouped
+            .get(&rock)
+            .map(|bucket| bucket.iter().filter(|a| **a == mana_action).count())
+            .unwrap_or(0);
+        assert_eq!(
+            count, 1,
+            "the per-object map must offer the mana ability exactly once during ManaPayment, got {count}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Three fixes for the convoke mana-payment modal, all surfaced from one live AI game (Venerated Loxodon convoked with Birds of Paradise).

### 1. Duplicate "Add one mana of any color" in the ability picker (engine)
During `WaitingFor::ManaPayment` the flat candidate list carries non-land mana abilities (so the AI/MP server can pay), and `legal_actions_full` also extends the per-object map via `activatable_object_mana_actions`. `is_mana_ability()` only strips land taps, so the flat `ActivateAbility` survived the filter and the grouped map listed it twice. Fixed with a per-object dedup at the grouped-map seam (the flat list must keep its single copy for the AI candidate space and the MP server payment gate). — CR 605.3a

### 2. Useless colored convoke taps offered (engine)
A green creature tapping convoke for a `{4}{W}` spell was offered a green tap that pays nothing (a colored convoke marker pays only a matching colored pip) and wastes the creature. `mana_payment_actions` now gates colored taps on `ManaCostShard::contributes_to` against the locked `pending_cast` cost (covers hybrid/Phyrexian/two-brid); unavailable cost falls back to offering every color so a useful option is never pruned. — CR 702.51a

### 3. Pool not updating as creatures are tapped (frontend)
Each `TapForConvoke` adds a `ConvokePayment`-restricted marker that the "Pool:" row deliberately filters out, so tapping produced no feedback. Added a distinct "Tapped:" row rendering the staged markers (pure display of engine pool state). New i18n key `convokeStaged` across all 7 locales. — CR 702.51a

### Tests
- `legal_actions_by_object_dedups_mana_ability_during_payment` (engine)
- `convoke_offers_only_cost_relevant_colored_taps` (engine)
- frontend type-check + i18n parity gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
