### PR TITLE
Avoid Saheeli-style commander copy legend-rule loops (#2438)

### DIFF
--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -26,6 +26,7 @@ use engine::game::players;
 
 use super::activation::turn_only;
 use super::context::PolicyContext;
+use super::copy_value::{copy_target_penalties, score_legend_rule_keep};
 use super::effect_classify::{
     aggregate_player_impact, aura_polarity, effect_polarity, effect_targets_object,
     extract_target_filter, is_spell_beneficial, targeted_object_impact, targeted_player_impact,
@@ -53,6 +54,7 @@ impl AntiSelfHarmPolicy {
                 .sum(),
             // Penalise accepting an optional effect whose life cost would kill or nearly kill us.
             GameAction::DecideOptionalEffect { accept: true } => score_optional_effect_accept(ctx),
+            GameAction::ChooseLegend { keep } => score_legend_rule_keep(ctx.state, *keep),
             _ => 0.0,
         }
     }
@@ -481,6 +483,12 @@ fn score_target_object(ctx: &PolicyContext<'_>, object_id: ObjectId, beneficial:
             };
         } else {
             score -= 6.0;
+        }
+    }
+
+    if ctx.effects().iter().any(|effect| matches!(effect, Effect::CopyTokenOf { .. })) {
+        if let Some(source) = ctx.source_object() {
+            score -= copy_target_penalties(ctx.state, ctx.ai_player, source.id, object);
         }
     }
 

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -492,7 +492,7 @@ fn score_target_object(ctx: &PolicyContext<'_>, object_id: ObjectId, beneficial:
         .any(|effect| matches!(effect, Effect::CopyTokenOf { .. }))
     {
         if let Some(source) = ctx.source_object() {
-            score -= copy_target_penalties(ctx.state, ctx.ai_player, source.id, object);
+            score -= copy_target_penalties(ctx.state, ctx.ai_player, Some(source.id), object);
         }
     }
 

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -486,7 +486,11 @@ fn score_target_object(ctx: &PolicyContext<'_>, object_id: ObjectId, beneficial:
         }
     }
 
