### PR TITLE
Fix Counterspell targeting banner showing "nonland permanent" (#2429)

### DIFF
--- a/client/src/components/targeting/TargetingOverlay.tsx
+++ b/client/src/components/targeting/TargetingOverlay.tsx
@@ -290,6 +290,11 @@ function inferTargetNoun(
     return t("targeting.nounTarget");
   }
   if (objectTargets.length === 0) return t("targeting.nounTarget");
+  // CR 112.1: Spells on the stack are not permanents; infer from zone so
+  // Counterspell-style targeting does not fall through to "nonland permanent".
+  if (objectTargets.every((obj) => obj.zone === "Stack")) {
+    return t("targeting.nounSpell");
+  }
   if (objectTargets.every((obj) => !obj.card_types.core_types.includes("Land"))) {
     return t("targeting.nounNonlandPermanent");
   }

--- a/client/src/components/targeting/__tests__/TargetingOverlay.test.tsx
+++ b/client/src/components/targeting/__tests__/TargetingOverlay.test.tsx
@@ -228,6 +228,59 @@ describe("TargetingOverlay", () => {
     });
   });
 
+  it("informs the player when the target slot is a spell on the stack", () => {
+    const dispatch = vi.fn().mockResolvedValue([]);
+    const stackSpellTarget = buildGameObjectWithCoreTypes(["Instant"], {
+      id: 8,
+      card_id: 8,
+      name: "Lightning Bolt",
+      zone: "Stack",
+    });
+
+    const counterspell = buildGameObjectWithCoreTypes(["Instant"], {
+      id: 9,
+      card_id: 9,
+      name: "Counterspell",
+      zone: "Stack",
+    });
+
+    const gameState = createGameState({
+      objects: {
+        "8": stackSpellTarget,
+        "9": counterspell,
+      },
+      waiting_for: {
+        type: "TargetSelection",
+        data: {
+          player: 0,
+          pending_cast: {
+            object_id: 9,
+            card_id: 9,
+            ability: { targets: [] },
+            cost: { type: "NoCost" },
+          },
+          target_slots: [{
+            legal_targets: [{ Object: 8 }],
+            optional: false,
+          }],
+          selection: { current_slot: 0, current_legal_targets: [{ Object: 8 }] },
+        },
+      },
+    });
+
+    act(() => {
+      useGameStore.setState({
+        gameState,
+        waitingFor: gameState.waiting_for,
+        dispatch,
+      });
+    });
+
+    render(<TargetingOverlay />);
+
+    expect(screen.getByText("a spell")).toBeInTheDocument();
+  });
+
   it("informs the player when the target slot is up to one nonland permanent", () => {
     const dispatch = vi.fn().mockResolvedValue([]);
     const nonLandTarget = buildGameObject({

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -424,6 +424,7 @@
     "one": "eine {{target}}",
     "nounPlayer": "Spieler",
     "nounNonlandPermanent": "bleibende Nichtländer-Karte",
+    "nounSpell": "Spruch",
     "nounCreature": "Kreatur",
     "nounPlaneswalker": "Planeswalker",
     "nounTargetPermanent": "bleibende Karte als Ziel",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -426,6 +426,7 @@
     "one": "a {{target}}",
     "nounPlayer": "player",
     "nounNonlandPermanent": "nonland permanent",
+    "nounSpell": "spell",
     "nounCreature": "creature",
     "nounPlaneswalker": "planeswalker",
     "nounTargetPermanent": "target permanent",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -424,6 +424,7 @@
     "one": "un(a) {{target}}",
     "nounPlayer": "jugador",
     "nounNonlandPermanent": "permanente que no sea tierra",
+    "nounSpell": "hechizo",
     "nounCreature": "criatura",
     "nounPlaneswalker": "planeswalker",
     "nounTargetPermanent": "permanente objetivo",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -424,6 +424,7 @@
     "one": "un(e) {{target}}",
     "nounPlayer": "joueur",
     "nounNonlandPermanent": "permanent non-terrain",
+    "nounSpell": "sort",
     "nounCreature": "créature",
     "nounPlaneswalker": "planeswalker",
     "nounTargetPermanent": "permanent ciblé",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -424,6 +424,7 @@
     "one": "un {{target}}",
     "nounPlayer": "giocatore",
     "nounNonlandPermanent": "permanente non Terra",
+    "nounSpell": "magia",
     "nounCreature": "creatura",
     "nounPlaneswalker": "planeswalker",
     "nounTargetPermanent": "permanente bersaglio",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -426,6 +426,7 @@
     "one": "{{target}}",
     "nounPlayer": "gracz",
     "nounNonlandPermanent": "trwały niebędący ziemią",
+    "nounSpell": "czar",
     "nounCreature": "stwór",
     "nounPlaneswalker": "wędrowiec",
     "nounTargetPermanent": "docelowy trwały",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -424,6 +424,7 @@
     "one": "um {{target}}",
     "nounPlayer": "jogador",
     "nounNonlandPermanent": "permanente que não seja terreno",
+    "nounSpell": "feitiço",
     "nounCreature": "criatura",
     "nounPlaneswalker": "planeswalker",
     "nounTargetPermanent": "permanente alvo",


### PR DESCRIPTION
## Summary

- Fixes [#2429](https://github.com/phase-rs/phase/issues/2429): when targeting a spell on the stack (e.g. Counterspell), the targeting banner now reads **"a spell"** instead of **"a nonland permanent"**.
- `inferTargetNoun()` now checks `obj.zone === "Stack"` before the nonland-permanent heuristic, since spells on the stack are not permanents (CR 112.1).
- Adds `targeting.nounSpell` to all locales and a `TargetingOverlay` unit test for Counterspell → Lightning Bolt targeting.

## Test plan

- [x] `npm test -- --run src/components/targeting/__tests__/TargetingOverlay.test.tsx`
- [ ] In-game: cast Counterspell, target an opponent's instant on the stack — banner should say "a spell" (not "nonland permanent")