### PR TITLE
fix(parser): scope Manufactor/Xorn token replacement to controller

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -9553,6 +9553,112 @@ mod tests {
         assert_eq!(count_subtype("Food"), 2, "Food batch doubled once");
     }
 
+    /// CR 614.1a + CR 109.5: Academy Manufactor's "If *you* would create..."
+    /// is scoped to the source's controller. When a different player creates a
+    /// Treasure token, the replacement must NOT fire — only the single Treasure
+    /// is created, with no Clue or Food (issue #1967). Mirrors the
+    /// `token_owner_scope` enforcement in the main applicability loop.
+    #[test]
+    fn academy_manufactor_does_not_apply_to_other_players_tokens_cr_614_1a() {
+        use crate::types::proposed_event::TokenCharacteristics;
+
+        fn artifact_spec(name: &str) -> TokenSpec {
+            TokenSpec {
+                characteristics: TokenCharacteristics {
+                    display_name: name.to_string(),
+                    power: None,
+                    toughness: None,
+                    core_types: vec![crate::types::card_type::CoreType::Artifact],
+                    subtypes: vec![name.to_string()],
+                    supertypes: Vec::new(),
+                    colors: Vec::new(),
+                    keywords: Vec::new(),
+                },
+                script_name: name.to_string(),
+                static_abilities: Vec::new(),
+                enter_with_counters: Vec::new(),
+                tapped: false,
+                enters_attacking: false,
+                sacrifice_at: None,
+                source_id: ObjectId(0),
+                controller: PlayerId(0),
+                attach_to: None,
+            }
+        }
+
+        let manufactor = ObjectId(700);
+        // CR 614.1a + CR 109.5: `token_owner_scope(You)` is what the parser now
+        // emits for the "if you would create" Manufactor shape.
+        let manufactor_repl = ReplacementDefinition::new(ReplacementEvent::CreateToken)
+            .condition(ReplacementCondition::TokenSubtypeMatches {
+                subtypes: vec![
+                    "Clue".to_string(),
+                    "Food".to_string(),
+                    "Treasure".to_string(),
+                ],
+            })
+            .token_owner_scope(ControllerRef::You)
+            .ensure_token_specs(vec![
+                artifact_spec("Clue"),
+                artifact_spec("Food"),
+                artifact_spec("Treasure"),
+            ]);
+
+        // Manufactor is controlled by PlayerId(0); the opponent PlayerId(1)
+        // will be the one creating a Treasure.
+        let mut state =
+            test_state_with_object(manufactor, Zone::Battlefield, vec![manufactor_repl]);
+
+        let mut treasure = artifact_spec("Treasure");
+        treasure.source_id = manufactor;
+        treasure.controller = PlayerId(1);
+        let proposed = ProposedEvent::CreateToken {
+            owner: PlayerId(1),
+            spec: Box::new(treasure),
+            copy: None,
+            enter_tapped: EtbTapState::Unspecified,
+            count: 1,
+            applied: HashSet::new(),
+        };
+
+        let mut events = Vec::new();
+        let result = replace_event(&mut state, proposed, &mut events);
+        let ReplacementResult::Execute(primary) = result else {
+            panic!("expected Execute; got {:?}", result);
+        };
+        crate::game::effects::token::apply_create_token_after_replacement(
+            &mut state,
+            primary,
+            &mut events,
+        );
+
+        let count_subtype = |sub: &str| {
+            state
+                .objects
+                .values()
+                .filter(|o| o.is_token && o.card_types.subtypes.iter().any(|s| s == sub))
+                .count()
+        };
+
+        // The opponent's lone Treasure is created unmodified; Manufactor does
+        // not bolt on a Clue and a Food because it does not own the event.
+        assert_eq!(
+            count_subtype("Treasure"),
+            1,
+            "opponent's single Treasure is created unmodified"
+        );
+        assert_eq!(
+            count_subtype("Clue"),
+            0,
+            "Manufactor must not add a Clue to another player's token creation"
+        );
+        assert_eq!(
+            count_subtype("Food"),
+            0,
+            "Manufactor must not add a Food to another player's token creation"
+        );
+    }
+
     /// CR 616.1: When candidates have both commuting Count modifications
     /// AND non-commutative EnterTapped modifications, the set must still
     /// be material and trigger a prompt. This catches the early-return bug

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4399,6 +4399,10 @@ fn parse_xorn_subtype_token_replacement(
             .condition(ReplacementCondition::TokenSubtypeMatches {
                 subtypes: vec![canonical_subtype],
             })
+            // CR 614.1a + CR 109.5: "If *you* would create..." scopes the
+            // replacement to the source's controller — it must not fire for
+            // tokens created by other players (issue #1967).
+            .token_owner_scope(ControllerRef::You)
             .additional_token_spec(spec)
             .description(original_text.to_string()),
     )
