### PR TITLE
fix(parser): preserve UntilEndOfTurn durations swallowed by clause parsing

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2328,6 +2328,53 @@ pub(crate) fn strip_trailing_duration(text: &str) -> (&str, Option<Duration>) {
         }
     }
 
+    // CR 611.2a: Duration mid-clause before a trailing conjunct, variable
+    // definition, or alternative expiry. End-of-string durations are handled
+    // above. Do NOT treat " unless " as a boundary here — unless-pay parsers
+    // (`try_parse_unless_player_have_deal_damage`, `extract_resolution_unless_pay_modifier`)
+    // own that tail and must see the full phrase.
+    for (phrase, duration) in [
+        (" until end of turn", Duration::UntilEndOfTurn),
+        (" this turn", Duration::UntilEndOfTurn),
+        (" until end of combat", Duration::UntilEndOfCombat),
+        (
+            " until the end of your next turn",
+            Duration::UntilEndOfNextTurnOf {
+                player: PlayerScope::Controller,
+            },
+        ),
+        (
+            " until the end of their next turn",
+            Duration::UntilEndOfNextTurnOf {
+                player: PlayerScope::Controller,
+            },
+        ),
+        (
+            " until their next turn",
+            Duration::UntilNextTurnOf {
+                player: PlayerScope::Controller,
+            },
+        ),
+        (
+            " until your next turn",
+            Duration::UntilNextTurnOf {
+                player: PlayerScope::Controller,
+            },
+        ),
+        (" until ~ leaves the battlefield", Duration::UntilHostLeavesPlay),
+        (
+            " until this creature leaves the battlefield",
+            Duration::UntilHostLeavesPlay,
+        ),
+    ] {
+        for delimiter in [", or ", ", where "] {
+            let pattern = format!("{phrase}{delimiter}");
+            if let Some(pos) = lower.find(&pattern) {
+                return (text[..pos].trim_end(), Some(duration));
+            }
+        }
+    }
+
     // CR 611.2b: "for as long as [condition]" — extract condition from trailing phrase.
     if let Some(pos) = lower.rfind(" for as long as ") {
         let condition_text = &lower[pos + " for as long as ".len()..];

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2361,7 +2361,10 @@ pub(crate) fn strip_trailing_duration(text: &str) -> (&str, Option<Duration>) {
                 player: PlayerScope::Controller,
             },
         ),
