### PR TITLE
chore(ci): brotli-compress R2-served JSON data files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,8 +154,26 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CARD_DATA_FILENAME: ${{ steps.card-data-hash.outputs.filename }}
         run: |
-          # Content-addressed card-data: immutable, year-long cache.
-          npx wrangler r2 object put "phase-rs-data/staging/$CARD_DATA_FILENAME" --file "client/public/$CARD_DATA_FILENAME" --remote --content-type application/json --cache-control "public, max-age=31536000, immutable"
+          # The r2.dev public endpoint does NOT compress on the fly, so these
+          # JSONs were served raw (~77 MB of scryfall data per cold game load).
+          # Pre-compress with brotli and store Content-Encoding: br. Every
+          # consumer fetches via browser/Bun fetch(), which decodes br
+          # transparently (R2 serves the stored bytes+header unconditionally —
+          # safe because 100% of these consumers are br-capable). q9: ~90%
+          # reduction at a fraction of q11's CPU, which matters on an
+          # every-merge path.
+          #
+          # Compress into a temp dir, never client/public: card-data.json and
+          # draft-pools.json are re-read AFTER this step (Stage server data
+          # artifact) and baked UNCOMPRESSED into the server image, which loads
+          # them from disk — a stray .br or in-place overwrite would break it.
+          command -v brotli >/dev/null || { sudo apt-get update && sudo apt-get install -y brotli; }
+          BRDIR="$(mktemp -d)"
+
+          # Content-addressed card-data: immutable, year-long cache. The hash is
+          # over the uncompressed file, so the URL stays a valid content key.
+          brotli -q 9 -c "client/public/$CARD_DATA_FILENAME" > "$BRDIR/card-data.br"
+          npx wrangler r2 object put "phase-rs-data/staging/$CARD_DATA_FILENAME" --file "$BRDIR/card-data.br" --remote --content-type application/json --content-encoding br --cache-control "public, max-age=31536000, immutable"
 
           # Mutable shared JSONs. Loop over the manifest.
           while IFS= read -r f; do
@@ -163,9 +181,12 @@ jobs:
               echo "::error::Expected data file client/public/$f was not generated"
               exit 1
             fi
-            npx wrangler r2 object put "phase-rs-data/staging/$f" --file "client/public/$f" --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
+            brotli -q 9 -c "client/public/$f" > "$BRDIR/$f.br"
+            npx wrangler r2 object put "phase-rs-data/staging/$f" --file "$BRDIR/$f.br" --remote --content-type application/json --content-encoding br --cache-control "public, max-age=60, must-revalidate"
           done < <(jq -r '.[]' data-files.json)
 