@@ -4475,6 +4479,10 @@ fn parse_manufactor_ensure_all_token_replacement(
             .condition(ReplacementCondition::TokenSubtypeMatches {
                 subtypes: condition_subtypes,
             })
+            // CR 614.1a + CR 109.5: "If *you* would create..." scopes the
+            // replacement to the source's controller — it must not fire for
+            // tokens created by other players (issue #1967).
+            .token_owner_scope(ControllerRef::You)
             .ensure_token_specs(specs)
             .description(original_text.to_string()),
     )
@@ -10396,6 +10404,14 @@ mod tests {
             }
             other => panic!("Expected TokenSubtypeMatches, got {other:?}"),
         }
+        // CR 614.1a + CR 109.5: "If you would create..." is scoped to the
+        // source's controller, so the replacement must not fire for tokens
+        // created by other players (issue #1967).
+        assert_eq!(
+            def.token_owner_scope,
+            Some(ControllerRef::You),
+            "Xorn 'if you would create' must scope to the controller's tokens"
+        );
         let spec = def
             .additional_token_spec
             .as_ref()
@@ -10437,6 +10453,15 @@ mod tests {
             }
             other => panic!("Expected TokenSubtypeMatches, got {other:?}"),
         }
+
+        // CR 614.1a + CR 109.5: "If you would create..." is scoped to the
+        // source's controller, so the replacement must not fire for tokens
+        // created by other players (issue #1967).
+        assert_eq!(
+            def.token_owner_scope,
+            Some(ControllerRef::You),
+            "Manufactor 'if you would create' must scope to the controller's tokens"
+        );
 
         let specs = def
             .ensure_token_specs


### PR DESCRIPTION
Closes #1967

## Problem
Academy Manufactor applied its replacement effect to Treasure/Clue/Food tokens created by **all players**, rather than only those created by its controller.

## Root cause
The "If *you* would create..." token-replacement parsers built their `ReplacementDefinition` without a `token_owner_scope`:
- `parse_manufactor_ensure_all_token_replacement` — Academy Manufactor ("a Clue, Food, or Treasure token, instead create one of each").
- `parse_xorn_subtype_token_replacement` — Xorn-class ("one or more `<subtype>` tokens, instead create those plus an additional").

The runtime already gates these in the applicability loop (`game/replacement.rs`): `token_owner_scope == Some(You)` restricts the replacement to events where the creating player is the source's controller. The sibling Chatterfang/"under your control" parser sets it, but these two never did — so with `token_owner_scope == None` the gate was skipped and the effect fired on every player's token creation.

## Fix
Both parsers now emit `.token_owner_scope(ControllerRef::You)`. Per **CR 109.5**, "you" on a static ability refers to the object's current controller; per **CR 614.1a**, the "instead" replacement only applies to events under that controller. Reuses the existing `token_owner_scope` building block — no new variants, no runtime changes.

## Tests
- New runtime regression: an opponent creating 1 Treasure yields exactly {1 Treasure, 0 Clue, 0 Food} (Manufactor does not fire).
- Existing Manufactor + Xorn parser tests extended to assert `token_owner_scope == Some(ControllerRef::You)` (fail without the fix).
- `cargo fmt --all` clean; parser-combinator gate exit 0; full `cargo test -p engine --lib` green (10452 passed, 0 failed).