### PR TITLE
feat(engine): implement Absorb keyword — self damage prevention (CR 702.64a)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -21170,11 +21170,68 @@ mod absorb_synthesis_tests {
     //! for free from `Minus`; CR 702.64c (each instance separate) is one
     //! replacement per instance.
     use super::*;
+    use crate::game::effects::deal_damage;
+    use crate::game::printed_cards::apply_card_face_to_object;
+    use crate::game::zones::create_object;
+    use crate::types::ability::{ResolvedAbility, TargetRef};
+    use crate::types::game_state::GameState;
+    use crate::types::identifiers::CardId;
+    use crate::types::player::PlayerId;
 
     fn absorb_face(n: u32) -> CardFace {
         let mut face = CardFace::default();
         face.keywords.push(Keyword::Absorb(n));
         face
+    }
+
+    fn absorb_creature_face(name: &str, keywords: Vec<Keyword>) -> CardFace {
+        let mut face = CardFace {
+            name: name.to_string(),
+            power: Some(PtValue::Fixed(3)),
+            toughness: Some(PtValue::Fixed(3)),
+            keywords,
+            ..CardFace::default()
+        };
+        face.card_type.core_types.push(CoreType::Creature);
+        synthesize_all(&mut face);
+        face
+    }
+
+    fn marked_damage_after_absorb_damage(keywords: Vec<Keyword>, damage: u32) -> u32 {
+        let face = absorb_creature_face("Absorb Test", keywords);
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Damage Source".to_string(),
+            Zone::Battlefield,
+        );
+        let target = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            face.name.clone(),
+            Zone::Battlefield,
+        );
+        apply_card_face_to_object(state.objects.get_mut(&target).unwrap(), &face);
+
+        let ability = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed {
+                    value: damage as i32,
+                },
+                target: TargetFilter::Any,
+                damage_source: None,
+            },
+            vec![TargetRef::Object(target)],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        deal_damage::resolve(&mut state, &ability, &mut events).unwrap();
+
+        state.objects[&target].damage_marked
     }
 
     #[test]
@@ -21241,5 +21298,23 @@ mod absorb_synthesis_tests {
             .replacements
             .iter()
             .all(|r| !is_absorb_replacement(r, 1)));
+    }
+
+    #[test]
+    fn absorb_runtime_prevents_damage_to_absorb_creature() {
+        assert_eq!(
+            marked_damage_after_absorb_damage(vec![Keyword::Absorb(2)], 5),
+            3,
+            "CR 702.64a: Absorb 2 prevents 2 damage from the event"
+        );
+    }
+
+    #[test]
+    fn absorb_runtime_applies_multiple_instances_separately() {
+        assert_eq!(
+            marked_damage_after_absorb_damage(vec![Keyword::Absorb(1), Keyword::Absorb(1)], 3),
+            1,
+            "CR 702.64c: two Absorb 1 instances each prevent 1 damage"
+        );
     }
 }

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -12,13 +12,14 @@ use crate::types::ability::{
     ActivationRestriction, AdditionalCost, AdditionalCostPaymentSource, AggregateFunction,
     AttackScope, AttackSubject, CardPlayMode, CastFromZoneDriver, CastManaObjectScope,
     CastManaSpentMetric, CastVariantPaid, ChoiceType, Comparator, ContinuousModification,
-    ControllerRef, CopyRetargetPermission, CounterTriggerFilter, DamageKindFilter, Duration,
-    Effect, FilterProp, KickerVariant, ManaContribution, ManaProduction, ModalSelectionCondition,
-    ModalSelectionConstraint, NinjutsuVariant, ObjectScope, ParsedCondition, PaymentCost,
-    PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
-    ReplacementCondition, ReplacementDefinition, RuntimeHandler, SearchSelectionConstraint,
-    StaticCondition, StaticDefinition, TargetChoiceTiming, TargetFilter, TriggerCondition,
-    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
+    ControllerRef, CopyRetargetPermission, CounterTriggerFilter, DamageKindFilter,
+    DamageModification, Duration, Effect, FilterProp, KickerVariant, ManaContribution,
+    ManaProduction, ModalSelectionCondition, ModalSelectionConstraint, NinjutsuVariant,
+    ObjectScope, ParsedCondition, PaymentCost, PlayerFilter, PlayerScope, PtStat, PtValue,
+    PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition,
+    RuntimeHandler, SearchSelectionConstraint, StaticCondition, StaticDefinition,
+    TargetChoiceTiming, TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
+    UnlessPayModifier,
 };
 use crate::types::card::{CardFace, CardLayout, CleaveVariant};
 use crate::types::card_type::{CardType, CoreType, Supertype};
