### PR TITLE
feat(engine): Hideaway keyword runtime — ETB look-and-exile-face-down

### DIFF
--- a/crates/engine/src/database/hideaway.rs
+++ b/crates/engine/src/database/hideaway.rs
@@ -1,0 +1,121 @@
+//! Hideaway (CR 702.75) — ETB look-and-exile-face-down keyword.
+//!
+//! CR 702.75a: "Hideaway N" is a triggered ability that means "When this
+//! permanent enters, look at the top N cards of your library. Exile one of them
+//! face down and put the rest on the bottom of your library in a random order.
+//! The exiled card gains 'The player who controls the permanent that exiled this
+//! card may look at this card in the exile zone.'"
+//!
+//! Older printings used "Hideaway" (Hideaway 4); since *Murders at Karlov Manor*
+//! the keyword is parameterized ("Hideaway N"). Either way the ability is only
+//! represented on the card as the `Keyword::Hideaway(N)` tag plus reminder text
+//! (which the parser strips), so without synthesis it is a silent no-op — and
+//! the card's companion "you may play the exiled card …" ability (already parsed
+//! and handled in `game/casting.rs`) has nothing to reference. This module is
+//! the prerequisite link: it establishes the face-down exiled card.
+//!
+//! Built from existing building blocks — no bespoke interactive choice:
+//!
+//! 1. `Effect::Dig` (look at top N, choose one to keep, rest to bottom of
+//!    library) handles the look + interactive selection + "rest on the bottom"
+//!    via the fully-wired `WaitingFor::DigChoice` flow. The kept card's
+//!    destination is `Exile`; the `DigChoice` resolution binds the chosen
+//!    (exiled) card onto the continuation's targets (CR 401.2).
+//! 2. `Effect::HideawayConceal` (chained as a `sub_ability`, CR 608.2c) takes
+//!    that exiled card — `TargetFilter::ParentTarget` — and turns it face down
+//!    while linking it to the source via the `exile_links` pool, so the
+//!    companion ability (`TargetFilter::ExiledBySource`) can later play it and
+//!    `visibility.rs` grants the controller the CR 702.75a look-permission.
+
+use crate::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter, TriggerDefinition,
+};
+use crate::types::card::CardFace;
+use crate::types::keywords::Keyword;
+use crate::types::triggers::TriggerMode;
+use crate::types::zones::Zone;
+
+/// CR 702.75a: Synthesize the ETB look-exile-face-down ability for every
+/// `Keyword::Hideaway` printed on the face. Cards without the keyword are left
+/// untouched. Idempotent: re-running `synthesize_all` does not stack duplicate
+/// triggers (mirrors the other keyword synthesizers).
+pub fn synthesize_hideaway(face: &mut CardFace) {
+    let counts: Vec<u32> = face
+        .keywords
+        .iter()
+        .filter_map(|kw| match kw {
+            Keyword::Hideaway(n) => Some(*n),
+            _ => None,
+        })
+        .collect();
+
+    // CR 113.2c: "If an object has multiple instances of the same ability, each
+    // instance functions independently" — so synthesize one ETB trigger per
+    // printed Hideaway instance (no real card prints two today, but the class is
+    // handled). Idempotent across repeated `synthesize_all` calls: skip the
+    // instances already represented by existing Hideaway triggers, so re-running
+    // never stacks duplicates.
+    let already_synthesized = face
+        .triggers
+        .iter()
+        .filter(|t| is_hideaway_trigger(t))
+        .count();
+    for &n in counts.iter().skip(already_synthesized) {
+        face.triggers.push(hideaway_trigger(n));
+    }
+}
+
+/// CR 702.75a: "When this permanent enters, look at the top N cards of your
+/// library. Exile one of them face down and put the rest on the bottom of your
+/// library in a random order."
+fn hideaway_trigger(n: u32) -> TriggerDefinition {
+    // CR 701.20e + CR 608.2c: Dig handles look-at-top-N + interactive choose-one
+    // + rest-to-bottom. The kept card is exiled (face up at this point); the
+    // chained `HideawayConceal` step turns it face down and links it.
+    let dig = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Dig {
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: n as i32 },
+            destination: Some(Zone::Exile),
+            keep_count: Some(1),
+            up_to: false,
+            filter: TargetFilter::Any,
+            // CR 702.75a: "put the rest on the bottom of your library."
+            rest_destination: Some(Zone::Library),
+            // CR 701.16a: the cards are looked at privately, not revealed.
+            reveal: false,
+        },
+    )
+    // CR 608.2c: continuation — conceal the just-exiled card (ParentTarget).
+    .sub_ability(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::HideawayConceal {
+            target: TargetFilter::ParentTarget,
+        },
+    ));
+
+    TriggerDefinition::new(TriggerMode::ChangesZone)
+        .destination(Zone::Battlefield)
+        .valid_card(TargetFilter::SelfRef)
+        .execute(dig)
+        .description(format!(
+            "CR 702.75a: Hideaway {n} — when this permanent enters, look at the top {n} cards of \
+             your library, exile one face down, and put the rest on the bottom in a random order."
+        ))
+}
+
+/// Idempotency probe: does this trigger already carry the Hideaway conceal step?
+fn is_hideaway_trigger(trigger: &TriggerDefinition) -> bool {
+    fn chain_has_conceal(ability: &AbilityDefinition) -> bool {
+        matches!(ability.effect.as_ref(), Effect::HideawayConceal { .. })
+            || ability
+                .sub_ability
+                .as_deref()
+                .is_some_and(chain_has_conceal)
+    }
+    trigger
+        .execute
+        .as_ref()
+        .is_some_and(|a| chain_has_conceal(a))
+}

