### PR TITLE
fix(parser): terminate 'named' card-name at verb boundary (issue #2016)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -31321,6 +31321,44 @@ mod tests {
         }
     }
 
+    /// Issue #2016: Bonder's Ornament — "each player who controls a permanent
+    /// named Bonder's Ornament draws a card" must produce ControlsCount with a
+    /// Named filter and deconjugated result "draw a card".
+    #[test]
+    fn strip_each_player_subject_named_permanent() {
+        use crate::types::ability::{Comparator, PlayerRelation, QuantityExpr};
+        let (scope, result) = strip_each_player_subject(
+            "each player who controls a permanent named Bonder's Ornament draws a card",
+        );
+        assert_eq!(result, "draw a card");
+        match scope {
+            Some(PlayerFilter::ControlsCount {
+                relation,
+                filter,
+                comparator,
+                count,
+            }) => {
+                assert_eq!(relation, PlayerRelation::All);
+                assert_eq!(comparator, Comparator::GE);
+                assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                match &filter {
+                    TargetFilter::Typed(tf) => {
+                        assert!(
+                            tf.properties.iter().any(|p| matches!(
+                                p,
+                                FilterProp::Named { name }
+                                    if name == "Bonder's Ornament"
+                            )),
+                            "filter must contain Named prop, got {tf:?}"
+                        );
+                    }
+                    other => panic!("expected Typed filter, got {other:?}"),
+                }
+            }
+            other => panic!("expected ControlsCount{{GE,Fixed(1)}}, got {other:?}"),
+        }
+    }
+
     /// CR 109.4 + CR 109.5: building-block coverage for the shared control
     /// predicate `parse_controls_permanent_object` — the comparator/count pair,
     /// the delegated object filter, the consumed-remainder shape, and the
@@ -31401,6 +31439,32 @@ mod tests {
         // Missing the "who …" lead → no predicate.
         let mut ctx = ParseContext::default();
         assert!(parse_controls_permanent_object("draws a card", &mut ctx).is_none());
+
+        // Issue #2016: "who controls a permanent named Bonder's Ornament draws
+        // a card" — the "named" suffix must terminate at the verb "draws" so
+        // the remainder carries the verb phrase.
+        let mut ctx = ParseContext::default();
+        let (comparator, count, filter, remainder) = parse_controls_permanent_object(
+            "who controls a permanent named Bonder's Ornament draws a card",
+            &mut ctx,
+        )
+        .expect("named-permanent control predicate must parse");
+        assert_eq!(comparator, Comparator::GE);
+        assert_eq!(count, QuantityExpr::Fixed { value: 1 });
+        match &filter {
+            TargetFilter::Typed(tf) => {
+                assert!(
+                    tf.properties.iter().any(|p| matches!(
+                        p,
+                        FilterProp::Named { name }
+                            if name == "Bonder's Ornament"
+                    )),
+                    "filter must contain Named prop, got {tf:?}"
+                );
+            }
+            other => panic!("expected Typed filter, got {other:?}"),
+        }
+        assert_eq!(remainder.trim_start(), "draws a card");
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1279,6 +1279,39 @@ fn parse_definite_parent_reference(input: &str) -> Option<(TargetFilter, &str)> 
     }
 }
 
