### PR TITLE
fix(coverage): don't flag deck-construction copy-limit lines as SilentDrop

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4428,6 +4428,9 @@ fn count_effective_oracle_lines(oracle_text: &str) -> usize {
         if is_commander_permission_sentence(&lower) {
             continue;
         }
+        if is_deck_construction_copy_limit_sentence(stripped) {
+            continue;
+        }
 
         // Check if this line contains a modal header ("choose one —", "choose two.", etc.)
         // Handles standalone headers, triggered modals ("when enters, choose one —"),
@@ -10108,11 +10111,25 @@ mod tests {
             "A deck can have any number of cards named Relentless Rats.",
             "A deck can have up to seven cards named Seven Dwarves.",
             "A deck can have up to nine cards named Nazgûl.",
+            "Megalegendary",
+            "Megalegendary (Your deck can have any number of cards named Vazal, the Compleat.)",
         ] {
             face.oracle_text = Some(oracle.to_string());
             assert!(
                 audit_card_lines(oracle, &face).is_empty(),
                 "deck-construction line falsely flagged as a finding: {oracle}"
+            );
+
+            let mut missing = Vec::new();
+            check_silent_drops(&Some(oracle.to_string()), &[], &mut missing);
+            assert!(
+                missing.is_empty(),
+                "deck-construction line falsely counted as SilentDrop: {oracle} -> {missing:?}"
+            );
+            assert_eq!(
+                count_effective_oracle_lines(oracle),
+                0,
+                "deck-construction line should not count as a runtime oracle line: {oracle}"
             );
         }
     }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3,7 +3,9 @@ use crate::database::CardDatabase;
 use crate::game::game_object::GameObject;
 use crate::game::static_abilities::{build_static_registry, static_registry, StaticAbilityHandler};
 use crate::game::triggers::{build_trigger_registry, trigger_registry};
-use crate::parser::oracle::is_commander_permission_sentence;
+use crate::parser::oracle::{
+    is_commander_permission_sentence, is_deck_construction_copy_limit_sentence,
+};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_util::SELF_REF_TYPE_PHRASES;
 use crate::types::ability::{
@@ -6424,6 +6426,17 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
             continue;
         }
 
+        // CR 100.2a / CR 903.5b: Deck-construction copy-limit lines ("A deck can
+        // have any number of cards named X.", "...up to seven cards named Seven
+        // Dwarves.", the Megalegendary line, etc.) are consumed by the parser as
+        // typed `DeckCopyLimit` metadata (see `compute_deck_copy_limit_from_text`,
+        // read by `deck_validation`), not as a resolvable ability — they
+        // legitimately produce no `ParsedElement`. Skip them so they are not
+        // falsely reported as `SilentDrop`.
+        if is_deck_construction_copy_limit_sentence(stripped) {
+            continue;
+        }
+
         // Skip very short lines (single keywords, type lines)
         if lower.len() < 5 {
             continue;
@@ -10082,6 +10095,26 @@ mod tests {
         face.oracle_text = Some(oracle.to_string());
 
         assert!(audit_card_lines(oracle, &face).is_empty());
+    }
+
+    #[test]
+    fn deck_construction_copy_limit_line_does_not_count_as_silent_drop() {
+        // CR 100.2a / CR 903.5b: "A deck can have any number of cards named X."
+        // (and the "up to N" / bare-Megalegendary variants) is consumed by the
+        // parser as typed DeckCopyLimit metadata, not a resolvable ability, so
+        // it must not be flagged as a SilentDrop. Covers the class, not one card.
+        let mut face = make_face();
+        for oracle in [
+            "A deck can have any number of cards named Relentless Rats.",
+            "A deck can have up to seven cards named Seven Dwarves.",
+            "A deck can have up to nine cards named Nazgûl.",
+        ] {
+            face.oracle_text = Some(oracle.to_string());
+            assert!(
+                audit_card_lines(oracle, &face).is_empty(),
+                "deck-construction line falsely flagged as a finding: {oracle}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes #2501

The semantic audit (`cargo semantic-audit`, the AI-CONTRIBUTOR pre-flight gate) falsely flagged **deck-construction copy-limit lines** as `SilentDrop` findings. Lines like "A deck can have any number of cards named X." are consumed by the parser as typed `DeckCopyLimit` metadata (CR 100.2a / CR 903.5b — `compute_deck_copy_limit_from_text`, read by `deck_validation`), not as resolvable abilities, so they correctly produce no `ParsedElement`. `audit_card_lines` already skipped the analogous non-ability lines (commander-permission sentences, modal headers, saga reminders) but not these, so a whole class of cards (Relentless Rats, Rat Colony, Persistent Petitioners, Shadowborn Apostle, Hare Apparent, Slime Against Humanity, Templar Knight, Tempest Hawk, Seven Dwarves, Nazgûl) showed spurious findings that misdirect contributors toward already-correct cards.

Fix: add a skip-guard in `audit_card_lines` that reuses the existing parser recognizer `is_deck_construction_copy_limit_sentence` (the same combinator that recognizes the line during parsing — no new string matching), plus a class-level regression test. This is an audit/tooling-accuracy change only: no game logic, AST, or runtime behavior changes.

## Files changed
- `crates/engine/src/game/coverage.rs` — skip-guard in `audit_card_lines` + import + `deck_construction_copy_limit_line_does_not_count_as_silent_drop` test.

## CR references
- CR 100.2a (four-of deckbuilding limit) and CR 903.5b (Commander singleton) — the rules these deck-construction overrides modify; cited in the new skip-guard comment alongside the existing parser annotations. Verified against `docs/MagicCompRules.txt`.

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high
Tier: Frontier

## Verification
- `cargo fmt --all` — clean.
- `cargo test -p engine --lib deck_construction` — 4 passed / 0 failed (new test + existing `is_deck_construction_copy_limit_sentence` recognizer cases).
- `cargo semantic-audit` re-run (30837 cards): cards-with-findings 267 → 257; `SilentDrop` 150 → 140 — exactly the 10 deck-construction false positives removed. Every other category unchanged (`DroppedCondition` 92, `DroppedDuration` 23, `WrongParameter` 7, `UnimplementedSubEffect` 1); no new findings; no "A deck can have …" lines remain in the report.
- Tilt was down in this environment, so cargo was run directly. This is an audit-only change with no AST/runtime/game-behavior impact, so the `/engine-implementer` pipeline does not apply.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