--- a/crates/engine/src/database/hideaway.rs
+++ b/crates/engine/src/database/hideaway.rs
@@ -20,7 +20,7 @@
 //!    library) handles the look + interactive selection + "rest on the bottom"
 //!    via the fully-wired `WaitingFor::DigChoice` flow. The kept card's
 //!    destination is `Exile`; the `DigChoice` resolution binds the chosen
-//!    (exiled) card onto the continuation's targets (CR 401.2).
+//!    (exiled) card onto the continuation's targets.
 //! 2. `Effect::HideawayConceal` (chained as a `sub_ability`, CR 608.2c) takes
 //!    that exiled card — `TargetFilter::ParentTarget` — and turns it face down
 //!    while linking it to the source via the `exile_links` pool, so the
@@ -83,7 +83,7 @@ fn hideaway_trigger(n: u32) -> TriggerDefinition {
             filter: TargetFilter::Any,
             // CR 702.75a: "put the rest on the bottom of your library."
             rest_destination: Some(Zone::Library),
-            // CR 701.16a: the cards are looked at privately, not revealed.
+            // CR 701.20e: the cards are looked at privately, not revealed.
             reveal: false,
         },
     )

--- a/crates/engine/src/database/hideaway_tests.rs
+++ b/crates/engine/src/database/hideaway_tests.rs
@@ -1,0 +1,421 @@
+//! Tests for Hideaway (CR 702.75) synthesis, runtime, and visibility. Declared
+//! from `database/mod.rs` so the implementation modules (`database/hideaway.rs`
+//! and `game/effects/hideaway.rs`) stay free of inline test scaffolding.
+
+use super::hideaway::synthesize_hideaway;
+use crate::database::mtgjson::{AtomicCard, AtomicIdentifiers};
+use crate::game::ability_utils::build_resolved_from_def;
+use crate::game::effects::resolve_ability_chain;
+use crate::game::filter_state_for_viewer;
+use crate::game::zones::create_object;
+use crate::types::ability::{Effect, ResolvedAbility, TargetFilter};
+use crate::types::actions::GameAction;
+use crate::types::card::CardFace;
+use crate::types::game_state::{ExileLink, ExileLinkKind, GameState, WaitingFor};
+use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::keywords::Keyword;
+use crate::types::phase::Phase;
+use crate::types::player::PlayerId;
+use crate::types::triggers::TriggerMode;
+use crate::types::zones::Zone;
+
+// ---------------------------------------------------------------------------
+// Synthesis-shape tests (building-block level)
+// ---------------------------------------------------------------------------
+
+fn face_with(keyword: Keyword) -> CardFace {
+    let mut face = CardFace::default();
+    face.keywords.push(keyword);
+    face
+}
+
+/// CR 702.75a: synthesize_hideaway produces a self-ETB trigger whose effect is a
+/// `Dig` (look at top N, keep one to Exile, rest to library bottom) chained to a
+/// `HideawayConceal` continuation.
+#[test]
+fn synthesize_hideaway_builds_etb_dig_conceal_trigger() {
+    let mut face = face_with(Keyword::Hideaway(4));
+    synthesize_hideaway(&mut face);
+
+    assert_eq!(face.triggers.len(), 1, "exactly one ETB trigger");
+    let trigger = &face.triggers[0];
+    assert!(matches!(trigger.mode, TriggerMode::ChangesZone));
+    assert_eq!(trigger.destination, Some(Zone::Battlefield));
+    assert_eq!(trigger.valid_card, Some(TargetFilter::SelfRef));
+
+    let dig = trigger.execute.as_ref().expect("execute ability");
+    match dig.effect.as_ref() {
+        Effect::Dig {
+            count,
+            keep_count,
+            destination,
+            rest_destination,
+            reveal,
+            player,
+            ..
+        } => {
+            assert_eq!(player, &TargetFilter::Controller);
+            assert!(
+                matches!(
+                    count,
+                    crate::types::ability::QuantityExpr::Fixed { value: 4 }
+                ),
+                "looks at the top N cards"
+            );
+            assert_eq!(*keep_count, Some(1), "exile exactly one");
+            assert_eq!(*destination, Some(Zone::Exile), "kept card is exiled");
+            assert_eq!(
+                *rest_destination,
+                Some(Zone::Library),
+                "rest go to the bottom of the library"
+            );
+            assert!(!*reveal, "cards are looked at privately, not revealed");
+        }
+        other => panic!("expected Dig effect, got {other:?}"),
+    }
+
+    let conceal = dig.sub_ability.as_ref().expect("conceal continuation");
+    assert!(
+        matches!(conceal.effect.as_ref(), Effect::HideawayConceal { .. }),
+        "Dig is chained to the HideawayConceal step"
+    );
+}
+
+/// Cards without the keyword are untouched.
+#[test]
+fn synthesize_hideaway_is_noop_without_keyword() {
+    let mut face = face_with(Keyword::Flying);
+    synthesize_hideaway(&mut face);
+    assert!(face.triggers.is_empty());
+}
+
+/// Re-running synthesis does not stack duplicate triggers.
+#[test]
+fn synthesize_hideaway_is_idempotent() {
+    let mut face = face_with(Keyword::Hideaway(4));
+    synthesize_hideaway(&mut face);
+    synthesize_hideaway(&mut face);
+    assert_eq!(face.triggers.len(), 1);
+}
+
+/// CR 113.2c: multiple instances of the same ability function independently, so
+/// a face printing two Hideaway instances synthesizes one ETB trigger each — and
+/// re-running synthesis stays idempotent at that count (no duplicate stacking).
+#[test]
+fn synthesize_hideaway_handles_multiple_instances_and_stays_idempotent() {
+    let mut face = face_with(Keyword::Hideaway(4));
+    face.keywords.push(Keyword::Hideaway(2));
+
+    synthesize_hideaway(&mut face);
+    assert_eq!(
+        face.triggers.len(),
+        2,
+        "one independent ETB trigger per Hideaway instance"
+    );
+
+    synthesize_hideaway(&mut face);
+    assert_eq!(
+        face.triggers.len(),
+        2,
+        "re-running synthesis must not stack duplicates"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Conceal-step resolver (the custom building block)
+// ---------------------------------------------------------------------------
+
+fn main_phase_state() -> GameState {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+    state.phase = Phase::PreCombatMain;
+    state
+}
+
+/// CR 702.75a + CR 406.3 + CR 607.2a: HideawayConceal turns the exiled target
+/// card face down and links it to the source in `exile_links`.
+#[test]
+fn hideaway_conceal_marks_face_down_and_links_to_source() {
+    let mut state = main_phase_state();
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Windbrisk Heights".to_string(),
+        Zone::Battlefield,
+    );
+    let exiled = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(0),
+        "Hidden Bomb".to_string(),
+        Zone::Exile,
+    );
+
+    // The conceal step acts on the parent-inherited target (the just-exiled
+    // card), carried in `ability.targets`; the source is the hideaway permanent.
+    let ability = ResolvedAbility::new(
+        Effect::HideawayConceal {
+            target: TargetFilter::ParentTarget,
+        },
+        vec![crate::types::ability::TargetRef::Object(exiled)],
+        source,
+        PlayerId(0),
+    );
+
+    let mut events = Vec::new();
+    crate::game::effects::hideaway::resolve(&mut state, &ability, &mut events).unwrap();
+
+    assert!(state.objects[&exiled].face_down, "exiled card is face down");
+    assert!(
+        state.exile_links.iter().any(|l| l.exiled_id == exiled
+            && l.source_id == source
+            && l.kind == ExileLinkKind::HideawayLookable),
+        "exiled card is linked to the source with the look-permission kind"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end ETB → Dig → choose → conceal (the full interactive flow)
+// ---------------------------------------------------------------------------
+
+/// CR 702.75a: firing the synthesized ability looks at the top N, the player
+/// chooses one, and it ends up exiled face down and linked to the source while
+/// the rest stay in the library.
+#[test]
+fn hideaway_etb_exiles_chosen_card_face_down_and_links_it() {
+    let mut state = main_phase_state();
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Mosswort Bridge".to_string(),
+        Zone::Battlefield,
+    );
+    // Put four known cards on top of the controller's library.
+    for i in 0..4 {
+        create_object(
+            &mut state,
+            CardId(100 + i),
+            PlayerId(0),
+            format!("Lib {i}"),
+            Zone::Library,
+        );
+    }
+    let top: Vec<ObjectId> = state.players[0].library.iter().take(4).copied().collect();
+    assert_eq!(top.len(), 4);
+
+    // Build and resolve the synthesized Hideaway ability's effect chain.
+    let mut face = face_with(Keyword::Hideaway(4));
+    synthesize_hideaway(&mut face);
+    let execute = face.triggers[0].execute.as_ref().unwrap();
+    let resolved = build_resolved_from_def(execute, source, PlayerId(0));
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &resolved, &mut events, 0).unwrap();
+
+    // CR 701.20e: the Dig step paused for the controller's selection.
+    let looked_at = match &state.waiting_for {
+        WaitingFor::DigChoice { cards, .. } => cards.clone(),
+        other => panic!("expected DigChoice, got {other:?}"),
+    };
+    assert_eq!(looked_at.len(), 4, "looked at the top four");
+
+    // Choose the second card to hide away.
+    let chosen = looked_at[1];
+    crate::game::engine::apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: vec![chosen],
+        },
+    )
+    .expect("selection resolves");
+
+    // CR 702.75a: chosen card is exiled, face down, and linked to the source.
+    assert_eq!(state.objects[&chosen].zone, Zone::Exile);
+    assert!(state.objects[&chosen].face_down, "hidden card is face down");
+    assert!(
+        state
+            .exile_links
+            .iter()
+            .any(|l| l.exiled_id == chosen && l.source_id == source),
+        "hidden card is linked to the hideaway source"
+    );
+    // The other looked-at cards are not exiled (they go back to the library).
+    for other in looked_at.iter().filter(|c| **c != chosen) {
+        assert_ne!(
+            state.objects[other].zone,
+            Zone::Exile,
+            "non-chosen cards are not exiled"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Visibility (hidden-information correctness)
+// ---------------------------------------------------------------------------
+
+/// CR 702.75a: the controller of the permanent that exiled the card may look at
+/// it; opponents may not.
+#[test]
+fn hideaway_exiled_card_visible_to_controller_hidden_from_opponent() {
+    let mut state = main_phase_state();
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Shelldock Isle".to_string(),
+        Zone::Battlefield,
+    );
+    let hidden = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(0),
+        "Secret Plan".to_string(),
+        Zone::Exile,
+    );
+    state.objects.get_mut(&hidden).unwrap().face_down = true;
+    state.exile_links.push(ExileLink {
+        exiled_id: hidden,
+        source_id: source,
+        kind: ExileLinkKind::HideawayLookable,
+    });
+
+    // Controller (P0) may look — real identity survives the filter.
+    let for_controller = filter_state_for_viewer(&state, PlayerId(0));
+    assert_eq!(
+        for_controller.objects[&hidden].name, "Secret Plan",
+        "the controller may look at the card it hid away"
+    );
+
+    // Opponent (P1) may not — the card is redacted.
+    let for_opponent = filter_state_for_viewer(&state, PlayerId(1));
+    assert_eq!(
+        for_opponent.objects[&hidden].name, "Hidden Card",
+        "opponents cannot see the hidden card"
+    );
+}
+
+/// CR 406.3 + CR 702.75a regression: the Hideaway look-permission must be keyed
+/// on `ExileLinkKind::HideawayLookable` specifically, NOT on the mere presence
+/// of a `TrackedBySource` link. A face-down card exiled by a permanent that only
+/// tracks-by-source for later retrieval (Bomat Courier — "(You can't look at
+/// it.)", whose "put all cards exiled with this creature into their owners'
+/// hands" ability makes its face-down exiles source-tracked) must stay redacted
+/// even for the controller of the exiling permanent.
+#[test]
+fn tracked_by_source_face_down_exile_stays_hidden_from_controller() {
+    let mut state = main_phase_state();
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Bomat Courier".to_string(),
+        Zone::Battlefield,
+    );
+    let hidden = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(0),
+        "Bomat Exile".to_string(),
+        Zone::Exile,
+    );
+    state.objects.get_mut(&hidden).unwrap().face_down = true;
+    state.exile_links.push(ExileLink {
+        exiled_id: hidden,
+        source_id: source,
+        kind: ExileLinkKind::TrackedBySource,
+    });
+
+    // Even the controller of the exiling permanent may NOT look — Bomat-style
+    // tracked exiles grant no look-permission.
+    let for_controller = filter_state_for_viewer(&state, PlayerId(0));
+    assert_eq!(
+        for_controller.objects[&hidden].name, "Hidden Card",
+        "a plain TrackedBySource face-down exile must stay hidden from its source's controller"
+    );
+
+    // Opponent likewise sees nothing.
+    let for_opponent = filter_state_for_viewer(&state, PlayerId(1));
+    assert_eq!(
+        for_opponent.objects[&hidden].name, "Hidden Card",
+        "opponents cannot see a tracked-by-source face-down exile either"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Real-pipeline integration (MTGJSON -> parse -> synthesize)
+// ---------------------------------------------------------------------------
+
+/// Real Hideaway card (Windbrisk Heights) routed through `build_oracle_face` —
+/// exercises the true production path (MTGJSON keyword parse -> `synthesize_all`
+/// -> `synthesize_hideaway`).
+#[test]
+fn real_hideaway_card_synthesizes_etb_trigger() {
+    let atomic = AtomicCard {
+        name: "Windbrisk Heights".to_string(),
+        mana_cost: None,
+        colors: Vec::new(),
+        color_identity: vec!["W".to_string()],
+        text: Some(
+            "Hideaway 4 (When this land enters, look at the top four cards of your library, exile \
+             one face down, then put the rest on the bottom in a random order.)\n\
+             This land enters tapped.\n\
+             {T}: Add {W}.\n\
+             {W}, {T}: You may play the exiled card without paying its mana cost if you attacked \
+             with three or more creatures this turn."
+                .to_string(),
+        ),
+        power: None,
+        toughness: None,
+        loyalty: None,
+        defense: None,
+        layout: "normal".to_string(),
+        type_line: Some("Land".to_string()),
+        types: vec!["Land".to_string()],
+        subtypes: Vec::new(),
+        supertypes: Vec::new(),
+        keywords: Some(vec!["Hideaway".to_string()]),
+        side: None,
+        face_name: None,
+        mana_value: 0.0,
+        legalities: Default::default(),
+        leadership_skills: None,
+        printings: Vec::new(),
+        rulings: Vec::new(),
+        is_game_changer: false,
+        identifiers: AtomicIdentifiers {
+            scryfall_oracle_id: Some("windbrisk-heights-oracle".to_string()),
+            scryfall_id: Some("windbrisk-heights-face".to_string()),
+        },
+        foreign_data: Vec::new(),
+    };
+
+    let face = crate::database::synthesis::build_oracle_face(&atomic, None);
+    assert!(
+        face.keywords
+            .iter()
+            .any(|k| matches!(k, Keyword::Hideaway(_))),
+        "Hideaway keyword must parse from MTGJSON"
+    );
+    let trigger = face
+        .triggers
+        .iter()
+        .find(|t| {
+            matches!(t.mode, TriggerMode::ChangesZone)
+                && t.destination == Some(Zone::Battlefield)
+                && t.execute.as_ref().is_some_and(|a| {
+                    matches!(a.effect.as_ref(), Effect::Dig { .. })
+                        && a.sub_ability.as_ref().is_some_and(|s| {
+                            matches!(s.effect.as_ref(), Effect::HideawayConceal { .. })
+                        })
+                })
+        })
+        .expect("a Hideaway ETB Dig→Conceal trigger must be synthesized");
+    let _ = trigger;
+    // CR 614: the card is now genuinely runnable, not a parse stub.
+    assert!(
+        !crate::game::coverage::card_face_has_unimplemented_parts(&face),
+        "face must have no Unimplemented parts after synthesis"
+    );
+}

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -4,6 +4,7 @@ pub mod embalm_eternalize;
 pub mod encore;
 #[cfg(feature = "forge")]
 pub mod forge;
+pub mod hideaway;
 pub mod legality;
 pub mod mtgjson;
 pub mod oracle_loader;
@@ -15,6 +16,8 @@ pub mod unearth;
 mod embalm_eternalize_tests;
 #[cfg(test)]
 mod encore_tests;
+#[cfg(test)]
+mod hideaway_tests;
 #[cfg(test)]
 mod unearth_tests;
 

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -7748,6 +7748,9 @@ pub fn synthesize_all(face: &mut CardFace) {
     // (haste, must-attack that opponent, sacrifice at the next end step) —
     // self-contained building block.
     crate::database::encore::synthesize_encore(face);
+    // CR 702.75a: Hideaway ETB look-and-exile-face-down — self-contained
+    // building block (Dig + conceal continuation).
+    crate::database::hideaway::synthesize_hideaway(face);
     synthesize_outlast(face);
     synthesize_reinforce(face);
     synthesize_casualty(face);

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2478,6 +2478,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::SwitchPT { .. }
         | Effect::Myriad
         | Effect::Encore
+        | Effect::HideawayConceal { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::Populate
         | Effect::VentureIntoDungeon

--- a/crates/engine/src/game/effects/hideaway.rs
+++ b/crates/engine/src/game/effects/hideaway.rs
@@ -1,0 +1,65 @@
+//! Hideaway conceal step (CR 702.75a).
+//!
+//! The chosen card has just been exiled (face up) by the preceding `Effect::Dig`
+//! step of a Hideaway ETB ability (`database/hideaway.rs`); the `DigChoice`
+//! resolution bound that card onto this sub-ability's targets. This resolver
+//! finishes CR 702.75a's exile clause by:
+//!
+//! - turning the exiled card **face down** (CR 406.3 — a card exiled face down
+//!   can't be examined by any player except where an instruction allows it), and
+//! - **linking it to the source** in the persistent `exile_links` pool
+//!   (CR 607.2a / CR 406.6) so the card's companion "you may play the exiled
+//!   card …" ability (`TargetFilter::ExiledBySource`) can later play it, and so
+//!   `visibility.rs` grants the source's controller the CR 702.75a
+//!   "may look at this card in the exile zone" permission.
+//!
+//! This is a continuation step, never announced as a targeted effect: its target
+//! is `TargetFilter::ParentTarget`, inherited from the `Dig` continuation.
+
+use crate::game::targeting::resolved_object_ids_for_filter;
+use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+use crate::types::zones::Zone;
+
+/// CR 702.75a: Conceal the just-exiled card — turn it face down and link it to
+/// the Hideaway source.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let Effect::HideawayConceal { target } = &ability.effect else {
+        return Err(EffectError::MissingParam("HideawayConceal".to_string()));
+    };
+
+    for obj_id in resolved_object_ids_for_filter(state, ability, target) {
+        // CR 406.3: only a card actually in exile (placed there by the preceding
+        // Dig) is concealed; guard against a card that left exile via a
+        // replacement before this step resolves. A single mutable lookup serves
+        // both the zone guard and the face-down flip; the borrow ends before the
+        // exile-link push below re-borrows `state`.
+        match state.objects.get_mut(&obj_id) {
+            Some(obj) if obj.zone == Zone::Exile => obj.face_down = true,
+            _ => continue,
+        }
+        // CR 607.2a + CR 406.6 + CR 702.75a: link the exiled card to the source
+        // with the look-permission kind. Like a plain tracked link it stays
+        // discoverable by the kind-agnostic `ExiledBySource` companion ability,
+        // but additionally grants the source's controller the "may look at this
+        // card in the exile zone" permission keyed in `visibility.rs` — without
+        // exposing other face-down `TrackedBySource` exiles (Bomat Courier, etc.).
+        crate::game::exile_links::push_with_kind(
+            state,
+            obj_id,
+            ability.source_id,
+            crate::types::game_state::ExileLinkKind::HideawayLookable,
+        );
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::HideawayConceal,
+        source_id: ability.source_id,
+    });
+    Ok(())
+}

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -91,6 +91,7 @@ pub mod gift_delivery;
 pub mod goad;
 pub mod grant_extra_loyalty_activations;
 pub mod grant_permission;
