### PR TITLE
Fix Ultima "tap land for {C}" mana-doubling trigger (#2431)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2436,11 +2436,18 @@ pub(super) fn match_taps_for_mana(
     if let GameEvent::TappedForMana {
         player_id,
         source_id: mana_source,
+        produced,
         ..
     } = event
     {
         if !taps_for_mana_card_matches(trigger, state, *mana_source, source_id) {
             return false;
+        }
+
+        if let Some(required) = &trigger.taps_for_mana_produced {
+            if !produced.iter().any(|mana_type| required.contains(mana_type)) {
+                return false;
+            }
         }
 
         valid_player_matches(trigger, state, *player_id, source_id)
@@ -6894,6 +6901,35 @@ mod tests {
         };
         let trigger = make_trigger(TriggerMode::TapsForMana);
         assert!(!match_taps_for_mana(&event, &trigger, source, &state));
+    }
+
+    #[test]
+    fn taps_for_mana_respects_produced_color_filter() {
+        let state = setup();
+        let source = ObjectId(5);
+        let colorless_event = GameEvent::TappedForMana {
+            player_id: PlayerId(0),
+            source_id: source,
+            produced: vec![crate::types::mana::ManaType::Colorless],
+            tap_state: ManaTapState::FromTap,
+        };
+        let green_event = GameEvent::TappedForMana {
+            player_id: PlayerId(0),
+            source_id: source,
+            produced: vec![crate::types::mana::ManaType::Green],
+            tap_state: ManaTapState::FromTap,
+        };
+
+        let mut trigger = make_trigger(TriggerMode::TapsForMana);
+        trigger.taps_for_mana_produced = Some(vec![crate::types::mana::ManaType::Colorless]);
+
+        assert!(match_taps_for_mana(
+            &colorless_event,
+            &trigger,
+            source,
+            &state
+        ));
+        assert!(!match_taps_for_mana(&green_event, &trigger, source, &state));
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2445,7 +2445,10 @@ pub(super) fn match_taps_for_mana(
         }
 
         if let Some(required) = &trigger.taps_for_mana_produced {
-            if !produced.iter().any(|mana_type| required.contains(mana_type)) {
+            if !produced
+                .iter()
+                .any(|mana_type| required.contains(mana_type))
+            {
                 return false;
             }
         }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2,7 +2,7 @@ use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{one_of, space1};
-use nom::combinator::{all_consuming, eof, opt, peek, recognize, rest, value};
+use nom::combinator::{all_consuming, eof, map, opt, peek, recognize, rest, value};
 use nom::multi::{many1, separated_list1};
 use nom::sequence::{delimited, pair, preceded, terminated};
 use nom::Parser;
@@ -5699,62 +5699,62 @@ fn parse_attachment_self_host(input: &str) -> OracleResult<'_, ()> {
     .parse(input)
 }
 
-/// CR 603.2 + CR 106.1: Map a brace-delimited mana symbol from a TapsForMana
-/// "for {…}" clause to the produced mana types that satisfy the trigger event.
-fn taps_for_mana_symbol_to_types(symbol: &str) -> Option<Vec<ManaType>> {
-    let symbol = symbol.trim().to_ascii_uppercase();
-    if symbol == "C" {
-        return Some(vec![ManaType::Colorless]);
-    }
-    fn single(code: &str) -> Option<ManaType> {
-        match code {
-            "W" => Some(ManaType::White),
-            "U" => Some(ManaType::Blue),
-            "B" => Some(ManaType::Black),
-            "R" => Some(ManaType::Red),
-            "G" => Some(ManaType::Green),
-            _ => None,
-        }
-    }
-    if let Some(mana_type) = single(&symbol) {
-        return Some(vec![mana_type]);
-    }
-    let mut types = Vec::new();
-    for part in symbol.split('/') {
-        types.push(single(part.trim())?);
-    }
-    Some(types)
+/// CR 603.2 + CR 106.1: Parse a single mana letter from inside `{…}`.
+fn parse_taps_for_mana_color_code(i: &str) -> OracleResult<'_, ManaType> {
+    alt((
+        value(ManaType::Colorless, alt((tag("C"), tag("c")))),
+        value(ManaType::White, alt((tag("W"), tag("w")))),
+        value(ManaType::Blue, alt((tag("U"), tag("u")))),
+        value(ManaType::Black, alt((tag("B"), tag("b")))),
+        value(ManaType::Red, alt((tag("R"), tag("r")))),
+        value(ManaType::Green, alt((tag("G"), tag("g")))),
+    ))
+    .parse(i)
+}
+
+/// CR 603.2 + CR 106.1: Parse one braced mana symbol, expanding hybrids
+/// (`{W/U}` → two types).
+fn parse_taps_for_mana_braced_symbol(i: &str) -> OracleResult<'_, Vec<ManaType>> {
+    let (rest, types) = delimited(
+        tag("{"),
+        separated_list1(tag("/"), parse_taps_for_mana_color_code),
+        tag("}"),
+    )
+    .parse(i)?;
+    Ok((rest, types))
+}
+
+/// CR 603.2 + CR 106.1: Parse the trailing "for mana" / "for {C}" /
+/// "for {G} or {U}" clause of a TapsForMana trigger subject.
+fn parse_taps_for_mana_for_clause_body(i: &str) -> OracleResult<'_, Option<Vec<ManaType>>> {
+    alt((
+        value(None, tag("mana")),
+        map(
+            separated_list1(
+                preceded(space1, tag("or ")),
+                parse_taps_for_mana_braced_symbol,
+            ),
+            |chunks| {
+                let mut produced = Vec::new();
+                for types in chunks {
+                    produced.extend(types);
+                }
+                Some(produced)
+            },
+        ),
+    ))
+    .parse(i)
 }
 
 /// CR 603.2 + CR 106.1: Split a TapsForMana subject line into the permanent
 /// filter text and an optional produced-mana constraint from the trailing
 /// "for mana" / "for {C}" / "for {G}" clause.
 fn split_taps_for_mana_for_clause(text: &str) -> Option<(String, Option<Vec<ManaType>>)> {
-    let (subject, for_clause) = text.rsplit_once(" for ")?;
-    let for_clause = for_clause.trim();
-    if for_clause == "mana" {
-        return Some((subject.to_string(), None));
-    }
-    if !for_clause.starts_with('{') {
-        return None;
-    }
-    let mut produced = Vec::new();
-    let mut rest = for_clause;
-    loop {
-        let end = rest.find('}')?;
-        let symbol = &rest[1..end];
-        produced.extend(taps_for_mana_symbol_to_types(symbol)?);
-        rest = rest[end + 1..].trim_start();
-        if let Some(after_or) = rest.strip_prefix("or ") {
-            rest = after_or.trim_start();
-            continue;
-        }
-        if rest.is_empty() {
-            break;
-        }
-        return None;
-    }
-    Some((subject.to_string(), Some(produced)))
+    let (_, (subject, for_clause)) = nom_primitives::split_once_on(text, " for ").ok()?;
+    let (_, produced) = all_consuming(parse_taps_for_mana_for_clause_body)
+        .parse(for_clause.trim())
+        .ok()?;
+    Some((subject.to_string(), produced))
 }
 
 /// Try to parse an event verb and build a TriggerDefinition from subject + event.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -46,7 +46,7 @@ use crate::types::ability::{AttackScope, AttackSubject};
 use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
 use crate::types::events::PlayerActionKind;