@@ -2676,6 +2677,67 @@ pub fn synthesize_riot(face: &mut CardFace) {
         .collect();
     for filter in static_grants {
         add_riot_replacements(face, filter, 1);
+    }
+}
+
+/// CR 702.64a: Absorb N — "If a source would deal damage to this creature,
+/// prevent N of that damage." A continuous, self-recipient damage replacement:
+/// `DamageModification::Minus { value: N }` saturating-subtracts N from each
+/// damage event whose recipient is this creature (`valid_card: SelfRef`). It is
+/// NOT a consumed shield, so it re-applies to every source and every event
+/// independently (CR 702.64b). No new variant — mirrors the continuous
+/// damage-prevention statics (Benevolent Unicorn class) and the self-scoped
+/// `valid_card(SelfRef)` damage replacements (persistent prevention shields).
+fn build_absorb_replacement(n: u32) -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::DamageDone)
+        .valid_card(TargetFilter::SelfRef)
+        .damage_modification(DamageModification::Minus { value: n })
+        .description(format!(
+            "CR 702.64a: Absorb {n} — if a source would deal damage to this creature, \
+             prevent {n} of that damage."
+        ))
+}
+
+/// CR 702.64a: Identity predicate for an Absorb `n` replacement — a self-recipient
+/// `DamageDone` replacement that subtracts `n` from the damage. Parameterized by
+/// `n` for count-based idempotency and so a granted-then-removed Absorb strips
+/// exactly its own replacement.
+fn is_absorb_replacement(r: &ReplacementDefinition, n: u32) -> bool {
+    matches!(r.event, ReplacementEvent::DamageDone)
+        && matches!(r.valid_card, Some(TargetFilter::SelfRef))
+        && matches!(
+            r.damage_modification,
+            Some(DamageModification::Minus { value }) if value == n
+        )
+}
+
+/// CR 702.64a/c: Synthesize Absorb into a continuous self-recipient damage
+/// replacement. CR 702.64c: multiple instances apply separately, so one
+/// replacement is installed per `Keyword::Absorb` instance (grouped by N).
+///
+/// Build-for-the-class: keyed entirely on `Keyword::Absorb(n)`, so every printed
+/// Absorb creature and every creature granted Absorb at runtime gets identical
+/// prevention. Idempotent across repeated invocations via per-N count matching
+/// (mirrors `add_riot_replacements`).
+pub fn synthesize_absorb(face: &mut CardFace) {
+    let mut counts: Vec<(u32, usize)> = Vec::new();
+    for kw in &face.keywords {
+        if let Keyword::Absorb(n) = kw {
+            match counts.iter_mut().find(|(value, _)| value == n) {
+                Some((_, c)) => *c += 1,
+                None => counts.push((*n, 1)),
+            }
+        }
+    }
+    for (n, desired) in counts {
+        let existing = face
+            .replacements
+            .iter()
+            .filter(|r| is_absorb_replacement(r, n))
+            .count();
+        for _ in existing..desired {
+            face.replacements.push(build_absorb_replacement(n));
+        }
     }
 }
 