+          # Badges are not in the manifest and their consumer is unaudited here;
+          # left uncompressed (tiny files) to keep this change scoped.
           for f in data/badges/*.json; do
             name=$(basename "$f")
             npx wrangler r2 object put "phase-rs-data/badges/$name" --file "$f" --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
@@ -193,6 +214,11 @@ jobs:
           }
           check "$CARD_DATA_FILENAME"
           while IFS= read -r f; do check "$f"; done < <(jq -r '.[]' data-files.json)
+          # Prove the brotli round-trip end-to-end on one small file: --compressed
+          # requests + decodes br, jq confirms it decoded to valid JSON. The 200
+          # checks above pass regardless of encoding; this is the real proof.
+          curl -s --compressed "$BASE/scryfall-sets.json" | jq empty \
+            || { echo "::error::brotli round-trip failed for scryfall-sets.json"; fail=1; }
           [ "$fail" = "0" ]
 
       - name: Stage server data artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,8 +350,22 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CARD_DATA_FILENAME: ${{ steps.card-data-hash.outputs.filename }}
         run: |
-          # Content-addressed card-data: immutable, year-long cache.
-          npx wrangler r2 object put "phase-rs-data/$CARD_DATA_FILENAME" --file "client/public/$CARD_DATA_FILENAME" --remote --content-type application/json --cache-control "public, max-age=31536000, immutable"
+          # The r2.dev public endpoint does NOT compress on the fly, so these
+          # JSONs were served raw. Pre-compress with brotli and store
+          # Content-Encoding: br — every consumer fetches via browser/Bun
+          # fetch(), which decodes br transparently. q9: ~90% reduction at a
+          # fraction of q11's CPU.
+          #
+          # Compress into a temp dir, never client/public: card-data.json /
+          # draft-pools.json are re-read after this step and baked UNCOMPRESSED
+          # into the server image (loaded from disk).
+          command -v brotli >/dev/null || { sudo apt-get update && sudo apt-get install -y brotli; }
+          BRDIR="$(mktemp -d)"
+
+          # Content-addressed card-data: immutable, year-long cache. The hash is
+          # over the uncompressed file, so the URL stays a valid content key.
+          brotli -q 9 -c "client/public/$CARD_DATA_FILENAME" > "$BRDIR/card-data.br"
+          npx wrangler r2 object put "phase-rs-data/$CARD_DATA_FILENAME" --file "$BRDIR/card-data.br" --remote --content-type application/json --content-encoding br --cache-control "public, max-age=31536000, immutable"
 
           # Mutable shared JSONs. Loop over the manifest.
           while IFS= read -r f; do
@@ -359,7 +373,8 @@ jobs:
               echo "::error::Expected data file client/public/$f was not generated"
               exit 1
             fi
-            npx wrangler r2 object put "phase-rs-data/$f" --file "client/public/$f" --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
+            brotli -q 9 -c "client/public/$f" > "$BRDIR/$f.br"
+            npx wrangler r2 object put "phase-rs-data/$f" --file "$BRDIR/$f.br" --remote --content-type application/json --content-encoding br --cache-control "public, max-age=60, must-revalidate"
           done < <(jq -r '.[]' data-files.json)
 
       - name: Verify R2 uploads landed
@@ -381,6 +396,10 @@ jobs:
           }
           check "$CARD_DATA_FILENAME"
           while IFS= read -r f; do check "$f"; done < <(jq -r '.[]' data-files.json)
+          # Prove the brotli round-trip end-to-end on one small file: --compressed
+          # requests + decodes br, jq confirms it decoded to valid JSON.
+          curl -s --compressed "$BASE/scryfall-sets.json" | jq empty \
+            || { echo "::error::brotli round-trip failed for scryfall-sets.json"; fail=1; }
           [ "$fail" = "0" ]
       - name: Remove R2-hosted data files from dist (Pages ships only the shell)
         # Single source of truth: data-files.json lists every JSON the frontend

--- a/scripts/deploy-cf.sh
+++ b/scripts/deploy-cf.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# r2.dev does not compress on the fly; we pre-compress every uploaded JSON with
+# brotli and store Content-Encoding: br (consumers fetch via browser/Bun fetch,
+# which decodes transparently). Fail early if brotli is missing.
+command -v brotli >/dev/null || { echo "ERROR: brotli required (brew install brotli)"; exit 1; }
+
 PROJECT_NAME="${1:-phase-rs}"
 R2_BUCKET="phase-rs-data"
 R2_PUBLIC="https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev"
@@ -25,6 +30,11 @@ jq '{total_cards, supported_cards, coverage_pct, coverage_by_format}' \
 
 # --- R2 uploads (run in background, parallel to WASM build) ---
 upload_to_r2() {
+  # Compress into a temp dir, never client/public: a stray .br there would be
+  # copied into dist by the later `pnpm build` and shipped to Pages.
+  local BRDIR
+  BRDIR="$(mktemp -d)"
+  trap 'rm -rf "$BRDIR"' RETURN
   # Upload JSON data files in parallel, skipping unchanged
   local json_pids=()
   for entry in \
@@ -39,17 +49,21 @@ upload_to_r2() {
     key="${entry%%:*}"
     file="${entry#*:}"
     (
-      local_hash=$(md5 -q "client/$file")
-      cached_hash=$(grep "^$key:" "$DEPLOY_CACHE" 2>/dev/null | cut -d: -f2 || true)
-      if [ "$local_hash" = "$cached_hash" ]; then
+      # The -br9 tag suffix versions the cache on encoding: a pre-existing entry
+      # recorded as a bare md5 (uncompressed upload) won't match, so the file is
+      # re-uploaded compressed exactly once, then stays cached.
+      local_tag="$(md5 -q "client/$file")-br9"
+      cached_tag=$(grep "^$key:" "$DEPLOY_CACHE" 2>/dev/null | cut -d: -f2 || true)
+      if [ "$local_tag" = "$cached_tag" ]; then
         echo "  = $key (unchanged)"
       else
-        echo "  ^ $key (uploading)"
+        echo "  ^ $key (compress + upload)"
+        brotli -q 9 -c "client/$file" > "$BRDIR/$key.br"
         (cd client && pnpm wrangler r2 object put "$R2_BUCKET/$key" \
-          --file "$file" --content-type application/json --remote)
+          --file "$BRDIR/$key.br" --content-type application/json --content-encoding br --remote)
         # Update cache atomically
         grep -v "^$key:" "$DEPLOY_CACHE" > "$DEPLOY_CACHE.tmp" 2>/dev/null || true
-        echo "$key:$local_hash" >> "$DEPLOY_CACHE.tmp"
+        echo "$key:$local_tag" >> "$DEPLOY_CACHE.tmp"
         mv "$DEPLOY_CACHE.tmp" "$DEPLOY_CACHE"
       fi
     ) &


### PR DESCRIPTION
The r2.dev public endpoint serves bucket objects uncompressed (no
on-the-fly compression), so the frontend downloaded ~77 MB of raw
scryfall + card-data JSON per cold game load. Pre-compress each uploaded
JSON with `brotli -q 9` and store `Content-Encoding: br` (~90% smaller,
byte-exact round-trip). Every consumer fetches via browser/Bun `fetch()`,
which decodes br transparently; R2 returns the stored bytes+header
unconditionally, which is safe because 100% of these consumers are
br-capable.

Compress into a temp dir, never client/public: card-data.json and
draft-pools.json are re-read after the upload step and baked UNCOMPRESSED
into the server image (the server loads them from disk). The verify step
gains an end-to-end `--compressed | jq empty` decode assertion. The
manual deploy-cf.sh path versions its upload cache (`-br9` tag) so
pre-cached files re-upload compressed exactly once. Badges and ci.yml
preview uploads are intentionally left uncompressed (the regression
gate's curl lacks --compressed).