-    if ctx.effects().iter().any(|effect| matches!(effect, Effect::CopyTokenOf { .. })) {
+    if ctx
+        .effects()
+        .iter()
+        .any(|effect| matches!(effect, Effect::CopyTokenOf { .. }))
+    {
         if let Some(source) = ctx.source_object() {
             score -= copy_target_penalties(ctx.state, ctx.ai_player, source.id, object);
         }

--- a/crates/phase-ai/src/policies/copy_value.rs
+++ b/crates/phase-ai/src/policies/copy_value.rs
@@ -6,7 +6,7 @@ use engine::game::filter::{matches_target_filter, FilterContext};
 use engine::game::game_object::GameObject;
 use engine::types::ability::{AbilityDefinition, Effect, TargetRef};
 use engine::types::actions::GameAction;
-use engine::types::card_type::Supertype;
+use engine::types::card_type::{CoreType, Supertype};
 use engine::types::game_state::{GameState, PendingCast, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
@@ -22,6 +22,8 @@ use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
 
 pub struct CopyValuePolicy;
+
+const COPY_SPELL_LOOP_PENALTY_SCALE: f64 = 0.004;
 
 impl CopyValuePolicy {
     pub fn score(&self, ctx: &PolicyContext<'_>) -> f64 {
@@ -54,10 +56,7 @@ impl CopyValuePolicy {
                 .iter()
                 .any(|e| matches!(e, Effect::CopyTokenOf { .. })) =>
             {
-                let source_id = ctx
-                    .source_object()
-                    .map(|source| source.id)
-                    .unwrap_or(*target_id);
+                let source_id = ctx.source_object().map(|source| source.id);
                 score_copy_token_target(ctx.state, ctx.ai_player, source_id, *target_id)
             }
             _ => 0.0,
@@ -71,7 +70,7 @@ pub(crate) fn score_legend_rule_keep(state: &GameState, keep: ObjectId) -> f64 {
     let Some(object) = state.objects.get(&keep) else {
         return -100.0;
     };
-    let mut score = evaluate_creature(state, keep);
+    let mut score = evaluate_legend_keep_permanent(state, keep, object);
     if object.is_commander {
         score += 80.0;
     }
@@ -81,17 +80,37 @@ pub(crate) fn score_legend_rule_keep(state: &GameState, keep: ObjectId) -> f64 {
     score
 }
 
+fn evaluate_legend_keep_permanent(state: &GameState, keep: ObjectId, object: &GameObject) -> f64 {
+    if object.card_types.core_types.contains(&CoreType::Creature) {
+        return evaluate_creature(state, keep);
+    }
+
+    if object
+        .card_types
+        .core_types
+        .contains(&CoreType::Planeswalker)
+    {
+        return object.mana_cost.mana_value() as f64 + 2.0;
+    }
+
+    if object.card_types.core_types.contains(&CoreType::Land) {
+        return 3.0;
+    }
+
+    (object.mana_cost.mana_value() as f64).min(6.0)
+}
+
 /// Penalties for copy effects that would trigger a wasteful legend-rule loop
 /// (issue #2438 — Saheeli copying her own commander).
 pub(crate) fn copy_target_penalties(
     state: &GameState,
     ai_player: PlayerId,
-    source_id: ObjectId,
+    source_id: Option<ObjectId>,
     target: &GameObject,
 ) -> f64 {
     let mut penalty = 0.0;
 
-    if target.id == source_id {
+    if source_id.is_some_and(|source_id| target.id == source_id) {
         penalty += 50.0;
     }
 
@@ -120,7 +139,7 @@ pub(crate) fn copy_target_penalties(
 fn score_copy_token_target(
     state: &GameState,
     ai_player: PlayerId,
-    source_id: ObjectId,
+    source_id: Option<ObjectId>,
     target_id: ObjectId,
 ) -> f64 {
     let Some(target) = state.objects.get(&target_id) else {
@@ -258,7 +277,8 @@ fn score_target_choice(
         copy_bonus += 0.06;
     }
 
-    copy_penalty += copy_target_penalties(state, ai_player, source_id, target);
+    copy_penalty += copy_target_penalties(state, ai_player, Some(source_id), target)
+        * COPY_SPELL_LOOP_PENALTY_SCALE;
 
     if base_creature_value < 3.0 {
         copy_penalty += 0.08;
@@ -613,6 +633,23 @@ mod tests {
     }
 
     #[test]
+    fn copy_spell_target_choice_scales_loop_penalty_to_fractional_score() {
+        let mut state = make_state();
+        let mockingbird_id = add_mockingbird_like_card(&mut state, Zone::Battlefield);
+        {
+            let obj = state.objects.get_mut(&mockingbird_id).unwrap();
+            obj.card_types.supertypes.push(Supertype::Legendary);
+            obj.is_commander = true;
+        }
+
+        let score = score_target_choice(&state, PlayerId(0), mockingbird_id, mockingbird_id);
+        assert!(
+            score > 0.0,
+            "copy-spell loop penalty must stay on the fractional target-score scale, got {score}"
+        );
+    }
+
+    #[test]
     fn copy_token_target_heavily_penalises_self_commander() {
         let mut state = make_state();
         let saheeli = add_creature(
@@ -630,10 +667,61 @@ mod tests {
             obj.is_commander = true;
         }
 
-        let score = score_copy_token_target(&state, PlayerId(0), saheeli, saheeli);
+        let score = score_copy_token_target(&state, PlayerId(0), Some(saheeli), saheeli);
         assert!(
             score < -50.0,
             "self-commander copy must be strongly penalised, got {score}"
+        );
+    }
+
+    #[test]
+    fn copy_token_target_without_source_does_not_apply_self_copy_penalty() {
+        let mut state = make_state();
+        let saheeli = add_creature(
+            &mut state,
+            1,
+            PlayerId(0),
+            "Saheeli, Radiant Creator",
+            2,
+            3,
+            4,
+        );
+        {
+            let obj = state.objects.get_mut(&saheeli).unwrap();
+            obj.card_types.supertypes.push(Supertype::Legendary);
+            obj.is_commander = true;
+        }
+
+        let unknown_source_score = score_copy_token_target(&state, PlayerId(0), None, saheeli);
+        let self_source_score =
+            score_copy_token_target(&state, PlayerId(0), Some(saheeli), saheeli);
+        assert!(
+            unknown_source_score > self_source_score + 45.0,
+            "unknown source must not be treated as self-copy: unknown={unknown_source_score}, self={self_source_score}"
+        );
+    }
+
+    #[test]
+    fn legend_rule_keep_scores_noncreature_permanent_value() {
+        let mut state = make_state();
+        let artifact = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "The One Ring".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&artifact).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.card_types.supertypes.push(Supertype::Legendary);
+            obj.mana_cost = ManaCost::generic(4);
+        }
+
+        let score = score_legend_rule_keep(&state, artifact);
+        assert!(
+            score >= 4.0,
+            "legend-rule keep score should value noncreature permanents, got {score}"
         );
     }
 

--- a/crates/phase-ai/src/policies/copy_value.rs
+++ b/crates/phase-ai/src/policies/copy_value.rs
@@ -3,7 +3,8 @@ use engine::ai_support::{
     project_copy_mana_spent_for_x,
 };
 use engine::game::filter::{matches_target_filter, FilterContext};
-use engine::types::ability::{AbilityDefinition, TargetRef};
+use engine::game::game_object::GameObject;
+use engine::types::ability::{AbilityDefinition, Effect, TargetRef};
 use engine::types::actions::GameAction;
 use engine::types::card_type::Supertype;
 use engine::types::game_state::{GameState, PendingCast, WaitingFor};
@@ -43,9 +44,88 @@ impl CopyValuePolicy {
             ) if valid_targets.contains(target_id) => {
                 score_target_choice(ctx.state, ctx.ai_player, *source_id, *target_id)
             }
+            (
+                WaitingFor::TargetSelection { .. }
+                | WaitingFor::TriggerTargetSelection { .. },
+                GameAction::ChooseTarget {
+                    target: Some(TargetRef::Object(target_id)),
+                },
+            ) if ctx.effects().iter().any(|e| matches!(e, Effect::CopyTokenOf { .. })) => {
+                let source_id = ctx
+                    .source_object()
+                    .map(|source| source.id)
+                    .unwrap_or(*target_id);
+                score_copy_token_target(ctx.state, ctx.ai_player, source_id, *target_id)
+            }
             _ => 0.0,
         }
     }
+}
+
+/// CR 704.5j: Prefer keeping commanders and non-token originals over ephemeral
+/// copy tokens when the legend rule fires.
+pub(crate) fn score_legend_rule_keep(state: &GameState, keep: ObjectId) -> f64 {
+    let Some(object) = state.objects.get(&keep) else {
+        return -100.0;
+    };
+    let mut score = evaluate_creature(state, keep);
+    if object.is_commander {
+        score += 80.0;
+    }
+    if object.is_token {
+        score -= 60.0;
+    }
+    score
+}
+
+/// Penalties for copy effects that would trigger a wasteful legend-rule loop
+/// (issue #2438 — Saheeli copying her own commander).
+pub(crate) fn copy_target_penalties(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    target: &GameObject,
+) -> f64 {
+    let mut penalty = 0.0;
+
+    if target.id == source_id {
+        penalty += 50.0;
+    }
+
+    if target.is_commander && target.controller == ai_player {
+        penalty += 40.0;
+    }
+
+    if target.controller == ai_player
+        && target.card_types.supertypes.contains(&Supertype::Legendary)
+        && state.battlefield.iter().any(|&id| {
+            id != target.id
+                && state.objects.get(&id).is_some_and(|other| {
+                    other.controller == ai_player
+                        && other.card_types.supertypes.contains(&Supertype::Legendary)
+                        && other.name == target.name
+                })
+                && !engine::game::sba::legend_rule_exempt(state, id)
+        })
+    {
+        penalty += 35.0;
+    }
+
+    penalty
+}
+
+fn score_copy_token_target(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    target_id: ObjectId,
+) -> f64 {
+    let Some(target) = state.objects.get(&target_id) else {
+        return -10.0;
+    };
+    let base = evaluate_creature(state, target_id);
+    let penalty = copy_target_penalties(state, ai_player, source_id, target);
+    base - penalty
 }
 
 impl TacticalPolicy for CopyValuePolicy {
@@ -175,11 +255,7 @@ fn score_target_choice(
         copy_bonus += 0.06;
     }
 
-    if target.controller == source.controller
-        && target.card_types.supertypes.contains(&Supertype::Legendary)
-    {
-        copy_penalty += 0.20;
-    }
+    copy_penalty += copy_target_penalties(state, ai_player, source_id, target);
 
     if base_creature_value < 3.0 {
         copy_penalty += 0.08;
@@ -531,5 +607,54 @@ mod tests {
         });
 
         assert!(score_large > score_small);
+    }
+
+    #[test]
+    fn copy_token_target_heavily_penalises_self_commander() {
+        let mut state = make_state();
+        let saheeli = add_creature(&mut state, 1, PlayerId(0), "Saheeli, Radiant Creator", 2, 3, 4);
+        {
+            let obj = state.objects.get_mut(&saheeli).unwrap();
+            obj.card_types.supertypes.push(Supertype::Legendary);
+            obj.is_commander = true;
+        }
+
+        let score = score_copy_token_target(&state, PlayerId(0), saheeli, saheeli);
+        assert!(
+            score < -50.0,
+            "self-commander copy must be strongly penalised, got {score}"
+        );
+    }
+
+    #[test]
+    fn legend_rule_keep_prefers_commander_over_copy_token() {
+        let mut state = make_state();
+        let commander = add_creature(&mut state, 1, PlayerId(0), "Saheeli, Radiant Creator", 2, 3, 4);
+        {
+            let obj = state.objects.get_mut(&commander).unwrap();
+            obj.card_types.supertypes.push(Supertype::Legendary);
+            obj.is_commander = true;
+        }
+        let copy_token = add_creature(
+            &mut state,
+            2,
+            PlayerId(0),
+            "Saheeli, Radiant Creator",
+            5,
+            5,
+            4,
+        );
+        {
+            let obj = state.objects.get_mut(&copy_token).unwrap();
+            obj.card_types.supertypes.push(Supertype::Legendary);
+            obj.is_token = true;
+        }
+
+        let commander_score = score_legend_rule_keep(&state, commander);
+        let token_score = score_legend_rule_keep(&state, copy_token);
+        assert!(
+            commander_score > token_score,
+            "commander ({commander_score}) must beat copy token ({token_score})"
+        );
     }
 }

--- a/crates/phase-ai/src/policies/copy_value.rs
+++ b/crates/phase-ai/src/policies/copy_value.rs
@@ -45,12 +45,15 @@ impl CopyValuePolicy {
                 score_target_choice(ctx.state, ctx.ai_player, *source_id, *target_id)
             }
             (
-                WaitingFor::TargetSelection { .. }
-                | WaitingFor::TriggerTargetSelection { .. },
+                WaitingFor::TargetSelection { .. } | WaitingFor::TriggerTargetSelection { .. },
                 GameAction::ChooseTarget {
                     target: Some(TargetRef::Object(target_id)),
                 },
-            ) if ctx.effects().iter().any(|e| matches!(e, Effect::CopyTokenOf { .. })) => {
+            ) if ctx
+                .effects()
+                .iter()
+                .any(|e| matches!(e, Effect::CopyTokenOf { .. })) =>
+            {
                 let source_id = ctx
                     .source_object()
                     .map(|source| source.id)
@@ -612,7 +615,15 @@ mod tests {
     #[test]
     fn copy_token_target_heavily_penalises_self_commander() {
         let mut state = make_state();
-        let saheeli = add_creature(&mut state, 1, PlayerId(0), "Saheeli, Radiant Creator", 2, 3, 4);
+        let saheeli = add_creature(
+            &mut state,
+            1,
+            PlayerId(0),
+            "Saheeli, Radiant Creator",
+            2,
+            3,
+            4,
+        );
         {
             let obj = state.objects.get_mut(&saheeli).unwrap();
             obj.card_types.supertypes.push(Supertype::Legendary);
@@ -629,7 +640,15 @@ mod tests {
     #[test]
     fn legend_rule_keep_prefers_commander_over_copy_token() {
         let mut state = make_state();
-        let commander = add_creature(&mut state, 1, PlayerId(0), "Saheeli, Radiant Creator", 2, 3, 4);
+        let commander = add_creature(
+            &mut state,
+            1,
+            PlayerId(0),
+            "Saheeli, Radiant Creator",
+            2,
+            3,
+            4,
+        );
         {
             let obj = state.objects.get_mut(&commander).unwrap();
             obj.card_types.supertypes.push(Supertype::Legendary);

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod combo_line;
 mod condition_gated_activation;
 pub(crate) mod context;
 mod control_change_awareness;
-mod copy_value;
+pub(crate) mod copy_value;
 mod downside_awareness;
 pub(crate) mod effect_classify;
 mod effect_timing;

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -14,6 +14,7 @@ use crate::planner::{
     apply_candidate, build_continuation_planner, PlannerServices, RankedCandidate, SearchBudget,
 };
 use crate::policies::context::PolicyContext;
+use crate::policies::copy_value::score_legend_rule_keep;
 use crate::policies::tutor::{score_search_choice_cards, score_search_choice_selection};
 use crate::policies::{PolicyId, PolicyRegistry, PolicyVerdict};
 use crate::tactical_gate::gate_candidates;
@@ -684,9 +685,14 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
             choice_text.map(|choice| GameAction::ChooseOption { choice })
         }
 
-        // Legend choice: pick the first candidate.
+        // CR 704.5j: keep the commander / original over ephemeral copy tokens.
         WaitingFor::ChooseLegend { candidates, .. } => candidates
-            .first()
+            .iter()
+            .max_by(|&&left, &&right| {
+                score_legend_rule_keep(state, left)
+                    .partial_cmp(&score_legend_rule_keep(state, right))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
             .map(|&keep| GameAction::ChooseLegend { keep }),
 
         // Battle protector: pick the first candidate.


### PR DESCRIPTION
## Summary

Fixes #2438

When the AI controlled Saheeli, Radiant Creator as commander, it repeatedly copied its own commander at combat, kept the 5/5 copy on the legend rule, sent the real commander to the command zone (increasing tax), then lost the copy to the end-step sacrifice — every turn, with no upside.

**Copy target policy:** `CopyTokenOf` target scoring now heavily penalises:
- Copying the ability source (self-copy)
- Copying your own commander (commander tax)
- Copying a legendary when you already control another with the same name (legend rule)

**Legend rule choice:** `ChooseLegend` now scores candidates to keep commanders and non-token originals over ephemeral copy tokens, instead of always picking the first candidate.

## Test plan

- [x] `cargo test -p phase-ai policies::copy_value::tests`
- [x] `cargo clippy -p phase-ai -- -D warnings`
- [x] `copy_token_target_heavily_penalises_self_commander` — self-commander copy scores strongly negative
- [x] `legend_rule_keep_prefers_commander_over_copy_token` — commander beats 5/5 copy token on legend choice