### PR TITLE
Fix Pack Leader combat damage prevention scoped to Dogs you control (#2437)

### DIFF
--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -110,6 +110,19 @@ fn untargeted_damage_filter(
     }
 }
 
+/// CR 614.1a: Typed permanent recipient filters ("Dogs you control",
+/// "attacking artifact creatures you control") route through the shield's
+/// `valid_card` slot — the runtime matches the damage recipient object
+/// against this filter. Player/context refs are handled by
+/// `untargeted_damage_filter` instead.
+fn typed_recipient_valid_card_filter(target: &TargetFilter) -> Option<TargetFilter> {
+    match target {
+        TargetFilter::Any | TargetFilter::ParentTarget => None,
+        filter if filter.is_context_ref() => None,
+        filter => Some(filter.clone()),
+    }
+}
+
 /// CR 615: Prevent damage — creates a prevention shield on the source object.
 ///
 /// The shield is stored as a `ReplacementDefinition` with `ShieldKind::Prevention`
@@ -189,6 +202,8 @@ pub fn resolve(
     if !host_on_parent_target_object {
         if let Some(filter) = untargeted_damage_filter(state, ability, &target) {
             shield = shield.damage_target_filter(filter);
+        } else if let Some(recipient_filter) = typed_recipient_valid_card_filter(&target) {
+            shield = shield.valid_card(recipient_filter);
         }
     }
 
@@ -690,6 +705,105 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    #[test]
+    fn typed_recipient_prevention_only_blocks_matching_creatures() {
+        use crate::types::ability::{ControllerRef, TypeFilter};
+        use crate::types::card_type::CoreType;
+
+        let mut state = GameState::new_two_player(42);
+        let pack_leader = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Pack Leader".to_string(),
+            Zone::Battlefield,
+        );
+        let dog = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Dog".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&dog).unwrap().card_types = crate::types::card_type::CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec!["Dog".to_string()],
+        };
+        let bear = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&bear).unwrap().card_types = crate::types::card_type::CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec!["Bear".to_string()],
+        };
+        let attacker = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::Typed(
+                    TypedFilter::creature()
+                        .with_type(TypeFilter::Subtype("Dog".into()))
+                        .controller(ControllerRef::You),
+                ),
+                scope: PreventionScope::CombatDamage,
+                damage_source_filter: None,
+            },
+            vec![],
+            pack_leader,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let shield = &state.objects.get(&pack_leader).unwrap().replacement_definitions[0];
+        assert_eq!(
+            shield.valid_card,
+            Some(TargetFilter::Typed(
+                TypedFilter::creature()
+                    .with_type(TypeFilter::Subtype("Dog".into()))
+                    .controller(ControllerRef::You)
+            ))
+        );
+
+        let ctx = deal_damage::DamageContext::from_source(&state, attacker).unwrap();
+        let dog_result = deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Object(dog),
+            3,
+            true,
+            &mut events,
+        )
+        .unwrap();
+        assert!(matches!(dog_result, deal_damage::DamageResult::Applied(0)));
+
+        let bear_result = deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Object(bear),
+            2,
+            true,
+            &mut events,
+        )
+        .unwrap();
+        assert!(matches!(bear_result, deal_damage::DamageResult::Applied(2)));
+        assert_eq!(state.objects.get(&bear).unwrap().damage_marked, 2);
     }
 
     /// CR 615.1a: A `Prevention { All }` shield is not depletion-based — it

