### PR TITLE
fix(parser): recognize that-spell power/toughness trigger refs

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1677,6 +1677,25 @@ fn parse_event_context_refs(input: &str) -> OracleResult<'_, QuantityRef> {
             },
             tag("that spell's mana value"),
         ),
+        // CR 208.3 + CR 608.2k: "that spell's power"/"toughness" — the cast
+        // event's source object IS the spell on the stack, and a creature spell
+        // has the power/toughness printed on its card (CR 208.3), so these read
+        // directly off the trigger-condition referent (CostPaidObject, the same
+        // CR 608.2k scope as "that creature's power"/"mana value" above). Covers
+        // the class of "Whenever you cast a creature spell, if that spell's
+        // power is N or greater, …" cards (Eshki, Temur's Roar — issue #2009).
+        value(
+            QuantityRef::Power {
+                scope: ObjectScope::CostPaidObject,
+            },
+            tag("that spell's power"),
+        ),
+        value(
+            QuantityRef::Toughness {
+                scope: ObjectScope::CostPaidObject,
+            },
+            tag("that spell's toughness"),
+        ),
         // CR 109.2a + CR 608.2c: "that [type] card's [property]" — anaphoric
         // reference to a card selected by an earlier instruction in the same
         // resolution sequence.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -25712,6 +25712,85 @@ mod snapshot_tests {
         insta::assert_json_snapshot!(def);
     }
 
