### PR TITLE
feat(engine): Haunt keyword runtime — exile-haunting + payoff from exile

### DIFF
--- a/crates/engine/src/database/haunt.rs
+++ b/crates/engine/src/database/haunt.rs
@@ -1,0 +1,171 @@
+//! Haunt (CR 702.55) — synthesis of the keyword's triggered abilities.
+//!
+//! `Keyword::Haunt` carries no parameters; the keyword's ability and its
+//! reminder text are otherwise dropped by the parser, so without synthesis a
+//! haunt card is a silent no-op. This module builds, for every `Keyword::Haunt`
+//! face:
+//!
+//! 1. **The haunt ability (CR 702.55a)** — a `ChangesZone` triggered ability
+//!    whose effect is [`Effect::ExileHaunting`] (resolved by `game/haunt.rs`):
+//!    - permanent (creature): "When this permanent is put into a graveyard from
+//!      the battlefield, exile it haunting target creature" — origin
+//!      `Battlefield`, destination `Graveyard` (a dies trigger);
+//!    - instant/sorcery: "When this spell is put into a graveyard during its
+//!      resolution, exile it haunting target creature" — origin `Stack`,
+//!      destination `Graveyard`, fired from the graveyard via `trigger_zones`.
+//!
+//! 2. **The haunt-payoff (CR 702.55c)** — a `HauntedCreatureDies` trigger that
+//!    fires from exile when the haunted creature dies. For a creature, the
+//!    payoff is the same effect as the card's "enters **or** the creature it
+//!    haunts dies" ability, whose ETB half the parser already produced; this
+//!    module clones that effect into the `HauntedCreatureDies` trigger (a single
+//!    `TriggerDefinition` cannot hold both the ETB and the haunted-dies trigger
+//!    conditions). For an instant/sorcery the payoff ("When the creature this
+//!    card haunts dies, …") is produced directly by the parser as a
+//!    `HauntedCreatureDies` trigger; this module only ensures it fires from
+//!    exile.
+
+use crate::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, TargetFilter, TriggerDefinition, TypeFilter,
+    TypedFilter,
+};
+use crate::types::card::CardFace;
+use crate::types::card_type::CoreType;
+use crate::types::keywords::Keyword;
+use crate::types::triggers::TriggerMode;
+use crate::types::zones::Zone;
+
+/// CR 702.55: Synthesize the haunt ability and the haunt-payoff trigger for a
+/// `Keyword::Haunt` face. Idempotent — re-running `synthesize_all` does not stack
+/// duplicate triggers.
+pub fn synthesize_haunt(face: &mut CardFace) {
+    if !face.keywords.iter().any(|k| matches!(k, Keyword::Haunt)) {
+        return;
+    }
+    // Idempotency: the synthesized haunt ability is the only `ExileHaunting`
+    // emitter, so its presence means synthesis already ran.
+    if face.triggers.iter().any(|t| {
+        trigger_chain_has(t, |a| {
+            matches!(a.effect.as_ref(), Effect::ExileHaunting { .. })
+        })
+    }) {
+        return;
+    }
+
+    let is_creature = face.card_type.core_types.contains(&CoreType::Creature);
+
+    // CR 702.55c: the creature-form payoff is the same effect as the card's ETB
+    // self-trigger ("enters or the creature it haunts dies"). Build the
+    // `HauntedCreatureDies` clones from the existing ETB self-triggers BEFORE
+    // appending the haunt ability (which is itself a self zone-change trigger
+    // and must not be mistaken for an ETB payoff).
+    let payoff_clones: Vec<TriggerDefinition> = if is_creature {
+        face.triggers
+            .iter()
+            .filter(|t| is_etb_self_trigger(t))
+            .filter_map(|t| {
+                t.execute
+                    .as_ref()
+                    .map(|e| haunt_payoff_trigger((**e).clone()))
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    // CR 702.55a: the haunt ability.
+    face.triggers.push(exile_haunting_trigger(is_creature));
+    face.triggers.extend(payoff_clones);
+
+    // CR 702.55c: spell-form payoff is produced by the parser as a
+    // `HauntedCreatureDies` trigger; ensure it functions in the exile zone.
+    if !is_creature {
+        for t in face.triggers.iter_mut() {
+            if matches!(t.mode, TriggerMode::HauntedCreatureDies) && t.trigger_zones.is_empty() {
+                t.trigger_zones = vec![Zone::Exile];
+            }
+        }
+    }
+}
+
+/// CR 702.55a: "exile it haunting target creature." The haunted creature is a
+/// real target chosen as the haunt trigger goes on the stack.
+fn exile_haunting_effect() -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ExileHaunting {
+            target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+        },
+    )
+    .description("CR 702.55a: Exile it haunting target creature.".to_string())
+}
+
+/// CR 702.55a: The haunt ability — a `ChangesZone` "put into a graveyard"
+/// trigger. A creature's fires on leaving the battlefield (dies); a spell's
+/// fires on leaving the stack (resolving to the graveyard), scanned from the
+/// graveyard via `trigger_zones`.
+fn exile_haunting_trigger(is_creature: bool) -> TriggerDefinition {
+    let origin = if is_creature {
+        Zone::Battlefield
+    } else {
+        Zone::Stack
+    };
+    let mut trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
+        .origin(origin)
+        .destination(Zone::Graveyard)
+        .valid_card(TargetFilter::SelfRef)
+        .execute(exile_haunting_effect())
+        .description(if is_creature {
+            "CR 702.55a: When this permanent is put into a graveyard from the battlefield, \
+             exile it haunting target creature."
+                .to_string()
+        } else {
+            "CR 702.55a: When this spell is put into a graveyard during its resolution, \
+             exile it haunting target creature."
+                .to_string()
+        });
+    if !is_creature {
+        // CR 113.6k: the source is in the graveyard when this self zone-change
+        // from the stack is scanned, so the trigger must function there.
+        trigger.trigger_zones = vec![Zone::Graveyard];
+    }
+    trigger
+}
+
+/// CR 702.55c: Build the haunt-payoff trigger from the card's parsed payoff
+/// effect. Fires from exile when the haunted creature dies.
+fn haunt_payoff_trigger(effect: AbilityDefinition) -> TriggerDefinition {
+    let mut trigger = TriggerDefinition::new(TriggerMode::HauntedCreatureDies)
+        .valid_card(TargetFilter::SelfRef)
+        .execute(effect)
+        .description(
+            "CR 702.55c: When the creature this card haunts dies, trigger the haunt payoff."
+                .to_string(),
+        );
+    trigger.trigger_zones = vec![Zone::Exile];
+    trigger
+}
+
+/// A card's ETB self-trigger: `ChangesZone` to the battlefield matching itself.
+/// For a haunt creature this is the "enters or the creature it haunts dies"
+/// ability, whose effect is the haunt payoff.
+fn is_etb_self_trigger(trigger: &TriggerDefinition) -> bool {
+    matches!(trigger.mode, TriggerMode::ChangesZone)
+        && trigger.destination == Some(Zone::Battlefield)
+        && trigger.valid_card == Some(TargetFilter::SelfRef)
+}
+
+/// Walk a trigger's `execute` ability chain, testing `pred` on each step.
+fn trigger_chain_has(
+    trigger: &TriggerDefinition,
+    pred: impl Fn(&AbilityDefinition) -> bool,
+) -> bool {
+    fn walk(ability: &AbilityDefinition, pred: &impl Fn(&AbilityDefinition) -> bool) -> bool {
+        pred(ability)
+            || ability
+                .sub_ability
+                .as_deref()
+                .is_some_and(|s| walk(s, pred))
+    }
+    trigger.execute.as_ref().is_some_and(|a| walk(a, &pred))
+}

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -4,6 +4,7 @@ pub mod embalm_eternalize;
 pub mod encore;
 #[cfg(feature = "forge")]
 pub mod forge;
+pub mod haunt;
 pub mod hideaway;
 pub mod legality;
 pub mod mtgjson;

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -7748,6 +7748,10 @@ pub fn synthesize_all(face: &mut CardFace) {
     // (haste, must-attack that opponent, sacrifice at the next end step) —
     // self-contained building block.
     crate::database::encore::synthesize_encore(face);
+    // CR 702.55: Haunt — the exile-haunting ability + the haunt-payoff trigger
+    // that fires from exile when the haunted creature dies. Runs after parser
+    // triggers so the creature-form payoff can clone the parsed ETB effect.
+    crate::database::haunt::synthesize_haunt(face);
     // CR 702.75a: Hideaway ETB look-and-exile-face-down — self-contained
     // building block (Dig + conceal continuation).
     crate::database::hideaway::synthesize_hideaway(face);

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2478,6 +2478,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::SwitchPT { .. }
         | Effect::Myriad
         | Effect::Encore
+        | Effect::ExileHaunting { .. }
         | Effect::HideawayConceal { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::Populate

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1847,6 +1847,7 @@ pub fn resolve_effect(
         Effect::CastCopyOfCard { .. } => cast_copy_of_card::resolve(state, ability, events),
         Effect::CopyTokenOf { .. } => token_copy::resolve(state, ability, events),
         Effect::Myriad => myriad::resolve(state, ability, events),
+        Effect::ExileHaunting { .. } => crate::game::haunt::resolve(state, ability, events),
         Effect::Encore => encore::resolve(state, ability, events),
         Effect::HideawayConceal { .. } => hideaway::resolve(state, ability, events),
         Effect::CopyTokenBlockingAttacker { .. } => {

--- a/crates/engine/src/game/haunt.rs
+++ b/crates/engine/src/game/haunt.rs
@@ -1,0 +1,126 @@
+//! Haunt (CR 702.55) — self-contained runtime for the keyword.
+//!
+//! Haunt is two abilities, mirroring the established Cipher pattern
+//! (`game/cipher.rs`) for an exiled card dynamically linked to a battlefield
+//! object:
+//!
+//! 1. **The haunt ability (CR 702.55a).** A triggered ability that exiles the
+//!    card *haunting target creature*, synthesized in `database/haunt.rs` as a
+//!    `TriggerMode::ChangesZone` "put into a graveyard" trigger whose effect is
+//!    [`Effect::ExileHaunting`] (resolved by [`resolve`] — the card, currently
+//!    in a graveyard, moves to exile and an [`ExileLinkKind::Haunt`] link
+//!    records the haunted creature). The two forms are:
+//!    - on a permanent: "When this permanent is put into a graveyard from the
+//!      battlefield, exile it haunting target creature";
+//!    - on an instant/sorcery: "When this spell is put into a graveyard during
+//!      its resolution, exile it haunting target creature".
+//!
+//! 2. **The haunt-payoff (CR 702.55c).** "Triggered abilities of cards with
+//!    haunt that refer to the haunted creature can trigger in the exile zone."
+//!    Modeled as `TriggerMode::HauntedCreatureDies` triggers carrying
+//!    `trigger_zones = [Exile]`; [`match_haunted_creature_dies`] fires one when
+//!    the creature the card haunts dies, looked up through the link.
+//!
+//! The link's lifetime (CR 702.55b) is handled by `zones.rs`: it is preserved
+//! when the haunted creature leaves the battlefield (so the payoff can read it
+//! at that moment) and pruned when the haunting card leaves exile.
+
+use crate::types::ability::{Effect, EffectError, ResolvedAbility};
+use crate::types::card_type::CoreType;
+use crate::types::events::GameEvent;
+use crate::types::game_state::{ExileLink, ExileLinkKind, GameState};
+use crate::types::identifiers::ObjectId;
+use crate::types::zones::Zone;
+
+/// CR 702.55b: Record that the exiled `card` haunts `creature`.
+fn add_haunt_link(state: &mut GameState, card: ObjectId, creature: ObjectId) {
+    state.exile_links.push(ExileLink {
+        exiled_id: card,
+        source_id: creature,
+        kind: ExileLinkKind::Haunt,
+    });
+}
+
+/// CR 702.55b: The creature `card` haunts, if any (the `source_id` of its
+/// `Haunt` link). `None` once the card is no longer haunting (link pruned on
+/// exile-exit).
+pub fn haunted_creature(state: &GameState, card: ObjectId) -> Option<ObjectId> {
+    state
+        .exile_links
+        .iter()
+        .find(|link| link.exiled_id == card && link.kind == ExileLinkKind::Haunt)
+        .map(|link| link.source_id)
+}
+
+/// CR 702.55a: Resolve the haunt ability — exile the source card from the
+/// graveyard haunting the target creature. The card was put into a graveyard by
+/// dying (permanent) or by resolving (spell); `ability.source_id` still names it
+/// (its `ObjectId` is stable across the zone change). The haunted creature is
+/// the ability's chosen target.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let Effect::ExileHaunting { .. } = &ability.effect else {
+        return Err(EffectError::MissingParam("ExileHaunting".to_string()));
+    };
+
+    // CR 608.2b: if the haunted creature is no longer a legal target the haunt
+    // ability is removed from the stack and doesn't resolve; by resolution the
+    // engine has already pruned illegal targets, so an empty target set means
+    // there is nothing to haunt and the card stays in its graveyard.
+    let Some(creature) = ability.targets.iter().find_map(|t| match t {
+        crate::types::ability::TargetRef::Object(id) => Some(*id),
+        crate::types::ability::TargetRef::Player(_) => None,
+    }) else {
+        return Ok(());
+    };
+
+    let card = ability.source_id;
+    // CR 702.55a: only a card actually in a graveyard can be exiled haunting —
+    // guard against the card having left the graveyard before this resolves.
+    if state
+        .objects
+        .get(&card)
+        .is_none_or(|obj| obj.zone != Zone::Graveyard)
+    {
+        return Ok(());
+    }
+
+    super::zones::move_to_zone(state, card, Zone::Exile, events);
+    add_haunt_link(state, card, creature);
+    Ok(())
+}
+
+/// CR 702.55c: A `HauntedCreatureDies` payoff trigger on a card in exile fires
+/// when the creature that card haunts dies — i.e. the event is that creature
+/// being put into a graveyard from the battlefield. `source_id` is the haunting
+/// card (the trigger source, in exile); the haunted creature is read from its
+/// `Haunt` link.
+pub fn match_haunted_creature_dies(
+    event: &GameEvent,
+    _trigger: &crate::types::ability::TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+) -> bool {
+    // CR 603.6c + CR 700.4: "dies" means a creature put into a graveyard from
+    // the battlefield. Read the dying object's core types from the event's
+    // pre-move snapshot (`record`) — its last-known information on the
+    // battlefield. `state.objects` now holds the *graveyard* object, which has
+    // shed any granted creature type (an animated land/artifact or a
+    // creature-land that died as a creature would otherwise fail this check).
+    let GameEvent::ZoneChanged {
+        object_id,
+        from: Some(Zone::Battlefield),
+        to: Zone::Graveyard,
+        record,
+    } = event
+    else {
+        return false;
+    };
+    if !record.core_types.contains(&CoreType::Creature) {
+        return false;
+    }
+    haunted_creature(state, source_id) == Some(*object_id)
+}

--- a/crates/engine/src/game/haunt_tests.rs
+++ b/crates/engine/src/game/haunt_tests.rs
@@ -1,0 +1,570 @@
+//! Tests for Haunt (CR 702.55). Declared from `game/mod.rs` so `haunt.rs`
+//! (runtime) and `database/haunt.rs` (synthesis) stay implementation-only.
+
+use std::sync::Arc;
+
+use super::haunt::{haunted_creature, match_haunted_creature_dies, resolve};
+use super::triggers::process_triggers;
+use super::zones::{create_object, move_to_zone};
+use crate::database::haunt::synthesize_haunt;
+use crate::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, ResolvedAbility, TargetFilter, TargetRef,
+    TriggerDefinition, TypeFilter, TypedFilter,
+};
+use crate::types::card::CardFace;
+use crate::types::card_type::CoreType;
+use crate::types::events::GameEvent;
+use crate::types::game_state::{ExileLink, ExileLinkKind, GameState, StackEntryKind};
+use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::keywords::Keyword;
+use crate::types::player::PlayerId;
+use crate::types::triggers::TriggerMode;
+use crate::types::zones::Zone;
+
+/// Whether an event is a creature dying (battlefield -> graveyard).
+fn is_dies_event(e: &GameEvent) -> bool {
+    matches!(
+        e,
+        GameEvent::ZoneChanged {
+            from: Some(Zone::Battlefield),
+            to: Zone::Graveyard,
+            ..
+        }
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Synthesis-shape tests (building-block level)
+// ---------------------------------------------------------------------------
+
+/// A creature face carrying Haunt plus an ETB self-trigger (the parsed "enters
+/// or the creature it haunts dies" payoff effect).
+fn haunt_creature_face() -> CardFace {
+    let mut face = CardFace::default();
+    face.card_type.core_types.push(CoreType::Creature);
+    face.keywords.push(Keyword::Haunt);
+    // The ETB self-trigger whose effect is the haunt payoff.
+    face.triggers.push(
+        TriggerDefinition::new(TriggerMode::ChangesZone)
+            .destination(Zone::Battlefield)
+            .valid_card(TargetFilter::SelfRef)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Destroy {
+                    target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Enchantment)),
+                    cant_regenerate: false,
+                },
+            )),
+    );
+    face
+}
+
+fn haunt_spell_face() -> CardFace {
+    let mut face = CardFace::default();
+    face.card_type.core_types.push(CoreType::Instant);
+    face.keywords.push(Keyword::Haunt);
+    face
+}
+
+fn exile_haunting_trigger(face: &CardFace) -> &TriggerDefinition {
+    face.triggers
+        .iter()
+        .find(|t| {
+            t.execute
+                .as_ref()
+                .is_some_and(|a| matches!(a.effect.as_ref(), Effect::ExileHaunting { .. }))
+        })
+        .expect("an ExileHaunting trigger must be synthesized")
+}
+
+/// CR 702.55a + CR 702.55c (creature): the dies haunt ability + a payoff clone.
+#[test]
+fn synthesize_haunt_creature_builds_dies_ability_and_payoff_clone() {
+    let mut face = haunt_creature_face();
+    synthesize_haunt(&mut face);
+
+    // CR 702.55a: dies trigger (Battlefield -> Graveyard) -> ExileHaunting target creature.
+    let haunt = exile_haunting_trigger(&face);
+    assert!(matches!(haunt.mode, TriggerMode::ChangesZone));
+    assert_eq!(haunt.origin, Some(Zone::Battlefield));
+    assert_eq!(haunt.destination, Some(Zone::Graveyard));
+    assert_eq!(haunt.valid_card, Some(TargetFilter::SelfRef));
+
+    // CR 702.55c: payoff clone — HauntedCreatureDies in the exile zone, same
+    // effect as the ETB trigger (Destroy an enchantment).
+    let payoff = face
+        .triggers
+        .iter()
+        .find(|t| matches!(t.mode, TriggerMode::HauntedCreatureDies))
+        .expect("a HauntedCreatureDies payoff must be synthesized");
+    assert_eq!(payoff.trigger_zones, vec![Zone::Exile]);
+    assert!(payoff
+        .execute
+        .as_ref()
+        .is_some_and(|a| matches!(a.effect.as_ref(), Effect::Destroy { .. })));
+}
+
+/// CR 702.55a (spell): the haunt ability fires when the spell is put into the
+/// graveyard from the stack, scanned from the graveyard.
+#[test]
+fn synthesize_haunt_spell_builds_stack_to_graveyard_ability() {
+    let mut face = haunt_spell_face();
+    synthesize_haunt(&mut face);
+
+    let haunt = exile_haunting_trigger(&face);
+    assert_eq!(haunt.origin, Some(Zone::Stack));
+    assert_eq!(haunt.destination, Some(Zone::Graveyard));
+    assert_eq!(haunt.trigger_zones, vec![Zone::Graveyard]);
+}
+
+#[test]
+fn synthesize_haunt_is_noop_without_keyword() {
+    let mut face = CardFace::default();
+    face.card_type.core_types.push(CoreType::Creature);
+    synthesize_haunt(&mut face);
+    assert!(face.triggers.is_empty());
+}
+
+#[test]
+fn synthesize_haunt_is_idempotent() {
+    let mut face = haunt_creature_face();
+    synthesize_haunt(&mut face);
+    let after_first = face.triggers.len();
+    synthesize_haunt(&mut face);
+    assert_eq!(face.triggers.len(), after_first);
+}
+
+// ---------------------------------------------------------------------------
+// Parser (spell-form payoff condition)
+// ---------------------------------------------------------------------------
+
+/// CR 702.55c: "When the creature this card haunts dies, …" parses to a
+/// HauntedCreatureDies trigger in the exile zone, with its effect intact.
+#[test]
+fn parser_recognizes_spell_haunt_payoff_condition() {
+    let def = crate::parser::oracle_trigger::parse_trigger_line(
+        "When the creature this card haunts dies, destroy target creature.",
+        "Test Haunt Spell",
+    );
+    assert!(matches!(def.mode, TriggerMode::HauntedCreatureDies));
+    assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+    assert_eq!(def.trigger_zones, vec![Zone::Exile]);
+    assert!(def
+        .execute
+        .as_ref()
+        .is_some_and(|a| matches!(a.effect.as_ref(), Effect::Destroy { .. })));
+}
+
+/// CR 119.3 + CR 102.1: a spell haunt card whose effect is "gain 1 life for each
+/// player" (Benediction of Moons) parses that quantity dynamically — no clause
+/// is silently swallowed once the card is no longer masked by an `Unknown`
+/// trigger.
+#[test]
+fn benediction_of_moons_gains_life_per_player_without_swallow() {
+    use crate::types::ability::{QuantityExpr, QuantityRef};
+    let oracle = "You gain 1 life for each player.\n\
+         Haunt (When this spell card is put into a graveyard after resolving, exile it haunting \
+         target creature.)\n\
+         When the creature this card haunts dies, you gain 1 life for each player.";
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        oracle,
+        "Benediction of Moons",
+        &["Haunt".to_string()],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    // No swallowed-clause diagnostic (the "for each player" multiplier is kept).
+    assert!(
+        !parsed.parse_warnings.iter().any(|w| matches!(
+            w,
+            crate::parser::oracle_ir::diagnostic::OracleDiagnostic::SwallowedClause { .. }
+        )),
+        "gain-life-for-each-player must not swallow a clause: {:?}",
+        parsed.parse_warnings
+    );
+    // The main effect's amount is the dynamic player count, not Fixed(1).
+    assert!(
+        parsed.abilities.iter().any(|a| matches!(
+            a.effect.as_ref(),
+            Effect::GainLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::PlayerCount { .. }
+                },
+                ..
+            }
+        )),
+        "gain life amount must be a dynamic player count"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Runtime — matcher, resolver, link lifetime
+// ---------------------------------------------------------------------------
+
+fn creature(state: &mut GameState, card: u64, name: &str, zone: Zone) -> ObjectId {
+    let id = create_object(state, CardId(card), PlayerId(0), name.to_string(), zone);
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.base_card_types.core_types.push(CoreType::Creature);
+    id
+}
+
+fn add_haunt_link(state: &mut GameState, card: ObjectId, creature: ObjectId) {
+    state.exile_links.push(ExileLink {
+        exiled_id: card,
+        source_id: creature,
+        kind: ExileLinkKind::Haunt,
+    });
+}
+
+/// CR 702.55c: the matcher fires only for the death of the exact creature the
+/// card haunts.
+#[test]
+fn match_haunted_creature_dies_only_for_the_haunted_creature() {
+    let mut state = GameState::new_two_player(1);
+    let haunting_card = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Ghost".into(),
+        Zone::Exile,
+    );
+    let haunted = creature(&mut state, 2, "Haunted", Zone::Battlefield);
+    let other = creature(&mut state, 3, "Other", Zone::Battlefield);
+    add_haunt_link(&mut state, haunting_card, haunted);
+
+    let mut events = Vec::new();
+    move_to_zone(&mut state, haunted, Zone::Graveyard, &mut events);
+    let dies_event = events
+        .iter()
+        .find(|e| is_dies_event(e))
+        .cloned()
+        .expect("haunted creature's ZoneChanged event");
+    let dummy = TriggerDefinition::new(TriggerMode::HauntedCreatureDies);
+    assert!(match_haunted_creature_dies(
+        &dies_event,
+        &dummy,
+        haunting_card,
+        &state
+    ));
+
+    // A different creature dying must not match.
+    let mut events2 = Vec::new();
+    move_to_zone(&mut state, other, Zone::Graveyard, &mut events2);
+    let other_event = events2
+        .into_iter()
+        .find(is_dies_event)
+        .expect("other creature's ZoneChanged event");
+    assert!(!match_haunted_creature_dies(
+        &other_event,
+        &dummy,
+        haunting_card,
+        &state
+    ));
+}
+
+/// CR 603.10a + CR 700.4: the dies check uses last-known information from the
+/// `ZoneChanged` record, not the graveyard object — an animated land /
+/// creature-land that died as a creature has shed its granted creature type by
+/// the time the trigger fires, but must still trigger the haunt payoff.
+#[test]
+fn match_haunted_creature_dies_uses_last_known_information() {
+    let mut state = GameState::new_two_player(1);
+    let haunting_card = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Ghost".into(),
+        Zone::Exile,
+    );
+    let haunted = creature(&mut state, 2, "Animated Land", Zone::Battlefield);
+    add_haunt_link(&mut state, haunting_card, haunted);
+
+    let mut events = Vec::new();
+    move_to_zone(&mut state, haunted, Zone::Graveyard, &mut events);
+    // The record snapshots its battlefield (creature) types; now strip the
+    // granted creature type from the graveyard object (de-animation).
+    {
+        let obj = state.objects.get_mut(&haunted).unwrap();
+        obj.card_types.core_types.clear();
+        obj.base_card_types.core_types.clear();
+    }
+    let dies_event = events
+        .into_iter()
+        .find(is_dies_event)
+        .expect("haunted creature's ZoneChanged event");
+    let dummy = TriggerDefinition::new(TriggerMode::HauntedCreatureDies);
+    assert!(
+        match_haunted_creature_dies(&dies_event, &dummy, haunting_card, &state),
+        "the dies check must read the record's LKI, not the graveyard object's current types"
+    );
+}
+
+/// CR 702.55a–b: resolving ExileHaunting moves the (graveyard) card to exile and
+/// links it to the targeted creature.
+#[test]
+fn resolve_exile_haunting_exiles_card_and_links_it() {
+    let mut state = GameState::new_two_player(1);
+    let card = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Thrull".into(),
+        Zone::Graveyard,
+    );
+    let target = creature(&mut state, 2, "Victim", Zone::Battlefield);
+
+    let ability = ResolvedAbility::new(
+        Effect::ExileHaunting {
+            target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+        },
+        vec![TargetRef::Object(target)],
+        card,
+        PlayerId(0),
+    );
+    let mut events = Vec::new();
+    resolve(&mut state, &ability, &mut events).unwrap();
+
+    assert_eq!(state.objects[&card].zone, Zone::Exile);
+    assert_eq!(haunted_creature(&state, card), Some(target));
+}
+
+/// CR 702.55b/c: the Haunt link survives the haunted creature leaving the
+/// battlefield (its death) — that is exactly when the payoff reads it.
+#[test]
+fn haunt_link_survives_the_haunted_creature_dying() {
+    let mut state = GameState::new_two_player(1);
+    let card = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Ghost".into(),
+        Zone::Exile,
+    );
+    let haunted = creature(&mut state, 2, "Haunted", Zone::Battlefield);
+    add_haunt_link(&mut state, card, haunted);
+
+    let mut events = Vec::new();
+    move_to_zone(&mut state, haunted, Zone::Graveyard, &mut events);
+    assert_eq!(
+        haunted_creature(&state, card),
+        Some(haunted),
+        "the link must persist through the haunted creature's death"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration — triggers actually fire
+// ---------------------------------------------------------------------------
+
+fn attach_synth(state: &mut GameState, id: ObjectId, face: &CardFace) {
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.trigger_definitions = face.triggers.clone().into();
+    obj.base_trigger_definitions = Arc::new(face.triggers.clone());
+}
+
+fn has_triggered_ability_on_stack(state: &GameState) -> bool {
+    state
+        .stack
+        .iter()
+        .any(|e| matches!(&e.kind, StackEntryKind::TriggeredAbility { .. }))
+}
+
+/// CR 702.55a (creature): the haunt ability fires when the permanent dies.
+#[test]
+fn haunt_ability_fires_when_creature_dies() {
+    let mut face = haunt_creature_face();
+    synthesize_haunt(&mut face);
+    let mut state = GameState::new_two_player(1);
+    state.active_player = PlayerId(0);
+    state.phase = crate::types::phase::Phase::PostCombatMain;
+    let _victim = creature(&mut state, 9, "Victim", Zone::Battlefield);
+    let card = creature(&mut state, 1, "Haunter", Zone::Battlefield);
+    attach_synth(&mut state, card, &face);
+
+    let mut events = Vec::new();
+    move_to_zone(&mut state, card, Zone::Graveyard, &mut events);
+    process_triggers(&mut state, &events);
+
+    assert!(
+        has_triggered_ability_on_stack(&state),
+        "the haunt (exile-haunting) ability must trigger on death"
+    );
+}
+
+/// CR 702.55a (spell): the haunt ability fires when the spell resolves to the
+/// graveyard from the stack — the key spell-form firing assumption.
+#[test]
+fn haunt_ability_fires_when_spell_resolves_to_graveyard() {
+    let mut face = haunt_spell_face();
+    synthesize_haunt(&mut face);
+    let mut state = GameState::new_two_player(1);
+    state.active_player = PlayerId(0);
+    state.phase = crate::types::phase::Phase::PostCombatMain;
+    let _victim = creature(&mut state, 9, "Victim", Zone::Battlefield);
+    let card = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Haunt Spell".into(),
+        Zone::Stack,
+    );
+    {
+        let obj = state.objects.get_mut(&card).unwrap();
+        obj.card_types.core_types.push(CoreType::Instant);
+        obj.base_card_types.core_types.push(CoreType::Instant);
+    }
+    attach_synth(&mut state, card, &face);
+
+    let mut events = Vec::new();
+    move_to_zone(&mut state, card, Zone::Graveyard, &mut events);
+    process_triggers(&mut state, &events);
+
+    assert!(
+        has_triggered_ability_on_stack(&state),
+        "the spell-form haunt ability must trigger when it resolves to the graveyard"
+    );
+}
+
+/// CR 702.55c: the haunt-payoff fires from exile when the haunted creature dies.
+#[test]
+fn haunt_payoff_fires_from_exile_when_haunted_creature_dies() {
+    let mut face = haunt_creature_face();
+    synthesize_haunt(&mut face);
+    let mut state = GameState::new_two_player(1);
+    state.active_player = PlayerId(0);
+    state.phase = crate::types::phase::Phase::PostCombatMain;
+    // CR 603.3c: the payoff destroys target enchantment — give it a legal target
+    // so the trigger is put on the stack.
+    let enchantment = create_object(
+        &mut state,
+        CardId(8),
+        PlayerId(0),
+        "Some Aura".into(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&enchantment).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.base_card_types.core_types.push(CoreType::Enchantment);
+    }
+
+    // The haunting card sits in exile carrying its synthesized payoff trigger.
+    let card = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Ghost".into(),
+        Zone::Exile,
+    );
+    attach_synth(&mut state, card, &face);
+    let haunted = creature(&mut state, 2, "Haunted", Zone::Battlefield);
+    add_haunt_link(&mut state, card, haunted);
+
+    let mut events = Vec::new();
+    move_to_zone(&mut state, haunted, Zone::Graveyard, &mut events);
+    process_triggers(&mut state, &events);
+
+    assert!(
+        has_triggered_ability_on_stack(&state),
+        "the haunt payoff must trigger from exile when the haunted creature dies"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Real-pipeline integration (MTGJSON -> parse -> synthesize)
+// ---------------------------------------------------------------------------
+
+use crate::database::mtgjson::{AtomicCard, AtomicIdentifiers};
+
+fn atomic(name: &str, types: &[&str], type_line: &str, oracle: &str) -> AtomicCard {
+    AtomicCard {
+        name: name.to_string(),
+        mana_cost: Some("{2}{W}{B}".to_string()),
+        colors: vec!["W".to_string(), "B".to_string()],
+        color_identity: vec!["W".to_string(), "B".to_string()],
+        text: Some(oracle.to_string()),
+        power: types.contains(&"Creature").then(|| "2".to_string()),
+        toughness: types.contains(&"Creature").then(|| "2".to_string()),
+        loyalty: None,
+        defense: None,
+        layout: "normal".to_string(),
+        type_line: Some(type_line.to_string()),
+        types: types.iter().map(|s| s.to_string()).collect(),
+        subtypes: Vec::new(),
+        supertypes: Vec::new(),
+        keywords: Some(vec!["Haunt".to_string()]),
+        side: None,
+        face_name: None,
+        mana_value: 4.0,
+        legalities: Default::default(),
+        leadership_skills: None,
+        printings: Vec::new(),
+        rulings: Vec::new(),
+        is_game_changer: false,
+        identifiers: AtomicIdentifiers {
+            scryfall_oracle_id: Some(format!("{name}-oracle")),
+            scryfall_id: Some(format!("{name}-face")),
+        },
+        foreign_data: Vec::new(),
+    }
+}
+
+/// Real creature-form haunt card (Absolver Thrull shape).
+#[test]
+fn real_creature_haunt_card_synthesizes_ability_and_payoff() {
+    let card = atomic(
+        "Absolver Thrull",
+        &["Creature"],
+        "Creature — Thrull Cleric",
+        "Haunt (When this creature dies, exile it haunting target creature.)\n\
+         When this creature enters or the creature it haunts dies, destroy target enchantment.",
+    );
+    let face = crate::database::synthesis::build_oracle_face(&card, None);
+    assert!(face.keywords.iter().any(|k| matches!(k, Keyword::Haunt)));
+    assert!(
+        face.triggers.iter().any(|t| t
+            .execute
+            .as_ref()
+            .is_some_and(|a| matches!(a.effect.as_ref(), Effect::ExileHaunting { .. }))),
+        "creature haunt must synthesize the exile-haunting ability"
+    );
+    assert!(
+        face.triggers
+            .iter()
+            .any(|t| matches!(t.mode, TriggerMode::HauntedCreatureDies)),
+        "creature haunt must synthesize the payoff trigger"
+    );
+    assert!(!crate::game::coverage::card_face_has_unimplemented_parts(
+        &face
+    ));
+}
+
+/// Real spell-form haunt card (Cry of Contrition shape).
+#[test]
+fn real_spell_haunt_card_synthesizes_ability_and_payoff() {
+    let card = atomic(
+        "Cry of Contrition",
+        &["Sorcery"],
+        "Sorcery",
+        "Target player discards a card.\n\
+         Haunt (When this spell card is put into a graveyard after resolving, exile it haunting \
+         target creature.)\n\
+         When the creature this card haunts dies, target player discards a card.",
+    );
+    let face = crate::database::synthesis::build_oracle_face(&card, None);
+    assert!(face.keywords.iter().any(|k| matches!(k, Keyword::Haunt)));
+    let haunt = face.triggers.iter().find(|t| {
+        t.execute
+            .as_ref()
+            .is_some_and(|a| matches!(a.effect.as_ref(), Effect::ExileHaunting { .. }))
+    });
+    let haunt = haunt.expect("spell haunt must synthesize the exile-haunting ability");
+    assert_eq!(haunt.origin, Some(Zone::Stack));
+    let payoff = face
+        .triggers
+        .iter()
+        .find(|t| matches!(t.mode, TriggerMode::HauntedCreatureDies))
+        .expect("spell haunt must parse the payoff trigger");
+    assert_eq!(payoff.trigger_zones, vec![Zone::Exile]);
+}

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -52,6 +52,12 @@ pub mod filter;
 pub mod functioning_abilities;
 pub mod game_object;
 pub mod gap_analysis;
+pub mod haunt;
+// Tests for `haunt` live in a sibling file (declared here, not in `haunt.rs`,
+// so `haunt.rs` stays implementation-only).
+#[cfg(test)]
+#[path = "haunt_tests.rs"]
+mod haunt_tests;
 pub mod keywords;
 pub mod layers;
 pub mod life_costs;

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -720,6 +720,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
         | Effect::Encore
+        | Effect::ExileHaunting { .. }
         | Effect::HideawayConceal { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -171,6 +171,11 @@ pub(crate) fn keys_from_trigger_def(def: &TriggerDefinition) -> (Keys, bool) {
             // CR 701.6: counter-targeting filter is dynamic; rare.
             return (keys, true);
         }
+        // CR 702.55c: Haunt payoff triggers live on a card in the EXILE zone and
+        // fire via the off-zone scan, never through this battlefield-scoped
+        // index. Route to `unclassified` so the index stays exhaustive without
+        // claiming a battlefield bucket these triggers can never occupy.
+        TriggerMode::HauntedCreatureDies => return (keys, true),
 
         // --- Combat ---
         TriggerMode::Attacks
@@ -702,6 +707,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::CopyTokenOf
         | EffectKind::Myriad
         | EffectKind::Encore
+        | EffectKind::ExileHaunting
         | EffectKind::HideawayConceal
         | EffectKind::BecomeCopy
         | EffectKind::ChooseCard

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -24,6 +24,9 @@ pub fn trigger_matcher(mode: TriggerMode) -> Option<TriggerMatcher> {
         TriggerMode::ChangesZone | TriggerMode::Evolve => match_changes_zone,
         TriggerMode::Evolved => match_evolved,
         TriggerMode::ChangesZoneAll => match_changes_zone_all,
+        // CR 702.55c: Haunt payoff — fires from exile when the haunted creature
+        // dies; resolved through the `ExileLinkKind::Haunt` link.
+        TriggerMode::HauntedCreatureDies => crate::game::haunt::match_haunted_creature_dies,
         TriggerMode::DamageDone
         | TriggerMode::DamageDoneOnce
         | TriggerMode::DamageAll
@@ -211,6 +214,11 @@ pub fn build_trigger_registry() -> HashMap<TriggerMode, TriggerMatcher> {
     // Core matchers with real logic
     r.insert(TriggerMode::ChangesZone, match_changes_zone);
     r.insert(TriggerMode::ChangesZoneAll, match_changes_zone_all);
+    // CR 702.55c: Haunt payoff — fires from exile when the haunted creature dies.
+    r.insert(
+        TriggerMode::HauntedCreatureDies,
+        crate::game::haunt::match_haunted_creature_dies,
+    );
     r.insert(TriggerMode::DamageDone, match_damage_done);
     r.insert(TriggerMode::DamageDoneOnce, match_damage_done);
     r.insert(TriggerMode::DamageAll, match_damage_done);

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -251,11 +251,16 @@ fn apply_zone_exit_cleanup(state: &mut GameState, object_id: ObjectId, from: Zon
         // `UntilSourceLeaves` links are intentionally preserved here because
         // `check_exile_returns` runs later in the priority loop and consumes
         // them to return the exiled cards (CR 610.3a).
+        // CR 702.55b + CR 702.55c: `Haunt` links are likewise preserved — the haunted
+        // creature leaving the battlefield (its death) is exactly when the
+        // card's haunt-payoff trigger reads the link to fire from exile. The
+        // link is pruned later, when the haunting card itself leaves exile.
         state.exile_links.retain(|link| {
             link.source_id != object_id
                 || matches!(
                     link.kind,
                     crate::types::game_state::ExileLinkKind::UntilSourceLeaves { .. }
+                        | crate::types::game_state::ExileLinkKind::Haunt
                 )
         });
     }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -326,6 +326,33 @@ fn parse_life_equal_quantity(after_verb_lower: &str) -> Option<QuantityExpr> {
         .map(|qty| QuantityExpr::Ref { qty })
 }
 
+/// CR 119.3 + CR 102.1: "gain 1 life for each player" (a/an/1) → the count of
+/// every player in the game (`PlayerFilter::All`). Narrow to the one-life-per
+/// form, the only shape that occurs (Benediction of Moons); other multipliers
+/// fall through to the generic quantity paths. `text` is the remainder after
+/// the "gain" verb, lowercased.
+fn parse_gain_life_per_player(after_gain_lower: &str) -> Option<QuantityExpr> {
+    // `(1|a|an) life for each player(s)` — `players` first so the longer tag
+    // wins; the optional trailing period is consumed so `all_consuming` accepts
+    // both the sentence-final and mid-clause forms.
+    all_consuming((
+        alt((
+            tag::<_, _, OracleError<'_>>("1 life for each "),
+            tag("a life for each "),
+            tag("an life for each "),
+        )),
+        alt((tag("players"), tag("player"))),
+        opt(tag(".")),
+    ))
+    .parse(after_gain_lower.trim())
+    .ok()
+    .map(|_| QuantityExpr::Ref {
+        qty: QuantityRef::PlayerCount {
+            filter: crate::types::ability::PlayerFilter::All,
+        },
+    })
+}
+
 pub(super) fn parse_numeric_imperative_ast(
     text: &str,
     lower: &str,
@@ -367,6 +394,13 @@ pub(super) fn parse_numeric_imperative_ast(
 
     if let Some(after_gain) = parse_life_verb_remainder(text, lower, "gain", "gains") {
         let after_lower = after_gain.to_ascii_lowercase();
+        // CR 119.3 + CR 102.1: "gain N life for each player" — the life gained is
+        // the number of players (the per-each amount is 1). Benediction of Moons.
+        // Probed before the bare-quantity fallback, which would otherwise parse
+        // "1" and silently drop the "for each player" multiplier.
+        if let Some(amount) = parse_gain_life_per_player(&after_lower) {
+            return Some(NumericImperativeAst::GainLife { amount });
+        }
         // CR 119.3: Handle "life equal to {quantity}" — dynamic amount from game state.
         // CR 119.3: target-relative quantity refs ("target creature's
         // power/toughness/mana value"). Mirrors LoseLife. Soul's Grace,

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3246,6 +3246,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::CopyTokenOf { .. }
         | Effect::Myriad
         | Effect::Encore
+        | Effect::ExileHaunting { .. }
         | Effect::HideawayConceal { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -6730,6 +6730,26 @@ fn try_parse_event(
 fn try_parse_named_trigger_mode(lower: &str) -> Option<(TriggerMode, TriggerDefinition)> {
     let mut def = make_base();
 
+    // CR 702.55c: Haunt payoff — "When the creature {this card|it} haunts dies".
+    // The standalone form appears on instant/sorcery haunt cards (Cry of
+    // Contrition, Seize the Soul); the creature-form disjunct ("~ enters or the
+    // creature it haunts dies") is split off at synthesis. The trigger functions
+    // in the exile zone, where the haunting card lives (CR 702.55b).
+    if (
+        alt((tag::<_, _, OracleError<'_>>("whenever "), tag("when "))),
+        tag("the creature "),
+        alt((tag("this card "), tag("it "))),
+        tag("haunts dies"),
+    )
+        .parse(lower)
+        .is_ok()
+    {
+        def.mode = TriggerMode::HauntedCreatureDies;
+        def.valid_card = Some(TargetFilter::SelfRef);
+        def.trigger_zones = vec![Zone::Exile];
+        return Some((TriggerMode::HauntedCreatureDies, def));
+    }
+
     if matches!(lower, "whenever chaos ensues" | "when chaos ensues") {
         def.mode = TriggerMode::ChaosEnsues;
         return Some((TriggerMode::ChaosEnsues, def));

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6200,6 +6200,15 @@ pub enum Effect {
     /// target (opponents and per-opponent attack binding are chosen by the
     /// effect, like `Myriad`).
     Encore,
+    /// CR 702.55a: Haunt — exile the source card (currently in a graveyard, put
+    /// there by dying or by resolving) from the graveyard, *haunting* the target
+    /// creature: it moves to exile and an `ExileLinkKind::Haunt` link records the
+    /// haunted creature. Resolver: `game/haunt.rs`. The target is the haunted
+    /// creature, chosen when the haunt triggered ability goes on the stack.
+    ExileHaunting {
+        #[serde(default = "default_target_filter_any")]
+        target: TargetFilter,
+    },
     /// CR 702.75a: Hideaway conceal step — turn the just-exiled `target` card
     /// face down and link it to the source in the `exile_links` pool. Chained as
     /// a `sub_ability` after the `Effect::Dig` of a Hideaway ETB ability
@@ -8157,7 +8166,11 @@ impl Effect {
             // target slot and so resolution-time re-validation (CR 608.2b) checks
             // it against the StackSpell/StackAbility filter instead of the
             // battlefield-only default (which would always fizzle a stack target).
-            | Effect::ChangeTargets { target, .. } => Some(target),
+            | Effect::ChangeTargets { target, .. }
+            // CR 702.55a: Haunt — "exile it haunting target creature". The
+            // haunted creature is a real target chosen as the haunt trigger goes
+            // on the stack, so it must be surfaced for the target-slot path.
+            | Effect::ExileHaunting { target } => Some(target),
 
             // CR 702.75a: Hideaway conceal acts on the just-exiled card inherited
             // from the parent `Dig` continuation (`ParentTarget`); it is never
@@ -8435,6 +8448,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::CopyTokenOf { .. } => "CopyTokenOf",
         Effect::Myriad => "Myriad",
         Effect::Encore => "Encore",
+        Effect::ExileHaunting { .. } => "ExileHaunting",
         Effect::HideawayConceal { .. } => "HideawayConceal",
         Effect::CopyTokenBlockingAttacker { .. } => "CopyTokenBlockingAttacker",
         Effect::BecomeCopy { .. } => "BecomeCopy",
@@ -8627,6 +8641,7 @@ pub enum EffectKind {
     CopyTokenOf,
     Myriad,
     Encore,
+    ExileHaunting,
     HideawayConceal,
     BecomeCopy,
     ChooseCard,
@@ -8816,6 +8831,7 @@ impl From<&Effect> for EffectKind {
             Effect::CopyTokenOf { .. } => EffectKind::CopyTokenOf,
             Effect::Myriad => EffectKind::Myriad,
             Effect::Encore => EffectKind::Encore,
+            Effect::ExileHaunting { .. } => EffectKind::ExileHaunting,
             Effect::HideawayConceal { .. } => EffectKind::HideawayConceal,
             // CR 707.2: classified as a copy-token effect — the block placement
             // is bookkeeping layered on top of the same token-copy creation.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -669,6 +669,17 @@ pub enum ExileLinkKind {
     /// creature leaves the battlefield (`zones.rs` battlefield-exit, since this
     /// is not an `UntilSourceLeaves` link) — exactly CR 702.99c's lifetime.
     Cipher,
+    /// CR 702.55b: Haunt — the exiled card (`exiled_id`) "haunts" the creature
+    /// (`source_id`) targeted by its haunt ability. The link drives the card's
+    /// haunt-payoff trigger, which fires from the exile zone when the haunted
+    /// creature dies (CR 702.55c). Unlike `Cipher`, this link is **preserved**
+    /// when the haunted creature leaves the battlefield (`zones.rs` battlefield
+    /// exit) — the haunted creature's death is exactly when the payoff must read
+    /// the link. The card "haunts the creature it haunts regardless of whether
+    /// or not that object is still a creature" (CR 702.55b), so the link is
+    /// pruned only when the haunting card itself leaves exile (`zones.rs`
+    /// exile-exit), not when the creature changes or dies.
+    Haunt,
     /// CR 702.75a: Hideaway — the card (`exiled_id`) was exiled face down by the
     /// permanent (`source_id`). Like `TrackedBySource` it tracks the card so the
     /// companion "you may play the exiled card" ability (`TargetFilter::

--- a/crates/engine/src/types/triggers.rs
+++ b/crates/engine/src/types/triggers.rs
@@ -523,6 +523,14 @@ pub enum TriggerMode {
     Waterbend,
     ElementalBend,
 
+    /// CR 702.55c: Haunt payoff — "When the creature this card haunts dies, …".
+    /// A dynamic, per-card trigger that fires while the card is in the exile zone
+    /// (`trigger_zones = [Exile]`): it matches a creature's death only when that
+    /// creature is the one the source card haunts, resolved through the
+    /// `ExileLinkKind::Haunt` link. Matched by
+    /// `game::haunt::match_haunted_creature_dies`.
+    HauntedCreatureDies,
+
     /// Fallback for unrecognized trigger mode strings.
     Unknown(String),
 }

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -388,6 +388,10 @@ fn redundancy_delta(
         // Hideaway ETB trigger (turn the just-exiled card face down + link it);
         // it is never independently chosen, so it carries no redundancy signal.
         | Effect::HideawayConceal { .. }
+        // CR 702.55a: ExileHaunting (the haunt ability — exile this card haunting
+        // target creature) is a triggered death/resolution effect, not a
+        // "redundant if already controlled" one.
+        | Effect::ExileHaunting { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
         | Effect::ChooseCard { .. }


### PR DESCRIPTION
## Summary

Closes: #2532 

Implements the runtime for the **Haunt** keyword (CR 702.55), which was parsed and typed (`Keyword::Haunt`) but had **no runtime behavior**. The gap spanned three layers: the keyword's exile-haunting ability was never synthesized, the haunt exile-link never existed, and the haunt-payoff was dropped at parse time — for creature cards the "or the creature it haunts dies" disjunct was lost (only the ETB half survived), and for spell cards "When the creature this card haunts dies" parsed as `Unknown`. So the keyword was a silent no-op and the payoff abilities were stranded with no creature to watch.

Fixes the Haunt feature gap (CR 702.55).

## Expected behavior (CR 702.55)

- **CR 702.55a** — Haunt is a triggered ability: on a permanent, "When this permanent is put into a graveyard from the battlefield, exile it haunting target creature"; on an instant/sorcery, "When this spell is put into a graveyard during its resolution, exile it haunting target creature."
- **CR 702.55b** — a card exiled this way *haunts* the targeted creature; the engine must track the link.
- **CR 702.55c** — triggered abilities of cards with haunt that refer to the haunted creature **can trigger from the exile zone** (the "when the creature it haunts dies" payoff).

## Approach

Modeled on the established **Cipher** pattern (`game/cipher.rs`) — an exiled card dynamically linked to a battlefield object, whose payoff fires through that link:

- **`ExileLinkKind::Haunt`** records the link between the exiled card and the haunted creature (CR 702.55b). It is **preserved** when the haunted creature leaves the battlefield — its death is exactly when the payoff reads the link — and pruned when the haunting card leaves exile.
- **`Effect::ExileHaunting { target }`** moves the source card from its graveyard to exile and creates the link (resolver in `game/haunt.rs`).
- **`TriggerMode::HauntedCreatureDies`** is the payoff trigger; it carries `trigger_zones = [Exile]` and is matched by `game::haunt::match_haunted_creature_dies`, which fires only for the death of the exact creature the source card haunts.

### The two trigger forms

The haunt ability is a `ChangesZone` "put into a graveyard" trigger:
- **creature** → origin `Battlefield`, destination `Graveyard` (a dies trigger, fired via the leaves-battlefield last-known-information scan);
- **instant/sorcery** → origin `Stack`, destination `Graveyard`, fired from the graveyard via `trigger_zones` (the off-zone destination scan). This path was verified empirically — see Testing.

### The payoff

A single `TriggerDefinition` cannot hold both the ETB and the haunted-dies conditions, so:
- **creature** ("enters **or** the creature it haunts dies") — synthesis clones the card's parsed ETB self-trigger effect into a `HauntedCreatureDies` trigger;
- **instant/sorcery** ("When the creature this card haunts dies, …") — the parser recognizes the condition directly (previously `Unknown`), and the effect parses normally.

## Changes

**New self-contained modules (inline-test-free):**
- `crates/engine/src/game/haunt.rs` — the runtime: the `ExileHaunting` resolver (graveyard → exile + link) and `match_haunted_creature_dies`.
- `crates/engine/src/database/haunt.rs` — `synthesize_haunt`: the haunt ability (both forms) + the creature-form payoff clone; ensures payoff triggers function in the exile zone. Wired into `synthesize_all`, idempotent.

**Types:** `ExileLinkKind::Haunt` (`types/game_state.rs`), `TriggerMode::HauntedCreatureDies` (`types/triggers.rs`), `Effect::ExileHaunting { target }` + `effect_variant_name` + `EffectKind` + `From<&Effect>` + `target_filter` (`types/ability.rs`).

**Runtime wiring:** `game/zones.rs` (preserve Haunt links past the haunted creature's death), `game/trigger_matchers.rs` (matcher registry), `game/effects/mod.rs` (effect dispatch), `game/trigger_index.rs` (classify the new `TriggerMode`/`EffectKind`).

**Parser:** `parser/oracle_trigger.rs` — a nom recognizer for the spell-form payoff condition "When the creature {this card|it} haunts dies".

**Exhaustive-match arms:** `game/coverage.rs`, `game/printed_cards.rs`, `parser/oracle_effect/sequence.rs` for `Effect::ExileHaunting`.

**Tests (`crates/engine/src/game/haunt_tests.rs`, declared from `game/mod.rs` so both impl modules stay inline-test-free):** synthesis shape (creature + spell), no-op/idempotency, parser recognition, matcher (positive + negative), the `ExileHaunting` resolver, the link surviving the haunted creature's death, full end-to-end firing — the haunt ability triggers on creature death **and** on spell resolution to the graveyard, and the payoff fires from exile when the haunted creature dies — plus real MTGJSON-pipeline cards (Absolver Thrull creature form, Cry of Contrition spell form).

## Impact

~10 cards the engine tags with `Keyword::Haunt` (Ravnica: Guildpact / Eventide — e.g. Absolver Thrull, Belfry Spirit, Blind Hunter, Orzhov Pontiff, Exhumer Thrull, Cry of Contrition, Seize the Soul), across both the creature form and the instant/sorcery form. Their defining mechanic — exile-haunting and the payoff that fires when the haunted creature dies — now works end to end.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy -p engine --all-targets` — clean (no warnings)
- `cargo test -p engine haunt` — **13/13 pass**, including the end-to-end "payoff fires from exile when the haunted creature dies" and "haunt ability fires when the spell resolves to the graveyard" cases.

CR 702.55.
