### PR TITLE
fix(engine): surface unless-pay choice before primary effect (#2361)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2876,6 +2876,30 @@ fn ability_with_event_context_targets(
     pending
 }
 
+/// CR 603.2: When an ability's `targets` are still empty at resolution but its
+/// effect carries an event-context recipient (`TriggeringPlayer`, etc.), bind
+/// that referent into `targets` before payer/effect resolution. Shared by the
+/// unless-pay interceptor and the main effect path (issue #2361).
+fn hydrate_event_context_targets<'a>(
+    state: &GameState,
+    ability: &'a ResolvedAbility,
+) -> Cow<'a, ResolvedAbility> {
+    if !ability.targets.is_empty() {
+        return Cow::Borrowed(ability);
+    }
+    let Some(filter) = extract_event_context_filter(&ability.effect) else {
+        return Cow::Borrowed(ability);
+    };
+    let Some(target_ref) =
+        crate::game::targeting::resolve_event_context_target(state, filter, ability.source_id)
+    else {
+        return Cow::Borrowed(ability);
+    };
+    let mut resolved = ability.clone();
+    resolved.targets = vec![target_ref];
+    Cow::Owned(resolved)
+}
+
 /// CR 603.2: Extract an event-context target filter from an effect, if present.
 /// Returns the filter only for event-context variants (TriggeringSpellController, etc.)
 /// that auto-resolve from `state.current_trigger_event` at resolution time.
@@ -3739,11 +3763,17 @@ fn resolve_chain_body(
     // intercepted here for both tax triggers and counter-target-spell unless
     // costs. Post-fold, the cost is the unified `AbilityCost` taxonomy.
     if let Some(ref unless_pay) = ability.unless_pay {
+        // CR 603.2 + CR 118.12a: Hydrate event-context targets before payer
+        // resolution so trigger unless-costs ("that player ... unless they pay")
+        // do not silently fall through when `ability.targets` is still empty
+        // (issue #2361).
+        let ability_for_unless = hydrate_event_context_targets(state, ability);
         // CR 118.12a: `resolve_unless_payers` yields the APNAP-ordered poll
         // list — one player for ordinary unless-costs, every player for
         // "unless any player pays ...". The first entry is prompted now; the
         // rest ride along in `WaitingFor::UnlessPayment.remaining`.
-        let unless_payers = resolve_unless_payers(state, ability, &unless_pay.payer);
+        let unless_payers =
+            resolve_unless_payers(state, ability_for_unless.as_ref(), &unless_pay.payer);
         if let Some((&payer, remaining_payers)) = unless_payers.split_first() {
             // CR 118.4 + CR 107.3c: Resolve a dynamic-generic mana cost into a
             // fixed `Mana { cost }` BEFORE entering the prompt — the runtime
@@ -3893,29 +3923,8 @@ fn resolve_chain_body(
         ability.effect,
         Effect::Unimplemented { .. } | Effect::RuntimeHandled { .. }
     ) {
-        // CR 603.2: If the ability has empty targets but its effect uses an event-context
-        // target filter (TriggeringSpellController, TriggeringSource, etc.), resolve the
-        // filter into an actual TargetRef using the current trigger event context.
-        let resolved_ability = if ability.targets.is_empty() {
-            if let Some(filter) = extract_event_context_filter(&ability.effect) {
-                if let Some(target_ref) = crate::game::targeting::resolve_event_context_target(
-                    state,
-                    filter,
-                    ability.source_id,
-                ) {
-                    let mut resolved = ability.clone();
-                    resolved.targets = vec![target_ref];
-                    Some(resolved)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-        let effective = resolved_ability.as_ref().unwrap_or(ability);
+        let hydrated = hydrate_event_context_targets(state, ability);
+        let effective = hydrated.as_ref();
 
         // CR 608.2b: Validate SharesQuality group constraints before applying effects.
         // If targets don't share the required quality, skip the effect.
@@ -5555,7 +5564,7 @@ mod tests {
         ControllerRef, DelayedTriggerCondition, Duration, FilterProp, ManaSpendPermission,
         ObjectProperty, PermissionGrantee, PlayerFilter, PlayerScope, PtValue, QuantityExpr,
         QuantityRef, SpellContext, StaticDefinition, TargetFilter, TargetRef, TypeFilter,
-        TypedFilter, UntilCondition, ZoneOwner,
+        TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
     };
     use crate::types::actions::GameAction;
     use crate::types::card::CardFace;
@@ -6537,6 +6546,110 @@ mod tests {
                 amount: QuantityExpr::Fixed { value: 2 }
             }
         ));
+    }
+
+    /// CR 118.12a + CR 603.2: Triggered unless-costs on event-context player
+    /// refs must hydrate targets before payer resolution (issue #2361).
+    #[test]
+    fn unless_pay_triggering_player_hydrates_before_prompt() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Esper Sentinel".to_string(),
+            Zone::Battlefield,
+        );
+        let mut ability = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::TriggeringPlayer,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        ability.unless_pay = Some(UnlessPayModifier {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::generic(1),
+            },
+            payer: TargetFilter::TriggeringPlayer,
+        });
+        state.current_trigger_event = Some(GameEvent::SpellCast {
+            card_id: CardId(99),
+            controller: PlayerId(1),
+            object_id: ObjectId(99),
+        });
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("unless-pay interceptor should arm a payment prompt");
+
+        match &state.waiting_for {
+            WaitingFor::UnlessPayment { player, .. } => {
+                assert_eq!(*player, PlayerId(1));
+            }
+            other => panic!("expected UnlessPayment for triggering player, got {other:?}"),
+        }
+    }
+
+    /// CR 118.12a + CR 701.9: Wrench Mind — "unless they discard an artifact
+    /// card" must surface `UnlessPayment` before the two-card discard (issue
+    /// #2361).
+    #[test]
+    fn unless_pay_wrench_mind_discard_artifact_prompts_payment() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Wrench Mind".to_string(),
+            Zone::Stack,
+        );
+        for i in 0..3 {
+            create_object(
+                &mut state,
+                CardId(10 + i),
+                PlayerId(1),
+                format!("Hand{i}"),
+                Zone::Hand,
+            );
+        }
+        let artifact_filter = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Artifact],
+            ..Default::default()
+        });
+        let mut ability = ResolvedAbility::new(
+            Effect::Discard {
+                count: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Player,
+                random: false,
+                unless_filter: None,
+                filter: None,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            source,
+            PlayerId(0),
+        );
+        ability.unless_pay = Some(UnlessPayModifier {
+            cost: AbilityCost::Discard {
+                count: QuantityExpr::Fixed { value: 1 },
+                filter: Some(artifact_filter),
+                random: false,
+                self_ref: false,
+            },
+            payer: TargetFilter::Player,
+        });
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("unless-pay interceptor should arm a payment prompt");
+
+        assert!(
+            matches!(state.waiting_for, WaitingFor::UnlessPayment { .. }),
+            "expected UnlessPayment prompt, got {:?}",
+            state.waiting_for
+        );
     }
 
     /// CR 107.3a: a bare `{X}` unless-cost (`ManaDynamic` with `Variable("X")`)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -20333,6 +20333,50 @@ mod tests {
         );
     }
 