+    /// CR 208.3 + CR 608.2k (issue #2009): "that spell's power/toughness" in a
+    /// `Whenever you cast a [creature] spell` trigger must gate the chained
+    /// sub-effects on the triggering spell's power. Before the fix the
+    /// `"that spell's power"` quantity ref was unrecognized, so
+    /// `parse_condition_text` returned `None` and `strip_leading_general_conditional`
+    /// silently dropped each `If that spell's power is N or greater, …` head —
+    /// the draw and damage fired on every creature spell regardless of power.
+    /// Asserts each chained sub-ability carries the right
+    /// `QuantityCheck { Power(CostPaidObject) GE N }` gate (Eshki, Temur's Roar).
+    #[test]
+    fn eshki_that_spell_power_gates_chained_effects() {
+        use crate::types::ability::{Comparator, ObjectScope, QuantityExpr, QuantityRef};
+
+        let power_ge = |n: i32| AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::CostPaidObject,
+                },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: n },
+        };
+
+        let def = parse_trigger_line(
+            "Whenever you cast a creature spell, put a +1/+1 counter on Eshki. If that spell's power is 4 or greater, draw a card. If that spell's power is 6 or greater, Eshki deals damage equal to Eshki's power to each opponent.",
+            "Eshki, Temur's Roar",
+        );
+
+        assert_eq!(def.mode, TriggerMode::SpellCast);
+        assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+
+        let execute = def.execute.as_ref().expect("execute ability present");
+        // First instruction (put a +1/+1 counter) is unconditional.
+        assert_eq!(execute.condition, None);
+
+        // "If that spell's power is 4 or greater, draw a card."
+        let draw = execute
+            .sub_ability
+            .as_ref()
+            .expect("draw sub-ability present");
+        assert_eq!(draw.condition.as_ref(), Some(&power_ge(4)));
+
+        // "If that spell's power is 6 or greater, Eshki deals damage …"
+        let damage = draw
+            .sub_ability
+            .as_ref()
+            .expect("damage sub-ability present");
+        assert_eq!(damage.condition.as_ref(), Some(&power_ge(6)));
+    }
+
+    /// CR 208.3 + CR 608.2k (issue #2009): building-block coverage — the bare
+    /// "that spell's power"/"toughness" quantity refs resolve through the same
+    /// `parse_quantity_ref` path as "that creature's power" and "that spell's
+    /// mana value", scoped to the trigger-condition referent (CostPaidObject).
+    #[test]
+    fn that_spell_power_toughness_quantity_refs() {
+        use crate::parser::oracle_nom::quantity::parse_quantity_ref;
+        use crate::types::ability::{ObjectScope, QuantityRef};
+
+        assert_eq!(
+            parse_quantity_ref("that spell's power"),
+            Ok((
+                "",
+                QuantityRef::Power {
+                    scope: ObjectScope::CostPaidObject,
+                }
+            ))
+        );
+        assert_eq!(
+            parse_quantity_ref("that spell's toughness"),
+            Ok((
+                "",
+                QuantityRef::Toughness {
+                    scope: ObjectScope::CostPaidObject,
+                }
+            ))
+        );
+    }
+
     /// CR 608.2c (issue #1584): Kathril's "Repeat this process for <10 keywords>"
     /// must replicate the conditional keyword-counter placement once per keyword
     /// — each placing that keyword's counter gated on a creature card in the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -25695,6 +25695,7 @@ mod tests {
 /// `parse_trigger_line_with_index_ir` / `lower_trigger_ir` refactor.
 #[cfg(test)]
 mod snapshot_tests {
+    use crate::parser::oracle_nom::quantity::parse_quantity_ref;
     use crate::types::ability::AbilityCondition;
 
     use super::*;
@@ -25723,8 +25724,6 @@ mod snapshot_tests {
     /// `QuantityCheck { Power(CostPaidObject) GE N }` gate (Eshki, Temur's Roar).
     #[test]
     fn eshki_that_spell_power_gates_chained_effects() {
-        use crate::types::ability::{Comparator, ObjectScope, QuantityExpr, QuantityRef};
-
         let power_ge = |n: i32| AbilityCondition::QuantityCheck {
             lhs: QuantityExpr::Ref {
                 qty: QuantityRef::Power {
@@ -25768,9 +25767,6 @@ mod snapshot_tests {
     /// mana value", scoped to the trigger-condition referent (CostPaidObject).
     #[test]
     fn that_spell_power_toughness_quantity_refs() {
-        use crate::parser::oracle_nom::quantity::parse_quantity_ref;
-        use crate::types::ability::{ObjectScope, QuantityRef};
-
         assert_eq!(
             parse_quantity_ref("that spell's power"),
             Ok((


### PR DESCRIPTION
Closes #2009

## Problem
Eshki, Temur's Roar fired all of its abilities on every creature spell cast, ignoring the per-power-level gates in its text:

> Whenever you cast a creature spell, put a +1/+1 counter on Eshki. **If that spell's power is 4 or greater,** draw a card. **If that spell's power is 6 or greater,** Eshki deals damage equal to Eshki's power to each opponent.

## Root cause
The quantity grammar (`parse_event_context_refs` in `oracle_nom/quantity.rs`) recognized `"that creature's power/toughness"` and `"that spell's mana value"`, but had **no** arm for `"that spell's power/toughness"`. As a result `parse_quantity_ref` failed on `"that spell's power"`, the condition parser returned `None`, and `strip_leading_general_conditional` silently dropped each `If that spell's power is N or greater, …` head. Both conditional sub-effects parsed with `condition: null`, so the draw and damage fired unconditionally.

## Fix
Added the missing `"that spell's power"` / `"that spell's toughness"` arms, mapping to `Power`/`Toughness { scope: CostPaidObject }` — the same CR 608.2k trigger-condition referent the sibling creature/mana-value arms use. A creature spell on the stack carries the power printed on its card (CR 208.3), so the runtime reads it off the cast event's source object. This covers the whole class of "if that spell's power/toughness is N…" cast triggers, not just Eshki.

## Tests
- `eshki_that_spell_power_gates_chained_effects` — asserts each chained sub-ability carries `QuantityCheck { Power(CostPaidObject) GE 4 }` / `GE 6 }`.
- `that_spell_power_toughness_quantity_refs` — building-block coverage for the two new quantity refs.
- `cargo fmt --all` clean; parser-combinator gate exit 0; full `cargo test -p engine --lib` green (10453 passed).