-use crate::types::mana::ManaColor;
+use crate::types::mana::{ManaColor, ManaType};
 use crate::types::phase::Phase;
 use crate::types::triggers::{AttackTargetFilter, TriggerMode};
 use crate::types::zones::Zone;
@@ -5699,6 +5699,64 @@ fn parse_attachment_self_host(input: &str) -> OracleResult<'_, ()> {
     .parse(input)
 }
 
+/// CR 603.2 + CR 106.1: Map a brace-delimited mana symbol from a TapsForMana
+/// "for {…}" clause to the produced mana types that satisfy the trigger event.
+fn taps_for_mana_symbol_to_types(symbol: &str) -> Option<Vec<ManaType>> {
+    let symbol = symbol.trim().to_ascii_uppercase();
+    if symbol == "C" {
+        return Some(vec![ManaType::Colorless]);
+    }
+    fn single(code: &str) -> Option<ManaType> {
+        match code {
+            "W" => Some(ManaType::White),
+            "U" => Some(ManaType::Blue),
+            "B" => Some(ManaType::Black),
+            "R" => Some(ManaType::Red),
+            "G" => Some(ManaType::Green),
+            _ => None,
+        }
+    }
+    if let Some(mana_type) = single(&symbol) {
+        return Some(vec![mana_type]);
+    }
+    let mut types = Vec::new();
+    for part in symbol.split('/') {
+        types.push(single(part.trim())?);
+    }
+    Some(types)
+}
+
+/// CR 603.2 + CR 106.1: Split a TapsForMana subject line into the permanent
+/// filter text and an optional produced-mana constraint from the trailing
+/// "for mana" / "for {C}" / "for {G}" clause.
+fn split_taps_for_mana_for_clause(text: &str) -> Option<(String, Option<Vec<ManaType>>)> {
+    let (subject, for_clause) = text.rsplit_once(" for ")?;
+    let for_clause = for_clause.trim();
+    if for_clause == "mana" {
+        return Some((subject.to_string(), None));
+    }
+    if !for_clause.starts_with('{') {
+        return None;
+    }
+    let mut produced = Vec::new();
+    let mut rest = for_clause;
+    loop {
+        let end = rest.find('}')?;
+        let symbol = &rest[1..end];
+        produced.extend(taps_for_mana_symbol_to_types(symbol)?);
+        rest = rest[end + 1..].trim_start();
+        if let Some(after_or) = rest.strip_prefix("or ") {
+            rest = after_or.trim_start();
+            continue;
+        }
+        if rest.is_empty() {
+            break;
+        }
+        return None;
+    }
+    Some((subject.to_string(), Some(produced)))
+}
+
 /// Try to parse an event verb and build a TriggerDefinition from subject + event.
 fn try_parse_event(
     subject: &TargetFilter,
@@ -8624,10 +8682,10 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         let Ok((rest, ())) = value((), tag::<_, _, OracleError<'_>>(prefix)).parse(lower) else {
             continue;
         };
-        let Some(subject_text) = rest.strip_suffix(" for mana") else {
+        let Some((subject_text, produced_filter)) = split_taps_for_mana_for_clause(rest) else {
             continue;
         };
-        let (filter, remainder) = parse_trigger_subject(subject_text, &mut ParseContext::default());
+        let (filter, remainder) = parse_trigger_subject(&subject_text, &mut ParseContext::default());
         if !remainder.trim().is_empty() {
             continue;
         }
@@ -8641,6 +8699,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         // which scopes to ControllerRef::Opponent.
         def.valid_card = Some(add_controller(filter, ControllerRef::You));
         def.valid_target = Some(TargetFilter::Controller);
+        def.taps_for_mana_produced = produced_filter;
         return Some((TriggerMode::TapsForMana, def));
     }
 
@@ -8649,23 +8708,27 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
     //   - "a player taps …"  → no controller constraint on the source
     //   - "an opponent taps …" → source must be opponent-controlled (Vorinclex class)
     // Nested nom dispatch: outer trigger verb → actor → subject-up-to-"for mana".
-    fn parse_taps_for_mana_line(i: &str) -> OracleResult<'_, (Option<ControllerRef>, &str)> {
-        preceded(
+    fn parse_taps_for_mana_line(
+        i: &str,
+    ) -> OracleResult<'_, (Option<ControllerRef>, String, Option<Vec<ManaType>>)> {
+        let (rest, actor_controller) = preceded(
             alt((tag("whenever "), tag("when "))),
-            pair(
-                alt((
-                    value(Some(ControllerRef::Opponent), tag("an opponent taps ")),
-                    value(None, tag("a player taps ")),
-                )),
-                terminated(take_until(" for mana"), tag(" for mana")),
-            ),
+            alt((
+                value(Some(ControllerRef::Opponent), tag("an opponent taps ")),
+                value(None, tag("a player taps ")),
+            )),
         )
-        .parse(i)
+        .parse(i)?;
+        let (subject_text, produced_filter) = split_taps_for_mana_for_clause(rest)
+            .ok_or_else(|| oracle_err(rest))?;
+        Ok(("", (actor_controller, subject_text, produced_filter)))
     }
-    if let Ok((rem, (actor_controller, subject_text))) = parse_taps_for_mana_line(lower) {
+    if let Ok((rem, (actor_controller, subject_text, produced_filter))) =
+        parse_taps_for_mana_line(lower)
+    {
         if rem.trim().is_empty() {
             let (mut filter, sub_rem) =
-                parse_trigger_subject(subject_text, &mut ParseContext::default());
+                parse_trigger_subject(&subject_text, &mut ParseContext::default());
             if sub_rem.trim().is_empty() {
                 if let Some(c) = actor_controller {
                     // Constrain subject to opponent-controlled permanents via the
@@ -8676,6 +8739,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
                 let mut def = make_base();
                 def.mode = TriggerMode::TapsForMana;
                 def.valid_card = Some(filter);
+                def.taps_for_mana_produced = produced_filter;
                 return Some((TriggerMode::TapsForMana, def));
             }
         }
@@ -16752,6 +16816,35 @@ mod tests {
             ))
         );
         assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+        assert_eq!(def.taps_for_mana_produced, None);
+    }
+
+    #[test]
+    fn trigger_you_tap_a_land_for_colorless_mana() {
+        let def = parse_trigger_line(
+            "Whenever you tap a land for {C}, add an additional {C}.",
+            "Ultima, Origin of Oblivion",
+        );
+        assert_eq!(def.mode, TriggerMode::TapsForMana);
+        assert_eq!(
+            def.valid_card,
+            Some(TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Land).controller(ControllerRef::You)
+            ))
+        );
+        assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+        assert_eq!(
+            def.taps_for_mana_produced,
+            Some(vec![ManaType::Colorless])
+        );
+        let execute = def.execute.as_deref().expect("trigger should execute");
+        assert!(matches!(
+            execute.effect.as_ref(),
+            Effect::Mana {
+                produced: crate::types::ability::ManaProduction::Colorless { count },
+                ..
+            } if matches!(count, QuantityExpr::Fixed { value: 1 })
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8685,7 +8685,8 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         let Some((subject_text, produced_filter)) = split_taps_for_mana_for_clause(rest) else {
             continue;
         };
-        let (filter, remainder) = parse_trigger_subject(&subject_text, &mut ParseContext::default());
+        let (filter, remainder) =
+            parse_trigger_subject(&subject_text, &mut ParseContext::default());
         if !remainder.trim().is_empty() {
             continue;
         }
@@ -8719,8 +8720,8 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
             )),
         )
         .parse(i)?;