--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -771,7 +771,11 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        let shield = &state.objects.get(&pack_leader).unwrap().replacement_definitions[0];
+        let shield = &state
+            .objects
+            .get(&pack_leader)
+            .unwrap()
+            .replacement_definitions[0];
         assert_eq!(
             shield.valid_card,
             Some(TargetFilter::Typed(

--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -96,6 +96,12 @@ fn player_damage_filter(player: PlayerId) -> DamageTargetFilter {
     }
 }
 
+fn any_player_damage_filter() -> DamageTargetFilter {
+    DamageTargetFilter::Player {
+        player: DamageTargetPlayerScope::Any,
+    }
+}
+
 fn untargeted_damage_filter(
     state: &GameState,
     ability: &ResolvedAbility,
@@ -103,6 +109,8 @@ fn untargeted_damage_filter(
 ) -> Option<DamageTargetFilter> {
     match target {
         TargetFilter::Any => None,
+        TargetFilter::Player => Some(any_player_damage_filter()),
+        TargetFilter::SpecificPlayer { id } => Some(player_damage_filter(*id)),
         filter if filter.is_context_ref() => Some(player_damage_filter(
             super::resolve_player_for_context_ref(state, ability, filter),
         )),
@@ -676,6 +684,88 @@ mod tests {
             deal_damage::DamageResult::Applied(0)
         ));
         assert_eq!(state.players[0].life, 20);
+    }
+
+    #[test]
+    fn player_recipient_prevention_uses_damage_target_filter() {
+        let mut state = GameState::new_two_player(42);
+        let shield_source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Player Shield".to_string(),
+            Zone::Stack,
+        );
+        let damage_source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        let creature = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Creature".to_string(),
+            Zone::Battlefield,
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::Player,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter: None,
+            },
+            vec![],
+            shield_source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        let shield = &state.pending_damage_replacements[0];
+        assert_eq!(
+            shield.damage_target_filter,
+            Some(DamageTargetFilter::Player {
+                player: DamageTargetPlayerScope::Any,
+            })
+        );
+        assert_eq!(shield.valid_card, None);
+
+        let ctx = deal_damage::DamageContext::from_source(&state, damage_source).unwrap();
+        let player_result = deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Player(PlayerId(1)),
+            3,
+            false,
+            &mut events,
+        )
+        .unwrap();
+        assert!(matches!(
+            player_result,
+            deal_damage::DamageResult::Applied(0)
+        ));
+        assert_eq!(state.players[1].life, 20);
+
+        let creature_result = deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Object(creature),
+            2,
+            false,
+            &mut events,
+        )
+        .unwrap();
+        assert!(matches!(
+            creature_result,
+            deal_damage::DamageResult::Applied(2)
+        ));
+        assert_eq!(state.objects.get(&creature).unwrap().damage_marked, 2);
     }
 
     #[test]

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -26,7 +26,7 @@ use crate::convert::quantity;
 use crate::convert::result::{ConvResult, ConversionGap};
 use crate::convert::static_effect;
 use crate::schema::types::{
-    Condition, CopyEffect, CopyEffects, CounterType, Expiration,
+    Condition, CopyEffect, CopyEffects, CounterType, DamageRecipientsList, Expiration,
     FutureReplacableEventWouldDealDamage, GameNumber, Permanent, Permanents, Player, Players,
     ReplacableEventWouldDealDamage, ReplacableEventWouldDraw, ReplacableEventWouldEnter,
     ReplacableEventWouldGainLife, ReplacableEventWouldPutCounters,
@@ -2645,11 +2645,11 @@ pub fn convert_create_replace_would_deal_damage_until(
         });
     }
     let amount = single_prevent_amount(actions)?;
-    let (scope, source_filter) = damage_event_to_prevent_scope(event)?;
+    let (scope, source_filter, target) = damage_event_to_prevent_params(event)?;
     Ok(engine::types::ability::Effect::PreventDamage {
         amount,
         amount_dynamic: None,
-        target: engine::types::ability::TargetFilter::Any,
+        target,
         scope,
         damage_source_filter: source_filter,
     })
@@ -2761,53 +2761,178 @@ fn require_prevention_only(actions: &[ReplacementActionWouldDealDamage]) -> Conv
     }
 }
 