-        (" until ~ leaves the battlefield", Duration::UntilHostLeavesPlay),
+        (
+            " until ~ leaves the battlefield",
+            Duration::UntilHostLeavesPlay,
+        ),
         (
             " until this creature leaves the battlefield",
             Duration::UntilHostLeavesPlay,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -2037,7 +2037,7 @@ fn try_parse_unless_player_have_deal_damage(
     ctx: &mut ParseContext,
 ) -> Option<ParsedEffectClause> {
     let (before_unless, _, after_unless) =
-        nom_primitives::scan_preceded(tp.lower, |i| tag(" unless a player has ").parse(i))?;
+        nom_primitives::scan_preceded(tp.lower, |i| tag("unless a player has ").parse(i))?;
     let cost = parse_unless_player_have_deal_damage_cost(after_unless)?;
     let cleaned = tp.original[..before_unless.trim_end().len()].trim();
     let diagnostics_snapshot = ctx.diagnostics.len();
@@ -8927,24 +8927,53 @@ fn try_parse_compound_shuffle(text: &str) -> Option<ParsedEffectClause> {
 /// that protects the bound recipients from post-distribution anaphoric
 /// re-targeting). Keeping the prefix grammar in one place ensures the guard
 /// and the distributor never drift.
+/// Second-subject axis: "{type phrase} you control each " (Alandra, Sky Dreamer:
+/// "~ and Drakes you control each get +X/+X until end of turn").
+fn parse_controlled_creature_each_second_subject(
+    rest: &str,
+) -> Option<(usize, TargetFilter)> {
+    const SUFFIX: &str = " you control each ";
+    let lower = rest.to_ascii_lowercase();
+    let pos = lower.find(SUFFIX)?;
+    let type_phrase = rest[..pos].trim();
+    if type_phrase.is_empty() || type_phrase.contains(" and ") {
+        return None;
+    }
+    let normalized = format!("all {type_phrase} you control");
+    let (filter, remainder) = parse_target(&normalized);
+    if !remainder.trim().is_empty() || matches!(filter, TargetFilter::None) {
+        return None;
+    }
+    Some((pos + SUFFIX.len(), filter))
+}
+
 fn parse_compound_subject_prefix(lower: &str) -> Option<(usize, TargetFilter, TargetFilter)> {
-    let parser: nom::IResult<&str, (TargetFilter, TargetFilter), OracleError<'_>> = (
-        alt((
-            value(TargetFilter::OriginalController, tag("you and ")),
-            value(TargetFilter::SelfRef, tag("~ and ")),
-        )),
-        alt((
-            value(TargetFilter::ScopedPlayer, tag("that player ")),
-            value(TargetFilter::Player, tag("target opponent ")),
-            value(TargetFilter::Player, tag("target player ")),
-            value(TargetFilter::ParentTarget, tag("that creature ")),
-        )),
-        value((), tag("each ")),
-    )
-        .parse(lower)
-        .map(|(rest, (first, second, ()))| (rest, (first, second)));
-    let (lower_rest, (first_filter, second_filter)) = parser.ok()?;
-    Some((lower.len() - lower_rest.len(), first_filter, second_filter))
+    for (first_tag, first_filter) in [
+        ("you and ", TargetFilter::OriginalController),
+        ("~ and ", TargetFilter::SelfRef),
+    ] {
+        let Some(rest) = lower.strip_prefix(first_tag) else {
+            continue;
+        };
+        for (second_tag, second_filter) in [
+            ("that player each ", TargetFilter::ScopedPlayer),
+            ("target opponent each ", TargetFilter::Player),
+            ("target player each ", TargetFilter::Player),
+            ("that creature each ", TargetFilter::ParentTarget),
+        ] {
+            if rest.starts_with(second_tag) {
+                let consumed = first_tag.len() + second_tag.len();
+                return Some((consumed, first_filter.clone(), second_filter));
+            }
+        }
+        if let Some((second_consumed, second_filter)) =
+            parse_controlled_creature_each_second_subject(rest)
+        {
+            let consumed = first_tag.len() + second_consumed;
+            return Some((consumed, first_filter, second_filter));
+        }
+    }
+    None
 }
 
 /// CR 109.5 + CR 608.2c: True when `text` opens with a compound-subject
@@ -16428,6 +16457,24 @@ fn extract_resolution_unless_pay_modifier(
         .is_ok()
     {
         return (text.to_string(), None);
+    }
+
+    // CR 118.12a: "[Effect] unless a player has [~] deal N to them" (Barbarian
+    // Bully). Checked before the generic "unless " scan so the player-have-deal
+    // shape is not misclassified as a mana-payment unless.
+    if let Some((before_unless, _, after_unless_lower)) =
+        nom_primitives::scan_preceded(&lower, |i| tag("unless a player has ").parse(i))
+    {
+        if let Some(cost) = parse_unless_player_have_deal_damage_cost(after_unless_lower) {
+            let cleaned = text[..before_unless.trim_end().len()].trim().to_string();
+            return (
+                cleaned,
+                Some(UnlessPayModifier {
+                    cost,
+                    payer: TargetFilter::AllPlayers,
+                }),
+            );
+        }
     }
 
     // CR 118.12a: "[Effect] unless they X [or Y]" — the targeted player is

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -8889,8 +8889,8 @@ fn try_parse_compound_shuffle(text: &str) -> Option<ParsedEffectClause> {
 /// <subject-B> each <body>" into an AbilityDefinition chain whose halves apply
 /// `<body>` to two different recipients.
 ///
-/// Recognized subject axes (each is one `alt()` call; permutations are never
-/// enumerated):
+/// Recognized static subject axes (each is one `alt()` call; permutations are
+/// never enumerated):
 /// - First subject: `you` → `OriginalController` (player axis), or `~` →
 ///   `SelfRef` (object axis — the ability source, e.g. Gogo).
 /// - Second subject: `that player` → `ScopedPlayer` (the iterated voter for
@@ -8918,9 +8918,9 @@ fn try_parse_compound_shuffle(text: &str) -> Option<ParsedEffectClause> {
 /// returned and the caller falls through to Unimplemented.
 /// CR 109.5 + CR 608.2c: Parse the compound-subject distribution prefix
 /// (`"<A> and <B> each "`), returning the two authoritatively-bound recipient
-/// filters and the remaining body text offset. Composed from independent
-/// dimensions (first-subject × second-subject × "each"); each axis is one
-/// `alt()` call so new compound forms extend without enumerating permutations.
+/// filters and the remaining body text offset. Static dimensions are composed
+/// from independent `alt()` axes; the dynamic controlled-creature subject is a
+/// fallback for type phrases such as "Drakes you control each".
 ///
 /// Shared by `try_parse_compound_subject_each` (which builds the distributed
 /// chain) and `text_is_compound_subject_distribution` (the chunk-loop guard
@@ -8929,14 +8929,16 @@ fn try_parse_compound_shuffle(text: &str) -> Option<ParsedEffectClause> {
 /// and the distributor never drift.
 /// Second-subject axis: "{type phrase} you control each " (Alandra, Sky Dreamer:
 /// "~ and Drakes you control each get +X/+X until end of turn").
-fn parse_controlled_creature_each_second_subject(
-    rest: &str,
-) -> Option<(usize, TargetFilter)> {
+fn parse_controlled_creature_each_second_subject(rest: &str) -> Option<(usize, TargetFilter)> {
     const SUFFIX: &str = " you control each ";
-    let lower = rest.to_ascii_lowercase();
-    let pos = lower.find(SUFFIX)?;
-    let type_phrase = rest[..pos].trim();
-    if type_phrase.is_empty() || type_phrase.contains(" and ") {
+    let (remaining, type_phrase) = terminated(
+        take_until::<_, _, OracleError<'_>>(SUFFIX),
+        tag::<_, _, OracleError<'_>>(SUFFIX),
+    )
+    .parse(rest)
+    .ok()?;
+    let type_phrase = type_phrase.trim();
+    if type_phrase.is_empty() || type_phrase_has_compound_conjunction(type_phrase) {
         return None;
     }
     let normalized = format!("all {type_phrase} you control");
@@ -8944,36 +8946,65 @@ fn parse_controlled_creature_each_second_subject(
     if !remainder.trim().is_empty() || matches!(filter, TargetFilter::None) {
         return None;
     }
-    Some((pos + SUFFIX.len(), filter))
+    Some((rest.len() - remaining.len(), filter))
+}
+
+fn type_phrase_has_compound_conjunction(type_phrase: &str) -> bool {
+    take_until::<_, _, OracleError<'_>>(" and ")
+        .parse(type_phrase)
+        .is_ok()
+}
+
+fn parse_static_compound_subject_prefix(
+    lower: &str,
+) -> Option<(usize, TargetFilter, TargetFilter)> {
+    let (remaining, (first_filter, second_filter)) = (
+        alt((
+            value(
+                TargetFilter::OriginalController,
+                tag::<_, _, OracleError<'_>>("you and "),
+            ),
+            value(TargetFilter::SelfRef, tag("~ and ")),
+        )),
+        alt((
+            value(
+                TargetFilter::ScopedPlayer,
+                tag::<_, _, OracleError<'_>>("that player each "),
+            ),
+            value(TargetFilter::Player, tag("target opponent each ")),
+            value(TargetFilter::Player, tag("target player each ")),
+            value(TargetFilter::ParentTarget, tag("that creature each ")),
+        )),
+    )
+        .parse(lower)
+        .ok()?;
+    Some((lower.len() - remaining.len(), first_filter, second_filter))
+}
+
+fn parse_dynamic_compound_subject_prefix(
+    lower: &str,
+) -> Option<(usize, TargetFilter, TargetFilter)> {
+    let (remaining, first_filter) = alt((
+        value(
+            TargetFilter::OriginalController,
+            tag::<_, _, OracleError<'_>>("you and "),
+        ),
+        value(TargetFilter::SelfRef, tag("~ and ")),
+    ))
+    .parse(lower)
+    .ok()?;
+    let (second_consumed, second_filter) =
+        parse_controlled_creature_each_second_subject(remaining)?;
+    Some((
+        lower.len() - remaining.len() + second_consumed,
+        first_filter,
+        second_filter,
+    ))
 }
 
 fn parse_compound_subject_prefix(lower: &str) -> Option<(usize, TargetFilter, TargetFilter)> {
-    for (first_tag, first_filter) in [
-        ("you and ", TargetFilter::OriginalController),
-        ("~ and ", TargetFilter::SelfRef),
-    ] {
-        let Some(rest) = lower.strip_prefix(first_tag) else {
-            continue;
-        };
-        for (second_tag, second_filter) in [
-            ("that player each ", TargetFilter::ScopedPlayer),
-            ("target opponent each ", TargetFilter::Player),
-            ("target player each ", TargetFilter::Player),
-            ("that creature each ", TargetFilter::ParentTarget),
-        ] {
-            if rest.starts_with(second_tag) {
-                let consumed = first_tag.len() + second_tag.len();
-                return Some((consumed, first_filter.clone(), second_filter));
-            }
-        }
-        if let Some((second_consumed, second_filter)) =
-            parse_controlled_creature_each_second_subject(rest)
-        {
-            let consumed = first_tag.len() + second_consumed;
-            return Some((consumed, first_filter, second_filter));
-        }
-    }
-    None
+    parse_static_compound_subject_prefix(lower)
+        .or_else(|| parse_dynamic_compound_subject_prefix(lower))
 }
 
 /// CR 109.5 + CR 608.2c: True when `text` opens with a compound-subject
@@ -8992,11 +9023,9 @@ fn try_parse_compound_subject_each(
     ctx: &mut ParseContext,
 ) -> Option<ParsedEffectClause> {
     let lower = text.to_lowercase();
-    // Compose the prefix from independent dimensions via the shared
-    //   first-subject × " and " × second-subject × " each " × <body>
-    // grammar in `parse_compound_subject_prefix` (kept in lockstep with the
-    // chunk-loop guard `text_is_compound_subject_distribution`). Each axis is
-    // one alt() call; we never enumerate the permutations.
+    // Compose the prefix through the shared grammar in
+    // `parse_compound_subject_prefix` (kept in lockstep with the chunk-loop guard
+    // `text_is_compound_subject_distribution`).
     let (consumed_prefix, first_filter, second_filter) =
         parse_compound_subject_prefix(lower.as_str())?;
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1227,12 +1227,22 @@ fn remainder_trimmed_starts_with_compound_subject_each(remainder: &str) -> bool 
     if result.is_ok() {
         return true;
     }
-    // "{type phrase} you control each " — mirror `parse_controlled_creature_each_second_subject`.
-    if let Some(pos) = lower.find(" you control each ") {
-        let type_phrase = lower[..pos].trim();
-        return !type_phrase.is_empty() && !type_phrase.contains(" and ");
-    }
-    false
+    controlled_creature_each_subject_starts(&lower)
+}
+
+fn controlled_creature_each_subject_starts(lower: &str) -> bool {
+    let Ok((_, type_phrase)) = terminated(
+        take_until::<_, _, OracleError<'_>>(" you control each "),
+        tag::<_, _, OracleError<'_>>(" you control each "),
+    )
+    .parse(lower) else {
+        return false;
+    };
+    let type_phrase = type_phrase.trim();
+    !type_phrase.is_empty()
+        && take_until::<_, _, OracleError<'_>>(" and ")
+            .parse(type_phrase)
+            .is_err()
 }
 
 /// Restricted clause-start check for bare " and " splitting (not after comma).
@@ -1545,10 +1555,13 @@ fn combat_requirement_conjunct_prepend(
     remainder_trimmed: &str,
 ) -> Option<String> {
     let remainder_lower = remainder_trimmed.to_ascii_lowercase();
+    let cant_be_blocked_restriction =
+        super::subject::is_cant_be_blocked_restriction_predicate(&remainder_lower);
     if !super::imperative::is_standalone_combat_requirement(&remainder_lower)
         && !super::subject::is_can_block_extra_predicate(&remainder_lower)
         && !super::subject::is_can_attack_despite_defender_predicate(&remainder_lower)
-        && !super::subject::is_cant_be_blocked_restriction_predicate(&remainder_lower)
+        && !(cant_be_blocked_restriction
+            && cant_be_blocked_restriction_needs_subject_reattach(&remainder_lower))
     {
         return None;
     }
@@ -1579,8 +1592,9 @@ fn combat_requirement_conjunct_prepend(
             alt((tag::<_, _, OracleError<'_>>(" gains "), tag(" gain ")))
                 .parse(after)
                 .ok()?;
-            // Map the verb position back onto the original-case slice.
-            let subject = before_and[..before_verb.len()].trim();
+            // Map the verb position back onto the original-case slice and keep
+            // only the local sentence's subject.
+            let subject = local_subject_before_continuous_verb(before_and, before_verb.len())?;
             (!subject.is_empty()).then_some(subject)
         })
         .or_else(|| {
@@ -1592,8 +1606,10 @@ fn combat_requirement_conjunct_prepend(
                     alt((tag::<_, _, OracleError<'_>>(" gets "), tag(" get ")))
                         .parse(after)
                         .ok()?;
-                    // Map the verb position back onto the original-case slice.
-                    let subject = before_and[..before_verb.len()].trim();
+                    // Map the verb position back onto the original-case slice
+                    // and keep only the local sentence's subject.
+                    let subject =
+                        local_subject_before_continuous_verb(before_and, before_verb.len())?;
                     (!subject.is_empty()).then_some(subject)
                 })
         })?;
@@ -1610,6 +1626,29 @@ fn combat_requirement_conjunct_prepend(
     } else {
         Some(format!("{subject_text} "))
     }
+}
+
+fn cant_be_blocked_restriction_needs_subject_reattach(remainder_lower: &str) -> bool {
+    // Plain inline evasion grants are owned by `parse_continuous_modifications`
+    // and must stay in one static definition. The where-suffixed form needs a
+    // split so the first conjunct's duration is not hidden behind the trailing
+    // variable definition.
+    nom_primitives::scan_contains(remainder_lower, "where ")
+}
+
+fn local_subject_before_continuous_verb(before_and: &str, before_verb_len: usize) -> Option<&str> {
+    let mut subject = before_and[..before_verb_len].trim();
+    let mut remaining = subject;
+    while let Ok((after_sentence, _)) = terminated(
+        take_until::<_, _, OracleError<'_>>(". "),
+        tag::<_, _, OracleError<'_>>(". "),
+    )
+    .parse(remaining)
+    {
+        subject = after_sentence.trim();
+        remaining = subject;
+    }
+    (!subject.is_empty()).then_some(subject)
 }
 
 /// CR 121.1 / CR 119.1: Returns true when the token immediately following a

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1224,7 +1224,15 @@ fn remainder_trimmed_starts_with_compound_subject_each(remainder: &str) -> bool 
         value((), tag("that creature each ")),
     ))
     .parse(lower.as_str());
-    result.is_ok()
+    if result.is_ok() {
+        return true;
+    }
+    // "{type phrase} you control each " — mirror `parse_controlled_creature_each_second_subject`.
+    if let Some(pos) = lower.find(" you control each ") {
+        let type_phrase = lower[..pos].trim();
+        return !type_phrase.is_empty() && !type_phrase.contains(" and ");
+    }
+    false
 }
 
 /// Restricted clause-start check for bare " and " splitting (not after comma).
@@ -1540,6 +1548,7 @@ fn combat_requirement_conjunct_prepend(
     if !super::imperative::is_standalone_combat_requirement(&remainder_lower)
         && !super::subject::is_can_block_extra_predicate(&remainder_lower)
         && !super::subject::is_can_attack_despite_defender_predicate(&remainder_lower)
+        && !super::subject::is_cant_be_blocked_restriction_predicate(&remainder_lower)
     {
         return None;
     }

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -650,6 +650,40 @@ pub(super) fn is_can_attack_despite_defender_predicate(lower: &str) -> bool {
     .is_ok()
 }
 
+/// CR 509.1b: predicate-only "can't be blocked [this turn] [except by … | by …]"
+/// conjunct left after the sequence splitter peels a trailing evasion restriction
+/// off a keyword/P/T grant ("gain haste until end of turn and can't be blocked
+/// this turn except by creatures with haste"). Used by
+/// `combat_requirement_conjunct_prepend` to re-attach the subject.
+pub(super) fn is_cant_be_blocked_restriction_predicate(lower: &str) -> bool {
+    let trimmed = lower.trim().trim_end_matches('.').trim();
+    let blocked_tail = trimmed
+        .strip_prefix("can't be blocked ")
+        .or_else(|| trimmed.strip_prefix("cannot be blocked "));
+    let Some(mut tail) = blocked_tail else {
+        return false;
+    };
+    tail = tail
+        .strip_prefix("this turn ")
+        .or_else(|| tail.strip_prefix("this combat "))
+        .unwrap_or(tail);
+    if tail.is_empty() {
+        return true;
+    }
+    tail.starts_with("except by ")
+        || tail.starts_with("by ")
+        || parse_restriction_modes(trimmed).is_some_and(|modes| {
+            modes.iter().any(|mode| {
+                matches!(
+                    mode,
+                    StaticMode::CantBeBlocked
+                        | StaticMode::CantBeBlockedBy { .. }
+                        | StaticMode::CantBeBlockedExceptBy { .. }
+                )
+            })
+        })
+}
+
 fn parse_extra_blockers_count(input: &str) -> OracleResult<'_, Option<u32>> {
     alt((
         map(
@@ -2657,6 +2691,8 @@ pub(crate) fn parse_restriction_modes(lower: &str) -> Option<Vec<StaticMode>> {
     if let Ok((except_text, _)) = alt((
         tag::<_, _, OracleError<'_>>("can't be blocked except by "),
         tag("cannot be blocked except by "),
+        tag("can't be blocked this turn except by "),
+        tag("cannot be blocked this turn except by "),
     ))
     .parse(lower)
     {

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1,7 +1,7 @@
 use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till, take_until};
-use nom::combinator::{all_consuming, map, opt, value, verify};
+use nom::combinator::{all_consuming, map, opt, rest, value, verify};
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
@@ -657,21 +657,7 @@ pub(super) fn is_can_attack_despite_defender_predicate(lower: &str) -> bool {
 /// `combat_requirement_conjunct_prepend` to re-attach the subject.
 pub(super) fn is_cant_be_blocked_restriction_predicate(lower: &str) -> bool {
     let trimmed = lower.trim().trim_end_matches('.').trim();
-    let blocked_tail = trimmed
-        .strip_prefix("can't be blocked ")
-        .or_else(|| trimmed.strip_prefix("cannot be blocked "));
-    let Some(mut tail) = blocked_tail else {
-        return false;
-    };
-    tail = tail
-        .strip_prefix("this turn ")
-        .or_else(|| tail.strip_prefix("this combat "))
-        .unwrap_or(tail);
-    if tail.is_empty() {
-        return true;
-    }
-    tail.starts_with("except by ")
-        || tail.starts_with("by ")
+    parse_cant_be_blocked_restriction_predicate(trimmed).is_ok()
         || parse_restriction_modes(trimmed).is_some_and(|modes| {
             modes.iter().any(|mode| {
                 matches!(
@@ -682,6 +668,20 @@ pub(super) fn is_cant_be_blocked_restriction_predicate(lower: &str) -> bool {
                 )
             })
         })
+}
+
+fn parse_cant_be_blocked_restriction_predicate(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = alt((
+        tag::<_, _, OracleError<'_>>("can't be blocked"),
+        tag("cannot be blocked"),
+    ))
+    .parse(input)?;
+    let (input, _) = opt(alt((tag(" this turn"), tag(" this combat")))).parse(input)?;
+    if input.is_empty() {
+        return Ok((input, ()));
+    }
+    let (input, _) = (tag(" "), alt((tag("except by "), tag("by "))), rest).parse(input)?;
+    Ok((input, ()))
 }
 
 fn parse_extra_blockers_count(input: &str) -> OracleResult<'_, Option<u32>> {

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -3138,4 +3138,77 @@ mod tests {
         );
         assert!(!has_swallowed_detector(&parsed, "Optional_MayHave"));
     }
+
+    /// Issue #2235 regression: representative cards whose Oracle text contains
+    /// "until end of turn" must surface a typed duration in the AST.
+    #[test]
+    fn duration_until_eot_agility_bobblehead() {
+        let parsed = parse_named(
+            "{T}: Add one mana of any color.\n\
+             {3}, {T}: Up to X target creatures you control each gain haste until end of turn and can't be blocked this turn except by creatures with haste, where X is the number of Bobbleheads you control as you activate this ability.",
+            "Agility Bobblehead",
+            &["Artifact"],
+        );
+        assert!(!has_swallowed_detector(&parsed, "Duration_UntilEndOfTurn"));
+    }
+
+    #[test]
+    fn duration_until_eot_alandra_sky_dreamer() {
+        let parsed = parse_named(
+            "Whenever you draw your second card each turn, create a 2/2 blue Drake creature token with flying.\n\
+             Whenever you draw your fifth card each turn, Alandra and Drakes you control each get +X/+X until end of turn, where X is the number of cards in your hand.",
+            "Alandra, Sky Dreamer",
+            &["Creature"],
+        );
+        assert!(!has_swallowed_detector(&parsed, "Duration_UntilEndOfTurn"));
+    }
+
+    #[test]
+    fn duration_until_eot_barbarian_bully() {
+        use crate::parser::oracle_effect::parse_effect_chain;
+        use crate::types::ability::AbilityKind;
+
+        let text = "This creature gets +2/+2 until end of turn unless a player has this creature deal 4 damage to them.";
+        let def = parse_effect_chain(text, AbilityKind::Activated);
+        assert!(
+            def.unless_pay.is_some(),
+            "unless_pay missing: {:?}",
+            def.unless_pay
+        );
+        assert_eq!(
+            def.duration,
+            Some(crate::types::ability::Duration::UntilEndOfTurn),
+            "chain duration missing: {:?}, effect={:?}",
+            def.duration,
+            def.effect
+        );
+
+        let parsed = parse_named(
+            "Discard a card at random: This creature gets +2/+2 until end of turn unless a player has this creature deal 4 damage to them. Activate only once each turn.",
+            "Barbarian Bully",
+            &["Creature"],
+        );
+        assert!(!has_swallowed_detector(&parsed, "Duration_UntilEndOfTurn"));
+    }
+
+    #[test]
+    fn duration_until_eot_dragon_egg() {
+        let parsed = parse_named(
+            "Defender\n\
+             When this creature dies, create a 2/2 red Dragon creature token with flying and \"{R}: This token gets +1/+0 until end of turn.\"",
+            "Dragon Egg",
+            &["Creature"],
+        );
+        assert!(!has_swallowed_detector(&parsed, "Duration_UntilEndOfTurn"));
+    }
+
+    #[test]
+    fn duration_until_eot_drop_tower() {
+        let parsed = parse_named(
+            "Visit — Target creature gains flying until end of turn, or until any player rolls a 1, whichever comes first.",
+            "Drop Tower",
+            &["Artifact"],
+        );
+        assert!(!has_swallowed_detector(&parsed, "Duration_UntilEndOfTurn"));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes [#2235](https://github.com/phase-rs/phase/issues/2235): the parser was dropping `until end of turn` durations while coverage still marked affected cards as supported (`Swallow:Duration_UntilEndOfTurn`).

- **Interior duration extraction** — `strip_trailing_duration` now peels mid-clause durations before `, or` and `, where` (e.g. Drop Tower visit triggers), without consuming ` unless ` tails owned by unless-pay parsers.
- **Unless-pay (Barbarian Bully)** — Fix `scan_preceded` tag for `unless a player has … deal damage` and wire the pattern through `extract_resolution_unless_pay_modifier` so duration and `unless_pay` both survive lowering.
- **Compound subject (Alandra, Sky Dreamer)** — Extend `~ and {creatures} you control each` as a compound-subject distribution axis.
- **Conjunctive grants (Agility Bobblehead)** — Split `gain … until end of turn and can't be blocked …` via evasion conjunct detection so the grant half keeps its duration; add `can't be blocked this turn except by` restriction parsing.

Adds six swallow-check regression tests covering Agility Bobblehead, Alandra, Barbarian Bully, Dragon Egg, and Drop Tower.

## Test plan

- [x] `cargo test -p engine duration_until_eot_`
- [x] `cargo test -p engine compound_subject`
- [ ] `./scripts/gen-card-data.sh`
- [ ] `target/tool/coverage-report data --all --warning-detector Duration_UntilEndOfTurn --warning-limit 5` (expect 0 matches)