### PR TITLE
Implement Prowl keyword (CR 702.76a)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2513,6 +2513,27 @@ fn casting_variant_candidates(
         candidates.push(CastingVariant::Freerunning);
     }
 
+    // CR 702.76a: Prowl — a hand alternative cost legal when a source the caster
+    // controlled dealt combat damage to a player this turn and, at that time, had
+    // any of this spell's creature types. The per-turn creature-type ledger is
+    // snapshot at damage time (`creature_types_dealt_combat_damage_this_turn`).
+    if obj.zone == Zone::Hand
+        && effective_spell_keywords(state, player, object_id)
+            .iter()
+            .any(|k| matches!(k, Keyword::Prowl(_)))
+        && state
+            .creature_types_dealt_combat_damage_this_turn
+            .get(&player)
+            .is_some_and(|types| {
+                obj.card_types
+                    .subtypes
+                    .iter()
+                    .any(|spell_type| types.contains(spell_type))
+            })
+    {
+        candidates.push(CastingVariant::Prowl);
+    }
+
     // CR 702.74a + CR 118.9: Evoke is a static alternative cost usable from any
     // zone the card can be cast from; surface it as a hand candidate so the gate
     // offers it when the printed cost is unaffordable. effective_spell_keywords
@@ -3202,6 +3223,19 @@ fn prepare_spell_cast_with_variant_override_inner(
     } else {
         None
     };
+    // CR 702.76a: When the caller opted into Prowl, substitute the prowl mana cost
+    // from the `Keyword::Prowl(cost)` payload (printed or granted). Mirrors the
+    // Freerunning/Overload cost-selection pattern.
+    let prowl_cost = if casting_variant == CastingVariant::Prowl {
+        effective_spell_keywords(state, player, object_id)
+            .iter()
+            .find_map(|k| match k {
+                crate::types::keywords::Keyword::Prowl(cost) => Some(cost.clone()),
+                _ => None,
+            })
+    } else {
+        None
+    };
     // CR 702.34a: When the flashback cost is purely non-mana (e.g. Battle Screech's
     // "tap three white creatures"), the spell pays no mana through the normal flow.
     // For compound flashback costs ("{1}{U}, Pay 3 life") we still want the mana
@@ -3293,6 +3327,7 @@ fn prepare_spell_cast_with_variant_override_inner(
             .or(effective_dash_cost_for_path)
             .or(effective_blitz_cost_for_path)
             .or(freerunning_cost)
+            .or(prowl_cost)
             .unwrap_or_else(|| obj.mana_cost.clone())
     };
     let has_granted_flash =
