### PR TITLE
feat(engine): mandatory-loop handling — CR 732.2 runaway backstop + CR 104.4b draw

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1047,6 +1047,15 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
     let events_baseline = result.events.len();
     let objects_baseline = state.objects.len();
 
+    // CR 104.4b: bounded-state mandatory-loop detection. Fingerprinting starts
+    // only after this many mandatory iterations (normal resolution settles far
+    // sooner, so it pays nothing); stored normalized snapshots are capped so a
+    // non-repeating mandatory sequence falls through to the Phase-1 backstop.
+    const FINGERPRINT_AFTER_ITERS: usize = 32;
+    const MAX_LOOP_WINDOW: usize = 128;
+    let mut mandatory_iters = 0usize;
+    let mut loop_window: Vec<(u64, GameState)> = Vec::new();
+
     let max_iterations = auto_pass_loop_max_iterations(state);
     let mut iteration = 0usize;
     loop {
@@ -1110,6 +1119,42 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
                             emit_resolution_halt(state, result);
                             return;
                         }
+
+                        // CR 104.4b: detect a repeating mandatory loop. Every
+                        // iteration here is mandatory by construction (a
+                        // meaningful action would have broken the loop), so the
+                        // window never spans an optional action. A cheap
+                        // fingerprint pre-filters; a true repeat is CONFIRMED by
+                        // deep state equality before any draw, so a fingerprint
+                        // collision can never cause a wrongful draw.
+                        mandatory_iters += 1;
+                        if mandatory_iters >= FINGERPRINT_AFTER_ITERS
+                            && matches!(result.waiting_for, WaitingFor::Priority { .. })
+                        {
+                            let fingerprint = state.loop_fingerprint();
+                            let normalized = state.normalize_for_loop();
+                            if loop_window.iter().any(|(fp, prior)| {
+                                *fp == fingerprint
+                                    && crate::types::game_state::loop_states_equal(
+                                        &normalized,
+                                        prior,
+                                    )
+                            }) {
+                                // CR 104.4b + CR 732.4: a mandatory action
+                                // repeated a prior state with no way to stop — a
+                                // draw. CR 801.16: limited-range partial draw N/A
+                                // while format_config.range_of_influence is None.
+                                result.events.push(GameEvent::GameOver { winner: None });
+                                result.waiting_for = WaitingFor::GameOver { winner: None };
+                                state.waiting_for = WaitingFor::GameOver { winner: None };
+                                match_flow::handle_game_over_transition(state);
+                                return;
+                            }
+                            if loop_window.len() < MAX_LOOP_WINDOW {
+                                loop_window.push((fingerprint, normalized));
+                            }
+                        }
+
                         if stack_empty_or_grew {
                             break;
                         }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -871,6 +871,95 @@ mod auto_pass_decision_tests {
         ));
     }
 
