### PR TITLE
fix(parser): split static "… and can’t be the target of …" so the targeting restriction isn’t dropped (CR 702.18a/702.11a)

### DIFF
--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -952,6 +952,79 @@ pub(crate) fn try_split_and_cant_be_sacrificed(text: &str) -> Option<Vec<StaticD
     Some(defs)
 }
 
+/// CR 702.18a / CR 702.11a: Decompose `"<grant or restriction> and can't be the
+/// target of …"` into the first conjunct's static(s) plus the targeting
+/// restriction, sharing the same `affected` set.
+///
+/// Without this split the trailing targeting prohibition was dropped: Spectral
+/// Shield ("Enchanted creature gets +0/+2 and can't be the target of spells.")
+/// parsed to only the +0/+2 grant, so the enchanted creature could still be
+/// targeted — the Aura's entire protection was lost. Mirrors
+/// `try_split_and_cant_be_attached`; the descriptive "can't be the target …"
+/// form is a `CantBeTargeted` `StaticMode` (or Hexproof for the opponents-only
+/// scope — CR 702.11a), not a `ContinuousModification`, so the continuous-grant
+/// default drops it. Scope classification reuses `classify_cant_be_targeted`,
+/// matching the standalone dispatch so the "your opponents control" qualifier is
+/// preserved rather than collapsed into blanket Shroud.
+pub(crate) fn try_split_and_cant_be_targeted(text: &str) -> Option<Vec<StaticDefinition>> {
+    type VE<'a> = OracleError<'a>;
+    let lower = text.to_lowercase();
+
+    let (before, _matched, _rest) = nom_primitives::scan_preceded(&lower, |i: &str| {
+        // Match both the ASCII and typographic U+2019 apostrophe, and both the
+        // "target of …" and bare "targeted" phrasings.
+        alt((
+            tag::<_, _, VE>("and can't be the target"),
+            tag::<_, _, VE>("and can\u{2019}t be the target"),
+            tag::<_, _, VE>("and can't be targeted"),
+            tag::<_, _, VE>("and can\u{2019}t be targeted"),
+        ))
+        .parse(i)
+    })?;
+
+    // Classify the whole trailing clause exactly as the standalone dispatch does
+    // (`dispatch.rs`), so "… your opponents control" → Hexproof (CR 702.11a) and
+    // the unqualified form → blanket Shroud (CR 702.18a). Decline if the tail is
+    // not a recognized targeting restriction.
+    let targeting_clause = &lower[before.len()..];
+    let scope = crate::parser::oracle_keyword::classify_cant_be_targeted(targeting_clause)?;
+
+    let cut_end = before
+        .trim_end_matches(|ch: char| ch == ',' || ch.is_whitespace())
+        .len();
+    let line_a = format!("{}.", text[..cut_end].trim_end_matches('.'));
+    let mut defs = parse_static_line_multi(&line_a);
+    if defs.is_empty() {
+        return None;
+    }
+    for def in &mut defs {
+        def.description = Some(text.to_string());
+    }
+
+    let affected = defs[0].affected.clone()?;
+    let companion = match scope {
+        // CR 702.11a: "… your opponents control" grants Hexproof so the
+        // permanent's own controller can still target it.
+        crate::parser::oracle_keyword::CantBeTargetedScope::OpponentsOnly => {
+            StaticDefinition::continuous()
+                .affected(affected)
+                .modifications(vec![ContinuousModification::AddKeyword {
+                    keyword: crate::types::keywords::Keyword::Hexproof,
+                }])
+                .description(text.to_string())
+        }
+        // CR 702.18a: blanket — can't be targeted by any player. Enforced in
+        // `targeting.rs::can_target` via the object's active static definitions.
+        crate::parser::oracle_keyword::CantBeTargetedScope::AnyPlayer => {
+            StaticDefinition::new(StaticMode::CantBeTargeted)
+                .affected(affected)
+                .description(text.to_string())
+        }
+    };
+    defs.push(companion);
+    Some(defs)
+}
+
 /// CR 509.1b: Classify a "can't be blocked …" evasion predicate (lowercased,
 /// starting with "can't be blocked") into the corresponding `StaticMode` and
 /// optional evasion condition, composing the same building blocks the standalone

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -968,7 +968,7 @@ pub(crate) fn try_split_and_cant_be_sacrificed(text: &str) -> Option<Vec<StaticD
 /// preserved rather than collapsed into blanket Shroud.
 pub(crate) fn try_split_and_cant_be_targeted(text: &str) -> Option<Vec<StaticDefinition>> {
     type VE<'a> = OracleError<'a>;
-    let lower = text.to_lowercase();
+    let lower = text.to_ascii_lowercase();
 
     let (before, _matched, _rest) = nom_primitives::scan_preceded(&lower, |i: &str| {
         // Match both the ASCII and typographic U+2019 apostrophe, and both the

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -102,8 +102,8 @@ mod support {
         try_parse_scoped_must_attack_block, try_split_and_can_attack_despite_defender,
         try_split_and_can_block_additional, try_split_and_cant_activate_abilities,
         try_split_and_cant_attack, try_split_and_cant_be_attached, try_split_and_cant_be_blocked,
-        try_split_and_cant_be_sacrificed, try_split_and_cant_block, try_split_and_doesnt_untap,
-        try_split_and_must_attack_block,
+        try_split_and_cant_be_sacrificed, try_split_and_cant_be_targeted, try_split_and_cant_block,
+        try_split_and_doesnt_untap, try_split_and_must_attack_block,
     };
     pub(super) use super::grammar::*;
     pub(super) use super::keyword_grant::{

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -646,6 +646,14 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
         return defs;
     }
 
+    // CR 702.18a / CR 702.11a: "<grant or restriction> and can't be the target of
+    // …" pairs a first clause with a targeting restriction under one subject
+    // (Spectral Shield). Split so the CantBeTargeted/Hexproof clause is not
+    // dropped.
+    if let Some(defs) = try_split_and_cant_be_targeted(&stripped) {
+        return defs;
+    }
+
     // CR 602.5: "<grant or restriction> and its activated abilities can't be
     // activated" pairs a first clause with an activation prohibition under one
     // subject (Viper's Kiss). Split so the CantBeActivated clause is not dropped.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -456,6 +456,56 @@ fn cant_be_attached_static_splits_both_prohibitions() {
     );
 }
 
+/// CR 702.18a: Spectral Shield — "Enchanted creature gets +0/+2 and can't be the
+/// target of spells." must decompose into BOTH the +0/+2 grant AND a
+/// `CantBeTargeted` static sharing the first conjunct's `affected` set.
+/// Previously the targeting restriction was dropped, so the enchanted creature
+/// could still be targeted — the Aura's entire protection was lost.
+#[test]
+fn cant_be_targeted_static_splits_from_grant() {
+    let defs =
+        parse_static_line_multi("Enchanted creature gets +0/+2 and can't be the target of spells.");
+    let targeting = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantBeTargeted)
+        .expect("expected a CantBeTargeted static");
+    assert!(
+        targeting.affected.is_some(),
+        "CantBeTargeted companion must share the first clause's affected set"
+    );
+    assert!(
+        defs.iter()
+            .any(|d| matches!(d.mode, StaticMode::Continuous)),
+        "the +0/+2 grant must be preserved, got {:?}",
+        defs.iter().map(|d| &d.mode).collect::<Vec<_>>()
+    );
+}
+
+/// CR 702.11a: the opponents-only targeting scope in a compound static must
+/// become Hexproof (controller can still target), NOT blanket Shroud — mirroring
+/// the standalone dispatch so the "your opponents control" qualifier is not lost.
+#[test]
+fn cant_be_targeted_opponents_scope_splits_as_hexproof() {
+    let defs = parse_static_line_multi(
+        "Enchanted creature gets +1/+1 and can't be the target of spells your opponents control.",
+    );
+    assert!(
+        defs.iter().any(|d| matches!(d.mode, StaticMode::Continuous)
+            && d.modifications
+                .contains(&ContinuousModification::AddKeyword {
+                    keyword: Keyword::Hexproof
+                })),
+        "expected a Hexproof grant (opponents-only scope), got {:?}",
+        defs.iter()
+            .map(|d| (&d.mode, &d.modifications))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !defs.iter().any(|d| d.mode == StaticMode::CantBeTargeted),
+        "opponents-only scope must NOT collapse into blanket Shroud"
+    );
+}
+
 /// CR 602.5: Viper's Kiss — "Enchanted creature gets -1/-1, and its activated
 /// abilities can't be activated." must decompose into BOTH the -1/-1 grant AND a
 /// `CantBeActivated` static. Previously the activation prohibition was dropped,