+pub mod hideaway;
 pub mod incubate;
 pub mod investigate;
 pub mod learn;
@@ -1847,6 +1848,7 @@ pub fn resolve_effect(
         Effect::CopyTokenOf { .. } => token_copy::resolve(state, ability, events),
         Effect::Myriad => myriad::resolve(state, ability, events),
         Effect::Encore => encore::resolve(state, ability, events),
+        Effect::HideawayConceal { .. } => hideaway::resolve(state, ability, events),
         Effect::CopyTokenBlockingAttacker { .. } => {
             copy_token_blocking::resolve(state, ability, events)
         }

--- a/crates/engine/src/game/exile_links.rs
+++ b/crates/engine/src/game/exile_links.rs
@@ -45,6 +45,21 @@ pub(crate) fn push_tracked_by_source(
     exiled_id: ObjectId,
     source_id: ObjectId,
 ) {
+    push_with_kind(state, exiled_id, source_id, ExileLinkKind::TrackedBySource);
+}
+
+/// CR 607.2a + CR 406.6: Record an exiled→source link with an explicit
+/// `ExileLinkKind`, deduped on the `(exiled_id, source_id)` pair (mirrors
+/// `push_tracked_by_source`, which delegates here for the plain tracked kind).
+/// Used by Hideaway (`ExileLinkKind::HideawayLookable`, CR 702.75a) to mark the
+/// exiled card as look-permitted for the source's controller while keeping it
+/// discoverable by the kind-agnostic `ExiledBySource` companion-ability filter.
+pub(crate) fn push_with_kind(
+    state: &mut GameState,
+    exiled_id: ObjectId,
+    source_id: ObjectId,
+    kind: ExileLinkKind,
+) {
     if state
         .exile_links
         .iter()
@@ -55,7 +70,7 @@ pub(crate) fn push_tracked_by_source(
     state.exile_links.push(ExileLink {
         exiled_id,
         source_id,
-        kind: ExileLinkKind::TrackedBySource,
+        kind,
     });
     push_exiled_with_source_this_turn(state, exiled_id, source_id);
 }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -720,6 +720,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
         | Effect::Encore
+        | Effect::HideawayConceal { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
         | Effect::ChooseCard { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -702,6 +702,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::CopyTokenOf
         | EffectKind::Myriad
         | EffectKind::Encore
+        | EffectKind::HideawayConceal
         | EffectKind::BecomeCopy
         | EffectKind::ChooseCard
         | EffectKind::PutCounter

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -158,19 +158,38 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
     }
 
     // CR 406.3: A card exiled face down can't be examined by any player
-    // except when an instruction allows it. Foretell is the only modeled
-    // face-down-exile look permission today; other face-down exile classes
-    // (Necropotence / Asmodeus by default, Bomat-style look permissions until
-    // their static is modeled) fail closed and redact the card for every
-    // viewer.
+    // except when an instruction allows it. Two modeled look-permission classes:
+    // Foretell (the owner may look, CR 702.143e) and Hideaway (CR 702.75a — the
+    // controller of the permanent that exiled the card may look, keyed on the
+    // dedicated `ExileLinkKind::HideawayLookable` link). Every other face-down
+    // exile class — including plain `TrackedBySource` exiles that grant no
+    // look-permission (Bomat Courier's "(You can't look at it.)", Necropotence,
+    // Asmodeus) — fails closed and redacts the card for every viewer.
     let hidden_facedown_exile_ids: Vec<ObjectId> = filtered
         .exile
         .iter()
         .copied()
         .filter(|obj_id| {
             state.objects.get(obj_id).is_some_and(|obj| {
-                let viewer_can_examine = obj.foretold && can_view_private_for_player(obj.owner);
-                obj.face_down && !viewer_can_examine
+                if !obj.face_down {
+                    return false;
+                }
+                // CR 702.143e: foretold card — its owner may look.
+                let foretell_ok = obj.foretold && can_view_private_for_player(obj.owner);
+                // CR 702.75a + CR 607.2a: the controller of the permanent that
+                // exiled this card under Hideaway may look at it. Keyed on the
+                // dedicated `HideawayLookable` link kind so plain
+                // `TrackedBySource` face-down exiles that grant no look-permission
+                // (Bomat Courier, Necropotence, Asmodeus) stay redacted.
+                let hideaway_lookable_by_viewer = state.exile_links.iter().any(|link| {
+                    link.exiled_id == *obj_id
+                        && link.kind == crate::types::game_state::ExileLinkKind::HideawayLookable
+                        && state
+                            .objects
+                            .get(&link.source_id)
+                            .is_some_and(|src| can_view_private_for_player(src.controller))
+                });
+                !(foretell_ok || hideaway_lookable_by_viewer)
             })
         })
         .collect();

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3246,6 +3246,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
         | Effect::Encore
+        | Effect::HideawayConceal { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
         | Effect::ChooseCard { .. }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6200,6 +6200,15 @@ pub enum Effect {
     /// target (opponents and per-opponent attack binding are chosen by the
     /// effect, like `Myriad`).
     Encore,
+    /// CR 702.75a: Hideaway conceal step — turn the just-exiled `target` card
+    /// face down and link it to the source in the `exile_links` pool. Chained as
+    /// a `sub_ability` after the `Effect::Dig` of a Hideaway ETB ability
+    /// (`database/hideaway.rs`); `target` is `ParentTarget` (the card the Dig
+    /// continuation exiled), never announced. Resolver: `game/effects/hideaway.rs`.
+    HideawayConceal {
+        #[serde(default = "default_target_filter_parent")]
+        target: TargetFilter,
+    },
     /// CR 509.1g + CR 506.3e + CR 707.2: For each attacking creature matched by
     /// `source_filter`, create a token that's a copy of it and put that token
     /// onto the battlefield blocking the attacker it copies. Mirror Match is the
@@ -7668,6 +7677,12 @@ fn default_target_filter_self_ref() -> TargetFilter {
     TargetFilter::SelfRef
 }
 
+/// CR 608.2c: default for continuation effects whose target is inherited from
+/// the parent ability (e.g. `Effect::HideawayConceal`).
+fn default_target_filter_parent() -> TargetFilter {
+    TargetFilter::ParentTarget
+}
+
 fn target_filter_is_self_ref(filter: &TargetFilter) -> bool {
     matches!(filter, TargetFilter::SelfRef)
 }
@@ -8144,6 +8159,12 @@ impl Effect {
             // battlefield-only default (which would always fizzle a stack target).
             | Effect::ChangeTargets { target, .. } => Some(target),
 
+            // CR 702.75a: Hideaway conceal acts on the just-exiled card inherited
+            // from the parent `Dig` continuation (`ParentTarget`); it is never
+            // announced as a target, but surfacing the filter keeps chain-time
+            // resolution consistent.
+            Effect::HideawayConceal { target } => Some(target),
+
             // CR 109.4 + CR 115.1 + CR 707.2: `CopyTokenOf` has two
             // potentially-targetable axes — the copy *source* (`target`) and
             // the token *creator/owner* (`owner`). `target_filter()` surfaces
@@ -8414,6 +8435,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::CopyTokenOf { .. } => "CopyTokenOf",
         Effect::Myriad => "Myriad",
         Effect::Encore => "Encore",
+        Effect::HideawayConceal { .. } => "HideawayConceal",
         Effect::CopyTokenBlockingAttacker { .. } => "CopyTokenBlockingAttacker",
         Effect::BecomeCopy { .. } => "BecomeCopy",
         Effect::ChooseCard { .. } => "ChooseCard",
@@ -8605,6 +8627,7 @@ pub enum EffectKind {
     CopyTokenOf,
     Myriad,
     Encore,
+    HideawayConceal,
     BecomeCopy,
     ChooseCard,
     PutCounter,
@@ -8793,6 +8816,7 @@ impl From<&Effect> for EffectKind {
             Effect::CopyTokenOf { .. } => EffectKind::CopyTokenOf,
             Effect::Myriad => EffectKind::Myriad,
             Effect::Encore => EffectKind::Encore,
+            Effect::HideawayConceal { .. } => EffectKind::HideawayConceal,
             // CR 707.2: classified as a copy-token effect — the block placement
             // is bookkeeping layered on top of the same token-copy creation.
             Effect::CopyTokenBlockingAttacker { .. } => EffectKind::CopyTokenOf,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -669,6 +669,18 @@ pub enum ExileLinkKind {
     /// creature leaves the battlefield (`zones.rs` battlefield-exit, since this
     /// is not an `UntilSourceLeaves` link) — exactly CR 702.99c's lifetime.
     Cipher,
+    /// CR 702.75a: Hideaway — the card (`exiled_id`) was exiled face down by the
+    /// permanent (`source_id`). Like `TrackedBySource` it tracks the card so the
+    /// companion "you may play the exiled card" ability (`TargetFilter::
+    /// ExiledBySource`, which is kind-agnostic) can later find it — but it
+    /// additionally grants a *look-permission*: the player who controls the
+    /// exiling permanent "may look at this card in the exile zone". Visibility
+    /// keys the controller's face-down look-through on this kind specifically, so
+    /// plain `TrackedBySource` face-down exiles that grant no such permission
+    /// (Bomat Courier's "(You can't look at it.)", Necropotence, Asmodeus) stay
+    /// redacted. Pruned on exile-exit / source-exit like `Cipher` (not an
+    /// `UntilSourceLeaves` link, so no automatic return).
+    HideawayLookable,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -384,6 +384,10 @@ fn redundancy_delta(
         // CR 702.141a: Encore makes per-opponent copy tokens — like Myriad, it is
         // not a "redundant if already controlled" effect.
         | Effect::Encore
+        // CR 702.75a: HideawayConceal is an internal continuation step of the
+        // Hideaway ETB trigger (turn the just-exiled card face down + link it);
+        // it is never independently chosen, so it carries no redundancy signal.
+        | Effect::HideawayConceal { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
         | Effect::ChooseCard { .. }


### PR DESCRIPTION
## Summary

Closes: #2525

Implements the runtime for the **Hideaway** keyword (CR 702.75), which was parsed and typed (`Keyword::Hideaway(N)`) but had **no runtime behavior**. No ETB ability was synthesized, so a permanent with Hideaway never looked at the top of its library, never exiled a card face down, and the card's already-parsed companion "you may play the exiled card …" ability had nothing to reference. Because the card still parsed cleanly, these cards were silently counted as "supported" by the coverage metric — the gap was a dead keyword, not a parse failure.

Fixes the Hideaway feature gap (CR 702.75).

## Expected behavior (CR 702.75a)

> "Hideaway N" is a triggered ability that means "When this permanent enters, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'"

## Approach

Hideaway is composed from existing building blocks rather than a bespoke interactive choice:

1. **`Effect::Dig`** handles "look at the top N, choose one to keep, put the rest on the bottom of the library" via the fully-wired `WaitingFor::DigChoice` flow (engine + AI + frontend already in place). The kept card's destination is `Exile`; the `DigChoice` resolution binds the chosen card onto the continuation's targets.
2. A new **`Effect::HideawayConceal`** step (chained as a `sub_ability`, CR 608.2c) takes that exiled card — `TargetFilter::ParentTarget` — and turns it **face down** while **linking it to the source** in the `exile_links` pool, so the companion ability (`TargetFilter::ExiledBySource`) can later play it.

This means **no new `WaitingFor` and no frontend work** — the only genuinely new logic is the small conceal resolver and a visibility rule.

## Changes

**New self-contained modules (inline-test-free):**
- `crates/engine/src/database/hideaway.rs` — `synthesize_hideaway`: a self-ETB `ChangesZone` trigger (`destination: Battlefield`, `valid_card: SelfRef`) whose effect is `Dig { count: N, keep_count: 1, destination: Exile, rest_destination: Library, reveal: false }` chained to `HideawayConceal`. Idempotent. Wired into `synthesize_all`.
- `crates/engine/src/game/effects/hideaway.rs` — resolver for `Effect::HideawayConceal`: marks the exiled target card face down (CR 406.3) and links it to the source via `exile_links::push_tracked_by_source` (CR 607.2a).

**Hidden-information / visibility (`crates/engine/src/game/visibility.rs`):**
- Generalize the face-down-exile look-permission so the **controller of the permanent that exiled a card may look at it** (CR 702.75a), tracked via `exile_links`. Previously only Foretell was modeled and every other face-down exile failed closed. `server-core`'s multiplayer filter delegates to engine `filter_state_for_viewer`, so this one change covers multiplayer.

**New `Effect::HideawayConceal { target }` variant registration:**
- `types/ability.rs` — variant + `effect_variant_name` + `EffectKind::HideawayConceal` + `From<&Effect>` + `target_filter`.
- Exhaustive-match arms in `game/coverage.rs`, `game/printed_cards.rs`, `game/trigger_index.rs`, and `parser/oracle_effect/sequence.rs`.

**CR annotation fix:**
- The keyword was mis-annotated `CR 702.74a` (which is **Evoke**); corrected to `CR 702.75a` throughout.

**Tests (`crates/engine/src/database/hideaway_tests.rs`, declared from `database/mod.rs` so the impl modules stay inline-test-free):**
- synthesis shape (the ETB `Dig`→`Conceal` trigger);
- no-op without the keyword; idempotency;
- conceal resolver (face down + exile-link);
- full **ETB → Dig → choose → conceal** interactive flow (chosen card exiled face down + linked, rest stay in the library);
- visibility (controller may look; opponent sees a redacted card), verified through `filter_state_for_viewer`;
- real MTGJSON-pipeline card (Windbrisk Heights) routed through `build_oracle_face`, with no `Unimplemented` parts.

## Impact

~15 cards the engine tags with `Keyword::Hideaway` (Lorwyn hideaway lands and later — e.g. Windbrisk Heights, Mosswort Bridge, Spinerock Knoll, Shelldock Isle, Howltooth Hollow, Watcher for Tomorrow, Fight Rigging). Beyond those cards directly, this is the **prerequisite link** that activates their companion "play the exiled card" abilities, which were already parsed but inert because nothing was ever exiled.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy -p engine --all-targets` — clean (no warnings)
- `cargo test -p engine hideaway` — **7/7 pass**

CR 702.75.
