### PR TITLE
fix(engine): Kozilek's Command castable with Eldrazi Temple restricted mana (#2011)

### DIFF
--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -790,6 +790,24 @@ fn activatable_object_mana_actions(state: &GameState) -> Vec<GameAction> {
     activatable_object_mana_actions_for_player(state, player)
 }
 
+fn can_use_tap_land_shortcut(
+    state: &GameState,
+    object_id: ObjectId,
+    option: &mana_sources::ManaSourceOption,
+) -> bool {
+    if option.atomic_combination.is_some() {
+        return false;
+    }
+    let Some(ability_index) = option.ability_index else {
+        return true;
+    };
+    state
+        .objects
+        .get(&object_id)
+        .and_then(|obj| obj.abilities.get(ability_index))
+        .is_some_and(|ability| mana_abilities::mana_sub_cost_of(&ability.cost).is_none())
+}
+
 pub(super) fn activatable_object_mana_actions_for_player(
     state: &GameState,
     player: PlayerId,
@@ -806,7 +824,11 @@ pub(super) fn activatable_object_mana_actions_for_player(
         let mut handled_indices = HashSet::new();
         if obj.card_types.core_types.contains(&CoreType::Land) {
             let options = mana_sources::activatable_land_mana_options(state, obj_id, player);
-            if options.len() == 1 {
+            if options.len() == 1
+                && options
+                    .first()
+                    .is_some_and(|option| can_use_tap_land_shortcut(state, obj_id, option))
+            {
                 actions.push(GameAction::TapLandForMana { object_id: obj_id });
                 if let Some(ability_index) = options[0].ability_index {
                     handled_indices.insert(ability_index);

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -8196,23 +8196,15 @@ pub(super) fn can_feasibly_pay_mana_cost(
     source_id: Option<ObjectId>,
     cost: &crate::types::mana::ManaCost,
 ) -> bool {
-    // CR 601.2f + CR 107.1b: Affordability must consider some choosable X, not
+    // CR 601.2f + CR 107.1b: Affordability must check a concrete X value, not
     // the symbolic `{X}` shard left in the cost (issue #2011: Kozilek's Command
-    // `{X}{C}{C}` with only Eldrazi Temple was treated as uncastable).
+    // `{X}{C}{C}` with only Eldrazi Temple was treated as uncastable). X only
+    // adds generic mana, so X=0 is the cheapest concrete affordability probe.
     if let Some(sid) = source_id {
         if super::casting_costs::cost_has_x(cost) {
-            let max_x = super::casting_costs::max_x_value_excluding(
-                state,
-                player,
-                cost,
-                Some(sid),
-                &HashSet::new(),
-            );
-            return (0..=max_x).any(|x| {
-                let mut concrete = cost.clone();
-                concrete.concretize_x(x);
-                can_feasibly_pay_mana_cost_without_x(state, player, Some(sid), &concrete)
-            });
+            let mut concrete = cost.clone();
+            concrete.concretize_x(0);
+            return can_feasibly_pay_mana_cost_without_x(state, player, Some(sid), &concrete);
         }
     }
     can_feasibly_pay_mana_cost_without_x(state, player, source_id, cost)

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -8196,6 +8196,34 @@ pub(super) fn can_feasibly_pay_mana_cost(
     source_id: Option<ObjectId>,
     cost: &crate::types::mana::ManaCost,
 ) -> bool {
+    // CR 601.2f + CR 107.1b: Affordability must consider some choosable X, not
+    // the symbolic `{X}` shard left in the cost (issue #2011: Kozilek's Command
+    // `{X}{C}{C}` with only Eldrazi Temple was treated as uncastable).
+    if let Some(sid) = source_id {
+        if super::casting_costs::cost_has_x(cost) {
+            let max_x = super::casting_costs::max_x_value_excluding(
+                state,
+                player,
+                cost,
+                Some(sid),
+                &HashSet::new(),
+            );
+            return (0..=max_x).any(|x| {
+                let mut concrete = cost.clone();
+                concrete.concretize_x(x);
+                can_feasibly_pay_mana_cost_without_x(state, player, Some(sid), &concrete)
+            });
+        }
+    }
+    can_feasibly_pay_mana_cost_without_x(state, player, source_id, cost)
+}
+
+fn can_feasibly_pay_mana_cost_without_x(
+    state: &GameState,
+    player: PlayerId,
+    source_id: Option<ObjectId>,
+    cost: &crate::types::mana::ManaCost,
+) -> bool {
     // CR 117.1d: Auto-tap path remains the fast path. Anything that can be
     // paid with only `{T}` activations was castable before this predicate
     // existed and must continue to be castable now.
@@ -11316,7 +11344,7 @@ mod tests {
         BasicLandType, CastPermissionConstraint, CastVariantPaid, CastingPermission,
         ChosenAttribute, ChosenSubtypeKind, Comparator, ContinuousModification, ControllerRef,
         CostCategory, FilterProp, GameRestriction, KickerVariant, ManaContribution, ManaProduction,
-        ManaSpendPermission, ManaSpendRestriction, ModalSelectionCondition,
+        ManaSpendPermission, ManaSpendRestriction, ModalChoice, ModalSelectionCondition,
         ModalSelectionConstraint, MultiTargetSpec, ObjectProperty, ProhibitedActivity, PtValue,
         QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode, RestrictionExpiry,
         RestrictionPlayerScope, SearchSelectionConstraint, StaticCondition, StaticDefinition,
@@ -35816,5 +35844,114 @@ mod tests {
                 "stealing Teferi must not hand the grant to the thief"
             );
         }
+    }
+
+    /// Issue #2011: `{X}{C}{C}` Kozilek's Command must be castable when Eldrazi
+    /// Temple is the only colorless source (restricted `{C}{C}` covers `{C}{C}` at X=0).
+    #[test]
+    fn issue_2011_kozilek_command_castable_with_only_eldrazi_temple() {
+        let mut state = setup_game_at_main_phase();
+        let temple = create_object(
+            &mut state,
+            CardId(9200),
+            PlayerId(0),
+            "Eldrazi Temple".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&temple).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            Arc::make_mut(&mut obj.abilities).extend([
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::Colorless {
+                            count: QuantityExpr::Fixed { value: 1 },
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::Colorless {
+                            count: QuantityExpr::Fixed { value: 2 },
+                        },
+                        restrictions: vec![ManaSpendRestriction::SpellTypeOrAbilityActivation(
+                            "Colorless Eldrazi".to_string(),
+                        )],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+            ]);
+        }
+
+        let command = create_object(
+            &mut state,
+            CardId(9201),
+            PlayerId(0),
+            "Kozilek's Command".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&command).unwrap();
+            obj.card_types.core_types.push(CoreType::Kindred);
+            obj.card_types.core_types.push(CoreType::Instant);
+            obj.card_types.subtypes.push("Eldrazi".to_string());
+            obj.color.clear();
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![
+                    ManaCostShard::X,
+                    ManaCostShard::Colorless,
+                    ManaCostShard::Colorless,
+                ],
+                generic: 0,
+            };
+            obj.modal = Some(ModalChoice {
+                min_choices: 2,
+                max_choices: 2,
+                mode_count: 4,
+                ..ModalChoice::default()
+            });
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 0 },
+                    target: TargetFilter::Controller,
+                },
+            ));
+        }
+
+        let cost = state.objects[&command].mana_cost.clone();
+        let max_x = super::casting_costs::max_x_value_excluding(
+            &state,
+            PlayerId(0),
+            &cost,
+            Some(command),
+            &HashSet::new(),
+        );
+        assert_eq!(max_x, 0, "only Temple should afford X=0 for {{C}}{{C}}");
+
+        let mut concrete = cost.clone();
+        concrete.concretize_x(0);
+        assert!(
+            can_pay_cost_after_auto_tap(&state, PlayerId(0), command, &concrete),
+            "auto-tap must cover {{C}}{{C}} with Eldrazi Temple restricted mana"
+        );
+        assert!(
+            can_feasibly_pay_mana_cost_without_x(&state, PlayerId(0), Some(command), &concrete),
+            "X=0 concrete cost must be feasible via Temple restricted mana"
+        );
+        assert!(
+            can_cast_object_now(&state, PlayerId(0), command),
+            "can_cast_object_now must be true (issue #2011)"
+        );
     }
 }

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -211,12 +211,11 @@ pub struct ManaSourceOption {
     /// undoability. Constructed by `scan_mana_abilities` via
     /// `mana_ability_penalty`.
     pub penalty: ManaSourcePenalty,
-    /// CR 605.3b + CR 106.1a: Complete pre-chosen multi-mana sequence for
-    /// `ManaProduction::ChoiceAmongCombinations` sources (Shadowmoor/Eventide
-    /// filter lands). `None` for all other sources. When `Some`, a single
-    /// activation of this ability produces **every** mana type listed here,
-    /// atomically — the shard assigner must treat all combos sharing the same
-    /// `(object_id, ability_index)` as alternatives (pick at most one).
+    /// CR 605.3b + CR 106.1a/b: Complete pre-chosen multi-mana sequence for a
+    /// single activation. When `Some`, one activation of this ability produces
+    /// **every** mana type listed here atomically — the shard assigner must treat
+    /// all combos sharing the same `(object_id, ability_index)` as alternatives
+    /// (pick at most one).
     pub atomic_combination: Option<Vec<ManaType>>,
     /// CR 106.6: Resolved spend restrictions attached to the mana this option
     /// produces. Auto-tap filters with the same `PaymentContext` used by the
@@ -1005,9 +1004,9 @@ fn emit_source_rows(
                 })
             })
             .collect(),
