### PR TITLE
fix(engine): accept and-joined spell types in mana spend restriction

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -11716,6 +11716,23 @@ mod tests {
         );
     }
 
+    // CR 106.6: Tablet of Discovery (issue #1975) phrases its restricted mana as
+    // "instant and sorcery spells". This must parse to the same two-type union
+    // the " or " phrasing yields so the runtime matcher accepts either type.
+    #[test]
+    fn mana_spend_restriction_instant_and_sorcery() {
+        use crate::parser::oracle_effect::mana::parse_mana_spend_restriction;
+        use crate::types::ability::ManaSpendRestriction;
+        let result =
+            parse_mana_spend_restriction("spend this mana only to cast instant and sorcery spells");
+        assert_eq!(
+            result.map(|(r, _)| r),
+            Some(ManaSpendRestriction::SpellType(
+                "Instant and Sorcery".to_string()
+            ))
+        );
+    }
+
     #[test]
     fn mana_spend_restriction_colorless_eldrazi_spell_or_activation() {
         use crate::parser::oracle_effect::mana::parse_mana_spend_restriction;

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -328,13 +328,25 @@ impl ManaRestriction {
         qualities: impl IntoIterator<Item = &'a String>,
     ) -> bool {
         let qualities = qualities.into_iter().collect::<Vec<_>>();
-        required.split(" or ").any(|alternative| {
-            alternative.split_whitespace().all(|part| {
-                qualities
-                    .iter()
-                    .any(|quality| quality.eq_ignore_ascii_case(part))
+        // CR 106.6: A restricted-spend type phrase names the *set* of objects the
+        // mana may be spent on. Both connectives — " or " and " and " — enumerate
+        // distinct acceptable types, so each is an alternative the object need
+        // only satisfy one of. Per the Melek, Izzet Paragon example (CR 601.3e),
+        // "instant and sorcery spells" (Tablet of Discovery, issue #1975) lets a
+        // spell that is an instant *or* a sorcery qualify; a single object is
+        // never required to carry both types. Whitespace within an alternative
+        // still ANDs (a compound single quality like "Colorless Eldrazi" must
+        // match every word).
+        required
+            .split(" or ")
+            .flat_map(|clause| clause.split(" and "))
+            .any(|alternative| {
+                alternative.split_whitespace().all(|part| {
+                    qualities
+                        .iter()
+                        .any(|quality| quality.eq_ignore_ascii_case(part))
+                })
             })
-        })
     }
 
     /// Returns `true` if this restriction permits spending mana on the given spell.
@@ -1667,6 +1679,47 @@ mod tests {
             source_subtypes: &no_subtypes,
         }));
         assert!(!restriction.allows(&PaymentContext::Effect));
+    }
+
+    // CR 106.6 + CR 601.2g: "Spend this mana only to cast instant and sorcery
+    // spells" (Tablet of Discovery, issue #1975) names a union of two distinct
+    // spell types. Per the Melek, Izzet Paragon example (CR 601.3e), an "instant
+    // and sorcery spells" permission lets a player cast a spell that is an
+    // instant OR a sorcery — a single spell never needs to be both. The "and"
+    // conjunction therefore distributes across the set of acceptable spells, the
+    // same way " or " does, rather than requiring one spell to carry both types.
+    #[test]
+    fn restriction_instant_and_sorcery_allows_either_type() {
+        let restriction =
+            ManaRestriction::OnlyForTypeSpellsOrAbilities("Instant and Sorcery".to_string());
+        let instant = SpellMeta {
+            types: vec!["Instant".to_string()],
+            subtypes: vec![],
+            keyword_kinds: vec![],
+            cast_from_zone: None,
+            mana_value: None,
+            color_count: None,
+        };
+        let sorcery = SpellMeta {
+            types: vec!["Sorcery".to_string()],
+            subtypes: vec![],
+            keyword_kinds: vec![],
+            cast_from_zone: None,
+            mana_value: None,
+            color_count: None,
+        };
+        let creature = SpellMeta {
+            types: vec!["Creature".to_string()],
+            subtypes: vec![],
+            keyword_kinds: vec![],
+            cast_from_zone: None,
+            mana_value: None,
+            color_count: None,
+        };
+        // Manamorphose is an instant — the {R}{R} restricted mana must pay for it.
+        assert!(restriction.allows_spell(&instant));
+        assert!(restriction.allows_spell(&sorcery));
+        assert!(!restriction.allows_spell(&creature));
     }
 
     // CR 105.2c + CR 106.6: The activation half uses the same compound-quality


### PR DESCRIPTION
Closes #1975

## Problem
Tablet of Discovery's second mana ability adds `{R}{R}` that may be "spent only to cast instant and sorcery spells." That restriction parses to `ManaRestriction::SpellType("Instant and Sorcery")`, but the runtime matcher (`matches_required_quality`) enumerated acceptable types by splitting only on `" or "`. With no `" or "` present, `"Instant and Sorcery"` remained a single conjunctive alternative, and the per-alternative `all(...)` check then required one spell to be `"Instant"` AND `"and"` AND `"Sorcery"` at once — impossible. Manamorphose (`{1}{G/U}`, an instant) was rejected, so the restricted mana appeared unusable for casting it.

## Fix
Split the required-quality phrase on both `" and "` and `" or "`, so each connective enumerates a distinct acceptable type the spell need only satisfy one of. Whitespace within an alternative still ANDs, so compound single qualities like `"Colorless Eldrazi"` stay conjunctive.

Per CR 106.6 and the Melek, Izzet Paragon example (CR 601.3e), "instant and sorcery spells" means the spell may be an instant **or** a sorcery — a single object never needs both types. The fix covers the whole class of "X and Y spells" restricted-spend phrasings, not just Tablet of Discovery. (Distinct from the #1234 colored-shard `can_feasibly_pay_mana_cost` limitation — this is restriction-eligibility matching, the correct layer.)

## Tests
- `restriction_instant_and_sorcery_allows_either_type` (runtime matcher): instant and sorcery accepted, creature rejected.
- `mana_spend_restriction_instant_and_sorcery` (parser): parses to `SpellType("Instant and Sorcery")`.
- Full `cargo test -p engine --lib` green (10453 passed); existing compound-quality "Colorless Eldrazi" tests unchanged; parser gate exit 0.