### PR TITLE
Fix/indomitable creativity reveal until artifact creature

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2266,6 +2266,12 @@ fn affected_objects_from_events(
                 // to that zone makes a downstream "from among the milled cards"
                 // sub-ability resolve against exactly the milled cards.
                 Effect::Mill { destination, .. } => Some(*destination),
+                // CR 701.20a + CR 608.2f: The kept card lands in `kept_destination`; scope the
+                // tracked set to that zone so downstream TrackedSet consumers (e.g. IC's
+                // ChangeZoneAll{Exile→Battlefield}) see only the kept card, not the rest pile.
+                Effect::RevealUntil {
+                    kept_destination, ..
+                } => Some(*kept_destination),
                 Effect::ExileTop { .. } | Effect::ExileFromTopUntil { .. } => {
                     Some(crate::types::zones::Zone::Exile)
                 }
@@ -8331,6 +8337,53 @@ mod tests {
             .filter(|o| o.name == "Treasure")
             .count();
         assert_eq!(treasures0, 0, "Empty chain must mint zero tokens");
+    }
+
+    /// CR 701.20a + CR 608.2f: an Indomitable Creativity-style
+    /// `RevealUntil(kept_destination=Exile)` publishes only the kept card as
+    /// the chain tracked set. Without the `RevealUntil` destination filter in
+    /// `affected_objects_from_events`, both the kept card and miss pile zone
+    /// changes would be published.
+    #[test]
+    fn reveal_until_exile_kept_publishes_only_kept_card_for_tracked_set() {
+        let miss = ObjectId(2);
+        let hit = ObjectId(3);
+        let events = vec![
+            GameEvent::ZoneChanged {
+                object_id: miss,
+                from: Some(Zone::Library),
+                to: Zone::Library,
+                record: Box::new(ZoneChangeRecord::test_minimal(
+                    miss,
+                    Some(Zone::Library),
+                    Zone::Library,
+                )),
+            },
+            GameEvent::ZoneChanged {
+                object_id: hit,
+                from: Some(Zone::Library),
+                to: Zone::Exile,
+                record: Box::new(ZoneChangeRecord::test_minimal(
+                    hit,
+                    Some(Zone::Library),
+                    Zone::Exile,
+                )),
+            },
+        ];
+        let effect = Effect::RevealUntil {
+            player: TargetFilter::Controller,
+            filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
+            kept_destination: Zone::Exile,
+            rest_destination: Zone::Library,
+            enter_tapped: false,
+            enters_attacking: false,
+            kept_optional_to: None,
+        };
+
+        assert_eq!(
+            affected_objects_from_events(&effect, &events, &[]),
+            vec![hit]
+        );
     }
 
     /// CR 608.2c + CR 400.7: a mass-destroy parent must publish the destroyed

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5452,15 +5452,11 @@ fn parse_threshold_comparator(input: &str) -> Option<Comparator> {
     .map(|(c, _)| c)
 }
 
-/// CR 701.20a: Parse the prefix `"reveal[s] cards from the top of <possessive>
-/// library until <pronoun> reveal[s] "` and return the remaining text containing
-/// the filter clause. Handles both second-person ("reveal cards from the top of
-/// your library until you reveal") and third-person possessive variants
-/// ("their/his/her/its library until they/he/she/it reveal[s]").
-///
-/// Returns the slice after the matched article (`a`/`an`), so the caller can
-/// extract the filter text directly.
-fn parse_reveal_until_prefix(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
+/// CR 701.20a: Shared prefix `"reveal[s] cards from the top of <possessive> library until "`.
+/// Returns the input positioned at the first token after `"until "`.
+/// Used by both the active-form and passive-form `RevealUntil` parsers so that
+/// any future possessive arm addition only needs to be made in one place.
+fn parse_reveal_cards_from_library_until(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
     // CR 701.20a: verb form — bare imperative ("reveal") or third-person ("reveals")
     let (input, _) = alt((tag("reveals "), tag("reveal "))).parse(input)?;
     let (input, _) = tag("cards from the top of ").parse(input)?;
@@ -5473,10 +5469,16 @@ fn parse_reveal_until_prefix(input: &str) -> nom::IResult<&str, (), OracleError<
         tag("his "),
         tag("her "),
         tag("its "),
+        // CR 109.5: "top of that library" — Mirror-Mad Phantasm class
+        tag("that "),
     ))
     .parse(input)?;
-    let (input, _) = tag("library until ").parse(input)?;
-    // Pronoun + matching verb form.
+    value((), tag("library until ")).parse(input)
+}
+
+fn parse_reveal_until_prefix(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
+    let (input, _) = parse_reveal_cards_from_library_until(input)?;
+    // Active-voice pronoun + matching verb form.
     let (input, _) = alt((
         tag("you reveal "),
         tag("they reveal "),
@@ -5489,48 +5491,117 @@ fn parse_reveal_until_prefix(input: &str) -> nom::IResult<&str, (), OracleError<
     Ok((input, ()))
 }
 
-/// CR 701.20a: Parse "reveal[s] cards from the top of <possessive> library
-/// until <pronoun> reveal[s] a [filter]". Builds the [`Effect::RevealUntil`]
-/// with `player` identifying whose library is revealed.
+/// CR 701.20a: Parse the **passive-voice** prefix `"reveal[s] cards from the top of
+/// <possessive> library until "`, returning `()`.
+/// Stops before the article — the caller (`try_parse_reveal_until`) extracts the
+/// article, filter phrase, and optional exile suffix using nom combinators in
+/// the function body.
 ///
-/// Defaults: kept_destination = Hand, rest_destination = Library (bottom).
-/// Subsequent "put that card" / "put the rest" sentences override via
-/// ContinuationAst.
+/// Covers: Indomitable Creativity, Blessed Reincarnation, Tunnel Vision.
+fn parse_reveal_until_passive_prefix(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
+    parse_reveal_cards_from_library_until(input)
+}
+
+fn parse_reveal_until_active_filter_text(input: &str) -> OracleResult<'_, &str> {
+    all_consuming(alt((
+        terminated(take_until(" card"), (tag(" card"), opt(tag(".")))),
+        terminated(take_until("."), tag(".")),
+        rest,
+    )))
+    .parse(input)
+}
+
+fn parse_reveal_until_passive_filter_text(input: &str) -> OracleResult<'_, &str> {
+    all_consuming(alt((terminated(take_until(" card"), tag(" card")), rest))).parse(input)
+}
+
+/// Build a [`TargetFilter`] from the bare filter phrase extracted from a `RevealUntil`
+/// until-clause (caller has already stripped the article and trailing `" card"` suffix).
+fn build_reveal_until_filter(filter_text: &str) -> TargetFilter {
+    // CR 701.20a: "with the chosen name" — active form (e.g. Abundance)
+    if nom_primitives::scan_contains(filter_text, "with the chosen name") {
+        return TargetFilter::HasChosenName;
+    }
+    // CR 701.20a: "with that name" — passive form (Tunnel Vision)
+    if nom_primitives::scan_contains(filter_text, "with that name") {
+        return TargetFilter::HasChosenName;
+    }
+    if filter_text == "nonland" {
+        return TargetFilter::Typed(
+            TypedFilter::default().with_type(TypeFilter::Non(Box::new(TypeFilter::Land))),
+        );
+    }
+    if let Some(filter) = try_parse_chosen_kind_filter(filter_text) {
+        return filter;
+    }
+    let (parsed, _) = parse_target(filter_text);
+    parsed
+}
+
+/// CR 701.20a: Parse `"reveal[s] cards from the top of <possessive> library until …"`
+/// in both active voice (`"until <pronoun> reveal[s] a <filter>"`) and
+/// passive voice (`"until a/an <filter> [card] is revealed [and exiles that card]"`).
+/// Builds [`Effect::RevealUntil`] with `player` identifying whose library is revealed.
 fn try_parse_reveal_until(tp: TextPair, player: TargetFilter) -> Option<ParsedEffectClause> {
-    let (_, rest_orig) = nom_on_lower(tp.original, tp.lower, parse_reveal_until_prefix)?;
+    // CR 701.20a: Active-voice form — "…until they reveal a <filter>".
+    let active_result = nom_on_lower(tp.original, tp.lower, parse_reveal_until_prefix);
+    if let Some((_, rest_orig)) = active_result {
+        let rest_lower = &tp.lower[tp.lower.len() - rest_orig.len()..];
+        let (_, filter_text) = parse_reveal_until_active_filter_text(rest_lower).ok()?;
+        let filter = build_reveal_until_filter(filter_text);
+        return Some(parsed_clause(Effect::RevealUntil {
+            player,
+            filter,
+            kept_destination: Zone::Hand,
+            rest_destination: Zone::Library,
+            enter_tapped: false,
+            enters_attacking: false,
+            kept_optional_to: None,
+        }));
+    }
+
+    // CR 701.20a: Passive-voice form — "…until a/an <filter> [card] is revealed
+    // [and exiles that card]" (Indomitable Creativity, Blessed Reincarnation,
+    // Tunnel Vision). Passive prefix stops before the article; extract article,
+    // filter phrase, and optional exile suffix here.
+    let (_, rest_orig) = nom_on_lower(tp.original, tp.lower, parse_reveal_until_passive_prefix)?;
     let rest_lower = &tp.lower[tp.lower.len() - rest_orig.len()..];
 
-    // Strip trailing period and " card" suffix to get the filter text.
-    let filter_text = rest_lower.trim_end_matches('.').trim_end_matches(" card");
+    // Consume the article ("a" / "an").
+    let (_, after_article_orig) =
+        nom_on_lower(rest_orig, rest_lower, nom_primitives::parse_article)?;
+    let after_article_lower = &rest_lower[rest_lower.len() - after_article_orig.len()..];
 
-    // Parse "card with the chosen name" specially.
-    let filter = if nom_primitives::scan_contains(filter_text, "with the chosen name") {
-        TargetFilter::HasChosenName
-    } else if filter_text == "nonland" {
-        TargetFilter::Typed(
-            TypedFilter::default().with_type(TypeFilter::Non(Box::new(TypeFilter::Land))),
-        )
-    } else if let Some(filter) = try_parse_chosen_kind_filter(filter_text) {
-        // CR 614.11 + CR 701.20a: Reveal-until loop inside a draw replacement
-        // whose filter is resolved from the player's earlier "land or nonland"
-        // labeled choice (Abundance). Delegate the "of the chosen kind"
-        // recognition to `parse_search_filter` — the same detector already
-        // consumed by the Seek-of-the-chosen-kind family — so the runtime
-        // `FilterProp::IsChosenLandOrNonlandKind` resolver lights up here for
-        // free without a parallel string-matching arm.
-        filter
+    // Capture everything up to " is revealed" — this is the filter phrase.
+    let (remainder, captured) = take_until::<_, _, OracleError<'_>>(" is revealed")
+        .parse(after_article_lower)
+        .ok()?;
+
+    // Strip trailing " card" if present ("artifact or creature card" → "artifact or creature").
+    // Tunnel Vision's captured = "card with that name" (no " card" suffix — handled by HasChosenName).
+    let (_, filter_text) = parse_reveal_until_passive_filter_text(captured).ok()?;
+
+    let filter = build_reveal_until_filter(filter_text);
+
+    // CR 406.2: Detect inline "and exiles that card" suffix. When present, the kept
+    // card goes directly to Exile. Consume " is revealed" via nom tag, then check
+    // the optional exile clause with a tag probe (.is_ok() since opt is infallible anyway).
+    let (after_is_revealed, _) = tag::<_, _, OracleError<'_>>(" is revealed")
+        .parse(remainder)
+        .ok()?;
+    let inline_exile = tag::<_, _, OracleError<'_>>(" and exiles that card")
+        .parse(after_is_revealed)
+        .is_ok();
+    let kept_destination = if inline_exile {
+        Zone::Exile
     } else {
-        let (parsed, _) = parse_target(filter_text);
-        parsed
+        Zone::Hand
     };
 
-    // CR 701.20a: Default destinations — most cards use hand + library bottom.
-    // Subsequent "put that card" / "put the rest" sentences refine these via
-    // RevealUntilKept / PutRest continuations.
     Some(parsed_clause(Effect::RevealUntil {
         player,
         filter,
-        kept_destination: Zone::Hand,
+        kept_destination,
         rest_destination: Zone::Library,
         enter_tapped: false,
         enters_attacking: false,
@@ -36392,6 +36463,117 @@ mod tests {
                 }
             ),
             "expected rest->graveyard, got: {:?}",
+            def.effect
+        );
+    }
+
+    /// CR 701.20a + CR 406.2: Passive form with inline exile — Indomitable Creativity pattern.
+    /// "its controller reveals cards … until an artifact or creature card is revealed and exiles that card."
+    #[test]
+    fn reveal_until_passive_inline_exile_ic_pattern() {
+        let def = parse_effect_chain(
+            "Its controller reveals cards from the top of their library until an artifact or creature card is revealed and exiles that card.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::RevealUntil {
+                    player: TargetFilter::ParentTargetController,
+                    kept_destination: Zone::Exile,
+                    rest_destination: Zone::Library,
+                    enter_tapped: false,
+                    enters_attacking: false,
+                    kept_optional_to: None,
+                    ..
+                }
+            ),
+            "expected RevealUntil(ParentTargetController, kept=Exile, rest=Library), got: {:?}",
+            def.effect
+        );
+        if let Effect::RevealUntil { filter, .. } = &*def.effect {
+            assert!(
+                matches!(filter, TargetFilter::Or { .. }),
+                "expected Or filter for artifact-or-creature, got: {:?}",
+                filter
+            );
+        }
+    }
+
+    /// CR 701.20a: Passive form without inline exile — Blessed Reincarnation pattern.
+    /// "That player reveals cards … until a creature card is revealed."
+    #[test]
+    fn reveal_until_passive_creature_br_pattern() {
+        let def = parse_effect_chain(
+            "That player reveals cards from the top of their library until a creature card is revealed.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::RevealUntil {
+                    kept_destination: Zone::Hand,
+                    rest_destination: Zone::Library,
+                    ..
+                }
+            ),
+            "expected RevealUntil(kept=Hand, rest=Library), got: {:?}",
+            def.effect
+        );
+        if let Effect::RevealUntil { filter, .. } = &*def.effect {
+            match filter {
+                TargetFilter::Typed(tf) => {
+                    assert!(
+                        tf.type_filters
+                            .iter()
+                            .any(|t| matches!(t, TypeFilter::Creature)),
+                        "expected Creature type filter, got: {:?}",
+                        tf
+                    );
+                }
+                _ => panic!("expected Typed filter for creature, got: {:?}", filter),
+            }
+        }
+    }
+
+    /// CR 701.20a: Passive form with HasChosenName — Tunnel Vision pattern.
+    /// "Target player reveals cards … until a card with that name is revealed."
+    #[test]
+    fn reveal_until_passive_has_chosen_name_tv_pattern() {
+        let def = parse_effect_chain(
+            "Target player reveals cards from the top of their library until a card with that name is revealed.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::RevealUntil {
+                    filter: TargetFilter::HasChosenName,
+                    ..
+                }
+            ),
+            "expected RevealUntil filter=HasChosenName, got: {:?}",
+            def.effect
+        );
+    }
+
+    /// CR 701.20a: Active form with "that library" possessive arm (Mirror-Mad Phantasm class).
+    #[test]
+    fn reveal_until_active_that_library_possessive() {
+        let def = parse_effect_chain(
+            "They reveal cards from the top of that library until they reveal a creature card.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::RevealUntil {
+                    kept_destination: Zone::Hand,
+                    rest_destination: Zone::Library,
+                    ..
+                }
+            ),
+            "expected RevealUntil with that-library active form, got: {:?}",
             def.effect
         );
     }


