### PR TITLE
Synthesize Transmute keyword (CR 702.53a)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -1633,6 +1633,105 @@ pub fn synthesize_cycling(face: &mut CardFace) {
     face.abilities.extend(cycling_abilities);
 }
 
+/// CR 702.53a: Synthesize Transmute into an activated ability that functions
+/// only while the card is in a player's hand. "Transmute [cost]" means
+/// "[Cost], Discard this card: Search your library for a card with the same mana
+/// value as the discarded card, reveal that card, and put it into your hand.
+/// Then shuffle your library. Activate only as a sorcery."
+///
+/// Mirrors `synthesize_cycling`'s Typecycling arm (discard-self + mana cost →
+/// `SearchLibrary` → put the found card to hand → shuffle, activatable from
+/// hand), swapping the subtype filter for a same-mana-value filter and adding the
+/// sorcery-speed restriction. Unlike Cycling/Typecycling it carries no
+/// `AbilityTag::Cycling` — transmute is not a cycling ability (CR 702.29).
+pub fn synthesize_transmute(face: &mut CardFace) {
+    let transmute_abilities: Vec<AbilityDefinition> = face
+        .keywords
+        .iter()
+        .filter_map(|kw| match kw {
+            Keyword::Transmute(cost) => {
+                // CR 702.53a + CR 601.2b/f–h: "[Cost], Discard this card".
+                let composite_cost = AbilityCost::Composite {
+                    costs: vec![
+                        AbilityCost::Mana { cost: cost.clone() },
+                        AbilityCost::Discard {
+                            count: QuantityExpr::Fixed { value: 1 },
+                            filter: None,
+                            random: false,
+                            self_ref: true,
+                        },
+                    ],
+                };
+                let filter = transmute_same_mana_value_filter();
+                // CR 702.53a: "Then shuffle your library."
+                let shuffle_def = AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::Shuffle {
+                        target: TargetFilter::Controller,
+                    },
+                );
+                // CR 702.53a: "reveal that card, and put it into your hand."
+                let mut put_in_hand_def = AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::ChangeZone {
+                        origin: Some(Zone::Library),
+                        destination: Zone::Hand,
+                        target: TargetFilter::Any,
+                        owner_library: false,
+                        enter_transformed: false,
+                        enters_under: None,
+                        enter_tapped: false,
+                        enters_attacking: false,
+                        up_to: false,
+                        enter_with_counters: vec![],
+                        face_down_profile: None,
+                    },
+                );
+                put_in_hand_def.sub_ability = Some(Box::new(shuffle_def));
+                // CR 702.53a: "Search your library for a card with the same mana
+                // value as the discarded card ... Activate only as a sorcery."
+                let mut def = AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::SearchLibrary {
+                        filter,
+                        count: QuantityExpr::Fixed { value: 1 },
+                        reveal: true,
+                        target_player: None,
+                        selection_constraint: SearchSelectionConstraint::None,
+                        split: None,
+                        source_zones: vec![crate::types::zones::Zone::Library],
+                    },
+                )
+                .cost(composite_cost)
+                .sorcery_speed();
+                // CR 702.53b: the ability functions only while the card is in hand.
+                def.activation_zone = Some(Zone::Hand);
+                def.sub_ability = Some(Box::new(put_in_hand_def));
+                Some(def)
+            }
+            _ => None,
+        })
+        .collect();
+
+    face.abilities.extend(transmute_abilities);
+}
+
+/// CR 702.53a: "a card with the same mana value as the discarded card." The
+/// discarded card is the transmute card itself, paid as the discard cost, so the
+/// filter compares a library card's mana value to the cost-paid object's mana
+/// value via `ObjectScope::CostPaidObject` — the same scope the parser emits for
+/// "with the same mana value as that card".
+fn transmute_same_mana_value_filter() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::Cmc {
+        comparator: Comparator::EQ,
+        value: QuantityExpr::Ref {
+            qty: QuantityRef::ObjectManaValue {
+                scope: ObjectScope::CostPaidObject,
+            },
+        },
+    }]))
+}
+
 /// CR 702.97a: Synthesize Scavenge into an activated ability on the card.
 ///
 /// Scavenge is an activated ability that functions only while the card with scavenge is
