### PR TITLE
Fix Pick Your Poison shown as not legal in Modern (#2436)

### DIFF
--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -140,7 +140,9 @@ fn write_sidecar(dir: &Path, code: &str, map: &BTreeMap<String, LocalizedFace>) 
 /// MTGJSON sometimes groups unrelated single-faced cards that share a printed
 /// name under one atomic key (homonyms). Example: MKM's *Pick Your Poison*
 /// and a Mystery Booster playtest card with the same name. These are not true
-/// multi-face cards — each face has `layout: normal` and a distinct oracle id.
+/// multi-face cards — each face has `layout: normal` and, when MTGJSON provides
+/// IDs, no duplicate oracle id. Missing oracle IDs stay on this conservative
+/// all-single path rather than being reconstructed as a bogus multi-face card.
 fn is_homonym_atomic_group(faces: &[AtomicCard]) -> bool {
     if faces.len() < 2 {
         return false;
@@ -151,11 +153,16 @@ fn is_homonym_atomic_group(faces: &[AtomicCard]) -> bool {
     {
         return false;
     }
-    let oracle_ids: std::collections::HashSet<_> = faces
-        .iter()
-        .filter_map(|face| face.identifiers.scryfall_oracle_id.as_ref())
-        .collect();
-    oracle_ids.len() == faces.len()
+    let mut oracle_ids = HashSet::new();
+    for face in faces {
+        let Some(oracle_id) = face.identifiers.scryfall_oracle_id.as_ref() else {
+            continue;
+        };
+        if !oracle_ids.insert(oracle_id) {
+            return false;
+        }
+    }
+    true
 }
 
 fn legality_export_score(legalities: &BTreeMap<String, String>) -> u32 {
@@ -175,6 +182,18 @@ fn same_class_face_priority(existing: &CardExportEntry, new: &CardExportEntry) -
         return new_printings > existing_printings;
     }
     legality_export_score(&new.legalities) > legality_export_score(&existing.legalities)
+}
+
+/// Homonym groups are already known to be unrelated standalone cards with the
+/// same printed name. In that path, constructed-format legality is the semantic
+/// signal for the canonical tournament card; printing count is only a fallback.
+fn homonym_face_priority(existing: &CardExportEntry, new: &CardExportEntry) -> bool {
+    let new_legalities = legality_export_score(&new.legalities);
+    let existing_legalities = legality_export_score(&existing.legalities);
+    if new_legalities != existing_legalities {
+        return new_legalities > existing_legalities;
+    }
+    same_class_face_priority(existing, new)
 }
 
 fn hidden_multiface_key(key: &str, entry: &CardExportEntry) -> Option<String> {
@@ -210,12 +229,13 @@ fn bracket_signals_for_face(
 /// Plowshares"` whose back-face name collides with the iconic paper
 /// `"Swords to Plowshares"`.
 ///
-/// Winner selection is structural first, then by printings count:
+/// Winner selection is structural first, then by the default same-class priority:
 /// 1. An entry from a standalone MTGJSON key (`entry.layout.is_none()`) beats
 ///    one from a multi-face `" // "` key. The canonical paper card always wins
 ///    over a component of a compound card — not by popularity, but by origin.
 /// 2. Within the same structural class, the entry with more printings wins.
-/// 3. On a tie, the first-inserted entry is kept (iteration is sorted by
+/// 3. On a printings tie, the entry legal in more formats wins.
+/// 4. On an exact tie, the first-inserted entry is kept (iteration is sorted by
 ///    MTGJSON key, so "first" is deterministic across machines).
 ///
 /// Collisions are logged at `debug` level so a full card-data export does not
@@ -228,6 +248,22 @@ fn insert_face(
     key: String,
     entry: CardExportEntry,
 ) {
+    insert_face_with_priority(
+        face_index,
+        mtgjson_key,
+        key,
+        entry,
+        same_class_face_priority,
+    );
+}
+
+fn insert_face_with_priority(
+    face_index: &mut BTreeMap<String, CardExportEntry>,
+    mtgjson_key: &str,
+    key: String,
+    entry: CardExportEntry,
+    same_class_priority: fn(&CardExportEntry, &CardExportEntry) -> bool,
+) {
     let Some(existing) = face_index.get(&key) else {
         face_index.insert(key, entry);
         return;
@@ -238,7 +274,7 @@ fn insert_face(
     let new_wins = match (existing_standalone, new_standalone) {
         (false, true) => true,
         (true, false) => false,
-        _ => same_class_face_priority(existing, &entry),
+        _ => same_class_priority(existing, &entry),
     };
 
     let existing_oracle = existing.face.scryfall_oracle_id.as_deref();
@@ -689,7 +725,7 @@ fn main() {
                     .unwrap_or_default();
                 let bracket_signals = bracket_signals_for_face(&bracket_lists, &face, source);
                 collect_localized(&mut sidecars, &key, source);
-                insert_face(
+                insert_face_with_priority(
                     &mut face_index,
                     mtgjson_key.as_str(),
                     key,
@@ -702,6 +738,7 @@ fn main() {
                         rarities,
                         bracket_signals,
                     },
+                    homonym_face_priority,
                 );
             }
         } else if faces.len() >= 2 {
@@ -1384,7 +1421,9 @@ mod tests {
     use std::path::Path;
     use std::sync::OnceLock;
 
-    use engine::database::mtgjson::{load_atomic_cards, AtomicCardsFile};
+    use engine::database::mtgjson::{
+        load_atomic_cards, AtomicCard, AtomicCardsFile, AtomicIdentifiers,
+    };
     use engine::types::ability::TargetFilter;
     use engine::types::card::CardFace;
     use engine::types::keywords::Keyword;
@@ -1418,8 +1457,50 @@ mod tests {
         }
     }
 
+    fn atomic_single(name: &str, oracle_id: Option<&str>) -> AtomicCard {
+        AtomicCard {
+            name: name.to_string(),
+            mana_cost: None,
+            colors: Vec::new(),
+            color_identity: Vec::new(),
+            power: None,
+            toughness: None,
+            loyalty: None,
+            defense: None,
+            text: None,
+            layout: "normal".to_string(),
+            type_line: None,
+            types: Vec::new(),
+            subtypes: Vec::new(),
+            supertypes: Vec::new(),
+            keywords: None,
+            side: None,
+            face_name: None,
+            mana_value: 0.0,
+            legalities: HashMap::new(),
+            leadership_skills: None,
+            printings: Vec::new(),
+            rulings: Vec::new(),
+            is_game_changer: false,
+            identifiers: AtomicIdentifiers {
+                scryfall_id: None,
+                scryfall_oracle_id: oracle_id.map(str::to_string),
+            },
+            foreign_data: Vec::new(),
+        }
+    }
+
     #[test]
     fn is_homonym_atomic_group_detects_distinct_single_faced_oracle_ids() {
+        let faces = vec![
+            atomic_single("Shared Name", Some("paper-oracle")),
+            atomic_single("Shared Name", Some("playtest-oracle")),
+        ];
+        assert!(is_homonym_atomic_group(&faces));
+    }
+
+    #[test]
+    fn is_homonym_atomic_group_rejects_true_multiface_cards() {
         let atomic = load_atomic_fixture();
         let faces = atomic
             .data
@@ -1432,29 +1513,52 @@ mod tests {
     }
 
     #[test]
-    fn insert_face_prefers_more_legalities_on_printings_tie() {
+    fn is_homonym_atomic_group_does_not_fall_back_to_multiface_for_missing_oracle_id() {
+        let faces = vec![
+            atomic_single("Shared Name", Some("known-oracle")),
+            atomic_single("Shared Name", None),
+        ];
+        assert!(
+            is_homonym_atomic_group(&faces),
+            "all-single groups with missing oracle ids should stay in standalone collision resolution"
+        );
+    }
+
+    #[test]
+    fn is_homonym_atomic_group_rejects_duplicate_known_oracle_ids() {
+        let faces = vec![
+            atomic_single("Shared Name", Some("same-oracle")),
+            atomic_single("Shared Name", Some("same-oracle")),
+        ];
+        assert!(!is_homonym_atomic_group(&faces));
+    }
+
+    #[test]
+    fn homonym_insert_prefers_legalities_before_printings() {
         let mut map = BTreeMap::new();
-        insert_face(
+        insert_face_with_priority(
             &mut map,
             "Pick Your Poison",
             "pick your poison".to_string(),
-            make_entry_with_legalities("playtest-oracle", &["CMB1", "CMB2"], None, &[]),
+            make_entry_with_legalities("playtest-oracle", &["CMB1", "CMB2", "MB2"], None, &[]),
+            homonym_face_priority,
         );
-        insert_face(
+        insert_face_with_priority(
             &mut map,
             "Pick Your Poison",
             "pick your poison".to_string(),
             make_entry_with_legalities(
                 "mkm-oracle",
-                &["MKM", "SOA"],
+                &["MKM"],
                 None,
                 &[("modern", "legal"), ("pioneer", "legal")],
             ),
+            homonym_face_priority,
         );
         assert_eq!(
             map["pick your poison"].face.scryfall_oracle_id.as_deref(),
             Some("mkm-oracle"),
-            "paper card with format legalities must win over a playtest homonym"
+            "homonym paper card with format legalities must beat a playtest card with more printings"
         );
         assert_eq!(
             map["pick your poison"]
@@ -1462,6 +1566,28 @@ mod tests {
                 .get("modern")
                 .map(String::as_str),
             Some("legal"),
+        );
+    }
+
+    #[test]
+    fn ordinary_same_class_insert_keeps_printings_before_legalities() {
+        let mut map = BTreeMap::new();
+        insert_face(
+            &mut map,
+            "Shared",
+            "shared".to_string(),
+            make_entry_with_legalities("many-printings", &["A", "B", "C"], None, &[]),
+        );
+        insert_face(
+            &mut map,
+            "Shared",
+            "shared".to_string(),
+            make_entry_with_legalities("legal-card", &["D"], None, &[("modern", "legal")]),
+        );
+        assert_eq!(
+            map["shared"].face.scryfall_oracle_id.as_deref(),
+            Some("many-printings"),
+            "ordinary same-class collisions keep the existing printings-first policy"
         );
     }
 

--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -137,6 +137,46 @@ fn write_sidecar(dir: &Path, code: &str, map: &BTreeMap<String, LocalizedFace>) 
         .unwrap_or_else(|e| panic!("Failed to promote {}: {e}", final_path.display()));
 }
 
+/// MTGJSON sometimes groups unrelated single-faced cards that share a printed
+/// name under one atomic key (homonyms). Example: MKM's *Pick Your Poison*
+/// and a Mystery Booster playtest card with the same name. These are not true
+/// multi-face cards — each face has `layout: normal` and a distinct oracle id.
+fn is_homonym_atomic_group(faces: &[AtomicCard]) -> bool {
+    if faces.len() < 2 {
+        return false;
+    }
+    if !faces
+        .iter()
+        .all(|face| map_layout(&face.layout) == LayoutKind::Single)
+    {
+        return false;
+    }
+    let oracle_ids: std::collections::HashSet<_> = faces
+        .iter()
+        .filter_map(|face| face.identifiers.scryfall_oracle_id.as_ref())
+        .collect();
+    oracle_ids.len() == faces.len()
+}
+
+fn legality_export_score(legalities: &BTreeMap<String, String>) -> u32 {
+    legalities
+        .values()
+        .filter(|status| status.as_str() == "legal")
+        .count() as u32
+}
+
+/// Within the same structural class (both standalone or both multi-face), pick
+/// the entry with more printings; on a tie, prefer the one legal in more
+/// formats so homonyms like *Pick Your Poison* resolve to the paper card.
+fn same_class_face_priority(existing: &CardExportEntry, new: &CardExportEntry) -> bool {
+    let new_printings = new.printings.len();
+    let existing_printings = existing.printings.len();
+    if new_printings != existing_printings {
+        return new_printings > existing_printings;
+    }
+    legality_export_score(&new.legalities) > legality_export_score(&existing.legalities)
+}
+
 fn hidden_multiface_key(key: &str, entry: &CardExportEntry) -> Option<String> {
     let oracle_id = entry.face.scryfall_oracle_id.as_ref()?;
     entry.layout.as_ref()?;
@@ -198,7 +238,7 @@ fn insert_face(
     let new_wins = match (existing_standalone, new_standalone) {
         (false, true) => true,
         (true, false) => false,
-        _ => entry.printings.len() > existing.printings.len(),
+        _ => same_class_face_priority(existing, &entry),
     };
 
     let existing_oracle = existing.face.scryfall_oracle_id.as_deref();
@@ -626,7 +666,45 @@ fn main() {
 
         let layout_kind = map_layout(&faces[0].layout);
 
-        if faces.len() >= 2 {
+        if is_homonym_atomic_group(faces) {
+            for source in faces.iter() {
+                let oracle_id = source.identifiers.scryfall_oracle_id.clone();
+                let mut face = build_oracle_face(source, oracle_id);
+                #[cfg(feature = "forge")]
+                if let Some(ref fi) = forge_index {
+                    engine::database::forge::apply_forge_fallback(&mut face, fi);
+                }
+                stamp_token_source_metadata(&mut face, &token_source_metadata);
+                let key = face.name.to_lowercase();
+                let legalities =
+                    legalities_to_export_map(&normalize_legalities(&source.legalities));
+
+                if stats && card_face_has_unimplemented_parts(&face) {
+                    cards_with_unimplemented += 1;
+                }
+
+                let rarities = rarity_map
+                    .get(&face.name.to_lowercase())
+                    .cloned()
+                    .unwrap_or_default();
+                let bracket_signals = bracket_signals_for_face(&bracket_lists, &face, source);
+                collect_localized(&mut sidecars, &key, source);
+                insert_face(
+                    &mut face_index,
+                    mtgjson_key.as_str(),
+                    key,
+                    CardExportEntry {
+                        face,
+                        legalities,
+                        layout: None,
+                        printings: source.printings.clone(),
+                        rulings: source.rulings.clone(),
+                        rarities,
+                        bracket_signals,
+                    },
+                );
+            }
+        } else if faces.len() >= 2 {
             let mut legalities_by_face = BTreeMap::new();
             let layout = build_export_layout(faces, oracle_id, layout_kind);
             for (face, source) in layout_faces(&layout).iter().zip(faces.iter()) {
@@ -1314,18 +1392,77 @@ mod tests {
     use super::*;
 
     fn make_entry(oracle_id: &str, printings: &[&str], layout: Option<&str>) -> CardExportEntry {
+        make_entry_with_legalities(oracle_id, printings, layout, &[])
+    }
+
+    fn make_entry_with_legalities(
+        oracle_id: &str,
+        printings: &[&str],
+        layout: Option<&str>,
+        legalities: &[(&str, &str)],
+    ) -> CardExportEntry {
         CardExportEntry {
             face: CardFace {
                 scryfall_oracle_id: Some(oracle_id.to_string()),
                 ..Default::default()
             },
-            legalities: BTreeMap::new(),
+            legalities: legalities
+                .iter()
+                .map(|(format, status)| (format.to_string(), status.to_string()))
+                .collect(),
             layout: layout.map(|s| s.to_string()),
             printings: printings.iter().map(|s| s.to_string()).collect(),
             rulings: Vec::new(),
             rarities: BTreeSet::new(),
             bracket_signals: BracketSignals::default(),
         }
+    }
+
+    #[test]
+    fn is_homonym_atomic_group_detects_distinct_single_faced_oracle_ids() {
+        let atomic = load_atomic_fixture();
+        let faces = atomic
+            .data
+            .get("Aang, Swift Savior // Aang and La, Ocean's Fury")
+            .expect("Aang faces should exist");
+        assert!(
+            !is_homonym_atomic_group(faces),
+            "true multi-face cards must not be treated as homonyms"
+        );
+    }
+
+    #[test]
+    fn insert_face_prefers_more_legalities_on_printings_tie() {
+        let mut map = BTreeMap::new();
+        insert_face(
+            &mut map,
+            "Pick Your Poison",
+            "pick your poison".to_string(),
+            make_entry_with_legalities("playtest-oracle", &["CMB1", "CMB2"], None, &[]),
+        );
+        insert_face(
+            &mut map,
+            "Pick Your Poison",
+            "pick your poison".to_string(),
+            make_entry_with_legalities(
+                "mkm-oracle",
+                &["MKM", "SOA"],
+                None,
+                &[("modern", "legal"), ("pioneer", "legal")],
+            ),
+        );
+        assert_eq!(
+            map["pick your poison"].face.scryfall_oracle_id.as_deref(),
+            Some("mkm-oracle"),
+            "paper card with format legalities must win over a playtest homonym"
+        );
+        assert_eq!(
+            map["pick your poison"]
+                .legalities
+                .get("modern")
+                .map(String::as_str),
+            Some("legal"),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes [#2436](https://github.com/phase-rs/phase/issues/2436): *Pick Your Poison* was incorrectly shown as not legal in Modern in the deckbuilder.
- MTGJSON's `AtomicCards.json` groups the MKM card and a Mystery Booster playtest card (same printed name, different oracle IDs) under one key. `oracle-gen` treated this as a multi-face card and exported only the first face — when that was the playtest variant (no `modern` legality), the deckbuilder defaulted to `not_legal`.
- Homonym groups (multiple `layout: normal` faces with distinct oracle IDs) are now exported as separate standalone cards. `insert_face` collision resolution also prefers entries with more format legalities when printings tie.

## Test plan

- [x] `cargo test -p engine --features cli --bin oracle-gen insert_face_prefers`
- [x] Manual: export with swapped MTGJSON face order → `pick your poison` has `modern: legal` and MKM oracle ID `9af4a832-d634-47aa-91ed-79d44fe08864`
- [ ] Regenerate `card-data.json` (`cargo run --release --bin oracle-gen -- data --stats`) and confirm deckbuilder shows *Pick Your Poison* as legal in Modern
- [ ] CI passes