### PR TITLE
fix(parser): split player control-handoff conjunct so it is not dropped

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -10503,7 +10503,7 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
         } if *fight_subject == TargetFilter::SelfRef => {
             *fight_subject = subject_filter;
         }
-        // CR 613.3 + CR 110.2: "[Player] gains control of [object]" — when the
+        // CR 613.1b + CR 110.2: "[Player] gains control of [object]" — when the
         // acting subject is a non-controller player (e.g. "an opponent of your
         // choice gains control of it"), the semantics are GIVE (the current
         // controller transfers the object to that player), not TAKE (the

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1042,7 +1042,7 @@ fn starts_you_control_subject_predicate(s: &str) -> bool {
     .is_ok()
 }
 
-/// CR 613.3 + CR 110.2: True when `s` is a "<player-subject> gains control of …"
+/// CR 613.1b + CR 110.2: True when `s` is a "<player-subject> gains control of …"
 /// clause — i.e. the control-handoff predicate where a *player* (not the acting
 /// controller) takes control of an object. The subject axis is the full set of
 /// player-noun phrases (`an opponent`, `an opponent of your choice`, `target
@@ -1058,7 +1058,7 @@ fn starts_you_control_subject_predicate(s: &str) -> bool {
 /// it"). Scoped to the "gains control of" verb so plain GainControl (the acting
 /// controller steals) stays on the un-split imperative path.
 fn starts_player_gains_control_clause(s: &str) -> bool {
-    let Ok((predicate, subject)) =
+    let Ok((_predicate, subject)) =
         take_until::<_, _, OracleError<'_>>(" gains control of ").parse(s)
     else {
         return false;
@@ -1067,13 +1067,10 @@ fn starts_player_gains_control_clause(s: &str) -> bool {
         return false;
     }
     // The span before the predicate must be a recognized player-subject phrase.
-    // `starts_with_subject_prefix` expects a trailing space, so re-attach the
-    // boundary consumed by `take_until` before validating.
-    let subject_phrase = format!("{} ", subject.trim_start());
-    super::subject::starts_with_subject_prefix(&subject_phrase)
-        && tag::<_, _, OracleError<'_>>(" gains control of ")
-            .parse(predicate)
-            .is_ok()
+    // Include the boundary space consumed by `take_until`; the predicate match
+    // above guarantees the next byte is the ASCII space before "gains".
+    let subject_phrase = &s[..subject.len() + 1];
+    super::subject::starts_with_subject_prefix(subject_phrase)
 }
 
 /// Inner implementation operating on pre-lowercased input.
@@ -1082,7 +1079,7 @@ fn starts_clause_text_lower(s: &str) -> bool {
         return false;
     }
 
-    // CR 613.3 + CR 110.2: "<player-subject> gains control of …" control-handoff
+    // CR 613.1b + CR 110.2: "<player-subject> gains control of …" control-handoff
     // clause (Slicer, Hired Muscle). A player subject + "gains control of"
     // predicate is never a noun-phrase continuation, so it must split off as its
     // own clause to reach the GiveControl subject-rewrite path.
@@ -1245,7 +1242,7 @@ pub(crate) fn starts_bare_and_clause(text: &str) -> bool {
 
 /// Inner implementation operating on pre-lowercased input.
 fn starts_bare_and_clause_lower(s: &str) -> bool {
-    // CR 613.3 + CR 110.2: "<player-subject> gains control of …" control-handoff
+    // CR 613.1b + CR 110.2: "<player-subject> gains control of …" control-handoff
     // clause (Slicer, Hired Muscle: "untap it, goad it, and an opponent of your
     // choice gains control of it"). A player subject + "gains control of"
     // predicate is always a standalone subject-predicate clause, never a

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1042,10 +1042,52 @@ fn starts_you_control_subject_predicate(s: &str) -> bool {
     .is_ok()
 }
 
+/// CR 613.3 + CR 110.2: True when `s` is a "<player-subject> gains control of …"
+/// clause — i.e. the control-handoff predicate where a *player* (not the acting
+/// controller) takes control of an object. The subject axis is the full set of
+/// player-noun phrases (`an opponent`, `an opponent of your choice`, `target
+/// opponent`, `that player`, `each opponent`, …) recognized by
+/// `subject::starts_with_subject_prefix`; the predicate is the fixed verb phrase
+/// "gains control of ". A player subject followed by this conjugated predicate is
+/// always a standalone subject-predicate clause that lowers to
+/// `Effect::GiveControl` (via the `GainControl → GiveControl` subject rewrite in
+/// `oracle_effect::mod`), never a noun-phrase continuation of the prior conjunct.
+/// So both the comma splitter and the bare-`and` splitter must peel it off as its
+/// own clause — otherwise the control transfer is silently dropped (Slicer, Hired
+/// Muscle: "untap it, goad it, and an opponent of your choice gains control of
+/// it"). Scoped to the "gains control of" verb so plain GainControl (the acting
+/// controller steals) stays on the un-split imperative path.
+fn starts_player_gains_control_clause(s: &str) -> bool {
+    let Ok((predicate, subject)) =
+        take_until::<_, _, OracleError<'_>>(" gains control of ").parse(s)
+    else {
+        return false;
+    };
+    if subject.trim().is_empty() {
+        return false;
+    }
+    // The span before the predicate must be a recognized player-subject phrase.
+    // `starts_with_subject_prefix` expects a trailing space, so re-attach the
+    // boundary consumed by `take_until` before validating.
+    let subject_phrase = format!("{} ", subject.trim_start());
+    super::subject::starts_with_subject_prefix(&subject_phrase)
+        && tag::<_, _, OracleError<'_>>(" gains control of ")
+            .parse(predicate)
+            .is_ok()
+}
+
 /// Inner implementation operating on pre-lowercased input.
 fn starts_clause_text_lower(s: &str) -> bool {
     if starts_multiword_keyword_continuation(s) {
         return false;
+    }
+
+    // CR 613.3 + CR 110.2: "<player-subject> gains control of …" control-handoff
+    // clause (Slicer, Hired Muscle). A player subject + "gains control of"
+    // predicate is never a noun-phrase continuation, so it must split off as its
+    // own clause to reach the GiveControl subject-rewrite path.
+    if starts_player_gains_control_clause(s) {
+        return true;
     }
 
     // Table-driven prefix check via nom tag() — try all imperative verbs and
@@ -1203,6 +1245,15 @@ pub(crate) fn starts_bare_and_clause(text: &str) -> bool {
 
 /// Inner implementation operating on pre-lowercased input.
 fn starts_bare_and_clause_lower(s: &str) -> bool {
+    // CR 613.3 + CR 110.2: "<player-subject> gains control of …" control-handoff
+    // clause (Slicer, Hired Muscle: "untap it, goad it, and an opponent of your
+    // choice gains control of it"). A player subject + "gains control of"
+    // predicate is always a standalone subject-predicate clause, never a
+    // noun-phrase continuation of the prior conjunct — split it off so it reaches
+    // the GiveControl subject-rewrite path instead of being dropped.
+    if starts_player_gains_control_clause(s) {
+        return true;
+    }
     // Split into multiple alt() groups chained with .or() for nom's tuple limit.
     let has_verb_prefix = alt((
         value((), tag::<_, _, OracleError<'_>>("add ")),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -26550,3 +26550,120 @@ mod snapshot_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod slicer_control_handoff_tests {
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::{AbilityDefinition, ControllerRef, Effect, TargetFilter};
+    use crate::types::TriggerMode;
+
+    /// Walk a chained `AbilityDefinition` collecting one effect per node (parent
+    /// then each nested `sub_ability`). Lets the regression assert the FULL set
+    /// of sub-effects in a "you may pay; if you do, A, B, and C" chain — the
+    /// Slicer defect dropped the trailing conjunct entirely (issue #2032).
+    fn flatten_effects(def: &AbilityDefinition) -> Vec<&Effect> {
+        let mut out = Vec::new();
+        let mut node = Some(def);
+        while let Some(d) = node {
+            out.push(&*d.effect);
+            node = d.sub_ability.as_deref();
+        }
+        out
+    }
+
+    /// CR 613.3 + CR 110.2 (issue #2032): Slicer, Hired Muscle's attack trigger
+    /// is "you may pay {2}. If you do, untap it, goad it, and an opponent of your
+    /// choice gains control of it." Before the fix the chunk splitter failed to
+    /// recognize the trailing "an opponent of your choice gains control of it"
+    /// conjunct as a clause, so the control-handoff sub-effect was silently
+    /// dropped — Slicer untapped (and goaded) but never changed control. The
+    /// trigger must lower to ALL of Untap + Goad + GiveControl(recipient=Opponent).
+    #[test]
+    fn slicer_attack_trigger_includes_all_three_sub_effects() {
+        let parsed = parse_oracle_text(
+            "Whenever Slicer, Hired Muscle attacks, you may pay {2}. If you do, untap it, goad it, and an opponent of your choice gains control of it.",
+            "Slicer, Hired Muscle",
+            &[],
+            &["Artifact".into(), "Creature".into()],
+            &["Equipment".into()],
+        );
+        let trigger = parsed
+            .triggers
+            .iter()
+            .find(|t| matches!(t.mode, TriggerMode::Attacks))
+            .expect("attack trigger must parse");
+        let execute = trigger.execute.as_ref().expect("execute must be Some");
+        let effects = flatten_effects(execute);
+
+        // PayCost → Untap → Goad → GiveControl, all present.
+        assert!(
+            effects.iter().any(|e| matches!(e, Effect::Untap { .. })),
+            "untap sub-effect must be present, got {effects:#?}",
+        );
+        assert!(
+            effects.iter().any(|e| matches!(e, Effect::Goad { .. })),
+            "goad sub-effect must be present, got {effects:#?}",
+        );
+        // The trailing conjunct — the sub-effect that was being dropped.
+        let give = effects
+            .iter()
+            .find_map(|e| match e {
+                Effect::GiveControl { recipient, .. } => Some(recipient),
+                _ => None,
+            })
+            .expect("control-handoff (GiveControl) sub-effect must not be dropped");
+        assert_eq!(
+            *give,
+            TargetFilter::Typed(
+                crate::types::ability::TypedFilter::default().controller(ControllerRef::Opponent)
+            ),
+            "GiveControl recipient must be an opponent (CR 110.2), got {give:?}",
+        );
+    }
+
+    /// Building-block coverage: a bare-`and` two-clause chain "untap it and an
+    /// opponent gains control of it" must also split the player-subject control
+    /// handoff into its own clause (not an `Unimplemented { name: "an" }`
+    /// fallback that drops the transfer). Exercises the
+    /// `starts_player_gains_control_clause` recognizer on the bare-`and` boundary
+    /// independent of the comma form. The control transfer may lower either to a
+    /// direct `GiveControl` (when the recipient is fully determined, e.g. "an
+    /// opponent of your choice") or to a `Choose(Opponent)` + `GainControl` pair
+    /// (when "an opponent" needs an explicit selection step) — both are correct
+    /// CR 110.2 handoffs; what must never happen is the clause being dropped.
+    #[test]
+    fn player_gains_control_splits_on_bare_and() {
+        let parsed = parse_oracle_text(
+            "Whenever ~ attacks, untap it and an opponent gains control of it.",
+            "Test Card",
+            &[],
+            &["Artifact".into(), "Creature".into()],
+            &[],
+        );
+        let trigger = parsed
+            .triggers
+            .iter()
+            .find(|t| matches!(t.mode, TriggerMode::Attacks))
+            .expect("attack trigger must parse");
+        let effects = flatten_effects(trigger.execute.as_ref().expect("execute"));
+        // The untap clause must survive…
+        assert!(
+            effects.iter().any(|e| matches!(e, Effect::Untap { .. })),
+            "untap sub-effect must be present, got {effects:#?}",
+        );
+        // …and the control handoff must be present in some valid lowered form,
+        // never an Unimplemented drop.
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::GiveControl { .. } | Effect::GainControl { .. })),
+            "bare-and player control handoff must lower to a control transfer, got {effects:#?}",
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::Unimplemented { .. })),
+            "control-handoff clause must not be dropped as Unimplemented, got {effects:#?}",
+        );
+    }
+}

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -26571,7 +26571,7 @@ mod slicer_control_handoff_tests {
         out
     }
 
-    /// CR 613.3 + CR 110.2 (issue #2032): Slicer, Hired Muscle's attack trigger
+    /// CR 613.1b + CR 110.2 (issue #2032): Slicer, Hired Muscle's attack trigger
     /// is "you may pay {2}. If you do, untap it, goad it, and an opponent of your
     /// choice gains control of it." Before the fix the chunk splitter failed to
     /// recognize the trailing "an opponent of your choice gains control of it"


### PR DESCRIPTION
Closes #2032

## Problem
Slicer, Hired Muscle's attack trigger — "Whenever Slicer attacks, you may pay {2}. If you do, untap it, goad it, **and an opponent of your choice gains control of it**" — untapped Slicer but never gave an opponent control. Choosing "yes" applied only the leading sub-effects; the trailing control-handoff conjunct was silently lost.

## Root cause
The clause splitter (`oracle_effect/sequence.rs`) decides clause boundaries via `starts_clause_text_lower` (comma path) and `starts_bare_and_clause_lower` (bare-`and` path). Neither recognized a **player-subject + "gains control of" predicate** as a clause starter, so the conjunct after "goad it, and" was never peeled into its own clause and the chained `sub_ability` ended at Goad. The existing `GainControl → GiveControl` subject rewrite was correct — the clause just never reached it.

## Fix
Added `starts_player_gains_control_clause`: `take_until(" gains control of ")` with the prefix validated as a player subject through the existing `subject::starts_with_subject_prefix` (covers "an opponent", "an opponent of your choice", "target opponent", "that player", "each opponent", …). Wired into both split paths. Scoped to the "gains control of" verb so a plain `GainControl` (the controller steals) stays on the un-split imperative path.

Builds for the class of player control-handoff cards, not just Slicer. CR-annotated (CR 613.3 + CR 110.2), nom combinators throughout, no verbatim string matching.

## Tests
New `slicer_control_handoff_tests` regression module: the full Slicer chain now lowers to Untap + Goad + GiveControl(recipient=Opponent), and the bare-`and` two-clause form splits the handoff (never an `Unimplemented` drop). Full `cargo test -p engine --lib` green (10472 passed); parser combinator gate passes.