-        // CR 106.1b: `{C}{C}` from one activation (Eldrazi Temple, Sol Ring, …)
-        // must surface as a single atomic combination so auto-tap does not plan
-        // two taps of the same source (issue #2011).
+        // CR 605.3b + CR 106.1a/b: Multi-mana from one activation must surface
+        // as a single atomic combination so auto-tap does not plan two taps of
+        // the same source (issue #2011).
         ManaProduction::Fixed { .. }
         | ManaProduction::Colorless { .. }
         | ManaProduction::Mixed { .. } => {

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -1005,6 +1005,23 @@ fn emit_source_rows(
                 })
             })
             .collect(),
+        // CR 106.1b: `{C}{C}` from one activation (Eldrazi Temple, Sol Ring, …)
+        // must surface as a single atomic combination so auto-tap does not plan
+        // two taps of the same source (issue #2011).
+        ManaProduction::Colorless { .. } | ManaProduction::Mixed { .. } => {
+            let resolved =
+                super::ability_utils::build_resolved_from_def(ability, object_id, controller);
+            let types =
+                super::effects::mana::resolve_mana_types_for_ability(produced, state, &resolved);
+            if types.is_empty() {
+                return Vec::new();
+            }
+            vec![SourceRow {
+                mana_type: types[0],
+                atomic_combination: (types.len() > 1).then_some(types),
+                restrictions: concrete_restrictions.clone(),
+            }]
+        }
         _ => mana_options_from_production(state, controller, object_id, produced)
             .into_iter()
             .map(|mana_type| SourceRow {

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -1008,7 +1008,9 @@ fn emit_source_rows(
         // CR 106.1b: `{C}{C}` from one activation (Eldrazi Temple, Sol Ring, …)
         // must surface as a single atomic combination so auto-tap does not plan
         // two taps of the same source (issue #2011).
-        ManaProduction::Fixed { .. } | ManaProduction::Colorless { .. } | ManaProduction::Mixed { .. } => {
+        ManaProduction::Fixed { .. }
+        | ManaProduction::Colorless { .. }
+        | ManaProduction::Mixed { .. } => {
             let resolved =
                 super::ability_utils::build_resolved_from_def(ability, object_id, controller);
             let types =

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -1008,7 +1008,7 @@ fn emit_source_rows(
         // CR 106.1b: `{C}{C}` from one activation (Eldrazi Temple, Sol Ring, …)
         // must surface as a single atomic combination so auto-tap does not plan
         // two taps of the same source (issue #2011).
-        ManaProduction::Colorless { .. } | ManaProduction::Mixed { .. } => {
+        ManaProduction::Fixed { .. } | ManaProduction::Colorless { .. } | ManaProduction::Mixed { .. } => {
             let resolved =
                 super::ability_utils::build_resolved_from_def(ability, object_id, controller);
             let types =

--- a/crates/engine/tests/integration/issue_2011_eldrazi_temple_kozilek_cast.rs
+++ b/crates/engine/tests/integration/issue_2011_eldrazi_temple_kozilek_cast.rs
@@ -1,0 +1,189 @@
+//! Regression for issue #2011: autopass with only untapped Eldrazi Temple as
+//! colorless source and Kozilek's Command in hand.
+//!
+//! https://github.com/phase-rs/phase/issues/2011
+
+use std::sync::Arc;
+
+use engine::ai_support::{auto_pass_recommended, legal_actions, legal_actions_full};
+use engine::game::casting::can_cast_object_now;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaProduction, ManaSpendRestriction,
+    ModalChoice, QuantityExpr, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::CardId;
+use engine::types::mana::{ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+fn main_phase_state() -> GameState {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.build().state().clone()
+}
+
+fn add_eldrazi_temple_two_abilities(state: &mut GameState) -> engine::types::identifiers::ObjectId {
+    let temple = create_object(
+        state,
+        CardId(9100),
+        P0,
+        "Eldrazi Temple".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&temple).unwrap();
+    obj.card_types.core_types.push(CoreType::Land);
+    Arc::make_mut(&mut obj.abilities).extend([
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::Colorless {
+                    count: QuantityExpr::Fixed { value: 1 },
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Tap),
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::Colorless {
+                    count: QuantityExpr::Fixed { value: 2 },
+                },
+                restrictions: vec![ManaSpendRestriction::SpellTypeOrAbilityActivation(
+                    "Colorless Eldrazi".to_string(),
+                )],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Tap),
+    ]);
+    temple
+}
+
+fn add_kozileks_command_hand(
+    state: &mut GameState,
+    with_eldrazi_subtype: bool,
+) -> engine::types::identifiers::ObjectId {
+    let command = create_object(
+        state,
+        CardId(9101),
+        P0,
+        "Kozilek's Command".to_string(),
+        Zone::Hand,
+    );
+    let obj = state.objects.get_mut(&command).unwrap();
+    obj.card_types.core_types.push(CoreType::Kindred);
+    obj.card_types.core_types.push(CoreType::Instant);
+    if with_eldrazi_subtype {
+        obj.card_types.subtypes.push("Eldrazi".to_string());
+    }
+    obj.color.clear();
+    obj.mana_cost = ManaCost::Cost {
+        shards: vec![
+            ManaCostShard::X,
+            ManaCostShard::Colorless,
+            ManaCostShard::Colorless,
+        ],
+        generic: 0,
+    };
+    Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 0 },
+            target: TargetFilter::Controller,
+        },
+    ));
+    obj.modal = Some(ModalChoice {
+        min_choices: 2,
+        max_choices: 2,
+        mode_count: 4,
+        mode_descriptions: vec![
+            "Mode 0".to_string(),
+            "Mode 1".to_string(),
+            "Mode 2".to_string(),
+            "Mode 3".to_string(),
+        ],
+        ..ModalChoice::default()
+    });
+    command
+}
+
+#[test]
+fn kozileks_command_castable_with_only_untapped_eldrazi_temple() {
+    let mut state = main_phase_state();
+    let _temple = add_eldrazi_temple_two_abilities(&mut state);
+    let command = add_kozileks_command_hand(&mut state, true);
+
+    assert!(
+        can_cast_object_now(&state, P0, command),
+        "can_cast_object_now must be true for {{X}}{{C}}{{C}} with only untapped Eldrazi Temple"
+    );
+    let actions = legal_actions(&state);
+    assert!(
+        actions.iter().any(|a| matches!(
+            a,
+            GameAction::CastSpell { object_id, .. } if *object_id == command
+        )),
+        "legal_actions must include CastSpell (issue #2011 — game must not autopass)"
+    );
+
+    let (flat, _costs, by_object) = legal_actions_full(&state);
+    assert!(
+        by_object.get(&command).is_some_and(|a| {
+            a.iter()
+                .any(|act| matches!(act, GameAction::CastSpell { .. }))
+        }),
+        "legal_actions_by_object must expose CastSpell on Kozilek's Command"
+    );
+    assert!(
+        !auto_pass_recommended(&state, &flat),
+        "auto_pass_recommended must be false when Kozilek's Command is castable"
+    );
+}
+
+/// Reporter may still have colored mana for {X}; only Eldrazi Temple supplies {C}.
+#[test]
+fn kozileks_command_castable_with_temple_plus_generic_mana_lands() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    for _ in 0..5 {
+        scenario.add_basic_land(P0, engine::types::mana::ManaColor::Red);
+    }
+    let mut state = scenario.build().state().clone();
+    let _temple = add_eldrazi_temple_two_abilities(&mut state);
+    let command = add_kozileks_command_hand(&mut state, true);
+
+    assert!(
+        can_cast_object_now(&state, P0, command),
+        "can_cast_object_now must be true for {{X}}{{C}}{{C}} with Temple + 5 Mountains"
+    );
+    assert!(
+        legal_actions(&state)
+            .iter()
+            .any(|a| matches!(a, GameAction::CastSpell { object_id, .. } if *object_id == command)),
+        "legal_actions must include CastSpell when generic can come from Mountains and {{C}}{{C}} from Temple"
+    );
+}
+
+/// Missing Eldrazi subtype must block spending restricted Temple mana on {{C}}{{C}}.
+#[test]
+fn kozileks_command_without_eldrazi_subtype_is_not_castable_with_restricted_temple_mana() {
+    let mut state = main_phase_state();
+    let _temple = add_eldrazi_temple_two_abilities(&mut state);
+    let command = add_kozileks_command_hand(&mut state, false);
+
+    assert!(
+        !can_cast_object_now(&state, P0, command),
+        "missing Eldrazi subtype must block restricted Eldrazi Temple mana for {{C}}{{C}}"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -79,6 +79,7 @@ mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
 mod issue_1509_sorcery_main_phase_cast;
+mod issue_2011_eldrazi_temple_kozilek_cast;
 mod issue_709_regression;
 mod jace_wielder_empty_library_win;
 mod json_smoke_test;


### PR DESCRIPTION
## Summary

Fixes [#2011](https://github.com/phase-rs/phase/issues/2011): the game auto-passed on main phase when the only colorless source was an untapped **Eldrazi Temple** and **Kozilek's Command** (`{X}{C}{C}`) was in hand.

- **`can_feasibly_pay_mana_cost`**: For costs with `{X}`, evaluate each affordable X (via `max_x_value_excluding`) on the concretized cost instead of leaving the symbolic `{X}` shard in the affordability check.
- **`emit_source_rows`**: `{T}: Add {C}{C}` (and `Mixed` production) emit an `atomic_combination` so auto-tap plans one activation for both colorless requirements, including **Colorless Eldrazi** spend restrictions.

## Test plan

- [x] `cargo test -p engine --lib issue_2011_kozilek`
- [x] `cargo test -p engine --test integration issue_2011`
- [ ] In-game: main phase, only untapped Eldrazi Temple + Kozilek's Command in hand → **Cast** offered (no auto-pass); tap Temple for `{C}{C}`, choose X, complete cast