+    /// CR 732.2: the halt helper pauses a runaway cascade to a settled Priority
+    /// for the active player, emits exactly one `ResolutionHalted` carrying the
+    /// deduped+sorted stack-source ids, and resets consecutive-pass tracking.
+    #[test]
+    fn emit_resolution_halt_settles_priority_and_emits_event() {
+        let mut state = priority_state();
+        state.active_player = PlayerId(0);
+        state.priority_passes.insert(PlayerId(1));
+        // Two entries share source 7 (must dedup to one), one distinct source 3.
+        for (entry_id, source) in [(1u64, 7u64), (2, 7), (3, 3)] {
+            state.stack.push_back(StackEntry {
+                id: ObjectId(entry_id),
+                source_id: ObjectId(source),
+                controller: PlayerId(0),
+                kind: StackEntryKind::KeywordAction {
+                    action: KeywordAction::Crew {
+                        vehicle_id: ObjectId(entry_id),
+                        paid_creature_ids: Vec::new(),
+                    },
+                },
+            });
+        }
+
+        let mut result = ActionResult {
+            events: Vec::new(),
+            waiting_for: state.waiting_for.clone(),
+            log_entries: Vec::new(),
+        };
+        emit_resolution_halt(&mut state, &mut result);
+
+        // Settled to the active player's priority, pass-tracking reset.
+        assert!(matches!(
+            result.waiting_for,
+            WaitingFor::Priority {
+                player: PlayerId(0)
+            }
+        ));
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::Priority {
+                player: PlayerId(0)
+            }
+        ));
+        assert_eq!(state.priority_player, PlayerId(0));
+        assert!(state.priority_passes.is_empty());
+
+        // Exactly one halt event, involved ids deduped (7 once) and sorted.
+        let involved: Vec<Vec<ObjectId>> = result
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                GameEvent::ResolutionHalted { involved } => Some(involved.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(involved.len(), 1);
+        assert_eq!(involved[0], vec![ObjectId(3), ObjectId(7)]);
+    }
+
+    /// CR 732.2 regression: a large but TERMINATING stack must resolve fully
+    /// without tripping the runaway backstop — the growth ceilings are sized
+    /// far above honest wide play (a 264-deep stack is nowhere near them).
+    #[test]
+    fn large_terminating_stack_does_not_halt() {
+        let mut state = priority_state();
+        for idx in 0..264 {
+            push_simple_stack_entry(&mut state, 30_000 + idx, PlayerId(0));
+        }
+
+        let result = apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::SetAutoPass {
+                mode: AutoPassRequest::UntilStackEmpty,
+            },
+        )
+        .unwrap();
+
+        assert!(state.stack.is_empty());
+        assert!(matches!(result.waiting_for, WaitingFor::Priority { .. }));
+        assert!(
+            !result
+                .events
+                .iter()
+                .any(|event| matches!(event, GameEvent::ResolutionHalted { .. })),
+            "a terminating stack must not trip the runaway-resolution backstop"
+        );
+    }
+
     #[test]
     fn until_stack_empty_stops_on_stack_growth() {
         let mut state = priority_state();
@@ -947,7 +1036,37 @@ mod auto_pass_decision_tests {
 /// Auto-pass loop: when a player has an auto-pass flag and receives priority,
 /// automatically pass for them until the goal condition is met or interrupted.
 fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
-    for _ in 0..auto_pass_loop_max_iterations(state) {
+    // CR 732.2: per-dispatch resource ceilings for a runaway mandatory cascade.
+    // Sized above the largest legitimate single-dispatch burst (a Scute Swarm
+    // landfall copies every Scute in one resolution — tested boards reach ~2,936
+    // permanents) yet far below the WASM linear-memory exhaustion threshold
+    // (hundreds of thousands of objects). The iteration cap below is the
+    // sustained-growth backstop; these deltas catch heavy-per-iteration loops.
+    const MAX_EVENT_GROWTH: usize = 50_000;
+    const MAX_OBJECT_GROWTH: usize = 16_000;
+    let events_baseline = result.events.len();
+    let objects_baseline = state.objects.len();
+
+    let max_iterations = auto_pass_loop_max_iterations(state);
+    let mut iteration = 0usize;
+    loop {
+        // CR 732.2: the iteration cap was exhausted while a mandatory cascade is
+        // still in flight (priority unsettled, non-empty stack, no meaningful
+        // action) — halt gracefully, the same way the growth ceilings do, rather
+        // than fall through and leave the game mid-cascade. Reached ONLY on true
+        // exhaustion: every productive exit below uses `break`, leaving the loop
+        // without passing this guard, so a normal short resolution never trips it.
+        if iteration >= max_iterations {
+            if matches!(result.waiting_for, WaitingFor::Priority { .. })
+                && !state.stack.is_empty()
+                && !priority_player_has_meaningful_action(state)
+            {
+                emit_resolution_halt(state, result);
+            }
+            break;
+        }
+        iteration += 1;
+
         match &result.waiting_for {
             WaitingFor::Priority { player } => {
                 let player = *player;
@@ -981,6 +1100,16 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
                             finish_completed_or_interrupted_until_stack_empty_sessions(state);
                         result.events.extend(events);
                         result.waiting_for = wf;
+                        // CR 732.2: a mandatory cascade growing the board or
+                        // event stream past the resource ceiling cannot settle —
+                        // halt gracefully rather than exhaust WASM memory.
+                        if result.events.len() - events_baseline > MAX_EVENT_GROWTH
+                            || state.objects.len().saturating_sub(objects_baseline)
+                                > MAX_OBJECT_GROWTH
+                        {
+                            emit_resolution_halt(state, result);
+                            return;
+                        }
                         if stack_empty_or_grew {
                             break;
                         }
@@ -1033,6 +1162,28 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
             _ => break,
         }
     }
+}
+
+/// CR 732.2: settle a runaway mandatory cascade gracefully. Pauses resolution,
+/// returns priority to the active player, and emits a non-fatal `ResolutionHalted`
+/// log event so the UI/log explains why the cascade stopped. Reached three ways:
+/// the event-growth ceiling, the object-growth ceiling, and iteration-cap
+/// exhaustion. NOT a draw — a net-progress loop is a CR 732.2 shortcut the engine
+/// cannot infer an iteration count for; a *repeating* state is a separate CR
+/// 104.4b draw.
+fn emit_resolution_halt(state: &mut GameState, result: &mut ActionResult) {
+    // Diagnostic-only: the in-flight cascade's distinct stack-source ids.
+    let mut involved: Vec<ObjectId> = state.stack.iter().map(|e| e.source_id).collect();
+    involved.sort_unstable_by_key(|id| id.0);
+    involved.dedup();
+    result.events.push(GameEvent::ResolutionHalted { involved });
+
+    priority::reset_priority(state);
+    let wf = WaitingFor::Priority {
+        player: state.active_player,
+    };
+    state.waiting_for = wf.clone();
+    result.waiting_for = wf;
 }
 
 /// CR 707.10c: Finalize a `CopyRetarget` flow — write the slot-derived targets

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -87,6 +87,9 @@ fn categorize(event: &GameEvent) -> LogCategory {
     match event {
         GameEvent::GameStarted
         | GameEvent::GameOver { .. }
+        // CR 732.2: a halted runaway resolution is game-flow control, grouped
+        // with GameOver under `Game` rather than object-state `State`.
+        | GameEvent::ResolutionHalted { .. }
         | GameEvent::PlayerLost { .. }
         | GameEvent::PlayerEliminated { .. }
         // CR 103.1: grouped with the setup event MulliganStarted under `Game`
@@ -791,6 +794,12 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
             ],
             None => vec![text("Game over — Draw")],
         },
+
+        // CR 732.2: engine-authored game-flow message — raw text, not t()-wrapped
+        // (the i18n boundary keeps engine/log pass-through strings raw).
+        GameEvent::ResolutionHalted { .. } => {
+            vec![text("Resolution halted — possible mandatory loop")]
+        }
 
         GameEvent::MonarchChanged { player_id } => {
             vec![player_seg(state, *player_id), text(" becomes the monarch")]

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -330,6 +330,8 @@ pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]
             | GameEvent::StackPushed { .. }
             | GameEvent::StackResolved { .. }
             | GameEvent::GameOver { .. }
+            // CR 732.2: a halted-resolution notification dirties no display state.
+            | GameEvent::ResolutionHalted { .. }
             | GameEvent::SpellCountered { .. }
             | GameEvent::EffectResolved { .. }
             | GameEvent::Unattached { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -433,7 +433,8 @@ fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
     };
 
     match event {
-        GameEvent::GameStarted => {}
+        // CR 732.2: a halted-resolution notification produces no trigger keys.
+        GameEvent::GameStarted | GameEvent::ResolutionHalted { .. } => {}
         GameEvent::TurnStarted { .. } => push(TriggerEventKey::TurnStarted),
         GameEvent::PhaseChanged { phase } => push(TriggerEventKey::BeginningOfPhase(*phase)),
         GameEvent::PriorityPassed { .. } => {}

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -788,6 +788,8 @@ fn count_matching_trigger_event_subjects(
         | GameEvent::StackResolved { .. }
         | GameEvent::DamageCleared { .. }
         | GameEvent::GameOver { .. }
+        // CR 732.2: a halted-resolution notification carries no trigger subject.
+        | GameEvent::ResolutionHalted { .. }
         | GameEvent::DamagePrevented { .. }
         | GameEvent::SpellCountered { .. }
         | GameEvent::CounterAdded { .. }

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -332,6 +332,17 @@ pub enum GameEvent {
     GameOver {
         winner: Option<PlayerId>,
     },
+    /// CR 732.2: A mandatory auto-resolution sequence hit the engine's resource
+    /// ceiling without settling — a net-progress loop the engine cannot
+    /// shortcut (CR 732.2 resolves these by a player-declared iteration count
+    /// the engine can't infer). Resolution is paused and priority returned to
+    /// the active player. NOT a draw: distinct from CR 104.4b, which requires a
+    /// *repeating* state (a true loop is detected separately and ends the game).
+    /// `involved` carries the in-flight cascade's distinct stack-source ids for
+    /// diagnostics only — never read by game logic.
+    ResolutionHalted {
+        involved: Vec<ObjectId>,
+    },
     DamageDealt {
         source_id: ObjectId,
         target: TargetRef,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5879,6 +5879,102 @@ impl GameState {
                 Some(crate::types::ability::PostReplacementContinuation::Template(template));
         }
     }
+
+    /// CR 104.4b: a cheap pre-filter fingerprint of loop-mutable state. It need
+    /// NOT be complete — a confirmation pass (`loop_states_equal`) deep-compares
+    /// before any draw, so a fingerprint collision can never cause a wrongful
+    /// draw; the fingerprint only decides *when to bother confirming*. Includes
+    /// the RNG stream position so a loop that consumes randomness (shuffle, coin
+    /// flip) gets a distinct fingerprint and is never confirmed — CR 104.4b
+    /// excludes loops containing a nondeterministic action.
+    pub(crate) fn loop_fingerprint(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.turn_number.hash(&mut h);
+        self.phase.hash(&mut h);
+        self.active_player.hash(&mut h);
+        self.priority_player.hash(&mut h);
+        self.stack.len().hash(&mut h);
+        self.objects.len().hash(&mut h);
+        // im::Vector<ObjectId>: Hash, ordered.
+        self.battlefield.hash(&mut h);
+        for player in &self.players {
+            player.id.hash(&mut h);
+            player.life.hash(&mut h);
+            player.hand.len().hash(&mut h);
+            player.library.len().hash(&mut h);
+            player.graveyard.len().hash(&mut h);
+        }
+        // Per-object tapped/damage rollup (id-sorted) cheaply distinguishes
+        // tap/untap and damage-ping states without a full content hash.
+        let mut ids: Vec<ObjectId> = self.objects.keys().copied().collect();
+        ids.sort_unstable_by_key(|id| id.0);
+        for id in &ids {
+            if let Some(object) = self.objects.get(id) {
+                id.0.hash(&mut h);
+                object.tapped.hash(&mut h);
+                object.damage_marked.hash(&mut h);
+            }
+        }
+        // Any randomness consumed ⇒ different stream position ⇒ no collision.
+        self.rng.get_word_pos().hash(&mut h);
+        h.finish()
+    }
+
+    /// Clone with the volatile, monotonically-advancing fields the `PartialEq`
+    /// impl compares zeroed/canonicalized, so two states reached at different
+    /// times can compare equal on everything a mandatory action could change.
+    pub(crate) fn normalize_for_loop(&self) -> GameState {
+        let mut clone = self.clone();
+        clone.state_revision = 0;
+        clone.next_timestamp = 0;
+        clone.next_object_id = 0;
+        clone.layers_dirty = LayersDirty::full();
+        clone.public_state_dirty = PublicStateDirty::all_dirty();
+        clone
+    }
+}
+
+/// CR 104.4b confirmation between two states that have BOTH already been
+/// `normalize_for_loop`d. Reuses `PartialEq` for the ~95 non-object fields and
+/// supplements its `objects.len()`-only object check with per-object content
+/// equality. Only a true match permits a draw, so the cheap `loop_fingerprint`
+/// can never cause a wrongful draw.
+pub(crate) fn loop_states_equal(a: &GameState, b: &GameState) -> bool {
+    a == b && objects_content_eq(&a.objects, &b.objects)
+}
+
+/// CR 104.4b: per-object mutable-content equality — supplements `GameState`'s
+/// `objects.len()`-only `PartialEq` object check. Card-intrinsic fields
+/// (`base_*`, abilities, definitions) are immutable for a given object id within
+/// a game and so cannot differ between two states; only the fields a mandatory
+/// action could change are compared.
+fn objects_content_eq(
+    a: &im::HashMap<ObjectId, GameObject, rustc_hash::FxBuildHasher>,
+    b: &im::HashMap<ObjectId, GameObject, rustc_hash::FxBuildHasher>,
+) -> bool {
+    a.len() == b.len()
+        && a.iter().all(|(id, x)| {
+            b.get(id).is_some_and(|y| {
+                x.controller == y.controller
+                    && x.zone == y.zone
+                    && x.tapped == y.tapped
+                    && x.face_down == y.face_down
+                    && x.flipped == y.flipped
+                    && x.transformed == y.transformed
+                    && x.damage_marked == y.damage_marked
+                    && x.dealt_deathtouch_damage == y.dealt_deathtouch_damage
+                    && x.attached_to == y.attached_to
+                    && x.attachments == y.attachments
+                    && x.paired_with == y.paired_with
+                    && x.counters == y.counters
+                    && x.power == y.power
+                    && x.toughness == y.toughness
+                    && x.loyalty == y.loyalty
+                    && x.defense == y.defense
+                    && x.name == y.name
+            })
+        })
 }
 
 impl Default for GameState {
@@ -6056,6 +6152,95 @@ mod tests {
         AbilityDefinition, AbilityKind, Effect, PostReplacementContinuation, QuantityExpr,
         ResolvedAbility, TargetFilter,
     };
+
+    /// CR 104.4b: the loop fingerprint must distinguish object tap state — else a
+    /// tap/untap loop's two phases would be indistinguishable. (A false negative
+    /// is safe; this guards detection quality, not correctness.)
+    #[test]
+    fn loop_fingerprint_reflects_object_tap_state() {
+        let mut state = GameState::new_two_player(7);
+        let object = GameObject::new(
+            ObjectId(500),
+            CardId(1),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.insert(ObjectId(500), object);
+        state.battlefield.push_back(ObjectId(500));
+
+        let untapped = state.loop_fingerprint();
+        if let Some(object) = state.objects.get_mut(&ObjectId(500)) {
+            object.tapped = true;
+        }
+        assert_ne!(
+            untapped,
+            state.loop_fingerprint(),
+            "tapping an object must change the loop fingerprint"
+        );
+    }
+
+    /// CR 104.4b: any randomness consumed advances the RNG stream position, which
+    /// the fingerprint includes — so a loop containing a shuffle/coin flip never
+    /// collides and is correctly NOT drawn.
+    #[test]
+    fn loop_fingerprint_reflects_rng_consumption() {
+        let mut state = GameState::new_two_player(7);
+        let before = state.loop_fingerprint();
+        state.rng.set_word_pos(4096);
+        assert_ne!(
+            before,
+            state.loop_fingerprint(),
+            "advancing the RNG stream must change the loop fingerprint"
+        );
+    }
+
+    /// CR 104.4b confirmation: two states reached at different times (advancing
+    /// the volatile counters PartialEq compares) but otherwise identical must
+    /// confirm as equal — else a real loop could never be confirmed and drawn.
+    #[test]
+    fn loop_states_equal_ignores_volatile_counters() {
+        let base = GameState::new_two_player(7);
+        let mut later = base.clone();
+        later.state_revision = 99;
+        later.next_timestamp = 42;
+        later.next_object_id = base.next_object_id + 5;
+
+        assert!(
+            loop_states_equal(&base.normalize_for_loop(), &later.normalize_for_loop()),
+            "states differing only in volatile counters must confirm as a repeat"
+        );
+    }
+
+    /// CR 104.4b confirmation must NOT treat two states as equal when an object's
+    /// mutable content differs — guards the `objects.len()`-only `PartialEq` gap
+    /// that would otherwise permit a wrongful draw.
+    #[test]
+    fn loop_states_equal_detects_object_content_difference() {
+        let mut a = GameState::new_two_player(7);
+        let object = GameObject::new(
+            ObjectId(500),
+            CardId(1),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        a.objects.insert(ObjectId(500), object);
+        a.battlefield.push_back(ObjectId(500));
+        let mut b = a.clone();
+        if let Some(object) = b.objects.get_mut(&ObjectId(500)) {
+            object.tapped = true;
+        }
+
+        assert!(
+            loop_states_equal(&a.normalize_for_loop(), &a.normalize_for_loop()),
+            "identical states must confirm as a repeat"
+        );
+        assert!(
+            !loop_states_equal(&a.normalize_for_loop(), &b.normalize_for_loop()),
+            "a tapped-vs-untapped object difference must NOT confirm (no wrongful draw)"
+        );
+    }
 
     #[test]
     fn default_creates_two_player_game() {


### PR DESCRIPTION
- **fix(engine): graceful runaway-resolution backstop (CR 732.2)**
- **feat(engine): CR 104.4b draw for repeating mandatory loops**