+/// CR 201.2: Scan `name_text` (the lowercase text after "named ") for the
+/// first word boundary where a conjugated verb begins, indicating the card
+/// name has ended and a verb phrase follows. Returns the byte offset of the
+/// space preceding the verb, or `None` if no verb boundary is found.
+///
+/// Delegates to `nom_primitives::scan_split_at_phrase` for word-boundary
+/// scanning with nom `tag()` combinators.
+fn find_verb_boundary_in_named(name_text: &str) -> Option<usize> {
+    // Conjugated 3rd-person verbs that commonly follow a card name in
+    // "each player who controls a permanent named X [verb]" patterns.
+    // Only verbs that do NOT appear in real MTG card names are included.
+    // Excluded: "gains" (Ill-Gotten Gains), "deals" (Orzhova, the Church
+    // of Deals), "gets" (Bird Gets the Worm), "has"/"is"/"are"/"enters"
+    // (too generic and appear in card names).
+    nom_primitives::scan_split_at_phrase(name_text, |i| {
+        alt((
+            value((), tag::<_, _, OracleError<'_>>("draws ")),
+            value((), tag("loses ")),
+            value((), tag("creates ")),
+            value((), tag("destroys ")),
+            value((), tag("discards ")),
+            value((), tag("exiles ")),
+            value((), tag("mills ")),
+            value((), tag("puts ")),
+            value((), tag("reveals ")),
+            value((), tag("sacrifices ")),
+            value((), tag("searches ")),
+        ))
+        .parse(i)
+    })
+    .map(|(prefix, _)| prefix.len().saturating_sub(1))
+}
+
 /// Parse a type phrase like "creature", "nonland permanent", "artifact or enchantment",
 /// "creature you control", "creature an opponent controls".
 ///
@@ -2054,8 +2087,12 @@ pub fn parse_type_phrase_with_ctx<'a>(
     let remaining_named = lower[pos..].trim_start();
     let named_offset = lower[pos..].len() - remaining_named.len();
     if let Ok((name_text, _)) = tag::<_, _, OracleError<'_>>("named ").parse(remaining_named) {
-        // Name extends to end-of-clause markers: comma, period, "you control", "that", or end.
-        let name_end = name_text.find([',', '.']).unwrap_or(name_text.len());
+        // Name extends to end-of-clause markers: comma, period, conjugated
+        // verb at a word boundary (CR 201.2), or end-of-input.
+        let punct_end = name_text.find([',', '.']).unwrap_or(name_text.len());
+        let name_end = find_verb_boundary_in_named(name_text)
+            .unwrap_or(punct_end)
+            .min(punct_end);
         let raw_name = name_text[..name_end].trim();
         if !raw_name.is_empty() {
             // Reconstruct original-case name from the same position in `text`
@@ -10533,5 +10570,43 @@ mod tests {
                 "leg {tf:?} missing superlative Cmc/Aggregate prop"
             );
         }
+    }
+
+    /// Issue #2016: "a permanent named Bonder's Ornament draws a card" must
+    /// terminate the card name at the verb "draws" so the remainder carries
+    /// the verb phrase. Without the verb-boundary scan, the name swallows
+    /// "draws a card" and the remainder is empty.
+    #[test]
+    fn named_card_terminates_at_verb_boundary() {
+        let (filter, rest) = parse_type_phrase("a permanent named Bonder's Ornament draws a card");
+        let TargetFilter::Typed(tf) = &filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(
+            tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::Named { name } if name == "Bonder's Ornament"
+            )),
+            "expected Named prop with 'Bonder's Ornament', got {tf:?}"
+        );
+        assert_eq!(rest.trim(), "draws a card");
+    }
+
+    /// Ensure the verb-boundary scan does not fire on card names that happen
+    /// to contain verb-like substrings when followed by a comma delimiter.
+    #[test]
+    fn named_card_with_comma_delimiter_still_works() {
+        let (filter, rest) = parse_type_phrase("a creature named Falkenrath Gorger, it gains");
+        let TargetFilter::Typed(tf) = &filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(
+            tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::Named { name } if name == "Falkenrath Gorger"
+            )),
+            "expected Named prop with 'Falkenrath Gorger', got {tf:?}"
+        );
+        assert_eq!(rest.trim_start_matches([',', ' ']), "it gains");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2016 — Bonder's Ornament draws cards for ALL players instead of only those who control a permanent named Bonder's Ornament.

## Root Cause

The `named` suffix parser in `parse_type_phrase_with_ctx` (`oracle_target.rs`) used only comma and period as end-of-name markers. For oracle text like:

> Each player who controls a permanent named Bonder's Ornament draws a card.

the name swallowed `draws a card` (up to the period), leaving an empty remainder. `strip_controls_permanent_clause` then returned `None` (because the verb phrase was empty), so the `who controls` predicate was dropped entirely and the card drew for ALL players with `player_scope = All`.

## Fix

Added `find_verb_boundary_in_named()` which scans word boundaries in the name text for conjugated 3rd-person verbs using nom `tag()` combinators. The earliest of {verb boundary, comma, period} is used as `name_end`.

**Included verbs:** draws, loses, creates, destroys, discards, exiles, mills, puts, reveals, sacrifices, searches

**Excluded verbs** (appear in real MTG card names): gains (Ill-Gotten Gains), deals (Orzhova, the Church of Deals), gets (Bird Gets the Worm), has/is/are/enters (too generic)

## Tests Added

1. **`oracle_target.rs::named_card_terminates_at_verb_boundary`** — verifies `parse_type_phrase` correctly terminates the name at "draws" and returns the verb phrase as remainder
2. **`oracle_target.rs::named_card_with_comma_delimiter_still_works`** — regression: comma-delimited names still terminate at the comma
3. **`oracle_effect/mod.rs::strip_each_player_subject_named_permanent`** — end-to-end: verifies the full `strip_each_player_subject` pipeline produces `ControlsCount` with a `Named` filter and deconjugated result "draw a card"
4. **`oracle_effect/mod.rs::parse_controls_permanent_object_core`** (extended) — verifies `parse_controls_permanent_object` returns the correct filter and remainder for the named-permanent case

## Files Changed

- `crates/engine/src/parser/oracle_target.rs` — added `find_verb_boundary_in_named()` helper + updated `name_end` calculation + 2 unit tests
- `crates/engine/src/parser/oracle_effect/mod.rs` — 2 integration-level tests
