### PR TITLE
feat(engine): Mayhem keyword (#2354) + self-referential damage-prevention scoping (Anti-Venom #2401)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -418,6 +418,7 @@ export type CastingVariant =
   | { type: "Escape" }
   | { type: "Retrace" }
   | { type: "Harmonize" }
+  | { type: "Mayhem" }
   | { type: "Flashback" }
   | { type: "Aftermath" }
   | {

--- a/client/src/components/modal/CastingVariantModal.tsx
+++ b/client/src/components/modal/CastingVariantModal.tsx
@@ -22,6 +22,7 @@ const VARIANT_KEYS: Partial<Record<CastingVariant["type"], string>> = {
   Escape: "variantEscape",
   Retrace: "variantRetrace",
   Harmonize: "variantHarmonize",
+  Mayhem: "variantMayhem",
   Flashback: "variantFlashback",
   Aftermath: "variantAftermath",
   GraveyardPermission: "variantGraveyardPermission",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1255,6 +1255,7 @@
     "variantEscape": "Mit Entrinnen wirken",
     "variantRetrace": "Mit Zurückverfolgen wirken",
     "variantHarmonize": "Mit Harmonisieren wirken",
+    "variantMayhem": "Mit Mayhem wirken",
     "variantFlashback": "Mit Flashback wirken",
     "variantAftermath": "Mit Nachwirkung wirken",
     "variantGraveyardPermission": "Aus dem Friedhof wirken",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1260,6 +1260,7 @@
     "variantEscape": "Cast with Escape",
     "variantRetrace": "Cast with Retrace",
     "variantHarmonize": "Cast with Harmonize",
+    "variantMayhem": "Cast with Mayhem",
     "variantFlashback": "Cast with Flashback",
     "variantAftermath": "Cast with Aftermath",
     "variantGraveyardPermission": "Cast from Graveyard",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1255,6 +1255,7 @@
     "variantEscape": "Lanzar con Evadir",
     "variantRetrace": "Lanzar con Retrazar",
     "variantHarmonize": "Lanzar con Armonizar",
+    "variantMayhem": "Lanzar con Mayhem",
     "variantFlashback": "Lanzar con Flashback",
     "variantAftermath": "Lanzar con Secuela",
     "variantGraveyardPermission": "Lanzar desde el cementerio",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1255,6 +1255,7 @@
     "variantEscape": "Lancer avec Évasion",
     "variantRetrace": "Lancer avec Recomposition",
     "variantHarmonize": "Lancer avec Harmonisation",
+    "variantMayhem": "Lancer avec Mayhem",
     "variantFlashback": "Lancer avec Flash-back",
     "variantAftermath": "Lancer avec Séquelles",
     "variantGraveyardPermission": "Lancer depuis le cimetière",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1255,6 +1255,7 @@
     "variantEscape": "Lancia con Fuggire",
     "variantRetrace": "Lancia con Ripercorrere",
     "variantHarmonize": "Lancia con Armonizzare",
+    "variantMayhem": "Lancia con Mayhem",
     "variantFlashback": "Lancia con Flashback",
     "variantAftermath": "Lancia con Conseguenze",
     "variantGraveyardPermission": "Lancia dal cimitero",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1255,6 +1255,7 @@
     "variantEscape": "Rzuć z Escape",
     "variantRetrace": "Rzuć z Retrace",
     "variantHarmonize": "Rzuć z Harmonize",
+    "variantMayhem": "Rzuć z Mayhem",
     "variantFlashback": "Rzuć z Flashback",
     "variantAftermath": "Rzuć z Aftermath",
     "variantGraveyardPermission": "Rzuć z cmentarza",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1255,6 +1255,7 @@
     "variantEscape": "Conjurar com Escapar",
     "variantRetrace": "Conjurar com Refazer",
     "variantHarmonize": "Conjurar com Harmonizar",
+    "variantMayhem": "Conjurar com Mayhem",
     "variantFlashback": "Conjurar com Flashback",
     "variantAftermath": "Conjurar com Sequência",
     "variantGraveyardPermission": "Conjurar do Cemitério",

--- a/client/src/viewmodel/keywordProps.ts
+++ b/client/src/viewmodel/keywordProps.ts
@@ -48,6 +48,7 @@ const KEYWORD_REMINDER_TEXT: Partial<Record<string, string>> = {
   "Skulk":         "Can't be blocked by creatures with greater power.",
   "Madness":       "If you discard this card, you may cast it for its madness cost instead.",
   "Escape":        "Cast from your graveyard for its escape cost by also exiling other cards from your graveyard.",
+  "Mayhem":        "Cast from your graveyard for its mayhem cost if you discarded it this turn.",
   "Evoke":         "Cast for its evoke cost and sacrifice it when it enters the battlefield.",
   "Embalm":        "Exile from your graveyard: create a white Zombie token copy of this card.",
   "Eternalize":    "Exile from your graveyard: create a 4/4 black Zombie token copy of this card.",

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -12711,6 +12711,28 @@ mod tests {
         );
     }
 
+    /// CR 702.187b + CR 118.9a: Mayhem is an alternative cost (only one
+    /// alternative cost may apply to a spell), but — unlike Flashback and
+    /// Harmonize — it does NOT exile the spell when it leaves the stack. The
+    /// spell resolves to its normal zone, so a card can be discarded and
+    /// Mayhem-cast again on a later turn.
+    #[test]
+    fn mayhem_variant_resolves_without_exile() {
+        assert!(
+            CastingVariant::Mayhem.uses_alternative_cost(),
+            "Mayhem replaces the mana cost, so it is an alternative cost",
+        );
+        assert!(
+            !CastingVariant::Mayhem.exiles_when_leaving_stack_for_any_reason(),
+            "Mayhem must not exile on resolution (CR 702.187b)",
+        );
+        assert_eq!(
+            CastingVariant::Mayhem.stack_to_graveyard_replacement(),
+            None,
+            "Mayhem must not replace the stack→graveyard move with exile",
+        );
+    }
+
     /// CR 702.187b + CR 514.2: The discard mark is turn-scoped — a card
     /// discarded on an earlier turn is no longer Mayhem-castable.
     #[test]

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -554,6 +554,18 @@ fn has_flashback_keyword(state: &GameState, object_id: ObjectId) -> bool {
     super::keywords::object_has_effective_keyword_kind(state, object_id, KeywordKind::Flashback)
 }
 
+/// CR 702.187b: Mayhem may be used only "as long as you discarded this card
+/// this turn." The mark is stamped on the graveyard object at discard time and
+/// auto-expires when the turn advances, so a simple equality against the
+/// current turn number is the gate.
+fn was_discarded_this_turn(state: &GameState, object_id: ObjectId) -> bool {
+    state
+        .objects
+        .get(&object_id)
+        .and_then(|obj| obj.discarded_turn)
+        == Some(state.turn_number)
+}
+
 /// CR 702.81: Check if an object has the Retrace keyword.
 fn has_retrace_keyword(state: &GameState, object_id: ObjectId) -> bool {
     super::keywords::object_has_effective_keyword_kind(state, object_id, KeywordKind::Retrace)
@@ -719,6 +731,10 @@ fn has_effective_graveyard_cast_keyword(
         || has_flashback_keyword(state, object_id)
         || has_aftermath_keyword(state, object_id)
         || super::keywords::effective_disturb_cost(state, object_id).is_some()
+        // CR 702.187b: Mayhem makes the graveyard a castable zone only while the
+        // card was discarded this turn.
+        || (was_discarded_this_turn(state, object_id)
+            && super::keywords::effective_mayhem_cost(state, object_id).is_some())
 }
 
 fn upsert_keyword_by_kind(keywords: &mut Vec<Keyword>, keyword: Keyword) {
@@ -2413,6 +2429,14 @@ fn casting_variant_candidates(
         {
             candidates.push(CastingVariant::Harmonize);
         }
+        // CR 702.187b: Mayhem is available only while the card was discarded this
+        // turn. The cost may be printed or granted to graveyard cards by a static
+        // (Green Goblin), so query the effective off-zone keyword cost.
+        if super::keywords::effective_mayhem_cost(state, object_id).is_some()
+            && was_discarded_this_turn(state, object_id)
+        {
+            candidates.push(CastingVariant::Mayhem);
+        }
         if super::keywords::effective_flashback_cost(state, object_id).is_some() {
             candidates.push(CastingVariant::Flashback);
         }
@@ -2825,6 +2849,15 @@ fn prepare_spell_cast_with_variant_override_inner(
         None
     };
 
+    // CR 702.187b: Mayhem — use the mayhem mana cost when casting from graveyard,
+    // but only while the card was discarded this turn. The cost may be granted to
+    // graveyard cards by a static (Green Goblin), so use the off-zone-aware lookup.
+    let mayhem_cost = if obj.zone == Zone::Graveyard && was_discarded_this_turn(state, object_id) {
+        super::keywords::effective_mayhem_cost(state, object_id)
+    } else {
+        None
+    };
+
     // CR 702.190a: Sneak alt-cost when casting from HAND. The
     // `effective_sneak_cost` lookup goes through `effective_keyword_for_object`
     // so off-zone keyword grants (e.g., statics that grant Sneak to cards in
@@ -2927,6 +2960,8 @@ fn prepare_spell_cast_with_variant_override_inner(
             CastingVariant::JumpStart
         } else if disturb_cost.is_some() {
             CastingVariant::Disturb
+        } else if mayhem_cost.is_some() {
+            CastingVariant::Mayhem
         } else if let Some(source) = graveyard_permission_src {
             // CR 110.4: For OncePerTurnPerPermanentType permissions, auto-pick
             // the slot when only one is available. When multiple slots are
@@ -3258,6 +3293,13 @@ fn prepare_spell_cast_with_variant_override_inner(
     } else {
         None
     };
+    // CR 702.187b: When casting via Mayhem, the mayhem mana cost replaces the
+    // card's mana cost (an alternative cost paid from the graveyard).
+    let effective_mayhem_cost_for_path = if casting_variant == CastingVariant::Mayhem {
+        mayhem_cost
+    } else {
+        None
+    };
     let mut mana_cost = if energy_cost_from_exile
         || hand_cast_free
         || next_spell_without_paying
@@ -3286,6 +3328,7 @@ fn prepare_spell_cast_with_variant_override_inner(
             .or(effective_harmonize_cost_for_path)
             .or(effective_flashback_mana_cost_for_path)
             .or(effective_disturb_cost_for_path)
+            .or(effective_mayhem_cost_for_path)
             .or(effective_sneak_cost_for_path)
             .or(effective_web_slinging_cost_for_path)
             .or(alt_cost_from_exile)
@@ -12583,6 +12626,101 @@ mod tests {
             prepared.mana_cost, state.objects[&object_id].mana_cost,
             "printed mana cost ({:?}) must NOT be paid when Freerunning override is selected",
             state.objects[&object_id].mana_cost,
+        );
+    }
+
+    fn mayhem_test_cost() -> ManaCost {
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 1,
+        }
+    }
+
+    /// CR 702.187b: Put an instant with a printed "Mayhem {1}{R}" keyword in the
+    /// controller's graveyard. Printed graveyard keywords live in
+    /// `base_keywords` (the off-zone keyword pipeline seeds from there), and the
+    /// printed mana cost ({3}{R}{R}) differs from the mayhem cost so cost
+    /// substitution is observable.
+    fn add_mayhem_card_in_graveyard(state: &mut GameState) -> ObjectId {
+        let object_id = create_object(
+            state,
+            CardId(2187),
+            PlayerId(0),
+            "Mayhem Test Instant".to_string(),
+            Zone::Graveyard,
+        );
+        let obj = state.objects.get_mut(&object_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Instant);
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+            generic: 3,
+        };
+        obj.base_keywords.push(Keyword::Mayhem(mayhem_test_cost()));
+        object_id
+    }
+
+    /// CR 702.187b: Mayhem may be used only "as long as you discarded this card
+    /// this turn." A card that reached the graveyard another way (e.g. milled)
+    /// must NOT be offered as a Mayhem cast.
+    #[test]
+    fn mayhem_unavailable_when_not_discarded_this_turn() {
+        let mut state = setup_game_at_main_phase();
+        let object_id = add_mayhem_card_in_graveyard(&mut state);
+        // `discarded_turn` left None — the card was not discarded.
+        let candidates = casting_variant_candidates(&state, PlayerId(0), object_id);
+        assert!(
+            !candidates.contains(&CastingVariant::Mayhem),
+            "Mayhem must not be a candidate when the card was not discarded this turn; \
+             got {candidates:?}",
+        );
+    }
+
+    /// CR 702.187b + CR 601.2b: When the card was discarded this turn, Mayhem is
+    /// surfaced as a candidate and preparation pays the mayhem cost rather than
+    /// the printed mana cost.
+    #[test]
+    fn mayhem_available_when_discarded_this_turn() {
+        let mut state = setup_game_at_main_phase();
+        let object_id = add_mayhem_card_in_graveyard(&mut state);
+        let turn = state.turn_number;
+        // Stamp the discard mark exactly as the discard pipeline does.
+        state.objects.get_mut(&object_id).unwrap().discarded_turn = Some(turn);
+
+        let candidates = casting_variant_candidates(&state, PlayerId(0), object_id);
+        assert!(
+            candidates.contains(&CastingVariant::Mayhem),
+            "Mayhem must be a candidate when the card was discarded this turn; got {candidates:?}",
+        );
+
+        let prepared = prepare_spell_cast_with_variant_override(
+            &state,
+            PlayerId(0),
+            object_id,
+            Some(CastingVariant::Mayhem),
+        )
+        .expect("mayhem override must prepare a spell cast");
+        assert_eq!(prepared.casting_variant, CastingVariant::Mayhem);
+        assert_eq!(
+            prepared.mana_cost,
+            mayhem_test_cost(),
+            "prepared mana cost must be the mayhem alt cost, not the printed mana cost",
+        );
+    }
+
+    /// CR 702.187b + CR 514.2: The discard mark is turn-scoped — a card
+    /// discarded on an earlier turn is no longer Mayhem-castable.
+    #[test]
+    fn mayhem_unavailable_after_turn_advances() {
+        let mut state = setup_game_at_main_phase();
+        let object_id = add_mayhem_card_in_graveyard(&mut state);
+        state.objects.get_mut(&object_id).unwrap().discarded_turn = Some(state.turn_number);
+
+        // A later turn: the mark no longer equals the current turn.
+        state.turn_number += 1;
+        let candidates = casting_variant_candidates(&state, PlayerId(0), object_id);
+        assert!(
+            !candidates.contains(&CastingVariant::Mayhem),
+            "Mayhem must expire once the turn advances; got {candidates:?}",
         );
     }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -446,7 +446,11 @@ pub fn spell_objects_available_to_cast(state: &GameState, player: PlayerId) -> V
                     || has_disturb_keyword(state, obj_id)
                     || retrace_has_discardable_land(state, player, obj_id)
                     || jumpstart_has_discardable_card(state, player, obj_id)
-                    || graveyard_has_enough_for_escape(state, player, obj_id))
+                    || graveyard_has_enough_for_escape(state, player, obj_id)
+                    // CR 702.187b: Mayhem is eligible only while the card was
+                    // discarded this turn.
+                    || (was_discarded_this_turn(state, obj_id)
+                        && super::keywords::effective_mayhem_cost(state, obj_id).is_some()))
         })
     }));
 

