### PR TITLE
fix(engine): reveal look-at-top-card peek to the looking player

### DIFF
--- a/crates/engine/src/game/effects/dig.rs
+++ b/crates/engine/src/game/effects/dig.rs
@@ -85,13 +85,13 @@ pub fn resolve(
         .collect::<Vec<_>>();
     let keep_count = keep_num.min(cards.len());
 
-    // CR 701.20a: Pure-peek pattern (keep_count = 0): "look at the top card" with no
+    // CR 701.20e: Pure-peek pattern (keep_count = 0): "look at the top card" with no
     // player selection — the sub_ability condition decides whether to take it. Set
     // last_revealed_ids so RevealedHasCardType can evaluate, then return without
     // creating a DigChoice interaction.
     if keep_count == 0 && !is_reveal {
         state.last_revealed_ids = cards.clone();
-        // CR 701.20a: "look at" privately reveals the cards to the looking
+        // CR 701.20e: "look at" privately reveals the cards to the looking
         // player. The looker is the ability controller (e.g. Delver of Secrets'
         // "look at the top card of your library"). Record the looker-scoped peek
         // window so `filter_state_for_viewer` keeps these cards visible to the
@@ -277,13 +277,13 @@ mod tests {
         assert_eq!(state.objects[&top_card].zone, Zone::Library);
         assert_eq!(state.players[1].library.front(), Some(&top_card));
         assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
-        // CR 701.20a: the looker is the ability controller, not the library
+        // CR 701.20e: the looker is the ability controller, not the library
         // owner — the peeked opponent card is visible to the controller only.
         assert_eq!(state.private_look_ids, vec![top_card]);
         assert_eq!(state.private_look_player, Some(PlayerId(0)));
     }
 
-    /// CR 701.20a (issue #2021, Delver of Secrets): a bare "look at the top card
+    /// CR 701.20e (issue #2021, Delver of Secrets): a bare "look at the top card
     /// of your library" peek must privately reveal the card to the looking
     /// player, so they can SEE it before deciding a subsequent "you may reveal
     /// that card" optional. The peek records a looker-scoped window
@@ -324,7 +324,7 @@ mod tests {
 
         assert_eq!(state.private_look_ids, vec![top_card]);
         assert_eq!(state.private_look_player, Some(PlayerId(0)));
-        // CR 701.20a: a private "look at" must NOT publicly reveal the card.
+        // CR 701.20e: a private "look at" must NOT publicly reveal the card.
         assert!(!state.revealed_cards.contains(&top_card));
 
         // The looking player (PlayerId(0)) can see the peeked card's identity.

--- a/crates/engine/src/game/effects/dig.rs
+++ b/crates/engine/src/game/effects/dig.rs
@@ -91,6 +91,15 @@ pub fn resolve(
     // creating a DigChoice interaction.
     if keep_count == 0 && !is_reveal {
         state.last_revealed_ids = cards.clone();
+        // CR 701.20a: "look at" privately reveals the cards to the looking
+        // player. The looker is the ability controller (e.g. Delver of Secrets'
+        // "look at the top card of your library"). Record the looker-scoped peek
+        // window so `filter_state_for_viewer` keeps these cards visible to the
+        // looker — and only the looker — through any subsequent "you may reveal
+        // that card" optional decision, instead of leaving the looking player to
+        // choose blind.
+        state.private_look_ids = cards.clone();
+        state.private_look_player = Some(ability.controller);
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::from(&ability.effect),
             source_id: ability.source_id,
@@ -268,6 +277,69 @@ mod tests {
         assert_eq!(state.objects[&top_card].zone, Zone::Library);
         assert_eq!(state.players[1].library.front(), Some(&top_card));
         assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+        // CR 701.20a: the looker is the ability controller, not the library
+        // owner — the peeked opponent card is visible to the controller only.
+        assert_eq!(state.private_look_ids, vec![top_card]);
+        assert_eq!(state.private_look_player, Some(PlayerId(0)));
+    }
+
+    /// CR 701.20a (issue #2021, Delver of Secrets): a bare "look at the top card
+    /// of your library" peek must privately reveal the card to the looking
+    /// player, so they can SEE it before deciding a subsequent "you may reveal
+    /// that card" optional. The peek records a looker-scoped window
+    /// (`private_look_ids` / `private_look_player`) that `filter_state_for_viewer`
+    /// surfaces to the looker and hides from opponents.
+    #[test]
+    fn look_at_top_card_makes_peek_visible_to_looker_only() {
+        use crate::game::visibility::filter_state_for_viewer;
+
+        let mut state = GameState::new_two_player(42);
+        create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Delver Top Card".to_string(),
+            Zone::Library,
+        );
+        let top_card = state.players[0].library[0];
+
+        // "look at the top card of your library" — Dig keep_count 0, no reveal.
+        let ability = ResolvedAbility::new(
+            Effect::Dig {
+                player: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 1 },
+                destination: None,
+                keep_count: Some(0),
+                up_to: false,
+                filter: TargetFilter::Any,
+                rest_destination: None,
+                reveal: false,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.private_look_ids, vec![top_card]);
+        assert_eq!(state.private_look_player, Some(PlayerId(0)));
+        // CR 701.20a: a private "look at" must NOT publicly reveal the card.
+        assert!(!state.revealed_cards.contains(&top_card));
+
+        // The looking player (PlayerId(0)) can see the peeked card's identity.
+        let looker_view = filter_state_for_viewer(&state, PlayerId(0));
+        assert_eq!(
+            looker_view.objects[&top_card].name, "Delver Top Card",
+            "the looking player must see the card they looked at"
+        );
+
+        // The opponent (PlayerId(1)) must NOT see it — the library card is hidden.
+        let opp_view = filter_state_for_viewer(&state, PlayerId(1));
+        assert_ne!(
+            opp_view.objects[&top_card].name, "Delver Top Card",
+            "the private look must not leak the card to opponents"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2993,7 +2993,7 @@ pub fn resolve_ability_chain(
     // across unrelated ability resolutions.
     if depth == 0 {
         state.last_revealed_ids.clear();
-        // CR 701.20a: A new top-level resolution ends any prior private "look at"
+        // CR 701.20e: A new top-level resolution ends any prior private "look at"
         // peek window — the looked-at card from an unrelated resolution must not
         // stay visible. Cleared here (depth 0 only) so a resumed optional-reveal
         // decision (which re-enters at depth 1) preserves the peek it depends on.

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2993,6 +2993,12 @@ pub fn resolve_ability_chain(
     // across unrelated ability resolutions.
     if depth == 0 {
         state.last_revealed_ids.clear();
+        // CR 701.20a: A new top-level resolution ends any prior private "look at"
+        // peek window — the looked-at card from an unrelated resolution must not
+        // stay visible. Cleared here (depth 0 only) so a resumed optional-reveal
+        // decision (which re-enters at depth 1) preserves the peek it depends on.
+        state.private_look_ids.clear();
+        state.private_look_player = None;
         state.last_zone_changed_ids.clear();
         // CR 608.2c + CR 701.38: Per-resolution ballot ledger; populated by
         // `vote::resolve_tally` and read by `PlayerFilter::VotedFor`. Clear

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1286,7 +1286,7 @@ fn apply_action(
         state.revealed_cards.clear();
     }
 
-    // CR 701.20a: A bare "look at the top card" peek is visible to the looker
+    // CR 701.20e: A bare "look at the top card" peek is visible to the looker
     // only until they act on it. The peek window must survive the action that
     // serves the dependent "you may reveal that card" optional (the looked-at
     // card is shown while that `OptionalEffectChoice` is pending), then clear on

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1090,6 +1090,16 @@ fn apply_action(
         state.revealed_cards.clear();
     }
 
+    // CR 701.20a: A bare "look at the top card" peek is visible to the looker
+    // only until they act on it. The peek window must survive the action that
+    // serves the dependent "you may reveal that card" optional (the looked-at
+    // card is shown while that `OptionalEffectChoice` is pending), then clear on
+    // the next action boundary — mirroring the momentary `revealed_cards` reveal.
+    if !matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }) {
+        state.private_look_ids.clear();
+        state.private_look_player = None;
+    }
+
     let mut events = Vec::new();
     let mut triggers_processed_inline = false;
 

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -60,7 +60,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         HashSet::new()
     };
 
-    // CR 701.20a: A bare "look at the top card" peek (Dig with keep_count == 0,
+    // CR 701.20e: A bare "look at the top card" peek (Dig with keep_count == 0,
     // reveal == false) privately reveals the card(s) to the looking player only.
     // `dig.rs` records the looker in `private_look_player`; surface the peeked
     // cards to that player so they can see the card while deciding a subsequent

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -60,6 +60,19 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         HashSet::new()
     };
 
+    // CR 701.20a: A bare "look at the top card" peek (Dig with keep_count == 0,
+    // reveal == false) privately reveals the card(s) to the looking player only.
+    // `dig.rs` records the looker in `private_look_player`; surface the peeked
+    // cards to that player so they can see the card while deciding a subsequent
+    // "you may reveal that card" optional (Delver of Secrets), without leaking it
+    // to opponents.
+    let private_look_visible: HashSet<ObjectId> = match state.private_look_player {
+        Some(looker) if can_view_private_for_player(looker) => {
+            state.private_look_ids.iter().copied().collect()
+        }
+        _ => HashSet::new(),
+    };
+
     let search_visible: HashSet<ObjectId> =
         if let WaitingFor::SearchChoice {
             player, ref cards, ..
@@ -111,6 +124,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         let owner = state.objects.get(&obj_id).map(|o| o.owner);
         let visible = manifest_dread_visible.contains(&obj_id)
             || dig_visible.contains(&obj_id)
+            || private_look_visible.contains(&obj_id)
             || search_visible.contains(&obj_id)
             // CR 701.20b: Revealed cards are visible to all players. For reveal-digs
             // ("reveal the top N"), dig cards are also in revealed_cards and must remain

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5078,6 +5078,22 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub last_revealed_ids: Vec<ObjectId>,
 
+    /// CR 701.20a: Cards the controller is privately "looking at" during the
+    /// current resolution — the looker-scoped peek window of a bare
+    /// "look at the top card of your library" (Dig with `keep_count == 0`,
+    /// `reveal == false`). Unlike `revealed_cards` (public, all players) and
+    /// `last_revealed_ids` (condition bookkeeping, not viewer-scoped), these ids
+    /// are surfaced by `filter_state_for_viewer` ONLY to `private_look_player`,
+    /// so the looking player can see the card while deciding a subsequent
+    /// "you may reveal that card" optional, without leaking it to opponents.
+    /// Cleared at depth 0 of `resolve_ability_chain` and at action boundaries
+    /// once no optional-effect decision that depends on the peek is pending.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub private_look_ids: Vec<ObjectId>,
+    /// CR 701.20a: The player to whom `private_look_ids` is visible (the looker).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub private_look_player: Option<PlayerId>,
+
     /// ObjectIds of objects moved by the most recent zone-change effect.
     /// Used by AbilityCondition::ZoneChangedThisWay to gate sub_abilities on
     /// whether the parent effect moved an object matching a type filter.
@@ -5738,6 +5754,8 @@ impl GameState {
             log_player_names: Vec::new(),
             last_created_token_ids: Vec::new(),
             last_revealed_ids: Vec::new(),
+            private_look_ids: Vec::new(),
+            private_look_player: None,
             last_zone_changed_ids: Vec::new(),
             last_vote_ballots: im::Vector::new(),
             player_actions_this_way: HashSet::new(),
@@ -6033,6 +6051,8 @@ impl PartialEq for GameState {
             && self.pending_cast == other.pending_cast
             && self.last_named_choice == other.last_named_choice
             && self.last_revealed_ids == other.last_revealed_ids
+            && self.private_look_ids == other.private_look_ids
+            && self.private_look_player == other.private_look_player
             && self.last_zone_changed_ids == other.last_zone_changed_ids
             && self.last_vote_ballots == other.last_vote_ballots
             && self.player_actions_this_way == other.player_actions_this_way

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5078,7 +5078,7 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub last_revealed_ids: Vec<ObjectId>,
 
-    /// CR 701.20a: Cards the controller is privately "looking at" during the
+    /// CR 701.20e: Cards the controller is privately "looking at" during the
     /// current resolution — the looker-scoped peek window of a bare
     /// "look at the top card of your library" (Dig with `keep_count == 0`,
     /// `reveal == false`). Unlike `revealed_cards` (public, all players) and
@@ -5090,7 +5090,7 @@ pub struct GameState {
     /// once no optional-effect decision that depends on the peek is pending.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub private_look_ids: Vec<ObjectId>,
-    /// CR 701.20a: The player to whom `private_look_ids` is visible (the looker).
+    /// CR 701.20e: The player to whom `private_look_ids` is visible (the looker).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub private_look_player: Option<PlayerId>,
 


### PR DESCRIPTION
Closes #2021

## Problem
Delver of Secrets' upkeep ability — "look at the top card of your library. You may reveal that card. If an instant or sorcery card is revealed this way, transform Delver of Secrets" — left the looking player unable to see the top card before deciding whether to reveal it. They had to choose blind.

## Root cause
"Look at the top card of your library" parses to `Dig { keep_count: 0, reveal: false }`. The pure-peek branch set `last_revealed_ids` (condition bookkeeping only, not viewer-scoped) and returned without making the card visible to anyone. The controller then reached the "you may reveal that card" optional with the card still hidden. Per CR 701.20a, "look at" privately reveals the card to the looking player.

## Fix
Builds for the whole "look at the top N of your library" class:
- New looker-scoped `GameState` fields `private_look_ids` / `private_look_player`, set in the peek branch (scoped to the ability controller, correctly distinct from the library owner).
- `filter_state_for_viewer` surfaces the peeked cards to the looker only, hidden from opponents (mirrors `dig_visible` / `search_visible`).
- Cleared at depth 0 of `resolve_ability_chain` and at action boundaries, preserved while the dependent `OptionalEffectChoice` is pending so the card stays visible through the reveal decision.

## Tests
- New `look_at_top_card_makes_peek_visible_to_looker_only`: looker sees the card; opponent sees "Hidden Card"; the private look is not publicly revealed. Verified to fail before the fix.
- Extended `pure_peek_uses_target_players_library_without_moving_cards` to assert looker scoping.
- Full engine lib suite green (10452 passed); clippy clean; parser-combinator gate exit 0.