+/// CR 614.2: Map a `DamageRecipientsList` onto the `Effect::PreventDamage`
+/// recipient axis. The engine's `prevent_damage::resolve` routes typed
+/// permanent filters through the shield's `valid_card` slot (Losheel /
+/// Pack Leader class).
+fn damage_recipients_list_to_prevent_target(
+    recipients: &DamageRecipientsList,
+) -> ConvResult<TargetFilter> {
+    use DamageRecipientsList as R;
+    Ok(match recipients {
+        R::APermanent(perms) => convert_permanents(perms)?,
+        R::APlayer(players) => {
+            let ctrl = players_to_controller(players)?;
+            TargetFilter::Typed(TypedFilter::default().controller(ctrl))
+        }
+        R::APlayerOrAPermanent(players, perms) => TargetFilter::Or {
+            filters: vec![
+                TargetFilter::Typed(TypedFilter::default().controller(players_to_controller(
+                    players,
+                )?)),
+                convert_permanents(perms)?,
+            ],
+        },
+    })
+}
+
+/// CR 614.2: Map a `SingleDamageRecipient` onto the `Effect::PreventDamage`
+/// recipient axis. Unrecognised shapes leave `Any` so the shield still
+/// prevents broadly rather than strict-failing the whole card.
+fn single_damage_recipient_to_prevent_target(
+    recipient: &SingleDamageRecipient,
+) -> ConvResult<TargetFilter> {
+    Ok(match recipient {
+        SingleDamageRecipient::Permanent(p) => convert_permanent(p)?,
+        SingleDamageRecipient::Player(p) => match &**p {
+            Player::You => TargetFilter::Controller,
+            other => TargetFilter::Typed(
+                TypedFilter::default().controller(player_to_controller(other)?),
+            ),
+        },
+        _ => TargetFilter::Any,
+    })
+}
+
 /// CR 615 + CR 614.1a: Decompose a `ReplacableEventWouldDealDamage` into
-/// the `(scope, damage_source_filter)` tuple expected by
+/// the `(scope, damage_source_filter, target)` tuple expected by
 /// `Effect::PreventDamage`. Combat-prefixed variants set
 /// `PreventionScope::CombatDamage`; others remain `AllDamage`. When the
 /// event names a typed source (`...ByACreature(perms)` /
 /// `...ByAPermanent(perms)`), convert via `convert_permanents` and use
 /// it as the source filter; otherwise leave the source slot `None`.
