### PR TITLE
fix(engine): Wayta doubles only damage-caused triggers (#2439)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3437,6 +3437,7 @@ fn trigger_cause_matches(
             record.core_types.contains(&CoreType::Creature)
         }
         TriggerCause::ControlledCreatureDealtDamage => {
+            // CR 603.2d: Wayta doubles triggers caused by a creature you control being dealt damage.
             let Some(GameEvent::DamageDealt { target, .. }) = event else {
                 return false;
             };

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3352,7 +3352,12 @@ fn apply_trigger_doubling(state: &GameState, pending: &mut Vec<PendingTriggerCon
                 continue;
             }
             // CR 603.2d: Check the cause predicate against the spawning event.
-            if !trigger_cause_matches(cause, trigger.trigger_event.as_ref()) {
+            if !trigger_cause_matches(
+                state,
+                cause,
+                trigger.trigger_event.as_ref(),
+                *doubler_controller,
+            ) {
                 continue;
             }
             // CR 603.2d: If the doubler specifies an affected filter (e.g. "creature you
@@ -3386,7 +3391,14 @@ fn apply_trigger_doubling(state: &GameState, pending: &mut Vec<PendingTriggerCon
 /// - `TriggerCause::CreatureAttacking` matches `AttackersDeclared` events.
 ///   CR 508.1a: every object declared as an attacker must be a creature,
 ///   so no further type check is required.
-fn trigger_cause_matches(cause: &TriggerCause, event: Option<&GameEvent>) -> bool {
+/// - `TriggerCause::ControlledCreatureDealtDamage` matches `DamageDealt`
+///   events whose target is a creature controlled by `doubler_controller`.
+fn trigger_cause_matches(
+    state: &GameState,
+    cause: &TriggerCause,
+    event: Option<&GameEvent>,
+    doubler_controller: PlayerId,
+) -> bool {
     match cause {
         TriggerCause::Any => true,
         TriggerCause::EntersBattlefield { core_types } => {
@@ -3423,6 +3435,19 @@ fn trigger_cause_matches(cause: &TriggerCause, event: Option<&GameEvent>) -> boo
                 return false;
             };
             record.core_types.contains(&CoreType::Creature)
+        }
+        TriggerCause::ControlledCreatureDealtDamage => {
+            let Some(GameEvent::DamageDealt { target, .. }) = event else {
+                return false;
+            };
+            let TargetRef::Object(target_id) = target else {
+                return false;
+            };
+            let Some(obj) = state.objects.get(target_id) else {
+                return false;
+            };
+            obj.controller == doubler_controller
+                && obj.card_types.core_types.contains(&CoreType::Creature)
         }
     }
 }
@@ -19218,6 +19243,110 @@ mod dedup_regression_tests {
         assert_eq!(
             observer_triggers, 2,
             "Drivnod must double the observer's dies trigger to 2 instances"
+        );
+    }
+
+    /// CR 603.2d: Wayta (ControlledCreatureDealtDamage cause) doubles only
+    /// triggers caused by a creature you control being dealt damage.
+    #[test]
+    fn wayta_doubles_damage_caused_triggers() {
+        use crate::types::statics::TriggerCause;
+
+        let (mut state, observer) = setup_with_observer(TriggerMode::DamageDone);
+        let _wayta = install_doubler(&mut state, TriggerCause::ControlledCreatureDealtDamage);
+        let damaged = create_object(
+            &mut state,
+            CardId(21),
+            PlayerId(0),
+            "Damaged Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&damaged)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        let source = create_object(
+            &mut state,
+            CardId(22),
+            PlayerId(1),
+            "Damage Source".to_string(),
+            Zone::Battlefield,
+        );
+
+        let event = GameEvent::DamageDealt {
+            source_id: source,
+            target: TargetRef::Object(damaged),
+            amount: 2,
+            is_combat: false,
+            excess: 0,
+        };
+
+        process_triggers(&mut state, &[event]);
+        super::drain_order_triggers_with_identity(&mut state);
+        let observer_triggers = state
+            .stack
+            .iter()
+            .filter(|e| e.source_id == observer)
+            .count();
+        assert_eq!(
+            observer_triggers, 2,
+            "Wayta must double damage-caused triggers of permanents the controller owns"
+        );
+    }
+
+    /// CR 603.2d: Wayta must not double triggers unrelated to controlled-creature damage.
+    #[test]
+    fn wayta_does_not_double_unrelated_triggers() {
+        use crate::types::statics::TriggerCause;
+
+        let (mut state, observer) = setup_with_observer(TriggerMode::ChangesZone);
+        state
+            .objects
+            .get_mut(&observer)
+            .unwrap()
+            .trigger_definitions[0]
+            .destination = Some(Zone::Battlefield);
+        let _wayta = install_doubler(&mut state, TriggerCause::ControlledCreatureDealtDamage);
+
+        let new_etb = create_object(
+            &mut state,
+            CardId(23),
+            PlayerId(0),
+            "Entering Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&new_etb)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let event = GameEvent::ZoneChanged {
+            object_id: new_etb,
+            from: Some(Zone::Hand),
+            to: Zone::Battlefield,
+            record: Box::new(ZoneChangeRecord::test_minimal(
+                new_etb,
+                Some(Zone::Hand),
+                Zone::Battlefield,
+            )),
+        };
+
+        process_triggers(&mut state, &[event]);
+        super::drain_order_triggers_with_identity(&mut state);
+        let observer_triggers = state
+            .stack
+            .iter()
+            .filter(|e| e.source_id == observer)
+            .count();
+        assert_eq!(
+            observer_triggers, 1,
+            "Wayta must not double ETB triggers when the cause is damage to your creature"
         );
     }
 

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1898,6 +1898,8 @@ pub(crate) fn parse_static_line_inner(
     // CR 603.2d: Trigger doubling — "triggers an additional time".
     //
     // Cause classification by phrasing:
+    // - "being dealt damage causes" / "dealt damage causes" — Wayta, Trainer
+    //   Prodigy (ControlledCreatureDealtDamage).
     // - "attacking causes" — Isshin, Two Heavens as One (CreatureAttacking).
     // - "entering" / "enters the battlefield" / "enters" — Panharmonicon-class
     //   (EntersBattlefield). Panharmonicon itself names "artifact or creature
@@ -1908,7 +1910,11 @@ pub(crate) fn parse_static_line_inner(
     //   unrestricted `Any` cause; the doubler's `affected` filter narrows
     //   which source's triggers qualify.
     if nom_primitives::scan_contains(tp.lower, "triggers an additional time") {
-        let cause = if nom_primitives::scan_contains(tp.lower, "attacking causes") {
+        let cause = if nom_primitives::scan_contains(tp.lower, "being dealt damage causes")
+            || nom_primitives::scan_contains(tp.lower, "dealt damage causes")
+        {
+            TriggerCause::ControlledCreatureDealtDamage
+        } else if nom_primitives::scan_contains(tp.lower, "attacking causes") {
             TriggerCause::CreatureAttacking
         } else if nom_primitives::scan_contains(tp.lower, "dying causes") {
             TriggerCause::CreatureDying

--- a/crates/engine/src/parser/oracle_static/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_static/snapshot_tests.rs
@@ -590,6 +590,25 @@ fn parses_teferi_cast_only_at_sorcery_speed_regression() {
     }
 }
 
+/// CR 603.2d: Damage-caused trigger doubler (Wayta, Trainer Prodigy).
+#[test]
+fn parses_wayta_damage_caused_doubler() {
+    let def = parse_static_line(
+        "If a creature you control being dealt damage causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.",
+    )
+    .expect("expected DoubleTriggers static for Wayta");
+    assert_eq!(
+        def.mode,
+        StaticMode::DoubleTriggers {
+            cause: TriggerCause::ControlledCreatureDealtDamage
+        }
+    );
+    assert!(
+        def.affected.is_none(),
+        "bare 'a permanent you control' must not add a redundant affected filter"
+    );
+}
+
 /// CR 603.2d: Source-restricted trigger doubler (Splinter, Radical Rat).
 /// "If a triggered ability of a Ninja creature you control triggers, that
 /// ability triggers an additional time." The cause is unrestricted (`Any`),

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -508,6 +508,11 @@ pub enum TriggerCause {
     /// to `Graveyard` for an object whose snapshot included `Creature` in
     /// its core types.
     CreatureDying,
+    /// CR 603.2d + CR 119.2: Trigger was caused by a creature you control
+    /// being dealt damage (Wayta, Trainer Prodigy-class). Matches
+    /// `GameEvent::DamageDealt` whose target is a creature controlled by the
+    /// doubler's controller.
+    ControlledCreatureDealtDamage,
 }
 
 impl fmt::Display for TriggerCause {
@@ -520,6 +525,9 @@ impl fmt::Display for TriggerCause {
             }
             TriggerCause::CreatureAttacking => write!(f, "CreatureAttacking"),
             TriggerCause::CreatureDying => write!(f, "CreatureDying"),
+            TriggerCause::ControlledCreatureDealtDamage => {
+                write!(f, "ControlledCreatureDealtDamage")
+            }
         }
     }
 }

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -508,7 +508,7 @@ pub enum TriggerCause {
     /// to `Graveyard` for an object whose snapshot included `Creature` in
     /// its core types.
     CreatureDying,
-    /// CR 603.2d + CR 119.2: Trigger was caused by a creature you control
+    /// CR 603.2d + CR 120.3: Trigger was caused by a creature you control
     /// being dealt damage (Wayta, Trainer Prodigy-class). Matches
     /// `GameEvent::DamageDealt` whose target is a creature controlled by the
     /// doubler's controller.

--- a/crates/engine/tests/integration/issue_2439_wayta_trigger_doubling.rs
+++ b/crates/engine/tests/integration/issue_2439_wayta_trigger_doubling.rs
@@ -1,0 +1,115 @@
+//! Regression for issue #2439: Wayta, Trainer Prodigy doubles all triggered
+//! abilities instead of only damage-caused ones.
+//!
+//! https://github.com/phase-rs/phase/issues/2439
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle_static::parse_static_line;
+use engine::types::ability::{StaticDefinition, TargetFilter, TriggerDefinition};
+use engine::types::card_type::CoreType;
+use engine::types::events::GameEvent;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::CardId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::statics::{StaticMode, TriggerCause};
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const WAYTA_DOUBLER: &str = "If a creature you control being dealt damage causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.";
+
+fn main_phase_two_player() -> GameState {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.build().state().clone()
+}
+
+fn install_damage_observer(state: &mut GameState) -> engine::types::identifiers::ObjectId {
+    let observer = create_object(
+        state,
+        CardId(2400),
+        P0,
+        "Damage Observer".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&observer).unwrap();
+    obj.card_types.core_types.push(CoreType::Enchantment);
+    obj.trigger_definitions
+        .push(TriggerDefinition::new(TriggerMode::DamageDone).valid_card(TargetFilter::Any));
+    observer
+}
+
+fn install_wayta_doubler(state: &mut GameState) -> engine::types::identifiers::ObjectId {
+    let StaticDefinition { mode, .. } =
+        parse_static_line(WAYTA_DOUBLER).expect("Wayta doubler static must parse");
+    assert_eq!(
+        mode,
+        StaticMode::DoubleTriggers {
+            cause: TriggerCause::ControlledCreatureDealtDamage
+        },
+        "Wayta must parse as damage-caused trigger doubling (#2439)"
+    );
+    let wayta = create_object(
+        state,
+        CardId(2401),
+        P0,
+        "Wayta, Trainer Prodigy".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&wayta).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.static_definitions
+        .push(parse_static_line(WAYTA_DOUBLER).unwrap());
+    wayta
+}
+
+#[test]
+fn wayta_parsed_static_doubles_only_damage_caused_triggers() {
+    let mut state = main_phase_two_player();
+    let observer = install_damage_observer(&mut state);
+    let _wayta = install_wayta_doubler(&mut state);
+
+    let damaged = create_object(
+        &mut state,
+        CardId(2402),
+        P0,
+        "Your Creature".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&damaged)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+    let source = create_object(
+        &mut state,
+        CardId(2403),
+        PlayerId(1),
+        "Opponent Source".to_string(),
+        Zone::Battlefield,
+    );
+
+    let event = GameEvent::DamageDealt {
+        source_id: source,
+        target: engine::types::ability::TargetRef::Object(damaged),
+        amount: 1,
+        is_combat: false,
+        excess: 0,
+    };
+
+    engine::game::triggers::process_triggers(&mut state, &[event]);
+    engine::game::triggers::drain_order_triggers_with_identity(&mut state);
+
+    let doubled = state
+        .stack
+        .iter()
+        .filter(|e| e.source_id == observer)
+        .count();
+    assert_eq!(
+        doubled, 2,
+        "damage to your creature must double the observer's damage trigger once"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -79,6 +79,7 @@ mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
 mod issue_1509_sorcery_main_phase_cast;
+mod issue_2439_wayta_trigger_doubling;
 mod issue_709_regression;
 mod jace_wielder_empty_library_win;
 mod json_smoke_test;


### PR DESCRIPTION
## Summary

Fixes [#2439](https://github.com/phase-rs/phase/issues/2439): **Wayta, Trainer Prodigy** was doubling every triggered ability of permanents you control instead of only those caused by a creature you control being dealt damage.

- Add `TriggerCause::ControlledCreatureDealtDamage` for Wayta-class static text.
- Parser: classify `"being dealt damage causes"` / `"dealt damage causes"` (was falling through to unrestricted `Any`).
- Runtime: `apply_trigger_doubling` matches only `GameEvent::DamageDealt` whose target is a creature controlled by the doubler’s controller.

## Test plan

- [x] `cargo test -p engine --lib wayta`
- [x] `cargo test -p engine --lib parses_wayta`
- [x] `cargo test -p engine --test integration issue_2439`
- [ ] In-game: Wayta on board — upkeep/ETB triggers fire once; damage to your creature doubles the caused trigger only