### PR TITLE
Fix Traumatic Critique discard step not firing after draw (#2435)

### DIFF
--- a/crates/engine/src/game/effects/discard.rs
+++ b/crates/engine/src/game/effects/discard.rs
@@ -58,12 +58,18 @@ pub fn resolve(
         _ => (1, false, None, TargetFilter::Any, false),
     };
 
-    // Check if targets specify specific cards to discard
+    // Check if targets specify specific cards to discard. Parent chain
+    // propagation can inherit non-hand object targets (e.g. Traumatic Critique's
+    // damage recipient) — those must not short-circuit the hand-choice path.
     let specific_targets: Vec<_> = ability
         .targets
         .iter()
         .filter_map(|t| {
-            if let TargetRef::Object(obj_id) = t {
+            let TargetRef::Object(obj_id) = t else {
+                return None;
+            };
+            let obj = state.objects.get(obj_id)?;
+            if obj.zone == Zone::Hand {
                 Some(*obj_id)
             } else {
                 None
@@ -1001,6 +1007,53 @@ mod tests {
         assert!(
             state.cost_payment_failed_flag,
             "cost_payment_failed_flag should be set when discard count is 0 (empty hand)"
+        );
+    }
+
+    #[test]
+    fn controller_filter_ignores_inherited_non_hand_object_targets() {
+        // CR 115.1 regression — Traumatic Critique: damage target is an
+        // inherited Object target, but "discard a card" is a hand choice for
+        // the spell's controller.
+        use crate::types::ability::QuantityExpr;
+        use crate::types::game_state::WaitingFor;
+
+        let mut state = GameState::new_two_player(42);
+        let p0_card_a = create_object(&mut state, CardId(1), PlayerId(0), "A".into(), Zone::Hand);
+        let _p0_card_b = create_object(&mut state, CardId(3), PlayerId(0), "B".into(), Zone::Hand);
+        let damage_target = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Creature".into(),
+            Zone::Battlefield,
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::Discard {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+                random: false,
+                unless_filter: None,
+                filter: None,
+            },
+            vec![TargetRef::Object(damage_target)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            matches!(
+                state.waiting_for,
+                WaitingFor::DiscardChoice { player: PlayerId(0), count: 1, .. }
+            ),
+            "must prompt controller to discard from hand, not silently skip inherited battlefield target"
+        );
+        assert!(
+            state.players[0].hand.contains(&p0_card_a),
+            "no discard should happen before the player chooses"
         );
     }
 

--- a/crates/engine/tests/integration/issue_2435_traumatic_critique.rs
+++ b/crates/engine/tests/integration/issue_2435_traumatic_critique.rs
@@ -1,0 +1,120 @@
+//! Traumatic Critique (MKM) — draw-then-discard must fire after damage.
+//!
+//! Oracle:
+//!   "Traumatic Critique deals X damage to any target. Draw two cards, then discard a card."
+//!
+//! Issue #2435: the mandatory discard step was silently skipped after damage + draw.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::engine::apply_as_current;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect, ResolvedAbility, SubAbilityLink, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::player::PlayerId;
+
+const TRAUMATIC_CRITIQUE_ORACLE: &str =
+    "Traumatic Critique deals X damage to any target. Draw two cards, then discard a card.";
+
+fn traumatic_critique_chain(
+    source_id: ObjectId,
+    controller: PlayerId,
+    damage_target: TargetRef,
+    x: u32,
+) -> ResolvedAbility {
+    let def = parse_effect_chain(TRAUMATIC_CRITIQUE_ORACLE, AbilityKind::Spell);
+    let mut ability = build_resolved_from_def(&def, source_id, controller);
+    ability.targets = vec![damage_target];
+    ability.chosen_x = Some(x);
+    ability
+}
+
+#[test]
+fn traumatic_critique_draw_then_discard_prompts_after_damage() {
+    let controller = P0;
+    let source_id = ObjectId(100);
+
+    let mut scenario = GameScenario::new();
+    scenario.add_card_to_hand(controller, "HandA");
+    let hand_b = scenario.add_card_to_hand(controller, "HandB");
+    scenario.add_card_to_library_top(controller, "Lib1");
+    scenario.add_card_to_library_top(controller, "Lib2");
+    let target = scenario.add_creature(P1, "Target", 2, 2).id();
+
+    let mut runner = scenario.build();
+    let state = runner.state_mut();
+
+    let hand_before = state.players[0].hand.len();
+    let lib_before = state.players[0].library.len();
+
+    let chain = traumatic_critique_chain(source_id, controller, TargetRef::Object(target), 2);
+    let draw = chain
+        .sub_ability
+        .as_ref()
+        .expect("DealDamage should chain to Draw");
+    assert!(
+        matches!(draw.effect, Effect::Draw { .. }),
+        "second step should be Draw, got {:?}",
+        draw.effect
+    );
+    assert_eq!(
+        draw.sub_link,
+        SubAbilityLink::SequentialSibling,
+        "Draw follows damage as the next sentence"
+    );
+    let discard = draw
+        .sub_ability
+        .as_ref()
+        .expect("Draw should chain to Discard");
+    assert!(matches!(discard.effect, Effect::Discard { .. }));
+
+    let mut events = Vec::new();
+    resolve_ability_chain(state, &chain, &mut events, 0).unwrap();
+
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, GameEvent::DamageDealt { .. })),
+        "damage step should resolve"
+    );
+    assert_eq!(
+        state.players[0].library.len(),
+        lib_before - 2,
+        "draw two cards should shrink library by 2"
+    );
+    assert_eq!(
+        state.players[0].hand.len(),
+        hand_before + 2,
+        "drew two cards before discard"
+    );
+
+    match &state.waiting_for {
+        WaitingFor::DiscardChoice { player, count, .. } => {
+            assert_eq!(
+                *player, controller,
+                "controller must discard, not damage target"
+            );
+            assert_eq!(*count, 1);
+        }
+        other => panic!("expected DiscardChoice after draw, got {other:?}"),
+    }
+
+    apply_as_current(
+        state,
+        GameAction::SelectCards {
+            cards: vec![hand_b],
+        },
+    )
+    .unwrap();
+
+    assert!(state.players[0].graveyard.contains(&hand_b));
+    assert_eq!(
+        state.players[0].hand.len(),
+        hand_before + 1,
+        "drew two, discarded one"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -88,6 +88,7 @@ mod issue_2374_fblthp_library_origin;
 mod issue_2376_pyromancers_ascension;
 mod issue_2415_rottenmouth_viper_sacrifice_cost;
 mod issue_2417_satoru_intervening_if;
+mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_580_solitude_evoke_prompt;
 mod issue_709_regression;


### PR DESCRIPTION
## Summary

- Fixes [#2435](https://github.com/phase-rs/phase/issues/2435): resolving *Traumatic Critique* dealt damage and drew two cards, but the mandatory "then discard a card" step was silently skipped.
- Parent target propagation inherits the spell's damage target into chained sub-abilities. `discard::resolve` treated that battlefield object as a specific discard target; since it is not in hand, the effect no-op'd instead of prompting the controller.
- Only inherited `Object` targets currently in the hand use the specific-discard path; otherwise the normal hand-choice flow runs.

## Test plan

- [x] `cargo test -p engine --lib controller_filter_ignores`
- [x] `cargo test -p engine --test integration traumatic_critique`
- [ ] Cast *Traumatic Critique* in-game: after damage + draw, verify discard prompt appears
- [ ] CI passes