@@ -7389,6 +7451,9 @@ pub fn synthesize_all(face: &mut CardFace) {
     // haste. Static grants of Riot synthesize matching ETB replacements from
     // their affected filters.
     synthesize_riot(face);
+    // CR 702.64a: Absorb N — continuous self-recipient damage replacement that
+    // prevents N from each source each time.
+    synthesize_absorb(face);
     // CR 702.98a: Unleash — optional ETB +1/+1 counter plus a "can't block while
     // it has a +1/+1 counter" static. Sibling of Riot's optional-counter shape.
     synthesize_unleash(face);
@@ -21092,5 +21157,89 @@ mod champion_runtime_tests {
                 .any(|link| { link.source_id == champion_id && link.exiled_id == elf_id }),
             "Champion LTB return should consume the source-tracked exile link"
         );
+    }
+}
+
+#[cfg(test)]
+mod absorb_synthesis_tests {
+    //! CR 702.64a shape tests: Absorb was parsed/typed but had no runtime.
+    //! `synthesize_absorb` installs a continuous self-recipient `DamageDone`
+    //! replacement that subtracts N from each incoming damage event
+    //! (`DamageModification::Minus { value: N }`, `valid_card: SelfRef`). The
+    //! continuous, non-consumed, per-source/per-event semantics (CR 702.64b) come
+    //! for free from `Minus`; CR 702.64c (each instance separate) is one
+    //! replacement per instance.
+    use super::*;
+
+    fn absorb_face(n: u32) -> CardFace {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Absorb(n));
+        face
+    }
+
+    #[test]
+    fn absorb_synthesizes_self_damage_prevention() {
+        let mut face = absorb_face(2);
+        synthesize_absorb(&mut face);
+        let r = face
+            .replacements
+            .iter()
+            .find(|r| is_absorb_replacement(r, 2))
+            .expect("Absorb should add a self-recipient damage replacement");
+        assert!(matches!(r.event, ReplacementEvent::DamageDone));
+        assert!(
+            matches!(r.valid_card, Some(TargetFilter::SelfRef)),
+            "CR 702.64a: only damage to THIS creature is prevented"
+        );
+        assert!(
+            matches!(
+                r.damage_modification,
+                Some(DamageModification::Minus { value: 2 })
+            ),
+            "CR 702.64a: prevent N (=2) of the damage"
+        );
+    }
+
+    #[test]
+    fn absorb_is_idempotent() {
+        let mut face = absorb_face(1);
+        synthesize_absorb(&mut face);
+        synthesize_absorb(&mut face);
+        assert_eq!(
+            face.replacements
+                .iter()
+                .filter(|r| is_absorb_replacement(r, 1))
+                .count(),
+            1,
+            "repeated synthesis must not duplicate the Absorb replacement"
+        );
+    }
+
+    #[test]
+    fn absorb_multiple_instances_apply_separately() {
+        // CR 702.64c: two instances of Absorb 1 prevent 1 each (2 total per source).
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Absorb(1));
+        face.keywords.push(Keyword::Absorb(1));
+        synthesize_absorb(&mut face);
+        assert_eq!(
+            face.replacements
+                .iter()
+                .filter(|r| is_absorb_replacement(r, 1))
+                .count(),
+            2,
+            "CR 702.64c: each Absorb instance installs its own prevention replacement"
+        );
+    }
+
+    #[test]
+    fn absorb_noop_without_keyword() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Flying);
+        synthesize_absorb(&mut face);
+        assert!(face
+            .replacements
+            .iter()
+            .all(|r| !is_absorb_replacement(r, 1)));
     }
 }


### PR DESCRIPTION
## Summary
Closes #2497

Implements the **Absorb** keyword (CR 702.64a), which was parsed/typed but had no runtime — there was no `synthesize_*` pass, so its damage-prevention static did nothing. Composes existing building blocks — **no new variants**.

## CR semantics (702.64a/b/c)
- **702.64a**: If a source would deal damage to this creature, prevent N of that damage.
- **702.64b**: Prevents only N from any one source at any one time; applies separately to other sources and to the same source at a different time (continuous, not a consumed shield).
- **702.64c**: Multiple instances each apply separately.

## Design (reuse, no new variants)
- New `synthesize_absorb` pass (registered in `synthesize_all`) installs a continuous self-recipient damage replacement: `ReplacementDefinition::new(ReplacementEvent::DamageDone).valid_card(TargetFilter::SelfRef).damage_modification(DamageModification::Minus { value: N })`.
- `valid_card(SelfRef)` scopes the replacement to damage whose **recipient** is this creature — the same self-recipient mechanism the persistent prevention shields use.
- `DamageModification::Minus { value: N }` saturating-subtracts N per event and is **not** consumed, so it re-applies to every source and every event (CR 702.64b) — distinct from `PreventionAmount::Next(N)` (a one-shot consumed shield).
- CR 702.64c: one replacement is installed per `Keyword::Absorb` instance (grouped by N, with count-based idempotency mirroring `add_riot_replacements`).

## Files changed
- `crates/engine/src/database/synthesis.rs` (`synthesize_absorb` + `build_absorb_replacement` + `is_absorb_replacement` + `synthesize_all` registration + 4 tests)

## CR references
- CR 702.64a/b/c (Absorb), CR 615 / CR 614.1a (damage prevention/replacement) — verified against `docs/MagicCompRules.txt`.

## Track
Developer

## LLM
Model: claude-opus-4-8

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine --lib` — clean (no warnings)
- `cargo test -p engine --lib` — full lib suite **10550 passed / 0 failed**; 4 new tests: replacement shape (DamageDone + SelfRef + Minus{N}), idempotency, multi-instance separateness (CR 702.64c → 2 replacements for 2 instances), no-op without the keyword.
- Keyword runtime is not measurable by `cargo coverage`, so verification is shape-based; the underlying `Minus` damage-replacement + `valid_card(SelfRef)` self-recipient scoping are already exercised by existing replacement tests.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