@@ -12617,6 +12652,137 @@ mod tests {
         assert!(
             !candidates.contains(&CastingVariant::Freerunning),
             "Freerunning must NOT be a candidate after turn cleanup; got {candidates:?}",
+        );
+    }
+
+    // ----- CR 702.76a: Prowl alternative-cost casts -------------------------
+
+    fn prowl_test_cost() -> ManaCost {
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 1,
+        }
+    }
+
+    /// A Tribal sorcery in P0's hand with creature type "Rogue", prowl {1}{U},
+    /// and a printed cost of {3}{U}{U}.
+    fn add_prowl_spell(state: &mut GameState) -> ObjectId {
+        let object_id = create_object(
+            state,
+            CardId(2076),
+            PlayerId(0),
+            "Prowl Test Spell".to_string(),
+            Zone::Hand,
+        );
+        let obj = state.objects.get_mut(&object_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Sorcery);
+        obj.card_types.subtypes.push("Rogue".to_string());
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue, ManaCostShard::Blue],
+            generic: 3,
+        };
+        obj.keywords.push(Keyword::Prowl(prowl_test_cost()));
+        object_id
+    }
+
+    /// CR 702.76a: With no matching combat damage this turn, Prowl is not offered.
+    #[test]
+    fn prowl_unavailable_without_matching_combat_damage() {
+        let mut state = setup_game_at_main_phase();
+        let object_id = add_prowl_spell(&mut state);
+        let candidates = casting_variant_candidates(&state, PlayerId(0), object_id);
+        assert!(
+            !candidates.contains(&CastingVariant::Prowl),
+            "Prowl must not be a candidate without a matching ledger entry; got {candidates:?}",
+        );
+    }
+
+    /// CR 702.76a: When a Rogue source the caster controlled dealt combat damage
+    /// this turn, Prowl is surfaced and the prowl cost replaces the printed cost.
+    #[test]
+    fn prowl_available_after_matching_creature_type_combat_damage() {
+        let mut state = setup_game_at_main_phase();
+        let object_id = add_prowl_spell(&mut state);
+        state
+            .creature_types_dealt_combat_damage_this_turn
+            .entry(PlayerId(0))
+            .or_default()
+            .insert("Rogue".to_string());
+
+        let candidates = casting_variant_candidates(&state, PlayerId(0), object_id);
+        assert!(
+            candidates.contains(&CastingVariant::Prowl),
+            "Prowl must be a candidate when a matching creature type dealt combat damage; \
+             got {candidates:?}",
+        );
+
+        let prepared = prepare_spell_cast_with_variant_override(
+            &state,
+            PlayerId(0),
+            object_id,
+            Some(CastingVariant::Prowl),
+        )
+        .expect("prowl override must prepare a spell cast");
+        assert_eq!(prepared.casting_variant, CastingVariant::Prowl);
+        assert_eq!(
+            prepared.mana_cost,
+            prowl_test_cost(),
+            "prepared mana cost must be the prowl alt cost, not the printed cost",
+        );
+        assert_ne!(
+            prepared.mana_cost, state.objects[&object_id].mana_cost,
+            "printed mana cost must NOT be paid when Prowl override is selected",
+        );
+    }
+
+    /// CR 702.76a: The recorded creature type must overlap one of the spell's
+    /// creature types — an unrelated type does not unlock Prowl.
+    #[test]
+    fn prowl_requires_creature_type_overlap() {
+        let mut state = setup_game_at_main_phase();
+        let object_id = add_prowl_spell(&mut state); // spell is a Rogue
+        state
+            .creature_types_dealt_combat_damage_this_turn
+            .entry(PlayerId(0))
+            .or_default()
+            .insert("Goblin".to_string());
+
+        let candidates = casting_variant_candidates(&state, PlayerId(0), object_id);
+        assert!(
+            !candidates.contains(&CastingVariant::Prowl),
+            "Prowl must require a creature-type overlap; Goblin damage must not unlock a \
+             Rogue spell; got {candidates:?}",
+        );
+    }
+
+    /// CR 702.76a + CR 514: The Prowl creature-type ledger is turn-scoped.
+    #[test]
+    fn prowl_ledger_resets_at_turn_cleanup() {
+        let mut state = setup_game_at_main_phase();
+        let object_id = add_prowl_spell(&mut state);
+        state
+            .creature_types_dealt_combat_damage_this_turn
+            .entry(PlayerId(0))
+            .or_default()
+            .insert("Rogue".to_string());
+        assert!(
+            casting_variant_candidates(&state, PlayerId(0), object_id)
+                .contains(&CastingVariant::Prowl),
+            "Prowl must be a candidate before cleanup",
+        );
+
+        crate::game::turns::start_next_turn(&mut state, &mut Vec::new());
+
+        assert!(
+            state
+                .creature_types_dealt_combat_damage_this_turn
+                .is_empty(),
+            "ledger must be cleared by start_next_turn",
+        );
+        assert!(
+            !casting_variant_candidates(&state, PlayerId(0), object_id)
+                .contains(&CastingVariant::Prowl),
+            "Prowl must NOT be a candidate after turn cleanup",
         );
     }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2551,12 +2551,14 @@ fn casting_variant_candidates(
             .any(|k| matches!(k, Keyword::Prowl(_)))
         && state
             .creature_types_dealt_combat_damage_this_turn
-            .get(&player)
-            .is_some_and(|types| {
-                obj.card_types
-                    .subtypes
-                    .iter()
-                    .any(|spell_type| types.contains(spell_type))
+            .iter()
+            .any(|(controller, creature_type)| {
+                *controller == player
+                    && obj
+                        .card_types
+                        .subtypes
+                        .iter()
+                        .any(|spell_type| spell_type == creature_type)
             })
     {
         candidates.push(CastingVariant::Prowl);
@@ -12869,9 +12871,7 @@ mod tests {
         let object_id = add_prowl_spell(&mut state);
         state
             .creature_types_dealt_combat_damage_this_turn
-            .entry(PlayerId(0))
-            .or_default()
-            .insert("Rogue".to_string());
+            .insert((PlayerId(0), "Rogue".to_string()));
 
         let candidates = casting_variant_candidates(&state, PlayerId(0), object_id);
         assert!(
@@ -12907,9 +12907,7 @@ mod tests {
         let object_id = add_prowl_spell(&mut state); // spell is a Rogue
         state
             .creature_types_dealt_combat_damage_this_turn
-            .entry(PlayerId(0))
-            .or_default()
-            .insert("Goblin".to_string());
+            .insert((PlayerId(0), "Goblin".to_string()));
 
         let candidates = casting_variant_candidates(&state, PlayerId(0), object_id);
         assert!(
@@ -12926,9 +12924,7 @@ mod tests {
         let object_id = add_prowl_spell(&mut state);
         state
             .creature_types_dealt_combat_damage_this_turn
-            .entry(PlayerId(0))
-            .or_default()
-            .insert("Rogue".to_string());
+            .insert((PlayerId(0), "Rogue".to_string()));
         assert!(
             casting_variant_candidates(&state, PlayerId(0), object_id)
                 .contains(&CastingVariant::Prowl),

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -1816,10 +1816,24 @@ fn collect_pending_triggers(
                         .iter()
                         .any(|s| s == "Assassin");
                 let is_commander = source_obj.is_commander;
+                // CR 702.76a + CR 608.2i: snapshot the controller and the source's
+                // creature types AT DAMAGE TIME (LKI) before any later mutation.
+                let controller = source_obj.controller;
+                let source_subtypes = source_obj.card_types.subtypes.clone();
                 if is_assassin_creature || is_commander {
                     state
                         .assassin_or_commander_dealt_combat_damage_this_turn
-                        .insert(source_obj.controller);
+                        .insert(controller);
+                }
+                // CR 702.76a: record this source's creature types under its
+                // controller so Prowl can later check "had any of this spell's
+                // creature types". A source with no subtypes contributes nothing.
+                if !source_subtypes.is_empty() {
+                    state
+                        .creature_types_dealt_combat_damage_this_turn
+                        .entry(controller)
+                        .or_default()
+                        .extend(source_subtypes);
                 }
             }
         }
@@ -18647,6 +18661,77 @@ mod dedup_regression_tests {
             "Assassin combat damage must seed the Freerunning eligibility ledger \
              with the source's controller (P0); ledger = {:?}",
             state.assassin_or_commander_dealt_combat_damage_this_turn,
+        );
+    }
+
+    /// CR 702.76a + CR 608.2i: A creature with a creature type dealing combat
+    /// damage to a player seeds the Prowl creature-type ledger under its
+    /// controller, snapshot at damage time. (Unlike the Freerunning ledger, this
+    /// is recorded for any controlled source's types, not gated on Assassin.)
+    #[test]
+    fn typed_creature_combat_damage_seeds_prowl_creature_type_ledger() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        let rogue = make_creature(&mut state, PlayerId(0), "Rogue Test", 1, 1);
+        {
+            // Subtype must live on both rows to survive the layer flush (see the
+            // assassin test above).
+            let obj = state.objects.get_mut(&rogue).unwrap();
+            obj.card_types.subtypes.push("Rogue".to_string());
+            obj.base_card_types = obj.card_types.clone();
+        }
+
+        let event = GameEvent::DamageDealt {
+            source_id: rogue,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 1,
+            is_combat: true,
+            excess: 0,
+        };
+        process_triggers(&mut state, &[event]);
+
+        assert!(
+            state
+                .creature_types_dealt_combat_damage_this_turn
+                .get(&PlayerId(0))
+                .is_some_and(|types| types.contains("Rogue")),
+            "Rogue combat damage must seed the Prowl creature-type ledger under P0; ledger = {:?}",
+            state.creature_types_dealt_combat_damage_this_turn,
+        );
+    }
+
+    /// CR 702.76a: Non-combat damage must NOT seed the Prowl ledger — the
+    /// predicate is "was dealt COMBAT damage this turn".
+    #[test]
+    fn noncombat_damage_does_not_seed_prowl_ledger() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        let rogue = make_creature(&mut state, PlayerId(0), "Rogue Test", 1, 1);
+        {
+            let obj = state.objects.get_mut(&rogue).unwrap();
+            obj.card_types.subtypes.push("Rogue".to_string());
+            obj.base_card_types = obj.card_types.clone();
+        }
+
+        let event = GameEvent::DamageDealt {
+            source_id: rogue,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 1,
+            is_combat: false,
+            excess: 0,
+        };
+        process_triggers(&mut state, &[event]);
+
+        assert!(
+            state
+                .creature_types_dealt_combat_damage_this_turn
+                .is_empty(),
+            "non-combat damage must not seed the Prowl ledger; ledger = {:?}",
+            state.creature_types_dealt_combat_damage_this_turn,
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -1829,11 +1829,11 @@ fn collect_pending_triggers(
                 // controller so Prowl can later check "had any of this spell's
                 // creature types". A source with no subtypes contributes nothing.
                 if !source_subtypes.is_empty() {
-                    state
-                        .creature_types_dealt_combat_damage_this_turn
-                        .entry(controller)
-                        .or_default()
-                        .extend(source_subtypes);
+                    state.creature_types_dealt_combat_damage_this_turn.extend(
+                        source_subtypes
+                            .into_iter()
+                            .map(|creature_type| (controller, creature_type)),
+                    );
                 }
             }
         }
@@ -18695,8 +18695,7 @@ mod dedup_regression_tests {
         assert!(
             state
                 .creature_types_dealt_combat_damage_this_turn
-                .get(&PlayerId(0))
-                .is_some_and(|types| types.contains("Rogue")),
+                .contains(&(PlayerId(0), "Rogue".to_string())),
             "Rogue combat damage must seed the Prowl creature-type ledger under P0; ledger = {:?}",
             state.creature_types_dealt_combat_damage_this_turn,
         );

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -587,6 +587,9 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
     state
         .assassin_or_commander_dealt_combat_damage_this_turn
         .clear();
+    // CR 702.76a + CR 514: Clear the Prowl creature-type ledger at cleanup — its
+    // "was dealt combat damage this turn" predicate is turn-scoped too.
+    state.creature_types_dealt_combat_damage_this_turn.clear();
     // CR 500.8: Clear any leftover extra phases from the previous turn.
     state.extra_phases.clear();
     // CR 700.14: Reset cumulative mana spent on spells for Expend triggers.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5080,15 +5080,16 @@ pub struct GameState {
     /// to gate the Freerunning cast permission on the spell's controller.
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub assassin_or_commander_dealt_combat_damage_this_turn: HashSet<PlayerId>,
-    /// CR 702.76a + CR 608.2i: Per-player set of the creature types of any source
-    /// that dealt combat damage to a player this turn while under that player's
-    /// control (snapshot at damage-dealing time — "looks back in time", so a
-    /// source that later changes types or leaves does not invalidate the entry).
+    /// CR 702.76a + CR 608.2i: Set of `(controller, creature type)` entries for
+    /// sources that dealt combat damage to a player this turn (snapshot at
+    /// damage-dealing time — "looks back in time", so a source that later
+    /// changes types or leaves does not invalidate the entry). Flat persistent
+    /// storage keeps `GameState::clone()` structurally shared on AI/search paths.
     /// Populated by the `DamageDealt` observer in `game::triggers` and cleared in
     /// `turns::start_next_turn` per CR 514. Read by `casting_variant_candidates`
     /// to gate the Prowl cast permission ("had any of this spell's creature types").
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub creature_types_dealt_combat_damage_this_turn: HashMap<PlayerId, HashSet<String>>,
+    #[serde(default, skip_serializing_if = "im::HashSet::is_empty")]
+    pub creature_types_dealt_combat_damage_this_turn: im::HashSet<(PlayerId, String)>,
     /// CR 700.14: Cumulative mana spent on spells this turn per player (for Expend triggers).
     #[serde(default)]
     pub mana_spent_on_spells_this_turn: HashMap<PlayerId, u32>,
@@ -5920,7 +5921,7 @@ impl GameState {
             battlefield_entries_this_turn: Vec::new(),
             damage_dealt_this_turn: im::Vector::new(),
             assassin_or_commander_dealt_combat_damage_this_turn: HashSet::new(),
-            creature_types_dealt_combat_damage_this_turn: HashMap::new(),
+            creature_types_dealt_combat_damage_this_turn: im::HashSet::new(),
             mana_spent_on_spells_this_turn: HashMap::new(),
             pending_spell_cost_reductions: Vec::new(),
             pending_next_spell_modifiers: Vec::new(),

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4064,6 +4064,14 @@ pub enum CastingVariant {
     /// matches a normal cast — no on-resolve special behavior — so this is a
     /// casting-context tag, not a resolution-affecting variant.
     Freerunning,
+    /// CR 702.76a: Cast from hand via Prowl's alternative cost. Legal only when a
+    /// player was dealt combat damage this turn by a source under the caster's
+    /// control that, at damage time, had any of this spell's creature types. The
+    /// printed mana cost is replaced by the `Keyword::Prowl(cost)` payload at cast
+    /// preparation (mirrors `Freerunning`/`Overload`). Resolution routing matches
+    /// a normal cast — no on-resolve special behavior — so this is a
+    /// casting-context tag, not a resolution-affecting variant.
+    Prowl,
     /// CR 702.133a: Cast from a graveyard via Jump-start. The card is cast for
     /// its normal mana cost plus an additional cost of discarding a card
     /// (CR 601.2b/601.2f–h) — so, like `Retrace`/`Aftermath`, this is an
@@ -4109,6 +4117,8 @@ impl CastingVariant {
             // CR 702.140a: Mutate replaces the spell's mana cost with the mutate
             // cost — an alternative cost, so only one may apply (CR 118.9a).
             | CastingVariant::Mutate
+            // CR 702.76a: Prowl substitutes the prowl cost for the printed cost.
+            | CastingVariant::Prowl
             | CastingVariant::Freerunning => true,
             CastingVariant::Normal
             | CastingVariant::Adventure
@@ -5064,6 +5074,15 @@ pub struct GameState {
     /// to gate the Freerunning cast permission on the spell's controller.
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub assassin_or_commander_dealt_combat_damage_this_turn: HashSet<PlayerId>,
+    /// CR 702.76a + CR 608.2i: Per-player set of the creature types of any source
+    /// that dealt combat damage to a player this turn while under that player's
+    /// control (snapshot at damage-dealing time — "looks back in time", so a
+    /// source that later changes types or leaves does not invalidate the entry).
+    /// Populated by the `DamageDealt` observer in `game::triggers` and cleared in
+    /// `turns::start_next_turn` per CR 514. Read by `casting_variant_candidates`
+    /// to gate the Prowl cast permission ("had any of this spell's creature types").
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub creature_types_dealt_combat_damage_this_turn: HashMap<PlayerId, HashSet<String>>,
     /// CR 700.14: Cumulative mana spent on spells this turn per player (for Expend triggers).
     #[serde(default)]
     pub mana_spent_on_spells_this_turn: HashMap<PlayerId, u32>,
@@ -5895,6 +5914,7 @@ impl GameState {
             battlefield_entries_this_turn: Vec::new(),
             damage_dealt_this_turn: im::Vector::new(),
             assassin_or_commander_dealt_combat_damage_this_turn: HashSet::new(),
+            creature_types_dealt_combat_damage_this_turn: HashMap::new(),
             mana_spent_on_spells_this_turn: HashMap::new(),
             pending_spell_cost_reductions: Vec::new(),
             pending_next_spell_modifiers: Vec::new(),
@@ -6308,6 +6328,8 @@ impl PartialEq for GameState {
             && self.damage_dealt_this_turn == other.damage_dealt_this_turn
             && self.assassin_or_commander_dealt_combat_damage_this_turn
                 == other.assassin_or_commander_dealt_combat_damage_this_turn
+            && self.creature_types_dealt_combat_damage_this_turn
+                == other.creature_types_dealt_combat_damage_this_turn
             && self.pending_spell_cost_reductions == other.pending_spell_cost_reductions
             && self.pending_next_spell_modifiers == other.pending_next_spell_modifiers
             && self.pending_etb_counters == other.pending_etb_counters


### PR DESCRIPTION
## Summary

Implements the **Prowl** keyword (CR 702.76), closing #2523. `Keyword::Prowl` was parsed but inert — its alternative cost was never offered, so prowl spells could only be hard-cast.

`CastingVariant::Prowl` is a near-exact mirror of the existing **Freerunning** alternative cost: both are "pay [cost] rather than the mana cost if a player was dealt combat damage this turn by a source under your control...". The only difference is the eligibility predicate.

## CR

**CR 702.76a** (verified against `docs/MagicCompRules.txt:4554`): *"You may pay [cost] rather than pay this spell's mana cost if a player was dealt combat damage this turn by a source that, at the time it dealt that damage, was under your control and had any of this spell's creature types."*

## Changes

- **`types/game_state.rs`**: `CastingVariant::Prowl` (+ `uses_alternative_cost` arm — it replaces the mana cost). New per-turn ledger `creature_types_dealt_combat_damage_this_turn: HashMap<PlayerId, HashSet<String>>` (field + init + `PartialEq`), parallel to Freerunning's boolean ledger.
- **`game/triggers.rs`**: in the existing `DamageDealt` combat observer (beside Freerunning's), snapshot the source's creature types at damage time (LKI, CR 608.2i) under its controller.
- **`game/turns.rs`**: clear the ledger at turn cleanup (CR 514).
- **`game/casting.rs`**: offer `CastingVariant::Prowl` from the hand cast-candidate flow when the spell's creature types intersect the controller's ledger; substitute the prowl cost (mirrors Freerunning's seam + `.or()` chain).

## The one contained new piece

Everything reuses Freerunning's tested alt-cost machinery. The only new building block is the creature-type ledger (vs. Freerunning's player-set), populated at the same combat-damage site and snapshot at damage time per CR 702.76a ("at the time it dealt that damage"). No new `Effect`, `AbilityCost`, or subsystem.

## Coverage

~8 Morningtide prowl cards (Notorious Throng, Oona's Blackguard, Stinkdrinker Bandit, Earwig Squad, Auntie's Snitch, Knowledge Exploitation, Thieves' Fortune, …).

## Tests

- **casting.rs**: not offered without matching combat damage; offered + prowl cost substituted after a matching creature type dealt damage; requires creature-type **overlap** (Goblin damage does not unlock a Rogue spell); ledger resets at turn cleanup.
- **triggers.rs**: a typed creature's combat damage seeds the ledger; non-combat damage does not.

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — clean (the new `CastingVariant` arm compile-checks every exhaustive match).
- Unit tests run in CI (local toolchain has a binutils/dlltool gap).

Closes #2523