### PR TITLE
fix(engine): let face-down permanent controller look at it

### DIFF
--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -164,6 +164,35 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         hide_card(&mut filtered, obj_id);
     }
 
+    // CR 708.5: "At any time, you may look at a face-down permanent you control
+    // (even if it's phased out). You can't look at face-down spells or
+    // permanents controlled by another player." A face-down battlefield
+    // permanent (manifest / morph / disguise / cloak) keeps its real identity in
+    // `back_face` while its public characteristics are the 2/2 face. That hidden
+    // identity is look-permission of the *controller* alone — strip `back_face`
+    // for every viewer who is not the controller so the underlying card never
+    // leaks to opponents over the wire. The controller (turn-control aware,
+    // matching the rest of this filter) retains it so their client can show them
+    // the face. DFC back faces (`face_down == false`) are public information and
+    // are intentionally left untouched.
+    let leaked_facedown_permanent_ids: Vec<ObjectId> = filtered
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|obj_id| {
+            state.objects.get(obj_id).is_some_and(|obj| {
+                obj.face_down
+                    && obj.back_face.is_some()
+                    && !can_view_private_for_player(obj.controller)
+            })
+        })
+        .collect();
+    for obj_id in leaked_facedown_permanent_ids {
+        if let Some(obj) = filtered.objects.get_mut(&obj_id) {
+            obj.back_face = None;
+        }
+    }
+
     if let WaitingFor::ManifestDreadChoice { player, ref cards } = state.waiting_for {
         if !can_view_private_for_player(player) {
             filtered.waiting_for = WaitingFor::ManifestDreadChoice {
@@ -1559,5 +1588,71 @@ mod tests {
         let opponent_obj = opponent_view.objects.get(&card_id).unwrap();
         assert_eq!(opponent_obj.name, "Hidden Card");
         assert!(opponent_obj.face_down);
+    }
+
+    /// Issue #2024 (Manifest): CR 708.5 — "At any time, you may look at a
+    /// face-down permanent you control." A manifested (or morph/disguise/cloak)
+    /// face-down battlefield permanent stores its real identity in `back_face`.
+    /// The permanent's *controller* must keep that identity in their filtered
+    /// view so the client can show them the face, while opponents must have it
+    /// redacted (CR 708.5 — you can't look at a face-down permanent controlled
+    /// by another player).
+    #[test]
+    fn face_down_battlefield_permanent_identity_visible_only_to_controller() {
+        use crate::game::morph::manifest;
+        use crate::types::card_type::{CardType, CoreType};
+
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let controller = PlayerId(0);
+        let secret = create_object(
+            &mut state,
+            CardId(7),
+            controller,
+            "Secret Manifest".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&secret).unwrap();
+            obj.power = Some(5);
+            obj.toughness = Some(4);
+            obj.card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec![],
+            };
+        }
+
+        let mut events = Vec::new();
+        manifest(&mut state, controller, &mut events).unwrap();
+
+        // Server-side, the face-down 2/2 carries its real identity in back_face.
+        assert!(state.objects[&secret].face_down);
+        assert_eq!(state.objects[&secret].zone, Zone::Battlefield);
+        let stored = state.objects[&secret].back_face.as_ref().unwrap();
+        assert_eq!(stored.name, "Secret Manifest");
+
+        // CR 708.5: the controller may look at their own face-down permanent —
+        // their filtered view keeps the underlying identity in back_face.
+        let controller_view = filter_state_for_viewer(&state, controller);
+        let controller_obj = controller_view.objects.get(&secret).unwrap();
+        assert!(controller_obj.face_down);
+        let controller_back = controller_obj
+            .back_face
+            .as_ref()
+            .expect("controller must retain back_face to look at their own manifest");
+        assert_eq!(controller_back.name, "Secret Manifest");
+        assert_eq!(controller_back.power, Some(5));
+
+        // CR 708.5: an opponent can't look at it — back_face is redacted, but
+        // the public 2/2 face is still shown.
+        let opponent_view = filter_state_for_viewer(&state, PlayerId(1));
+        let opponent_obj = opponent_view.objects.get(&secret).unwrap();
+        assert!(opponent_obj.face_down);
+        assert!(
+            opponent_obj.back_face.is_none(),
+            "opponent must not see the manifested card's hidden identity"
+        );
+        assert_eq!(opponent_obj.power, Some(2));
+        assert_eq!(opponent_obj.toughness, Some(2));
     }
 }

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -180,19 +180,20 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
 
     // CR 708.5: "At any time, you may look at a face-down permanent you control
     // (even if it's phased out). You can't look at face-down spells or