-        let (subject_text, produced_filter) = split_taps_for_mana_for_clause(rest)
-            .ok_or_else(|| oracle_err(rest))?;
+        let (subject_text, produced_filter) =
+            split_taps_for_mana_for_clause(rest).ok_or_else(|| oracle_err(rest))?;
         Ok(("", (actor_controller, subject_text, produced_filter)))
     }
     if let Ok((rem, (actor_controller, subject_text, produced_filter))) =
@@ -16833,10 +16834,7 @@ mod tests {
             ))
         );
         assert_eq!(def.valid_target, Some(TargetFilter::Controller));
-        assert_eq!(
-            def.taps_for_mana_produced,
-            Some(vec![ManaType::Colorless])
-        );
+        assert_eq!(def.taps_for_mana_produced, Some(vec![ManaType::Colorless]));
         let execute = def.execute.as_deref().expect("trigger should execute");
         assert!(matches!(
             execute.effect.as_ref(),

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11005,6 +11005,13 @@ pub struct TriggerDefinition {
     /// When `Some(Won)`, fires only on wins; `Some(Lost)` only on losses; `None` fires on any flip.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coin_flip_result: Option<CoinFlipResult>,
+    /// CR 603.2 + CR 106.1: Produced-mana filter for `TriggerMode::TapsForMana`
+    /// triggers whose event text specifies "for {C}" / "for {G}" rather than
+    /// the generic "for mana". When `Some`, the `TappedForMana` event must
+    /// include at least one produced unit matching the set; `None` accepts any
+    /// mana type (the "for mana" form). Ignored by other trigger modes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub taps_for_mana_produced: Option<Vec<ManaType>>,
 }
 
 impl TriggerDefinition {
@@ -11039,6 +11046,7 @@ impl TriggerDefinition {
             damage_amount: None,
             life_amount: None,
             coin_flip_result: None,
+            taps_for_mana_produced: None,
         }
     }
 
@@ -13314,6 +13322,7 @@ mod tests {
             damage_amount: None,
             life_amount: None,
             coin_flip_result: None,
+            taps_for_mana_produced: None,
         };
         let json = serde_json::to_string(&trigger).unwrap();
         let deserialized: TriggerDefinition = serde_json::from_str(&json).unwrap();

--- a/crates/engine/tests/integration/issue_2431_ultima_tap_land_for_c.rs
+++ b/crates/engine/tests/integration/issue_2431_ultima_tap_land_for_c.rs
@@ -1,0 +1,115 @@
+//! Regression for GitHub issue #2431 — Ultima, Origin of Oblivion's mana-doubling
+//! trigger must fire when the controller taps a land for {C}.
+//!
+//! Oracle: "Whenever you tap a land for {C}, add an additional {C}."
+
+use std::sync::Arc;
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaProduction, QuantityExpr,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::mana::ManaType;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+
+fn ultima_mana_trigger() -> engine::types::ability::TriggerDefinition {
+    let parsed = parse_oracle_text(
+        "Whenever you tap a land for {C}, add an additional {C}.",
+        "Ultima, Origin of Oblivion",
+        &[],
+        &[String::from("Creature")],
+        &[],
+    );
+    parsed.triggers.into_iter().next().expect("one trigger")
+}
+
+fn add_colorless_land(scenario: &mut GameScenario) -> engine::types::identifiers::ObjectId {
+    scenario
+        .add_creature(P0, "Colorless Land", 0, 0)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Colorless {
+                        count: QuantityExpr::Fixed { value: 1 },
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Tap),
+        )
+        .id()
+}
+
+#[test]
+fn ultima_tap_land_for_c_doubles_colorless_mana() {
+    let trigger = ultima_mana_trigger();
+    assert_eq!(trigger.mode, TriggerMode::TapsForMana);
+    assert_eq!(
+        trigger.taps_for_mana_produced,
+        Some(vec![ManaType::Colorless])
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Ultima, Origin of Oblivion", 5, 5)
+        .with_trigger_definition(trigger);
+    let land = add_colorless_land(&mut scenario);
+
+    let mut runner = scenario.build();
+    {
+        let obj = runner.state_mut().objects.get_mut(&land).unwrap();
+        obj.card_types.core_types = vec![CoreType::Land];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = None;
+        obj.toughness = None;
+        obj.base_power = None;
+        obj.base_toughness = None;
+        Arc::make_mut(&mut obj.abilities);
+    }
+
+    runner
+        .act(GameAction::TapLandForMana { object_id: land })
+        .expect("tapping a colorless land must succeed");
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(ManaType::Colorless),
+        2,
+        "Ultima must add an additional {{C}} when a land is tapped for colorless mana"
+    );
+}
+
+#[test]
+fn ultima_tap_land_for_c_ignores_colored_mana() {
+    let trigger = ultima_mana_trigger();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Ultima, Origin of Oblivion", 5, 5)
+        .with_trigger_definition(trigger);
+    let forest = scenario.add_basic_land(P0, engine::types::mana::ManaColor::Green);
+
+    let mut runner = scenario.build();
+    runner
+        .act(GameAction::TapLandForMana { object_id: forest })
+        .expect("tapping Forest for {G} must succeed");
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(ManaType::Green),
+        1,
+        "Ultima must not double mana when the land was tapped for colored mana"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -89,6 +89,7 @@ mod issue_2374_fblthp_library_origin;
 mod issue_2376_pyromancers_ascension;
 mod issue_2415_rottenmouth_viper_sacrifice_cost;
 mod issue_2417_satoru_intervening_if;
+mod issue_2431_ultima_tap_land_for_c;
 mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_580_solitude_evoke_prompt;


### PR DESCRIPTION
## Summary
- Parse `TapsForMana` triggers whose event text uses `"for {C}"` (and other mana-symbol suffixes), not only `"for mana"`.
- Add `TriggerDefinition::taps_for_mana_produced` so matchers require the tapped land to have produced the specified mana type.
- Fixes Ultima, Origin of Oblivion's second ability: tapping a blighted land for `{C}` now adds an additional `{C}`.
Fixes phase-rs/phase#2431
## Test plan
- [x] `cargo test -p engine trigger_you_tap_a_land_for_colorless`
- [x] `cargo test -p engine taps_for_mana_respects_produced`
- [x] `cargo test -p engine ultima_tap_land_for_c`
- [ ] Manual: Ultima on battlefield, blight a land, tap it for `{C}` → pool has 2 colorless
