### PR TITLE
fix(engine): Nourishing Shoal pitch alternative cost and X binding (#2372)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9491,6 +9491,8 @@ fn find_eligible_hand_cost_targets(
     source: ObjectId,
     filter: Option<&TargetFilter>,
 ) -> Vec<ObjectId> {
+    let effective_filter = super::cost_payability::exile_cost_effective_filter(filter);
+    let filter_ref = effective_filter.as_ref();
     let ctx = super::filter::FilterContext::from_source(state, source);
     state
         .players
@@ -9502,7 +9504,7 @@ fn find_eligible_hand_cost_targets(
                 .copied()
                 .filter(|&id| {
                     id != source
-                        && filter.is_none_or(|f| {
+                        && filter_ref.is_none_or(|f| {
                             super::filter::matches_target_filter(state, id, f, &ctx)
                         })
                 })

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9534,8 +9534,12 @@ pub(crate) fn find_eligible_exile_for_cost_targets(
     zone: ExileCostSourceZone,
     filter: Option<&TargetFilter>,
 ) -> Vec<ObjectId> {
+    let effective_filter = super::cost_payability::exile_cost_effective_filter(filter);
+    let filter_ref = effective_filter.as_ref();
     match zone {
-        ExileCostSourceZone::Hand => find_eligible_hand_cost_targets(state, player, source, filter),
+        ExileCostSourceZone::Hand => {
+            find_eligible_hand_cost_targets(state, player, source, filter_ref)
+        }
         ExileCostSourceZone::Graveyard => {
             let ctx = super::filter::FilterContext::from_source(state, source);
             state
@@ -9547,7 +9551,7 @@ pub(crate) fn find_eligible_exile_for_cost_targets(
                         .copied()
                         .filter(|&id| {
                             id != source
-                                && filter.is_none_or(|f| {
+                                && filter_ref.is_none_or(|f| {
                                     super::filter::matches_target_filter(state, id, f, &ctx)
                                 })
                         })

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1493,6 +1493,15 @@ fn finish_exile_selection_for_cost(
     // `TargetFilter::CostPaidObject` resolves during ability resolution.
     if let Some(&first) = chosen.first() {
         if let Some(obj) = state.objects.get(&first) {
+            // CR 107.3a + CR 118.9: Shoal-style alternative costs ("exile a
+            // [color] card with mana value X") define X from the pitched card's
+            // mana value rather than a prior announcement.
+            if pending.ability.chosen_x.is_none()
+                && pending.cost == crate::types::mana::ManaCost::NoCost
+                && pending.base_cost.as_ref().is_some_and(cost_has_x)
+            {
+                pending.ability.chosen_x = Some(obj.mana_cost.mana_value());
+            }
             pending
                 .ability
                 .set_cost_paid_object_recursive(CostPaidObjectSnapshot {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1500,7 +1500,9 @@ fn finish_exile_selection_for_cost(
                 && pending.cost == crate::types::mana::ManaCost::NoCost
                 && pending.base_cost.as_ref().is_some_and(cost_has_x)
             {
-                pending.ability.chosen_x = Some(obj.mana_cost.mana_value());
+                pending
+                    .ability
+                    .set_chosen_x_recursive(obj.mana_cost.mana_value());
             }
             pending
                 .ability

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -43,8 +43,47 @@ fn is_pitch_bound_cmc_eq_x_prop(prop: &FilterProp) -> bool {
 pub(crate) fn target_filter_has_pitch_bound_x(filter: &TargetFilter) -> bool {
     match filter {
         TargetFilter::Typed(tf) => tf.properties.iter().any(is_pitch_bound_cmc_eq_x_prop),
-        TargetFilter::Or { filters } => filters.iter().any(target_filter_has_pitch_bound_x),
-        _ => false,
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(target_filter_has_pitch_bound_x)
+        }
+        TargetFilter::Not { filter } | TargetFilter::TrackedSetFiltered { filter, .. } => {
+            target_filter_has_pitch_bound_x(filter)
+        }
+        TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::SelfRef
+        | TargetFilter::SourceOrPaired
+        | TargetFilter::StackAbility { .. }
+        | TargetFilter::StackSpell
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::Neighbor { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::AttachedTo
+        | TargetFilter::LastCreated
+        | TargetFilter::CostPaidObject
+        | TargetFilter::TrackedSet { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSource
+        | TargetFilter::ParentTarget
+        | TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::SourceChosenPlayer
+        | TargetFilter::OriginalController
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::HasChosenName
+        | TargetFilter::ChosenDamageSource
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => false,
     }
 }
 
@@ -62,7 +101,51 @@ pub(crate) fn relax_pitch_bound_x_filter(filter: &TargetFilter) -> TargetFilter 
         TargetFilter::Or { filters } => TargetFilter::Or {
             filters: filters.iter().map(relax_pitch_bound_x_filter).collect(),
         },
-        other => other.clone(),
+        TargetFilter::And { filters } => TargetFilter::And {
+            filters: filters.iter().map(relax_pitch_bound_x_filter).collect(),
+        },
+        TargetFilter::Not { filter } => TargetFilter::Not {
+            filter: Box::new(relax_pitch_bound_x_filter(filter)),
+        },
+        TargetFilter::TrackedSetFiltered { id, filter } => TargetFilter::TrackedSetFiltered {
+            id: *id,
+            filter: Box::new(relax_pitch_bound_x_filter(filter)),
+        },
+        TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::SelfRef
+        | TargetFilter::SourceOrPaired
+        | TargetFilter::StackAbility { .. }
+        | TargetFilter::StackSpell
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::Neighbor { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::AttachedTo
+        | TargetFilter::LastCreated
+        | TargetFilter::CostPaidObject
+        | TargetFilter::TrackedSet { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSource
+        | TargetFilter::ParentTarget
+        | TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::SourceChosenPlayer
+        | TargetFilter::OriginalController
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::HasChosenName
+        | TargetFilter::ChosenDamageSource
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => filter.clone(),
     }
 }
 

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -15,7 +15,9 @@
 //! existing eligibility helpers in sibling modules rather than reimplementing
 //! the enumerations.
 
-use crate::types::ability::{AbilityCost, TargetFilter};
+use crate::types::ability::{
+    AbilityCost, Comparator, FilterProp, QuantityExpr, QuantityRef, TargetFilter, TypedFilter,
+};
 use crate::types::card_type::CoreType;
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
@@ -23,6 +25,58 @@ use crate::types::zones::Zone;
 use crate::types::GameState;
 
 use super::filter::{matches_target_filter, matches_target_filter_in_owner_zone, FilterContext};
+
+fn is_pitch_bound_cmc_eq_x_prop(prop: &FilterProp) -> bool {
+    matches!(
+        prop,
+        FilterProp::Cmc {
+            comparator: Comparator::EQ,
+            value: QuantityExpr::Ref {
+                qty: QuantityRef::Variable { name },
+            },
+        } if name == "X"
+    )
+}
+
+/// True when a cost filter uses the Shoal pattern: "with mana value X" where X
+/// is defined by the card chosen to pay the cost, not by a prior announcement.
+pub(crate) fn target_filter_has_pitch_bound_x(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(tf) => tf.properties.iter().any(is_pitch_bound_cmc_eq_x_prop),
+        TargetFilter::Or { filters } => filters.iter().any(target_filter_has_pitch_bound_x),
+        _ => false,
+    }
+}
+
+pub(crate) fn relax_pitch_bound_x_filter(filter: &TargetFilter) -> TargetFilter {
+    match filter {
+        TargetFilter::Typed(tf) => TargetFilter::Typed(TypedFilter {
+            properties: tf
+                .properties
+                .iter()
+                .filter(|p| !is_pitch_bound_cmc_eq_x_prop(p))
+                .cloned()
+                .collect(),
+            ..tf.clone()
+        }),
+        TargetFilter::Or { filters } => TargetFilter::Or {
+            filters: filters.iter().map(relax_pitch_bound_x_filter).collect(),
+        },
+        other => other.clone(),
+    }
+}
+
+/// CR 107.3a + CR 118.9: Until the player chooses the pitched card, relax the
+/// CMC=X constraint for 601.2b eligibility on Shoal-style exile costs.
+pub(crate) fn exile_cost_effective_filter(filter: Option<&TargetFilter>) -> Option<TargetFilter> {
+    filter.map(|f| {
+        if target_filter_has_pitch_bound_x(f) {
+            relax_pitch_bound_x_filter(f)
+        } else {
+            f.clone()
+        }
+    })
+}
 
 impl AbilityCost {
     /// CR 605.3a + CR 602.2b + CR 601.2g-h: Payability gate for ACTIVATED
@@ -177,8 +231,16 @@ impl AbilityCost {
                     };
                 }
                 let zone = exile_cost_effective_zone(*zone, filter.as_ref());
-                eligible_exile_cost_objects(state, player, source, zone, filter.as_ref(), *count)
-                    .len()
+                let effective_filter = exile_cost_effective_filter(filter.as_ref());
+                eligible_exile_cost_objects(
+                    state,
+                    player,
+                    source,
+                    zone,
+                    effective_filter.as_ref(),
+                    *count,
+                )
+                .len()
                     >= *count as usize
             }
             // CR 702.167a/b: Craft's materials cost — payable iff enough
@@ -461,10 +523,12 @@ pub(super) fn eligible_exile_cost_objects(
                 .collect();
         }
     };
+    let effective_filter = exile_cost_effective_filter(filter);
+    let filter_ref = effective_filter.as_ref();
     let ctx = FilterContext::from_source(state, source);
     ids.filter(|&id| {
         id != source
-            && filter.is_none_or(|f| matches_target_filter_in_owner_zone(state, id, f, &ctx))
+            && filter_ref.is_none_or(|f| matches_target_filter_in_owner_zone(state, id, f, &ctx))
     })
     .collect()
 }
@@ -944,6 +1008,79 @@ mod tests {
         assert!(
             cost.is_payable(&scenario.state, P0, src),
             "'remove any number of' must be payable with counters present",
+        );
+    }
+
+    /// Issue #2372 — Nourishing Shoal: CMC=X is defined by the pitched card, so
+    /// payability must not require a pre-announced X.
+    #[test]
+    fn shoal_pitch_exile_cost_payable_with_any_green_hand_card() {
+        use crate::game::zones::create_object;
+        use crate::parser::oracle_cost::parse_oracle_cost;
+        use crate::types::card_type::CoreType;
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::{ManaColor, ManaCost};
+
+        let mut state = GameState::new_two_player(42);
+        let caster = PlayerId(0);
+        let shoal = create_object(
+            &mut state,
+            CardId(700),
+            caster,
+            "Nourishing Shoal".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&shoal).unwrap();
+            obj.card_types.core_types.push(CoreType::Instant);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![
+                    crate::types::mana::ManaCostShard::X,
+                    crate::types::mana::ManaCostShard::Green,
+                    crate::types::mana::ManaCostShard::Green,
+                ],
+                generic: 0,
+            };
+        }
+
+        let green_two_drop = create_object(
+            &mut state,
+            CardId(701),
+            caster,
+            "Green Two Drop".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&green_two_drop).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.color.push(ManaColor::Green);
+            obj.mana_cost = ManaCost::generic(2);
+        }
+
+        let cost = parse_oracle_cost("exile a green card with mana value X from your hand");
+        assert!(
+            cost.is_payable(&state, caster, shoal),
+            "Shoal pitch cost must be payable when any green card can set X"
+        );
+
+        let AbilityCost::Exile { filter, .. } = cost else {
+            panic!("expected Exile cost");
+        };
+        let eligible = super::eligible_exile_cost_objects(
+            &state,
+            caster,
+            shoal,
+            Zone::Hand,
+            filter.as_ref(),
+            1,
+        );
+        assert!(
+            eligible.contains(&green_two_drop),
+            "green hand card must be eligible regardless of CMC before X is chosen: {eligible:?}"
+        );
+        assert!(
+            !eligible.contains(&shoal),
+            "cast source must be excluded from pitch eligibility"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -1349,6 +1349,46 @@ mod tests {
     }
 
     #[test]
+    fn alt_cost_nourishing_shoal_exile_green_card_with_mana_value_x() {
+        use crate::types::ability::{
+            Comparator, FilterProp, QuantityExpr, QuantityRef, TargetFilter,
+        };
+
+        let option = parse_spell_casting_option_line(
+            "You may exile a green card with mana value X from your hand rather than pay this spell's mana cost.",
+            "Nourishing Shoal",
+        )
+        .expect("Nourishing Shoal alt-cost should parse (#2372)");
+        match option {
+            SpellCastingOption {
+                kind: crate::types::ability::SpellCastingOptionKind::AlternativeCost,
+                cost:
+                    Some(AbilityCost::Exile {
+                        filter: Some(filter),
+                        zone,
+                        ..
+                    }),
+                condition: None,
+            } => {
+                assert_eq!(zone, Some(crate::types::zones::Zone::Hand));
+                let TargetFilter::Typed(typed) = filter else {
+                    panic!("expected typed exile filter, got {filter:?}");
+                };
+                assert!(typed.properties.iter().any(|p| matches!(
+                    p,
+                    FilterProp::Cmc {
+                        comparator: Comparator::EQ,
+                        value: QuantityExpr::Ref {
+                            qty: QuantityRef::Variable { name },
+                        },
+                    } if name == "X"
+                )));
+            }
+            other => panic!("expected AlternativeCost(Exile), got {other:?}"),
+        }
+    }
+
+    #[test]
     fn alt_cost_pay_mana_composite_regression_unchanged() {
         // Force of Will shape — composite cost via " and " split.
         let option = parse_spell_casting_option_line(

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -1559,6 +1559,37 @@ mod tests {
     }
 
     #[test]
+    fn cost_exile_colored_card_with_mana_value_x_from_hand() {
+        use crate::types::ability::{Comparator, FilterProp, QuantityExpr, QuantityRef};
+
+        match parse_oracle_cost("Exile a green card with mana value X from your hand") {
+            AbilityCost::Exile {
+                zone,
+                filter: Some(TargetFilter::Typed(typed)),
+                ..
+            } => {
+                assert_eq!(zone, Some(Zone::Hand));
+                assert!(typed.properties.iter().any(|p| matches!(
+                    p,
+                    FilterProp::HasColor {
+                        color: crate::types::mana::ManaColor::Green
+                    }
+                )));
+                assert!(typed.properties.iter().any(|p| matches!(
+                    p,
+                    FilterProp::Cmc {
+                        comparator: Comparator::EQ,
+                        value: QuantityExpr::Ref {
+                            qty: QuantityRef::Variable { name }
+                        }
+                    } if name == "X"
+                )));
+            }
+            other => panic!("Expected Exile with green + CmcEQ(X), got {:?}", other),
+        }
+    }
+
+    #[test]
     fn cost_exile_colored_card_from_hand() {
         match parse_oracle_cost("Exile a blue card from your hand") {
             AbilityCost::Exile {

--- a/crates/engine/tests/integration/issue_2372_nourishing_shoal_alt_cost.rs
+++ b/crates/engine/tests/integration/issue_2372_nourishing_shoal_alt_cost.rs
@@ -1,0 +1,168 @@
+//! Regression for issue #2372: Nourishing Shoal must offer and execute its
+//! pitch alternative cost (exile a green card with mana value X), binding X to
+//! the exiled card's mana value for the life-gain effect.
+//!
+//! https://github.com/phase-rs/phase/issues/2372
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle_cost::parse_oracle_cost;
+use engine::types::ability::{
+    AdditionalCost, Effect, QuantityExpr, SpellCastingOption, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{StackEntryKind, WaitingFor};
+use engine::types::identifiers::CardId;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+fn setup_shoal_scenario() -> (
+    engine::game::scenario::GameRunner,
+    engine::types::identifiers::ObjectId,
+    CardId,
+    engine::types::identifiers::ObjectId,
+) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let alt_cost = parse_oracle_cost("exile a green card with mana value X from your hand");
+
+    let shoal = scenario
+        .add_creature_to_hand(P0, "Nourishing Shoal", 0, 0)
+        .as_instant()
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::X, ManaCostShard::Green, ManaCostShard::Green],
+            generic: 0,
+        })
+        .with_ability(Effect::GainLife {
+            amount: QuantityExpr::Ref {
+                qty: engine::types::ability::QuantityRef::Variable {
+                    name: "X".to_string(),
+                },
+            },
+            player: TargetFilter::Controller,
+        })
+        .id();
+
+    let green_filler = scenario.add_creature_to_hand(P0, "Green Filler", 2, 2).id();
+
+    let mut runner = scenario.build();
+    {
+        let s = runner.state_mut();
+        let shoal_obj = s.objects.get_mut(&shoal).unwrap();
+        shoal_obj
+            .casting_options
+            .push(SpellCastingOption::alternative_cost(alt_cost));
+        shoal_obj.color.push(ManaColor::Green);
+
+        let green = s.objects.get_mut(&green_filler).unwrap();
+        green.card_types.core_types.push(CoreType::Creature);
+        green.color.push(ManaColor::Green);
+        green.mana_cost = ManaCost::generic(3);
+    }
+
+    let card_id = runner.state().objects[&shoal].card_id;
+    (runner, shoal, card_id, green_filler)
+}
+
+#[test]
+fn nourishing_shoal_cast_surfaces_pitch_alternative_choice() {
+    let (mut runner, shoal, card_id, _) = setup_shoal_scenario();
+    let life_before = runner.life(P0);
+
+    let result = runner
+        .act(GameAction::CastSpell {
+            object_id: shoal,
+            card_id,
+            targets: vec![],
+        })
+        .expect("cast Nourishing Shoal");
+
+    assert!(
+        matches!(
+            result.waiting_for,
+            WaitingFor::OptionalCostChoice {
+                cost: AdditionalCost::Choice(_, _),
+                ..
+            }
+        ),
+        "expected OptionalCostChoice for pitch alt cost, got {:?}",
+        result.waiting_for
+    );
+    assert_eq!(life_before, runner.life(P0));
+}
+
+#[test]
+fn nourishing_shoal_pitch_exile_binds_x_and_gains_life() {
+    let (mut runner, shoal, card_id, green_filler) = setup_shoal_scenario();
+    let life_before = runner.life(P0);
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: shoal,
+            card_id,
+            targets: vec![],
+        })
+        .expect("cast");
+
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("accept pitch cost");
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::PayCost {
+                kind: engine::types::game_state::PayCostKind::ExileFromZone {
+                    zone: engine::types::zones::ExileCostSourceZone::Hand,
+                },
+                ..
+            }
+        ),
+        "expected exile-from-hand payment, got {:?}",
+        runner.state().waiting_for
+    );
+
+    let WaitingFor::PayCost { choices, .. } = &runner.state().waiting_for else {
+        unreachable!();
+    };
+    assert!(choices.contains(&green_filler));
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![green_filler],
+        })
+        .expect("exile green card for pitch");
+
+    assert!(
+        !runner.state().stack.is_empty(),
+        "Nourishing Shoal must reach the stack after paying the pitch cost"
+    );
+    if let StackEntryKind::Spell {
+        ability: Some(ability),
+        ..
+    } = &runner.state().stack.last().unwrap().kind
+    {
+        assert_eq!(
+            ability.chosen_x,
+            Some(3),
+            "X must be bound from the exiled card's mana value before resolution"
+        );
+    } else {
+        panic!("expected spell on stack after pitch payment");
+    }
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.life(P0),
+        life_before + 3,
+        "X must equal the exiled card's mana value (3)"
+    );
+    assert_eq!(
+        runner.state().objects[&green_filler].zone,
+        Zone::Exile,
+        "pitched card must be exiled"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -84,6 +84,7 @@ mod issue_2345_lavinia_no_mana_spent;
 mod issue_2360_the_rack;
 mod issue_2361_unless_pay_choice;
 mod issue_2371_triskaidekaphile;
+mod issue_2372_nourishing_shoal_alt_cost;
 mod issue_2374_fblthp_library_origin;
 mod issue_2376_pyromancers_ascension;
 mod issue_2417_satoru_intervening_if;


### PR DESCRIPTION
## Summary

Fixes [#2372](https://github.com/phase-rs/phase/issues/2372).

Nourishing Shoal’s pitch alternative (“exile a green card with mana value X from your hand”) was never offered at cast time, and X was not bound for “You gain X life.”

- **Payability (CR 601.2b):** Shoal-style exile costs use `Cmc EQ Variable("X")` where X is defined by the pitched card, not a prior announcement. Relax that constraint for eligibility checks so any legal green hand card makes the alternative payable.
- **Target selection:** `find_eligible_hand_cost_targets` uses the same relaxed filter so the exile prompt lists valid cards.
- **X binding (CR 107.3a / 118.9):** After the player exiles the pitched card, set `chosen_x` from that card’s mana value when the spell was cast via the alternative cost, so `GainLife { X }` resolves on the stack.

Parser coverage was already correct; this is a runtime casting/payment fix.

## Test plan

- [x] `cargo test -p engine --lib shoal_pitch`
- [x] `cargo test -p engine --lib alt_cost_nourishing`
- [x] `cargo test -p engine --lib cost_exile_colored`
- [x] `cargo test -p engine issue_2372`
- [ ] `cargo fmt --check`
- [ ] Full `cargo test -p engine` (CI)