-    // permanents controlled by another player." A face-down battlefield
-    // permanent (manifest / morph / disguise / cloak) keeps its real identity in
-    // `back_face` while its public characteristics are the 2/2 face. That hidden
-    // identity is look-permission of the *controller* alone — strip `back_face`
-    // for every viewer who is not the controller so the underlying card never
-    // leaks to opponents over the wire. The controller (turn-control aware,
-    // matching the rest of this filter) retains it so their client can show them
-    // the face. DFC back faces (`face_down == false`) are public information and
-    // are intentionally left untouched.
-    let leaked_facedown_permanent_ids: Vec<ObjectId> = filtered
+    // permanents controlled by another player." Face-down objects on the
+    // battlefield (manifest / morph / disguise / cloak) and any future modeled
+    // face-down stack spells keep their real identity in `back_face`. That
+    // hidden identity is look-permission of the *controller* alone — strip
+    // `back_face` for every viewer who is not the controller so the underlying
+    // card never leaks to opponents over the wire. The controller (turn-control
+    // aware, matching the rest of this filter) retains it so their client can
+    // show them the face. DFC back faces (`face_down == false`) are public
+    // information and are intentionally left untouched.
+    let leaked_facedown_object_ids: Vec<ObjectId> = filtered
         .battlefield
         .iter()
         .copied()
+        .chain(filtered.stack.iter().map(|entry| entry.id))
         .filter(|obj_id| {
             state.objects.get(obj_id).is_some_and(|obj| {
                 obj.face_down
@@ -201,7 +202,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
             })
         })
         .collect();
-    for obj_id in leaked_facedown_permanent_ids {
+    for obj_id in leaked_facedown_object_ids {
         if let Some(obj) = filtered.objects.get_mut(&obj_id) {
             obj.back_face = None;
         }
@@ -576,6 +577,7 @@ fn hide_card(state: &mut GameState, obj_id: ObjectId) {
         obj.casting_permissions.clear();
         obj.printed_ref = None;
         obj.base_printed_ref = None;
+        obj.back_face = None;
         obj.token_image_ref = None;
         obj.source_related_token_ids.clear();
         obj.foretold = false;
@@ -616,8 +618,11 @@ fn redact_pending_trigger_context_for_observer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::morph::manifest;
+    use crate::game::printed_cards::snapshot_object_face;
     use crate::game::zones::create_object;
     use crate::types::ability::{BeholdCostAction, Effect, ResolvedAbility};
+    use crate::types::card_type::{CardType, CoreType};
     use crate::types::format::FormatConfig;
     use crate::types::game_state::{
         AutoMayChoice, CastPaymentMode, CastingVariant, CostResume, ManaAbilityResume,
@@ -741,6 +746,30 @@ mod tests {
         assert_eq!(hidden.name, "Hidden Card");
         assert!(hidden.source_related_token_ids.is_empty());
         assert!(hidden.token_image_ref.is_none());
+    }
+
+    #[test]
+    fn hidden_cards_redact_back_face_identity() {
+        let mut state = GameState::new_two_player(42);
+        let card_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Front Face".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&card_id).unwrap();
+            let mut back_face = snapshot_object_face(obj);
+            back_face.name = "Secret Back Face".to_string();
+            obj.back_face = Some(back_face);
+        }
+
+        let filtered = filter_state_for_viewer(&state, PlayerId(0));
+        let hidden = filtered.objects.get(&card_id).unwrap();
+
+        assert_eq!(hidden.name, "Hidden Card");
+        assert!(hidden.back_face.is_none());
     }
 
     #[test]
@@ -1613,9 +1642,6 @@ mod tests {
     /// by another player).
     #[test]
     fn face_down_battlefield_permanent_identity_visible_only_to_controller() {
-        use crate::game::morph::manifest;
-        use crate::types::card_type::{CardType, CoreType};
-
         let mut state = GameState::new(FormatConfig::standard(), 2, 42);
         let controller = PlayerId(0);
         let secret = create_object(


### PR DESCRIPTION
Closes #2024

## Problem
Manifested permanents (and morph/disguise/cloak face-down permanents) couldn't be looked at by their own controller, and their hidden identity leaked to opponents.

When a card is manifested, the engine blanks the on-battlefield object to a vanilla 2/2 and stashes the real card in `back_face`. That `back_face` was serialized to **every** viewer with no per-viewer redaction, and the engine had no model of CR 708.5 for battlefield face-down permanents — only for hidden-zone (hand/library/exile) face-down cards. So opponents could see the manifested card's identity, while the controller (rendered the same "Face-Down Card" as everyone) had no way to look at their own permanent.

## Fix
`filter_state_for_viewer` now redacts `back_face` for any viewer who is **not** the controller of a face-down battlefield permanent (turn-control aware, consistent with the rest of the filter). Per **CR 708.5** — "you may look at a face-down permanent you control … you can't look at face-down permanents controlled by another player":
- **Controller** keeps `back_face` → their client can show the face.
- **Opponents** get `back_face` stripped → identity no longer leaks; they still see the public 2/2.

A single, class-wide fix covering manifest, morph, disguise, and cloak, since they share the `face_down` + `back_face` representation. DFC back faces (`face_down == false`) are public information and are left untouched.

## Tests
- Added `face_down_battlefield_permanent_identity_visible_only_to_controller` (fails without the fix).
- `cargo test -p engine --lib visibility::` 27 passed; morph/manifest suites green; full `cargo test -p engine --lib` green (10452 passed).