@@ -7634,6 +7733,10 @@ pub fn synthesize_all(face: &mut CardFace) {
     synthesize_level_up(face);
     synthesize_specialize(face);
     synthesize_cycling(face);
+    // CR 702.53a: Transmute — "[Cost], Discard this card: search your library for
+    // a card with the same mana value, reveal it, put it in hand, then shuffle.
+    // Activate only as a sorcery."
+    synthesize_transmute(face);
     synthesize_scavenge(face);
     // CR 702.128a / CR 702.129a: Embalm / Eternalize graveyard-activated
     // token-copy abilities (self-contained building block in its own module).
@@ -8890,6 +8993,111 @@ mod cycling_synthesis_tests {
         ));
         let shuffle = put_in_hand.sub_ability.as_ref().expect("shuffle");
         assert!(matches!(&*shuffle.effect, Effect::Shuffle { .. }));
+    }
+}
+
+#[cfg(test)]
+mod transmute_synthesis_tests {
+    use super::*;
+    use crate::types::ability::ActivationRestriction;
+
+    fn transmute_face() -> CardFace {
+        CardFace {
+            keywords: vec![Keyword::Transmute(ManaCost::Cost {
+                generic: 1,
+                shards: vec![ManaCostShard::Blue, ManaCostShard::Blue],
+            })],
+            ..CardFace::default()
+        }
+    }
+
+    /// CR 702.53a: `synthesize_transmute` installs one from-hand, sorcery-speed
+    /// activated ability whose cost is "{cost}, Discard this card", whose effect
+    /// searches the library for a same-mana-value card, and whose sub-ability
+    /// chain puts the found card into hand then shuffles.
+    #[test]
+    fn synthesize_transmute_builds_same_mana_value_tutor() {
+        let mut face = transmute_face();
+        synthesize_transmute(&mut face);
+
+        assert_eq!(face.abilities.len(), 1, "one transmute ability per keyword");
+        let ability = face.abilities.first().expect("transmute ability");
+        assert_eq!(ability.kind, AbilityKind::Activated);
+        // CR 702.53b: functions only while the card is in hand.
+        assert_eq!(ability.activation_zone, Some(Zone::Hand));
+        // CR 702.53a: "Activate only as a sorcery."
+        assert!(ability.sorcery_speed);
+        assert!(ability
+            .activation_restrictions
+            .contains(&ActivationRestriction::AsSorcery));
+        // Transmute is NOT a cycling ability (CR 702.29 vs CR 702.53).
+        assert!(ability.ability_tag.is_none());
+
+        // Cost: Composite[Mana, Discard this card (self_ref)].
+        match &ability.cost {
+            Some(AbilityCost::Composite { costs }) => {
+                assert!(costs.iter().any(|c| matches!(c, AbilityCost::Mana { .. })));
+                assert!(costs.iter().any(|c| matches!(
+                    c,
+                    AbilityCost::Discard {
+                        self_ref: true,
+                        count: QuantityExpr::Fixed { value: 1 },
+                        ..
+                    }
+                )));
+            }
+            other => panic!("expected Composite cost, got {other:?}"),
+        }
+
+        // Effect: SearchLibrary with a same-mana-value-as-discarded-card filter.
+        let Effect::SearchLibrary { filter, reveal, .. } = &*ability.effect else {
+            panic!("expected SearchLibrary, got {:?}", ability.effect);
+        };
+        assert!(*reveal, "CR 702.53a: reveal that card");
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected typed filter, got {filter:?}");
+        };
+        assert!(
+            tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::Cmc {
+                    comparator: Comparator::EQ,
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectManaValue {
+                            scope: ObjectScope::CostPaidObject
+                        }
+                    }
+                }
+            )),
+            "filter must match a card with the same mana value as the discarded card, got {:?}",
+            tf.properties
+        );
+
+        // Sub-ability chain: put found card to hand (Library→Hand), then shuffle.
+        let put_in_hand = ability
+            .sub_ability
+            .as_ref()
+            .expect("put-in-hand sub-ability");
+        assert!(matches!(
+            &*put_in_hand.effect,
+            Effect::ChangeZone {
+                origin: Some(Zone::Library),
+                destination: Zone::Hand,
+                ..
+            }
+        ));
+        let shuffle = put_in_hand
+            .sub_ability
+            .as_ref()
+            .expect("shuffle sub-ability");
+        assert!(matches!(&*shuffle.effect, Effect::Shuffle { .. }));
+    }
+
+    #[test]
+    fn synthesize_transmute_is_noop_without_keyword() {
+        let mut face = CardFace::default();
+        synthesize_transmute(&mut face);
+        assert!(face.abilities.is_empty());
     }
 }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1,9 +1,9 @@
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AdditionalCost, CardPlayMode,
     CastTimingPermission, CastingPermission, ChoiceType, ContinuousModification, CostObjectCount,
