### PR TITLE
feat(engine): infinite-mana debug toggle

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1426,6 +1426,7 @@ export type DebugAction =
   | { type: "ModifyPlayerCounters"; data: { player_id: PlayerId; counter_kind: PlayerCounterKind; delta: number } }
   | { type: "ModifyEnergy"; data: { player_id: PlayerId; delta: number } }
   | { type: "AddMana"; data: { player_id: PlayerId; mana: ManaType[] } }
+  | { type: "SetInfiniteMana"; data: { player_id: PlayerId; enabled: boolean } }
   | { type: "SetPhase"; data: { phase: Phase; active_player: PlayerId } }
   | { type: "RunStateBasedActions" }
   | {

--- a/client/src/components/chrome/DebugPlayerActions.tsx
+++ b/client/src/components/chrome/DebugPlayerActions.tsx
@@ -5,6 +5,7 @@ import { usePerspectivePlayerId } from "../../hooks/usePlayerId";
 import { useUiStore } from "../../stores/uiStore";
 import {
   AccordionItem,
+  CheckboxInput,
   FieldRow,
   ManaTypeSelect,
   NumberInput,
@@ -153,6 +154,25 @@ function AddManaForm({ onDispatch }: Props) {
   );
 }
 
+function InfiniteManaForm({ onDispatch }: Props) {
+  const [playerId, setPlayerId] = useState<PlayerId>(0);
+  const [enabled, setEnabled] = useState(true);
+
+  return (
+    <>
+      <FieldRow label="Player">
+        <PlayerSelect value={playerId} onChange={setPlayerId} />
+      </FieldRow>
+      <FieldRow label="State">
+        <CheckboxInput checked={enabled} onChange={setEnabled} label="Enabled" />
+      </FieldRow>
+      <SubmitButton onClick={() => onDispatch({ type: "SetInfiniteMana", data: { player_id: playerId, enabled } })}>
+        Apply
+      </SubmitButton>
+    </>
+  );
+}
+
 function ModifyPlayerCountersForm({ onDispatch }: Props) {
   const [playerId, setPlayerId] = useState<PlayerId>(0);
   const [counterKind, setCounterKind] = useState<PlayerCounterKind>("Poison");
@@ -253,6 +273,13 @@ export function DebugPlayerActions({ onDispatch }: Props) {
       </AccordionItem>
       <AccordionItem label="Add Mana" expanded={expanded === "mana"} onToggle={() => toggle("mana")}>
         <AddManaForm onDispatch={onDispatch} />
+      </AccordionItem>
+      <AccordionItem
+        label="Infinite Mana"
+        expanded={expanded === "infinite-mana"}
+        onToggle={() => toggle("infinite-mana")}
+      >
+        <InfiniteManaForm onDispatch={onDispatch} />
       </AccordionItem>
       <AccordionItem label="Modify Counters" expanded={expanded === "counters"} onToggle={() => toggle("counters")}>
         <ModifyPlayerCountersForm onDispatch={onDispatch} />

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -153,6 +153,10 @@ pub fn apply(
     sync_waiting_for(state, &result.waiting_for);
     run_auto_pass_loop(state, &mut result);
     reconcile_terminal_result(state, &mut result);
+    // Debug "infinite mana" (CR 500.5 suppressed for flagged players): restore any
+    // pool that a spend during this action depleted, before public state is
+    // finalized and the next affordability probe runs. No-op when none flagged.
+    super::mana_payment::refill_infinite_mana(state);
     remember_public_reveals(state, &result.events);
     // Targeted public-state dirty marking over the full accumulated event set
     // (the auto-pass loop appends events). `finalize_public_state` is the only

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -371,6 +371,17 @@ pub fn apply_debug_action(
             }
         }
 
+        DebugAction::SetInfiniteMana { player_id, enabled } => {
+            validate_player(state, player_id)?;
+            if enabled {
+                state.debug_infinite_mana.insert(player_id);
+                // Seed immediately so the pool reads full before the next probe.
+                super::mana_payment::refill_infinite_mana(state);
+            } else {
+                state.debug_infinite_mana.remove(&player_id);
+            }
+        }
+
         DebugAction::SetPhase {
             phase,
             active_player,

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -13,6 +13,68 @@ use crate::types::player::PlayerId;
 /// CR 107.4a: The five colors are white ({W}), blue ({U}), black ({B}), red ({R}), green ({G}).
 pub type ColorDemand = [u32; 5];
 
+/// Units of each mana type kept in a debug "infinite mana" pool. Large enough to
+/// cover any single resolution's worth of spends, small enough that the pool's
+/// linear spend scan (`ManaPool` is a `Vec<ManaUnit>`) stays cheap.
+const INFINITE_MANA_PER_TYPE: usize = 100;
+
+/// The six mana types an infinite-mana pool is seeded with: the five colors
+/// (CR 105.1) plus colorless (CR 107.4c).
+const INFINITE_MANA_TYPES: [ManaType; 6] = [
+    ManaType::White,
+    ManaType::Blue,
+    ManaType::Black,
+    ManaType::Red,
+    ManaType::Green,
+    ManaType::Colorless,
+];
+
+/// Debug-only: top every player in `GameState::debug_infinite_mana` back up to
+/// `INFINITE_MANA_PER_TYPE` unrestricted, non-expiring units of each mana type.
+///
+/// Idempotent — only the shortfall is added — and returns immediately when no
+/// player is flagged, so it is cheap to call after every action. Paired with the
+/// `UnitDisposition::Keep` override in `turns::drain_pending_phase_transition_progress`
+/// (which suppresses the CR 500.4 end-of-step empty for flagged players), this
+/// keeps the pool continuously full. Both the affordability check
+/// (`reduce_cost_by_pool`) and the real payment path read the same
+/// `player.mana_pool`, so a flagged player can pay any cost without divergence
+/// between "shows castable" and "actually pays".
+///
+/// NOT a rules-legal effect — a developer convenience gated behind the same
+/// debug-action permission as every other `DebugAction`.
+pub fn refill_infinite_mana(state: &mut GameState) {
+    if state.debug_infinite_mana.is_empty() {
+        return;
+    }
+    let flagged: Vec<PlayerId> = state.debug_infinite_mana.iter().copied().collect();
+    for &player_id in &flagged {
+        let Some(player) = state.players.iter_mut().find(|p| p.id == player_id) else {
+            continue;
+        };
+        for color in INFINITE_MANA_TYPES {
+            // Count only the units this top-up owns (unrestricted, non-expiring)
+            // so card-produced restricted/expiring mana never suppresses a refill.
+            let have = player
+                .mana_pool
+                .mana
+                .iter()
+                .filter(|u| u.color == color && u.restrictions.is_empty() && u.expiry.is_none())
+                .count();
+            for _ in have..INFINITE_MANA_PER_TYPE {
+                player
+                    .mana_pool
+                    .add(ManaUnit::new(color, ObjectId(0), false, Vec::new()));
+            }
+        }
+    }
+    // Mark display dirty only after the mutable-player borrow above is released.
+    for &player_id in &flagged {
+        super::public_state::mark_public_state_player_dirty(state, player_id);
+    }
+    super::public_state::mark_mana_display_dirty(state);
+}
+
 fn mana_type_to_demand_index(mt: ManaType) -> Option<usize> {
     match mt {
         ManaType::White => Some(0),
@@ -3024,5 +3086,106 @@ mod tests {
                 life_colors: crate::types::mana::LifePaymentColors::EMPTY
             }
         ));
+    }
+
+    /// `refill_infinite_mana` is the debug "infinite mana" building block. It must
+    /// seed every flagged player's pool to `INFINITE_MANA_PER_TYPE` units of each
+    /// of the six mana types, restore that cap after a spend without unbounded
+    /// growth (idempotent), no-op when no player is flagged, and never touch an
+    /// unflagged player.
+    #[test]
+    fn refill_infinite_mana_seeds_tops_up_and_isolates_players() {
+        let mut state = GameState::new_two_player(0);
+        let p1 = state.players[1].id;
+
+        // No player flagged → cheap no-op.
+        refill_infinite_mana(&mut state);
+        assert!(state.players[0].mana_pool.mana.is_empty());
+
+        // Flag P0 → seeded to the cap for each of the six types; P1 untouched.
+        state.debug_infinite_mana.insert(state.players[0].id);
+        refill_infinite_mana(&mut state);
+        for color in INFINITE_MANA_TYPES {
+            let n = state.players[0]
+                .mana_pool
+                .mana
+                .iter()
+                .filter(|u| u.color == color)
+                .count();
+            assert_eq!(n, INFINITE_MANA_PER_TYPE, "{color:?} seeded to cap");
+        }
+        let p1_pool = state.players.iter().find(|p| p.id == p1).unwrap();
+        assert!(
+            p1_pool.mana_pool.mana.is_empty(),
+            "unflagged player untouched"
+        );
+
+        // Spend two units, refill restores to the cap — idempotent, no growth.
+        assert!(state.players[0].mana_pool.spend(ManaType::White).is_some());
+        assert!(state.players[0].mana_pool.spend(ManaType::Green).is_some());
+        refill_infinite_mana(&mut state);
+        let total: usize = INFINITE_MANA_TYPES
+            .iter()
+            .map(|&c| {
+                state.players[0]
+                    .mana_pool
+                    .mana
+                    .iter()
+                    .filter(|u| u.color == c)
+                    .count()
+            })
+            .sum();
+        assert_eq!(
+            total,
+            INFINITE_MANA_PER_TYPE * INFINITE_MANA_TYPES.len(),
+            "topped back up to cap with no unbounded growth"
+        );
+    }
+
+    /// The `SetInfiniteMana` debug handler must add the player to
+    /// `debug_infinite_mana` and seed the pool immediately on enable (so the next
+    /// affordability probe reads full), and remove the flag on disable.
+    #[test]
+    fn set_infinite_mana_handler_toggles_flag_and_seeds() {
+        use crate::game::engine_debug::apply_debug_action;
+        use crate::types::actions::DebugAction;
+
+        let mut state = GameState::new_two_player(0);
+        let p0 = state.players[0].id;
+        let mut events = Vec::new();
+
+        apply_debug_action(
+            &mut state,
+            p0,
+            DebugAction::SetInfiniteMana {
+                player_id: p0,
+                enabled: true,
+            },
+            &mut events,
+        )
+        .expect("enable infinite mana");
+        assert!(state.debug_infinite_mana.contains(&p0));
+        for color in INFINITE_MANA_TYPES {
+            assert!(
+                state.players[0]
+                    .mana_pool
+                    .mana
+                    .iter()
+                    .any(|u| u.color == color),
+                "{color:?} seeded on enable"
+            );
+        }
+
+        apply_debug_action(
+            &mut state,
+            p0,
+            DebugAction::SetInfiniteMana {
+                player_id: p0,
+                enabled: false,
+            },
+            &mut events,
+        )
+        .expect("disable infinite mana");
+        assert!(!state.debug_infinite_mana.contains(&p0));
     }
 }

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -39,7 +39,7 @@ pub fn next_phase(phase: Phase) -> Phase {
     PHASE_ORDER[(idx + 1) % PHASE_ORDER.len()]
 }
 
-/// CR 500.4: Advance to the next phase/step, clearing mana pools.
+/// CR 500.5: Advance to the next phase/step, clearing mana pools.
 pub fn advance_phase(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // CR 500.8: Extra phases are inserted *directly after* their anchor phase
     // (e.g., Aurelia's "after this phase" extra combat is inserted after the
@@ -230,6 +230,12 @@ pub(super) fn drain_pending_phase_transition_progress(
         // decisions. The `enumerate` runs over the full pool so `pool_index`
         // stays aligned with the retained expiry units that remain in
         // `mana_pool.mana`.
+        // Debug-only: CR 500.5 end-of-step empty is suppressed for a player with
+        // the infinite-mana toggle active — every non-expiry unit is dispositioned
+        // `Keep` instead of `Drop` so the pool survives the step transition. This
+        // is the partner of `mana_payment::refill_infinite_mana`; together they
+        // keep a flagged player's pool continuously full.
+        let keep_for_infinite_mana = state.debug_infinite_mana.contains(&player_id);
         let units: Vec<crate::types::mana::UnitDecision> = state
             .players
             .iter()
@@ -243,7 +249,11 @@ pub(super) fn drain_pending_phase_transition_progress(
                     .map(|(idx, u)| crate::types::mana::UnitDecision {
                         pool_index: idx,
                         color: u.color,
-                        disposition: crate::types::mana::UnitDisposition::Drop,
+                        disposition: if keep_for_infinite_mana {
+                            crate::types::mana::UnitDisposition::Keep
+                        } else {
+                            crate::types::mana::UnitDisposition::Drop
+                        },
                     })
                     .collect()
             })

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -833,6 +833,12 @@ pub enum DebugAction {
         player_id: PlayerId,
         mana: Vec<ManaType>,
     },
+    /// Toggle "infinite mana" for a player (debug-only). While `enabled`, the
+    /// engine keeps the player's mana pool topped up after every action and
+    /// suppresses the end-of-step empty (CR 500.5) for that player, so any cost
+    /// is payable. Setting `enabled = false` clears the toggle; the pool then
+    /// empties normally on the next step transition. Off by default.
+    SetInfiniteMana { player_id: PlayerId, enabled: bool },
 
     // ── Game Flow ─────────────────────────────────────────────────────────
     /// Advance or rewind to a specific phase/step.
@@ -1091,6 +1097,11 @@ impl DebugAction {
             DebugAction::AddMana { player_id, mana } => {
                 format!("AddMana ({} gains {:?})", player_label(*player_id), mana)
             }
+            DebugAction::SetInfiniteMana { player_id, enabled } => format!(
+                "SetInfiniteMana ({} {})",
+                player_label(*player_id),
+                if *enabled { "on" } else { "off" }
+            ),
             DebugAction::SetPhase {
                 phase,
                 active_player,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4600,6 +4600,16 @@ pub struct GameState {
     #[serde(default)]
     pub debug_permitted: BTreeSet<PlayerId>,
 
+    /// Set of players for whom the "infinite mana" debug toggle is active. While
+    /// a player is in this set, their mana pool is topped up after every action
+    /// (`mana_payment::refill_infinite_mana`) and is NOT emptied at end of
+    /// step/phase — CR 500.5 is deliberately suppressed for this player only.
+    /// This is a debug-only departure from the rules, gated behind the same
+    /// debug-action permission as every other `DebugAction`. Toggled via
+    /// `DebugAction::SetInfiniteMana`; empty by default.
+    #[serde(default)]
+    pub debug_infinite_mana: BTreeSet<PlayerId>,
+
     #[serde(default)]
     pub match_config: MatchConfig,
     #[serde(default)]
@@ -5762,6 +5772,7 @@ impl GameState {
             commander_declined_zone_return: HashSet::new(),
             debug_mode: false,
             debug_permitted: BTreeSet::new(),
+            debug_infinite_mana: BTreeSet::new(),
         }
     }
 

--- a/crates/server-core/src/game_action_payload_guard.rs
+++ b/crates/server-core/src/game_action_payload_guard.rs
@@ -227,6 +227,7 @@ fn guard_debug_action_payload(action: &DebugAction) -> Result<(), String> {
         | DebugAction::SetLife { .. }
         | DebugAction::ModifyPlayerCounters { .. }
         | DebugAction::ModifyEnergy { .. }
+        | DebugAction::SetInfiniteMana { .. }
         | DebugAction::SetPhase { .. }
         | DebugAction::RunStateBasedActions
         | DebugAction::CreateTokenCopy { .. } => {}


### PR DESCRIPTION
Add a per-player "Infinite Mana" debug toggle to the developer menu.
While enabled for a player, the engine keeps that player's mana pool
topped up after every action (mana_payment::refill_infinite_mana) and
suppresses the CR 500.5 end-of-step empty for them (UnitDisposition::Keep
in the step-end drain). Both the affordability check and the real payment
path read the same player.mana_pool, so the pool staying full means
spells show castable and actually pay.

- types/game_state.rs: debug_infinite_mana: BTreeSet<PlayerId>
- types/actions.rs: DebugAction::SetInfiniteMana { player_id, enabled }
- game/mana_payment.rs: refill_infinite_mana (idempotent, capped at 100/type)
- game/engine_debug.rs: handler seeds the pool on enable
- game/engine.rs: refill at the apply() tail after each action
- game/turns.rs: Keep disposition for flagged players in the drain
- server-core: classify the new variant in the payload-size guard
- client: SetInfiniteMana TS type + Infinite Mana accordion toggle

Tests: refill building block (seed/top-up/isolation) + handler round-trip.
