### PR TITLE
fix(frontend): make Choose X range slider interactive on first show

### DIFF
--- a/client/src/components/hand/MobileHandDrawer.tsx
+++ b/client/src/components/hand/MobileHandDrawer.tsx
@@ -41,7 +41,12 @@ export function MobileHandDrawer() {
   });
 
   useEffect(() => {
-    if (waitingForType === "TargetSelection" || waitingForType === "TriggerTargetSelection") {
+    if (
+      waitingForType === "TargetSelection"
+      || waitingForType === "TriggerTargetSelection"
+      || waitingForType === "ChooseXValue"
+      || waitingForType === "PayAmountChoice"
+    ) {
       setOpen(false);
     }
   }, [waitingForType, setOpen]);

--- a/client/src/components/mana/ChooseXValueUI.tsx
+++ b/client/src/components/mana/ChooseXValueUI.tsx
@@ -65,13 +65,16 @@ export function ChooseXValueUI() {
   return (
     <AnimatePresence>
       <motion.div
-        className="fixed inset-x-0 bottom-0 z-40 flex justify-center pb-4"
+        className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center pb-4"
         initial={{ y: 80, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         exit={{ y: 80, opacity: 0 }}
         transition={{ duration: 0.25 }}
       >
-        <div className="rounded-xl bg-gray-900/95 p-4 shadow-2xl ring-1 ring-gray-700 min-w-[320px] max-w-[420px]">
+        {/* Re-enable events on the panel: when DialogHost is click-through
+            (peeked convoke payment) or `pointer-events: none`, the strip must
+            opt back in — same contract as ManaPaymentUI (CR 702.51a). */}
+        <div className="pointer-events-auto rounded-xl bg-gray-900/95 p-4 shadow-2xl ring-1 ring-gray-700 min-w-[320px] max-w-[420px]">
           <h3 className="mb-3 text-center text-sm font-semibold text-gray-300">
             {t("mana.chooseXTitle")}
             {cardName && (

--- a/client/src/components/mana/PayAmountChoiceUI.tsx
+++ b/client/src/components/mana/PayAmountChoiceUI.tsx
@@ -47,13 +47,13 @@ export function PayAmountChoiceUI() {
   return (
     <AnimatePresence>
       <motion.div
-        className="fixed inset-x-0 bottom-0 z-40 flex justify-center pb-4"
+        className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center pb-4"
         initial={{ y: 80, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         exit={{ y: 80, opacity: 0 }}
         transition={{ duration: 0.25 }}
       >
-        <div className="min-w-[320px] max-w-[420px] rounded-xl bg-gray-900/95 p-4 shadow-2xl ring-1 ring-gray-700">
+        <div className="pointer-events-auto min-w-[320px] max-w-[420px] rounded-xl bg-gray-900/95 p-4 shadow-2xl ring-1 ring-gray-700">
           <h3 className="mb-3 text-center text-sm font-semibold text-gray-300">
             {t("mana.chooseAmountTitle")}
             {sourceName && (

--- a/client/src/components/mana/__tests__/ChooseXValueUI.test.tsx
+++ b/client/src/components/mana/__tests__/ChooseXValueUI.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { ChooseXValueUI } from "../ChooseXValueUI";
+import { DialogHost } from "../../modal/DialogHost.tsx";
 import { useGameStore } from "../../../stores/gameStore";
 import type { GameState, PendingCast, WaitingFor } from "../../../adapter/types";
 
@@ -198,5 +199,32 @@ describe("ChooseXValueUI", () => {
 
     const { container } = render(<ChooseXValueUI />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("range slider accepts input when mounted inside DialogHost (#2427)", () => {
+    const dispatch = vi.fn().mockResolvedValue([]);
+    const waitingFor = chooseXWaitingFor(5);
+
+    act(() => {
+      useGameStore.setState({
+        gameState: createGameState({
+          turn_decision_controller: 0,
+          active_player: 0,
+          waiting_for: waitingFor,
+        }),
+        waitingFor,
+        dispatch,
+      });
+    });
+
+    render(
+      <DialogHost>
+        <ChooseXValueUI />
+      </DialogHost>,
+    );
+
+    const slider = screen.getByLabelText("Choose X value") as HTMLInputElement;
+    fireEvent.change(slider, { target: { value: "4" } });
+    expect(screen.getByRole("button", { name: "Confirm X = 4" })).toBeInTheDocument();
   });
 });

--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -160,11 +160,16 @@ export function DialogHost({ children }: { children: ReactNode }) {
   // right (mirrors the stack panel — established muscle memory). On narrow
   // viewports it slides down (more reachable on phones).
   const isNarrow = useIsNarrowViewport();
+  // Only apply the peek slide transform while peeked. Framer-motion keeps a
+  // residual `transform` (even at `{ x: 0, y: 0 }`) whenever `animate` is set,
+  // which breaks `<input type="range">` hit-testing in bottom-anchored panels
+  // such as ChooseXValueUI — the slider looks fine but ignores drags until
+  // something else reflows the tree (issue #2427).
   const slideTransform = peeked
     ? isNarrow
       ? { x: 0, y: "calc(100vh - 64px)" }
       : { x: "calc(100vw - 32px)", y: 0 }
-    : { x: 0, y: 0 };
+    : undefined;
 
   return (
     <DialogPeekCtx.Provider value={ctxValue}>
@@ -183,7 +188,7 @@ export function DialogHost({ children }: { children: ReactNode }) {
             ? { pointerEvents: clickThrough || peeked ? "none" : undefined }
             : undefined
         }
-        animate={peekable ? slideTransform : undefined}
+        animate={peekable && peeked ? slideTransform : undefined}
         transition={
           shouldReduceMotion
             ? { duration: 0 }

--- a/client/src/components/modal/__tests__/DialogHost.test.tsx
+++ b/client/src/components/modal/__tests__/DialogHost.test.tsx
@@ -172,4 +172,18 @@ describe("DialogHost", () => {
     });
     expect(screen.queryByLabelText("Restore dialog")).not.toBeInTheDocument();
   });
+
+  it("does not apply a peek slide transform while the dialog is visible but un-peeked (#2427)", () => {
+    // Framer-motion keeps a residual CSS transform whenever `animate` is set —
+    // even at `{ x: 0, y: 0 }` — which breaks range inputs in bottom panels.
+    // The slide transform must only be active while `peeked` is true.
+    setWaitingFor({ type: "ChooseXValue", data: { player: 0, max: 3 } } as never);
+    const { container } = render(
+      <DialogHost>
+        <div data-testid="child" />
+      </DialogHost>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    expect(wrapper?.style.transform ?? "").toBe("");
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes [#2427](https://github.com/phase-rs/phase/issues/2427): the X-value slider in the mana/Choose X payment panel was unresponsive until clicking elsewhere on the board.
- Root cause: `DialogHost` always set Framer Motion `animate` for peekable prompts (even at `{ x: 0, y: 0 }`), leaving a residual CSS `transform` on the host. `<input type="range">` inside transformed ancestors often fails hit-testing in browsers.
- Only apply the peek slide transform when the dialog is actually peeked.
- Align `ChooseXValueUI` and `PayAmountChoiceUI` with `ManaPaymentUI`'s `pointer-events-none` strip + `pointer-events-auto` panel pattern so controls stay clickable under click-through hosts.
- Close the mobile hand drawer when entering `ChooseXValue` or `PayAmountChoice`.

## Test plan

- [ ] Cast a spell with `{X}` in the cost (e.g. Chord of Calling) and confirm the X slider responds immediately without clicking the board first.
- [ ] Confirm Confirm/Cancel buttons still work on the Choose X panel.
- [ ] On mobile, verify the hand drawer closes when Choose X appears.
- [ ] Peek a centered dialog, restore it, and confirm peek slide still works.
- [ ] Convoke/improvise mana payment: panel controls and board taps still work.
- [x] `pnpm exec vitest run src/components/modal/__tests__/DialogHost.test.tsx src/components/mana/__tests__/ChooseXValueUI.test.tsx`