### PR DESCRIPTION
## Summary

Closes #2426

Fixes Indomitable Creativity (#2426): the passive-voice `"reveals cards from the top of their library until a <filter> [card] is revealed [and exiles that card]"` clause was not recognized by `try_parse_reveal_until`, causing IC, Blessed Reincarnation, and Tunnel Vision to emit `RevealTop{count:1}` (only the top card shown) instead of the correct `RevealUntil` loop.

- Add `parse_reveal_until_passive_prefix` — nom combinator for the passive form, stopping before the article so the caller extracts the filter
- Extend `try_parse_reveal_until` with a dual active/passive path; passive path uses `take_until(" is revealed")` + `strip_suffix(" card")` + `opt(tag(" and exiles that card"))` for inline exile detection (`kept_destination = Zone::Exile`)
- Extract `build_reveal_until_filter` shared helper (adds `"with that name"` → `HasChosenName` for Tunnel Vision)
- Add `tag("that ")` to possessive `alt` arms in active prefix (Mirror-Mad Phantasm class)
- Scope `affected_objects_from_events` tracked set to `kept_destination` for `RevealUntil` so IC's downstream `ChangeZoneAll{Exile→Battlefield}` sees only the kept card, not the rest pile
- 4 new parser tests: IC inline-exile, Blessed Reincarnation, Tunnel Vision HasChosenName, "that library" active possessive

## Files changed

- `crates/engine/src/parser/oracle_effect/mod.rs` — passive prefix combinator, dual-path `try_parse_reveal_until`, `build_reveal_until_filter` helper, possessive arm, 4 tests
- `crates/engine/src/game/effects/mod.rs` — `RevealUntil` arm in `affected_objects_from_events` inner `dest_zone` match

## CR references

- `CR 701.20a` — reveal-until loop mechanic (reveal one at a time until condition met)
- `CR 701.20b` — revealing doesn't move cards out of their zone
- `CR 608.2f` — actions on multiple objects processed simultaneously (tracked-set scoping)
- `CR 406.2` — exiling a card puts it into the exile zone (inline exile suffix)
- `CR 109.5` — "that library" possessive referencing a previously mentioned library

## Track

Developer

## LLM

Model: claude-sonnet-4-6
Thinking: high

## Gate A

```
(exit 0 — no output, all checks passed)
```

## Anchored on

- `crates/engine/src/parser/oracle_effect/mod.rs:5463` — existing `parse_reveal_until_prefix` (active-voice form): same `alt((tag("reveals "), tag("reveal ")))` + possessive `alt` + `value((), tag(...))` structure mirrored in `parse_reveal_until_passive_prefix`
- `crates/engine/src/parser/oracle_effect/mod.rs:5352` — existing `try_parse_next_matches_until` passive filter extraction: same `take_until(" is revealed")` + `strip_suffix(" card")` pattern used in the new passive path

## Verification

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo test -p engine` — 10542 passed / 0 failed (unit + integration subset); 4 pre-existing integration test failures unrelated to this change (see CI Failures)
- All 28 RevealUntil tests pass including 4 new ones
- `./scripts/gen-card-data.sh` — IC: `RevealUntil { kept_destination: Exile, filter: Or[Artifact,Creature] }` ✓; Blessed Reincarnation: `RevealUntil` ✓; Tunnel Vision: `RevealUntil { filter: HasChosenName }` ✓

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

4 pre-existing integration tests on this branch fail due to unimplemented engine logic unrelated to the RevealUntil fix (The Rack replacement trigger, Pyromancer's Ascension counter trigger, anaphoric scope guard). These were added by a concurrent agent and were failing before this change. They do not affect the IC fix.