+    /// CR 118.12a + CR 701.9: Wrench Mind — "unless they discard an artifact
+    /// card" must hoist to `unless_pay`, not fire the two-card discard
+    /// unconditionally (issue #2361).
+    #[test]
+    fn effect_wrench_mind_unless_discard_artifact_card() {
+        let def = parse_effect_chain(
+            "Target player discards two cards unless they discard an artifact card",
+            AbilityKind::Spell,
+        );
+        let unless_pay = def.unless_pay.expect("should attach unless_pay");
+        assert_eq!(unless_pay.payer, TargetFilter::Player);
+        match &unless_pay.cost {
+            AbilityCost::Discard { count, filter, .. } => {
+                assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                assert!(filter.is_some(), "artifact filter required");
+            }
+            other => panic!("expected Discard unless cost, got {other:?}"),
+        }
+        match &*def.effect {
+            Effect::Discard { count, .. } => {
+                assert_eq!(*count, QuantityExpr::Fixed { value: 2 });
+            }
+            other => panic!("expected Discard primary effect, got {other:?}"),
+        }
+    }
+
+    /// Tyrannize — "unless they pay 7 life" must attach `unless_pay` with a
+    /// life cost (issue #2361).
+    #[test]
+    fn effect_tyrannize_unless_pay_seven_life() {
+        let def = parse_effect_chain(
+            "Target player discards their hand unless they pay 7 life",
+            AbilityKind::Spell,
+        );
+        let unless_pay = def.unless_pay.expect("should attach unless_pay");
+        assert_eq!(unless_pay.payer, TargetFilter::Player);
+        assert!(matches!(
+            unless_pay.cost,
+            AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 7 }
+            }
+        ));
+    }
+
     /// CR 118.12a: "unless they pay {N}" — `they` anaphors to the targeted
     /// player when the effect targets a player (Flay).
     #[test]