-fn damage_event_to_prevent_scope(
+/// Recipient-bearing variants populate `target` from the event's damage
+/// recipient description.
+fn damage_event_to_prevent_params(
     event: &ReplacableEventWouldDealDamage,
 ) -> ConvResult<(
     engine::types::ability::PreventionScope,
     Option<engine::types::ability::TargetFilter>,
+    engine::types::ability::TargetFilter,
 )> {
     use engine::types::ability::PreventionScope;
     use ReplacableEventWouldDealDamage as E;
     Ok(match event {
-        E::CombatDamageWouldBeDealt
-        | E::CombatDamageWouldBeDealtToARecipient(_)
-        | E::CombatDamageWouldBeDealtToRecipient(_) => (PreventionScope::CombatDamage, None),
-        E::CombatDamageWouldBeDealtByACreature(perms)
-        | E::CombatDamageWouldBeDealtByACreatureToARecipient(perms, _)
-        | E::CombatDamageWouldBeDealtByACreatureToASetOfRecipients(perms, _)
-        | E::CombatDamageWouldBeDealtByACreatureToRecipient(perms, _) => (
+        E::CombatDamageWouldBeDealt => (PreventionScope::CombatDamage, None, TargetFilter::Any),
+        E::CombatDamageWouldBeDealtToARecipient(recipients) => (
+            PreventionScope::CombatDamage,
+            None,
+            damage_recipients_list_to_prevent_target(recipients)?,
+        ),
+        E::CombatDamageWouldBeDealtToRecipient(recipient) => (
+            PreventionScope::CombatDamage,
+            None,
+            single_damage_recipient_to_prevent_target(recipient)?,
+        ),
+        E::CombatDamageWouldBeDealtByACreature(perms) => (
             PreventionScope::CombatDamage,
             Some(convert_permanents(perms)?),
+            TargetFilter::Any,
         ),
-        E::CombatDamageWouldBeDealtByCreature(perm)
-        | E::CombatDamageWouldBeDealtByCreatureToARecipient(perm, _)
-        | E::CombatDamageWouldBeDealtByCreatureToRecipient(perm, _) => (
+        E::CombatDamageWouldBeDealtByACreatureToARecipient(perms, recipients) => (
+            PreventionScope::CombatDamage,
+            Some(convert_permanents(perms)?),
+            damage_recipients_list_to_prevent_target(recipients)?,
+        ),
+        E::CombatDamageWouldBeDealtByACreatureToASetOfRecipients(perms, recipients) => (
+            PreventionScope::CombatDamage,
+            Some(convert_permanents(perms)?),
+            damage_recipients_list_to_prevent_target(recipients)?,
+        ),
+        E::CombatDamageWouldBeDealtByACreatureToRecipient(perms, recipient) => (
+            PreventionScope::CombatDamage,
+            Some(convert_permanents(perms)?),
+            single_damage_recipient_to_prevent_target(recipient)?,
+        ),
+        E::CombatDamageWouldBeDealtByCreature(perm) => (
             PreventionScope::CombatDamage,
             Some(convert_permanent(perm)?),
+            TargetFilter::Any,
         ),
-        E::DamageWouldBeDealtByAPermanent(perms)
-        | E::DamageWouldBeDealtByAPermanentToARecipient(perms, _)
-        | E::DamageWouldBeDealtByAPermanentToRecipient(perms, _) => {
-            (PreventionScope::AllDamage, Some(convert_permanents(perms)?))
-        }
-        E::DamageWouldBeDealtByASource(sources)
-        | E::DamageWouldBeDealtByASourceToARecipient(sources, _)
-        | E::DamageWouldBeDealtByASourceToRecipient(sources, _) => (
+        E::CombatDamageWouldBeDealtByCreatureToARecipient(perm, recipients) => (
+            PreventionScope::CombatDamage,
+            Some(convert_permanent(perm)?),
+            damage_recipients_list_to_prevent_target(recipients)?,
+        ),
+        E::CombatDamageWouldBeDealtByCreatureToRecipient(perm, recipient) => (
+            PreventionScope::CombatDamage,
+            Some(convert_permanent(perm)?),
+            single_damage_recipient_to_prevent_target(recipient)?,
+        ),
+        E::DamageWouldBeDealtToARecipient(recipients) => (
+            PreventionScope::AllDamage,
+            None,
+            damage_recipients_list_to_prevent_target(recipients)?,
+        ),
+        E::DamageWouldBeDealtToRecipient(recipient) => (
+            PreventionScope::AllDamage,
+            None,
+            single_damage_recipient_to_prevent_target(recipient)?,
+        ),
+        E::DamageWouldBeDealtByAPermanent(perms) => (
+            PreventionScope::AllDamage,
+            Some(convert_permanents(perms)?),
+            TargetFilter::Any,
+        ),
+        E::DamageWouldBeDealtByAPermanentToARecipient(perms, recipients) => (
+            PreventionScope::AllDamage,
+            Some(convert_permanents(perms)?),
+            damage_recipients_list_to_prevent_target(recipients)?,
+        ),
+        E::DamageWouldBeDealtByAPermanentToRecipient(perms, recipient) => (
+            PreventionScope::AllDamage,
+            Some(convert_permanents(perms)?),
+            single_damage_recipient_to_prevent_target(recipient)?,
+        ),
+        E::DamageWouldBeDealtByASource(sources) => (
             PreventionScope::AllDamage,
             Some(damage_sources_to_filter(sources)?),
+            TargetFilter::Any,
         ),
-        E::DamageWouldBeDealtBySource(source)
-        | E::DamageWouldBeDealtBySourceToRecipient(source, _) => (
+        E::DamageWouldBeDealtByASourceToARecipient(sources, recipients) => (
+            PreventionScope::AllDamage,
+            Some(damage_sources_to_filter(sources)?),
+            damage_recipients_list_to_prevent_target(recipients)?,
+        ),
+        E::DamageWouldBeDealtByASourceToRecipient(sources, recipient) => (
+            PreventionScope::AllDamage,
+            Some(damage_sources_to_filter(sources)?),
+            single_damage_recipient_to_prevent_target(recipient)?,
+        ),
+        E::DamageWouldBeDealtBySource(source) => (
             PreventionScope::AllDamage,
             Some(single_damage_source_to_filter(source)),
+            TargetFilter::Any,
+        ),
+        E::DamageWouldBeDealtBySourceToRecipient(source, recipient) => (
+            PreventionScope::AllDamage,
+            Some(single_damage_source_to_filter(source)),
+            single_damage_recipient_to_prevent_target(recipient)?,
+        ),
+        E::NoncombatDamageWouldBeDealtToARecipient(recipients) => (
+            PreventionScope::AllDamage,
+            None,
+            damage_recipients_list_to_prevent_target(recipients)?,
+        ),
+        E::NoncombatDamageWouldBeDealtToRecipient(recipient) => (
+            PreventionScope::AllDamage,
+            None,
+            single_damage_recipient_to_prevent_target(recipient)?,
+        ),
+        E::NoncombatDamageWouldBeDealtByASourceToARecipient(sources, recipients) => (
+            PreventionScope::AllDamage,
+            Some(damage_sources_to_filter(sources)?),
+            damage_recipients_list_to_prevent_target(recipients)?,
         ),
         // CR 614.x: `Or` over a list of inner events — the engine has no
         // OR slot on `Effect::PreventDamage`. Strict-fail (rather than
@@ -2984,6 +3109,50 @@ mod tests {
                 decline: Some(decline),
             } if matches!(&*decline.effect, Effect::Tap { target } if *target == TargetFilter::SelfRef)
         ));
+    }
+
+    #[test]
+    fn pack_leader_prevent_damage_scopes_to_dogs_you_control() {
+        use engine::types::ability::{ControllerRef, PreventionAmount, PreventionScope, TypeFilter};
+        use crate::schema::types::{
+            CreatureType, DamageRecipientsList, ReplacableEventWouldDealDamage,
+        };
+
+        let effect = convert_create_replace_would_deal_damage_until(
+            &ReplacableEventWouldDealDamage::CombatDamageWouldBeDealtToARecipient(
+                DamageRecipientsList::APermanent(Box::new(Permanents::And(vec![
+                    Permanents::IsCreatureType(CreatureType::Dog),
+                    Permanents::ControlledByAPlayer(Box::new(Players::SinglePlayer(Box::new(
+                        Player::You,
+                    )))),
+                ]))),
+            ),
+            &[ReplacementActionWouldDealDamage::PreventThatDamage],
+            &Expiration::UntilEndOfTurn,
+        )
+        .unwrap();
+
+        let Effect::PreventDamage {
+            amount,
+            target,
+            scope,
+            damage_source_filter,
+            ..
+        } = effect
+        else {
+            panic!("expected PreventDamage, got {effect:?}");
+        };
+        assert_eq!(amount, PreventionAmount::All);
+        assert_eq!(scope, PreventionScope::CombatDamage);
+        assert!(damage_source_filter.is_none());
+        assert_eq!(
+            target,
+            TargetFilter::Typed(
+                TypedFilter::creature()
+                    .with_type(TypeFilter::Subtype("Dog".into()))
+                    .controller(ControllerRef::You)
+            )
+        );
     }
 
     #[test]

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -2777,9 +2777,9 @@ fn damage_recipients_list_to_prevent_target(
         }
         R::APlayerOrAPermanent(players, perms) => TargetFilter::Or {
             filters: vec![
-                TargetFilter::Typed(TypedFilter::default().controller(players_to_controller(
-                    players,
-                )?)),
+                TargetFilter::Typed(
+                    TypedFilter::default().controller(players_to_controller(players)?),
+                ),
                 convert_permanents(perms)?,
             ],
         },
@@ -2796,9 +2796,9 @@ fn single_damage_recipient_to_prevent_target(
         SingleDamageRecipient::Permanent(p) => convert_permanent(p)?,
         SingleDamageRecipient::Player(p) => match &**p {
             Player::You => TargetFilter::Controller,
-            other => TargetFilter::Typed(
-                TypedFilter::default().controller(player_to_controller(other)?),
-            ),
+            other => {
+                TargetFilter::Typed(TypedFilter::default().controller(player_to_controller(other)?))
+            }
         },
         _ => TargetFilter::Any,
     })
@@ -3113,9 +3113,11 @@ mod tests {
 
     #[test]
     fn pack_leader_prevent_damage_scopes_to_dogs_you_control() {
-        use engine::types::ability::{ControllerRef, PreventionAmount, PreventionScope, TypeFilter};
         use crate::schema::types::{
             CreatureType, DamageRecipientsList, ReplacableEventWouldDealDamage,
+        };
+        use engine::types::ability::{
+            ControllerRef, PreventionAmount, PreventionScope, TypeFilter,
         };
 
         let effect = convert_create_replace_would_deal_damage_until(

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -2771,37 +2771,59 @@ fn damage_recipients_list_to_prevent_target(
     use DamageRecipientsList as R;
     Ok(match recipients {
         R::APermanent(perms) => convert_permanents(perms)?,
-        R::APlayer(players) => {
-            let ctrl = players_to_controller(players)?;
-            TargetFilter::Typed(TypedFilter::default().controller(ctrl))
+        R::APlayer(players) => players_to_prevent_target(players)?,
+        R::APlayerOrAPermanent(_, _) => {
+            return Err(ConversionGap::EnginePrerequisiteMissing {
+                engine_type: "Effect::PreventDamage::target",
+                needed_variant: "combined player-plus-permanent damage recipient".into(),
+            });
         }
-        R::APlayerOrAPermanent(players, perms) => TargetFilter::Or {
-            filters: vec![
-                TargetFilter::Typed(
-                    TypedFilter::default().controller(players_to_controller(players)?),
-                ),
-                convert_permanents(perms)?,
-            ],
-        },
     })
 }
 
+fn players_to_prevent_target(players: &Players) -> ConvResult<TargetFilter> {
+    match players {
+        Players::SinglePlayer(player) => player_to_prevent_target(player),
+        // CR 614.1a: "a player" is a damage-recipient class, not an object
+        // controller filter. `prevent_damage::resolve` maps `TargetFilter::Player`
+        // to `DamageTargetPlayerScope::Any` when no target slot is present.
+        Players::AnyPlayer => Ok(TargetFilter::Player),
+        other => Err(ConversionGap::EnginePrerequisiteMissing {
+            engine_type: "Effect::PreventDamage::target",
+            needed_variant: format!("player damage recipient {other:?}"),
+        }),
+    }
+}
+
+fn player_to_prevent_target(player: &Player) -> ConvResult<TargetFilter> {
+    match player {
+        Player::You | Player::HostPlayer | Player::HostController | Player::SelfPlayer => {
+            Ok(TargetFilter::Controller)
+        }
+        Player::Ref_TargetPlayer
+        | Player::Ref_TargetPlayer1
+        | Player::Ref_TargetPlayer2
+        | Player::Ref_TargetPlayer3 => Ok(TargetFilter::Player),
+        other => Err(ConversionGap::EnginePrerequisiteMissing {
+            engine_type: "Effect::PreventDamage::target",
+            needed_variant: format!("player damage recipient {other:?}"),
+        }),
+    }
+}
+
 /// CR 614.2: Map a `SingleDamageRecipient` onto the `Effect::PreventDamage`
-/// recipient axis. Unrecognised shapes leave `Any` so the shield still
-/// prevents broadly rather than strict-failing the whole card.
+/// recipient axis.
 fn single_damage_recipient_to_prevent_target(
     recipient: &SingleDamageRecipient,
 ) -> ConvResult<TargetFilter> {
-    Ok(match recipient {
-        SingleDamageRecipient::Permanent(p) => convert_permanent(p)?,
-        SingleDamageRecipient::Player(p) => match &**p {
-            Player::You => TargetFilter::Controller,
-            other => {
-                TargetFilter::Typed(TypedFilter::default().controller(player_to_controller(other)?))
-            }
-        },
-        _ => TargetFilter::Any,
-    })
+    match recipient {
+        SingleDamageRecipient::Permanent(p) => convert_permanent(p),
+        SingleDamageRecipient::Player(p) => player_to_prevent_target(p),
+        other => Err(ConversionGap::EnginePrerequisiteMissing {
+            engine_type: "Effect::PreventDamage::target",
+            needed_variant: format!("SingleDamageRecipient::{other:?}"),
+        }),
+    }
 }
 
 /// CR 615 + CR 614.1a: Decompose a `ReplacableEventWouldDealDamage` into
@@ -3155,6 +3177,61 @@ mod tests {
                     .controller(ControllerRef::You)
             )
         );
+    }
+
+    #[test]
+    fn player_damage_recipient_maps_to_player_target_filter() {
+        use crate::schema::types::DamageRecipientsList;
+
+        assert_eq!(
+            damage_recipients_list_to_prevent_target(&DamageRecipientsList::APlayer(Box::new(
+                Players::AnyPlayer
+            )))
+            .unwrap(),
+            TargetFilter::Player
+        );
+        assert_eq!(
+            damage_recipients_list_to_prevent_target(&DamageRecipientsList::APlayer(Box::new(
+                Players::SinglePlayer(Box::new(Player::You))
+            )))
+            .unwrap(),
+            TargetFilter::Controller
+        );
+    }
+
+    #[test]
+    fn mixed_player_or_permanent_damage_recipient_strict_fails() {
+        use crate::schema::types::DamageRecipientsList;
+
+        let err =
+            damage_recipients_list_to_prevent_target(&DamageRecipientsList::APlayerOrAPermanent(
+                Box::new(Players::AnyPlayer),
+                Box::new(Permanents::AnyPermanent),
+            ))
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ConversionGap::EnginePrerequisiteMissing {
+                engine_type: "Effect::PreventDamage::target",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn unrecognized_single_damage_recipient_strict_fails() {
+        let err =
+            single_damage_recipient_to_prevent_target(&SingleDamageRecipient::DistributedAnyTarget)
+                .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ConversionGap::EnginePrerequisiteMissing {
+                engine_type: "Effect::PreventDamage::target",
+                ..
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes [#2437](https://github.com/phase-rs/phase/issues/2437): Pack Leader’s attack trigger was preventing **all** combat damage instead of only combat damage dealt to **Dogs you control**.
- **mtgish-import:** `convert_create_replace_would_deal_damage_until` now extracts damage recipients from prevention events (`CombatDamageWouldBeDealtToARecipient`, etc.) and sets `Effect::PreventDamage.target` accordingly.
- **engine:** `prevent_damage::resolve` routes typed permanent recipient filters (e.g. Dog + controller You) through the prevention shield’s `valid_card` slot, matching the existing Losheel-style scoped-prevention pattern.

## Test plan

- [x] `cargo test -p mtgish-import --lib pack_leader_prevent_damage_scopes`
- [x] `cargo test -p engine --lib typed_recipient_prevention_only_blocks`
- [ ] Manual: Pack Leader attacks → Dogs you control take no combat damage; other creatures still take combat damage normally