-    Duration, Effect, GameRestriction, ModalSelectionCondition, ObjectScope, PlayerScope,
-    ProhibitedActivity, QuantityExpr, QuantityRef, ResolvedAbility, RestrictionPlayerScope,
-    StaticDefinition, TargetFilter, TargetRef,
+    CostPaidObjectSnapshot, Duration, Effect, GameRestriction, ModalSelectionCondition,
+    ObjectScope, PlayerScope, ProhibitedActivity, QuantityExpr, QuantityRef, ResolvedAbility,
+    RestrictionPlayerScope, StaticDefinition, TargetFilter, TargetRef,
 };
 use crate::types::actions::AlternativeCastDecision;
 use crate::types::card::LayoutKind;
@@ -9903,6 +9903,35 @@ fn find_non_self_discard(cost: &AbilityCost) -> Option<(&QuantityExpr, Option<&T
     }
 }
 
+fn has_self_ref_discard_cost(cost: &AbilityCost) -> bool {
+    match cost {
+        AbilityCost::Discard { self_ref: true, .. } => true,
+        AbilityCost::Composite { costs } => costs.iter().any(has_self_ref_discard_cost),
+        _ => false,
+    }
+}
+
+/// CR 117.1 + CR 400.7j + CR 608.2k: Self-discard activation costs move the
+/// source out of hand before the ability resolves, so ability-scoped filters
+/// like Transmute's same-mana-value search need a public-characteristics
+/// snapshot attached to the resolving ability before cost payment.
+pub(crate) fn stamp_self_ref_discard_cost_paid_object(
+    state: &GameState,
+    source_id: ObjectId,
+    ability: &mut ResolvedAbility,
+    cost: &AbilityCost,
+) {
+    if !has_self_ref_discard_cost(cost) {
+        return;
+    }
+    if let Some(obj) = state.objects.get(&source_id) {
+        ability.set_cost_paid_object_recursive(CostPaidObjectSnapshot {
+            object_id: source_id,
+            lki: obj.snapshot_for_mana_spent(),
+        });
+    }
+}
+
 /// CR 118.3 + CR 602.2b: Detect a non-self "exile a card from hand/graveyard"
 /// activation cost requiring interactive card selection (Jhoira of the Ghitu).
 /// Self-ref exile (Scavenge, Suspend) returns `None` — that shape is auto-paid
@@ -11016,6 +11045,7 @@ pub fn handle_activate_ability(
                         ability_index,
                     ));
                 }
+                stamp_self_ref_discard_cost_paid_object(state, source_id, &mut resolved, cost);
                 if let AbilityCostPaymentOutcome::Paused { remaining_cost } =
                     pay_ability_cost_for_activation(state, player, source_id, cost, events)?
                 {
@@ -11105,6 +11135,7 @@ pub fn handle_activate_ability(
                 ability_index,
             ));
         }