--- a/crates/engine/tests/integration/issue_2361_unless_pay_choice.rs
+++ b/crates/engine/tests/integration/issue_2361_unless_pay_choice.rs
@@ -1,0 +1,149 @@
+//! Regression for issue #2361: spells with "unless [cost]" must offer the
+//! alternative payment before applying the primary effect.
+//!
+//! https://github.com/phase-rs/phase/issues/2361
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{AbilityCost, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const WRENCH_MIND_ORACLE: &str =
+    "Target player discards two cards unless they discard an artifact card.";
+
+fn add_mana(runner: &mut engine::game::scenario::GameRunner, mana: &[ManaType]) {
+    let dummy = ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool;
+    for m in mana {
+        pool.add(ManaUnit::new(*m, dummy, false, vec![]));
+    }
+}
+
+fn hand_len(
+    runner: &engine::game::scenario::GameRunner,
+    player: engine::types::player::PlayerId,
+) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.hand.len())
+        .unwrap_or(0)
+}
+
+#[test]
+fn wrench_mind_parsed_ability_carries_unless_pay() {
+    let mut scenario = GameScenario::new();
+    let wrench = scenario
+        .add_spell_to_hand_from_oracle(P0, "Wrench Mind", false, WRENCH_MIND_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black, ManaCostShard::Black],
+            generic: 0,
+        })
+        .id();
+    let runner = scenario.build();
+    let ability = &runner.state().objects[&wrench].abilities[0];
+    let unless_pay = ability
+        .unless_pay
+        .as_ref()
+        .expect("Wrench Mind spell ability must carry unless_pay (#2361)");
+    assert_eq!(unless_pay.payer, TargetFilter::Player);
+    assert!(matches!(unless_pay.cost, AbilityCost::Discard { .. }));
+}
+
+#[test]
+fn wrench_mind_cast_resolve_stops_at_unless_payment() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    for i in 0..7 {
+        scenario.add_spell_to_hand(P1, &format!("P1 Card {i}"), true);
+    }
+    let wrench = scenario
+        .add_spell_to_hand_from_oracle(P0, "Wrench Mind", false, WRENCH_MIND_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black, ManaCostShard::Black],
+            generic: 0,
+        })
+        .id();
+    let mut runner = scenario.build();
+    add_mana(&mut runner, &[ManaType::Black, ManaType::Black]);
+
+    runner.cast(wrench).target_player(P1).resolve();
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+        "SpellCast driver must stop at UnlessPayment for manual choice, got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(hand_len(&runner, P1), 7);
+}
+
+#[test]
+fn wrench_mind_resolution_surfaces_unless_payment_before_discard() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P1 holds seven cards so the primary effect would matter.
+    for i in 0..7 {
+        scenario.add_spell_to_hand(P1, &format!("P1 Card {i}"), true);
+    }
+
+    let wrench = scenario
+        .add_spell_to_hand_from_oracle(P0, "Wrench Mind", false, WRENCH_MIND_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black, ManaCostShard::Black],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    add_mana(&mut runner, &[ManaType::Black, ManaType::Black]);
+
+    runner
+        .act(engine::types::actions::GameAction::CastSpell {
+            object_id: wrench,
+            card_id: runner.state().objects[&wrench].card_id,
+            targets: vec![],
+        })
+        .expect("cast Wrench Mind");
+
+    // Drive through targeting.
+    for _ in 0..16 {
+        match &runner.state().waiting_for {
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .choose_first_legal_target()
+                    .expect("choose P1 as target");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner.act(GameAction::PassPriority).expect("pay mana");
+            }
+            WaitingFor::Priority { .. } => break,
+            other => panic!("unexpected pre-resolution prompt: {other:?}"),
+        }
+    }
+
+    // Resolve the spell from the stack.
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+        "Wrench Mind must offer unless-cost payment before discarding two cards, got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        hand_len(&runner, P1),
+        7,
+        "no cards should be discarded before the unless choice"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -80,6 +80,7 @@ mod integration_bending;
 mod integration_landfall;
 mod issue_1509_sorcery_main_phase_cast;
 mod issue_2011_eldrazi_temple_kozilek_cast;
+mod issue_2361_unless_pay_choice;
 mod issue_2417_satoru_intervening_if;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_709_regression;


### PR DESCRIPTION
## Summary

- Fixes [#2361](https://github.com/phase-rs/phase/issues/2361): cards with **"unless [cost]"** (Wrench Mind, Tyrannize, Winternight Stories, etc.) were applying the primary effect without offering the alternative payment.
- **Runtime:** Extract `hydrate_event_context_targets()` and invoke it before the unless-pay interceptor resolves payers. When `ability.targets` is empty but the effect uses an event-context player ref (`TriggeringPlayer`, etc.), targets are now bound from the trigger event before payer resolution, so `WaitingFor::UnlessPayment` is armed instead of falling through.
- Reuse the same hydration helper on the main effect path (DRY with the prior inline block).

## Test plan

- [x] `cargo test -p engine --lib unless_pay_triggering_player_hydrates`
- [x] `cargo test -p engine --lib unless_pay_wrench_mind`
- [x] `cargo test -p engine --lib effect_wrench_mind_unless_discard_artifact_card`
- [x] `cargo test -p engine --lib effect_tyrannize_unless_pay_seven_life`
- [x] `cargo test -p engine --test integration issue_2361`
- [x] `cargo fmt --check`

Fixes #2361