### PR TITLE
fix(engine): address Gemini review on CR 104.4b loop detection (#2335)

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use std::collections::VecDeque;
 use thiserror::Error;
 
 use crate::types::ability::{EffectKind, KeywordAction, TargetRef};
@@ -1054,7 +1055,7 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
     const FINGERPRINT_AFTER_ITERS: usize = 32;
     const MAX_LOOP_WINDOW: usize = 128;
     let mut mandatory_iters = 0usize;
-    let mut loop_window: Vec<(u64, GameState)> = Vec::new();
+    let mut loop_window: VecDeque<(u64, GameState)> = VecDeque::new();
 
     let max_iterations = auto_pass_loop_max_iterations(state);
     let mut iteration = 0usize;
@@ -1112,7 +1113,7 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
                         // CR 732.2: a mandatory cascade growing the board or
                         // event stream past the resource ceiling cannot settle —
                         // halt gracefully rather than exhaust WASM memory.
-                        if result.events.len() - events_baseline > MAX_EVENT_GROWTH
+                        if result.events.len().saturating_sub(events_baseline) > MAX_EVENT_GROWTH
                             || state.objects.len().saturating_sub(objects_baseline)
                                 > MAX_OBJECT_GROWTH
                         {
@@ -1150,9 +1151,20 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
                                 match_flow::handle_game_over_transition(state);
                                 return;
                             }
-                            if loop_window.len() < MAX_LOOP_WINDOW {
-                                loop_window.push((fingerprint, normalized));
+                            // CR 104.4b: a sliding window of the most recent
+                            // MAX_LOOP_WINDOW distinct states. A fill-once-and-stop
+                            // buffer never records the cycle of a loop whose
+                            // repeating phase begins after a long mandatory preamble
+                            // (more than MAX_LOOP_WINDOW transient states), silently
+                            // downgrading that bounded-state draw to a Phase-1 halt.
+                            // Evicting the oldest keeps any period <= MAX_LOOP_WINDOW
+                            // detectable regardless of when the cycle starts; the
+                            // deep loop_states_equal confirmation above still gates
+                            // every draw, so eviction never risks a wrongful draw.
+                            if loop_window.len() == MAX_LOOP_WINDOW {
+                                loop_window.pop_front();
                             }
+                            loop_window.push_back((fingerprint, normalized));
                         }
 
                         if stack_empty_or_grew {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5905,17 +5905,22 @@ impl GameState {
             player.library.len().hash(&mut h);
             player.graveyard.len().hash(&mut h);
         }
-        // Per-object tapped/damage rollup (id-sorted) cheaply distinguishes
-        // tap/untap and damage-ping states without a full content hash.
-        let mut ids: Vec<ObjectId> = self.objects.keys().copied().collect();
-        ids.sort_unstable_by_key(|id| id.0);
-        for id in &ids {
-            if let Some(object) = self.objects.get(id) {
-                id.0.hash(&mut h);
-                object.tapped.hash(&mut h);
-                object.damage_marked.hash(&mut h);
-            }
+        // Per-object tapped/damage rollup cheaply distinguishes tap/untap and
+        // damage-ping states without a full content hash. Folded together with XOR
+        // so the rollup is order-independent (im::HashMap iteration order is not
+        // stable across states) in O(N) with zero allocation — sorting the id set
+        // on every call was the hot-path cost on large boards (~2,936 permanents).
+        // Each per-object hash folds in the unique id, so equal (tapped, damage)
+        // on different objects never cancels.
+        let mut objects_rollup = 0u64;
+        for (id, object) in &self.objects {
+            let mut object_hash = rustc_hash::FxHasher::default();
+            id.0.hash(&mut object_hash);
+            object.tapped.hash(&mut object_hash);
+            object.damage_marked.hash(&mut object_hash);
+            objects_rollup ^= object_hash.finish();
         }
+        objects_rollup.hash(&mut h);
         // Any randomness consumed ⇒ different stream position ⇒ no collision.
         self.rng.get_word_pos().hash(&mut h);
         h.finish()
@@ -5962,6 +5967,11 @@ fn objects_content_eq(
                     && x.face_down == y.face_down
                     && x.flipped == y.flipped
                     && x.transformed == y.transformed
+                    // CR 702.26: phasing is mutable per-object status that leaves
+                    // zone and objects.len() unchanged, so two states differing only
+                    // in phased-in/out must not compare equal — else a loop that
+                    // phases a permanent in and out is a wrongful CR 104.4b draw.
+                    && x.phase_status == y.phase_status
                     && x.damage_marked == y.damage_marked
                     && x.dealt_deathtouch_damage == y.dealt_deathtouch_damage
                     && x.attached_to == y.attached_to


### PR DESCRIPTION
Four follow-ups from the post-merge Gemini review of #2335:

- Sliding loop-detection window (HIGH). The fill-once-and-stop buffer
  (`if len < MAX`) only recorded the first 128 distinct states after the
  fingerprinting threshold, so a bounded-state loop whose cycle begins
  after a long mandatory preamble was never recorded and silently
  downgraded from a CR 104.4b draw to a CR 732.2 halt. Switch
  `loop_window` to a `VecDeque` and evict the oldest entry so any period
  <= MAX_LOOP_WINDOW is detectable regardless of when the cycle starts.
  The deep `loop_states_equal` confirmation still gates every draw, so
  eviction never risks a wrongful draw.

- Phasing in loop-state equality (CR 702.26). `objects_content_eq`
  omitted phasing status; phasing leaves zone and `objects.len()`
  unchanged, so a loop that phases a permanent in and out could compare
  equal and trigger a wrongful CR 104.4b draw. Compare `phase_status`
  (the typed enum field; Gemini's suggested `phased_out` bool does not
  exist).

- Order-independent fingerprint rollup. `loop_fingerprint` allocated and
  sorted the full id set on every call to make the per-object tapped/
  damage rollup order-independent. Fold per-object hashes with XOR
  instead: O(N), zero allocation, order-independent. This is the hot
  path on large boards (~2,936 permanents). Each per-object hash folds
  in the unique id, and the fingerprint is only a pre-filter, so XOR
  cancellation is both vanishingly unlikely and harmless.

- Saturating event-growth check. Match the adjacent object-growth line
  by using `saturating_sub` for the event-growth delta.