--- a/crates/engine/src/game/effects/discard.rs
+++ b/crates/engine/src/game/effects/discard.rs
@@ -25,6 +25,25 @@ pub(crate) enum DiscardOutcome {
     NeedsReplacementChoice(PlayerId),
 }
 
+/// CR 701.9a: To discard a card, move it from its owner's hand to their graveyard.
+/// CR 702.187b: Mayhem's cast permission is gated by the graveyard card having
+/// been discarded this turn, so stamp that marker at the same completion point
+/// that records the discard event.
+pub(crate) fn complete_discard_to_graveyard(
+    state: &mut GameState,
+    object_id: ObjectId,
+    player_id: PlayerId,
+    events: &mut Vec<GameEvent>,
+) {
+    zones::move_to_zone(state, object_id, Zone::Graveyard, events);
+    crate::game::restrictions::record_discard(state, player_id);
+    crate::game::restrictions::record_card_discarded(state, object_id);
+    events.push(GameEvent::Discarded {
+        player_id,
+        object_id,
+    });
+}
+
 /// CR 701.9a: To discard a card, move it from owner's hand to their graveyard.
 /// If targets specify specific cards, discard those; otherwise discard from end of hand.
 pub fn resolve(
@@ -104,14 +123,7 @@ pub fn resolve(
                             object_id: oid,
                             ..
                         } => {
-                            zones::move_to_zone(state, oid, Zone::Graveyard, events);
-                            crate::game::restrictions::record_discard(state, pid);
-                            // CR 702.187b: Mark the graveyard card for Mayhem's gate.
-                            crate::game::restrictions::record_card_discarded(state, oid);
-                            events.push(GameEvent::Discarded {
-                                player_id: pid,
-                                object_id: oid,
-                            });
+                            complete_discard_to_graveyard(state, oid, pid, events);
                         }
                         zone_event @ ProposedEvent::ZoneChange { object_id: oid, .. } => {
                             // Replacement redirected (e.g., Madness → exile instead of graveyard).
@@ -263,14 +275,7 @@ pub(crate) fn discard_as_cost_with_source(
                 object_id: oid,
                 ..
             } => {
-                zones::move_to_zone(state, oid, Zone::Graveyard, events);
-                crate::game::restrictions::record_discard(state, pid);
-                // CR 702.187b: Mark the graveyard card for Mayhem's gate.
-                crate::game::restrictions::record_card_discarded(state, oid);
-                events.push(GameEvent::Discarded {
-                    player_id: pid,
-                    object_id: oid,
-                });
+                complete_discard_to_graveyard(state, oid, pid, events);
             }
             zone_event @ ProposedEvent::ZoneChange { object_id: oid, .. } => {
                 // CR 614.1c: Replacement redirected destination (e.g., Madness → exile).
@@ -444,6 +449,7 @@ mod tests {
         assert!(matches!(outcome, DiscardOutcome::Complete));
         assert!(state.exile.contains(&card));
         assert!(!state.players[0].graveyard.contains(&card));
+        assert_eq!(state.objects[&card].discarded_turn, None);
         assert!(events.iter().any(
             |event| matches!(event, GameEvent::Discarded { object_id, .. } if *object_id == card)
         ));
@@ -581,6 +587,7 @@ mod tests {
         assert!(state
             .players_who_discarded_card_this_turn
             .contains(&PlayerId(0)));
+        assert_eq!(state.objects[&card].discarded_turn, Some(state.turn_number));
         assert_eq!(
             state
                 .cards_discarded_this_turn_by_player

--- a/crates/engine/src/game/effects/discard.rs
+++ b/crates/engine/src/game/effects/discard.rs
@@ -106,6 +106,8 @@ pub fn resolve(
                         } => {
                             zones::move_to_zone(state, oid, Zone::Graveyard, events);
                             crate::game::restrictions::record_discard(state, pid);
+                            // CR 702.187b: Mark the graveyard card for Mayhem's gate.
+                            crate::game::restrictions::record_card_discarded(state, oid);
                             events.push(GameEvent::Discarded {
                                 player_id: pid,
                                 object_id: oid,
@@ -263,6 +265,8 @@ pub(crate) fn discard_as_cost_with_source(
             } => {
                 zones::move_to_zone(state, oid, Zone::Graveyard, events);
                 crate::game::restrictions::record_discard(state, pid);
+                // CR 702.187b: Mark the graveyard card for Mayhem's gate.
+                crate::game::restrictions::record_card_discarded(state, oid);
                 events.push(GameEvent::Discarded {
                     player_id: pid,
                     object_id: oid,

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -924,6 +924,8 @@ pub(super) fn handle_ward_discard_choice(
 
     zones::move_to_zone(state, chosen[0], Zone::Graveyard, events);
     restrictions::record_discard(state, player);
+    // CR 702.187b: Mark the graveyard card for Mayhem's gate.
+    restrictions::record_card_discarded(state, chosen[0]);
     events.push(GameEvent::Discarded {
         player_id: player,
         object_id: chosen[0],

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -20,7 +20,6 @@ use super::engine::{
 use super::engine_priority;
 use super::life_costs::{pay_life_as_cost, PayLifeCostResult};
 use super::mana_abilities;
-use super::restrictions;
 use super::zones;
 
 pub(super) fn handle_optional_effect_choice(
@@ -922,14 +921,7 @@ pub(super) fn handle_ward_discard_choice(
         ));
     }
 
-    zones::move_to_zone(state, chosen[0], Zone::Graveyard, events);
-    restrictions::record_discard(state, player);
-    // CR 702.187b: Mark the graveyard card for Mayhem's gate.
-    restrictions::record_card_discarded(state, chosen[0]);
-    events.push(GameEvent::Discarded {
-        player_id: player,
-        object_id: chosen[0],
-    });
+    effects::discard::complete_discard_to_graveyard(state, chosen[0], player, events);
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::from(&pending_effect.effect),
         source_id: pending_effect.source_id,

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -220,14 +220,9 @@ pub(super) fn handle_replacement_choice(
                     object_id,
                     ..
                 } => {
-                    zones::move_to_zone(state, object_id, Zone::Graveyard, events);
-                    crate::game::restrictions::record_discard(state, player_id);
-                    // CR 702.187b: Mark the graveyard card for Mayhem's gate.
-                    crate::game::restrictions::record_card_discarded(state, object_id);
-                    events.push(GameEvent::Discarded {
-                        player_id,
-                        object_id,
-                    });
+                    effects::discard::complete_discard_to_graveyard(
+                        state, object_id, player_id, events,
+                    );
                 }
                 // CR 106.3 + CR 106.4: Mana production accepted after replacement choice.
                 // In practice CR 614.5 mana-type replacements don't require a choice and

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -222,6 +222,8 @@ pub(super) fn handle_replacement_choice(
                 } => {
                     zones::move_to_zone(state, object_id, Zone::Graveyard, events);
                     crate::game::restrictions::record_discard(state, player_id);
+                    // CR 702.187b: Mark the graveyard card for Mayhem's gate.
+                    crate::game::restrictions::record_card_discarded(state, object_id);
                     events.push(GameEvent::Discarded {
                         player_id,
                         object_id,

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -450,6 +450,15 @@ pub struct GameObject {
     // filters — NOT for summoning-sickness (see `summoning_sick`).
     pub entered_battlefield_turn: Option<u32>,
 
+    // CR 702.187b: Global turn on which this card was put into a graveyard as a
+    // result of a discard. Used by the Mayhem keyword's "as long as you
+    // discarded this card this turn" gate. Compared against the current turn
+    // number at query time, so it auto-expires when the turn advances; reset to
+    // `None` whenever the object changes zones (a card that leaves the graveyard
+    // and returns is a new object that was not discarded).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discarded_turn: Option<u32>,
+
     /// CR 302.6: Summoning-sickness state flag. True when this permanent has
     /// NOT been continuously under its controller's control since that player's
     /// most recent turn began — i.e., it can't attack or pay `{T}`/`{Q}` costs
@@ -982,6 +991,7 @@ impl GameObject {
             base_characteristics_initialized: false,
             timestamp: 0,
             entered_battlefield_turn: None,
+            discarded_turn: None,
             summoning_sick: false,
             echo_due: false,
             cast_variant_paid: None,

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -99,6 +99,19 @@ pub fn effective_escape_data(state: &GameState, object_id: ObjectId) -> Option<(
     }
 }
 
+/// CR 702.187b: Effective Mayhem alt-cost for a card in the graveyard, honoring
+/// off-zone characteristic grants (e.g. Green Goblin's "Each nonland card in
+/// your graveyard has mayhem. The mayhem cost is equal to its mana cost.") in
+/// addition to a printed Mayhem keyword. The availability gate ("discarded this
+/// turn") is checked separately by the caster, not here.
+pub fn effective_mayhem_cost(state: &GameState, object_id: ObjectId) -> Option<ManaCost> {
+    let keyword = effective_keyword_for_object(state, object_id, KeywordKind::Mayhem)?;
+    match keyword {
+        Keyword::Mayhem(cost) => Some(resolve_keyword_mana_cost(state, object_id, &cost)),
+        _ => None,
+    }
+}
+
 /// CR 702.190a: Effective Sneak alt-cost for an object, honoring off-zone characteristic
 /// grants (e.g., Ninja Teen's "creature cards in your graveyard have sneak {cost}").
 pub fn effective_sneak_cost(state: &GameState, object_id: ObjectId) -> Option<ManaCost> {

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -273,6 +273,20 @@ pub fn record_discard(state: &mut crate::types::game_state::GameState, player: P
         .or_insert(0) += 1;
 }
 
+/// CR 702.187b: Stamp a card that was just put into a graveyard by a discard
+/// with the current turn, so the Mayhem keyword's "as long as you discarded
+/// this card this turn" gate can recognize it. The mark auto-expires when the
+/// turn advances (compared against `turn_number` at query time) and is cleared
+/// by `move_to_zone` on any subsequent zone change. Call only when the
+/// discarded card actually went to the graveyard (not when a replacement
+/// redirected it elsewhere, e.g. Madness → exile).
+pub fn record_card_discarded(state: &mut crate::types::game_state::GameState, object_id: ObjectId) {
+    let turn = state.turn_number;
+    if let Some(obj) = state.objects.get_mut(&object_id) {
+        obj.discarded_turn = Some(turn);
+    }
+}
+
 pub fn record_token_created(state: &mut crate::types::game_state::GameState, object_id: ObjectId) {
     if let Some(obj) = state.objects.get(&object_id) {
         state

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -61,6 +61,13 @@ fn apply_zone_exit_cleanup(state: &mut GameState, object_id: ObjectId, from: Zon
     // re-drawn does not surface as "still revealed."
     state.revealed_cards.remove(&object_id);
     state.public_revealed_cards.remove(&object_id);
+    // CR 400.7 + CR 702.187b: The "discarded this turn" mark (Mayhem's gate)
+    // belongs to the old object. Clear it on any zone change so a card that
+    // leaves the graveyard and returns is not treated as still discarded; the
+    // discard pipeline re-stamps it after the move-to-graveyard completes.
+    if let Some(obj) = state.objects.get_mut(&object_id) {
+        obj.discarded_turn = None;
+    }
     // CR 400.7 + CR 403.4: Activation-use history belongs to the old
     // object. `ObjectId` is storage identity here, so clear per-object counts
     // at the zone-change boundary before the same id can represent a new object.

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -12366,6 +12366,52 @@ mod tests {
     }
 
     #[test]
+    fn green_goblin_full_face_parses_mayhem_and_graveyard_cost_reduction() {
+        // CR 702.187b + CR 601.2f: The full Green Goblin face — flying/menace,
+        // the graveyard-cast cost reduction, and the Goblin Formula mayhem grant
+        // — must all parse (Norman Osborn // Green Goblin, #2354). The two novel
+        // statics (cost reduction scoped to graveyard casts, and the mayhem
+        // grant) are asserted here; the printed evasion keywords arrive via the
+        // MTGJSON keyword array.
+        use crate::types::statics::{CostModifyMode, StaticMode};
+        let result = parse(
+            "Flying, menace\n\
+             Spells you cast from your graveyard cost {2} less to cast.\n\
+             Goblin Formula — Each nonland card in your graveyard has mayhem. \
+             The mayhem cost is equal to its mana cost.",
+            "Green Goblin",
+            &[],
+            &["Creature"],
+            &["Goblin", "Human", "Villain"],
+        );
+        assert!(
+            result.statics.iter().any(|static_def| {
+                static_def
+                    .modifications
+                    .contains(&ContinuousModification::AddKeyword {
+                        keyword: Keyword::Mayhem(ManaCost::SelfManaCost),
+                    })
+            }),
+            "missing mayhem grant static: {:?}",
+            result.statics
+        );
+        assert!(
+            result.statics.iter().any(|static_def| {
+                matches!(
+                    &static_def.mode,
+                    StaticMode::ModifyCost {
+                        mode: CostModifyMode::Reduce,
+                        amount: ManaCost::Cost { generic: 2, .. },
+                        ..
+                    }
+                )
+            }),
+            "missing graveyard-cast cost reduction static: {:?}",
+            result.statics
+        );
+    }
+
+    #[test]
     fn green_goblin_goblin_formula_line_grants_mayhem() {
         // CR 702.187b: the real card line carries the "Goblin Formula —" ability
         // word and a parenthesized reminder; both must be stripped so the grant

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -71,7 +71,7 @@ use super::oracle_spacecraft::parse_spacecraft_threshold_lines;
 use super::oracle_special::{
     attach_die_result_branches_to_chain, normalize_self_refs_for_static,
     parse_cumulative_upkeep_keyword, parse_defiler_cost_reduction, parse_escape_keyword,
-    parse_harmonize_keyword, parse_solve_condition, try_parse_die_roll_table,
+    parse_harmonize_keyword, parse_mayhem_keyword, parse_solve_condition, try_parse_die_roll_table,
 };
 use super::oracle_static::{
     lower_static_ir, parse_cast_spells_alternative_cost_multi,
@@ -1133,6 +1133,7 @@ fn is_spell_resolution_instruction_line(
         || lower_starts_with(&lower, "activate ")
         || lower_starts_with(&lower, "suspend ")
         || lower_starts_with(&lower, "harmonize ")
+        || lower_starts_with(&lower, "mayhem ")
         || lower_starts_with(&lower, "flashback")
         || lower_starts_with(&lower, "buyback")
         || lower_starts_with(&lower, "this spell costs ")
@@ -2832,6 +2833,18 @@ pub(crate) fn parse_oracle_ir(
         if lower_starts_with(&lower, "harmonize ") {
             if let Some(harmonize_kw) = parse_harmonize_keyword(&line) {
                 result.extracted_keywords.push(harmonize_kw);
+                i += 1;
+                continue;
+            }
+        }
+
+        // CR 702.187b: Mayhem {cost} — parse mana cost from Oracle text, same as
+        // Harmonize. MTGJSON's keywords array carries only the bare "Mayhem"
+        // name, so the cost is extracted here. Must run before the spell
+        // imperative catch-all so the line is a keyword, not an effect.
+        if lower_starts_with(&lower, "mayhem ") {
+            if let Some(mayhem_kw) = parse_mayhem_keyword(&line) {
+                result.extracted_keywords.push(mayhem_kw);
                 i += 1;
                 continue;
             }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -12366,6 +12366,34 @@ mod tests {
     }
 
     #[test]
+    fn green_goblin_goblin_formula_line_grants_mayhem() {
+        // CR 702.187b: the real card line carries the "Goblin Formula —" ability
+        // word and a parenthesized reminder; both must be stripped so the grant
+        // is recognized (Norman Osborn // Green Goblin, #2354).
+        let result = parse(
+            "Goblin Formula — Each nonland card in your graveyard has mayhem. \
+             The mayhem cost is equal to its mana cost. (You may cast a card from \
+             your graveyard for its mayhem cost if you discarded it this turn. \
+             Timing rules still apply.)",
+            "Green Goblin",
+            &[],
+            &["Creature"],
+            &["Goblin", "Human", "Villain"],
+        );
+        assert!(
+            result.statics.iter().any(|static_def| {
+                static_def
+                    .modifications
+                    .contains(&ContinuousModification::AddKeyword {
+                        keyword: Keyword::Mayhem(ManaCost::SelfManaCost),
+                    })
+            }),
+            "Green Goblin's Goblin Formula must grant Mayhem to graveyard cards; got {:?}",
+            result.statics
+        );
+    }
+
+    #[test]
     fn helper_parses_same_line_escape_grant_continuation() {
         let static_def = try_parse_graveyard_keyword_static_with_continuation(
             "Each nonland card in your graveyard has escape. The escape cost is equal to the card's mana cost plus exile three other cards from your graveyard.",

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -649,6 +649,31 @@ fn parse_graveyard_keyword_continuation(
                 exile_count,
             })
         }
+        GraveyardGrantedKeywordKind::Mayhem => {
+            // CR 702.187b: "The mayhem cost is equal to [its/that card's/the
+            // card's] mana cost." (Green Goblin's Goblin Formula). Mirrors the
+            // Flashback continuation; the cost resolves to the card's own mana
+            // cost via `ManaCost::SelfManaCost`.
+            let (_, rest) = nom_on_lower(text, &lower, |i| {
+                value((), tag("the mayhem cost is equal to ")).parse(i)
+            })?;
+            let rest_lower = rest.to_lowercase();
+            let (_, rest) = nom_on_lower(rest, &rest_lower, |i| {
+                value(
+                    (),
+                    alt((
+                        tag("that card's mana cost"),
+                        tag("the card's mana cost"),
+                        tag("its mana cost"),
+                    )),
+                )
+                .parse(i)
+            })?;
+            if !continuation_fully_consumed(rest) {
+                return None;
+            }
+            Some(Keyword::Mayhem(ManaCost::SelfManaCost))
+        }
     }
 }
 
@@ -12292,6 +12317,52 @@ mod tests {
                     },
                 })
         }));
+    }
+
+    #[test]
+    fn top_level_static_mayhem_grant_stays_on_graveyard_cards() {
+        // CR 702.187b: Green Goblin's "Goblin Formula" grants Mayhem to every
+        // nonland card in the controller's graveyard, with the mayhem cost equal
+        // to that card's own mana cost (ManaCost::SelfManaCost). The general
+        // off-zone keyword-grant pipeline then surfaces it to the cast path
+        // (Norman Osborn // Green Goblin, #2354).
+        let result = parse(
+            "Each nonland card in your graveyard has mayhem.\nThe mayhem cost is equal to its mana cost.",
+            "Green Goblin",
+            &[],
+            &["Creature"],
+            &["Goblin", "Human", "Villain"],
+        );
+        assert!(result.extracted_keywords.is_empty());
+        assert_eq!(result.statics.len(), 1);
+        let static_def = &result.statics[0];
+        let TargetFilter::Typed(tf) = static_def
+            .affected
+            .as_ref()
+            .expect("expected affected filter")
+        else {
+            panic!("expected typed affected filter");
+        };
+        assert_eq!(
+            tf.controller,
+            Some(crate::types::ability::ControllerRef::You)
+        );
+        assert!(
+            tf.properties.contains(&FilterProp::InZone {
+                zone: Zone::Graveyard
+            }),
+            "missing graveyard filter: {:?}",
+            tf.properties
+        );
+        assert!(
+            static_def
+                .modifications
+                .contains(&ContinuousModification::AddKeyword {
+                    keyword: Keyword::Mayhem(ManaCost::SelfManaCost),
+                }),
+            "missing mayhem grant: {:?}",
+            static_def.modifications
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1430,6 +1430,7 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::Emerge(_) => "emerge".to_string(),
         Keyword::Escape { .. } => "escape".to_string(),
         Keyword::Harmonize(_) => "harmonize".to_string(),
+        Keyword::Mayhem(_) => "mayhem".to_string(),
         Keyword::Evoke(_) => "evoke".to_string(),
         Keyword::Foretell(_) => "foretell".to_string(),
         Keyword::Mutate(_) => "mutate".to_string(),

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4989,7 +4989,6 @@ fn parse_damage_prevention_replacement(
     {
         Some(damage_target_controller())
     } else if nom_primitives::scan_contains(working_lower, "dealt to target creature")
-        || nom_primitives::scan_contains(working_lower, "dealt to ~")
         || nom_primitives::scan_contains(working_lower, "dealt to and dealt by ~")
     {
         Some(DamageTargetFilter::CreatureOnly)
@@ -5009,16 +5008,18 @@ fn parse_damage_prevention_replacement(
     // `damage_target_filter = None` caused the shield to prevent ALL damage to
     // any target, which was the Multiclass Baldric / Inviolability / Artifact Ward
     // class of bug.
-    let valid_card_filter: Option<TargetFilter> =
-        nom_primitives::scan_at_word_boundaries(working_lower, |input| {
-            preceded(
-                tag::<_, _, OracleError<'_>>("dealt to "),
-                terminated(
-                    parse_attached_subject_target_filter,
-                    alt((value((), eof), value((), multispace1), value((), tag(".")))),
-                ),
-            )
-            .parse(input)
+    let valid_card_filter: Option<TargetFilter> = parse_self_recipient_valid_card(working_lower)
+        .or_else(|| {
+            nom_primitives::scan_at_word_boundaries(working_lower, |input| {
+                preceded(
+                    tag::<_, _, OracleError<'_>>("dealt to "),
+                    terminated(
+                        parse_attached_subject_target_filter,
+                        alt((value((), eof), value((), multispace1), value((), tag(".")))),
+                    ),
+                )
+                .parse(input)
+            })
         })
         .or_else(|| parse_damage_recipient_valid_card_filter(working_lower));
 
@@ -5119,6 +5120,32 @@ fn parse_damage_prevention_replacement(
     }
 
     Some(def)
+}
+
+/// CR 614.1a + CR 615 + CR 608.2c: Scope a static damage-prevention shield to
+/// its own source when the recipient is the bare self-reference ("If damage
+/// would be dealt to ~, prevent that damage …" — Anti-Venom, Phyrexian Hydra,
+/// Stormwild Capridor, Hostility). The shield lives on the source object, so
+/// `valid_card: SelfRef` makes it fire only on damage to that object. Without
+/// this the recipient fell through to `DamageTargetFilter::CreatureOnly`, which
+/// over-applied the shield to *every* creature on the battlefield.
+///
+/// Only the bare self-recipient matches: "dealt to ~" must close at a clause
+/// boundary (`,`/`.`/`this turn`/end), never `~'s` or `~ and/or …` continuations
+/// that name a wider or different scope (e.g. the "dealt to and dealt by ~"
+/// both-directions form, which keeps its existing handling).
+fn parse_self_recipient_valid_card(working_lower: &str) -> Option<TargetFilter> {
+    nom_primitives::scan_at_word_boundaries(working_lower, |input| {
+        let (rest, _) = tag::<_, _, OracleError<'_>>("dealt to ~").parse(input)?;
+        peek(alt((
+            value((), eof::<&str, OracleError<'_>>),
+            value((), char(',')),
+            value((), char('.')),
+            value((), tag::<_, _, OracleError<'_>>(" this turn")),
+        )))
+        .parse(rest)?;
+        Ok((rest, TargetFilter::SelfRef))
+    })
 }
 
 /// CR 614.1a: Extract the typed event-recipient filter from a damage-prevention
@@ -6207,6 +6234,63 @@ mod tests {
                 );
             }
             other => panic!("expected Effect::PutCounter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn anti_venom_self_prevention_scopes_to_source_not_all_creatures() {
+        // CR 615 + CR 614.1a + CR 608.2c: Anti-Venom's "If damage would be dealt
+        // to ~, prevent that damage and put that many +1/+1 counters on ~" is a
+        // continuous static replacement scoped to the source itself — not to
+        // every creature (#2401). The bare self-recipient must produce a
+        // `valid_card: SelfRef` (so the shield fires only on damage to the
+        // source) and must NOT be coerced to `DamageTargetFilter::CreatureOnly`
+        // (which over-applied the shield to all creatures' damage).
+        let def = parse_replacement_line(
+            "If damage would be dealt to ~, prevent that damage and put that many \
+             +1/+1 counters on ~.",
+            "Anti-Venom, Horrifying Healer",
+        )
+        .expect("Anti-Venom should parse as a damage prevention replacement");
+
+        assert_eq!(def.event, ReplacementEvent::DamageDone);
+        assert!(matches!(
+            def.shield_kind,
+            ShieldKind::Prevention {
+                amount: PreventionAmount::All
+            }
+        ));
+        assert_eq!(
+            def.valid_card,
+            Some(TargetFilter::SelfRef),
+            "self-recipient prevention must scope to the source via valid_card SelfRef, got {:?}",
+            def.valid_card
+        );
+        assert!(
+            def.damage_target_filter.is_none(),
+            "self-recipient must NOT be coerced to CreatureOnly (which prevents all \
+             creatures' damage), got {:?}",
+            def.damage_target_filter
+        );
+
+        // CR 615.5: The +1/+1 counter rider lands on the source itself.
+        let execute = def.execute.as_ref().expect("counter rider present");
+        match &*execute.effect {
+            Effect::PutCounter {
+                counter_type,
+                target,
+                ..
+            } => {
+                assert_eq!(*counter_type, CounterType::Plus1Plus1);
+                assert!(
+                    matches!(
+                        target,
+                        TargetFilter::SelfRef | TargetFilter::PostReplacementDamageTarget
+                    ),
+                    "counter must land on the source (self), got {target:?}"
+                );
+            }
+            other => panic!("expected Effect::PutCounter rider, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4989,6 +4989,7 @@ fn parse_damage_prevention_replacement(
     {
         Some(damage_target_controller())
     } else if nom_primitives::scan_contains(working_lower, "dealt to target creature")
+        || nom_primitives::scan_contains(working_lower, "dealt to ~")
         || nom_primitives::scan_contains(working_lower, "dealt to and dealt by ~")
     {
         Some(DamageTargetFilter::CreatureOnly)
@@ -5008,18 +5009,16 @@ fn parse_damage_prevention_replacement(
     // `damage_target_filter = None` caused the shield to prevent ALL damage to
     // any target, which was the Multiclass Baldric / Inviolability / Artifact Ward
     // class of bug.
-    let valid_card_filter: Option<TargetFilter> = parse_self_recipient_valid_card(working_lower)
-        .or_else(|| {
-            nom_primitives::scan_at_word_boundaries(working_lower, |input| {
-                preceded(
-                    tag::<_, _, OracleError<'_>>("dealt to "),
-                    terminated(
-                        parse_attached_subject_target_filter,
-                        alt((value((), eof), value((), multispace1), value((), tag(".")))),
-                    ),
-                )
-                .parse(input)
-            })
+    let valid_card_filter: Option<TargetFilter> =
+        nom_primitives::scan_at_word_boundaries(working_lower, |input| {
+            preceded(
+                tag::<_, _, OracleError<'_>>("dealt to "),
+                terminated(
+                    parse_attached_subject_target_filter,
+                    alt((value((), eof), value((), multispace1), value((), tag(".")))),
+                ),
+            )
+            .parse(input)
         })
         .or_else(|| parse_damage_recipient_valid_card_filter(working_lower));
 
@@ -5120,32 +5119,6 @@ fn parse_damage_prevention_replacement(
     }
 
     Some(def)
-}
-
-/// CR 614.1a + CR 615 + CR 608.2c: Scope a static damage-prevention shield to
-/// its own source when the recipient is the bare self-reference ("If damage
-/// would be dealt to ~, prevent that damage …" — Anti-Venom, Phyrexian Hydra,
-/// Stormwild Capridor, Hostility). The shield lives on the source object, so
-/// `valid_card: SelfRef` makes it fire only on damage to that object. Without
-/// this the recipient fell through to `DamageTargetFilter::CreatureOnly`, which
-/// over-applied the shield to *every* creature on the battlefield.
-///
-/// Only the bare self-recipient matches: "dealt to ~" must close at a clause
-/// boundary (`,`/`.`/`this turn`/end), never `~'s` or `~ and/or …` continuations
-/// that name a wider or different scope (e.g. the "dealt to and dealt by ~"
-/// both-directions form, which keeps its existing handling).
-fn parse_self_recipient_valid_card(working_lower: &str) -> Option<TargetFilter> {
-    nom_primitives::scan_at_word_boundaries(working_lower, |input| {
-        let (rest, _) = tag::<_, _, OracleError<'_>>("dealt to ~").parse(input)?;
-        peek(alt((
-            value((), eof::<&str, OracleError<'_>>),
-            value((), char(',')),
-            value((), char('.')),
-            value((), tag::<_, _, OracleError<'_>>(" this turn")),
-        )))
-        .parse(rest)?;
-        Ok((rest, TargetFilter::SelfRef))
-    })
 }
 
 /// CR 614.1a: Extract the typed event-recipient filter from a damage-prevention
@@ -6234,63 +6207,6 @@ mod tests {
                 );
             }
             other => panic!("expected Effect::PutCounter, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn anti_venom_self_prevention_scopes_to_source_not_all_creatures() {
-        // CR 615 + CR 614.1a + CR 608.2c: Anti-Venom's "If damage would be dealt
-        // to ~, prevent that damage and put that many +1/+1 counters on ~" is a
-        // continuous static replacement scoped to the source itself — not to
-        // every creature (#2401). The bare self-recipient must produce a
-        // `valid_card: SelfRef` (so the shield fires only on damage to the
-        // source) and must NOT be coerced to `DamageTargetFilter::CreatureOnly`
-        // (which over-applied the shield to all creatures' damage).
-        let def = parse_replacement_line(
-            "If damage would be dealt to ~, prevent that damage and put that many \
-             +1/+1 counters on ~.",
-            "Anti-Venom, Horrifying Healer",
-        )
-        .expect("Anti-Venom should parse as a damage prevention replacement");
-
-        assert_eq!(def.event, ReplacementEvent::DamageDone);
-        assert!(matches!(
-            def.shield_kind,
-            ShieldKind::Prevention {
-                amount: PreventionAmount::All
-            }
-        ));
-        assert_eq!(
-            def.valid_card,
-            Some(TargetFilter::SelfRef),
-            "self-recipient prevention must scope to the source via valid_card SelfRef, got {:?}",
-            def.valid_card
-        );
-        assert!(
-            def.damage_target_filter.is_none(),
-            "self-recipient must NOT be coerced to CreatureOnly (which prevents all \
-             creatures' damage), got {:?}",
-            def.damage_target_filter
-        );
-
-        // CR 615.5: The +1/+1 counter rider lands on the source itself.
-        let execute = def.execute.as_ref().expect("counter rider present");
-        match &*execute.effect {
-            Effect::PutCounter {
-                counter_type,
-                target,
-                ..
-            } => {
-                assert_eq!(*counter_type, CounterType::Plus1Plus1);
-                assert!(
-                    matches!(
-                        target,
-                        TargetFilter::SelfRef | TargetFilter::PostReplacementDamageTarget
-                    ),
-                    "counter must land on the source (self), got {target:?}"
-                );
-            }
-            other => panic!("expected Effect::PutCounter rider, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -1,8 +1,10 @@
 use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
-use nom::bytes::complete::tag;
+use nom::bytes::complete::{tag, take_until};
+use nom::character::complete::char;
 use nom::combinator::opt;
 use nom::combinator::value;
+use nom::sequence::delimited;
 use nom::Parser;
 
 use crate::types::ability::{
@@ -395,18 +397,25 @@ pub(super) fn parse_escape_keyword(line: &str) -> Option<Keyword> {
 }
 
 pub(super) fn parse_harmonize_keyword(line: &str) -> Option<Keyword> {
-    let lower = line.to_lowercase();
-    let ((), rest) = nom_on_lower(line, &lower, |i| value((), tag("harmonize ")).parse(i))?;
-    let cost_str = if let Some(paren_start) = rest.find('(') {
-        rest[..paren_start].trim()
-    } else {
-        rest.trim()
-    };
-    if cost_str.is_empty() {
-        return None;
-    }
-    let cost = crate::database::mtgjson::parse_mtgjson_mana_cost(cost_str);
+    let cost = parse_keyword_mana_cost_line(line, "harmonize ")?;
     Some(Keyword::Harmonize(cost))
+}
+
+fn parse_keyword_mana_cost_line(line: &str, keyword: &'static str) -> Option<ManaCost> {
+    let lower = line.to_lowercase();
+    let ((), rest) = nom_on_lower(line, &lower, |i| value((), tag(keyword)).parse(i))?;
+    let (after_cost, cost) = nom_primitives::parse_mana_cost(rest.trim_start()).ok()?;
+    let after_cost = after_cost.trim();
+    if !after_cost.is_empty() {
+        let lower_after_cost = after_cost.to_lowercase();
+        let ((), remainder) = nom_on_lower(after_cost, &lower_after_cost, |i| {
+            value((), delimited(char('('), take_until(")"), char(')'))).parse(i)
+        })?;
+        if !remainder.trim().is_empty() {
+            return None;
+        }
+    }
+    Some(cost)
 }
 
 /// CR 702.187b: Parse a "Mayhem {cost}" Oracle line into `Keyword::Mayhem`.
@@ -414,17 +423,7 @@ pub(super) fn parse_harmonize_keyword(line: &str) -> Option<Keyword> {
 /// cost is extracted here from the card's Oracle text (the cost precedes the
 /// parenthesized reminder text). Mirrors `parse_harmonize_keyword`.
 pub(super) fn parse_mayhem_keyword(line: &str) -> Option<Keyword> {
-    let lower = line.to_lowercase();
-    let ((), rest) = nom_on_lower(line, &lower, |i| value((), tag("mayhem ")).parse(i))?;
-    let cost_str = if let Some(paren_start) = rest.find('(') {
-        rest[..paren_start].trim()
-    } else {
-        rest.trim()
-    };
-    if cost_str.is_empty() {
-        return None;
-    }
-    let cost = crate::database::mtgjson::parse_mtgjson_mana_cost(cost_str);
+    let cost = parse_keyword_mana_cost_line(line, "mayhem ")?;
     Some(Keyword::Mayhem(cost))
 }
 

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -409,6 +409,25 @@ pub(super) fn parse_harmonize_keyword(line: &str) -> Option<Keyword> {
     Some(Keyword::Harmonize(cost))
 }
 
+/// CR 702.187b: Parse a "Mayhem {cost}" Oracle line into `Keyword::Mayhem`.
+/// MTGJSON's keywords array carries only the bare "Mayhem" name, so the mana
+/// cost is extracted here from the card's Oracle text (the cost precedes the
+/// parenthesized reminder text). Mirrors `parse_harmonize_keyword`.
+pub(super) fn parse_mayhem_keyword(line: &str) -> Option<Keyword> {
+    let lower = line.to_lowercase();
+    let ((), rest) = nom_on_lower(line, &lower, |i| value((), tag("mayhem ")).parse(i))?;
+    let cost_str = if let Some(paren_start) = rest.find('(') {
+        rest[..paren_start].trim()
+    } else {
+        rest.trim()
+    };
+    if cost_str.is_empty() {
+        return None;
+    }
+    let cost = crate::database::mtgjson::parse_mtgjson_mana_cost(cost_str);
+    Some(Keyword::Mayhem(cost))
+}
+
 /// CR 702.24a: Dispatch a cumulative-upkeep cost text into a typed
 /// `AbilityCost`. Tries disjunctive mana (`"{G} or {W}"`), then pure mana
 /// (`"{1}"`), then falls back to the generic single-cost parser (which handles

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -45,6 +45,7 @@ pub(crate) fn try_parse_graveyard_keyword_grant_clause(
         alt((
             value(GraveyardGrantedKeywordKind::Flashback, tag("flashback")),
             value(GraveyardGrantedKeywordKind::Escape, tag("escape")),
+            value(GraveyardGrantedKeywordKind::Mayhem, tag("mayhem")),
         ))
         .parse(i)
     })?

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -329,6 +329,7 @@ pub(crate) fn target_filter_is_your_graveyard(filter: &TargetFilter) -> bool {
 pub(crate) enum GraveyardGrantedKeywordKind {
     Flashback,
     Escape,
+    Mayhem,
 }
 
 impl GraveyardGrantedKeywordKind {
@@ -339,6 +340,10 @@ impl GraveyardGrantedKeywordKind {
             }
             GraveyardGrantedKeywordKind::Escape => {
                 keyword.kind() == crate::types::keywords::KeywordKind::Escape
+            }
+            // CR 702.187b: Green Goblin grants Mayhem to graveyard cards.
+            GraveyardGrantedKeywordKind::Mayhem => {
+                keyword.kind() == crate::types::keywords::KeywordKind::Mayhem
             }
         }
     }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1671,6 +1671,31 @@ fn static_this_spell_cost_less_self_scoped_in_castable_zones() {
 }
 
 #[test]
+fn green_goblin_graveyard_cast_cost_reduction_diagnostic() {
+    // Green Goblin: "Spells you cast from your graveyard cost {2} less to cast."
+    // Diagnostic: confirm this parses to a cost-reduction static (not dropped).
+    let def = parse_static_line("Spells you cast from your graveyard cost {2} less to cast.");
+    assert!(
+        def.is_some(),
+        "graveyard-cast cost reduction did not parse to a static",
+    );
+    let def = def.unwrap();
+    assert!(
+        matches!(
+            def.mode,
+            StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
+                amount: ManaCost::Cost { generic: 2, .. },
+                ..
+            }
+        ),
+        "expected ModifyCost Reduce by {{2}}, got mode={:?} affected={:?}",
+        def.mode,
+        def.affected,
+    );
+}
+
+#[test]
 fn chandras_incinerator_self_cost_reduction_uses_noncombat_damage_to_opponents() {
     let def = parse_static_line(
         "This spell costs {X} less to cast, where X is the total amount of noncombat damage dealt to your opponents this turn.",

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3847,6 +3847,11 @@ pub enum CastingVariant {
     /// CR 702.180a: Cast from graveyard for harmonize cost. On resolution, exiled
     /// instead of going anywhere else (unlike Escape which returns to graveyard).
     Harmonize,
+    /// CR 702.187b: Cast from graveyard for mayhem cost (allowed only while the
+    /// card was discarded this turn). Unlike Flashback/Harmonize, the spell is
+    /// NOT exiled — it resolves normally (like Escape), so it can be discarded
+    /// and recast again on a later turn.
+    Mayhem,
     /// CR 702.34a: Cast from graveyard for flashback cost. On resolution (or
     /// whenever leaving the stack for any reason), exiled instead of going anywhere else.
     Flashback,
@@ -4085,6 +4090,7 @@ impl CastingVariant {
             CastingVariant::Warp
             | CastingVariant::Escape
             | CastingVariant::Harmonize
+            | CastingVariant::Mayhem
             | CastingVariant::Flashback
             | CastingVariant::HandPermission { .. }
             | CastingVariant::Sneak { .. }

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -2741,6 +2741,14 @@ mod tests {
             assert_eq!(shards.len(), 2); // BB
         }
 
+        // CR 702.187b: Mayhem carries a plain mana cost.
+        let mayhem = Keyword::from_str("Mayhem:1R").unwrap();
+        assert!(matches!(mayhem, Keyword::Mayhem(ManaCost::Cost { .. })));
+        if let Keyword::Mayhem(ManaCost::Cost { generic, shards }) = &mayhem {
+            assert_eq!(*generic, 1);
+            assert_eq!(shards.len(), 1); // R
+        }
+
         let ward = Keyword::from_str("Ward:2").unwrap();
         assert!(matches!(
             ward,

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -171,6 +171,7 @@ pub enum KeywordKind {
     Dash,
     Craft,
     Harmonize,
+    Mayhem,
     Warp,
     Devour,
     Offspring,
@@ -563,6 +564,11 @@ pub enum Keyword {
     /// CR 702.180: Harmonize {cost} — cast from graveyard for harmonize cost,
     /// tap up to one creature to reduce cost by its power, exile on resolution.
     Harmonize(ManaCost),
+    /// CR 702.187b: Mayhem {cost} — "As long as you discarded this card this
+    /// turn, you may cast it from your graveyard by paying [cost] rather than
+    /// paying its mana cost." Unlike Flashback/Harmonize, the spell is NOT
+    /// exiled on resolution — it resolves normally (like Escape).
+    Mayhem(ManaCost),
     /// CR 702.74a + CR 118.9: see `EvokeCost` for the mana / non-mana split.
     /// Pure-mana evoke (Lorwyn cycle) is `EvokeCost::Mana`; MH2 Incarnations
     /// (Solitude et al.) carry `EvokeCost::NonMana(AbilityCost::Exile { .. })`.
@@ -1021,6 +1027,7 @@ impl Keyword {
             Keyword::Dash(_) => KeywordKind::Dash,
             Keyword::Craft { .. } => KeywordKind::Craft,
             Keyword::Harmonize(_) => KeywordKind::Harmonize,
+            Keyword::Mayhem(_) => KeywordKind::Mayhem,
             Keyword::Warp(_) => KeywordKind::Warp,
             Keyword::Devour(_) => KeywordKind::Devour,
             Keyword::Offspring(_) => KeywordKind::Offspring,
@@ -1619,6 +1626,9 @@ impl FromStr for Keyword {
                 "dash" => return Ok(Keyword::Dash(parse_keyword_mana_cost(p))),
                 "emerge" => return Ok(Keyword::Emerge(parse_keyword_mana_cost(p))),
                 "harmonize" => return Ok(Keyword::Harmonize(parse_keyword_mana_cost(p))),
+                // CR 702.187b: Mayhem {cost} — cast from graveyard if discarded
+                // this turn for the mayhem (mana) cost.
+                "mayhem" => return Ok(Keyword::Mayhem(parse_keyword_mana_cost(p))),
                 "escape" => {
                     return Ok(Keyword::Escape {
                         cost: parse_keyword_mana_cost(p),
@@ -2313,6 +2323,9 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         // CR 702.138: MTGJSON provides bare "Escape" with no structured cost data.
         // Placeholder values — the Oracle parser overwrites with real cost/exile_count.
         "Harmonize" => Ok(Keyword::Harmonize(mana(data)?)),
+        // CR 702.187b: MTGJSON may provide bare "Mayhem"; the Oracle parser
+        // overwrites with the real mana cost extracted from reminder text.
+        "Mayhem" => Ok(Keyword::Mayhem(mana(data)?)),
         "Escape" => Ok(Keyword::Escape {
             cost: ManaCost::default(),
             exile_count: 0,


### PR DESCRIPTION
Mayhem keyword implementation for CR 702.187b (#2354), after maintainer cleanup to keep this PR scoped to the keyword mechanic only. The earlier Anti-Venom / prevention-recipient work was removed because #2495 has already landed that fix.

## Mayhem keyword — CR 702.187b

Norman Osborn // Green Goblin's Mayhem keyword was unimplemented. This PR now implements it end-to-end:

- **Type + parsing:** Adds `Keyword::Mayhem(ManaCost)` and `KeywordKind::Mayhem`, including `FromStr`, tagged JSON, display-name mapping, and a `Mayhem {cost}` Oracle-line extractor.
- **Discarded-this-turn gate:** Adds `GameObject.discarded_turn`, stamps it at the discard-to-graveyard completion point, clears it on any zone change, and checks it against the current turn number so it auto-expires.
- **Casting:** Adds `CastingVariant::Mayhem`; graveyard cards are Mayhem-castable only while discarded this turn, the mayhem cost replaces the mana cost, and the spell resolves normally without Flashback/Harmonize-style exile.
- **Green Goblin grant:** Parses `Each nonland card in your graveyard has mayhem. The mayhem cost is equal to its mana cost.` through the existing graveyard keyword-grant pipeline as `AddKeyword(Mayhem(SelfManaCost))`.
- **Surfacing:** Mayhem-castable graveyard cards appear in legal actions, and the client displays the Mayhem cast option and keyword tooltip.

## Maintainer cleanup

- Merged current `origin/main` into the branch.
- Dropped the duplicate prevention-recipient parser change because #2495 already covers it.
- Centralized Mayhem discard stamping in a single discard-completion helper instead of repeating it at caller sites.
- Replaced keyword-cost parenthesis trimming with the existing mana-cost combinator plus a nom-delimited reminder parser.
- Added focused assertions that normal discard stamps `discarded_turn` and replacement-redirected discard does not.

## Tests / validation

Coverage includes keyword parsing, Oracle extraction, Green Goblin's grant line, full Green Goblin face parsing, candidate gating, Mayhem cost substitution, no-exile resolution contract, and the discard-stamp helper behavior. `cargo fmt --all` was run locally; broad validation is the GitHub CI run on the pushed head.