+        stamp_self_ref_discard_cost_paid_object(state, source_id, &mut resolved, cost);
         if let AbilityCostPaymentOutcome::Paused { remaining_cost } =
             pay_ability_cost_for_activation(state, player, source_id, cost, events)?
         {
@@ -34838,6 +34869,99 @@ mod tests {
         assert!(
             !state.battlefield.contains(&ent),
             "Generous Ent must not be a battlefield permanent after Forestcycling resolves"
+        );
+    }
+
+    /// CR 702.53a: Transmute searches for a card with the same mana value as
+    /// the discarded card. This exercises the full runtime path where paying
+    /// the self-discard cost snapshots the discarded object before the search
+    /// filter resolves `QuantityRef::ObjectManaValue { CostPaidObject }`.
+    #[test]
+    fn transmute_search_uses_discarded_cards_mana_value() {
+        use crate::game::scenario::{GameScenario, P0};
+        use crate::types::mana::{ManaType, ManaUnit};
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let transmute_card = scenario
+            .add_creature_to_hand(P0, "Test Transmuter", 2, 2)
+            .with_mana_cost(ManaCost::generic(3))
+            .from_oracle_text("Transmute {1}{U}{B}")
+            .id();
+        let same_mana_value = scenario
+            .add_spell_to_library_top(P0, "Same Mana Value", false)
+            .with_mana_cost(ManaCost::generic(3))
+            .id();
+        scenario
+            .add_spell_to_library_top(P0, "Wrong Mana Value", false)
+            .with_mana_cost(ManaCost::generic(2));
+        scenario.with_mana_pool(
+            P0,
+            vec![
+                ManaUnit::new(ManaType::Colorless, ObjectId(9_990), false, vec![]),
+                ManaUnit::new(ManaType::Blue, ObjectId(9_991), false, vec![]),
+                ManaUnit::new(ManaType::Black, ObjectId(9_992), false, vec![]),
+            ],
+        );
+
+        let mut runner = scenario.build();
+        let state = runner.state_mut();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        let transmute_idx = state
+            .objects
+            .get(&transmute_card)
+            .unwrap()
+            .abilities
+            .iter()
+            .position(|ability| matches!(ability.kind, AbilityKind::Activated))
+            .expect("synthesized transmute activated ability");
+        assert!(
+            can_activate_ability_now(state, PlayerId(0), transmute_card, transmute_idx),
+            "transmute ability should be activatable from hand at sorcery speed"
+        );
+
+        let mut events = Vec::new();
+        handle_activate_ability(
+            state,
+            PlayerId(0),
+            transmute_card,
+            transmute_idx,
+            &mut events,
+        )
+        .unwrap();
+
+        assert_eq!(
+            state.objects[&transmute_card].zone,
+            Zone::Graveyard,
+            "transmute discards the source card as an activation cost"
+        );
+
+        crate::game::stack::resolve_top(state, &mut events);
+        let search_cards = match &state.waiting_for {
+            WaitingFor::SearchChoice { cards, .. } => cards.clone(),
+            other => {
+                panic!("expected Transmute to ask for a same-mana-value search, got {other:?}")
+            }
+        };
+        assert_eq!(
+            search_cards,
+            vec![same_mana_value],
+            "Transmute must offer only cards whose mana value matches the discarded card"
+        );
+
+        crate::game::engine::apply_as_current(
+            state,
+            GameAction::SelectCards {
+                cards: vec![same_mana_value],
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            state.objects[&same_mana_value].zone,
+            Zone::Hand,
+            "Transmute should put the selected same-mana-value card into hand"
         );
     }
 

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1663,7 +1663,7 @@ pub(super) fn push_activated_ability_to_stack(
     player: PlayerId,
     source_id: ObjectId,
     ability_index: usize,
-    resolved: ResolvedAbility,
+    mut resolved: ResolvedAbility,
     remaining_cost: Option<&crate::types::ability::AbilityCost>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
@@ -1686,6 +1686,12 @@ pub(super) fn push_activated_ability_to_stack(
                 ability_index,
             ));
         }
+        super::casting::stamp_self_ref_discard_cost_paid_object(
+            state,
+            source_id,
+            &mut resolved,
+            cost,
+        );
         if let super::casting::AbilityCostPaymentOutcome::Paused { remaining_cost } =
             super::casting::pay_ability_cost_for_activation(state, player, source_id, cost, events)?
         {

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -459,7 +459,7 @@ fn pay_activation_costs_after_target_selection(
     state: &mut GameState,
     player: PlayerId,
     pending: &PendingCast,
-    assigned_ability: ResolvedAbility,
+    mut assigned_ability: ResolvedAbility,
     ability_index: usize,
     events: &mut Vec<GameEvent>,
 ) -> Result<Option<WaitingFor>, EngineError> {
@@ -489,6 +489,12 @@ fn pay_activation_costs_after_target_selection(
                 player,
                 ability_index,
             );
+        super::casting::stamp_self_ref_discard_cost_paid_object(
+            state,
+            pending.object_id,
+            &mut assigned_ability,
+            activation_cost,
+        );
         if let super::casting::AbilityCostPaymentOutcome::Paused { remaining_cost } =
             pay_ability_cost_for_activation(
                 state,

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -2518,7 +2518,7 @@ mod tests {
 
     #[test]
     fn extract_keyword_line_transmute() {
-        // CR 702.52a: Transmute {cost} — single-keyword line with parameterized cost
+        // CR 702.53a: Transmute {cost} — single-keyword line with parameterized cost
         let mtgjson_kws = vec!["transmute".to_string()];
 
         // Verify parse_keyword_from_oracle works directly

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -777,8 +777,10 @@ pub enum Keyword {
     /// CR 702.99a: Cipher — exile this spell encoded on a creature you control;
     /// whenever that creature deals combat damage to a player, cast a copy.
     Cipher,
-    /// CR 702.52a: Transmute {cost} — discard this card and pay {cost} to search
-    /// your library for a card with the same mana value.
+    /// CR 702.53a: Transmute {cost} — "[Cost], Discard this card: Search your
+    /// library for a card with the same mana value as the discarded card, reveal
+    /// it, put it into your hand, then shuffle. Activate only as a sorcery."
+    /// Runtime: `synthesize_transmute` (database/synthesis.rs).
     Transmute(ManaCost),
     /// CR 702.120a: Escalate [cost] — additional cost for each mode chosen beyond the first
     /// on a modal spell.
@@ -1806,7 +1808,7 @@ impl FromStr for Keyword {
                     let capitalized = capitalize_first(type_str);
                     return Ok(Keyword::Champion(capitalized));
                 }
-                // CR 702.52a: Transmute {cost}
+                // CR 702.53a: Transmute {cost}
                 "transmute" => return Ok(Keyword::Transmute(parse_keyword_mana_cost(p))),
                 // CR 702.120a: Escalate [cost]
                 "escalate" => {
@@ -2590,7 +2592,7 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
             })
         }
         // CR 702.47a / CR 702.166a / CR 702.43a / CR 702.72a / CR 702.149a
-        // CR 702.132a / CR 702.133a / CR 702.99a / CR 702.52a / CR 702.148a / CR 702.125a
+        // CR 702.132a / CR 702.133a / CR 702.99a / CR 702.53a / CR 702.148a / CR 702.125a
         "Splice" => Ok(Keyword::Splice(data.as_str().unwrap_or("").to_string())),
         "Bargain" => Ok(Keyword::Bargain),
         "Sunburst" => Ok(Keyword::Sunburst),


### PR DESCRIPTION
## Summary

Implements the **Transmute** keyword (CR 702.53), closing #2515. `Keyword::Transmute` was parsed but inert — no activated ability was synthesized, so a transmute card could never be transmuted.

`synthesize_transmute` is a near line-for-line mirror of the already-synthesized **Typecycling** arm in `synthesize_cycling`: a from-hand activated ability whose cost is "{cost}, Discard this card", whose effect searches the library for a card, reveals it, puts it into hand, then shuffles.

## CR

**CR 702.53a** (verified against `docs/MagicCompRules.txt:4402`): *"[Cost], Discard this card: Search your library for a card with the same mana value as the discarded card, reveal that card, and put it into your hand. Then shuffle your library. Activate only as a sorcery."*

## Changes

- **`database/synthesis.rs`**: `synthesize_transmute` + `transmute_same_mana_value_filter`, wired into `synthesize_all` after `synthesize_cycling`.
  - Cost: `Composite[Mana, Discard { self_ref: true }]`.
  - Effect: `SearchLibrary` (reveal) → sub-ability `ChangeZone { Library → Hand }` → `Shuffle`.
  - `activation_zone = Hand`; `.sorcery_speed()`; no `AbilityTag::Cycling` (transmute is not a cycling ability).
- **`types/keywords.rs`** + **`parser/oracle_keyword.rs`**: corrected four comments that mislabeled Transmute as **CR 702.52a** (that rule is *Dredge*); the verified rule is **CR 702.53a**.

## The one distinct piece

Everything is reused from Typecycling except the search filter. Instead of a subtype filter, transmute matches a card with the **same mana value as the discarded card**:

```rust
FilterProp::Cmc {
    comparator: Comparator::EQ,
    value: QuantityExpr::Ref {
        qty: QuantityRef::ObjectManaValue { scope: ObjectScope::CostPaidObject },
    },
}
```

`CostPaidObject` is the discarded transmute card — the same representation the parser already emits for "with the same mana value as that card". No new `Effect`, `FilterProp`, `QuantityRef`, or subsystem.

## Coverage

~12 transmute cards (Tolaria West, Muddle the Mixture, Drift of Phantasms, Dimir House Guard, Perplex, Shred Memory, Clutch of the Undercity, Brainspoil, Dizzy Spell, …), several eternal-playable.

## Tests

`mod transmute_synthesis_tests`: asserts the full ability shape — `Composite[Mana, Discard{self_ref}]` cost, `SearchLibrary` with the same-mana-value `Cmc{EQ, ObjectManaValue{CostPaidObject}}` filter, `activation_zone = Hand`, `AsSorcery` restriction, no cycling tag, and the put-to-hand → shuffle sub-ability chain; plus no-op-without-keyword.

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — clean.
- `scripts/check-parser-combinators.sh` — passes.
- Unit tests run in CI (local toolchain has a binutils/dlltool gap).

Closes #2515