### PR DESCRIPTION
## What

A compound static pairing a first clause (P/T change, keyword grant, or another restriction) with a "can't be the target of …" clause under one subject dropped the targeting restriction entirely. `parse_static_line_multi_inner` has `try_split_and_*` splitters for every other compound shape (despite-defender, must-attack/block, can-block-additional, can't-be-blocked, can't-block, can't-attack, doesn't-untap, can't-activate-abilities, can't-be-sacrificed, can't-be-enchanted/equipped) but **none for the targeting restriction**, and the continuous-grant default has no arm for it (`CantBeTargeted` is a `StaticMode`, not a `ContinuousModification`), so the clause produced no modifications and was discarded.

**Spectral Shield** ("Enchanted creature gets +0/+2 and can't be the target of spells.") parsed to only the +0/+2 grant, so the enchanted creature could still be targeted — the Aura's entire protection was silently lost.

This is the same root-cause pattern as the merged #2452 (attach prohibitions), applied to the targeting-restriction clause.

## Fix

Add `try_split_and_cant_be_targeted`, mirroring `try_split_and_cant_be_attached`:

- nom `scan_preceded` locates the "and can't be the target / targeted" conjunction (ASCII + U+2019 apostrophe, both phrasings);
- the first conjunct is re-parsed via `parse_static_line_multi`;
- the trailing clause is classified through the **existing** `classify_cant_be_targeted` helper so the scope is preserved — "… your opponents control" → Hexproof (CR 702.11a, controller can still target) and the unqualified form → blanket Shroud (CR 702.18a). This avoids the lossy collapse that #2256 fixed for the standalone path.
- the companion shares the first conjunct's `affected` set.

## CR

- **CR 702.18a** — Shroud: "can't be the target of spells or abilities" (unqualified form → blanket `CantBeTargeted`).
- **CR 702.11a** — Hexproof: the "… your opponents control" variant; controller can still target.

## Tests

- `cant_be_targeted_static_splits_from_grant` — Spectral Shield decomposes into the +0/+2 `Continuous` **and** a `CantBeTargeted` static sharing the first conjunct's `affected`.
- `cant_be_targeted_opponents_scope_splits_as_hexproof` — the opponents-only scope splits as a Hexproof grant, NOT blanket Shroud.

All 12 `*_splits_from_*` splitter regression tests pass (incl. Anti-Magic Aura, which this splitter correctly declines so the attach splitter still handles it); targeting-enforcement tests pass; `cargo fmt --all` clean; parser-combinator gate passes.

Fixes #2521
